### PR TITLE
feat(kura,cli): scope the Xcode CAS snapshot to trunk, and ingest it ahead of the build

### DIFF
--- a/cas-plugin/AGENTS.md
+++ b/cas-plugin/AGENTS.md
@@ -33,12 +33,14 @@ The crate builds two artifacts from shared modules: the `cdylib` (`libtuist_cas_
 
 ## Configuration (environment)
 
-The plugin runs in one of two modes. **Proxy mode** (`TUIST_CAS_PROXY_SOCKET` set) delegates all remote work to the per-machine proxy over a unix socket; this is the productized path and the one the benchmarks measure. **Direct mode** (no proxy socket, `TUIST_CAS_REMOTE_GRPC_URL` set) opens a REAPI channel per compiler process; kept for benchmarks. Without either, the plugin is a pure passthrough.
+The plugin never talks to kura itself: all remote work goes to the per-machine proxy over a unix socket. It finds the proxy at `TUIST_CAS_PROXY_SOCKET`, falling back to the well-known socket so a build started outside `tuist` (⌘B) still reaches it. Without a proxy the plugin is a pure passthrough to the upstream plugin, local CAS only.
+
+The proxy is what makes the machine's caching coherent: it holds one REAPI connection and token for every build, sees every publication from both the Swift and Clang lanes (so `upload: false` can be enforced in one place), and owns the trunk snapshot and its ingestion. A per-compiler-process channel could do none of that.
 
 - `TUIST_CAS_UPSTREAM_PLUGIN` - path to the wrapped plugin (default: `$DEVELOPER_DIR/usr/lib/libToolchainCASPlugin.dylib`).
-- `TUIST_CAS_PROXY_SOCKET` - unix socket of the per-machine proxy; when set the plugin runs in proxy mode.
+- `TUIST_CAS_PROXY_SOCKET` - unix socket of the per-machine proxy; unset falls back to the well-known socket.
 - `TUIST_CAS_ACCOUNT`, `TUIST_CAS_PROJECT` - the `account/project` this build's cache belongs to, used to declare the instance to the proxy. Lower precedence than the `tuist-instance` plugin option (see below); when neither is present the proxy falls back to its `cas_path -> instance` registry.
-- `TUIST_CAS_REMOTE_GRPC_URL`, `TUIST_CAS_TOKEN` - REAPI endpoint + bearer. In proxy mode these configure the proxy (one endpoint/token, many instances); in direct mode they configure this process.
+- `TUIST_CAS_REMOTE_GRPC_URL`, `TUIST_CAS_TOKEN` - REAPI endpoint + bearer. Read by the proxy (one endpoint/token, many instances); the plugin ignores them.
 - `TUIST_CAS_UPLOAD` (default true) - upload policy from `xcodeCache(upload:)`. When false the plugin still serves remote read hits but publishes nothing (no value graphs to proxy or remote). Lower precedence than the `tuist-upload` plugin option (see below).
 - `TUIST_CAS_PREFETCH` (default 24) - size of the plugin's prefetch/upload worker pool.
 - `TUIST_CAS_LOG` - append per-process stats (hits, misses, prefetched, cache get/put latency) on dispose.
@@ -77,11 +79,12 @@ TUIST_CAS_SERVER_URL="https://tuist.dev" ./target/release/tuist-cas-proxy
 xcodebuild ... \
   COMPILATION_CACHE_ENABLE_CACHING=YES COMPILATION_CACHE_ENABLE_PLUGIN=YES \
   COMPILATION_CACHE_PLUGIN_PATH="$PWD/target/release/libtuist_cas_plugin.dylib" \
+  COMPILATION_CACHE_REMOTE_SERVICE_PATH="<proxy socket>" \
   COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES \
   OTHER_SWIFT_FLAGS="-cas-plugin-option tuist-instance=<account>/<project>"
 ```
 
-For **direct mode** (no proxy, bench/debug), put `TUIST_CAS_REMOTE_GRPC_URL` + `TUIST_CAS_TOKEN` in the build environment instead of running a proxy: the plugin opens its own REAPI channel per compiler.
+`COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what `tuist generate` sets, and leaving it out of a hand-run bench measures a different product: it is the only thing gating the build system's Clang lane (`CASOptions.hasRemoteCache`), so without it C and Objective-C cache locally and never remotely. The plugin consumes the matching option rather than forwarding it, so the socket never reaches Xcode's own remote client.
 
 Requires `SWIFT_ENABLE_EXPLICIT_MODULES` and works with Xcode 26.x. `TUIST_CAS_LOG=/tmp/cas.log` appends per-process stats on dispose and `COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS` prints Xcode's hit/miss remarks in the build log. In a shipped CLI all of this is automatic (`tuist setup cache` + `tuist generate`; the dylib and proxy ship next to `tuist`).
 

--- a/cas-plugin/AGENTS.md
+++ b/cas-plugin/AGENTS.md
@@ -42,7 +42,7 @@ The proxy is what makes the machine's caching coherent: it holds one REAPI conne
 - `TUIST_CAS_ACCOUNT`, `TUIST_CAS_PROJECT` - the `account/project` this build's cache belongs to, used to declare the instance to the proxy. Lower precedence than the `tuist-instance` plugin option (see below); when neither is present the proxy falls back to its `cas_path -> instance` registry.
 - `TUIST_CAS_REMOTE_GRPC_URL`, `TUIST_CAS_TOKEN` - REAPI endpoint + bearer. Read by the proxy (one endpoint/token, many instances); the plugin ignores them.
 - `TUIST_CAS_UPLOAD` (default true) - upload policy from `xcodeCache(upload:)`. When false the plugin still serves remote read hits but publishes nothing (no value graphs to proxy or remote). Lower precedence than the `tuist-upload` plugin option (see below).
-- `TUIST_CAS_PREFETCH` (default 24) - size of the plugin's prefetch/upload worker pool.
+- `TUIST_CAS_PREFETCH` (default `full`) - how much of the trunk snapshot the proxy pulls before a build asks for it. `full` fetches the snapshot and materializes its whole byte closure ahead of the build. `keys` fetches only the snapshot (one round trip, orders of magnitude lighter than the bytes) and pulls no bytes ahead of time; `tuist setup cache` selects it on CI, where the proxy and the build start together so there is no window to warm in. `0` (also `off`/`false`/`no`/`none`) disables both layers: no snapshot, no warm, every resolve a per-key round trip and every object on demand. Anything unrecognized reads as `full`, so a typo cannot quietly turn caching down.
 - `TUIST_CAS_LOG` - append per-process stats (hits, misses, prefetched, cache get/put latency) on dispose.
 
 ## Configuration (plugin options)

--- a/cas-plugin/Cargo.lock
+++ b/cas-plugin/Cargo.lock
@@ -752,6 +752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +779,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1045,6 +1068,8 @@ dependencies = [
  "libloading",
  "prost",
  "rusqlite",
+ "serde",
+ "serde_json",
  "sha2",
  "time",
  "tokio",
@@ -1225,6 +1250,12 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/cas-plugin/Cargo.toml
+++ b/cas-plugin/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/bin/tuist-cas-proxy.rs"
 [dependencies]
 libloading = "0.8"
 zstd = "0.13"
+# The sources registry is written by `tuist setup cache` (Swift) and read here,
+# so it is JSON rather than a format each side hand-rolls and can drift on.
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 libc = "0.2"
 bazel-remote-apis = "0.27.0"
 tonic = { version = "0.14.2", features = ["tls-ring", "tls-native-roots"] }

--- a/cas-plugin/examples/snapshot_probe.rs
+++ b/cas-plugin/examples/snapshot_probe.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tuist_cas_plugin::reapi::{blob_digest, ManifestEntry, Remote, RemoteConfig};
+use tuist_cas_plugin::reapi::{blob_digest, reapi_instance, ManifestEntry, Remote, RemoteConfig};
 use tuist_cas_plugin::token::TokenProvider;
 
 fn decode_snapshot_header(bytes: &[u8]) -> Option<(u64, u32, Vec<[u8; 32]>)> {
@@ -56,7 +56,17 @@ fn now_ms() -> u64 {
 }
 
 fn main() {
-    let config = RemoteConfig::from_env().expect("TUIST_CAS_REMOTE_GRPC_URL required");
+    // This probe is the only thing that talks to kura without a proxy in front
+    // of it, so it builds its own config: the plugin reaches the remote solely
+    // through the proxy, and the proxy is handed its endpoint explicitly.
+    let config = RemoteConfig {
+        grpc_url: std::env::var("TUIST_CAS_REMOTE_GRPC_URL")
+            .expect("TUIST_CAS_REMOTE_GRPC_URL required"),
+        instance: reapi_instance(
+            &std::env::var("TUIST_CAS_PROJECT").unwrap_or_else(|_| "tuist".into()),
+        )
+        .to_string(),
+    };
     let tokens = TokenProvider::from_env();
     let remote = Remote::new(config, tokens.clone());
 

--- a/cas-plugin/examples/snapshot_probe.rs
+++ b/cas-plugin/examples/snapshot_probe.rs
@@ -92,7 +92,7 @@ fn main() {
     // stored version and turns the watermark comparison into a false negative.
     let published_at = now_ms();
     remote
-        .update_action(&action_key, &manifest)
+        .update_action(&action_key, &manifest, None, None)
         .expect("update_action failed");
     println!("[{published_at}] action result published");
 
@@ -132,7 +132,7 @@ fn main() {
     }];
     let republished_at = now_ms();
     remote
-        .update_action(&action_key, &manifest2)
+        .update_action(&action_key, &manifest2, None, None)
         .expect("re-publish failed");
     println!("[{republished_at}] action result RE-published (same key, new content)");
     if (0..10).any(|round| {
@@ -156,7 +156,7 @@ fn poll(
     published_at: u64,
 ) -> bool {
     tokens.refresh_if_expiring(Duration::from_secs(120));
-    match remote.get_snapshot(None) {
+    match remote.get_snapshot(None, None) {
         Ok(Some(bytes)) => match decode_snapshot_header(&bytes) {
             Some((watermark, nodes, keys)) => {
                 println!(

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -27,9 +27,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use proxy_proto::{ProxyClient, Resolution};
-use prefetch::Prefetcher;
-use reapi::{ManifestEntry, OpStats, Remote, RemoteConfig};
-use token::TokenProvider;
+use reapi::OpStats;
 use types::*;
 use upstream::Upstream;
 
@@ -181,34 +179,6 @@ impl PublishRecord {
             spool_path,
         })
     }
-
-    fn encode_item(&self) -> Vec<u8> {
-        let body = self.encode_body();
-        let mut item = Vec::with_capacity(2 + body.len() + 128);
-        item.extend_from_slice(&(body.len() as u16).to_be_bytes());
-        item.extend_from_slice(&body);
-        if let Some(path) = &self.spool_path {
-            item.extend_from_slice(path.to_string_lossy().as_bytes());
-        }
-        item
-    }
-
-    fn decode_item(item: &[u8]) -> Option<Self> {
-        if item.len() < 2 {
-            return None;
-        }
-        let body_len = u16::from_be_bytes([item[0], item[1]]) as usize;
-        if item.len() < 2 + body_len {
-            return None;
-        }
-        let path_bytes = &item[2 + body_len..];
-        let spool_path = if path_bytes.is_empty() {
-            None
-        } else {
-            Some(std::path::PathBuf::from(String::from_utf8_lossy(path_bytes).into_owned()))
-        };
-        Self::decode_body(&item[2..2 + body_len], spool_path)
-    }
 }
 
 /// Reads a boolean env var, treating unset as `default` and `0`/`false`/`no`/`off`
@@ -267,10 +237,11 @@ fn resolve_upload(state: &OptionsState) -> bool {
 struct CasState {
     up: &'static Upstream,
     cas: llcas_cas_t,
-    remote: Option<Arc<Remote>>,
-    // Proxy mode: all remote work is delegated to the per-machine proxy
-    // over a unix socket; this process runs no gRPC client at all.
-    proxy: Option<ProxyClient>,
+    // All remote work is delegated to the per-machine proxy over a unix
+    // socket; this process runs no gRPC client at all. Always present: an
+    // unconfigured socket resolves to the well-known path, and a proxy that is
+    // not listening degrades per op rather than up front.
+    proxy: ProxyClient,
     // The account/project this build's cache belongs to, declared to the proxy
     // so it routes to the right instance. Empty for an Xcode ⌘B build (no CLI
     // env); the proxy then falls back to its primed cas_path mapping.
@@ -286,11 +257,9 @@ struct CasState {
     remote_hits: Mutex<std::collections::HashMap<Vec<u8>, Vec<u8>>>,
     created_at: std::time::Instant,
     cas_dir: Option<std::path::PathBuf>,
-    sweeper: Mutex<Option<std::thread::JoinHandle<()>>>,
     // Uploads value-object graphs on actioncache_put. Deliberately NOT hooked
     // on store_object: the compiler stores input ingests and scan trees every
     // build (warm included), and mirroring those re-uploads the world.
-    uploader: Prefetcher,
     // The client puts the same (key, value) many times per build; only the
     // first becomes a publication. Publish items carry unique spool paths, so
     // the queue's content dedup cannot do this.
@@ -299,9 +268,7 @@ struct CasState {
     // warm build re-fetches (read side) and re-compresses/re-hashes (publish
     // side) the same nodes once per referencing key.
     known_local: Mutex<std::collections::HashSet<Vec<u8>>>,
-    publish_cache: Mutex<std::collections::HashMap<Vec<u8>, (reapi::Digest, Vec<Vec<u8>>)>>,
     stats_remote_entry_hits: AtomicU64,
-    stats_remote_node_hits: AtomicU64,
     stats_remote_misses: AtomicU64,
     // Time spent resolving demand-driven remote work (entry read-through and
     // object-load materialization). This bounds how far warm-remote can sit
@@ -317,8 +284,6 @@ struct CasState {
     stats_mat_store: OpStats,
     stats_mat_store_bytes: AtomicU64,
     stats_local_put_ms: AtomicU64,
-    stats_upload_walk_loads: AtomicU64,
-    stats_manifest_entries: AtomicU64,
 }
 
 /// Process CPU (user+system) in milliseconds, for attributing wall-time gaps
@@ -518,25 +483,22 @@ pub unsafe extern "C" fn llcas_cas_create(
         return std::ptr::null_mut();
     }
 
-    let explicit_socket = std::env::var("TUIST_CAS_PROXY_SOCKET")
+    // All remote work goes through the proxy, so there is always one to address:
+    // an unset socket falls back to the well-known path rather than disabling
+    // remote caching, because the Xcode ⌘B case carries no CLI environment and
+    // would otherwise silently build local-only. If nothing is listening there
+    // the connect fails per op and we degrade to the local CAS.
+    let socket_path = std::env::var("TUIST_CAS_PROXY_SOCKET")
         .ok()
-        .filter(|socket| !socket.is_empty());
-    let has_direct_endpoint = std::env::var("TUIST_CAS_REMOTE_GRPC_URL").is_ok();
-    // Proxy mode when a socket is given, or (the Xcode ⌘B case, which carries
-    // no CLI environment) when no direct endpoint is configured: fall back to
-    // the well-known proxy socket so a running proxy is used, else the
-    // connect fails and we degrade to the local CAS. Direct mode is bench-only.
-    let proxy = explicit_socket
-        .or_else(|| (!has_direct_endpoint).then(default_proxy_socket))
-        .map(|socket_path| ProxyClient { socket_path });
-    // Which mode this frontend landed in, logged once per CAS create. A build
-    // that silently degrades to local-only (proxy unreachable, no endpoint) is
-    // otherwise indistinguishable from a cold cache: both just emit misses.
+        .filter(|socket| !socket.is_empty())
+        .unwrap_or_else(default_proxy_socket);
+    let proxy = ProxyClient { socket_path };
+    // Logged once per CAS create: a build that degrades to local-only (proxy
+    // unreachable) is otherwise indistinguishable from a cold cache, since both
+    // just emit misses.
     log_line(&format!(
-        "cas create: proxy={:?} direct_endpoint={} cas_dir={:?}",
-        proxy.as_ref().map(|client| client.socket_path.as_str()),
-        has_direct_endpoint,
-        state.ondisk_path,
+        "cas create: proxy={:?} cas_dir={:?}",
+        proxy.socket_path, state.ondisk_path,
     ));
     // The account/project this build's cache belongs to, routed to the proxy.
     // Prefer the `tuist-instance` plugin option (baked into build settings by
@@ -552,12 +514,6 @@ pub unsafe extern "C" fn llcas_cas_create(
             _ => String::new(),
         }
     });
-    let remote = if proxy.is_some() {
-        None
-    } else {
-        RemoteConfig::from_env().map(|config| Remote::new(config, TokenProvider::from_env()))
-    };
-    let has_remote = remote.is_some();
     let cas_dir = state
         .ondisk_path
         .as_ref()
@@ -566,20 +522,15 @@ pub unsafe extern "C" fn llcas_cas_create(
     let state_ptr = Box::into_raw(Box::new(CasState {
         up,
         cas: upstream_cas,
-        remote,
         proxy,
         proxy_instance,
         upload: resolve_upload(state),
         created_at: std::time::Instant::now(),
         cas_dir,
-        sweeper: Mutex::new(None),
-        uploader: Prefetcher::new(),
         published: Mutex::new(std::collections::HashSet::new()),
         remote_hits: Mutex::new(std::collections::HashMap::new()),
         known_local: Mutex::new(std::collections::HashSet::new()),
-        publish_cache: Mutex::new(std::collections::HashMap::new()),
         stats_remote_entry_hits: AtomicU64::new(0),
-        stats_remote_node_hits: AtomicU64::new(0),
         stats_remote_misses: AtomicU64::new(0),
         stats_demand_wait_ms: AtomicU64::new(0),
         stats_client_store: OpStats::default(),
@@ -587,38 +538,7 @@ pub unsafe extern "C" fn llcas_cas_create(
         stats_mat_store: OpStats::default(),
         stats_mat_store_bytes: AtomicU64::new(0),
         stats_local_put_ms: AtomicU64::new(0),
-        stats_upload_walk_loads: AtomicU64::new(0),
-        stats_manifest_entries: AtomicU64::new(0),
     }));
-    if has_remote {
-        let cas_addr = state_ptr as usize;
-        (*state_ptr).uploader.configure(Prefetcher::worker_count(), move |item| {
-            upload_process(cas_addr, item);
-        });
-        // Spawn a sweeper only when there is something to sweep: most
-        // processes find an empty spool, and a per-process thread plus its
-        // dispose-join costs real wall time multiplied by thousands of
-        // short-lived compiler processes.
-        let has_spool_entries = spool_dir(&*state_ptr)
-            .and_then(|dir| std::fs::read_dir(dir).ok())
-            .map(|mut entries| entries.next().is_some())
-            .unwrap_or(false);
-        if has_spool_entries {
-            *(*state_ptr).sweeper.lock().unwrap() = Some(std::thread::spawn(move || {
-                // Only processes that live a while sweep: a short-lived
-                // frontend claiming records it cannot finish just bounces
-                // them back to the spool.
-                for _ in 0..75 {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                    let state = cas_state(cas_addr as llcas_cas_t);
-                    if state.uploader.is_shutdown() {
-                        return;
-                    }
-                }
-                sweep_spool(cas_addr);
-            }));
-        }
-    }
     state_ptr as llcas_cas_t
 }
 
@@ -626,52 +546,6 @@ fn spool_dir(state: &CasState) -> Option<std::path::PathBuf> {
     state.cas_dir.as_ref().map(|dir| dir.join("tuist-spool"))
 }
 
-/// Requeues publications left behind by processes that died before their
-/// uploader finished (most compiler processes exit without disposing the
-/// CAS). Every plugin instance with a remote sweeps once at creation; files
-/// are claimed by rename so concurrent sweepers do not duplicate work, and
-/// claims from dead pids are re-claimable.
-fn sweep_spool(cas_addr: usize) {
-    let state = unsafe { cas_state(cas_addr as llcas_cas_t) };
-    let Some(dir) = spool_dir(state) else { return };
-    let Ok(entries) = std::fs::read_dir(&dir) else { return };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        // The proxy writes each record's publish tags beside it. Claiming one
-        // here would fail to decode and delete it, and the record it belongs to
-        // would then be re-tagged with whatever is checked out at that point.
-        if name.ends_with(crate::proxy::TAGS_SUFFIX) {
-            continue;
-        }
-        let base = if let Some((base, claim_pid)) = name.split_once(".claim-") {
-            // A claim from a live process is in flight; a dead claimant's
-            // record is fair game again.
-            let alive = claim_pid
-                .parse::<i32>()
-                .map(|pid| unsafe { libc::kill(pid, 0) } == 0)
-                .unwrap_or(false);
-            if alive {
-                continue;
-            }
-            base.to_string()
-        } else {
-            name.to_string()
-        };
-        let claimed = dir.join(format!("{base}.claim-{}", std::process::id()));
-        if std::fs::rename(&path, &claimed).is_err() {
-            continue;
-        }
-        if let Ok(bytes) = std::fs::read(&claimed) {
-            if let Some(record) = PublishRecord::decode_body(&bytes, Some(claimed.clone())) {
-                state.uploader.enqueue(record.encode_item());
-            } else {
-                let _ = std::fs::remove_file(&claimed);
-            }
-        }
-    }
-}
 
 /// Writes the publication's write-ahead record. Returns the path the worker
 /// deletes after a successful publish.
@@ -704,39 +578,8 @@ pub unsafe extern "C" fn llcas_cas_dispose(cas: llcas_cas_t) {
         // process exit. Post-shutdown sweeper enqueues are dropped harmlessly
         // (the records persist for a later sweep).
         // Bounded drain keeps process exit off the build's critical path;
-        // whatever is still queued is spooled for later processes to upload.
-        let drain_budget = std::env::var("TUIST_CAS_DRAIN_MS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(50);
-        let drain_started = std::time::Instant::now();
-        // Leftovers are simply dropped: each publication's write-ahead record
-        // survives on disk and a later sweep completes it.
-        let leftovers = state
-            .uploader
-            .drain_stop_timeout(std::time::Duration::from_millis(drain_budget));
-        let spooled = leftovers.len();
-        if let Some(sweeper) = state.sweeper.lock().unwrap().take() {
-            let _ = sweeper.join();
-        }
-        if let Some(remote) = &state.remote {
-            let drain_ms = drain_started.elapsed().as_millis();
-            log_line(&format!(
-                "dispose: drain={drain_ms}ms spooled={spooled} cpu={}ms life={}ms walks up={} remote entry hits={} manifest entries={} blobs fetched={} misses={} demand_wait={}ms | gets {} | posts {}",
-                process_cpu_ms(),
-                state.created_at.elapsed().as_millis(),
-                state.stats_upload_walk_loads.load(Ordering::Relaxed),
-                state.stats_remote_entry_hits.load(Ordering::Relaxed),
-                state.stats_manifest_entries.load(Ordering::Relaxed),
-                state.stats_remote_node_hits.load(Ordering::Relaxed),
-                state.stats_remote_misses.load(Ordering::Relaxed),
-                state.stats_demand_wait_ms.load(Ordering::Relaxed),
-                remote.get_stats.summary(),
-                remote.post_stats.summary(),
-            ));
-        }
-        // Ingestion counters are logged with or without a remote so a floor
-        // build produces the same accounting as a warm-remote build.
+        // Ingestion counters, logged whether or not this build reached the
+        // proxy, so a floor build produces the same accounting as a warm one.
         if state.stats_client_store.count.load(Ordering::Relaxed) > 0
             || state.stats_mat_store.count.load(Ordering::Relaxed) > 0
         {
@@ -756,22 +599,6 @@ pub unsafe extern "C" fn llcas_cas_dispose(cas: llcas_cas_t) {
     drop(Box::from_raw(state_ptr));
 }
 
-/// Diagnostic: records which executable missed which key remotely, so miss
-/// populations can be attributed to task classes and compared across builds.
-fn log_miss(key: &[u8]) {
-    static EXE: OnceLock<String> = OnceLock::new();
-    let exe = EXE.get_or_init(|| {
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-            .unwrap_or_else(|| "unknown".into())
-    });
-    let mut hex = String::with_capacity(key.len() * 2);
-    for byte in key {
-        hex.push_str(&format!("{byte:02x}"));
-    }
-    log_line(&format!("miss exe={exe} key={hex}"));
-}
 
 pub fn log_line(message: &str) {
     if let Ok(path) = std::env::var("TUIST_CAS_LOG") {
@@ -827,8 +654,8 @@ pub unsafe extern "C" fn llcas_cas_prune_ondisk_data(cas: llcas_cas_t, error: *m
     // re-fetching them and hand back a broken graph. Prune is infrequent, so the
     // occasional re-warm from an over-broad invalidation is cheap.
     state.known_local.lock().unwrap().clear();
-    if let (Some(client), Some(cas_dir)) = (&state.proxy, &state.cas_dir) {
-        let _ = client.invalidate(&cas_dir.to_string_lossy());
+    if let Some(cas_dir) = &state.cas_dir {
+        let _ = state.proxy.invalidate(&cas_dir.to_string_lossy());
     }
     result
 }
@@ -978,45 +805,6 @@ unsafe fn digest_bytes(state: &CasState, id: llcas_objectid_t) -> Vec<u8> {
     std::slice::from_raw_parts(digest.data, digest.size).to_vec()
 }
 
-/// Stores one fetched node into the upstream local CAS.
-unsafe fn store_node(state: &CasState, node: &reapi::Node) -> bool {
-    let mut ref_ids = Vec::with_capacity(node.refs.len());
-    for reference in &node.refs {
-        let digest = llcas_digest_t { data: reference.as_ptr(), size: reference.len() };
-        let mut id = llcas_objectid_t { opaque: 0 };
-        let mut id_error: *mut c_char = std::ptr::null_mut();
-        if (state.up.llcas_cas_get_objectid)(state.cas, digest, &mut id, &mut id_error) {
-            if !id_error.is_null() {
-                (state.up.llcas_string_dispose)(id_error);
-            }
-            return false;
-        }
-        ref_ids.push(id);
-    }
-    let data = llcas_data_t { data: node.data.as_ptr() as *const c_void, size: node.data.len() };
-    let mut stored = llcas_objectid_t { opaque: 0 };
-    let mut store_error: *mut c_char = std::ptr::null_mut();
-    let started = std::time::Instant::now();
-    let failed = (state.up.llcas_cas_store_object)(
-        state.cas,
-        data,
-        ref_ids.as_ptr(),
-        ref_ids.len(),
-        &mut stored,
-        &mut store_error,
-    );
-    state.stats_mat_store.record(started.elapsed());
-    state
-        .stats_mat_store_bytes
-        .fetch_add(node.data.len() as u64, Ordering::Relaxed);
-    if failed {
-        if !store_error.is_null() {
-            (state.up.llcas_string_dispose)(store_error);
-        }
-        return false;
-    }
-    true
-}
 
 unsafe fn load_object_impl(
     state: &CasState,
@@ -1033,33 +821,27 @@ unsafe fn load_object_impl(
     // node is produced: FETCH_OBJECT blocks until the proxy has it (present,
     // mid-materialization, or fetched on demand), then the local load retries.
     if result == LLCAS_LOOKUP_RESULT_NOTFOUND {
-        if let Some(client) = &state.proxy {
-            let digest = (state.up.llcas_objectid_get_digest)(state.cas, id);
-            let digest = std::slice::from_raw_parts(digest.data, digest.size);
-            let cas_path = state
-                .cas_dir
-                .as_ref()
-                .map(|dir| dir.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            match client.fetch_object(&cas_path, &state.proxy_instance, digest) {
-                Ok(true) => {
-                    if !upstream_error.is_null() {
-                        (state.up.llcas_string_dispose)(upstream_error);
-                    }
-                    upstream_error = std::ptr::null_mut();
-                    let retried = (state.up.llcas_cas_load_object)(
-                        state.cas,
-                        id,
-                        loaded,
-                        &mut upstream_error,
-                    );
-                    adopt_error(state.up, upstream_error, error);
-                    return retried;
+        let digest = (state.up.llcas_objectid_get_digest)(state.cas, id);
+        let digest = std::slice::from_raw_parts(digest.data, digest.size);
+        let cas_path = state
+            .cas_dir
+            .as_ref()
+            .map(|dir| dir.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        match state.proxy.fetch_object(&cas_path, &state.proxy_instance, digest) {
+            Ok(true) => {
+                if !upstream_error.is_null() {
+                    (state.up.llcas_string_dispose)(upstream_error);
                 }
-                Ok(false) => {}
-                Err(message) => {
-                    log_line(&format!("proxy fetch_object error: {message}"));
-                }
+                upstream_error = std::ptr::null_mut();
+                let retried =
+                    (state.up.llcas_cas_load_object)(state.cas, id, loaded, &mut upstream_error);
+                adopt_error(state.up, upstream_error, error);
+                return retried;
+            }
+            Ok(false) => {}
+            Err(message) => {
+                log_line(&format!("proxy fetch_object error: {message}"));
             }
         }
     }
@@ -1094,9 +876,7 @@ pub unsafe extern "C" fn llcas_cas_load_object_async(
     let mut loaded = llcas_loaded_object_t { opaque: 0 };
     let mut probe_error: *mut c_char = std::ptr::null_mut();
     let result = (state.up.llcas_cas_load_object)(state.cas, id, &mut loaded, &mut probe_error);
-    if result != LLCAS_LOOKUP_RESULT_NOTFOUND
-        || (state.remote.is_none() && state.proxy.is_none())
-    {
+    if result != LLCAS_LOOKUP_RESULT_NOTFOUND {
         let _ = ours_cancel_token(cancel_tok);
         let error = adopt_upstream_string(state.up, probe_error);
         callback(ctx_cb, result, loaded, error);
@@ -1188,7 +968,7 @@ unsafe fn actioncache_get_impl(
     let mut upstream_error: *mut c_char = std::ptr::null_mut();
     let result =
         (state.up.llcas_actioncache_get_for_digest)(state.cas, key_digest, p_value, globally, &mut upstream_error);
-    if result != LLCAS_LOOKUP_RESULT_NOTFOUND || (state.remote.is_none() && state.proxy.is_none()) {
+    if result != LLCAS_LOOKUP_RESULT_NOTFOUND {
         adopt_error(state.up, upstream_error, error);
         return result;
     }
@@ -1197,197 +977,62 @@ unsafe fn actioncache_get_impl(
     }
 
     let _demand_guard = DemandWaitGuard { state, started: std::time::Instant::now() };
-    if let Some(client) = &state.proxy {
-        let cas_path = state
-            .cas_dir
-            .as_ref()
-            .map(|dir| dir.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        match client.resolve(&cas_path, &state.proxy_instance, key) {
-            Ok(Resolution::Hit(value_digest)) => {
-                state.stats_remote_entry_hits.fetch_add(1, Ordering::Relaxed);
-                // Remember the association: the client re-puts replayed results
-                // at the end of its job, and re-publishing a (key, value) that
-                // just came FROM the remote is pure churn — a spool write on
-                // the compile path plus a proxy publish check per key
-                // (thousands per warm build). actioncache_put_remote skips
-                // puts that match this map.
-                state
-                    .remote_hits
-                    .lock()
-                    .unwrap()
-                    .insert(key.to_vec(), value_digest.clone());
-                let value_digest_t =
-                    llcas_digest_t { data: value_digest.as_ptr(), size: value_digest.len() };
-                let mut value_id = llcas_objectid_t { opaque: 0 };
-                let mut id_error: *mut c_char = std::ptr::null_mut();
-                if (state.up.llcas_cas_get_objectid)(state.cas, value_digest_t, &mut value_id, &mut id_error) {
-                    adopt_error(state.up, id_error, error);
-                    return LLCAS_LOOKUP_RESULT_ERROR;
-                }
-                // The local association outlives the value graph (the build
-                // system prunes the store several times per build), so a later
-                // get can hit it locally with the objects gone. That is safe
-                // ONLY because the load path self-heals: a local load miss
-                // consults the proxy (FETCH_OBJECT), whose fetch instructions
-                // are retained after materialization and also cover locally
-                // published nodes — clang fails the build outright on a
-                // missing object, it does not recompile.
-                let mut put_error: *mut c_char = std::ptr::null_mut();
-                if (state.up.llcas_actioncache_put_for_digest)(state.cas, key_digest, value_id, false, &mut put_error) {
-                    adopt_error(state.up, put_error, error);
-                    return LLCAS_LOOKUP_RESULT_ERROR;
-                }
-                if !p_value.is_null() {
-                    *p_value = value_id;
-                }
-                return LLCAS_LOOKUP_RESULT_SUCCESS;
+    let client = &state.proxy;
+    let cas_path = state
+        .cas_dir
+        .as_ref()
+        .map(|dir| dir.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    match client.resolve(&cas_path, &state.proxy_instance, key) {
+        Ok(Resolution::Hit(value_digest)) => {
+            state.stats_remote_entry_hits.fetch_add(1, Ordering::Relaxed);
+            // Remember the association: the client re-puts replayed results
+            // at the end of its job, and re-publishing a (key, value) that
+            // just came FROM the remote is pure churn — a spool write on
+            // the compile path plus a proxy publish check per key
+            // (thousands per warm build). actioncache_put_remote skips
+            // puts that match this map.
+            state
+                .remote_hits
+                .lock()
+                .unwrap()
+                .insert(key.to_vec(), value_digest.clone());
+            let value_digest_t =
+                llcas_digest_t { data: value_digest.as_ptr(), size: value_digest.len() };
+            let mut value_id = llcas_objectid_t { opaque: 0 };
+            let mut id_error: *mut c_char = std::ptr::null_mut();
+            if (state.up.llcas_cas_get_objectid)(state.cas, value_digest_t, &mut value_id, &mut id_error) {
+                adopt_error(state.up, id_error, error);
+                return LLCAS_LOOKUP_RESULT_ERROR;
             }
-            Ok(Resolution::Miss) => {
-                state.stats_remote_misses.fetch_add(1, Ordering::Relaxed);
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
+            // The local association outlives the value graph (the build
+            // system prunes the store several times per build), so a later
+            // get can hit it locally with the objects gone. That is safe
+            // ONLY because the load path self-heals: a local load miss
+            // consults the proxy (FETCH_OBJECT), whose fetch instructions
+            // are retained after materialization and also cover locally
+            // published nodes — clang fails the build outright on a
+            // missing object, it does not recompile.
+            let mut put_error: *mut c_char = std::ptr::null_mut();
+            if (state.up.llcas_actioncache_put_for_digest)(state.cas, key_digest, value_id, false, &mut put_error) {
+                adopt_error(state.up, put_error, error);
+                return LLCAS_LOOKUP_RESULT_ERROR;
             }
-            Err(message) => {
-                state.stats_remote_misses.fetch_add(1, Ordering::Relaxed);
-                log_line(&format!("proxy resolve error: {message}"));
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
+            if !p_value.is_null() {
+                *p_value = value_id;
             }
+            return LLCAS_LOOKUP_RESULT_SUCCESS;
         }
-    }
-    let remote = state.remote.as_ref().unwrap();
-    let manifest = match remote.get_action(key) {
-        Ok(Some(manifest)) if !manifest.is_empty() => manifest,
-        Ok(_) => {
+        Ok(Resolution::Miss) => {
             state.stats_remote_misses.fetch_add(1, Ordering::Relaxed);
-            log_miss(key);
             return LLCAS_LOOKUP_RESULT_NOTFOUND;
         }
         Err(message) => {
             state.stats_remote_misses.fetch_add(1, Ordering::Relaxed);
-            log_line(&format!("get_action failed: {message}"));
+            log_line(&format!("proxy resolve error: {message}"));
             return LLCAS_LOOKUP_RESULT_NOTFOUND;
         }
-    };
-    state.stats_remote_entry_hits.fetch_add(1, Ordering::Relaxed);
-    state
-        .stats_manifest_entries
-        .fetch_add(manifest.len() as u64, Ordering::Relaxed);
-
-    // The manifest names every blob in the value graph up front; fetch only
-    // what the local CAS lacks, in one batched round trip.
-    let missing: Vec<&ManifestEntry> = manifest
-        .iter()
-        .filter(|entry| {
-            if state
-                .known_local
-                .lock()
-                .unwrap()
-                .contains(&entry.llcas_digest)
-            {
-                return false;
-            }
-            let digest_t =
-                llcas_digest_t { data: entry.llcas_digest.as_ptr(), size: entry.llcas_digest.len() };
-            let mut id = llcas_objectid_t { opaque: 0 };
-            let mut id_error: *mut c_char = std::ptr::null_mut();
-            if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut id_error) {
-                if !id_error.is_null() {
-                    (state.up.llcas_string_dispose)(id_error);
-                }
-                return true;
-            }
-            // Authoritative presence check: an actual load, the same call the
-            // consumer will make.
-            let mut loaded = llcas_loaded_object_t { opaque: 0 };
-            let mut check_error: *mut c_char = std::ptr::null_mut();
-            let present = (state.up.llcas_cas_load_object)(state.cas, id, &mut loaded, &mut check_error);
-            if !check_error.is_null() {
-                (state.up.llcas_string_dispose)(check_error);
-            }
-            if present == LLCAS_LOOKUP_RESULT_SUCCESS {
-                state
-                    .known_local
-                    .lock()
-                    .unwrap()
-                    .insert(entry.llcas_digest.clone());
-                return false;
-            }
-            true
-        })
-        .collect();
-    if !missing.is_empty() {
-        // Blobs the server inlined into the GetActionResult response (see
-        // reapi::ManifestEntry::contents) need no second round-trip;
-        // batch-read only the remainder.
-        let digests: Vec<_> = missing
-            .iter()
-            .filter(|entry| entry.contents.is_none())
-            .map(|entry| entry.blob.clone())
-            .collect();
-        let contents = if digests.is_empty() {
-            std::collections::HashMap::new()
-        } else {
-            match remote.batch_read(&digests) {
-                Ok(contents) => contents,
-                Err(message) => {
-                    log_line(&format!("batch_read failed: {message}"));
-                    return LLCAS_LOOKUP_RESULT_NOTFOUND;
-                }
-            }
-        };
-        for entry in &missing {
-            // An unreadable or absent blob means the published graph is
-            // incomplete; degrade to a miss and let the client recompute.
-            let Some(blob) = entry
-                .contents
-                .as_ref()
-                .or_else(|| contents.get(&entry.blob.hash))
-            else {
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
-            };
-            let Some(frame) = reapi::decompress_frame(blob) else {
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
-            };
-            let Some(node) = reapi::decode_frame(&frame) else {
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
-            };
-            if !store_node(state, &node) {
-                return LLCAS_LOOKUP_RESULT_NOTFOUND;
-            }
-            state
-                .known_local
-                .lock()
-                .unwrap()
-                .insert(entry.llcas_digest.clone());
-            state.stats_remote_node_hits.fetch_add(1, Ordering::Relaxed);
-        }
     }
-    let value_digest = manifest[0].llcas_digest.clone();
-
-    let value_digest_t = llcas_digest_t { data: value_digest.as_ptr(), size: value_digest.len() };
-    let mut value_id = llcas_objectid_t { opaque: 0 };
-    let mut id_error: *mut c_char = std::ptr::null_mut();
-    if (state.up.llcas_cas_get_objectid)(state.cas, value_digest_t, &mut value_id, &mut id_error) {
-        adopt_error(state.up, id_error, error);
-        return LLCAS_LOOKUP_RESULT_ERROR;
-    }
-
-    let mut put_error: *mut c_char = std::ptr::null_mut();
-    let put_started = std::time::Instant::now();
-    let put_failed =
-        (state.up.llcas_actioncache_put_for_digest)(state.cas, key_digest, value_id, false, &mut put_error);
-    state
-        .stats_local_put_ms
-        .fetch_add(put_started.elapsed().as_millis() as u64, Ordering::Relaxed);
-    if put_failed {
-        adopt_error(state.up, put_error, error);
-        return LLCAS_LOOKUP_RESULT_ERROR;
-    }
-
-    if !p_value.is_null() {
-        *p_value = value_id;
-    }
-    LLCAS_LOOKUP_RESULT_SUCCESS
 }
 
 #[no_mangle]
@@ -1423,7 +1068,7 @@ pub unsafe extern "C" fn llcas_actioncache_get_for_digest_async(
     let mut probe_error: *mut c_char = std::ptr::null_mut();
     let result =
         (state.up.llcas_actioncache_get_for_digest)(state.cas, key_digest, &mut value, globally, &mut probe_error);
-    if result != LLCAS_LOOKUP_RESULT_NOTFOUND || (state.remote.is_none() && state.proxy.is_none()) {
+    if result != LLCAS_LOOKUP_RESULT_NOTFOUND {
         let _ = ours_cancel_token(cancel_tok);
         let error = adopt_upstream_string(state.up, probe_error);
         callback(ctx_cb, result, value, error);
@@ -1448,7 +1093,7 @@ pub unsafe extern "C" fn llcas_actioncache_get_for_digest_async(
 }
 
 unsafe fn actioncache_put_remote(state: &CasState, key: &[u8], value: llcas_objectid_t) {
-    if state.proxy.is_some() && state.upload {
+    if state.upload {
         let value_digest = digest_bytes(state, value);
         // This exact association was served FROM the remote earlier in this
         // process (see actioncache_get_impl): publishing it back is pure churn.
@@ -1471,181 +1116,15 @@ unsafe fn actioncache_put_remote(state: &CasState, key: &[u8], value: llcas_obje
                 .as_ref()
                 .map(|dir| dir.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            if let Some(client) = &state.proxy {
-                // Failure is fine: the record survives for the proxy sweep.
-                let _ = client.publish(&cas_path, &state.proxy_instance, &path.to_string_lossy());
-            }
+            // Failure is fine: the record survives for the proxy sweep.
+            let _ =
+                state.proxy.publish(&cas_path, &state.proxy_instance, &path.to_string_lossy());
         }
         return;
     }
-    if state.remote.is_some() && state.upload {
-        if std::env::var("TUIST_CAS_LOG_PUTS").is_ok() {
-            let mut hex = String::with_capacity(key.len() * 2);
-            for byte in key {
-                hex.push_str(&format!("{byte:02x}"));
-            }
-            log_line(&format!("put key={hex}"));
-        }
-        let value_digest = digest_bytes(state, value);
-        if !state
-            .published
-            .lock()
-            .unwrap()
-            .insert((key.to_vec(), value_digest.clone()))
-        {
-            return;
-        }
-        let mut record = PublishRecord {
-            key: key.to_vec(),
-            value_digest,
-            spool_path: None,
-        };
-        record.spool_path = write_publish_record(state, &record);
-        state.uploader.enqueue(record.encode_item());
-    }
 }
 
-/// Loads a node from the local CAS and encodes its transport blob. Returns
-/// the compressed frame and the node's child digests.
-unsafe fn encode_node_blob(
-    state: &CasState,
-    digest: &[u8],
-) -> Result<(Vec<u8>, Vec<Vec<u8>>), String> {
-    state.stats_upload_walk_loads.fetch_add(1, Ordering::Relaxed);
-    let digest_t = llcas_digest_t { data: digest.as_ptr(), size: digest.len() };
-    let mut id = llcas_objectid_t { opaque: 0 };
-    let mut id_error: *mut c_char = std::ptr::null_mut();
-    if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut id_error) {
-        if !id_error.is_null() {
-            (state.up.llcas_string_dispose)(id_error);
-        }
-        return Err("objectid".into());
-    }
-    let mut loaded = llcas_loaded_object_t { opaque: 0 };
-    let mut load_error: *mut c_char = std::ptr::null_mut();
-    let result = (state.up.llcas_cas_load_object)(state.cas, id, &mut loaded, &mut load_error);
-    if !load_error.is_null() {
-        (state.up.llcas_string_dispose)(load_error);
-    }
-    if result != LLCAS_LOOKUP_RESULT_SUCCESS {
-        return Err("local load".into());
-    }
-    let data = (state.up.llcas_loaded_object_get_data)(state.cas, loaded);
-    let node_data = std::slice::from_raw_parts(data.data as *const u8, data.size);
-    let refs = (state.up.llcas_loaded_object_get_refs)(state.cas, loaded);
-    let count = (state.up.llcas_object_refs_get_count)(state.cas, refs);
-    let mut ref_digests = Vec::with_capacity(count);
-    for index in 0..count {
-        let child = (state.up.llcas_object_refs_get_id)(state.cas, refs, index);
-        ref_digests.push(digest_bytes(state, child));
-    }
-    let blob = reapi::compress_frame(&reapi::encode_frame(&ref_digests, node_data));
-    Ok((blob, ref_digests))
-}
 
-/// Uploader worker: completes one publication over REAPI. Fast-skips when
-/// this exact result is already published; otherwise walks the closure from
-/// the local CAS, uploads only the blobs the server reports missing, and
-/// publishes the ActionResult manifest LAST, so a reader can never observe
-/// an entry whose graph is incomplete. On failure the write-ahead record
-/// survives for a later sweep.
-fn upload_process(cas_addr: usize, item: Vec<u8>) {
-    unsafe {
-        let state = cas_state(cas_addr as llcas_cas_t);
-        let Some(remote) = &state.remote else { return };
-        let Some(record) = PublishRecord::decode_item(&item) else { return };
-
-        let outcome = (|| -> Result<(), String> {
-            // Existence probe: only the first entry's digest is compared, so
-            // skip the wildcard inline hint the resolve path uses.
-            if let Ok(Some(manifest)) = remote.probe_action(&record.key) {
-                if manifest.first().map(|entry| entry.llcas_digest.as_slice())
-                    == Some(record.value_digest.as_slice())
-                {
-                    return Ok(());
-                }
-            }
-
-            // Walk the closure from the shared local CAS, root first. Shared
-            // subtrees appear in many closures; the publish cache makes each
-            // unique node's load + compress + hash happen once per process.
-            let mut entries: Vec<ManifestEntry> = Vec::new();
-            let mut blobs: Vec<Option<Vec<u8>>> = Vec::new();
-            let mut visited = std::collections::HashSet::new();
-            let mut pending = std::collections::VecDeque::from([record.value_digest.clone()]);
-            while let Some(digest) = pending.pop_front() {
-                if !visited.insert(digest.clone()) {
-                    continue;
-                }
-                if let Some((blob_digest, children)) =
-                    state.publish_cache.lock().unwrap().get(&digest).cloned()
-                {
-                    entries.push(ManifestEntry { llcas_digest: digest, blob: blob_digest, contents: None });
-                    blobs.push(None);
-                    pending.extend(children);
-                    continue;
-                }
-                let (blob, children) = encode_node_blob(state, &digest)?;
-                let blob_digest = reapi::blob_digest(&blob);
-                state
-                    .publish_cache
-                    .lock()
-                    .unwrap()
-                    .insert(digest.clone(), (blob_digest.clone(), children.clone()));
-                entries.push(ManifestEntry { llcas_digest: digest, blob: blob_digest, contents: None });
-                blobs.push(Some(blob));
-                pending.extend(children);
-            }
-
-            // Server-side dedup: upload only what the server lacks. Bytes
-            // dropped by the cache are re-encoded only if actually needed.
-            let missing =
-                remote.find_missing(entries.iter().map(|entry| entry.blob.clone()).collect())?;
-            let missing_set: std::collections::HashSet<(String, i64)> = missing
-                .into_iter()
-                .map(|digest| (digest.hash, digest.size_bytes))
-                .collect();
-            let mut uploads: Vec<(reapi::Digest, Vec<u8>)> = Vec::new();
-            for (entry, blob) in entries.iter().zip(blobs) {
-                if !missing_set.contains(&(entry.blob.hash.clone(), entry.blob.size_bytes)) {
-                    continue;
-                }
-                let bytes = match blob {
-                    Some(bytes) => bytes,
-                    None => encode_node_blob(state, &entry.llcas_digest)?.0,
-                };
-                uploads.push((entry.blob.clone(), bytes));
-            }
-            if !uploads.is_empty() {
-                remote.batch_update(uploads)?;
-            }
-            // Direct-to-kura, which is bench-only (see the mode selection in
-            // `llcas_cas_create`: a real build, including a ⌘B one, always goes
-            // through the proxy). No proxy means no sources registry, so the
-            // tags come from the environment. That is the same override the
-            // proxy honours ahead of the registry, so a bench attributes a
-            // publish the way a CI job does.
-            let branch = std::env::var("TUIST_CAS_BRANCH")
-                .ok()
-                .filter(|value| !value.is_empty());
-            let trunk = std::env::var("TUIST_CAS_TRUNK_BRANCH")
-                .ok()
-                .filter(|value| !value.is_empty());
-            remote.update_action(&record.key, &entries, branch.as_deref(), trunk.as_deref())
-        })();
-
-        match outcome {
-            Ok(()) => {
-                if let Some(path) = &record.spool_path {
-                    let _ = std::fs::remove_file(path);
-                }
-            }
-            Err(reason) => {
-                log_line(&format!("publish failed ({reason}); record kept for sweep"));
-            }
-        }
-    }
-}
 
 #[no_mangle]
 pub unsafe extern "C" fn llcas_actioncache_put_for_digest(

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -590,21 +590,6 @@ pub unsafe extern "C" fn llcas_cas_create(
         stats_upload_walk_loads: AtomicU64::new(0),
         stats_manifest_entries: AtomicU64::new(0),
     }));
-    // Tell the proxy this build's upload policy. Only we can: it arrives as a
-    // compiler option and the proxy never sees build settings. It writes on its
-    // own behalf (a per-key hit queues a re-publish), and that write does not
-    // pass through the check below, so without this a read-only machine still
-    // wrote to the server. Best-effort and once per CAS: an older proxy answers
-    // "bad op", which leaves it doing what it does today.
-    if let (Some(proxy), Some(dir)) = (&(*state_ptr).proxy, &(*state_ptr).cas_dir) {
-        if let Some(dir) = dir.to_str() {
-            if let Err(message) =
-                proxy.declare_upload(dir, &(*state_ptr).proxy_instance, (*state_ptr).upload)
-            {
-                log_line(&format!("proxy declare_upload failed: {message}"));
-            }
-        }
-    }
     if has_remote {
         let cas_addr = state_ptr as usize;
         (*state_ptr).uploader.configure(Prefetcher::worker_count(), move |item| {

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -639,6 +639,12 @@ fn sweep_spool(cas_addr: usize) {
         let path = entry.path();
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
+        // The proxy writes each record's publish tags beside it. Claiming one
+        // here would fail to decode and delete it, and the record it belongs to
+        // would then be re-tagged with whatever is checked out at that point.
+        if name.ends_with(crate::proxy::TAGS_SUFFIX) {
+            continue;
+        }
         let base = if let Some((base, claim_pid)) = name.split_once(".claim-") {
             // A claim from a live process is in flight; a dead claimant's
             // record is fair game again.

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -2,10 +2,16 @@
 //! libToolchainCASPlugin for local storage and hashing, and adds kura-backed
 //! remoteness over the Bazel Remote Execution API (see reapi.rs).
 //!
-//! The build system runs in its fast "plugin-local" mode (no
-//! COMPILATION_CACHE_REMOTE_SERVICE_PATH); this plugin owns all remote
-//! traffic. Interception is deliberately not keyed on the `globally` flag,
-//! which is never set on this path.
+//! This plugin owns all remote traffic. `COMPILATION_CACHE_REMOTE_SERVICE_PATH`
+//! points at our proxy's socket, but Xcode's own remote client never sees it: we
+//! consume the matching `remote-service-path` option below rather than forwarding
+//! it to the wrapped plugin. The setting is still required, because it is what
+//! turns on the build system's clang caching lane, which routes C, Objective-C,
+//! precompiled modules and headers through whichever CAS plugin is configured.
+//! Without it, only Swift compilations are shared.
+//!
+//! Interception is therefore not keyed on the `globally` flag: the clang lane
+//! sets it and the Swift path does not, and both are ours to serve.
 
 pub mod analytics;
 pub mod proxy;

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -590,6 +590,21 @@ pub unsafe extern "C" fn llcas_cas_create(
         stats_upload_walk_loads: AtomicU64::new(0),
         stats_manifest_entries: AtomicU64::new(0),
     }));
+    // Tell the proxy this build's upload policy. Only we can: it arrives as a
+    // compiler option and the proxy never sees build settings. It writes on its
+    // own behalf (a per-key hit queues a re-publish), and that write does not
+    // pass through the check below, so without this a read-only machine still
+    // wrote to the server. Best-effort and once per CAS: an older proxy answers
+    // "bad op", which leaves it doing what it does today.
+    if let (Some(proxy), Some(dir)) = (&(*state_ptr).proxy, &(*state_ptr).cas_dir) {
+        if let Some(dir) = dir.to_str() {
+            if let Err(message) =
+                proxy.declare_upload(dir, &(*state_ptr).proxy_instance, (*state_ptr).upload)
+            {
+                log_line(&format!("proxy declare_upload failed: {message}"));
+            }
+        }
+    }
     if has_remote {
         let cas_addr = state_ptr as usize;
         (*state_ptr).uploader.configure(Prefetcher::worker_count(), move |item| {

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -1619,9 +1619,12 @@ fn upload_process(cas_addr: usize, item: Vec<u8>) {
             if !uploads.is_empty() {
                 remote.batch_update(uploads)?;
             }
-            // Direct-to-kura (no proxy): the branch/trunk this build is
-            // attributed to come from the environment the CLI set — there is no
-            // proxy here to derive them from the project's source root.
+            // Direct-to-kura, which is bench-only (see the mode selection in
+            // `llcas_cas_create`: a real build, including a ⌘B one, always goes
+            // through the proxy). No proxy means no sources registry, so the
+            // tags come from the environment. That is the same override the
+            // proxy honours ahead of the registry, so a bench attributes a
+            // publish the way a CI job does.
             let branch = std::env::var("TUIST_CAS_BRANCH")
                 .ok()
                 .filter(|value| !value.is_empty());

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -523,6 +523,15 @@ pub unsafe extern "C" fn llcas_cas_create(
     let proxy = explicit_socket
         .or_else(|| (!has_direct_endpoint).then(default_proxy_socket))
         .map(|socket_path| ProxyClient { socket_path });
+    // Which mode this frontend landed in, logged once per CAS create. A build
+    // that silently degrades to local-only (proxy unreachable, no endpoint) is
+    // otherwise indistinguishable from a cold cache: both just emit misses.
+    log_line(&format!(
+        "cas create: proxy={:?} direct_endpoint={} cas_dir={:?}",
+        proxy.as_ref().map(|client| client.socket_path.as_str()),
+        has_direct_endpoint,
+        state.ondisk_path,
+    ));
     // The account/project this build's cache belongs to, routed to the proxy.
     // Prefer the `tuist-instance` plugin option (baked into build settings by
     // `tuist generate`, so it reaches every compiler frontend including an Xcode
@@ -1598,7 +1607,16 @@ fn upload_process(cas_addr: usize, item: Vec<u8>) {
             if !uploads.is_empty() {
                 remote.batch_update(uploads)?;
             }
-            remote.update_action(&record.key, &entries)
+            // Direct-to-kura (no proxy): the branch/trunk this build is
+            // attributed to come from the environment the CLI set — there is no
+            // proxy here to derive them from the project's source root.
+            let branch = std::env::var("TUIST_CAS_BRANCH")
+                .ok()
+                .filter(|value| !value.is_empty());
+            let trunk = std::env::var("TUIST_CAS_TRUNK_BRANCH")
+                .ok()
+                .filter(|value| !value.is_empty());
+            remote.update_action(&record.key, &entries, branch.as_deref(), trunk.as_deref())
         })();
 
         match outcome {

--- a/cas-plugin/src/prefetch.rs
+++ b/cas-plugin/src/prefetch.rs
@@ -122,10 +122,6 @@ impl Prefetcher {
         }
     }
 
-    pub fn is_shutdown(&self) -> bool {
-        self.shutdown.load(Ordering::Acquire) || self.draining.load(Ordering::Acquire)
-    }
-
     pub fn enqueue(&self, digest: Vec<u8>) {
         if digest.is_empty() || self.shutdown.load(Ordering::Acquire) {
             return;

--- a/cas-plugin/src/prefetch.rs
+++ b/cas-plugin/src/prefetch.rs
@@ -60,13 +60,6 @@ impl Prefetcher {
         }
     }
 
-    pub fn worker_count() -> usize {
-        std::env::var("TUIST_CAS_PREFETCH")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(24)
-    }
-
     /// Registers the worker configuration; workers spawn lazily on the first
     /// enqueue. `process` runs on plain threads; the caller guarantees the
     /// backing state outlives the workers by joining them via `stop` or

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -868,44 +868,48 @@ impl DemandCoalescer {
     }
 }
 
-/// A git context read from an instance's source root, memoized on a TTL.
-struct GitContext {
+/// What setup recorded for an instance, memoized on a TTL so a publish does not
+/// re-read the registry file.
+struct SourceContext {
     read_at: Instant,
-    /// The current checked-out branch (`git rev-parse --abbrev-ref HEAD`), or
-    /// `None` on a detached HEAD (CI) — the env override covers that case.
-    branch: Option<String>,
-    /// The repo's default branch (`origin/HEAD`), used as the trunk to scope the
-    /// snapshot to, or `None` when the remote head is unknown.
     trunk: Option<String>,
+    ci_branch: Option<String>,
 }
 
-/// How long a derived git context is reused before the proxy re-reads HEAD, so
-/// a branch switch is picked up within seconds without forking git per publish.
+/// How long a recorded context is reused before the proxy re-reads the registry,
+/// so a project set up after startup is picked up within seconds.
 const GIT_CONTEXT_TTL: Duration = Duration::from_secs(15);
 
-/// The (branch, trunk) pair `git_context` resolves, cloned out from under the
+/// The (branch, trunk) pair `source_context` resolves, cloned out from under the
 /// cache lock.
-struct GitBranches {
+struct SourceBranches {
     branch: Option<String>,
     trunk: Option<String>,
 }
 
 /// What `tuist setup cache` recorded for an instance.
+///
+/// Note what is NOT here: the checkout. Nothing about a publish is read from the
+/// working copy any more, which is what makes a moved, renamed, or duplicated one
+/// unable to mis-attribute a build. Setup still writes the source root into the
+/// registry's second column and this deliberately ignores it, so a proxy from
+/// before this change keeps parsing the columns after it.
 struct RegisteredSource {
-    /// The project's checkout, which the branch of each publish is read from.
-    root: PathBuf,
-    /// The branch `tuist setup cache` saw, recorded ONLY on CI, whose checkout is
-    /// detached and so tells `git rev-parse` nothing. A launchd agent does not
-    /// inherit the job's environment, so the provider's branch variable is
-    /// unreachable from here and the command inside the job has to hand it over.
-    /// Never recorded off CI, where reading git live is both possible and correct
-    /// across a `git checkout`.
+    /// The branch `tuist setup cache` saw in the CI job's environment, recorded
+    /// ONLY on CI. A launchd agent does not inherit the job's environment, so the
+    /// provider's branch variable is unreachable from here and the command inside
+    /// the job has to hand it over.
+    ///
+    /// `None` off CI, and that is the design rather than a gap: the snapshot is
+    /// what trunk looks like as CI built it, so CI is the only publisher whose
+    /// branch has to be right. A local publish goes out untagged, stays out of
+    /// every trunk view, and is still stored and served per key.
     ci_branch: Option<String>,
-    /// The project's default branch, as the server knows it. Authoritative over
-    /// the checkout's `origin/HEAD`: which branch is trunk is a property of the
-    /// project, not of how this machine happened to clone it (a fork, a mirror,
-    /// or a clone whose remote head was never set all get it wrong locally).
-    /// `None` when setup could not reach the server.
+    /// The project's default branch, as the server knows it. Which branch is
+    /// trunk is a property of the project, not of how this machine happened to
+    /// clone it (a fork, a mirror, or a clone whose remote head was never set all
+    /// get it wrong locally). `None` when setup could not reach the server, which
+    /// means no scoping: what a client too old to ask for it already gets.
     trunk: Option<String>,
 }
 
@@ -935,7 +939,7 @@ pub struct Proxy {
     active_instances: Mutex<HashSet<String>>,
     // instance -> the last git context read from its source root, refreshed on
     // a short TTL so per-publish tagging is a cache hit, not a git fork.
-    git_cache: Mutex<HashMap<String, GitContext>>,
+    source_cache: Mutex<HashMap<String, SourceContext>>,
     paths: Mutex<HashMap<String, &'static PathState>>,
     publisher: Prefetcher,
     // Resolves/publishes that arrived with no declared instance and no primed
@@ -1017,7 +1021,7 @@ impl Proxy {
                     .map(|path| load_sources(&sources_path_for(path)))
                     .unwrap_or_default(),
             ),
-            git_cache: Mutex::new(HashMap::new()),
+            source_cache: Mutex::new(HashMap::new()),
             registry_path,
             paths: Mutex::new(HashMap::new()),
             publisher: Prefetcher::new(),
@@ -1904,14 +1908,15 @@ impl Proxy {
     /// where they are used (the upload, which runs after the queue wait, the
     /// existence probe and the closure's blob transfers, tens of seconds over
     /// a WAN link, and mostly AFTER the build that produced them has exited).
-    /// Resolving there reads whatever is checked out by then, so a `git checkout`
-    /// straight after a build permanently re-tags that build's still-draining
-    /// outputs with the new branch: a trunk build's outputs land tagged
-    /// `feature` and drop out of the trunk view they belong in.
     ///
-    /// Binding at accept costs nothing: `git_context` is memoized on
-    /// GIT_CONTEXT_TTL, so this forks git at most once per TTL per instance,
-    /// never per publish.
+    /// Resolving there would read whatever the registry says by then, and the
+    /// registry moves: a shared CI runner rewrites it on every job's setup. So
+    /// job A's still-draining outputs would be tagged with job B's branch, and a
+    /// trunk build's outputs would land tagged `feature` and drop out of the
+    /// trunk view they belong in.
+    ///
+    /// Binding at accept costs nothing: the context is memoized, so this reads
+    /// the registry at most once per TTL per instance, never per publish.
     fn enqueue_publish(&self, cas_path: &str, instance: &str, record_path: &str) {
         let (branch, trunk) = self.record_tags(instance, record_path);
         let mut item = Vec::with_capacity(
@@ -2606,81 +2611,77 @@ impl Proxy {
     /// from the instance's registered source root, then the branch
     /// `tuist setup cache` recorded for a CI checkout.
     ///
-    /// Live git outranks the recorded branch because it survives a `git checkout`
-    /// under this long-lived proxy, and it is only absent when HEAD is detached.
-    /// The recorded branch is therefore reached exactly on CI, which is where git
-    /// cannot answer and where an untagged publish would otherwise land in every
-    /// project's trunk baseline: CI is the fleet's main publisher, so leaving it
-    /// untagged would pollute the very view this scoping exists to keep clean.
+    /// The branch to attribute a publish to: the env override, then what setup
+    /// recorded from the CI job's environment.
+    ///
+    /// Nothing derives this from the checkout. The snapshot is what trunk looks
+    /// like as CI built it, so CI is the only publisher whose branch has to be
+    /// right, and CI is exactly where a checkout cannot answer anyway, its HEAD
+    /// being detached. Deleting the live derivation deleted a class of bug with
+    /// it: a registered root could be moved, renamed, or shared by two worktrees
+    /// of one project, and each of those quietly attributed a build to the wrong
+    /// branch. None of it is reachable from a value the CI job told us about
+    /// itself.
     fn resolve_branch(&self, instance: &str) -> Option<String> {
         if let Ok(branch) = std::env::var("TUIST_CAS_BRANCH") {
             if !branch.is_empty() {
                 return Some(branch);
             }
         }
-        self.git_context(instance)
-            .branch
-            .or_else(|| self.registered_source(instance).and_then(|source| source.ci_branch))
+        self.source_context(instance).branch
     }
 
-    /// The trunk to scope this instance's snapshot to: the env override first,
-    /// then the source root's default branch (`origin/HEAD`).
+    /// The trunk to scope this instance's snapshot to: the env override, then the
+    /// project's configured default branch. A server decision, never the
+    /// checkout's `origin/HEAD`.
     fn resolve_trunk(&self, instance: &str) -> Option<String> {
         if let Ok(trunk) = std::env::var("TUIST_CAS_TRUNK_BRANCH") {
             if !trunk.is_empty() {
                 return Some(trunk);
             }
         }
-        self.git_context(instance).trunk
+        self.source_context(instance).trunk
     }
 
-    /// The instance's git context, memoized on GIT_CONTEXT_TTL. A refresh also
-    /// re-reads the sources registry, so a project set up after this proxy
-    /// started (a second project on the machine) is picked up without a restart.
-    fn git_context(&self, instance: &str) -> GitBranches {
+    /// What setup recorded for the instance, memoized on GIT_CONTEXT_TTL so a
+    /// publish does not re-read the registry. A refresh re-reads it, so a project
+    /// set up after this proxy started is picked up without a restart.
+    fn source_context(&self, instance: &str) -> SourceBranches {
         {
-            let cache = self.git_cache.lock().unwrap();
+            let cache = self.source_cache.lock().unwrap();
             if let Some(context) = cache.get(instance) {
                 if context.read_at.elapsed() < GIT_CONTEXT_TTL {
-                    return GitBranches {
-                        branch: context.branch.clone(),
+                    return SourceBranches {
+                        branch: context.ci_branch.clone(),
                         trunk: context.trunk.clone(),
                     };
                 }
             }
         }
         let source = self.registered_source(instance);
-        let (branch, trunk) = match source {
-            // The server's default branch wins over the checkout's `origin/HEAD`;
-            // the latter is only a fallback for a setup that could not reach the
-            // server, or a registry written before setup recorded the trunk.
-            Some(source) => (
-                git_current_branch(&source.root),
-                source.trunk.or_else(|| git_trunk_branch(&source.root)),
-            ),
-            None => (None, None),
-        };
+        let trunk = source.as_ref().and_then(|source| source.trunk.clone());
+        let branch = source.as_ref().and_then(|source| source.ci_branch.clone());
         {
-            let cache = self.git_cache.lock().unwrap();
+            let cache = self.source_cache.lock().unwrap();
             let changed = cache
                 .get(instance)
-                .map(|context| context.branch != branch || context.trunk != trunk)
+                .map(|context| context.ci_branch != branch || context.trunk != trunk)
                 .unwrap_or(true);
             if changed {
                 crate::log_line(&format!(
-                    "git context for {instance}: branch={branch:?} trunk={trunk:?}"
+                    "source context for {instance}: branch={branch:?} trunk={trunk:?}"
                 ));
             }
         }
-        self.git_cache.lock().unwrap().insert(
+        self.source_cache.lock().unwrap().insert(
             instance.to_string(),
-            GitContext {
+            SourceContext {
                 read_at: Instant::now(),
-                branch: branch.clone(),
                 trunk: trunk.clone(),
+                ci_branch: branch.clone(),
             },
         );
-        GitBranches { branch, trunk }
+        SourceBranches { branch, trunk }
     }
 
     /// What setup registered for the instance, reloading the sources registry so
@@ -2688,7 +2689,6 @@ impl Proxy {
     /// miss in `git_context`.
     fn registered_source(&self, instance: &str) -> Option<RegisteredSource> {
         let clone = |source: &RegisteredSource| RegisteredSource {
-            root: source.root.clone(),
             trunk: source.trunk.clone(),
             ci_branch: source.ci_branch.clone(),
         };
@@ -3032,16 +3032,19 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
             // empty when a branch was recorded without one, so the columns stay
             // positional.
             let mut columns = line.split('\t');
-            let (Some(instance), Some(root)) = (columns.next(), columns.next()) else {
+            // The second column is the source root. Setup still writes it and
+            // this deliberately steps over it: nothing here reads the checkout
+            // any more, but a proxy from before that keeps parsing the columns
+            // after it, so the format does not have to move.
+            let (Some(instance), Some(_root)) = (columns.next(), columns.next()) else {
                 continue;
             };
-            if instance.is_empty() || root.is_empty() {
+            if instance.is_empty() {
                 continue;
             }
             map.insert(
                 instance.to_string(),
                 RegisteredSource {
-                    root: PathBuf::from(root),
                     trunk: columns.next().filter(|trunk| !trunk.is_empty()).map(str::to_owned),
                     ci_branch: columns.next().filter(|branch| !branch.is_empty()).map(str::to_owned),
                 },
@@ -3049,47 +3052,6 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
         }
     }
     map
-}
-
-/// The currently checked-out branch of a repo, or `None` on a detached HEAD
-/// (git prints "HEAD") or when the path is not a repo.
-fn git_current_branch(root: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if branch.is_empty() || branch == "HEAD" {
-        None
-    } else {
-        Some(branch)
-    }
-}
-
-/// A repo's default branch, read from `origin/HEAD` (e.g. "main"). `None` when
-/// the remote head is unset (a bare local repo) — the caller then leaves the
-/// snapshot unscoped or takes the env/server-provided trunk.
-fn git_trunk_branch(root: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    // `--short` yields "origin/main"; the trunk is the branch name.
-    head.rsplit('/')
-        .next()
-        .filter(|name| !name.is_empty())
-        .map(str::to_owned)
 }
 
 unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, String> {
@@ -3214,8 +3176,12 @@ mod tests {
         let path = dir.join("registry.sources");
         // Row 1 is what a setup that reached the server writes; row 2 is the
         // older two-column form (and what a setup that could not reach the
-        // server still writes). Both must parse, and the old one must leave the
-        // trunk to be derived from the checkout rather than swallowing a column.
+        // server still writes). Both must parse, and an absent trunk column must
+        // stay absent rather than swallowing the column after it.
+        //
+        // The second column is the source root, which nothing reads any more.
+        // Setup still writes it, and stepping over it rather than dropping it is
+        // what lets a proxy from before that keep parsing the columns after it.
         std::fs::write(
             &path,
             "tuist/mastodon\t/src/mastodon\tmain\ntuist/legacy\t/src/legacy\n",
@@ -3225,10 +3191,12 @@ mod tests {
         let sources = load_sources(&path);
         assert_eq!(sources.len(), 2);
         let scoped = sources.get("tuist/mastodon").expect("scoped entry");
-        assert_eq!(scoped.root, PathBuf::from("/src/mastodon"));
-        assert_eq!(scoped.trunk.as_deref(), Some("main"));
+        assert_eq!(
+            scoped.trunk.as_deref(),
+            Some("main"),
+            "the trunk is read from the third column, not the second"
+        );
         let legacy = sources.get("tuist/legacy").expect("legacy entry");
-        assert_eq!(legacy.root, PathBuf::from("/src/legacy"));
         assert_eq!(legacy.trunk, None, "an absent trunk column is not a path");
         assert_eq!(
             scoped.ci_branch, None,
@@ -3238,40 +3206,29 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    // Publishing is asynchronous and durable: a record is queued here and uploaded
-    // by a pool thread later, after the queue wait and the closure's WAN transfers
-    // typically after the build that produced it has exited. Resolving the tags
-    // at the upload would therefore read whatever HEAD says by then, so a
-    // `git checkout` right after a trunk build would re-tag that build's
-    // still-draining outputs `feature` and drop them out of the trunk view.
+    /// Publishing is asynchronous and durable: a record is queued, then uploaded
+    /// after the queue wait, the existence probe and the closure's transfers,
+    /// which is typically after the build that produced it has exited. Resolving
+    /// the tags at the upload would read whatever the registry says by then.
+    ///
+    /// A shared CI runner is where that bites: job A's still-draining outputs
+    /// would be tagged with job B's branch, because B's setup rewrote the row A
+    /// was accepted under.
     #[test]
     fn a_queued_publish_keeps_the_branch_it_was_accepted_on() {
         let dir = std::env::temp_dir().join(format!("tuist-publish-tag-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
-        let root = dir.join("checkout");
-        std::fs::create_dir_all(&root).expect("temp dir");
-        let git = |args: &[&str]| {
-            let status = std::process::Command::new("git")
-                .arg("-C")
-                .arg(&root)
-                .args(args)
-                .output()
-                .expect("git");
-            assert!(status.status.success(), "git {args:?}");
-        };
-        git(&["init", "-b", "main"]);
-        git(&["config", "user.email", "bench@tuist.dev"]);
-        git(&["config", "user.name", "bench"]);
-        std::fs::write(root.join("file"), "contents").expect("write");
-        git(&["add", "."]);
-        git(&["commit", "-m", "initial"]);
-
+        std::fs::create_dir_all(&dir).expect("temp dir");
         let registry = dir.join("registry");
-        std::fs::write(
-            sources_path_for(&registry),
-            format!("tuist/mastodon\t{}\tmain\n", root.display()),
-        )
-        .expect("write sources");
+        let sources = sources_path_for(&registry);
+        let record_branch = |branch: &str| {
+            std::fs::write(
+                &sources,
+                format!("tuist/mastodon\t/src/mastodon\tmain\t{branch}\n"),
+            )
+            .expect("write sources");
+        };
+        record_branch("release/4.2");
 
         let proxy = Proxy::new(
             "http://127.0.0.1:1".into(),
@@ -3288,12 +3245,13 @@ mod tests {
             .publisher
             .configure(1, move |item| sink.lock().unwrap().push(item));
 
-        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/on-main");
-        git(&["checkout", "-b", "feature"]);
-        // The proxy would otherwise reuse the memoized context for GIT_CONTEXT_TTL;
-        // expiring it is what a real checkout gets for free by waiting.
-        proxy.git_cache.lock().unwrap().clear();
-        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/on-feature");
+        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/from-the-release-job");
+        // The next job on this runner runs setup, which rewrites the row.
+        record_branch("main");
+        // The proxy would otherwise reuse the memoized context for the TTL;
+        // expiring it is what the next job gets for free by taking longer.
+        proxy.source_cache.lock().unwrap().clear();
+        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/from-the-main-job");
 
         proxy
             .publisher
@@ -3312,53 +3270,41 @@ mod tests {
             )
         };
         let (branch, trunk, record) = tags(&items[0]);
-        assert_eq!(record, "/spool/on-main");
+        assert_eq!(record, "/spool/from-the-release-job");
         assert_eq!(
-            branch, "main",
-            "the record accepted on main stays tagged main after the checkout moved"
+            branch, "release/4.2",
+            "the record keeps the branch it was accepted under, after the next \
+             job on this runner rewrote the registry"
         );
         assert_eq!(trunk, "main");
         let (branch, trunk, record) = tags(&items[1]);
-        assert_eq!(record, "/spool/on-feature");
-        assert_eq!(branch, "feature", "a later record takes the new branch");
-        assert_eq!(trunk, "main", "the trunk is the project's, not the checkout's");
+        assert_eq!(record, "/spool/from-the-main-job");
+        assert_eq!(branch, "main", "a later record takes the new branch");
+        assert_eq!(trunk, "main", "the trunk is the project's either way");
 
         drop(items);
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// Binding at accept only protects a record for as long as the queue holds it.
-    /// A proxy restart mid-drain, or a build that spooled before the path was
-    /// primed, leaves the record on disk for a later sweep to re-enqueue, and by
-    /// then the checkout has usually moved on.
+    /// A sweeper claims a record the producing build left behind, and it resolves
+    /// tags at sweep time, long after that build is gone. The sidecar is what
+    /// carries the answer forward: without it a record swept on the next job
+    /// would be tagged with that job's branch.
     #[test]
     fn a_reswept_record_keeps_the_branch_that_produced_it() {
         let dir = std::env::temp_dir().join(format!("tuist-sidecar-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
-        let root = dir.join("checkout");
-        std::fs::create_dir_all(&root).expect("temp dir");
-        let git = |args: &[&str]| {
-            let status = std::process::Command::new("git")
-                .arg("-C")
-                .arg(&root)
-                .args(args)
-                .output()
-                .expect("git");
-            assert!(status.status.success(), "git {args:?}");
-        };
-        git(&["init", "-b", "main"]);
-        git(&["config", "user.email", "bench@tuist.dev"]);
-        git(&["config", "user.name", "bench"]);
-        std::fs::write(root.join("file"), "contents").expect("write");
-        git(&["add", "."]);
-        git(&["commit", "-m", "initial"]);
-
+        std::fs::create_dir_all(&dir).expect("temp dir");
         let registry = dir.join("registry");
-        std::fs::write(
-            sources_path_for(&registry),
-            format!("tuist/mastodon\t{}\tmain\n", root.display()),
-        )
-        .expect("write sources");
+        let sources = sources_path_for(&registry);
+        let record_branch = |branch: &str| {
+            std::fs::write(
+                &sources,
+                format!("tuist/mastodon\t/src/mastodon\tmain\t{branch}\n"),
+            )
+            .expect("write sources");
+        };
+        record_branch("main");
 
         let cas_path = dir.join("cas");
         let spool = cas_path.join("tuist-spool");
@@ -3380,26 +3326,18 @@ mod tests {
             .publisher
             .configure(1, move |item| sink.lock().unwrap().push(item));
 
-        // The build hands us the record while main is checked out.
-        proxy.enqueue_publish(
-            &cas_path.to_string_lossy(),
-            "tuist/mastodon",
-            &record_path,
-        );
+        // The build hands us the record while the main job owns the registry.
+        proxy.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
         assert!(
             spool.join("1234-0.tags").exists(),
             "accepting a record writes its tags beside it"
         );
 
-        // The proxy dies before draining, someone checks out a feature branch,
-        // and a later sweep finds the record still sitting in the spool.
-        git(&["checkout", "-b", "feature"]);
-        proxy.git_cache.lock().unwrap().clear();
-        proxy.enqueue_publish(
-            &cas_path.to_string_lossy(),
-            "tuist/mastodon",
-            &record_path,
-        );
+        // The proxy dies before draining. The next job on this runner runs setup,
+        // rewriting the registry, and a later sweep finds the record still there.
+        record_branch("feature/theirs");
+        proxy.source_cache.lock().unwrap().clear();
+        proxy.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
 
         proxy
             .publisher
@@ -3416,7 +3354,8 @@ mod tests {
         assert_eq!(
             branch_of(&items[1]),
             "main",
-            "the re-enqueued record keeps the branch it was produced on, not the one checked out now"
+            "the re-enqueued record keeps the branch that produced it, not the one \
+             whose job happens to own the registry when it is swept"
         );
 
         drop(items);

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -73,6 +73,47 @@ const SNAPSHOT_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 const SNAPSHOT_IDLE_EVICT: Duration = Duration::from_secs(60 * 60);
 const SNAPSHOT_MAX_INSTANCES: usize = 8;
 
+// How long after the last CAS operation the machine still counts as busy. A
+// build's traffic arrives in bursts with gaps between them (a link step, a test
+// run, the developer reading a diagnostic), so a short window would read those
+// gaps as idle and start competing with the build it is meant to stay out of.
+const BUSY_AFTER_LAST_OP: Duration = Duration::from_secs(90);
+// One-minute load average per core above which the machine counts as busy. The
+// one-minute figure is the shortest the kernel keeps, so it already lags a
+// burst; staying under 1.0 keeps a core's worth of headroom for the developer.
+const BUSY_LOAD_PER_CORE: f64 = 0.6;
+// How often to say we are holding off. The tick is every 10s, so an unthrottled
+// line would bury the log through a long build.
+const BUSY_LOG_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Why a machine in this state is too busy for background snapshot work, or
+/// None when it is free enough. `idle` is the time since the last CAS operation
+/// (None when no path has served one yet). Pure so the policy is unit-testable.
+fn busy_verdict(idle: Option<Duration>, load_per_core: Option<f64>) -> Option<String> {
+    if let Some(idle) = idle {
+        if idle < BUSY_AFTER_LAST_OP {
+            return Some(format!("a build was active {}s ago", idle.as_secs()));
+        }
+    }
+    match load_per_core {
+        Some(load) if load > BUSY_LOAD_PER_CORE => Some(format!("load is {load:.2} per core")),
+        _ => None,
+    }
+}
+
+/// The one-minute load average per core, or None if the platform will not say.
+fn load_per_core() -> Option<f64> {
+    let mut averages = [0f64; 3];
+    // SAFETY: getloadavg fills at most `nelem` entries of an array we own, and
+    // returns how many it wrote (-1 if it cannot).
+    let written = unsafe { libc::getloadavg(averages.as_mut_ptr(), 1) };
+    if written < 1 {
+        return None;
+    }
+    let cores = std::thread::available_parallelism().ok()?.get() as f64;
+    Some(averages[0] / cores)
+}
+
 /// The snapshot delta cadence, honoring TUIST_CAS_SNAPSHOT_DELTA_INTERVAL
 /// (seconds) and falling back to SNAPSHOT_DELTA_INTERVAL_DEFAULT_SECS.
 fn snapshot_delta_interval() -> Duration {
@@ -798,6 +839,9 @@ pub struct Proxy {
     // background on an instance's first resolve; while it is in flight (or
     // when the server has none) resolves use the per-key path.
     snapshots: Mutex<HashMap<String, SnapshotState>>,
+    // When we last said a refresh was held off for a busy machine (see
+    // `log_busy`).
+    busy_logged_at: Mutex<Option<Instant>>,
 
     // Keys answered by a per-key lookup while a snapshot was Ready: they fell
     // out of the server's size-capped wire view, which ranks by version — a
@@ -855,6 +899,7 @@ impl Proxy {
             materialize_jobs: Mutex::new(HashMap::new()),
             job_counter: AtomicU64::new(0),
             snapshots: Mutex::new(HashMap::new()),
+            busy_logged_at: Mutex::new(None),
             unprimed: AtomicU64::new(0),
             view_refresh: Mutex::new(VecDeque::new()),
             view_refreshed: Mutex::new(HashSet::new()),
@@ -1864,6 +1909,44 @@ impl Proxy {
         }
     }
 
+    /// Why background snapshot work should wait, or None when the machine is
+    /// free enough to do it. Two signals, both cheap enough for every tick:
+    ///
+    /// - a recent CAS operation, meaning a build is running (or just was). This
+    ///   is the traffic a refresh would actually be stealing from, and it is the
+    ///   one case where slowing the machine down also slows down the very build
+    ///   the cache exists to make fast.
+    /// - the load average per core, which catches whatever else is running,
+    ///   since a machine busy with something other than a build never touches
+    ///   the CAS and would otherwise read as idle.
+    ///
+    /// Note this does not sense network throughput. A build's own fetches are
+    /// covered by the first signal; unrelated saturation (a big download) is
+    /// not, and would need per-interface counters to see.
+    fn busy_reason(&self) -> Option<String> {
+        let now = self.epoch.elapsed();
+        let idle = self
+            .paths
+            .lock()
+            .unwrap()
+            .values()
+            .map(|state| Duration::from_millis(state.last_used.load(Ordering::Relaxed)))
+            .max()
+            .map(|last_op| now.saturating_sub(last_op));
+        busy_verdict(idle, load_per_core())
+    }
+
+    /// Rate-limits the "holding off" line to BUSY_LOG_INTERVAL.
+    fn log_busy(&self, reason: &str) {
+        let mut logged_at = self.busy_logged_at.lock().unwrap();
+        let now = Instant::now();
+        if logged_at.is_some_and(|at| now.duration_since(at) < BUSY_LOG_INTERVAL) {
+            return;
+        }
+        *logged_at = Some(now);
+        crate::log_line(&format!("snapshot refresh held off: {reason}"));
+    }
+
     /// Sweeps orphaned publication records for every known CAS path whose
     /// instance the proxy knows (an unprimed path has nothing to publish to).
     pub fn sweep(&self) {
@@ -2051,6 +2134,13 @@ impl Proxy {
     /// long-lived proxy), and BOUNDS the cache: instances idle past
     /// SNAPSHOT_IDLE_EVICT are dropped and the map is capped at
     /// SNAPSHOT_MAX_INSTANCES by evicting the least recently used.
+    ///
+    /// All of that fetching waits for a machine that is not busy (see
+    /// `busy_reason`); the point of a refresh is to have the trunk ready for the
+    /// *next* build, which makes it worth nothing and costly now if it lands in
+    /// the middle of this one. An instance's FIRST snapshot is not this path
+    /// (`ensure_snapshot` on demand, `prefetch_known_snapshots` at startup) and
+    /// is never held off: it is what the build in front of us is waiting on.
     pub fn refresh_snapshots(&self) {
         let now = Instant::now();
         enum Plan {
@@ -2110,6 +2200,19 @@ impl Proxy {
                     }
                     _ => {}
                 }
+            }
+        }
+        // Everything above is bookkeeping over what we already hold, so it runs
+        // regardless; what follows fetches and ingests, so it waits for a free
+        // machine. Checked only when something is actually due, both to keep the
+        // held-off line honest and because a due refresh is the only thing the
+        // wait costs: the next tick re-plans it, so nothing is dropped, it is
+        // deferred. A machine that is never free simply keeps the view it has,
+        // which costs hits and never correctness.
+        if !plans.is_empty() {
+            if let Some(reason) = self.busy_reason() {
+                self.log_busy(&reason);
+                return;
             }
         }
         for plan in plans {
@@ -3127,6 +3230,42 @@ mod tests {
     fn gone_cas_dir_is_reclaimed_regardless_of_idle() {
         assert!(should_reclaim(Duration::from_secs(0), true));
         assert!(should_reclaim(IDLE_RECLAIM + Duration::from_secs(1), true));
+    }
+
+    // A build that touched the CAS moments ago holds off a refresh, however
+    // quiet the CPU looks: between two bursts of compiles the load average has
+    // not caught up yet, and the build is exactly who we would be stealing from.
+    #[test]
+    fn recent_build_holds_off_a_refresh() {
+        let reason = busy_verdict(Some(BUSY_AFTER_LAST_OP - Duration::from_secs(1)), Some(0.0));
+        assert!(reason.is_some_and(|reason| reason.contains("build")));
+    }
+
+    // Once the build is long done and the machine is quiet, the refresh runs.
+    #[test]
+    fn quiet_machine_refreshes() {
+        assert!(
+            busy_verdict(Some(BUSY_AFTER_LAST_OP + Duration::from_secs(1)), Some(0.1)).is_none()
+        );
+        // A proxy that has served nothing yet has no last op to go on.
+        assert!(busy_verdict(None, Some(0.1)).is_none());
+    }
+
+    // Something other than a build can keep the machine busy: it never touches
+    // the CAS, so load is the only thing that sees it.
+    #[test]
+    fn loaded_machine_holds_off_a_refresh_with_no_build() {
+        let reason = busy_verdict(
+            Some(BUSY_AFTER_LAST_OP + Duration::from_secs(1)),
+            Some(BUSY_LOAD_PER_CORE + 0.1),
+        );
+        assert!(reason.is_some_and(|reason| reason.contains("load")));
+    }
+
+    // A platform that will not report load must not wedge the refresh forever.
+    #[test]
+    fn unknown_load_does_not_hold_off_a_refresh() {
+        assert!(busy_verdict(Some(BUSY_AFTER_LAST_OP + Duration::from_secs(1)), None).is_none());
     }
 
     fn generation(ino: u64, birth_nanos: u128) -> CasGeneration {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -955,17 +955,17 @@ pub struct Proxy {
     // a proxy restart. See proxy_proto for why the fallback exists.
     path_instance: Mutex<HashMap<String, String>>,
     registry_path: Option<PathBuf>,
-    // instance -> the project's source root, registered by `tuist setup cache`
-    // (the per-project step that installs this proxy). The branch and trunk a
-    // publish is tagged with are derived live from this repo's git HEAD, so a
-    // branch switch needs no re-setup and nothing branch-specific ever enters a
-    // build setting (which could pollute the compile cache key).
+    // instance -> what `tuist setup cache` recorded for it: the project's trunk,
+    // the CI job's branch, and the upload policy. Not the checkout: nothing about
+    // a publish is read from a working copy, which is what stops a moved,
+    // renamed or duplicated one mis-attributing a build. Nothing branch-specific
+    // enters a build setting either, which could pollute the compile cache key.
     instance_sources: Mutex<HashMap<String, RegisteredSource>>,
     // Instances a build has touched since this proxy started; bounds trunk
     // ingestion to projects actually in use (see `instance_active`).
     active_instances: Mutex<HashSet<String>>,
-    // instance -> the last git context read from its source root, refreshed on
-    // a short TTL so per-publish tagging is a cache hit, not a git fork.
+    // instance -> the last context read from the registry, refreshed on a short
+    // TTL so per-publish tagging is a cache hit rather than a file read.
     source_cache: Mutex<HashMap<String, SourceContext>>,
     paths: Mutex<HashMap<String, &'static PathState>>,
     publisher: Prefetcher,
@@ -2673,18 +2673,6 @@ impl Proxy {
         }
     }
 
-    /// Queues materialization of every graph the snapshot describes: bulk
-    /// content warming with no keylog and no demand ordering — resolves
-    /// answer from the snapshot regardless and loads self-heal per object,
-    /// so this only keeps the link busy so most loads find bytes already
-    /// local. Once per snapshot fetch (i.e. per proxy lifetime per
-    /// instance); after a mid-day wipe, demand-driven jobs and per-object
-    /// self-heals carry re-materialization.
-    /// The git branch a publish for this instance is attributed to: the env
-    /// override first (a manual build or a bench), then the branch derived live
-    /// from the instance's registered source root, then the branch
-    /// `tuist setup cache` recorded for a CI checkout.
-    ///
     /// The branch to attribute a publish to: the env override, then what setup
     /// recorded from the CI job's environment.
     ///
@@ -2787,6 +2775,13 @@ impl Proxy {
         }
     }
 
+    /// Queues materialization of every graph the snapshot describes: bulk
+    /// content warming with no keylog and no demand ordering. Resolves answer
+    /// from the snapshot regardless and loads self-heal per object, so this only
+    /// keeps the link busy so most loads find bytes already local. Once per
+    /// snapshot fetch (i.e. per proxy lifetime per instance); after a mid-day
+    /// wipe, demand-driven jobs and per-object self-heals carry
+    /// re-materialization.
     fn prematerialize_snapshot(&self, instance: &str, snapshot: &Snapshot) {
         let cas_paths: Vec<String> = self
             .path_instance
@@ -3089,9 +3084,11 @@ fn load_registry(path: &Path) -> HashMap<String, String> {
     map
 }
 
-/// The instance -> source-root registry sits next to the cas_path registry,
-/// written by `tuist setup cache` (which knows both the full handle and the
-/// project path). `<registry>.sources`, TSV `instance\tsource-root`.
+/// The sources registry sits next to the cas_path registry, written by
+/// `tuist setup cache` (the only place that has the project's configuration).
+/// `<registry>.sources`, TSV
+/// `instance \t source-root \t trunk \t ci-branch \t upload`. The source root
+/// is still written and no longer read; see `RegisteredSource`.
 fn sources_path_for(registry: &Path) -> PathBuf {
     let mut path = registry.to_path_buf().into_os_string();
     path.push(".sources");

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -44,7 +44,11 @@ const MAX_PUBLISH_CACHE: usize = 500_000;
 const MAX_PENDING_OBJECTS: usize = 1_000_000;
 
 // Snapshot refresh cadence and cache bounds (see `refresh_snapshots`).
-const SNAPSHOT_DELTA_INTERVAL: Duration = Duration::from_secs(120);
+// Default cadence for the incremental (watermark-scoped) snapshot delta of an
+// active instance, overridable via TUIST_CAS_SNAPSHOT_DELTA_INTERVAL (seconds).
+// A delta is a cheap fetch of only the trunk entries newer than what we hold,
+// so this trades trunk freshness against a small periodic round trip.
+const SNAPSHOT_DELTA_INTERVAL_DEFAULT_SECS: u64 = 10 * 60;
 // How long a FETCH_OBJECT with no registered instruction waits for the
 // instance's snapshot to arrive before answering not-found (it runs on a
 // compiler worker thread, which demand fetches already block on network I/O).
@@ -68,6 +72,16 @@ const DEMAND_BATCH_LINGER: Duration = Duration::from_millis(3);
 const SNAPSHOT_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 const SNAPSHOT_IDLE_EVICT: Duration = Duration::from_secs(60 * 60);
 const SNAPSHOT_MAX_INSTANCES: usize = 8;
+
+/// The snapshot delta cadence, honoring TUIST_CAS_SNAPSHOT_DELTA_INTERVAL
+/// (seconds) and falling back to SNAPSHOT_DELTA_INTERVAL_DEFAULT_SECS.
+fn snapshot_delta_interval() -> Duration {
+    std::env::var("TUIST_CAS_SNAPSHOT_DELTA_INTERVAL")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(SNAPSHOT_DELTA_INTERVAL_DEFAULT_SECS))
+}
 // The bulk-warm budget, in value-graph nodes (each node is one blob fetch).
 // Sized past the largest closure a single build replays (~37.5k on the CLI
 // fixture) so a right-sized namespace still warms completely.
@@ -1926,7 +1940,7 @@ impl Proxy {
     }
 
     /// Called from the maintenance loop: keeps Ready snapshots fresh with
-    /// deltas (SNAPSHOT_DELTA_INTERVAL), replaces them wholesale on
+    /// deltas (snapshot_delta_interval), replaces them wholesale on
     /// SNAPSHOT_FULL_INTERVAL (deltas only ADD; the full fetch re-applies the
     /// server's blob-presence gate after evictions), retries Absent after
     /// SNAPSHOT_RETRY_INTERVAL (the server may have been upgraded under this
@@ -1975,7 +1989,7 @@ impl Proxy {
                             plans.push(Plan::Full {
                                 instance: instance.clone(),
                             });
-                        } else if now.duration_since(*refreshed_at) > SNAPSHOT_DELTA_INTERVAL {
+                        } else if now.duration_since(*refreshed_at) > snapshot_delta_interval() {
                             plans.push(Plan::Delta {
                                 instance: instance.clone(),
                                 watermark: snapshot.watermark,

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -2272,9 +2272,10 @@ impl Proxy {
             };
             // Carrying the tags of the build that took the hit is what makes this
             // the reclaim path. These entries are, by definition, outside the
-            // trunk view: sending no tags would re-attribute every one of them to
-            // nobody, and an untagged entry is in EVERY trunk view, so a feature
-            // branch's own keys would flow into trunk's just by being read. With
+            // trunk view, and this is often the only thing that will ever put one
+            // back: sending no tags would re-attribute every one of them to
+            // nobody, and an untagged entry is in NO trunk view, so trunk's own
+            // keys would be dropped from it by the very act of reading them. With
             // the tags, a feature hit stays out and a trunk hit takes the entry
             // back.
             if refresh

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -937,6 +937,7 @@ struct SourceBranches {
 /// Note what is NOT here: the checkout. Nothing about a publish is read from the
 /// working copy, which is what makes a moved, renamed, or duplicated one unable
 /// to mis-attribute a build.
+#[derive(serde::Deserialize)]
 struct RegisteredSource {
     /// The branch `tuist setup cache` saw in the CI job's environment, recorded
     /// ONLY on CI. A launchd agent does not inherit the job's environment, so the
@@ -947,12 +948,14 @@ struct RegisteredSource {
     /// what trunk looks like as CI built it, so CI is the only publisher whose
     /// branch has to be right. A local publish goes out untagged, stays out of
     /// every trunk view, and is still stored and served per key.
+    #[serde(default, rename = "branch")]
     ci_branch: Option<String>,
     /// The project's default branch, as the server knows it. Which branch is
     /// trunk is a property of the project, not of how this machine happened to
     /// clone it (a fork, a mirror, or a clone whose remote head was never set all
     /// get it wrong locally). `None` when setup could not reach the server, which
     /// means no scoping: what a client too old to ask for it already gets.
+    #[serde(default)]
     trunk: Option<String>,
     /// The project's `xcodeCache.upload`.
     ///
@@ -961,7 +964,14 @@ struct RegisteredSource {
     /// plugin options, so the CAS it creates for its Clang caching has no idea
     /// what the project asked for and defaults to uploading. The proxy is the
     /// only place that sees both lanes, so it is where the policy is enforced.
+    ///
+    /// Absent is permissive: nothing recorded is nothing to withhold.
+    #[serde(default = "uploads_by_default")]
     upload: bool,
+}
+
+fn uploads_by_default() -> bool {
+    true
 }
 
 pub struct Proxy {
@@ -3126,8 +3136,9 @@ fn load_registry(path: &Path) -> HashMap<String, String> {
 
 /// The sources registry sits next to the cas_path registry, written by
 /// `tuist setup cache` (the only place that has the project's configuration).
-/// `<registry>.sources`, one row per instance: `instance [\t key=value]...`.
-/// See `load_sources` for the fields.
+/// `<registry>.sources`: a JSON object of instance -> `RegisteredSource`. JSON
+/// because the writer is Swift and the reader is here, and a format each side
+/// hand-rolls is one each side can drift on.
 fn sources_path_for(registry: &Path) -> PathBuf {
     let mut path = registry.to_path_buf().into_os_string();
     path.push(".sources");
@@ -3142,38 +3153,16 @@ fn sources_path_for(registry: &Path) -> PathBuf {
 /// window.
 fn load_sources(path: &Path) -> Option<HashMap<String, RegisteredSource>> {
     let body = std::fs::read_to_string(path).ok()?;
-    let mut map = HashMap::new();
-    for line in body.lines() {
-        // `instance [\t key=value]...`, written by `registerSource` in the CLI.
-        // Named rather than positional because every field is optional: a
-        // positional row has to hold an absent field's place, and reading one
-        // column out of step silently answers with another field's value.
-        // Unknown fields are ignored, so setup may record more than this proxy
-        // understands.
-        let mut fields = line.split('\t');
-        let Some(instance) = fields.next().filter(|instance| !instance.is_empty()) else {
-            continue;
-        };
-        let mut source = RegisteredSource {
-            trunk: None,
-            ci_branch: None,
-            // Nothing recorded is nothing to withhold.
-            upload: true,
-        };
-        for field in fields {
-            // A ref may contain `=`, so only the first one separates.
-            match field.split_once('=') {
-                Some(("trunk", value)) if !value.is_empty() => source.trunk = Some(value.to_owned()),
-                Some(("branch", value)) if !value.is_empty() => {
-                    source.ci_branch = Some(value.to_owned())
-                }
-                Some(("upload", value)) => source.upload = value != "0",
-                _ => {}
-            }
-        }
-        map.insert(instance.to_string(), source);
-    }
-    Some(map)
+    // A file torn or truncated under us reads as unreadable rather than as a
+    // subset of the projects, which is the answer that matters: a project this
+    // read forgot would come back as unknown, and unknown has to be allowed to
+    // upload.
+    serde_json::from_str(&body)
+        .map_err(|error| {
+            crate::log_line(&format!("sources registry at {}: {error}", path.display()));
+            error
+        })
+        .ok()
 }
 
 unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, String> {
@@ -3323,7 +3312,11 @@ mod tests {
         // parse, and the bare row must leave the proxy unscoped rather than
         // dropping the project entirely, which would read as "no policy" and
         // hand an opted-out project an upload.
-        std::fs::write(&path, "tuist/mastodon\ttrunk=main\ntuist/legacy\n").expect("write registry");
+        std::fs::write(
+            &path,
+            r#"{"tuist/mastodon":{"trunk":"main"},"tuist/legacy":{}}"#,
+        )
+        .expect("write registry");
 
         let sources = load_sources(&path).expect("a readable registry parses");
         assert_eq!(sources.len(), 2);
@@ -3368,7 +3361,7 @@ mod tests {
         let record_branch = |branch: &str| {
             std::fs::write(
                 &sources,
-                format!("tuist/mastodon\ttrunk=main\tbranch={branch}\n"),
+                format!(r#"{{"tuist/mastodon":{{"trunk":"main","branch":"{branch}"}}}}"#),
             )
             .expect("write sources");
         };
@@ -3444,7 +3437,7 @@ mod tests {
         let record_branch = |branch: &str| {
             std::fs::write(
                 &sources,
-                format!("tuist/mastodon\ttrunk=main\tbranch={branch}\n"),
+                format!(r#"{{"tuist/mastodon":{{"trunk":"main","branch":"{branch}"}}}}"#),
             )
             .expect("write sources");
         };
@@ -3545,22 +3538,24 @@ mod tests {
 
     /// The CI branch, which `tuist setup cache` records only from inside a CI job
     /// (the proxy is a launchd agent and never sees the provider's branch
-    /// variable). Every field here is optional, which is why they are named: this
-    /// is the shape a positional row got wrong, because it has to hold an absent
-    /// field's place and any reader out of step answers with its neighbour.
+    /// variable). Every field here is optional, so what this pins is that an
+    /// absent one reads as its default rather than as its neighbour's value:
+    /// setup writes only what it knows, and it usually does not know all three.
     #[test]
-    fn sources_registry_reads_each_field_by_name_whatever_else_the_row_carries() {
+    fn sources_registry_defaults_every_field_setup_did_not_record() {
         let dir = std::env::temp_dir().join(format!("tuist-sources-ci-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         let path = dir.join("registry.sources");
         std::fs::write(
             &path,
-            "tuist/ci\ttrunk=main\tbranch=feature/x\n\
-             tuist/no-trunk\tbranch=feature/y\n\
-             tuist/reordered\tupload=0\tbranch=feature/z\ttrunk=main\n\
-             tuist/newer-setup\ttrunk=main\tsomething-we-do-not-know=1\n\
-             tuist/equals\tbranch=feature/a=b\n\
-             tuist/dev\ttrunk=main\n",
+            r#"{
+                "tuist/ci":        {"trunk": "main", "branch": "feature/x"},
+                "tuist/no-trunk":  {"branch": "feature/y"},
+                "tuist/read-only": {"trunk": "main", "upload": false},
+                "tuist/newer":     {"trunk": "main", "something-we-do-not-know": 1},
+                "tuist/dev":       {"trunk": "main"},
+                "tuist/bare":      {}
+            }"#,
         )
         .expect("write registry");
 
@@ -3568,34 +3563,39 @@ mod tests {
         let ci = sources.get("tuist/ci").expect("ci entry");
         assert_eq!(ci.trunk.as_deref(), Some("main"));
         assert_eq!(ci.ci_branch.as_deref(), Some("feature/x"));
+        assert!(ci.upload, "an absent upload is permissive");
 
-        // A branch without a trunk: the case that made the positional row hold an
-        // empty column, and the one a reader dropping empties read as the trunk.
+        // A branch without a trunk. Setup records these separately (the trunk is
+        // the server's answer, the branch the job's), so either can be missing.
         let no_trunk = sources.get("tuist/no-trunk").expect("no-trunk entry");
         assert_eq!(no_trunk.trunk, None);
         assert_eq!(no_trunk.ci_branch.as_deref(), Some("feature/y"));
 
-        let reordered = sources.get("tuist/reordered").expect("reordered entry");
-        assert_eq!(reordered.trunk.as_deref(), Some("main"));
-        assert_eq!(reordered.ci_branch.as_deref(), Some("feature/z"));
-        assert!(!reordered.upload, "a named field means the same in any order");
+        assert!(!sources.get("tuist/read-only").expect("read-only entry").upload);
 
-        // A setup newer than this proxy: unknown fields are skipped rather than
-        // shifting the ones it does know.
-        let newer = sources.get("tuist/newer-setup").expect("newer entry");
+        // A setup newer than this proxy: unknown fields are ignored rather than
+        // failing the whole file, which would take every project's policy with it.
+        let newer = sources.get("tuist/newer").expect("newer entry");
         assert_eq!(newer.trunk.as_deref(), Some("main"));
-        assert!(newer.upload);
-
-        // Git allows `=` in a ref, so only the first one separates.
-        let equals = sources.get("tuist/equals").expect("equals entry");
-        assert_eq!(equals.ci_branch.as_deref(), Some("feature/a=b"));
 
         let dev = sources.get("tuist/dev").expect("dev entry");
         assert_eq!(
             dev.ci_branch, None,
             "off CI nothing records a branch, so a developer's publishes stay untagged"
         );
-        assert!(dev.upload, "nothing recorded is nothing to withhold");
+
+        let bare = sources.get("tuist/bare").expect("bare entry");
+        assert_eq!(bare.trunk, None);
+        assert_eq!(bare.ci_branch, None);
+        assert!(bare.upload, "nothing recorded is nothing to withhold");
+
+        // Unreadable is not the same as empty: a project this read forgot would
+        // come back as unknown, and unknown has to be allowed to upload.
+        std::fs::write(&path, "{not json").expect("write garbage");
+        assert!(
+            load_sources(&path).is_none(),
+            "a registry that cannot be decoded reports so, rather than reporting none"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -4221,7 +4221,7 @@ mod tests {
             std::fs::write(
                 &sources,
                 format!(
-                    "tuist/one\ttrunk=main\tbranch={branch}\ntuist/two\ttrunk=main\tbranch={branch}\n"
+                    r#"{{"tuist/one":{{"trunk":"main","branch":"{branch}"}},"tuist/two":{{"trunk":"main","branch":"{branch}"}}}}"#
                 ),
             )
             .expect("write sources");
@@ -4281,7 +4281,7 @@ mod tests {
         let registry = dir.join("registry");
         std::fs::write(
             sources_path_for(&registry),
-            "tuist/one\ttrunk=main\tbranch=main\n",
+            r#"{"tuist/one":{"trunk":"main","branch":"main"}}"#,
         )
         .expect("write sources");
 
@@ -4336,7 +4336,7 @@ mod tests {
         let sources = sources_path_for(&registry);
         std::fs::write(
             &sources,
-            "tuist/reader\ttrunk=main\tupload=0\ntuist/writer\ttrunk=main\n",
+            r#"{"tuist/reader":{"trunk":"main","upload":false},"tuist/writer":{"trunk":"main"}}"#,
         )
         .expect("write sources");
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -176,6 +176,17 @@ fn remove_record(record_path: &str) {
     let _ = std::fs::remove_file(tags_path(record_path));
 }
 
+/// Whether a re-put can be dropped without a `publish` round trip. True only
+/// when its value matches one we already resolved AND it is not a trunk publish:
+/// a trunk publish is the reclaim path and must reach `publish` even on a value
+/// match, because the entry it matches may still carry a feature-branch tag that
+/// only republishing under the trunk tag can claim into the trunk view. A trunk
+/// publish is one that names a branch equal to the trunk it targets.
+fn is_redundant_reput(branch: Option<&str>, trunk: Option<&str>, value_matches: bool) -> bool {
+    let reclaims_into_trunk = branch.is_some() && branch == trunk;
+    value_matches && !reclaims_into_trunk
+}
+
 /// How much of a trunk snapshot to pull before a build asks for it. The two
 /// layers cost different orders of magnitude and are worth disabling
 /// separately, so one setting names all three states rather than leaving the
@@ -2052,11 +2063,21 @@ impl Proxy {
         // that with a get_action round trip per record; the resolved map
         // already knows, so drop those records here for free. A Hit with a
         // DIFFERENT value (a genuine local recompute) still publishes.
-        if let Some(Resolution::Hit(value)) = state.resolved.lock().unwrap().get(&record.key) {
-            if value == &record.value_digest {
-                remove_record(&record_path);
-                return;
-            }
+        //
+        // But `resolved` remembers the value, not the tag it carries remotely,
+        // and a trunk build's re-put is the reclaim path: the entry it matches
+        // may still be tagged with a feature branch, and only republishing it
+        // under the trunk tag pulls it into the trunk view (`sticky_branch`
+        // then lets trunk claim it). So a trunk re-put must reach `publish` even
+        // when the value matches; only a feature, local, or untagged re-put,
+        // which reclaims nothing into trunk, is free to drop here.
+        let value_matches = {
+            let resolved = state.resolved.lock().unwrap();
+            matches!(resolved.get(&record.key), Some(Resolution::Hit(value)) if value == &record.value_digest)
+        };
+        if is_redundant_reput(branch.as_deref(), trunk.as_deref(), value_matches) {
+            remove_record(&record_path);
+            return;
         }
         match self.publish(&remote, state, &record, branch.as_deref(), trunk.as_deref()) {
             Ok(()) => {
@@ -3279,6 +3300,28 @@ unsafe fn encode_node_blob(
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    /// The churn-skip must not swallow the reclaim: a trunk build re-putting a
+    /// value it already resolved may be republishing an entry that is still
+    /// tagged with a feature branch, and only that publish pulls it into the
+    /// trunk view.
+    #[test]
+    fn a_trunk_reput_is_never_dropped_as_churn() {
+        // Feature, local (no branch), and fully untagged re-puts reclaim nothing
+        // into trunk, so a value match is genuine churn.
+        assert!(is_redundant_reput(Some("feature/x"), Some("main"), true));
+        assert!(is_redundant_reput(None, Some("main"), true));
+        assert!(is_redundant_reput(None, None, true));
+
+        // A trunk publish (branch == trunk) is the reclaim path: even on a value
+        // match it must reach `publish`, so it is never redundant.
+        assert!(!is_redundant_reput(Some("main"), Some("main"), true));
+
+        // A value mismatch is a genuine recompute and always publishes, trunk or
+        // not.
+        assert!(!is_redundant_reput(Some("feature/x"), Some("main"), false));
+        assert!(!is_redundant_reput(Some("main"), Some("main"), false));
+    }
 
     /// The two layers cost different orders of magnitude, so the middle state is
     /// the one CI runs on and the one this parse exists to keep reachable. A

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -3404,35 +3404,46 @@ mod tests {
         std::fs::write(&record, b"record").expect("record");
         let record_path = record.to_string_lossy().into_owned();
 
-        let proxy = Proxy::new(
-            "http://127.0.0.1:1".into(),
-            crate::token::TokenProvider::from_env(),
-            String::new(),
-            Some(registry),
-            None,
-        );
         let captured: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
-        let sink = Arc::clone(&captured);
-        proxy
-            .publisher
-            .configure(1, move |item| sink.lock().unwrap().push(item));
+        // One per proxy: a publisher is owned by the process that ran it, and
+        // draining one stops it for good.
+        let start_proxy = || {
+            let proxy = Proxy::new(
+                "http://127.0.0.1:1".into(),
+                crate::token::TokenProvider::from_env(),
+                String::new(),
+                Some(registry.clone()),
+                None,
+            );
+            let sink = Arc::clone(&captured);
+            proxy
+                .publisher
+                .configure(1, move |item| sink.lock().unwrap().push(item));
+            proxy
+        };
 
         // The build hands us the record while the main job owns the registry.
-        proxy.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
+        let producing = start_proxy();
+        producing.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
         assert!(
             spool.join("1234-0.tags").exists(),
             "accepting a record writes its tags beside it"
         );
-
-        // The proxy dies before draining. The next job on this runner runs setup,
-        // rewriting the registry, and a later sweep finds the record still there.
-        record_branch("feature/theirs");
-        proxy.source_cache.lock().unwrap().clear();
-        proxy.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
-
-        proxy
+        producing
             .publisher
             .drain_stop_timeout(std::time::Duration::from_secs(10));
+
+        // The next job on this runner runs setup, rewriting the registry, and a
+        // later sweep finds the record still there. That sweep runs in a proxy
+        // that never saw the build: a fresh process, so nothing but the sidecar
+        // survives to tell it which branch produced this record.
+        record_branch("feature/theirs");
+        let sweeping = start_proxy();
+        sweeping.enqueue_publish(&cas_path.to_string_lossy(), "tuist/mastodon", &record_path);
+        sweeping
+            .publisher
+            .drain_stop_timeout(std::time::Duration::from_secs(10));
+
         let items = captured.lock().unwrap();
         assert_eq!(items.len(), 2);
         let branch_of = |item: &[u8]| {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -1784,13 +1784,36 @@ impl Proxy {
     }
 
     /// PUBLISH notify: queue the record for the publisher pool. Items encode
-    /// instance + cas_path + record path.
+    /// instance + cas_path + the (branch, trunk) bound here + record path.
+    ///
+    /// The tags are resolved NOW, when the build hands us the record, and not
+    /// where they are used (the upload, which runs after the queue wait, the
+    /// existence probe and the closure's blob transfers, tens of seconds over
+    /// a WAN link, and mostly AFTER the build that produced them has exited).
+    /// Resolving there reads whatever is checked out by then, so a `git checkout`
+    /// straight after a build permanently re-tags that build's still-draining
+    /// outputs with the new branch: a trunk build's outputs land tagged
+    /// `feature` and drop out of the trunk view they belong in.
+    ///
+    /// Binding at accept costs nothing: `git_context` is memoized on
+    /// GIT_CONTEXT_TTL, so this forks git at most once per TTL per instance,
+    /// never per publish.
     fn enqueue_publish(&self, cas_path: &str, instance: &str, record_path: &str) {
-        let mut item = Vec::with_capacity(4 + instance.len() + cas_path.len() + record_path.len());
+        let branch = self.resolve_branch(instance).unwrap_or_default();
+        let trunk = self.resolve_trunk(instance).unwrap_or_default();
+        let mut item = Vec::with_capacity(
+            8 + instance.len() + cas_path.len() + branch.len() + trunk.len() + record_path.len(),
+        );
         item.extend_from_slice(&(instance.len() as u16).to_be_bytes());
         item.extend_from_slice(instance.as_bytes());
         item.extend_from_slice(&(cas_path.len() as u16).to_be_bytes());
         item.extend_from_slice(cas_path.as_bytes());
+        // Empty encodes `None`: neither resolver can yield an empty branch name
+        // (both reject it), so the round trip is lossless.
+        item.extend_from_slice(&(branch.len() as u16).to_be_bytes());
+        item.extend_from_slice(branch.as_bytes());
+        item.extend_from_slice(&(trunk.len() as u16).to_be_bytes());
+        item.extend_from_slice(trunk.as_bytes());
         item.extend_from_slice(record_path.as_bytes());
         self.publisher.enqueue(item);
     }
@@ -1799,11 +1822,19 @@ impl Proxy {
         let Some((instance, rest)) = take_u16_field(item) else {
             return;
         };
-        let Some((cas_path, record_path)) = take_u16_field(rest) else {
+        let Some((cas_path, rest)) = take_u16_field(rest) else {
+            return;
+        };
+        let Some((branch, rest)) = take_u16_field(rest) else {
+            return;
+        };
+        let Some((trunk, record_path)) = take_u16_field(rest) else {
             return;
         };
         let instance = String::from_utf8_lossy(instance).into_owned();
         let cas_path = String::from_utf8_lossy(cas_path).into_owned();
+        let branch = non_empty(&String::from_utf8_lossy(branch));
+        let trunk = non_empty(&String::from_utf8_lossy(trunk));
         let record_path = String::from_utf8_lossy(record_path).into_owned();
         let remote = self.remote_for(&instance);
         let Ok(state) = self.path_state(&cas_path) else {
@@ -1833,7 +1864,7 @@ impl Proxy {
                 return;
             }
         }
-        match self.publish(&instance, &remote, state, &record) {
+        match self.publish(&remote, state, &record, branch.as_deref(), trunk.as_deref()) {
             Ok(()) => {
                 let _ = std::fs::remove_file(&record_path);
                 state.stats_published.fetch_add(1, Ordering::Relaxed);
@@ -1848,12 +1879,15 @@ impl Proxy {
         }
     }
 
+    /// `branch`/`trunk` are the tags bound when this record was accepted (see
+    /// `enqueue_publish`), not resolved here: by now the checkout may have moved.
     fn publish(
         &self,
-        instance: &str,
         remote: &Remote,
         state: &'static PathState,
         record: &PublishRecord,
+        branch: Option<&str>,
+        trunk: Option<&str>,
     ) -> Result<(), String> {
         let op_start = Instant::now();
         // Existence probe: only the first entry's digest is compared, so skip
@@ -1955,9 +1989,7 @@ impl Proxy {
                 }
             }
         }
-        let branch = self.resolve_branch(instance);
-        let trunk = self.resolve_trunk(instance);
-        let result = remote.update_action(&record.key, &entries, branch.as_deref(), trunk.as_deref());
+        let result = remote.update_action(&record.key, &entries, branch, trunk);
         if let Some(analytics) = &self.analytics {
             analytics.record_keyvalue(&record.key, "write", op_start.elapsed().as_secs_f64());
         }
@@ -2775,6 +2807,12 @@ impl Proxy {
     }
 }
 
+/// An owned copy of `value`, or `None` when it is empty. Publisher items encode
+/// an absent branch or trunk as a zero-length field.
+fn non_empty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
 /// Reads a `u16`-length-prefixed field from the front of `buf`, returning it
 /// and the remainder. `None` if the buffer is truncated.
 fn take_u16_field(buf: &[u8]) -> Option<(&[u8], &[u8])> {
@@ -3025,6 +3063,95 @@ mod tests {
             "a registry written before the branch column carries no branch"
         );
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // Publishing is asynchronous and durable: a record is queued here and uploaded
+    // by a pool thread later, after the queue wait and the closure's WAN transfers
+    // typically after the build that produced it has exited. Resolving the tags
+    // at the upload would therefore read whatever HEAD says by then, so a
+    // `git checkout` right after a trunk build would re-tag that build's
+    // still-draining outputs `feature` and drop them out of the trunk view.
+    #[test]
+    fn a_queued_publish_keeps_the_branch_it_was_accepted_on() {
+        let dir = std::env::temp_dir().join(format!("tuist-publish-tag-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        let root = dir.join("checkout");
+        std::fs::create_dir_all(&root).expect("temp dir");
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .output()
+                .expect("git");
+            assert!(status.status.success(), "git {args:?}");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "bench@tuist.dev"]);
+        git(&["config", "user.name", "bench"]);
+        std::fs::write(root.join("file"), "contents").expect("write");
+        git(&["add", "."]);
+        git(&["commit", "-m", "initial"]);
+
+        let registry = dir.join("registry");
+        std::fs::write(
+            sources_path_for(&registry),
+            format!("tuist/mastodon\t{}\tmain\n", root.display()),
+        )
+        .expect("write sources");
+
+        let proxy = Proxy::new(
+            "http://127.0.0.1:1".into(),
+            crate::token::TokenProvider::from_env(),
+            String::new(),
+            Some(registry),
+            None,
+        );
+        let captured: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        // Replaces the publisher's real worker before any enqueue starts it, so
+        // the queued items land here instead of being uploaded to a remote.
+        proxy
+            .publisher
+            .configure(1, move |item| sink.lock().unwrap().push(item));
+
+        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/on-main");
+        git(&["checkout", "-b", "feature"]);
+        // The proxy would otherwise reuse the memoized context for GIT_CONTEXT_TTL;
+        // expiring it is what a real checkout gets for free by waiting.
+        proxy.git_cache.lock().unwrap().clear();
+        proxy.enqueue_publish("/cas", "tuist/mastodon", "/spool/on-feature");
+
+        proxy
+            .publisher
+            .drain_stop_timeout(std::time::Duration::from_secs(10));
+        let items = captured.lock().unwrap();
+        assert_eq!(items.len(), 2, "both records queued");
+        let tags = |item: &[u8]| {
+            let (_, rest) = take_u16_field(item).expect("instance");
+            let (_, rest) = take_u16_field(rest).expect("cas path");
+            let (branch, rest) = take_u16_field(rest).expect("branch");
+            let (trunk, record) = take_u16_field(rest).expect("trunk");
+            (
+                String::from_utf8_lossy(branch).into_owned(),
+                String::from_utf8_lossy(trunk).into_owned(),
+                String::from_utf8_lossy(record).into_owned(),
+            )
+        };
+        let (branch, trunk, record) = tags(&items[0]);
+        assert_eq!(record, "/spool/on-main");
+        assert_eq!(
+            branch, "main",
+            "the record accepted on main stays tagged main after the checkout moved"
+        );
+        assert_eq!(trunk, "main");
+        let (branch, trunk, record) = tags(&items[1]);
+        assert_eq!(record, "/spool/on-feature");
+        assert_eq!(branch, "feature", "a later record takes the new branch");
+        assert_eq!(trunk, "main", "the trunk is the project's, not the checkout's");
+
+        drop(items);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -1697,6 +1697,15 @@ impl Proxy {
         // survive that one. The resolve path restats for the same reason; this
         // is the door it does not cover.
         self.check_generation(state);
+        // And a demand fetch IS the build working. The resolves all land during
+        // planning, so a long compile phase afterwards is nothing but these: with
+        // only resolves and publishes stamping this, the machine reads as idle
+        // ~90s into the phase that is most bandwidth-bound, and the idle gate
+        // starts the refresh whose whole purpose was to stay out of the build's
+        // way, competing for the link the fetch below is waiting on.
+        state
+            .last_used
+            .store(self.epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
         if state.load_present(digest) {
             return Ok(true);
         }
@@ -4060,6 +4069,27 @@ mod tests {
         assert!(
             compiler_view.load_present(&digest),
             "an object stored after the wipe must be visible to a handle opened              independently: otherwise the proxy is writing into a deleted store"
+        );
+    }
+
+    /// The idle gate reads `last_used`, and a build that has finished planning
+    /// does nothing but demand fetches. If they do not count as activity, the
+    /// machine looks idle exactly while it is most bandwidth-bound.
+    #[test]
+    fn a_demand_fetch_counts_as_the_machine_being_busy() {
+        let dir = TempCasDir::new("busy-fetch");
+        let state = path_state_for(&dir.path());
+        let proxy = test_proxy();
+        // A sentinel rather than 0: the proxy's epoch is fresh here, so a real
+        // stamp is ~0ms and would be indistinguishable from never having run.
+        state.last_used.store(u64::MAX, Ordering::Relaxed);
+
+        let _ = proxy.fetch_object(state, &dir.path(), "", &[0xAB; 32]);
+
+        assert!(
+            state.last_used.load(Ordering::Relaxed) < u64::MAX,
+            "a demand fetch must keep the machine marked busy, or the idle gate \
+             starts competing with the build it is meant to avoid"
         );
     }
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -139,20 +139,6 @@ fn prematerialize_max_nodes() -> usize {
         .unwrap_or(PREMATERIALIZE_MAX_NODES)
 }
 
-/// Whether to fully ingest a trunk-scoped snapshot into the local CAS ahead of
-/// the build, rather than warming only the newest `PREMATERIALIZE_MAX_NODES`.
-///
-/// On by default where it is affordable and where it pays: the scoping bounds
-/// the warm to the project's trunk closure instead of a whole shared namespace,
-/// the warm runs off any build's critical path, it is idempotent (objects
-/// already on disk are skipped, so steady state only fetches the delta a new
-/// trunk snapshot introduced), and Xcode's own size-LRU bounds the store it
-/// lands in. Measured on a mastodon-sized project: ~12s of off-path fetching
-/// turns a from-scratch trunk build from ~57s into ~33s at 50ms RTT, cutting
-/// demand stalls ~14x.
-///
-/// `TUIST_CAS_INGEST_TRUNK=0` opts out, for a metered or slow link where
-/// pulling the trunk closure up front is not worth it.
 /// Suffix of the file that carries a spool record's publish tags. Both this
 /// proxy's `sweep` and the plugin's own `sweep_spool` walk the spool directory
 /// and must skip it.
@@ -190,8 +176,48 @@ fn remove_record(record_path: &str) {
     let _ = std::fs::remove_file(tags_path(record_path));
 }
 
-fn ingest_trunk_enabled() -> bool {
-    std::env::var("TUIST_CAS_INGEST_TRUNK").as_deref() != Ok("0")
+/// How much of a trunk snapshot to pull before a build asks for it. The two
+/// layers cost different orders of magnitude and are worth disabling
+/// separately, so one setting names all three states rather than leaving the
+/// middle one to be spelled with a node budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrefetchMode {
+    /// Nothing proactive: no snapshot, no warm. Every resolve is a per-key
+    /// round trip and every object arrives on demand.
+    Off,
+    /// The snapshot only: one round trip for the trunk's keys, no bytes pulled
+    /// ahead of the build that needs them. What CI wants: keys are orders of
+    /// magnitude lighter than bytes, and a machine whose proxy and build start
+    /// together has no window to warm in, so the byte layer would race the build
+    /// it is meant to help.
+    Keys,
+    /// The snapshot and its whole byte closure, materialized ahead of the build.
+    ///
+    /// The default, because it is affordable and it pays: the trunk scoping
+    /// bounds the warm to the project's closure instead of a whole shared
+    /// namespace, it runs off any build's critical path, it is idempotent
+    /// (objects already on disk are skipped, so steady state only fetches the
+    /// delta a new snapshot introduced), and Xcode's size-LRU bounds the store
+    /// it lands in. Measured on a mastodon-sized project: ~12s of off-path
+    /// fetching turns a from-scratch trunk build from ~57s into ~33s at 50ms
+    /// RTT, cutting demand stalls ~14x.
+    Full,
+}
+
+/// Pure so the policy is testable without writing to the process environment.
+/// An unrecognized value reads as `Full`, matching how the other flags treat
+/// anything that is not an explicit opt-out: a typo must not silently turn
+/// caching down.
+fn prefetch_mode_from(value: Option<&str>) -> PrefetchMode {
+    match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("0" | "off" | "false" | "no" | "none") => PrefetchMode::Off,
+        Some("keys") => PrefetchMode::Keys,
+        _ => PrefetchMode::Full,
+    }
+}
+
+fn prefetch_mode() -> PrefetchMode {
+    prefetch_mode_from(std::env::var("TUIST_CAS_PREFETCH").ok().as_deref())
 }
 // View refresh: per-key hits taken while a snapshot was Ready get their
 // manifests re-published in the background (see Proxy.view_refresh). The
@@ -1164,7 +1190,7 @@ impl Proxy {
         let instance = instance.to_string();
         // Off-thread: this runs from a resolve, and `resolve_trunk` can fork git.
         std::thread::spawn(move || {
-            if !ingest_trunk_enabled() || proxy.resolve_trunk(&instance).is_none() {
+            if prefetch_mode() != PrefetchMode::Full || proxy.resolve_trunk(&instance).is_none() {
                 return;
             }
             let Some(snapshot) = proxy.snapshot_ready(&instance) else {
@@ -2447,6 +2473,14 @@ impl Proxy {
     /// background — never on a resolve path. One fetch per proxy lifetime:
     /// entries published later resolve through the ordinary per-key path.
     fn ensure_snapshot(&self, instance: &str, remote: &Arc<Remote>) {
+        // The one place a snapshot enters the map, so this is the whole of what
+        // `PrefetchMode::Off` has to stop. Nothing downstream can run without a
+        // snapshot: the refresh only plans deltas for instances already here,
+        // the warm walks a snapshot's keys, and a fetch instruction gives up
+        // immediately when no fetch is in flight rather than waiting one out.
+        if prefetch_mode() == PrefetchMode::Off {
+            return;
+        }
         {
             let mut snapshots = self.snapshots.lock().unwrap();
             if snapshots.contains_key(instance) {
@@ -2783,6 +2817,13 @@ impl Proxy {
     /// wipe, demand-driven jobs and per-object self-heals carry
     /// re-materialization.
     fn prematerialize_snapshot(&self, instance: &str, snapshot: &Snapshot) {
+        // `Keys` buys the snapshot's breadth and declines to pull its bytes. The
+        // budget below cannot express that: its zero means "no cap", and its
+        // smallest honest value still warms a node, so the only way to fetch
+        // nothing is not to start.
+        if prefetch_mode() == PrefetchMode::Keys {
+            return;
+        }
         let cas_paths: Vec<String> = self
             .path_instance
             .lock()
@@ -2811,11 +2852,12 @@ impl Proxy {
             // namespace measured). The budget covers a large build's closure;
             // everything past it stays resolvable and self-heals on demand.
             // With a trunk-scoped snapshot the closure IS the budget's target,
-            // so full ingestion (the layer above key caching) warms all of it —
+            // so full ingestion (the layer above key caching) warms all of it:
             // the scoping already bounds it to the trunk, not the whole polluted
-            // namespace. Unscoped, or opted out, keep the node budget.
+            // namespace. Unscoped, or not yet a real build, keep the node budget.
+            // The mode is necessarily Full here, the other two having stopped
+            // above.
             let configured = if self.resolve_trunk(instance).is_some()
-                && ingest_trunk_enabled()
                 && self.instance_active(instance)
             {
                 0
@@ -3252,6 +3294,28 @@ unsafe fn encode_node_blob(
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    /// The two layers cost different orders of magnitude, so the middle state is
+    /// the one CI runs on and the one this parse exists to keep reachable. A
+    /// value that fell through to `Full` here would turn CI's one round trip
+    /// into a full closure pull, which is the failure this pins.
+    #[test]
+    fn prefetch_keys_is_its_own_mode_and_not_a_way_of_spelling_off() {
+        assert_eq!(prefetch_mode_from(Some("keys")), PrefetchMode::Keys);
+        assert_eq!(prefetch_mode_from(Some("KEYS")), PrefetchMode::Keys);
+        assert_eq!(prefetch_mode_from(Some(" keys ")), PrefetchMode::Keys);
+
+        for off in ["0", "off", "false", "no", "none", "OFF"] {
+            assert_eq!(prefetch_mode_from(Some(off)), PrefetchMode::Off, "{off}");
+        }
+
+        // Unset is the default, and so is anything unrecognized: a typo must not
+        // quietly turn caching down, which is the direction that costs a build.
+        assert_eq!(prefetch_mode_from(None), PrefetchMode::Full);
+        assert_eq!(prefetch_mode_from(Some("full")), PrefetchMode::Full);
+        assert_eq!(prefetch_mode_from(Some("kyes")), PrefetchMode::Full);
+        assert_eq!(prefetch_mode_from(Some("")), PrefetchMode::Full);
+    }
 
     #[test]
     fn sources_registry_keeps_reading_entries_written_without_a_trunk() {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -935,10 +935,8 @@ struct SourceBranches {
 /// What `tuist setup cache` recorded for an instance.
 ///
 /// Note what is NOT here: the checkout. Nothing about a publish is read from the
-/// working copy any more, which is what makes a moved, renamed, or duplicated one
-/// unable to mis-attribute a build. Setup still writes the source root into the
-/// registry's second column and this deliberately ignores it, so a proxy from
-/// before this change keeps parsing the columns after it.
+/// working copy, which is what makes a moved, renamed, or duplicated one unable
+/// to mis-attribute a build.
 struct RegisteredSource {
     /// The branch `tuist setup cache` saw in the CI job's environment, recorded
     /// ONLY on CI. A launchd agent does not inherit the job's environment, so the
@@ -3128,9 +3126,8 @@ fn load_registry(path: &Path) -> HashMap<String, String> {
 
 /// The sources registry sits next to the cas_path registry, written by
 /// `tuist setup cache` (the only place that has the project's configuration).
-/// `<registry>.sources`, TSV
-/// `instance \t source-root \t trunk \t ci-branch \t upload`. The source root
-/// is still written and no longer read; see `RegisteredSource`.
+/// `<registry>.sources`, one row per instance: `instance [\t key=value]...`.
+/// See `load_sources` for the fields.
 fn sources_path_for(registry: &Path) -> PathBuf {
     let mut path = registry.to_path_buf().into_os_string();
     path.push(".sources");
@@ -3146,36 +3143,35 @@ fn sources_path_for(registry: &Path) -> PathBuf {
 fn load_sources(path: &Path) -> Option<HashMap<String, RegisteredSource>> {
     let body = std::fs::read_to_string(path).ok()?;
     let mut map = HashMap::new();
-    {
-        for line in body.lines() {
-            // `instance \t source-root [\t trunk [\t ci-branch]]`. Both trailing
-            // columns are optional: a registry written by an older setup, or by
-            // one that could not reach the server, still parses and leaves the
-            // trunk to be derived from the checkout. The trunk's place is held
-            // empty when a branch was recorded without one, so the columns stay
-            // positional.
-            let mut columns = line.split('\t');
-            // The second column is the source root. Setup still writes it and
-            // this deliberately steps over it: nothing here reads the checkout
-            // any more, but a proxy from before that keeps parsing the columns
-            // after it, so the format does not have to move.
-            let (Some(instance), Some(_root)) = (columns.next(), columns.next()) else {
-                continue;
-            };
-            if instance.is_empty() {
-                continue;
+    for line in body.lines() {
+        // `instance [\t key=value]...`, written by `registerSource` in the CLI.
+        // Named rather than positional because every field is optional: a
+        // positional row has to hold an absent field's place, and reading one
+        // column out of step silently answers with another field's value.
+        // Unknown fields are ignored, so setup may record more than this proxy
+        // understands.
+        let mut fields = line.split('\t');
+        let Some(instance) = fields.next().filter(|instance| !instance.is_empty()) else {
+            continue;
+        };
+        let mut source = RegisteredSource {
+            trunk: None,
+            ci_branch: None,
+            // Nothing recorded is nothing to withhold.
+            upload: true,
+        };
+        for field in fields {
+            // A ref may contain `=`, so only the first one separates.
+            match field.split_once('=') {
+                Some(("trunk", value)) if !value.is_empty() => source.trunk = Some(value.to_owned()),
+                Some(("branch", value)) if !value.is_empty() => {
+                    source.ci_branch = Some(value.to_owned())
+                }
+                Some(("upload", value)) => source.upload = value != "0",
+                _ => {}
             }
-            map.insert(
-                instance.to_string(),
-                RegisteredSource {
-                    trunk: columns.next().filter(|trunk| !trunk.is_empty()).map(str::to_owned),
-                    ci_branch: columns.next().filter(|branch| !branch.is_empty()).map(str::to_owned),
-                    // Absent is a registry written before the column, and
-                    // uploading is what that machine already does.
-                    upload: columns.next() != Some("0"),
-                },
-            );
         }
+        map.insert(instance.to_string(), source);
     }
     Some(map)
 }
@@ -3322,19 +3318,12 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("tuist-sources-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         let path = dir.join("registry.sources");
-        // Row 1 is what a setup that reached the server writes; row 2 is the
-        // older two-column form (and what a setup that could not reach the
-        // server still writes). Both must parse, and an absent trunk column must
-        // stay absent rather than swallowing the column after it.
-        //
-        // The second column is the source root, which nothing reads any more.
-        // Setup still writes it, and stepping over it rather than dropping it is
-        // what lets a proxy from before that keep parsing the columns after it.
-        std::fs::write(
-            &path,
-            "tuist/mastodon\t/src/mastodon\tmain\ntuist/legacy\t/src/legacy\n",
-        )
-        .expect("write registry");
+        // Row 1 is what a setup that reached the server writes; row 2 is a setup
+        // that could not, so it knows the project but not its trunk. Both must
+        // parse, and the bare row must leave the proxy unscoped rather than
+        // dropping the project entirely, which would read as "no policy" and
+        // hand an opted-out project an upload.
+        std::fs::write(&path, "tuist/mastodon\ttrunk=main\ntuist/legacy\n").expect("write registry");
 
         let sources = load_sources(&path).expect("a readable registry parses");
         assert_eq!(sources.len(), 2);
@@ -3379,7 +3368,7 @@ mod tests {
         let record_branch = |branch: &str| {
             std::fs::write(
                 &sources,
-                format!("tuist/mastodon\t/src/mastodon\tmain\t{branch}\n"),
+                format!("tuist/mastodon\ttrunk=main\tbranch={branch}\n"),
             )
             .expect("write sources");
         };
@@ -3455,7 +3444,7 @@ mod tests {
         let record_branch = |branch: &str| {
             std::fs::write(
                 &sources,
-                format!("tuist/mastodon\t/src/mastodon\tmain\t{branch}\n"),
+                format!("tuist/mastodon\ttrunk=main\tbranch={branch}\n"),
             )
             .expect("write sources");
         };
@@ -3554,20 +3543,24 @@ mod tests {
         assert_eq!(decode_tags(b"garbage"), None, "a torn write re-resolves");
     }
 
-    // The CI branch column, which `tuist setup cache` writes only from inside a CI
-    // job (the proxy is a launchd agent and never sees the provider's branch
-    // variable). A branch recorded without a trunk keeps the trunk's place, so the
-    // columns stay positional.
+    /// The CI branch, which `tuist setup cache` records only from inside a CI job
+    /// (the proxy is a launchd agent and never sees the provider's branch
+    /// variable). Every field here is optional, which is why they are named: this
+    /// is the shape a positional row got wrong, because it has to hold an absent
+    /// field's place and any reader out of step answers with its neighbour.
     #[test]
-    fn sources_registry_reads_the_ci_branch_column() {
+    fn sources_registry_reads_each_field_by_name_whatever_else_the_row_carries() {
         let dir = std::env::temp_dir().join(format!("tuist-sources-ci-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         let path = dir.join("registry.sources");
         std::fs::write(
             &path,
-            "tuist/ci\t/src/ci\tmain\tfeature/x\n\
-             tuist/no-trunk\t/src/no-trunk\t\tfeature/y\n\
-             tuist/dev\t/src/dev\tmain\n",
+            "tuist/ci\ttrunk=main\tbranch=feature/x\n\
+             tuist/no-trunk\tbranch=feature/y\n\
+             tuist/reordered\tupload=0\tbranch=feature/z\ttrunk=main\n\
+             tuist/newer-setup\ttrunk=main\tsomething-we-do-not-know=1\n\
+             tuist/equals\tbranch=feature/a=b\n\
+             tuist/dev\ttrunk=main\n",
         )
         .expect("write registry");
 
@@ -3576,19 +3569,33 @@ mod tests {
         assert_eq!(ci.trunk.as_deref(), Some("main"));
         assert_eq!(ci.ci_branch.as_deref(), Some("feature/x"));
 
+        // A branch without a trunk: the case that made the positional row hold an
+        // empty column, and the one a reader dropping empties read as the trunk.
         let no_trunk = sources.get("tuist/no-trunk").expect("no-trunk entry");
-        assert_eq!(no_trunk.trunk, None, "the empty trunk column is not a trunk");
-        assert_eq!(
-            no_trunk.ci_branch.as_deref(),
-            Some("feature/y"),
-            "the branch is still found in its own column"
-        );
+        assert_eq!(no_trunk.trunk, None);
+        assert_eq!(no_trunk.ci_branch.as_deref(), Some("feature/y"));
+
+        let reordered = sources.get("tuist/reordered").expect("reordered entry");
+        assert_eq!(reordered.trunk.as_deref(), Some("main"));
+        assert_eq!(reordered.ci_branch.as_deref(), Some("feature/z"));
+        assert!(!reordered.upload, "a named field means the same in any order");
+
+        // A setup newer than this proxy: unknown fields are skipped rather than
+        // shifting the ones it does know.
+        let newer = sources.get("tuist/newer-setup").expect("newer entry");
+        assert_eq!(newer.trunk.as_deref(), Some("main"));
+        assert!(newer.upload);
+
+        // Git allows `=` in a ref, so only the first one separates.
+        let equals = sources.get("tuist/equals").expect("equals entry");
+        assert_eq!(equals.ci_branch.as_deref(), Some("feature/a=b"));
 
         let dev = sources.get("tuist/dev").expect("dev entry");
         assert_eq!(
             dev.ci_branch, None,
-            "a developer's row records no branch: the proxy reads git live"
+            "off CI nothing records a branch, so a developer's publishes stay untagged"
         );
+        assert!(dev.upload, "nothing recorded is nothing to withhold");
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -4214,7 +4221,7 @@ mod tests {
             std::fs::write(
                 &sources,
                 format!(
-                    "tuist/one\t/src/one\tmain\t{branch}\ntuist/two\t/src/two\tmain\t{branch}\n"
+                    "tuist/one\ttrunk=main\tbranch={branch}\ntuist/two\ttrunk=main\tbranch={branch}\n"
                 ),
             )
             .expect("write sources");
@@ -4274,7 +4281,7 @@ mod tests {
         let registry = dir.join("registry");
         std::fs::write(
             sources_path_for(&registry),
-            "tuist/one\t/src/one\tmain\tmain\n",
+            "tuist/one\ttrunk=main\tbranch=main\n",
         )
         .expect("write sources");
 
@@ -4329,7 +4336,7 @@ mod tests {
         let sources = sources_path_for(&registry);
         std::fs::write(
             &sources,
-            "tuist/reader\t/src/reader\tmain\t\t0\ntuist/writer\t/src/writer\tmain\n",
+            "tuist/reader\ttrunk=main\tupload=0\ntuist/writer\ttrunk=main\n",
         )
         .expect("write sources");
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -692,6 +692,28 @@ impl DemandCoalescer {
     }
 }
 
+/// A git context read from an instance's source root, memoized on a TTL.
+struct GitContext {
+    read_at: Instant,
+    /// The current checked-out branch (`git rev-parse --abbrev-ref HEAD`), or
+    /// `None` on a detached HEAD (CI) — the env override covers that case.
+    branch: Option<String>,
+    /// The repo's default branch (`origin/HEAD`), used as the trunk to scope the
+    /// snapshot to, or `None` when the remote head is unknown.
+    trunk: Option<String>,
+}
+
+/// How long a derived git context is reused before the proxy re-reads HEAD, so
+/// a branch switch is picked up within seconds without forking git per publish.
+const GIT_CONTEXT_TTL: Duration = Duration::from_secs(15);
+
+/// The (branch, trunk) pair `git_context` resolves, cloned out from under the
+/// cache lock.
+struct GitBranches {
+    branch: Option<String>,
+    trunk: Option<String>,
+}
+
 pub struct Proxy {
     grpc_url: String,
     tokens: Arc<TokenProvider>,
@@ -707,6 +729,15 @@ pub struct Proxy {
     // a proxy restart. See proxy_proto for why the fallback exists.
     path_instance: Mutex<HashMap<String, String>>,
     registry_path: Option<PathBuf>,
+    // instance -> the project's source root, registered by `tuist setup cache`
+    // (the per-project step that installs this proxy). The branch and trunk a
+    // publish is tagged with are derived live from this repo's git HEAD, so a
+    // branch switch needs no re-setup and nothing branch-specific ever enters a
+    // build setting (which could pollute the compile cache key).
+    instance_sources: Mutex<HashMap<String, PathBuf>>,
+    // instance -> the last git context read from its source root, refreshed on
+    // a short TTL so per-publish tagging is a cache hit, not a git fork.
+    git_cache: Mutex<HashMap<String, GitContext>>,
     paths: Mutex<HashMap<String, &'static PathState>>,
     publisher: Prefetcher,
     // Resolves/publishes that arrived with no declared instance and no primed
@@ -776,6 +807,13 @@ impl Proxy {
             epoch: Instant::now(),
             remotes: Mutex::new(HashMap::new()),
             path_instance: Mutex::new(path_instance),
+            instance_sources: Mutex::new(
+                registry_path
+                    .as_deref()
+                    .map(|path| load_sources(&sources_path_for(path)))
+                    .unwrap_or_default(),
+            ),
+            git_cache: Mutex::new(HashMap::new()),
             registry_path,
             paths: Mutex::new(HashMap::new()),
             publisher: Prefetcher::new(),
@@ -1585,7 +1623,7 @@ impl Proxy {
                 return;
             }
         }
-        match self.publish(&remote, state, &record) {
+        match self.publish(&instance, &remote, state, &record) {
             Ok(()) => {
                 let _ = std::fs::remove_file(&record_path);
                 state.stats_published.fetch_add(1, Ordering::Relaxed);
@@ -1602,6 +1640,7 @@ impl Proxy {
 
     fn publish(
         &self,
+        instance: &str,
         remote: &Remote,
         state: &'static PathState,
         record: &PublishRecord,
@@ -1706,7 +1745,9 @@ impl Proxy {
                 }
             }
         }
-        let result = remote.update_action(&record.key, &entries);
+        let branch = self.resolve_branch(instance);
+        let trunk = self.resolve_trunk(instance);
+        let result = remote.update_action(&record.key, &entries, branch.as_deref(), trunk.as_deref());
         if let Some(analytics) = &self.analytics {
             analytics.record_keyvalue(&record.key, "write", op_start.elapsed().as_secs_f64());
         }
@@ -1841,7 +1882,12 @@ impl Proxy {
             else {
                 break;
             };
-            if remote.update_action(&key, &manifest).is_err() {
+            // These are re-publishes of entries already in the cache, so they
+            // ride without a branch/trunk: a same-bytes refresh inside the
+            // damping window is a no-op, and an aged one lands untagged in the
+            // trunk baseline (still included, still protected from feature
+            // steals) rather than being wrongly re-attributed.
+            if remote.update_action(&key, &manifest, None, None).is_err() {
                 break;
             }
             sent += 1;
@@ -1896,7 +1942,7 @@ impl Proxy {
 
     /// One full snapshot fetch + decode, returning the resulting state.
     fn fetch_full_snapshot(&self, instance: &str, remote: &Arc<Remote>) -> SnapshotState {
-        match remote.get_snapshot(None) {
+        match remote.get_snapshot(None, self.resolve_trunk(instance).as_deref()) {
             Ok(Some(bytes)) => match Snapshot::decode(&bytes) {
                 Some(snapshot) => {
                     crate::log_line(&format!(
@@ -2020,7 +2066,8 @@ impl Proxy {
                     watermark,
                 } => {
                     let remote = self.remote_for(&instance);
-                    match remote.get_snapshot(Some(watermark)) {
+                    let trunk = self.resolve_trunk(&instance);
+                    match remote.get_snapshot(Some(watermark), trunk.as_deref()) {
                         Ok(Some(bytes)) => {
                             let Some(delta) = Snapshot::decode(&bytes) else {
                                 continue;
@@ -2090,6 +2137,86 @@ impl Proxy {
     /// local. Once per snapshot fetch (i.e. per proxy lifetime per
     /// instance); after a mid-day wipe, demand-driven jobs and per-object
     /// self-heals carry re-materialization.
+    /// The git branch a publish for this instance is attributed to: the env
+    /// override first (CI, whose HEAD is detached; or a manual build), then the
+    /// branch derived live from the instance's registered source root.
+    fn resolve_branch(&self, instance: &str) -> Option<String> {
+        if let Ok(branch) = std::env::var("TUIST_CAS_BRANCH") {
+            if !branch.is_empty() {
+                return Some(branch);
+            }
+        }
+        self.git_context(instance).branch
+    }
+
+    /// The trunk to scope this instance's snapshot to: the env override first,
+    /// then the source root's default branch (`origin/HEAD`).
+    fn resolve_trunk(&self, instance: &str) -> Option<String> {
+        if let Ok(trunk) = std::env::var("TUIST_CAS_TRUNK_BRANCH") {
+            if !trunk.is_empty() {
+                return Some(trunk);
+            }
+        }
+        self.git_context(instance).trunk
+    }
+
+    /// The instance's git context, memoized on GIT_CONTEXT_TTL. A refresh also
+    /// re-reads the sources registry, so a project set up after this proxy
+    /// started (a second project on the machine) is picked up without a restart.
+    fn git_context(&self, instance: &str) -> GitBranches {
+        {
+            let cache = self.git_cache.lock().unwrap();
+            if let Some(context) = cache.get(instance) {
+                if context.read_at.elapsed() < GIT_CONTEXT_TTL {
+                    return GitBranches {
+                        branch: context.branch.clone(),
+                        trunk: context.trunk.clone(),
+                    };
+                }
+            }
+        }
+        let root = self.source_root(instance);
+        let (branch, trunk) = match root {
+            Some(root) => (git_current_branch(&root), git_trunk_branch(&root)),
+            None => (None, None),
+        };
+        {
+            let cache = self.git_cache.lock().unwrap();
+            let changed = cache
+                .get(instance)
+                .map(|context| context.branch != branch || context.trunk != trunk)
+                .unwrap_or(true);
+            if changed {
+                crate::log_line(&format!(
+                    "git context for {instance}: branch={branch:?} trunk={trunk:?}"
+                ));
+            }
+        }
+        self.git_cache.lock().unwrap().insert(
+            instance.to_string(),
+            GitContext {
+                read_at: Instant::now(),
+                branch: branch.clone(),
+                trunk: trunk.clone(),
+            },
+        );
+        GitBranches { branch, trunk }
+    }
+
+    /// The instance's registered source root, reloading the sources registry so
+    /// a mapping written after startup is visible. Cheap: only runs on a TTL
+    /// miss in `git_context`.
+    fn source_root(&self, instance: &str) -> Option<PathBuf> {
+        if let Some(path) = self.registry_path.as_deref() {
+            let sources = load_sources(&sources_path_for(path));
+            let root = sources.get(instance).cloned();
+            *self.instance_sources.lock().unwrap() = sources;
+            root
+        } else {
+            self.instance_sources.lock().unwrap().get(instance).cloned()
+        }
+    }
+
     fn prematerialize_snapshot(&self, instance: &str, snapshot: &Snapshot) {
         let cas_paths: Vec<String> = self
             .path_instance
@@ -2112,10 +2239,14 @@ impl Proxy {
             // namespace measured). The budget covers a large build's closure;
             // everything past it stays resolvable and self-heals on demand.
             // With a trunk-scoped snapshot the closure IS the budget's target,
-            // so full ingestion (the layer above key caching) is the same loop
-            // with the cap lifted: TUIST_CAS_PREMATERIALIZE_NODES=0 warms the
-            // entire snapshot.
-            let configured = prematerialize_max_nodes();
+            // so full ingestion (the layer above key caching) warms all of it —
+            // the scoping already bounds it to the trunk, not the whole polluted
+            // namespace. Unscoped, keep the node budget (or TUIST_CAS_PREMATERIALIZE_NODES).
+            let configured = if self.resolve_trunk(instance).is_some() {
+                0
+            } else {
+                prematerialize_max_nodes()
+            };
             let mut budget = configured;
             let mut enqueued = 0usize;
             for key_hash in &snapshot.key_order {
@@ -2370,6 +2501,70 @@ fn load_registry(path: &Path) -> HashMap<String, String> {
         }
     }
     map
+}
+
+/// The instance -> source-root registry sits next to the cas_path registry,
+/// written by `tuist setup cache` (which knows both the full handle and the
+/// project path). `<registry>.sources`, TSV `instance\tsource-root`.
+fn sources_path_for(registry: &Path) -> PathBuf {
+    let mut path = registry.to_path_buf().into_os_string();
+    path.push(".sources");
+    PathBuf::from(path)
+}
+
+fn load_sources(path: &Path) -> HashMap<String, PathBuf> {
+    let mut map = HashMap::new();
+    if let Ok(body) = std::fs::read_to_string(path) {
+        for line in body.lines() {
+            if let Some((instance, root)) = line.split_once('\t') {
+                if !instance.is_empty() && !root.is_empty() {
+                    map.insert(instance.to_string(), PathBuf::from(root));
+                }
+            }
+        }
+    }
+    map
+}
+
+/// The currently checked-out branch of a repo, or `None` on a detached HEAD
+/// (git prints "HEAD") or when the path is not a repo.
+fn git_current_branch(root: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() || branch == "HEAD" {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+/// A repo's default branch, read from `origin/HEAD` (e.g. "main"). `None` when
+/// the remote head is unset (a bare local repo) — the caller then leaves the
+/// snapshot unscoped or takes the env/server-provided trunk.
+fn git_trunk_branch(root: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // `--short` yields "origin/main"; the trunk is the branch name.
+    head.rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
 }
 
 unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, String> {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -199,6 +199,12 @@ fn ingest_trunk_enabled() -> bool {
 // well under an hour without contending with the build's own traffic; the
 // queue cap bounds memory if the server never accepts them.
 const VIEW_REFRESH_PER_TICK: usize = 100;
+/// How many refreshes a proxy remembers having done, to suppress duplicates.
+/// Deliberately its own bound: the queue's cap protects memory against a server
+/// that never accepts, while this one is a history whose entries are never
+/// retired, so reusing that number turned "the queue is full" into "this machine
+/// is finished refreshing". Full means forget, never refuse.
+const VIEW_REFRESH_HISTORY_MAX: usize = 200_000;
 const VIEW_REFRESH_MAX_QUEUE: usize = 50_000;
 
 /// How long a cached miss is served before it is re-resolved. Positive results
@@ -1036,7 +1042,7 @@ impl Proxy {
             instance_sources: Mutex::new(
                 registry_path
                     .as_deref()
-                    .map(|path| load_sources(&sources_path_for(path)))
+                    .and_then(|path| load_sources(&sources_path_for(path)))
                     .unwrap_or_default(),
             ),
             source_cache: Mutex::new(HashMap::new()),
@@ -1944,6 +1950,14 @@ impl Proxy {
         // records arrive here, and so do the sweeper's, so refusing here is what
         // makes `upload: false` mean it.
         if !self.upload_enabled(instance) {
+            // The record is already durable. The Clang lane wrote it before
+            // asking, because its plugin instance never saw the policy, so
+            // refusing the request without dropping the record leaves it for
+            // every later sweep to find: the spool grows without bound, and the
+            // first time the policy reads as enabled (the project turns uploads
+            // on, or a registry read fails open) it hands the sweeper a backlog
+            // of everything produced while the project was read-only.
+            remove_record(record_path);
             return;
         }
         let (branch, trunk) = self.record_tags(instance, record_path);
@@ -2321,7 +2335,19 @@ impl Proxy {
         );
         {
             let mut refreshed = self.view_refreshed.lock().unwrap();
-            if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(dedup.clone()) {
+            // Forget everything rather than refuse everything. A successful claim
+            // is never removed, so this set is a lifetime history, and bounding
+            // it the way the QUEUE is bounded meant that once a machine had
+            // refreshed enough keys it would never refresh another one, however
+            // empty the queue. Identity now includes the instance and the tags,
+            // so a few large projects or a run of branches reach that sooner.
+            //
+            // Dropping the history costs at most a re-publish of something
+            // already published, which the server damps.
+            if refreshed.len() >= VIEW_REFRESH_HISTORY_MAX {
+                refreshed.clear();
+            }
+            if !refreshed.insert(dedup.clone()) {
                 return;
             }
         }
@@ -2746,10 +2772,16 @@ impl Proxy {
             upload: source.upload,
         };
         if let Some(path) = self.registry_path.as_deref() {
-            let sources = load_sources(&sources_path_for(path));
-            let source = sources.get(instance).map(clone);
-            *self.instance_sources.lock().unwrap() = sources;
-            source
+            match load_sources(&sources_path_for(path)) {
+                Some(sources) => {
+                    let source = sources.get(instance).map(clone);
+                    *self.instance_sources.lock().unwrap() = sources;
+                    source
+                }
+                // Unreadable: keep what we last saw rather than forgetting every
+                // project's policy because one read lost a race with setup.
+                None => self.instance_sources.lock().unwrap().get(instance).map(clone),
+            }
         } else {
             self.instance_sources.lock().unwrap().get(instance).map(clone)
         }
@@ -3066,9 +3098,16 @@ fn sources_path_for(registry: &Path) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
+/// `None` when the registry could not be read at all, which is NOT the same as
+/// an empty one: setup rewrites this file, and a read landing mid-rewrite would
+/// otherwise turn every project on the machine into an unknown one. Unknown
+/// means "no policy recorded", and the answer there has to be permissive, so a
+/// transient read error would quietly hand an opted-out project an upload
+/// window.
+fn load_sources(path: &Path) -> Option<HashMap<String, RegisteredSource>> {
+    let body = std::fs::read_to_string(path).ok()?;
     let mut map = HashMap::new();
-    if let Ok(body) = std::fs::read_to_string(path) {
+    {
         for line in body.lines() {
             // `instance \t source-root [\t trunk [\t ci-branch]]`. Both trailing
             // columns are optional: a registry written by an older setup, or by
@@ -3099,7 +3138,7 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
             );
         }
     }
-    map
+    Some(map)
 }
 
 unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, String> {
@@ -3236,8 +3275,15 @@ mod tests {
         )
         .expect("write registry");
 
-        let sources = load_sources(&path);
+        let sources = load_sources(&path).expect("a readable registry parses");
         assert_eq!(sources.len(), 2);
+        // Unreadable is not the same as empty, and the difference decides whether
+        // an opted-out project keeps its policy: setup rewrites this file, and a
+        // read landing mid-rewrite must not be mistaken for "no projects here".
+        assert!(
+            load_sources(&dir.join("does-not-exist")).is_none(),
+            "a registry that cannot be read reports so, rather than reporting none"
+        );
         let scoped = sources.get("tuist/mastodon").expect("scoped entry");
         assert_eq!(
             scoped.trunk.as_deref(),
@@ -3453,7 +3499,7 @@ mod tests {
         )
         .expect("write registry");
 
-        let sources = load_sources(&path);
+        let sources = load_sources(&path).expect("a readable registry parses");
         let ci = sources.get("tuist/ci").expect("ci entry");
         assert_eq!(ci.trunk.as_deref(), Some("main"));
         assert_eq!(ci.ci_branch.as_deref(), Some("feature/x"));

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -18,8 +18,8 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::prefetch::Prefetcher;
 use crate::proxy_proto::{
-    read_request, write_response, Request, OP_DECLARE_UPLOAD, OP_FETCH_OBJECT, OP_INVALIDATE,
-    OP_PUBLISH, OP_RESOLVE,
+    read_request, write_response, Request, OP_FETCH_OBJECT, OP_INVALIDATE, OP_PUBLISH,
+    OP_RESOLVE,
     STATUS_ERROR, STATUS_HIT, STATUS_MISS,
 };
 use crate::reapi::{self, ManifestEntry, Remote, RemoteConfig};
@@ -874,6 +874,7 @@ struct SourceContext {
     read_at: Instant,
     trunk: Option<String>,
     ci_branch: Option<String>,
+    upload: bool,
 }
 
 /// How long a recorded context is reused before the proxy re-reads the registry,
@@ -885,6 +886,7 @@ const GIT_CONTEXT_TTL: Duration = Duration::from_secs(15);
 struct SourceBranches {
     branch: Option<String>,
     trunk: Option<String>,
+    upload: bool,
 }
 
 /// What `tuist setup cache` recorded for an instance.
@@ -911,6 +913,14 @@ struct RegisteredSource {
     /// get it wrong locally). `None` when setup could not reach the server, which
     /// means no scoping: what a client too old to ask for it already gets.
     trunk: Option<String>,
+    /// The project's `xcodeCache.upload`.
+    ///
+    /// The plugin checks this too, from a compiler option, but that option only
+    /// reaches Swift: swift-build's `CASOptions` carries a plugin PATH and no
+    /// plugin options, so the CAS it creates for its Clang caching has no idea
+    /// what the project asked for and defaults to uploading. The proxy is the
+    /// only place that sees both lanes, so it is where the policy is enforced.
+    upload: bool,
 }
 
 pub struct Proxy {
@@ -982,9 +992,6 @@ pub struct Proxy {
     // identical re-publishes of entries fresher than a day, so a fleet of
     // cold machines cannot stampede version bumps.
     view_refresh: Mutex<VecDeque<ViewRefresh>>,
-    /// Per cas_path upload policy, declared by the plugin at CAS create. Absent
-    /// means a client too old to say, which is the behaviour it already has.
-    path_upload: Mutex<HashMap<String, bool>>,
     view_refreshed: Mutex<HashSet<Vec<u8>>>,
 
     // instance -> demand-fetch coalescer, created on first demand miss. Groups
@@ -1033,7 +1040,6 @@ impl Proxy {
             busy_logged_at: Mutex::new(None),
             unprimed: AtomicU64::new(0),
             view_refresh: Mutex::new(VecDeque::new()),
-            path_upload: Mutex::new(HashMap::new()),
             view_refreshed: Mutex::new(HashSet::new()),
             demand_coalescers: Mutex::new(HashMap::new()),
             active_instances: Mutex::new(HashSet::new()),
@@ -1154,15 +1160,17 @@ impl Proxy {
         });
     }
 
-    /// This path's upload policy. Unknown means a plugin too old to declare it,
-    /// and the answer there has to be the behaviour that client already gets.
-    fn upload_enabled(&self, cas_path: &str) -> bool {
-        self.path_upload
-            .lock()
-            .unwrap()
-            .get(cas_path)
-            .copied()
-            .unwrap_or(true)
+    /// Whether this instance's project allows uploading.
+    ///
+    /// Read here rather than trusted from the client, because the client cannot
+    /// speak for the whole build. The plugin's own check sees a compiler option,
+    /// which reaches Swift; swift-build's Clang caching runs against a CAS
+    /// created with a plugin path and no options, so that lane defaults to
+    /// uploading and would publish straight through an explicit opt-out. Every
+    /// publication passes through here, from either lane and from the sweeper,
+    /// so this is the one place the project's answer can be made to hold.
+    fn upload_enabled(&self, instance: &str) -> bool {
+        self.source_context(instance).upload
     }
 
     /// Whether a build for this instance has touched this proxy since it
@@ -1388,7 +1396,7 @@ impl Proxy {
         // machine. Without a snapshot, per-key is just the normal path and
         // says nothing about view membership.
         if snapshot_ready {
-            self.queue_view_refresh(remote, &state.cas_path, instance, key, &manifest);
+            self.queue_view_refresh(remote, instance, key, &manifest);
         }
         let action_ms = phase.elapsed().as_millis() as u64;
         state.ms_action.fetch_add(action_ms, Ordering::Relaxed);
@@ -1918,6 +1926,15 @@ impl Proxy {
     /// Binding at accept costs nothing: the context is memoized, so this reads
     /// the registry at most once per TTL per instance, never per publish.
     fn enqueue_publish(&self, cas_path: &str, instance: &str, record_path: &str) {
+        // The project's answer, enforced where both lanes meet. The plugin
+        // declines to publish when its own option says so, but that option only
+        // reaches Swift: the build system's Clang caching creates its CAS with a
+        // plugin path and no options, so it asks to publish regardless. Its
+        // records arrive here, and so do the sweeper's, so refusing here is what
+        // makes `upload: false` mean it.
+        if !self.upload_enabled(instance) {
+            return;
+        }
         let (branch, trunk) = self.record_tags(instance, record_path);
         let mut item = Vec::with_capacity(
             8 + instance.len() + cas_path.len() + branch.len() + trunk.len() + record_path.len(),
@@ -2271,7 +2288,6 @@ impl Proxy {
     fn queue_view_refresh(
         &self,
         remote: &Arc<Remote>,
-        cas_path: &str,
         instance: &str,
         key: &[u8],
         manifest: &[ManifestEntry],
@@ -2281,7 +2297,7 @@ impl Proxy {
         // not get to write to the server because the proxy found reading
         // interesting, so the read-only case declines and pays the per-key round
         // trip it was always paying.
-        if !self.upload_enabled(cas_path) {
+        if !self.upload_enabled(instance) {
             return;
         }
         {
@@ -2654,6 +2670,7 @@ impl Proxy {
                     return SourceBranches {
                         branch: context.ci_branch.clone(),
                         trunk: context.trunk.clone(),
+                        upload: context.upload,
                     };
                 }
             }
@@ -2661,6 +2678,8 @@ impl Proxy {
         let source = self.registered_source(instance);
         let trunk = source.as_ref().and_then(|source| source.trunk.clone());
         let branch = source.as_ref().and_then(|source| source.ci_branch.clone());
+        // Unknown instance: nothing recorded, so nothing to withhold.
+        let upload = source.as_ref().map(|source| source.upload).unwrap_or(true);
         {
             let cache = self.source_cache.lock().unwrap();
             let changed = cache
@@ -2679,9 +2698,10 @@ impl Proxy {
                 read_at: Instant::now(),
                 trunk: trunk.clone(),
                 ci_branch: branch.clone(),
+                upload,
             },
         );
-        SourceBranches { branch, trunk }
+        SourceBranches { branch, trunk, upload }
     }
 
     /// What setup registered for the instance, reloading the sources registry so
@@ -2691,6 +2711,7 @@ impl Proxy {
         let clone = |source: &RegisteredSource| RegisteredSource {
             trunk: source.trunk.clone(),
             ci_branch: source.ci_branch.clone(),
+            upload: source.upload,
         };
         if let Some(path) = self.registry_path.as_deref() {
             let sources = load_sources(&sources_path_for(path));
@@ -2908,14 +2929,6 @@ impl Proxy {
                 }
                 write_response(&mut stream, STATUS_HIT, &[])
             }
-            OP_DECLARE_UPLOAD => {
-                let upload = request.payload.first().copied().unwrap_or(1) != 0;
-                self.path_upload
-                    .lock()
-                    .unwrap()
-                    .insert(request.cas_path.clone(), upload);
-                write_response(&mut stream, STATUS_HIT, &[])
-            }
             OP_INVALIDATE => {
                 // A prune emptied this path's on-disk CAS in place; drop our marks
                 // so a resolve re-fetches. Only if we already track the path — an
@@ -3047,6 +3060,9 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
                 RegisteredSource {
                     trunk: columns.next().filter(|trunk| !trunk.is_empty()).map(str::to_owned),
                     ci_branch: columns.next().filter(|branch| !branch.is_empty()).map(str::to_owned),
+                    // Absent is a registry written before the column, and
+                    // uploading is what that machine already does.
+                    upload: columns.next() != Some("0"),
                 },
             );
         }
@@ -4032,14 +4048,48 @@ mod tests {
         );
     }
 
-    /// A view refresh is the proxy writing on its own initiative: nothing the
-    /// compiler asked for produces it, so it never passes the plugin's upload
-    /// check. A machine configured not to upload must not write to the server
-    /// because the proxy found reading interesting.
+    /// `upload: false` has to hold for the whole build, and only the proxy can
+    /// make it. The plugin checks a compiler option, which reaches Swift;
+    /// swift-build's Clang caching creates its CAS with a plugin path and NO
+    /// options, so that lane never sees the project's answer and asks to publish
+    /// regardless. Its records arrive at `enqueue_publish`, and so do the
+    /// sweeper's, which is why the refusal lives there and not in the client.
     #[test]
-    fn a_read_only_build_queues_no_view_refresh() {
-        let proxy = test_proxy();
-        let remote = proxy.remote_for("tuist/mastodon");
+    fn a_read_only_project_publishes_nothing_and_refreshes_nothing() {
+        let dir = std::env::temp_dir().join(format!("tuist-upload-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let registry = dir.join("registry");
+        let sources = sources_path_for(&registry);
+        std::fs::write(
+            &sources,
+            "tuist/reader\t/src/reader\tmain\t\t0\ntuist/writer\t/src/writer\tmain\n",
+        )
+        .expect("write sources");
+
+        let proxy = Proxy::new(
+            "http://127.0.0.1:1".into(),
+            crate::token::TokenProvider::from_env(),
+            String::new(),
+            Some(registry),
+            None,
+        );
+        let captured: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        proxy
+            .publisher
+            .configure(1, move |item| sink.lock().unwrap().push(item));
+
+        // What the Clang lane does: it never saw the option, so it asks.
+        proxy.enqueue_publish("/cas", "tuist/reader", "/spool/from-the-clang-lane");
+        proxy
+            .publisher
+            .drain_stop_timeout(std::time::Duration::from_secs(10));
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "a project that opted out publishes nothing, however the record got here"
+        );
+
         let manifest = vec![ManifestEntry {
             llcas_digest: vec![0xAA],
             blob: reapi::Digest {
@@ -4048,34 +4098,20 @@ mod tests {
             },
             contents: None,
         }];
+        let remote = proxy.remote_for("tuist/reader");
+        proxy.queue_view_refresh(&remote, "tuist/reader", b"key-1", &manifest);
+        assert_eq!(
+            proxy.view_refresh.lock().unwrap().len(),
+            0,
+            "and it does not write on the proxy's own initiative either"
+        );
 
-        // Undeclared is a plugin too old to say, and it keeps what it has today.
-        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-1", &manifest);
+        // A project that did not opt out is untouched.
+        let remote = proxy.remote_for("tuist/writer");
+        proxy.queue_view_refresh(&remote, "tuist/writer", b"key-2", &manifest);
         assert_eq!(proxy.view_refresh.lock().unwrap().len(), 1);
 
-        proxy
-            .path_upload
-            .lock()
-            .unwrap()
-            .insert("/cas".to_string(), false);
-        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-2", &manifest);
-        assert_eq!(
-            proxy.view_refresh.lock().unwrap().len(),
-            1,
-            "a read-only path adds nothing to the refresh queue"
-        );
-
-        proxy
-            .path_upload
-            .lock()
-            .unwrap()
-            .insert("/cas".to_string(), true);
-        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-3", &manifest);
-        assert_eq!(
-            proxy.view_refresh.lock().unwrap().len(),
-            2,
-            "an uploading path still refreshes"
-        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     // A demand fetch is a door into the same store, and it does not have to come

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -18,7 +18,8 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::prefetch::Prefetcher;
 use crate::proxy_proto::{
-    read_request, write_response, Request, OP_FETCH_OBJECT, OP_INVALIDATE, OP_PUBLISH, OP_RESOLVE,
+    read_request, write_response, Request, OP_DECLARE_UPLOAD, OP_FETCH_OBJECT, OP_INVALIDATE,
+    OP_PUBLISH, OP_RESOLVE,
     STATUS_ERROR, STATUS_HIT, STATUS_MISS,
 };
 use crate::reapi::{self, ManifestEntry, Remote, RemoteConfig};
@@ -977,6 +978,9 @@ pub struct Proxy {
     // identical re-publishes of entries fresher than a day, so a fleet of
     // cold machines cannot stampede version bumps.
     view_refresh: Mutex<VecDeque<ViewRefresh>>,
+    /// Per cas_path upload policy, declared by the plugin at CAS create. Absent
+    /// means a client too old to say, which is the behaviour it already has.
+    path_upload: Mutex<HashMap<String, bool>>,
     view_refreshed: Mutex<HashSet<Vec<u8>>>,
 
     // instance -> demand-fetch coalescer, created on first demand miss. Groups
@@ -1025,6 +1029,7 @@ impl Proxy {
             busy_logged_at: Mutex::new(None),
             unprimed: AtomicU64::new(0),
             view_refresh: Mutex::new(VecDeque::new()),
+            path_upload: Mutex::new(HashMap::new()),
             view_refreshed: Mutex::new(HashSet::new()),
             demand_coalescers: Mutex::new(HashMap::new()),
             active_instances: Mutex::new(HashSet::new()),
@@ -1143,6 +1148,17 @@ impl Proxy {
             ));
             proxy.prematerialize_snapshot(&instance, &snapshot);
         });
+    }
+
+    /// This path's upload policy. Unknown means a plugin too old to declare it,
+    /// and the answer there has to be the behaviour that client already gets.
+    fn upload_enabled(&self, cas_path: &str) -> bool {
+        self.path_upload
+            .lock()
+            .unwrap()
+            .get(cas_path)
+            .copied()
+            .unwrap_or(true)
     }
 
     /// Whether a build for this instance has touched this proxy since it
@@ -1368,7 +1384,7 @@ impl Proxy {
         // machine. Without a snapshot, per-key is just the normal path and
         // says nothing about view membership.
         if snapshot_ready {
-            self.queue_view_refresh(remote, instance, key, &manifest);
+            self.queue_view_refresh(remote, &state.cas_path, instance, key, &manifest);
         }
         let action_ms = phase.elapsed().as_millis() as u64;
         state.ms_action.fetch_add(action_ms, Ordering::Relaxed);
@@ -2241,10 +2257,19 @@ impl Proxy {
     fn queue_view_refresh(
         &self,
         remote: &Arc<Remote>,
+        cas_path: &str,
         instance: &str,
         key: &[u8],
         manifest: &[ManifestEntry],
     ) {
+        // A refresh is a write, and this one is ours, not the build's: nothing
+        // the compiler asked for produced it. A machine told not to upload does
+        // not get to write to the server because the proxy found reading
+        // interesting, so the read-only case declines and pays the per-key round
+        // trip it was always paying.
+        if !self.upload_enabled(cas_path) {
+            return;
+        }
         {
             let mut refreshed = self.view_refreshed.lock().unwrap();
             if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(key.to_vec()) {
@@ -2872,6 +2897,14 @@ impl Proxy {
                 } else {
                     self.note_unprimed(&request.cas_path);
                 }
+                write_response(&mut stream, STATUS_HIT, &[])
+            }
+            OP_DECLARE_UPLOAD => {
+                let upload = request.payload.first().copied().unwrap_or(1) != 0;
+                self.path_upload
+                    .lock()
+                    .unwrap()
+                    .insert(request.cas_path.clone(), upload);
                 write_response(&mut stream, STATUS_HIT, &[])
             }
             OP_INVALIDATE => {
@@ -4027,6 +4060,52 @@ mod tests {
         assert!(
             compiler_view.load_present(&digest),
             "an object stored after the wipe must be visible to a handle opened              independently: otherwise the proxy is writing into a deleted store"
+        );
+    }
+
+    /// A view refresh is the proxy writing on its own initiative: nothing the
+    /// compiler asked for produces it, so it never passes the plugin's upload
+    /// check. A machine configured not to upload must not write to the server
+    /// because the proxy found reading interesting.
+    #[test]
+    fn a_read_only_build_queues_no_view_refresh() {
+        let proxy = test_proxy();
+        let remote = proxy.remote_for("tuist/mastodon");
+        let manifest = vec![ManifestEntry {
+            llcas_digest: vec![0xAA],
+            blob: reapi::Digest {
+                hash: "bb".repeat(32),
+                size_bytes: 7,
+            },
+            contents: None,
+        }];
+
+        // Undeclared is a plugin too old to say, and it keeps what it has today.
+        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-1", &manifest);
+        assert_eq!(proxy.view_refresh.lock().unwrap().len(), 1);
+
+        proxy
+            .path_upload
+            .lock()
+            .unwrap()
+            .insert("/cas".to_string(), false);
+        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-2", &manifest);
+        assert_eq!(
+            proxy.view_refresh.lock().unwrap().len(),
+            1,
+            "a read-only path adds nothing to the refresh queue"
+        );
+
+        proxy
+            .path_upload
+            .lock()
+            .unwrap()
+            .insert("/cas".to_string(), true);
+        proxy.queue_view_refresh(&remote, "/cas", "tuist/mastodon", b"key-3", &manifest);
+        assert_eq!(
+            proxy.view_refresh.lock().unwrap().len(),
+            2,
+            "an uploading path still refreshes"
         );
     }
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -751,7 +751,18 @@ struct ViewRefresh {
     manifest: Vec<ManifestEntry>,
     branch: Option<String>,
     trunk: Option<String>,
+    /// Carried so a refresh that never happens can release its claim.
+    dedup: RefreshKey,
 }
+
+/// What makes a refresh distinct: the instance it belongs to, the action, and the
+/// tags it would write.
+///
+/// All four matter. The key alone collides across projects, and it collides
+/// across branches, which is worse: a feature build refreshing a key would
+/// suppress the later trunk hit for it, for the proxy's lifetime, and that hit is
+/// the only thing that reclaims the entry into the trunk view.
+type RefreshKey = (String, Vec<u8>, Option<String>, Option<String>);
 
 /// Result of a coalesced demand fetch, taken by exactly one waiter.
 enum DemandResult {
@@ -992,7 +1003,7 @@ pub struct Proxy {
     // identical re-publishes of entries fresher than a day, so a fleet of
     // cold machines cannot stampede version bumps.
     view_refresh: Mutex<VecDeque<ViewRefresh>>,
-    view_refreshed: Mutex<HashSet<Vec<u8>>>,
+    view_refreshed: Mutex<HashSet<RefreshKey>>,
 
     // instance -> demand-fetch coalescer, created on first demand miss. Groups
     // concurrent OP_FETCH_OBJECT blob reads into shared BatchReadBlobs calls.
@@ -2300,9 +2311,17 @@ impl Proxy {
         if !self.upload_enabled(instance) {
             return;
         }
+        let branch = self.resolve_branch(instance);
+        let trunk = self.resolve_trunk(instance);
+        let dedup: RefreshKey = (
+            instance.to_string(),
+            key.to_vec(),
+            branch.clone(),
+            trunk.clone(),
+        );
         {
             let mut refreshed = self.view_refreshed.lock().unwrap();
-            if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(key.to_vec()) {
+            if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(dedup.clone()) {
                 return;
             }
         }
@@ -2320,9 +2339,15 @@ impl Proxy {
                 remote: remote.clone(),
                 key: key.to_vec(),
                 manifest: stripped,
-                branch: self.resolve_branch(instance),
-                trunk: self.resolve_trunk(instance),
+                branch,
+                trunk,
+                dedup,
             });
+        } else {
+            // Claimed but not queued: hold the claim and this refresh never
+            // happens and can never be asked for again.
+            drop(queue);
+            self.view_refreshed.lock().unwrap().remove(&dedup);
         }
     }
 
@@ -2353,6 +2378,13 @@ impl Proxy {
                 )
                 .is_err()
             {
+                // Release the claim so a later hit can ask again. This item is
+                // the one being dropped (the rest of the batch stays queued and
+                // retries next tick, so their claims stand), and without letting
+                // go of it, "the next cold build that pays the per-key round trip
+                // re-queues the key" describes something that cannot happen: the
+                // claim outlives the work and suppresses every later attempt.
+                self.view_refreshed.lock().unwrap().remove(&refresh.dedup);
                 break;
             }
             sent += 1;
@@ -4046,6 +4078,122 @@ mod tests {
             "a demand fetch must keep the machine marked busy, or the idle gate \
              starts competing with the build it is meant to avoid"
         );
+    }
+
+    /// The reclaim path only works if a trunk hit can still be asked for after a
+    /// feature hit for the same action. On a shared runner that ordering is
+    /// routine, and a dedup keyed on the action alone would suppress the trunk
+    /// hit for the proxy's lifetime, quietly disabling the mechanism the whole
+    /// scoping leans on.
+    #[test]
+    fn a_refresh_is_distinct_per_instance_and_per_tag() {
+        let dir = std::env::temp_dir().join(format!("tuist-refresh-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let registry = dir.join("registry");
+        let sources = sources_path_for(&registry);
+        let record = |branch: &str| {
+            std::fs::write(
+                &sources,
+                format!(
+                    "tuist/one\t/src/one\tmain\t{branch}\ntuist/two\t/src/two\tmain\t{branch}\n"
+                ),
+            )
+            .expect("write sources");
+        };
+        record("feature");
+
+        let proxy = Proxy::new(
+            "http://127.0.0.1:1".into(),
+            crate::token::TokenProvider::from_env(),
+            String::new(),
+            Some(registry),
+            None,
+        );
+        let manifest = vec![ManifestEntry {
+            llcas_digest: vec![0xAA],
+            blob: reapi::Digest {
+                hash: "bb".repeat(32),
+                size_bytes: 7,
+            },
+            contents: None,
+        }];
+        let queued = || proxy.view_refresh.lock().unwrap().len();
+        let one = proxy.remote_for("tuist/one");
+
+        proxy.queue_view_refresh(&one, "tuist/one", b"shared-key", &manifest);
+        assert_eq!(queued(), 1);
+        // Same everything: the second one is the same work.
+        proxy.queue_view_refresh(&one, "tuist/one", b"shared-key", &manifest);
+        assert_eq!(queued(), 1, "an identical refresh is not queued twice");
+
+        // Same action, another project. Keys collide across instances.
+        let two = proxy.remote_for("tuist/two");
+        proxy.queue_view_refresh(&two, "tuist/two", b"shared-key", &manifest);
+        assert_eq!(queued(), 2, "another project's identical key is its own refresh");
+
+        // The trunk job now takes a hit on the key the feature job refreshed.
+        record("main");
+        proxy.source_cache.lock().unwrap().clear();
+        proxy.queue_view_refresh(&one, "tuist/one", b"shared-key", &manifest);
+        assert_eq!(
+            queued(),
+            3,
+            "a trunk hit reclaims a key a feature hit refreshed first: suppressing \
+             it would disable the reclaim path entirely"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The remote here cannot be reached, so the drain fails, which is the point:
+    /// a refresh that did not happen must be askable again.
+    #[test]
+    fn a_failed_refresh_can_be_asked_for_again() {
+        let dir = std::env::temp_dir().join(format!("tuist-refresh-fail-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let registry = dir.join("registry");
+        std::fs::write(
+            sources_path_for(&registry),
+            "tuist/one\t/src/one\tmain\tmain\n",
+        )
+        .expect("write sources");
+
+        let proxy = Proxy::new(
+            "http://127.0.0.1:1".into(),
+            crate::token::TokenProvider::from_env(),
+            String::new(),
+            Some(registry),
+            None,
+        );
+        let manifest = vec![ManifestEntry {
+            llcas_digest: vec![0xAA],
+            blob: reapi::Digest {
+                hash: "bb".repeat(32),
+                size_bytes: 7,
+            },
+            contents: None,
+        }];
+        let one = proxy.remote_for("tuist/one");
+
+        proxy.queue_view_refresh(&one, "tuist/one", b"key", &manifest);
+        assert_eq!(proxy.view_refresh.lock().unwrap().len(), 1);
+        proxy.refresh_view_keys();
+        assert_eq!(
+            proxy.view_refresh.lock().unwrap().len(),
+            0,
+            "the failed item is dropped from the queue"
+        );
+
+        proxy.queue_view_refresh(&one, "tuist/one", b"key", &manifest);
+        assert_eq!(
+            proxy.view_refresh.lock().unwrap().len(),
+            1,
+            "and it can be queued again, which is what the retry comment promises"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// `upload: false` has to hold for the whole build, and only the proxy can

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -1671,6 +1671,16 @@ impl Proxy {
         declared_instance: &str,
         digest: &[u8],
     ) -> Result<bool, String> {
+        // Restat before answering. A demand fetch can be the FIRST thing to
+        // arrive after a wipe: the compiler asks for an object it could not
+        // load, and nothing makes a resolve come first. Every answer below is
+        // about whatever store this handle is bound to, so bound to a deleted
+        // one, `load_present` reports an object the compiler cannot see and a
+        // fetch stores into a directory nothing reads. Both end as the
+        // `missing object` the rebind exists to prevent, and clang does not
+        // survive that one. The resolve path restats for the same reason; this
+        // is the door it does not cover.
+        self.check_generation(state);
         if state.load_present(digest) {
             return Ok(true);
         }
@@ -4017,6 +4027,36 @@ mod tests {
         assert!(
             compiler_view.load_present(&digest),
             "an object stored after the wipe must be visible to a handle opened              independently: otherwise the proxy is writing into a deleted store"
+        );
+    }
+
+    // A demand fetch is a door into the same store, and it does not have to come
+    // after a resolve: the compiler asks for an object the moment it fails to
+    // load one. If a wipe lands in between, this is the first thing to touch the
+    // dead handle, and answering "present" from it tells the compiler an object
+    // is there that its own live CAS has never seen.
+    #[test]
+    fn a_demand_fetch_arriving_first_after_a_wipe_does_not_answer_from_the_dead_store() {
+        let dir = TempCasDir::new("wipe-fetch");
+        let state = path_state_for(&dir.path());
+        let digest = store_probe_object(state, b"present-before-the-wipe");
+        let proxy = test_proxy();
+        assert!(
+            proxy
+                .fetch_object(state, &dir.path(), "", &digest)
+                .expect("fetch should not error"),
+            "sanity: served from the live store before the wipe"
+        );
+
+        // No resolve in between: the wipe, then the fetch.
+        dir.wipe();
+
+        assert!(
+            !proxy
+                .fetch_object(state, &dir.path(), "", &digest)
+                .expect("fetch should not error"),
+            "a fetch after a wipe must not report an object the compiler's own CAS \
+             cannot see: that is the `missing object` this rebind exists to prevent"
         );
     }
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -777,6 +777,13 @@ struct GitBranches {
 struct RegisteredSource {
     /// The project's checkout, which the branch of each publish is read from.
     root: PathBuf,
+    /// The branch `tuist setup cache` saw, recorded ONLY on CI, whose checkout is
+    /// detached and so tells `git rev-parse` nothing. A launchd agent does not
+    /// inherit the job's environment, so the provider's branch variable is
+    /// unreachable from here and the command inside the job has to hand it over.
+    /// Never recorded off CI, where reading git live is both possible and correct
+    /// across a `git checkout`.
+    ci_branch: Option<String>,
     /// The project's default branch, as the server knows it. Authoritative over
     /// the checkout's `origin/HEAD`: which branch is trunk is a property of the
     /// project, not of how this machine happened to clone it (a fork, a mirror,
@@ -2299,15 +2306,25 @@ impl Proxy {
     /// instance); after a mid-day wipe, demand-driven jobs and per-object
     /// self-heals carry re-materialization.
     /// The git branch a publish for this instance is attributed to: the env
-    /// override first (CI, whose HEAD is detached; or a manual build), then the
-    /// branch derived live from the instance's registered source root.
+    /// override first (a manual build or a bench), then the branch derived live
+    /// from the instance's registered source root, then the branch
+    /// `tuist setup cache` recorded for a CI checkout.
+    ///
+    /// Live git outranks the recorded branch because it survives a `git checkout`
+    /// under this long-lived proxy, and it is only absent when HEAD is detached.
+    /// The recorded branch is therefore reached exactly on CI, which is where git
+    /// cannot answer and where an untagged publish would otherwise land in every
+    /// project's trunk baseline: CI is the fleet's main publisher, so leaving it
+    /// untagged would pollute the very view this scoping exists to keep clean.
     fn resolve_branch(&self, instance: &str) -> Option<String> {
         if let Ok(branch) = std::env::var("TUIST_CAS_BRANCH") {
             if !branch.is_empty() {
                 return Some(branch);
             }
         }
-        self.git_context(instance).branch
+        self.git_context(instance)
+            .branch
+            .or_else(|| self.registered_source(instance).and_then(|source| source.ci_branch))
     }
 
     /// The trunk to scope this instance's snapshot to: the env override first,
@@ -2377,6 +2394,7 @@ impl Proxy {
         let clone = |source: &RegisteredSource| RegisteredSource {
             root: source.root.clone(),
             trunk: source.trunk.clone(),
+            ci_branch: source.ci_branch.clone(),
         };
         if let Some(path) = self.registry_path.as_deref() {
             let sources = load_sources(&sources_path_for(path));
@@ -2690,10 +2708,12 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
     let mut map = HashMap::new();
     if let Ok(body) = std::fs::read_to_string(path) {
         for line in body.lines() {
-            // `instance \t source-root [\t trunk]`. The trunk column is optional:
-            // a registry written by an older setup, or by one that could not
-            // reach the server, still parses and leaves the trunk to be derived
-            // from the checkout.
+            // `instance \t source-root [\t trunk [\t ci-branch]]`. Both trailing
+            // columns are optional: a registry written by an older setup, or by
+            // one that could not reach the server, still parses and leaves the
+            // trunk to be derived from the checkout. The trunk's place is held
+            // empty when a branch was recorded without one, so the columns stay
+            // positional.
             let mut columns = line.split('\t');
             let (Some(instance), Some(root)) = (columns.next(), columns.next()) else {
                 continue;
@@ -2706,6 +2726,7 @@ fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
                 RegisteredSource {
                     root: PathBuf::from(root),
                     trunk: columns.next().filter(|trunk| !trunk.is_empty()).map(str::to_owned),
+                    ci_branch: columns.next().filter(|branch| !branch.is_empty()).map(str::to_owned),
                 },
             );
         }
@@ -2884,6 +2905,49 @@ mod tests {
         let legacy = sources.get("tuist/legacy").expect("legacy entry");
         assert_eq!(legacy.root, PathBuf::from("/src/legacy"));
         assert_eq!(legacy.trunk, None, "an absent trunk column is not a path");
+        assert_eq!(
+            scoped.ci_branch, None,
+            "a registry written before the branch column carries no branch"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The CI branch column, which `tuist setup cache` writes only from inside a CI
+    // job (the proxy is a launchd agent and never sees the provider's branch
+    // variable). A branch recorded without a trunk keeps the trunk's place, so the
+    // columns stay positional.
+    #[test]
+    fn sources_registry_reads_the_ci_branch_column() {
+        let dir = std::env::temp_dir().join(format!("tuist-sources-ci-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("registry.sources");
+        std::fs::write(
+            &path,
+            "tuist/ci\t/src/ci\tmain\tfeature/x\n\
+             tuist/no-trunk\t/src/no-trunk\t\tfeature/y\n\
+             tuist/dev\t/src/dev\tmain\n",
+        )
+        .expect("write registry");
+
+        let sources = load_sources(&path);
+        let ci = sources.get("tuist/ci").expect("ci entry");
+        assert_eq!(ci.trunk.as_deref(), Some("main"));
+        assert_eq!(ci.ci_branch.as_deref(), Some("feature/x"));
+
+        let no_trunk = sources.get("tuist/no-trunk").expect("no-trunk entry");
+        assert_eq!(no_trunk.trunk, None, "the empty trunk column is not a trunk");
+        assert_eq!(
+            no_trunk.ci_branch.as_deref(),
+            Some("feature/y"),
+            "the branch is still found in its own column"
+        );
+
+        let dev = sources.get("tuist/dev").expect("dev entry");
+        assert_eq!(
+            dev.ci_branch, None,
+            "a developer's row records no branch: the proxy reads git live"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -152,6 +152,43 @@ fn prematerialize_max_nodes() -> usize {
 ///
 /// `TUIST_CAS_INGEST_TRUNK=0` opts out, for a metered or slow link where
 /// pulling the trunk closure up front is not worth it.
+/// Suffix of the file that carries a spool record's publish tags. Both this
+/// proxy's `sweep` and the plugin's own `sweep_spool` walk the spool directory
+/// and must skip it.
+pub const TAGS_SUFFIX: &str = ".tags";
+
+/// The sidecar path for a record, keyed off the base name so it is still found
+/// once a sweeper has claimed the record as `<base>.claim-<pid>`.
+fn tags_path(record_path: &str) -> std::path::PathBuf {
+    let path = std::path::Path::new(record_path);
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let base = name.split_once(".claim-").map(|(b, _)| b).unwrap_or(name);
+    path.with_file_name(format!("{base}{TAGS_SUFFIX}"))
+}
+
+/// `branch\ntrunk`, where an empty field encodes `None`. Neither resolver can
+/// yield an empty branch name, so the round trip is lossless: the same encoding
+/// the publish queue item uses.
+fn encode_tags(branch: &str, trunk: &str) -> Vec<u8> {
+    format!("{branch}\n{trunk}").into_bytes()
+}
+
+fn decode_tags(bytes: &[u8]) -> Option<(String, String)> {
+    let contents = std::str::from_utf8(bytes).ok()?;
+    let (branch, trunk) = contents.split_once('\n')?;
+    Some((branch.to_string(), trunk.to_string()))
+}
+
+/// Deletes a spool record and the tags written beside it. A leaked sidecar
+/// would be read back by whatever record later reuses that name.
+fn remove_record(record_path: &str) {
+    let _ = std::fs::remove_file(record_path);
+    let _ = std::fs::remove_file(tags_path(record_path));
+}
+
 fn ingest_trunk_enabled() -> bool {
     std::env::var("TUIST_CAS_INGEST_TRUNK").as_deref() != Ok("0")
 }
@@ -704,7 +741,16 @@ unsafe impl Sync for PathState {}
 
 /// One queued view refresh: the instance's client, the action key, and the
 /// manifest to re-publish.
-type ViewRefresh = (Arc<Remote>, Vec<u8>, Vec<ManifestEntry>);
+/// A per-key hit queued for background re-publish, with the tags bound when it
+/// was queued rather than when it drains: the drain runs on a maintenance tick,
+/// by which point the checkout may have moved.
+struct ViewRefresh {
+    remote: Arc<Remote>,
+    key: Vec<u8>,
+    manifest: Vec<ManifestEntry>,
+    branch: Option<String>,
+    trunk: Option<String>,
+}
 
 /// Result of a coalesced demand fetch, taken by exactly one waiter.
 enum DemandResult {
@@ -1183,6 +1229,7 @@ impl Proxy {
     fn resolve(
         &self,
         remote: &Arc<Remote>,
+        instance: &str,
         state: &'static PathState,
         key: &[u8],
         snapshot: Option<&Snapshot>,
@@ -1270,7 +1317,8 @@ impl Proxy {
         // this resolve's marks if a wipe/prune advances the counter mid-resolve.
         self.check_generation(state);
         let observed = state.gen_counter.load(Ordering::SeqCst);
-        let outcome = self.resolve_uncached(remote, state, key, observed, snapshot.is_some());
+        let outcome =
+            self.resolve_uncached(remote, instance, state, key, observed, snapshot.is_some());
         {
             let mut inflight = state.inflight.lock().unwrap();
             inflight.remove(key);
@@ -1282,6 +1330,7 @@ impl Proxy {
     fn resolve_uncached(
         &self,
         remote: &Arc<Remote>,
+        instance: &str,
         state: &'static PathState,
         key: &[u8],
         observed: u64,
@@ -1319,7 +1368,7 @@ impl Proxy {
         // machine. Without a snapshot, per-key is just the normal path and
         // says nothing about view membership.
         if snapshot_ready {
-            self.queue_view_refresh(remote, key, &manifest);
+            self.queue_view_refresh(remote, instance, key, &manifest);
         }
         let action_ms = phase.elapsed().as_millis() as u64;
         state.ms_action.fetch_add(action_ms, Ordering::Relaxed);
@@ -1784,6 +1833,36 @@ impl Proxy {
     }
 
     /// PUBLISH notify: queue the record for the publisher pool. Items encode
+    /// The tags to publish a record under, preferring the pair bound the first
+    /// time we accepted it.
+    ///
+    /// Binding at accept only holds for as long as we hold the queue, and the
+    /// record outlives that. It sits in the spool until its upload drains, so a
+    /// proxy restart mid-drain, or an unprimed Xcode build that spools before any
+    /// project has primed the path, leaves it for a later `sweep` or for the
+    /// plugin's own sweeper to re-send. Resolving there reads whatever is checked
+    /// out by then, which is exactly how a trunk build's orphaned outputs come
+    /// back tagged with the feature branch someone checked out afterwards.
+    ///
+    /// So the first accept, the closest we ever stand to the producing build,
+    /// writes the pair beside the record, and every later re-enqueue reads it
+    /// back. Best-effort by design: a record we never accepted while primed has
+    /// no sidecar, and resolving live is the only guess left.
+    fn record_tags(&self, instance: &str, record_path: &str) -> (String, String) {
+        let sidecar = tags_path(record_path);
+        if let Ok(contents) = std::fs::read(&sidecar) {
+            if let Some((branch, trunk)) = decode_tags(&contents) {
+                return (branch, trunk);
+            }
+        }
+        let branch = self.resolve_branch(instance).unwrap_or_default();
+        let trunk = self.resolve_trunk(instance).unwrap_or_default();
+        // A torn write would be read back as "no sidecar" and re-resolved, so
+        // failing here costs a re-resolve, never a wrong tag.
+        let _ = std::fs::write(&sidecar, encode_tags(&branch, &trunk));
+        (branch, trunk)
+    }
+
     /// instance + cas_path + the (branch, trunk) bound here + record path.
     ///
     /// The tags are resolved NOW, when the build hands us the record, and not
@@ -1799,8 +1878,7 @@ impl Proxy {
     /// GIT_CONTEXT_TTL, so this forks git at most once per TTL per instance,
     /// never per publish.
     fn enqueue_publish(&self, cas_path: &str, instance: &str, record_path: &str) {
-        let branch = self.resolve_branch(instance).unwrap_or_default();
-        let trunk = self.resolve_trunk(instance).unwrap_or_default();
+        let (branch, trunk) = self.record_tags(instance, record_path);
         let mut item = Vec::with_capacity(
             8 + instance.len() + cas_path.len() + branch.len() + trunk.len() + record_path.len(),
         );
@@ -1849,7 +1927,7 @@ impl Proxy {
         let Some(record) =
             PublishRecord::decode_body(&bytes, Some(std::path::PathBuf::from(&record_path)))
         else {
-            let _ = std::fs::remove_file(&record_path);
+            remove_record(&record_path);
             return;
         };
         // The client re-puts replayed results at the end of its job, so a warm
@@ -1860,13 +1938,13 @@ impl Proxy {
         // DIFFERENT value (a genuine local recompute) still publishes.
         if let Some(Resolution::Hit(value)) = state.resolved.lock().unwrap().get(&record.key) {
             if value == &record.value_digest {
-                let _ = std::fs::remove_file(&record_path);
+                remove_record(&record_path);
                 return;
             }
         }
         match self.publish(&remote, state, &record, branch.as_deref(), trunk.as_deref()) {
             Ok(()) => {
-                let _ = std::fs::remove_file(&record_path);
+                remove_record(&record_path);
                 state.stats_published.fetch_add(1, Ordering::Relaxed);
                 state.resolved.lock().unwrap().insert(
                     record.key.clone(),
@@ -1896,6 +1974,19 @@ impl Proxy {
             if manifest.first().map(|entry| entry.llcas_digest.as_slice())
                 == Some(record.value_digest.as_slice())
             {
+                // Same bytes, so there is nothing to upload. That used to end
+                // it, which meant a trunk build could recompute a result a
+                // feature branch had published first and never take the tag
+                // back: the entry stayed `feature` and stayed out of the trunk
+                // view forever, which is the reclaim half of what this scoping
+                // is for. Bytes are no longer the whole of an entry's identity,
+                // so re-send the manifest we just probed, carrying our tags and
+                // nothing else. The server damps a true no-op; we cannot tell
+                // one from here without asking what tag it holds, which is the
+                // round trip this would be making anyway.
+                if branch.is_some() || trunk.is_some() {
+                    remote.update_action(&record.key, &manifest, branch, trunk)?;
+                }
                 return Ok(());
             }
         }
@@ -2100,6 +2191,12 @@ impl Proxy {
             };
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
+                    // A sidecar is not a record. Publishing one would fail to
+                    // decode and delete it, throwing away the tags it exists to
+                    // carry, and the record beside it would then resolve live.
+                    if name.ends_with(TAGS_SUFFIX) {
+                        continue;
+                    }
                     // Claims are ours alone now; reclaim anything.
                     let base = name.split_once(".claim-").map(|(b, _)| b.to_string());
                     let path = match base {
@@ -2131,7 +2228,13 @@ impl Proxy {
     /// `Proxy.view_refresh`). Inlined contents are stripped: the refresh only
     /// re-sends the llcas→blob mapping, and the blobs are already on the
     /// server (the per-key hit proved the entry serveable).
-    fn queue_view_refresh(&self, remote: &Arc<Remote>, key: &[u8], manifest: &[ManifestEntry]) {
+    fn queue_view_refresh(
+        &self,
+        remote: &Arc<Remote>,
+        instance: &str,
+        key: &[u8],
+        manifest: &[ManifestEntry],
+    ) {
         {
             let mut refreshed = self.view_refreshed.lock().unwrap();
             if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(key.to_vec()) {
@@ -2148,7 +2251,13 @@ impl Proxy {
             .collect();
         let mut queue = self.view_refresh.lock().unwrap();
         if queue.len() < VIEW_REFRESH_MAX_QUEUE {
-            queue.push_back((remote.clone(), key.to_vec(), stripped));
+            queue.push_back(ViewRefresh {
+                remote: remote.clone(),
+                key: key.to_vec(),
+                manifest: stripped,
+                branch: self.resolve_branch(instance),
+                trunk: self.resolve_trunk(instance),
+            });
         }
     }
 
@@ -2158,16 +2267,26 @@ impl Proxy {
     pub fn refresh_view_keys(&self) {
         let mut sent = 0_usize;
         while sent < VIEW_REFRESH_PER_TICK {
-            let Some((remote, key, manifest)) = self.view_refresh.lock().unwrap().pop_front()
-            else {
+            let Some(refresh) = self.view_refresh.lock().unwrap().pop_front() else {
                 break;
             };
-            // These are re-publishes of entries already in the cache, so they
-            // ride without a branch/trunk: a same-bytes refresh inside the
-            // damping window is a no-op, and an aged one lands untagged in the
-            // trunk baseline (still included, still protected from feature
-            // steals) rather than being wrongly re-attributed.
-            if remote.update_action(&key, &manifest, None, None).is_err() {
+            // Carrying the tags of the build that took the hit is what makes this
+            // the reclaim path. These entries are, by definition, outside the
+            // trunk view: sending no tags would re-attribute every one of them to
+            // nobody, and an untagged entry is in EVERY trunk view, so a feature
+            // branch's own keys would flow into trunk's just by being read. With
+            // the tags, a feature hit stays out and a trunk hit takes the entry
+            // back.
+            if refresh
+                .remote
+                .update_action(
+                    &refresh.key,
+                    &refresh.manifest,
+                    refresh.branch.as_deref(),
+                    refresh.trunk.as_deref(),
+                )
+                .is_err()
+            {
                 break;
             }
             sent += 1;
@@ -2721,7 +2840,7 @@ impl Proxy {
                 self.ensure_snapshot(&instance, &remote);
                 let snapshot = self.snapshot_ready(&instance);
                 let outcome = self.path_state(&request.cas_path).and_then(|state| {
-                    self.resolve(&remote, state, &request.payload, snapshot.as_deref())
+                    self.resolve(&remote, &instance, state, &request.payload, snapshot.as_deref())
                 });
                 match outcome {
                     Ok(Some(value)) => write_response(&mut stream, STATUS_HIT, &value),
@@ -3153,6 +3272,128 @@ mod tests {
 
         drop(items);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Binding at accept only protects a record for as long as the queue holds it.
+    /// A proxy restart mid-drain, or a build that spooled before the path was
+    /// primed, leaves the record on disk for a later sweep to re-enqueue, and by
+    /// then the checkout has usually moved on.
+    #[test]
+    fn a_reswept_record_keeps_the_branch_that_produced_it() {
+        let dir = std::env::temp_dir().join(format!("tuist-sidecar-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        let root = dir.join("checkout");
+        std::fs::create_dir_all(&root).expect("temp dir");
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .output()
+                .expect("git");
+            assert!(status.status.success(), "git {args:?}");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "bench@tuist.dev"]);
+        git(&["config", "user.name", "bench"]);
+        std::fs::write(root.join("file"), "contents").expect("write");
+        git(&["add", "."]);
+        git(&["commit", "-m", "initial"]);
+
+        let registry = dir.join("registry");
+        std::fs::write(
+            sources_path_for(&registry),
+            format!("tuist/mastodon\t{}\tmain\n", root.display()),
+        )
+        .expect("write sources");
+
+        let cas_path = dir.join("cas");
+        let spool = cas_path.join("tuist-spool");
+        std::fs::create_dir_all(&spool).expect("spool");
+        let record = spool.join("1234-0");
+        std::fs::write(&record, b"record").expect("record");
+        let record_path = record.to_string_lossy().into_owned();
+
+        let proxy = Proxy::new(
+            "http://127.0.0.1:1".into(),
+            crate::token::TokenProvider::from_env(),
+            String::new(),
+            Some(registry),
+            None,
+        );
+        let captured: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        proxy
+            .publisher
+            .configure(1, move |item| sink.lock().unwrap().push(item));
+
+        // The build hands us the record while main is checked out.
+        proxy.enqueue_publish(
+            &cas_path.to_string_lossy(),
+            "tuist/mastodon",
+            &record_path,
+        );
+        assert!(
+            spool.join("1234-0.tags").exists(),
+            "accepting a record writes its tags beside it"
+        );
+
+        // The proxy dies before draining, someone checks out a feature branch,
+        // and a later sweep finds the record still sitting in the spool.
+        git(&["checkout", "-b", "feature"]);
+        proxy.git_cache.lock().unwrap().clear();
+        proxy.enqueue_publish(
+            &cas_path.to_string_lossy(),
+            "tuist/mastodon",
+            &record_path,
+        );
+
+        proxy
+            .publisher
+            .drain_stop_timeout(std::time::Duration::from_secs(10));
+        let items = captured.lock().unwrap();
+        assert_eq!(items.len(), 2);
+        let branch_of = |item: &[u8]| {
+            let (_, rest) = take_u16_field(item).expect("instance");
+            let (_, rest) = take_u16_field(rest).expect("cas path");
+            let (branch, _) = take_u16_field(rest).expect("branch");
+            String::from_utf8_lossy(branch).into_owned()
+        };
+        assert_eq!(branch_of(&items[0]), "main");
+        assert_eq!(
+            branch_of(&items[1]),
+            "main",
+            "the re-enqueued record keeps the branch it was produced on, not the one checked out now"
+        );
+
+        drop(items);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A sweeper claims a record by renaming it to `<base>.claim-<pid>`, so the
+    /// sidecar has to be found from the claimed name too.
+    #[test]
+    fn a_claimed_record_still_finds_its_tags() {
+        assert_eq!(tags_path("/spool/1234-0"), tags_path("/spool/1234-0.claim-9"));
+        assert_eq!(
+            tags_path("/spool/1234-0"),
+            std::path::PathBuf::from("/spool/1234-0.tags")
+        );
+    }
+
+    #[test]
+    fn tags_round_trip_through_the_sidecar() {
+        let encoded = encode_tags("feature/tags", "main");
+        assert_eq!(
+            decode_tags(&encoded),
+            Some(("feature/tags".to_string(), "main".to_string()))
+        );
+        // An absent branch is the empty field, the same encoding the queue uses.
+        assert_eq!(
+            decode_tags(&encode_tags("", "main")),
+            Some((String::new(), "main".to_string()))
+        );
+        assert_eq!(decode_tags(b"garbage"), None, "a torn write re-resolves");
     }
 
     // The CI branch column, which `tuist setup cache` writes only from inside a CI

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -978,12 +978,55 @@ impl Proxy {
         // machine" is known, which is what bounds trunk ingestion (see
         // `instance_active`).
         if let Some(instance) = &instance {
-            let mut active = self.active_instances.lock().unwrap();
-            if !active.contains(instance) {
-                active.insert(instance.clone());
+            // `insert` reports the transition, and the guard is dropped before
+            // the hook: what it kicks off takes locks of its own.
+            let newly_active = self
+                .active_instances
+                .lock()
+                .unwrap()
+                .insert(instance.clone());
+            if newly_active {
+                self.ingest_on_activation(instance);
             }
         }
         instance
+    }
+
+    /// Ingests the trunk closure of an instance that has just become active but
+    /// whose snapshot arrived before it did.
+    ///
+    /// The startup prefetch warms under the node budget by design: nothing is
+    /// active that early, and that is exactly what stops a restart from pulling
+    /// the closure of every project the registry has ever seen. But the budget
+    /// then sticks. The snapshot is Ready, nothing re-materializes it, and the
+    /// first build after a restart — the build the prefetch exists to help —
+    /// would wait out SNAPSHOT_FULL_INTERVAL for the closure it was meant to
+    /// have. So the same signal that bounds the fan-out lifts the budget, for
+    /// this one instance, the moment it stops being a guess.
+    ///
+    /// Reachable once per instance per proxy lifetime. It no-ops unless a
+    /// snapshot is already Ready: an instance whose snapshot lands after the
+    /// build (the on-demand path) is materialized with the instance already
+    /// active and needs nothing here.
+    fn ingest_on_activation(&self, instance: &str) {
+        if self.snapshot_ready(instance).is_none() {
+            return;
+        }
+        let proxy: &'static Proxy = unsafe { &*(self as *const Proxy) };
+        let instance = instance.to_string();
+        // Off-thread: this runs from a resolve, and `resolve_trunk` can fork git.
+        std::thread::spawn(move || {
+            if !ingest_trunk_enabled() || proxy.resolve_trunk(&instance).is_none() {
+                return;
+            }
+            let Some(snapshot) = proxy.snapshot_ready(&instance) else {
+                return;
+            };
+            crate::log_line(&format!(
+                "ingesting {instance}'s trunk closure: prefetched before any build, so it warmed under the node budget"
+            ));
+            proxy.prematerialize_snapshot(&instance, &snapshot);
+        });
     }
 
     /// Whether a build for this instance has touched this proxy since it
@@ -993,6 +1036,10 @@ impl Proxy {
     /// projects the developer may not have opened in months. In-memory on
     /// purpose — a fresh proxy ingests nothing until you actually build, which
     /// is the conservative direction.
+    ///
+    /// It gates the budget rather than the warm, so a prefetched-but-inactive
+    /// instance still warms its newest nodes; `ingest_on_activation` is what
+    /// lifts the budget once the guess resolves into a real build.
     fn instance_active(&self, instance: &str) -> bool {
         self.active_instances.lock().unwrap().contains(instance)
     }

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -96,6 +96,24 @@ fn prematerialize_max_nodes() -> usize {
         .and_then(|value| value.parse().ok())
         .unwrap_or(PREMATERIALIZE_MAX_NODES)
 }
+
+/// Whether to fully ingest a trunk-scoped snapshot into the local CAS ahead of
+/// the build, rather than warming only the newest `PREMATERIALIZE_MAX_NODES`.
+///
+/// On by default where it is affordable and where it pays: the scoping bounds
+/// the warm to the project's trunk closure instead of a whole shared namespace,
+/// the warm runs off any build's critical path, it is idempotent (objects
+/// already on disk are skipped, so steady state only fetches the delta a new
+/// trunk snapshot introduced), and Xcode's own size-LRU bounds the store it
+/// lands in. Measured on a mastodon-sized project: ~12s of off-path fetching
+/// turns a from-scratch trunk build from ~57s into ~33s at 50ms RTT, cutting
+/// demand stalls ~14x.
+///
+/// `TUIST_CAS_INGEST_TRUNK=0` opts out, for a metered or slow link where
+/// pulling the trunk closure up front is not worth it.
+fn ingest_trunk_enabled() -> bool {
+    std::env::var("TUIST_CAS_INGEST_TRUNK").as_deref() != Ok("0")
+}
 // View refresh: per-key hits taken while a snapshot was Ready get their
 // manifests re-published in the background (see Proxy.view_refresh). The
 // per-tick batch keeps a full cold build's backlog (~10k keys) draining in
@@ -714,6 +732,18 @@ struct GitBranches {
     trunk: Option<String>,
 }
 
+/// What `tuist setup cache` recorded for an instance.
+struct RegisteredSource {
+    /// The project's checkout, which the branch of each publish is read from.
+    root: PathBuf,
+    /// The project's default branch, as the server knows it. Authoritative over
+    /// the checkout's `origin/HEAD`: which branch is trunk is a property of the
+    /// project, not of how this machine happened to clone it (a fork, a mirror,
+    /// or a clone whose remote head was never set all get it wrong locally).
+    /// `None` when setup could not reach the server.
+    trunk: Option<String>,
+}
+
 pub struct Proxy {
     grpc_url: String,
     tokens: Arc<TokenProvider>,
@@ -734,7 +764,10 @@ pub struct Proxy {
     // publish is tagged with are derived live from this repo's git HEAD, so a
     // branch switch needs no re-setup and nothing branch-specific ever enters a
     // build setting (which could pollute the compile cache key).
-    instance_sources: Mutex<HashMap<String, PathBuf>>,
+    instance_sources: Mutex<HashMap<String, RegisteredSource>>,
+    // Instances a build has touched since this proxy started; bounds trunk
+    // ingestion to projects actually in use (see `instance_active`).
+    active_instances: Mutex<HashSet<String>>,
     // instance -> the last git context read from its source root, refreshed on
     // a short TTL so per-publish tagging is a cache hit, not a git fork.
     git_cache: Mutex<HashMap<String, GitContext>>,
@@ -826,6 +859,7 @@ impl Proxy {
             view_refresh: Mutex::new(VecDeque::new()),
             view_refreshed: Mutex::new(HashSet::new()),
             demand_coalescers: Mutex::new(HashMap::new()),
+            active_instances: Mutex::new(HashSet::new()),
             analytics,
         }));
         let proxy_addr = proxy as *const Proxy as usize;
@@ -876,15 +910,39 @@ impl Proxy {
     /// empty one falls back to whatever a prior build primed. `None` means an
     /// unprimed ⌘B build: the caller degrades it to a miss.
     fn resolve_instance(&self, cas_path: &str, declared: &str) -> Option<String> {
-        if !declared.is_empty() {
+        let instance = if !declared.is_empty() {
             let mut map = self.path_instance.lock().unwrap();
             if map.get(cas_path).map(String::as_str) != Some(declared) {
                 map.insert(cas_path.to_string(), declared.to_string());
                 self.persist_registry(&map);
             }
-            return Some(declared.to_string());
+            Some(declared.to_string())
+        } else {
+            self.path_instance.lock().unwrap().get(cas_path).cloned()
+        };
+        // Every caller of this is real build traffic (a resolve, a demand fetch,
+        // a publish), and nothing else reaches it — the startup prefetch does
+        // not. So this is the seam where "a project is being built on this
+        // machine" is known, which is what bounds trunk ingestion (see
+        // `instance_active`).
+        if let Some(instance) = &instance {
+            let mut active = self.active_instances.lock().unwrap();
+            if !active.contains(instance) {
+                active.insert(instance.clone());
+            }
         }
-        self.path_instance.lock().unwrap().get(cas_path).cloned()
+        instance
+    }
+
+    /// Whether a build for this instance has touched this proxy since it
+    /// started. Trunk ingestion is gated on it, because the registry accumulates
+    /// every project ever built on the machine: without this, one proxy restart
+    /// would fan out and pull the full trunk closure of all of them (GBs) for
+    /// projects the developer may not have opened in months. In-memory on
+    /// purpose — a fresh proxy ingests nothing until you actually build, which
+    /// is the conservative direction.
+    fn instance_active(&self, instance: &str) -> bool {
+        self.active_instances.lock().unwrap().contains(instance)
     }
 
     fn persist_registry(&self, map: &HashMap<String, String>) {
@@ -2175,9 +2233,15 @@ impl Proxy {
                 }
             }
         }
-        let root = self.source_root(instance);
-        let (branch, trunk) = match root {
-            Some(root) => (git_current_branch(&root), git_trunk_branch(&root)),
+        let source = self.registered_source(instance);
+        let (branch, trunk) = match source {
+            // The server's default branch wins over the checkout's `origin/HEAD`;
+            // the latter is only a fallback for a setup that could not reach the
+            // server, or a registry written before setup recorded the trunk.
+            Some(source) => (
+                git_current_branch(&source.root),
+                source.trunk.or_else(|| git_trunk_branch(&source.root)),
+            ),
             None => (None, None),
         };
         {
@@ -2203,17 +2267,21 @@ impl Proxy {
         GitBranches { branch, trunk }
     }
 
-    /// The instance's registered source root, reloading the sources registry so
+    /// What setup registered for the instance, reloading the sources registry so
     /// a mapping written after startup is visible. Cheap: only runs on a TTL
     /// miss in `git_context`.
-    fn source_root(&self, instance: &str) -> Option<PathBuf> {
+    fn registered_source(&self, instance: &str) -> Option<RegisteredSource> {
+        let clone = |source: &RegisteredSource| RegisteredSource {
+            root: source.root.clone(),
+            trunk: source.trunk.clone(),
+        };
         if let Some(path) = self.registry_path.as_deref() {
             let sources = load_sources(&sources_path_for(path));
-            let root = sources.get(instance).cloned();
+            let source = sources.get(instance).map(clone);
             *self.instance_sources.lock().unwrap() = sources;
-            root
+            source
         } else {
-            self.instance_sources.lock().unwrap().get(instance).cloned()
+            self.instance_sources.lock().unwrap().get(instance).map(clone)
         }
     }
 
@@ -2241,8 +2309,11 @@ impl Proxy {
             // With a trunk-scoped snapshot the closure IS the budget's target,
             // so full ingestion (the layer above key caching) warms all of it —
             // the scoping already bounds it to the trunk, not the whole polluted
-            // namespace. Unscoped, keep the node budget (or TUIST_CAS_PREMATERIALIZE_NODES).
-            let configured = if self.resolve_trunk(instance).is_some() {
+            // namespace. Unscoped, or opted out, keep the node budget.
+            let configured = if self.resolve_trunk(instance).is_some()
+                && ingest_trunk_enabled()
+                && self.instance_active(instance)
+            {
                 0
             } else {
                 prematerialize_max_nodes()
@@ -2512,15 +2583,28 @@ fn sources_path_for(registry: &Path) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn load_sources(path: &Path) -> HashMap<String, PathBuf> {
+fn load_sources(path: &Path) -> HashMap<String, RegisteredSource> {
     let mut map = HashMap::new();
     if let Ok(body) = std::fs::read_to_string(path) {
         for line in body.lines() {
-            if let Some((instance, root)) = line.split_once('\t') {
-                if !instance.is_empty() && !root.is_empty() {
-                    map.insert(instance.to_string(), PathBuf::from(root));
-                }
+            // `instance \t source-root [\t trunk]`. The trunk column is optional:
+            // a registry written by an older setup, or by one that could not
+            // reach the server, still parses and leaves the trunk to be derived
+            // from the checkout.
+            let mut columns = line.split('\t');
+            let (Some(instance), Some(root)) = (columns.next(), columns.next()) else {
+                continue;
+            };
+            if instance.is_empty() || root.is_empty() {
+                continue;
             }
+            map.insert(
+                instance.to_string(),
+                RegisteredSource {
+                    root: PathBuf::from(root),
+                    trunk: columns.next().filter(|trunk| !trunk.is_empty()).map(str::to_owned),
+                },
+            );
         }
     }
     map
@@ -2673,6 +2757,33 @@ unsafe fn encode_node_blob(
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    #[test]
+    fn sources_registry_keeps_reading_entries_written_without_a_trunk() {
+        let dir = std::env::temp_dir().join(format!("tuist-sources-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("registry.sources");
+        // Row 1 is what a setup that reached the server writes; row 2 is the
+        // older two-column form (and what a setup that could not reach the
+        // server still writes). Both must parse, and the old one must leave the
+        // trunk to be derived from the checkout rather than swallowing a column.
+        std::fs::write(
+            &path,
+            "tuist/mastodon\t/src/mastodon\tmain\ntuist/legacy\t/src/legacy\n",
+        )
+        .expect("write registry");
+
+        let sources = load_sources(&path);
+        assert_eq!(sources.len(), 2);
+        let scoped = sources.get("tuist/mastodon").expect("scoped entry");
+        assert_eq!(scoped.root, PathBuf::from("/src/mastodon"));
+        assert_eq!(scoped.trunk.as_deref(), Some("main"));
+        let legacy = sources.get("tuist/legacy").expect("legacy entry");
+        assert_eq!(legacy.root, PathBuf::from("/src/legacy"));
+        assert_eq!(legacy.trunk, None, "an absent trunk column is not a path");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn snapshot_decodes_the_server_wire_format() {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -13,7 +13,7 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::prefetch::Prefetcher;
@@ -275,7 +275,14 @@ fn generation_changed(stored: Option<CasGeneration>, current: Option<CasGenerati
 /// until killed.
 pub struct PathState {
     up: &'static Upstream,
-    cas: llcas_cas_t,
+    // The handle addressing the store at `cas_path`. Behind a lock because it
+    // is REBOUND when the directory is wiped and recreated: an llcas handle
+    // holds the store's files open, so after an `rm -rf DerivedData` the old
+    // handle keeps answering from the deleted directory's still-open inodes --
+    // reads report objects the compiler cannot see, and writes land where
+    // nothing will ever read them. Readers hold the guard across their whole
+    // FFI call so a swap can never dispose a handle mid-use.
+    cas: RwLock<llcas_cas_t>,
     // The on-disk CAS directory this state wraps, kept so a resolve can restat
     // it for wipe detection (see `generation`).
     cas_path: String,
@@ -609,12 +616,75 @@ impl PathState {
         // Clearing it wholesale meant one mid-build prune signal threw away
         // the read-ahead wavefront's work and sent every later lookup back to
         // the remote (measured: ~2x the remote round trips of the key set).
+        // Keeping it is only safe while that guard probes the store the
+        // consumer reads: a wipe must rebind the handle (see `reopen_cas`)
+        // BEFORE this runs, or every retained Hit is re-verified against the
+        // deleted store and served as a `missing object` build failure.
         for shard in &self.known_local {
             shard.lock().unwrap().clear();
         }
         // `pending_objects` is also KEPT: entries are content-addressed fetch
         // instructions, valid for any incarnation of the store — after a wipe
         // they let demand loads refill exactly what is asked for.
+    }
+
+    /// Rebinds `cas` to the store that now lives at `cas_path`, releasing the
+    /// handle to the previous one. Called when a wipe is detected: an llcas
+    /// handle keeps the store's files open, so a deleted directory's inodes stay
+    /// alive and reachable THROUGH THAT HANDLE ALONE. Everything the proxy does
+    /// with it afterwards addresses a store no other process can see -- and
+    /// silently: the reads answer SUCCESS and the writes report success.
+    /// Dropping the marks is not enough on its own, because `load_present`
+    /// re-learns them from that same handle.
+    ///
+    /// The fresh handle is opened before the lock is taken, so a failure leaves
+    /// the existing one in place; the stale handle is disposed only once the
+    /// swap holds the write lock, where no thread can be inside a call with it.
+    /// Disposing (rather than leaking) also lets go of the deleted store's
+    /// inodes, which is what actually returns the disk the user meant to free.
+    fn reopen_cas(&self) -> Result<(), String> {
+        let fresh = unsafe { open_cas(self.up, &self.cas_path)? };
+        let mut cas = self.cas.write().unwrap();
+        let stale = std::mem::replace(&mut *cas, fresh);
+        unsafe { (self.up.llcas_cas_dispose)(stale) };
+        Ok(())
+    }
+
+    /// Authoritative on-disk presence for `digest`: an actual llcas load, the
+    /// same call the consumer will make, bypassing the known-local cache. Used
+    /// both by `is_local` (which memoizes a positive result) and to guard a
+    /// cached Hit against a wiped local CAS, where the in-memory marks lie.
+    /// Only as authoritative as the handle is current -- see `reopen_cas`.
+    fn load_present(&self, digest: &[u8]) -> bool {
+        // Held across the probe: a concurrent `reopen_cas` must not dispose the
+        // handle between the objectid lookup and the containment check.
+        let cas = self.cas.read().unwrap();
+        unsafe {
+            let digest_t = llcas_digest_t {
+                data: digest.as_ptr(),
+                size: digest.len(),
+            };
+            let mut id = llcas_objectid_t { opaque: 0 };
+            let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
+            if (self.up.llcas_cas_get_objectid)(*cas, digest_t, &mut id, &mut error) {
+                if !error.is_null() {
+                    (self.up.llcas_string_dispose)(error);
+                }
+                return false;
+            }
+            // Existence check, not a data load: this runs once per served hit
+            // and once per manifest-entry probe, so loading object bytes here
+            // put real I/O on the resolve path (thousands of loads per warm
+            // build). A wiped or pruned store answers NOTFOUND either way,
+            // which is all the stale-hit guard needs.
+            let mut contains_error: *mut std::ffi::c_char = std::ptr::null_mut();
+            let result =
+                (self.up.llcas_cas_contains_object)(*cas, id, false, &mut contains_error);
+            if !contains_error.is_null() {
+                (self.up.llcas_string_dispose)(contains_error);
+            }
+            result == LLCAS_LOOKUP_RESULT_SUCCESS
+        }
     }
 }
 
@@ -1069,7 +1139,7 @@ impl Proxy {
         let cas = unsafe { open_cas(up, cas_path)? };
         let state: &'static PathState = Box::leak(Box::new(PathState {
             up,
-            cas,
+            cas: RwLock::new(cas),
             cas_path: cas_path.to_string(),
             generation: Mutex::new(cas_generation(cas_path)),
             gen_counter: AtomicU64::new(0),
@@ -1140,7 +1210,7 @@ impl Proxy {
         match fast_path(
             &state.resolved,
             key,
-            |value| self.load_present(state, value) || state.fetchable(value),
+            |value| state.load_present(value) || state.fetchable(value),
             || state.invalidate(),
         ) {
             FastPath::Hit(value) => return Ok(Some(value)),
@@ -1183,7 +1253,7 @@ impl Proxy {
                     _ => None,
                 };
                 if let Some(value) = peeked {
-                    if self.load_present(state, &value) || state.fetchable(&value) {
+                    if state.load_present(&value) || state.fetchable(&value) {
                         return Ok(Some(value));
                     }
                 }
@@ -1552,7 +1622,7 @@ impl Proxy {
         declared_instance: &str,
         digest: &[u8],
     ) -> Result<bool, String> {
-        if self.load_present(state, digest) {
+        if state.load_present(digest) {
             return Ok(true);
         }
         let pending = state.pending_objects.lock().unwrap().get(digest).cloned();
@@ -1659,20 +1729,36 @@ impl Proxy {
     }
 
     /// Detects a wiped-and-recreated on-disk CAS (a deleted DerivedData under
-    /// this long-lived proxy) from a change in the CAS directory's identity and
-    /// drops the now-stale in-memory marks (`resolved`, `known_local`,
-    /// `publish_cache`) so a resolve re-probes and re-materializes authoritatively.
-    /// Called at the head of every resolve, so it covers uncached/changed keys
-    /// and parallel builds, not only re-requested cached Hits. The generation
-    /// lock is held across the invalidation so a concurrent resolve can't observe
-    /// the new generation as unchanged and filter against `known_local` while it
-    /// is being cleared.
+    /// this long-lived proxy) from a change in the CAS directory's identity,
+    /// rebinds the CAS handle to the new store, and drops the now-stale
+    /// in-memory marks (`resolved`, `known_local`, `publish_cache`) so a resolve
+    /// re-probes and re-materializes authoritatively. Called at the head of
+    /// every resolve, so it covers uncached/changed keys and parallel builds,
+    /// not only re-requested cached Hits. The generation lock is held across the
+    /// invalidation so a concurrent resolve can't observe the new generation as
+    /// unchanged and filter against `known_local` while it is being cleared.
+    ///
+    /// The handle is rebound BEFORE the counter is bumped, so a resolve that
+    /// probed the old store cannot have its answer committed: it snapshotted
+    /// `observed` before the bump, so `committable` drops the write. Dropping
+    /// the marks without rebinding would achieve nothing -- `load_present` would
+    /// re-learn every one of them from the deleted store (see `reopen_cas`).
     fn check_generation(&self, state: &PathState) {
         let Some(current) = cas_generation(&state.cas_path) else {
             return;
         };
         let mut stored = state.generation.lock().unwrap();
         if generation_changed(*stored, Some(current)) {
+            if let Err(message) = state.reopen_cas() {
+                // Leave `stored` untouched so the next resolve retries: serving
+                // from the old handle is answering about a store that no longer
+                // exists, which fails the compiler with `missing object`.
+                crate::log_line(&format!(
+                    "cas reopen after wipe failed for {}: {message}",
+                    state.cas_path
+                ));
+                return;
+            }
             state.invalidate();
             state.publish_cache.lock().unwrap().clear();
         }
@@ -1683,7 +1769,7 @@ impl Proxy {
         if state.shard(digest).lock().unwrap().contains(digest) {
             return true;
         }
-        if self.load_present(state, digest) {
+        if state.load_present(digest) {
             // Memoize the authoritative load only while still on this generation:
             // a wipe/prune that cleared the shards must not have this present-now
             // fact re-inserted for what may already be a replaced store.
@@ -1694,39 +1780,6 @@ impl Proxy {
             true
         } else {
             false
-        }
-    }
-
-    /// Authoritative on-disk presence for `digest`: an actual llcas load, the
-    /// same call the consumer will make, bypassing the known-local cache. Used
-    /// both by `is_local` (which memoizes a positive result) and to guard a
-    /// cached Hit against a wiped local CAS, where the in-memory marks lie.
-    fn load_present(&self, state: &PathState, digest: &[u8]) -> bool {
-        unsafe {
-            let digest_t = llcas_digest_t {
-                data: digest.as_ptr(),
-                size: digest.len(),
-            };
-            let mut id = llcas_objectid_t { opaque: 0 };
-            let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
-            if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut error) {
-                if !error.is_null() {
-                    (state.up.llcas_string_dispose)(error);
-                }
-                return false;
-            }
-            // Existence check, not a data load: this runs once per served hit
-            // and once per manifest-entry probe, so loading object bytes here
-            // put real I/O on the resolve path (thousands of loads per warm
-            // build). A wiped or pruned store answers NOTFOUND either way,
-            // which is all the stale-hit guard needs.
-            let mut contains_error: *mut std::ffi::c_char = std::ptr::null_mut();
-            let result =
-                (state.up.llcas_cas_contains_object)(state.cas, id, false, &mut contains_error);
-            if !contains_error.is_null() {
-                (state.up.llcas_string_dispose)(contains_error);
-            }
-            result == LLCAS_LOOKUP_RESULT_SUCCESS
         }
     }
 
@@ -2467,6 +2520,13 @@ impl Proxy {
             let Ok(state) = self.path_state(&cas_path) else {
                 continue;
             };
+            // Restat before warming. Nothing else on this path is a resolve, so
+            // without this a snapshot arriving after a wipe warms through a
+            // handle bound to the deleted store: the fetches cost bandwidth, the
+            // stores land where nothing reads them, and they hold the wiped
+            // directory's inodes on disk. The resolve that eventually rebinds
+            // discards it all. One restat per snapshot, not per key.
+            self.check_generation(state);
             let observed = state.gen_counter.load(Ordering::SeqCst);
             // Warm newest-first (the wire order) and stop at the node budget:
             // a shared namespace's snapshot carries every project's history,
@@ -2846,6 +2906,10 @@ unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, Str
 }
 
 unsafe fn store_node(state: &PathState, node: &reapi::Node) -> Result<(), String> {
+    // Held for the whole store: the ref objectids are only meaningful to the
+    // handle that minted them, and a wipe must not swap it out mid-write.
+    let cas_guard = state.cas.read().unwrap();
+    let cas = *cas_guard;
     let mut ref_ids = Vec::with_capacity(node.refs.len());
     for reference in &node.refs {
         let digest = llcas_digest_t {
@@ -2854,7 +2918,7 @@ unsafe fn store_node(state: &PathState, node: &reapi::Node) -> Result<(), String
         };
         let mut id = llcas_objectid_t { opaque: 0 };
         let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
-        if (state.up.llcas_cas_get_objectid)(state.cas, digest, &mut id, &mut error) {
+        if (state.up.llcas_cas_get_objectid)(cas, digest, &mut id, &mut error) {
             if !error.is_null() {
                 (state.up.llcas_string_dispose)(error);
             }
@@ -2869,7 +2933,7 @@ unsafe fn store_node(state: &PathState, node: &reapi::Node) -> Result<(), String
     let mut stored = llcas_objectid_t { opaque: 0 };
     let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
     let failed = (state.up.llcas_cas_store_object)(
-        state.cas,
+        cas,
         data,
         ref_ids.as_ptr(),
         ref_ids.len(),
@@ -2889,13 +2953,17 @@ unsafe fn encode_node_blob(
     state: &PathState,
     digest: &[u8],
 ) -> Result<(Vec<u8>, Vec<Vec<u8>>), String> {
+    // Held for the whole decode: the loaded object and every id/digest borrowed
+    // out of it below belong to this handle, so a wipe must not dispose it here.
+    let cas_guard = state.cas.read().unwrap();
+    let cas = *cas_guard;
     let digest_t = llcas_digest_t {
         data: digest.as_ptr(),
         size: digest.len(),
     };
     let mut id = llcas_objectid_t { opaque: 0 };
     let mut id_error: *mut std::ffi::c_char = std::ptr::null_mut();
-    if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut id_error) {
+    if (state.up.llcas_cas_get_objectid)(cas, digest_t, &mut id, &mut id_error) {
         if !id_error.is_null() {
             (state.up.llcas_string_dispose)(id_error);
         }
@@ -2903,21 +2971,21 @@ unsafe fn encode_node_blob(
     }
     let mut loaded = llcas_loaded_object_t { opaque: 0 };
     let mut load_error: *mut std::ffi::c_char = std::ptr::null_mut();
-    let result = (state.up.llcas_cas_load_object)(state.cas, id, &mut loaded, &mut load_error);
+    let result = (state.up.llcas_cas_load_object)(cas, id, &mut loaded, &mut load_error);
     if !load_error.is_null() {
         (state.up.llcas_string_dispose)(load_error);
     }
     if result != LLCAS_LOOKUP_RESULT_SUCCESS {
         return Err("local load".into());
     }
-    let data = (state.up.llcas_loaded_object_get_data)(state.cas, loaded);
+    let data = (state.up.llcas_loaded_object_get_data)(cas, loaded);
     let node_data = std::slice::from_raw_parts(data.data as *const u8, data.size);
-    let refs = (state.up.llcas_loaded_object_get_refs)(state.cas, loaded);
-    let count = (state.up.llcas_object_refs_get_count)(state.cas, refs);
+    let refs = (state.up.llcas_loaded_object_get_refs)(cas, loaded);
+    let count = (state.up.llcas_object_refs_get_count)(cas, refs);
     let mut ref_digests = Vec::with_capacity(count);
     for index in 0..count {
-        let child = (state.up.llcas_object_refs_get_id)(state.cas, refs, index);
-        let digest = (state.up.llcas_objectid_get_digest)(state.cas, child);
+        let child = (state.up.llcas_object_refs_get_id)(cas, refs, index);
+        let digest = (state.up.llcas_objectid_get_digest)(cas, child);
         ref_digests.push(std::slice::from_raw_parts(digest.data, digest.size).to_vec());
     }
     let blob = reapi::compress_frame(&reapi::encode_frame(&ref_digests, node_data));
@@ -3437,6 +3505,178 @@ mod tests {
         assert_ne!(
             before, after,
             "a recreated CAS directory must read as a new generation"
+        );
+    }
+
+    // A Proxy with no remote: the wipe tests only drive `check_generation`,
+    // which is local-only (restat, rebind, drop marks).
+    fn test_proxy() -> &'static Proxy {
+        Proxy::new(
+            "http://127.0.0.1:1".to_string(),
+            crate::token::TokenProvider::from_env(),
+            crate::upstream_path(),
+            None,
+            None,
+        )
+    }
+
+    // Builds a PathState over a real on-disk CAS at `path`, the way `path_state`
+    // does, so the wipe tests drive the production probe rather than a copy.
+    fn path_state_for(path: &str) -> &'static PathState {
+        let up = unsafe { Upstream::load(&crate::upstream_path()).unwrap() };
+        let up: &'static Upstream = Box::leak(Box::new(up));
+        let cas = unsafe { open_cas(up, path).unwrap() };
+        Box::leak(Box::new(PathState {
+            up,
+            cas: RwLock::new(cas),
+            cas_path: path.to_string(),
+            generation: Mutex::new(cas_generation(path)),
+            gen_counter: AtomicU64::new(0),
+            resolved: Mutex::new(HashMap::new()),
+            inflight: Mutex::new(HashSet::new()),
+            inflight_cvar: Condvar::new(),
+            known_local: std::array::from_fn(|_| Mutex::new(HashSet::new())),
+            publish_cache: Mutex::new(HashMap::new()),
+            last_used: AtomicU64::new(0),
+            pending_objects: Mutex::new(HashMap::new()),
+            stats_resolves: AtomicU64::new(0),
+            stats_remote_hits: AtomicU64::new(0),
+            stats_misses: AtomicU64::new(0),
+            stats_snapshot_hits: AtomicU64::new(0),
+            stats_demand_fetched: AtomicU64::new(0),
+            stats_blobs_fetched: AtomicU64::new(0),
+            stats_blobs_inlined: AtomicU64::new(0),
+            stats_published: AtomicU64::new(0),
+            ms_action: AtomicU64::new(0),
+            ms_filter: AtomicU64::new(0),
+            ms_fetch: AtomicU64::new(0),
+            ms_decode: AtomicU64::new(0),
+            ms_store: AtomicU64::new(0),
+        }))
+    }
+
+    // Stores a childless object and returns its digest.
+    fn store_probe_object(state: &PathState, payload: &[u8]) -> Vec<u8> {
+        unsafe {
+            let cas = *state.cas.read().unwrap();
+            let data = llcas_data_t {
+                data: payload.as_ptr() as *const std::ffi::c_void,
+                size: payload.len(),
+            };
+            let mut id = llcas_objectid_t { opaque: 0 };
+            let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
+            assert!(
+                !(state.up.llcas_cas_store_object)(
+                    cas,
+                    data,
+                    std::ptr::null(),
+                    0,
+                    &mut id,
+                    &mut error
+                ),
+                "store must succeed"
+            );
+            let digest = (state.up.llcas_objectid_get_digest)(cas, id);
+            std::slice::from_raw_parts(digest.data, digest.size).to_vec()
+        }
+    }
+
+    struct TempCasDir(std::path::PathBuf);
+
+    impl TempCasDir {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!("cas-{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+        fn path(&self) -> String {
+            self.0.to_string_lossy().into_owned()
+        }
+        // The user action: `rm -rf DerivedData`, then the build recreates it.
+        fn wipe(&self) {
+            std::fs::remove_dir_all(&self.0).unwrap();
+            std::fs::create_dir_all(&self.0).unwrap();
+        }
+    }
+
+    impl Drop for TempCasDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    // The regression this whole guard exists for. An llcas handle pins the store
+    // it opened: after the directory is wiped, the pre-wipe handle still answers
+    // from the deleted inodes, so `load_present` reports objects the compiler
+    // cannot see. `is_local` trusts it, skips re-fetching, and clang -- which
+    // FAILS rather than recompiles on a missing object -- breaks the build.
+    // Rebinding the handle is what makes the probe authoritative again.
+    #[test]
+    fn load_present_does_not_answer_from_a_wiped_store() {
+        let dir = TempCasDir::new("wipe-read");
+        let state = path_state_for(&dir.path());
+        let digest = store_probe_object(state, b"tuist-cas-wipe-probe");
+        assert!(
+            state.load_present(&digest),
+            "sanity: the object is present before the wipe"
+        );
+
+        dir.wipe();
+        state.reopen_cas().unwrap();
+
+        assert!(
+            !state.load_present(&digest),
+            "a wiped store must read as empty: reporting the object present              skips the re-fetch and fails the compiler with `missing object`"
+        );
+    }
+
+    // The write half: a store through a pre-wipe handle reports success but
+    // lands in the deleted store, so re-fetching alone could never heal the
+    // build. After rebinding, what the proxy writes is what the compiler reads.
+    #[test]
+    fn stores_after_a_wipe_land_in_the_live_store() {
+        let dir = TempCasDir::new("wipe-write");
+        let state = path_state_for(&dir.path());
+
+        dir.wipe();
+        state.reopen_cas().unwrap();
+
+        let digest = store_probe_object(state, b"stored-after-the-wipe");
+        // A handle opened fresh is what the compiler in its own process gets.
+        let compiler_view = path_state_for(&dir.path());
+        assert!(
+            compiler_view.load_present(&digest),
+            "an object stored after the wipe must be visible to a handle opened              independently: otherwise the proxy is writing into a deleted store"
+        );
+    }
+
+    // check_generation is the only caller that rebinds, and it must do so from
+    // the wipe signal alone -- the marks it drops are worthless while the handle
+    // they get re-learned through still points at the deleted store.
+    #[test]
+    fn a_wipe_rebinds_the_handle_and_drops_the_marks() {
+        let dir = TempCasDir::new("wipe-guard");
+        let state = path_state_for(&dir.path());
+        let digest = store_probe_object(state, b"marked-local-before-the-wipe");
+        state.shard(&digest).lock().unwrap().insert(digest.clone());
+        let before = state.gen_counter.load(Ordering::SeqCst);
+
+        dir.wipe();
+        let proxy = test_proxy();
+        proxy.check_generation(state);
+
+        assert!(
+            state.gen_counter.load(Ordering::SeqCst) > before,
+            "a wipe must advance the generation so in-flight writes are dropped"
+        );
+        assert!(
+            !state.shard(&digest).lock().unwrap().contains(&digest),
+            "the known-local mark must be dropped"
+        );
+        assert!(
+            !state.load_present(&digest),
+            "and the probe behind it must now read the live store"
         );
     }
 }

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -72,6 +72,16 @@ const SNAPSHOT_MAX_INSTANCES: usize = 8;
 // Sized past the largest closure a single build replays (~37.5k on the CLI
 // fixture) so a right-sized namespace still warms completely.
 const PREMATERIALIZE_MAX_NODES: usize = 60_000;
+
+/// The bulk-warm budget, overridable for the full-ingestion layer: `0` lifts
+/// the cap entirely so the whole (trunk-scoped) snapshot is materialized into
+/// the local CAS ahead of any build. Default keeps the shipped bound.
+fn prematerialize_max_nodes() -> usize {
+    std::env::var("TUIST_CAS_PREMATERIALIZE_NODES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(PREMATERIALIZE_MAX_NODES)
+}
 // View refresh: per-key hits taken while a snapshot was Ready get their
 // manifests re-published in the background (see Proxy.view_refresh). The
 // per-tick batch keeps a full cold build's backlog (~10k keys) draining in
@@ -2087,13 +2097,20 @@ impl Proxy {
             // link the demand loads share (562s vs the 134s a right-sized
             // namespace measured). The budget covers a large build's closure;
             // everything past it stays resolvable and self-heals on demand.
-            let mut budget = PREMATERIALIZE_MAX_NODES;
+            // With a trunk-scoped snapshot the closure IS the budget's target,
+            // so full ingestion (the layer above key caching) is the same loop
+            // with the cap lifted: TUIST_CAS_PREMATERIALIZE_NODES=0 warms the
+            // entire snapshot.
+            let configured = prematerialize_max_nodes();
+            let mut budget = configured;
             let mut enqueued = 0usize;
             for key_hash in &snapshot.key_order {
                 let Some(manifest) = snapshot.manifest(key_hash) else {
                     continue;
                 };
-                budget = budget.saturating_sub(manifest.len());
+                if configured != 0 {
+                    budget = budget.saturating_sub(manifest.len());
+                }
                 let id = self.job_counter.fetch_add(1, Ordering::Relaxed);
                 self.materialize_jobs.lock().unwrap().insert(
                     id,
@@ -2106,7 +2123,7 @@ impl Proxy {
                 );
                 self.prematerializer.enqueue(id.to_be_bytes().to_vec());
                 enqueued += 1;
-                if budget == 0 {
+                if configured != 0 && budget == 0 {
                     break;
                 }
             }
@@ -2115,6 +2132,27 @@ impl Proxy {
                     "snapshot warm capped for {instance}: {enqueued} newest of {} keys enqueued",
                     snapshot.key_order.len()
                 ));
+            }
+            if enqueued > 0 {
+                // Drain watcher: logs when the warm's jobs have all been
+                // processed, with wall time — the cost side of proactive
+                // ingestion, and the bench's "ingested, off critical path"
+                // gate. Watches the shared job map, so it reads drained only
+                // once demand jobs are also quiet (fine: the warm phase
+                // precedes any build).
+                let proxy: &'static Proxy = unsafe { &*(self as *const Proxy) };
+                let instance = instance.to_string();
+                let started = Instant::now();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    if proxy.materialize_jobs.lock().unwrap().is_empty() {
+                        crate::log_line(&format!(
+                            "snapshot warm drained for {instance}: {enqueued} keys in {:.1}s",
+                            started.elapsed().as_secs_f64()
+                        ));
+                        return;
+                    }
+                });
             }
         }
     }

--- a/cas-plugin/src/proxy_proto.rs
+++ b/cas-plugin/src/proxy_proto.rs
@@ -48,6 +48,18 @@ pub const OP_INVALIDATE: u8 = 3;
 /// yet (or that a prune removed). Runs on compiler worker threads, never on the
 /// build engine's serial task-setup path, so it may block on the remote.
 pub const OP_FETCH_OBJECT: u8 = 4;
+/// This build's upload policy, declared once per CAS create. Only the plugin
+/// reads `xcodeCache.upload` (it arrives as a compiler option, which the proxy
+/// never sees), but the proxy writes on its own behalf: a per-key hit queues a
+/// re-publish that ranks the entry back into the view. That write never passes
+/// through the plugin's check, so a machine configured not to upload was still
+/// writing to the server. payload = 1 byte, 0 = do not upload.
+///
+/// Additive on purpose: a proxy too old to know this op answers "bad op", the
+/// plugin ignores that, and the machine keeps the behaviour it has today. That
+/// is worth more than a protocol bump here, which a long-lived agent would turn
+/// into every build on the machine degrading to local-only until it restarts.
+pub const OP_DECLARE_UPLOAD: u8 = 5;
 
 pub const STATUS_MISS: u8 = 0;
 pub const STATUS_HIT: u8 = 1;
@@ -207,6 +219,32 @@ impl ProxyClient {
             Ok(())
         } else {
             Err(format!("proxy invalidate: {}", String::from_utf8_lossy(&body)))
+        }
+    }
+
+    /// Best-effort: an older proxy rejects the op, and the caller wants the
+    /// build to proceed either way.
+    pub fn declare_upload(&self, cas_path: &str, instance: &str, upload: bool) -> Result<(), String> {
+        let mut stream = self.connect().map_err(|e| format!("proxy connect: {e}"))?;
+        write_request(
+            &mut stream,
+            &Request {
+                version: PROTOCOL_VERSION,
+                op: OP_DECLARE_UPLOAD,
+                cas_path: cas_path.to_string(),
+                instance: instance.to_string(),
+                payload: vec![u8::from(upload)],
+            },
+        )
+        .map_err(|e| format!("proxy send: {e}"))?;
+        let (status, body) = read_response(&mut stream).map_err(|e| format!("proxy recv: {e}"))?;
+        if status == STATUS_HIT {
+            Ok(())
+        } else {
+            Err(format!(
+                "proxy declare_upload: {}",
+                String::from_utf8_lossy(&body)
+            ))
         }
     }
 

--- a/cas-plugin/src/proxy_proto.rs
+++ b/cas-plugin/src/proxy_proto.rs
@@ -48,18 +48,6 @@ pub const OP_INVALIDATE: u8 = 3;
 /// yet (or that a prune removed). Runs on compiler worker threads, never on the
 /// build engine's serial task-setup path, so it may block on the remote.
 pub const OP_FETCH_OBJECT: u8 = 4;
-/// This build's upload policy, declared once per CAS create. Only the plugin
-/// reads `xcodeCache.upload` (it arrives as a compiler option, which the proxy
-/// never sees), but the proxy writes on its own behalf: a per-key hit queues a
-/// re-publish that ranks the entry back into the view. That write never passes
-/// through the plugin's check, so a machine configured not to upload was still
-/// writing to the server. payload = 1 byte, 0 = do not upload.
-///
-/// Additive on purpose: a proxy too old to know this op answers "bad op", the
-/// plugin ignores that, and the machine keeps the behaviour it has today. That
-/// is worth more than a protocol bump here, which a long-lived agent would turn
-/// into every build on the machine degrading to local-only until it restarts.
-pub const OP_DECLARE_UPLOAD: u8 = 5;
 
 pub const STATUS_MISS: u8 = 0;
 pub const STATUS_HIT: u8 = 1;
@@ -219,32 +207,6 @@ impl ProxyClient {
             Ok(())
         } else {
             Err(format!("proxy invalidate: {}", String::from_utf8_lossy(&body)))
-        }
-    }
-
-    /// Best-effort: an older proxy rejects the op, and the caller wants the
-    /// build to proceed either way.
-    pub fn declare_upload(&self, cas_path: &str, instance: &str, upload: bool) -> Result<(), String> {
-        let mut stream = self.connect().map_err(|e| format!("proxy connect: {e}"))?;
-        write_request(
-            &mut stream,
-            &Request {
-                version: PROTOCOL_VERSION,
-                op: OP_DECLARE_UPLOAD,
-                cas_path: cas_path.to_string(),
-                instance: instance.to_string(),
-                payload: vec![u8::from(upload)],
-            },
-        )
-        .map_err(|e| format!("proxy send: {e}"))?;
-        let (status, body) = read_response(&mut stream).map_err(|e| format!("proxy recv: {e}"))?;
-        if status == STATUS_HIT {
-            Ok(())
-        } else {
-            Err(format!(
-                "proxy declare_upload: {}",
-                String::from_utf8_lossy(&body)
-            ))
         }
     }
 

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -284,24 +284,6 @@ fn authed_request<T>(message: T, auth: Option<&AuthValue>) -> tonic::Request<T> 
     request
 }
 
-/// The git branch a publish is attributed to, so kura can scope a trunk
-/// snapshot to it. Sourced from the environment for now — the validation
-/// harness sets it per build; the production path will carry it per publish
-/// from the plugin's `OP_PUBLISH` (the CLI bakes the branch as a plugin option).
-fn env_branch() -> Option<String> {
-    std::env::var("TUIST_CAS_BRANCH")
-        .ok()
-        .filter(|value| !value.is_empty())
-}
-
-/// The trunk branch a snapshot fetch asks kura to scope to (e.g. "main"). When
-/// unset, kura serves the unscoped snapshot exactly as before.
-fn env_trunk_branch() -> Option<String> {
-    std::env::var("TUIST_CAS_TRUNK_BRANCH")
-        .ok()
-        .filter(|value| !value.is_empty())
-}
-
 impl Remote {
     pub fn new(config: RemoteConfig, tokens: Arc<TokenProvider>) -> Arc<Self> {
         Arc::new(Self {
@@ -485,7 +467,11 @@ impl Remote {
     /// server has no snapshot support (an ordinary not-found), and the caller
     /// stays on the per-key path.
     /// `after` asks for a delta: only entries written after that watermark.
-    pub fn get_snapshot(&self, after: Option<u64>) -> Result<Option<Vec<u8>>, String> {
+    pub fn get_snapshot(
+        &self,
+        after: Option<u64>,
+        trunk: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
         let mut client = self.ac_client()?;
         let mut inline_output_files = vec!["*".to_string()];
         if let Some(after) = after {
@@ -497,12 +483,11 @@ impl Remote {
             inline_output_files,
             ..Default::default()
         };
-        let trunk = env_trunk_branch();
         let response = retry_call(|| {
             runtime().block_on(client.get_action_result(self.authed_with(
                 request.clone(),
                 "x-tuist-trunk-branch",
-                trunk.as_deref(),
+                trunk,
             )))
         });
         match response {
@@ -655,7 +640,13 @@ impl Remote {
 
     /// Publishes the entry. Called only after every blob in the manifest is
     /// known to be on the server.
-    pub fn update_action(&self, key: &[u8], manifest: &[ManifestEntry]) -> Result<(), String> {
+    pub fn update_action(
+        &self,
+        key: &[u8],
+        manifest: &[ManifestEntry],
+        branch: Option<&str>,
+        trunk: Option<&str>,
+    ) -> Result<(), String> {
         let started = Instant::now();
         let result = (|| {
             let mut client = self.ac_client()?;
@@ -676,17 +667,11 @@ impl Remote {
                 action_result: Some(action_result),
                 ..Default::default()
             };
-            let branch = env_branch();
-            let trunk = env_trunk_branch();
             retry_call(|| {
                 // The trunk rides the write too: kura keeps trunk-baseline
                 // keys sticky against feature-branch republishes.
-                let mut request = self.authed_with(
-                    request.clone(),
-                    "x-tuist-branch",
-                    branch.as_deref(),
-                );
-                if let Some(trunk) = trunk.as_deref().filter(|trunk| !trunk.is_empty()) {
+                let mut request = self.authed_with(request.clone(), "x-tuist-branch", branch);
+                if let Some(trunk) = trunk.filter(|trunk| !trunk.is_empty()) {
                     if let Ok(value) = tonic::metadata::MetadataValue::try_from(trunk) {
                         request.metadata_mut().insert("x-tuist-trunk-branch", value);
                     }

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -284,6 +284,24 @@ fn authed_request<T>(message: T, auth: Option<&AuthValue>) -> tonic::Request<T> 
     request
 }
 
+/// The git branch a publish is attributed to, so kura can scope a trunk
+/// snapshot to it. Sourced from the environment for now — the validation
+/// harness sets it per build; the production path will carry it per publish
+/// from the plugin's `OP_PUBLISH` (the CLI bakes the branch as a plugin option).
+fn env_branch() -> Option<String> {
+    std::env::var("TUIST_CAS_BRANCH")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+/// The trunk branch a snapshot fetch asks kura to scope to (e.g. "main"). When
+/// unset, kura serves the unscoped snapshot exactly as before.
+fn env_trunk_branch() -> Option<String> {
+    std::env::var("TUIST_CAS_TRUNK_BRANCH")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
 impl Remote {
     pub fn new(config: RemoteConfig, tokens: Arc<TokenProvider>) -> Arc<Self> {
         Arc::new(Self {
@@ -305,6 +323,25 @@ impl Remote {
 
     fn authed<T>(&self, message: T) -> tonic::Request<T> {
         authed_request(message, self.authorization().as_ref())
+    }
+
+    /// An authed request carrying one extra ASCII metadata header (e.g. the
+    /// branch a publish is attributed to). A malformed value is dropped rather
+    /// than failing the call — the header is advisory and kura defaults without
+    /// it.
+    fn authed_with<T>(
+        &self,
+        message: T,
+        header: &'static str,
+        value: Option<&str>,
+    ) -> tonic::Request<T> {
+        let mut request = self.authed(message);
+        if let Some(value) = value.filter(|value| !value.is_empty()) {
+            if let Ok(value) = tonic::metadata::MetadataValue::try_from(value) {
+                request.metadata_mut().insert(header, value);
+            }
+        }
+        request
     }
 
     fn channel(&self) -> Result<Channel, String> {
@@ -460,8 +497,13 @@ impl Remote {
             inline_output_files,
             ..Default::default()
         };
+        let trunk = env_trunk_branch();
         let response = retry_call(|| {
-            runtime().block_on(client.get_action_result(self.authed(request.clone())))
+            runtime().block_on(client.get_action_result(self.authed_with(
+                request.clone(),
+                "x-tuist-trunk-branch",
+                trunk.as_deref(),
+            )))
         });
         match response {
             Ok(response) => Ok(response
@@ -634,8 +676,22 @@ impl Remote {
                 action_result: Some(action_result),
                 ..Default::default()
             };
+            let branch = env_branch();
+            let trunk = env_trunk_branch();
             retry_call(|| {
-                runtime().block_on(client.update_action_result(self.authed(request.clone())))
+                // The trunk rides the write too: kura keeps trunk-baseline
+                // keys sticky against feature-branch republishes.
+                let mut request = self.authed_with(
+                    request.clone(),
+                    "x-tuist-branch",
+                    branch.as_deref(),
+                );
+                if let Some(trunk) = trunk.as_deref().filter(|trunk| !trunk.is_empty()) {
+                    if let Ok(value) = tonic::metadata::MetadataValue::try_from(trunk) {
+                        request.metadata_mut().insert("x-tuist-trunk-branch", value);
+                    }
+                }
+                runtime().block_on(client.update_action_result(request))
             })
             .map_err(|status| format!("update_action: {status}"))?;
             Ok(())

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -75,17 +75,6 @@ pub fn reapi_instance(full_handle: &str) -> &str {
         .unwrap_or(full_handle)
 }
 
-impl RemoteConfig {
-    pub fn from_env() -> Option<Self> {
-        let grpc_url = std::env::var("TUIST_CAS_REMOTE_GRPC_URL").ok()?;
-        let project = std::env::var("TUIST_CAS_PROJECT").unwrap_or_else(|_| "tuist".into());
-        Some(Self {
-            grpc_url,
-            instance: reapi_instance(&project).to_string(),
-        })
-    }
-}
-
 pub struct Node {
     pub refs: Vec<Vec<u8>>,
     pub data: Vec<u8>,

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -307,21 +307,35 @@ impl Remote {
         authed_request(message, self.authorization().as_ref())
     }
 
-    /// An authed request carrying one extra ASCII metadata header (e.g. the
-    /// branch a publish is attributed to). A malformed value is dropped rather
-    /// than failing the call — the header is advisory and kura defaults without
-    /// it.
+    /// An authed request carrying a git ref (the branch a publish is attributed
+    /// to, or the trunk to scope a view by) as metadata.
+    ///
+    /// Sent twice, and both are load-bearing. Git allows any UTF-8 in a ref name,
+    /// but an ASCII metadata value takes visible ASCII only, so `feature/café`
+    /// fails to convert and used to be dropped in silence: the publish went out
+    /// untagged, or the view came back unscoped, and nothing said why. The `-bin`
+    /// header carries the bytes whatever they are.
+    ///
+    /// The ASCII header stays because a node that predates the binary one reads
+    /// only that, and dropping it would untag every ASCII ref on the way through
+    /// a rolling deploy. So: ASCII when it fits, bytes always, and a reader takes
+    /// the binary one first.
     fn authed_with<T>(
         &self,
         message: T,
         header: &'static str,
+        binary_header: &'static str,
         value: Option<&str>,
     ) -> tonic::Request<T> {
         let mut request = self.authed(message);
         if let Some(value) = value.filter(|value| !value.is_empty()) {
-            if let Ok(value) = tonic::metadata::MetadataValue::try_from(value) {
-                request.metadata_mut().insert(header, value);
+            if let Ok(ascii) = tonic::metadata::MetadataValue::try_from(value) {
+                request.metadata_mut().insert(header, ascii);
             }
+            request.metadata_mut().insert_bin(
+                binary_header,
+                tonic::metadata::MetadataValue::from_bytes(value.as_bytes()),
+            );
         }
         request
     }
@@ -487,6 +501,7 @@ impl Remote {
             runtime().block_on(client.get_action_result(self.authed_with(
                 request.clone(),
                 "x-tuist-trunk-branch",
+                "x-tuist-trunk-branch-bin",
                 trunk,
             )))
         });
@@ -670,11 +685,20 @@ impl Remote {
             retry_call(|| {
                 // The trunk rides the write too: kura keeps trunk-baseline
                 // keys sticky against feature-branch republishes.
-                let mut request = self.authed_with(request.clone(), "x-tuist-branch", branch);
+                let mut request = self.authed_with(
+                    request.clone(),
+                    "x-tuist-branch",
+                    "x-tuist-branch-bin",
+                    branch,
+                );
                 if let Some(trunk) = trunk.filter(|trunk| !trunk.is_empty()) {
                     if let Ok(value) = tonic::metadata::MetadataValue::try_from(trunk) {
                         request.metadata_mut().insert("x-tuist-trunk-branch", value);
                     }
+                    request.metadata_mut().insert_bin(
+                        "x-tuist-trunk-branch-bin",
+                        tonic::metadata::MetadataValue::from_bytes(trunk.as_bytes()),
+                    );
                 }
                 runtime().block_on(client.update_action_result(request))
             })

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -415,8 +415,15 @@ public struct Environment: Environmenting {
         "tuist.cache.\(fullHandle.replacingOccurrences(of: "/", with: "_"))"
     }
 
+    /// Anchored to `HOME` rather than `stateDirectory` on purpose, even though the
+    /// two agree by default. `stateDirectory` honors `XDG_STATE_HOME`, and the
+    /// plugin resolves this same path from `HOME` alone inside compiler frontends,
+    /// which carry no CLI environment (`default_proxy_socket` in cas-plugin says so
+    /// on its side). Honoring XDG here would point Xcode at a socket the proxy is
+    /// not listening on, and Xcode answers an unreachable service by retrying every
+    /// cache request rather than failing fast.
     public func casProxySocketPath() -> AbsolutePath {
-        stateDirectory.appending(component: "cas-proxy.sock")
+        homeDirectory.appending(components: [".local", "state", "tuist", "cas-proxy.sock"])
     }
 
     public func casProxySocketPathString() -> String {

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -80,6 +80,14 @@ public protocol Environmenting: Sendable {
     /// A cache socket path string for a given full handle with $HOME prefix to be environment-independent
     func cacheSocketPathString(for fullHandle: String) -> String
 
+    /// The machine-wide CAS proxy's unix socket. Unlike `cacheSocketPath(for:)` this
+    /// is not per-project: one proxy serves every project on the machine.
+    func casProxySocketPath() -> AbsolutePath
+
+    /// The CAS proxy's socket with a $HOME prefix, to be environment-independent when
+    /// baked into a build setting.
+    func casProxySocketPathString() -> String
+
     /// Returns the LaunchAgent label for the per-project Xcode cache daemon (the
     /// non-kura path) of the given full handle. Shared between `tuist setup cache`
     /// (which registers the LaunchAgent) and `tuist teardown cache` (which boots it out).
@@ -405,6 +413,26 @@ public struct Environment: Environmenting {
 
     public func cacheLaunchAgentLabel(for fullHandle: String) -> String {
         "tuist.cache.\(fullHandle.replacingOccurrences(of: "/", with: "_"))"
+    }
+
+    public func casProxySocketPath() -> AbsolutePath {
+        stateDirectory.appending(component: "cas-proxy.sock")
+    }
+
+    public func casProxySocketPathString() -> String {
+        homeRelative(casProxySocketPath())
+    }
+
+    /// A path with its `$HOME` prefix restored, so a value baked into a build
+    /// setting does not hard-code one machine's home directory.
+    private func homeRelative(_ path: AbsolutePath) -> String {
+        let pathString = path.pathString
+        let homeDirectoryPathString = homeDirectory.pathString
+        if pathString.hasPrefix(homeDirectoryPathString) {
+            return "$HOME" + pathString.dropFirst(homeDirectoryPathString.count)
+        } else {
+            return pathString
+        }
     }
 
     public func casProxyLaunchAgentLabel() -> String {

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -87,6 +87,14 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
         "tuist.cache.\(fullHandle.replacingOccurrences(of: "/", with: "_"))"
     }
 
+    public func casProxySocketPath() -> AbsolutePath {
+        stateDirectory.appending(component: "cas-proxy.sock")
+    }
+
+    public func casProxySocketPathString() -> String {
+        "$HOME/cas-proxy.sock"
+    }
+
     public func casProxyLaunchAgentLabel() -> String {
         "tuist.cas-proxy"
     }

--- a/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
@@ -80,8 +80,8 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
                     //
                     // The path points at the machine-wide proxy, not a per-project daemon,
                     // and the plugin CONSUMES this option rather than forwarding it to the
-                    // wrapped Apple plugin — whose own remote client would otherwise run its
-                    // much slower choreography against this socket. So it turns the lane on
+                    // wrapped Apple plugin, whose own remote client would otherwise run its
+                    // much slower choreography against this socket. So the flag flips
                     // without handing Apple's client the connection.
                     baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = .string(
                         Environment.current.casProxySocketPathString()

--- a/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
@@ -56,31 +56,35 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
                     // Hand the plugin its per-project options as compiler flags, which
                     // reach every frontend — including an Xcode ⌘B build that carries
                     // no CLI environment — so the proxy can route (and honor the upload
-                    // policy) without the CLI.
-                    //
-                    // Swift only: clang/ObjC never loads the CAS plugin (Xcode routes its
-                    // compilation caching to the builtin CAS at
-                    // `DerivedData/CompilationCache.noindex/builtin`), so C/ObjC/module/PCH
-                    // is cached locally but never published. This is the single largest
-                    // limit on how much of a build a remote cache can replay, and it is
-                    // Apple's to lift — no build setting changes it.
-                    //
-                    // It is worth being precise about what it costs, because it is easy to
-                    // misread as the cache being ineffective: the builtin CAS lives under
-                    // the shared DerivedData root, so wiping DerivedData deletes it. A
-                    // from-scratch build then restores every Swift key from the remote
-                    // snapshot and recompiles all of clang — measured on mastodon as 378
-                    // misses that are 100% clang (PCM/PrecompileModule/CompileC) with 0
-                    // Swift. The clang keys themselves are stable: keep that CAS across a
-                    // wipe and the same build replays 930/930 (70s -> 23s). Closing it
-                    // means seeding the builtin CAS, not tuning anything here.
-                    //
-                    // Corollary for anyone cleaning: drop Build products and keep
-                    // `CompilationCache.noindex`, and a rebuild replays completely.
+                    // policy) without the CLI. These reach Swift only; the setting below
+                    // is what brings clang in.
                     baseSettings["OTHER_SWIFT_FLAGS"] = Self.appendingCASPluginOptions(
                         fullHandle: fullHandle,
                         upload: tuist.xcodeCache.upload,
                         to: baseSettings["OTHER_SWIFT_FLAGS"]
+                    )
+                    // This is what makes C/ObjC, precompiled modules and PCHs shareable,
+                    // and it is easy to mistake for the legacy daemon's socket setting.
+                    //
+                    // clang does not load a CAS plugin, so left alone it caches only into
+                    // Xcode's builtin CAS, which never leaves the machine. The build system
+                    // covers clang itself instead, but only where it considers a remote
+                    // cache present, and it decides that purely by `remoteServicePath != nil`
+                    // (swift-build's `CASOptions.hasRemoteCache`). That one flag gates both
+                    // halves: uploading a clang or module output after a successful compile,
+                    // and requesting the materialize-key task that fetches one back. Leave
+                    // this unset and neither happens, so every C/ObjC/PCM/PCH compile stays
+                    // local and a machine with a cold cache recompiles all of it. Measured on
+                    // mastodon against an empty CAS: 259/930 tasks cached without this,
+                    // 930/930 with it.
+                    //
+                    // The path points at the machine-wide proxy, not a per-project daemon,
+                    // and the plugin CONSUMES this option rather than forwarding it to the
+                    // wrapped Apple plugin — whose own remote client would otherwise run its
+                    // much slower choreography against this socket. So it turns the lane on
+                    // without handing Apple's client the connection.
+                    baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = .string(
+                        Environment.current.casProxySocketPathString()
                     )
                 } else {
                     // Kura is enabled but the bundled dylib is absent, so the build

--- a/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
@@ -56,9 +56,27 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
                     // Hand the plugin its per-project options as compiler flags, which
                     // reach every frontend — including an Xcode ⌘B build that carries
                     // no CLI environment — so the proxy can route (and honor the upload
-                    // policy) without the CLI. Swift only: clang/ObjC never loads the CAS
-                    // plugin (Xcode routes its compilation caching to the builtin CAS),
-                    // so C/ObjC is cached locally but never remote.
+                    // policy) without the CLI.
+                    //
+                    // Swift only: clang/ObjC never loads the CAS plugin (Xcode routes its
+                    // compilation caching to the builtin CAS at
+                    // `DerivedData/CompilationCache.noindex/builtin`), so C/ObjC/module/PCH
+                    // is cached locally but never published. This is the single largest
+                    // limit on how much of a build a remote cache can replay, and it is
+                    // Apple's to lift — no build setting changes it.
+                    //
+                    // It is worth being precise about what it costs, because it is easy to
+                    // misread as the cache being ineffective: the builtin CAS lives under
+                    // the shared DerivedData root, so wiping DerivedData deletes it. A
+                    // from-scratch build then restores every Swift key from the remote
+                    // snapshot and recompiles all of clang — measured on mastodon as 378
+                    // misses that are 100% clang (PCM/PrecompileModule/CompileC) with 0
+                    // Swift. The clang keys themselves are stable: keep that CAS across a
+                    // wipe and the same build replays 930/930 (70s -> 23s). Closing it
+                    // means seeding the builtin CAS, not tuning anything here.
+                    //
+                    // Corollary for anyone cleaning: drop Build products and keep
+                    // `CompilationCache.noindex`, and a rebuild replays completely.
                     baseSettings["OTHER_SWIFT_FLAGS"] = Self.appendingCASPluginOptions(
                         fullHandle: fullHandle,
                         upload: tuist.xcodeCache.upload,

--- a/cli/Sources/TuistGit/GitController.swift
+++ b/cli/Sources/TuistGit/GitController.swift
@@ -211,6 +211,24 @@ public struct GitController: GitControlling {
         "BUILD_SOURCEBRANCHNAME",
     ]
 
+    /// GitHub's branch, for the events `GITHUB_HEAD_REF` does not cover.
+    ///
+    /// That variable is defined for pull requests and nothing else, so a push, or
+    /// a workflow that checks out an explicit SHA, falls through to git. A
+    /// detached checkout leaves git unable to name the branch either, and the
+    /// build then reports no branch at all.
+    ///
+    /// `GITHUB_REF_NAME` is set on every event, but on a tag push it names the
+    /// tag, and a tag is not a branch: recording one would attribute the build to
+    /// a ref no trunk can ever match. `GITHUB_REF_TYPE` is what separates them.
+    private static func githubBranch(environment: [String: String]) -> String? {
+        guard environment["GITHUB_REF_TYPE"] == "branch",
+              let name = environment["GITHUB_REF_NAME"],
+              !name.isEmpty
+        else { return nil }
+        return name
+    }
+
     public func gitInfo(workingDirectory: AbsolutePath) async throws -> GitInfo {
         let environment = environment.variables
 
@@ -239,6 +257,7 @@ public struct GitController: GitControlling {
         let ciBranch = Self.branchEnvironmentVariables
             .compactMap { environment[$0] }
             .first { !$0.isEmpty }
+            ?? Self.githubBranch(environment: environment)
 
         let branchName: String?
         if let ciBranch {

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -217,7 +217,7 @@ struct SetupCacheCommandService {
                 COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES
                 OTHER_SWIFT_FLAGS=$(inherited) -cas-plugin-option tuist-instance=\(fullHandle)
 
-                `COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what lets C, Objective-C and precompiled modules be shared too — without it only Swift is, and a machine with a cold cache recompiles the rest.
+                `COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what lets C, Objective-C and precompiled modules be shared too. Without it only Swift is shared, and a machine with a cold cache recompiles the rest.
 
                 `COMPILATION_CACHE_ENABLE_PLUGIN`, `COMPILATION_CACHE_PLUGIN_PATH` and `COMPILATION_CACHE_REMOTE_SERVICE_PATH` are not directly exposed by Xcode; add them as user-defined build settings. See the docs for the plugin path: https://tuist.dev/en/docs/guides/features/cache/xcode-cache
                 """

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -35,14 +35,11 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
 /// What setup knows about a project that the proxy cannot work out for itself
 /// (see `load_sources` in cas-plugin).
 ///
-/// A row is the instance followed by `key=value` fields, tab separated. The
-/// fields are named rather than positional because every value here is optional,
-/// and a positional row has to hold an absent one's place: a branch recorded
-/// without a trunk leaves an empty column, and anything that drops empties reads
-/// the branch as the trunk. Naming them also means a field added later cannot
-/// shift the ones already there, and that a reader can ignore what it does not
-/// know. Git forbids tabs in a ref, so no value can contain the separator.
-private struct RegisteredSource {
+/// The registry is a JSON object of instance -> this. JSON because we write it
+/// and the proxy reads it from another language: a format each side hand-rolls
+/// is one each side can drift on, and every value here is optional, which is the
+/// shape a hand-rolled one gets wrong first.
+private struct RegisteredSource: Codable {
     /// The project's configured default branch, which is a server-side decision.
     /// The proxy would otherwise have to guess it from the local clone's
     /// `origin/HEAD`, a property of how this machine cloned rather than of the
@@ -56,34 +53,23 @@ private struct RegisteredSource {
     /// with no plugin options at all. Recorded here so one answer covers both.
     let upload: Bool
 
-    static func from(row: Substring) -> (instance: String, source: RegisteredSource)? {
-        let fields = row.split(separator: "\t")
-        guard let instance = fields.first, !instance.isEmpty else { return nil }
-        var values: [String: String] = [:]
-        for field in fields.dropFirst() {
-            // A ref may contain `=`, so only the first one separates.
-            let pair = field.split(separator: "=", maxSplits: 1)
-            guard pair.count == 2 else { continue }
-            values[String(pair[0])] = String(pair[1])
-        }
-        return (
-            String(instance),
-            RegisteredSource(
-                trunk: values["trunk"],
-                branch: values["branch"],
-                // Nothing recorded is nothing to withhold.
-                upload: values["upload"] != "0"
-            )
-        )
+    init(trunk: String?, branch: String?, upload: Bool) {
+        self.trunk = trunk
+        self.branch = branch
+        self.upload = upload
     }
 
-    func row(instance: String) -> String {
-        var fields = [instance]
-        if let trunk, !trunk.isEmpty { fields.append("trunk=\(trunk)") }
-        if let branch, !branch.isEmpty { fields.append("branch=\(branch)") }
-        // Uploading is the default, so this only appears when it says no.
-        if !upload { fields.append("upload=0") }
-        return fields.joined(separator: "\t")
+    /// Hand-written rather than synthesized, so that an absent field means here
+    /// what it means to the proxy. The synthesized one requires every
+    /// non-optional, which would make this side reject a registry the proxy
+    /// reads happily: the drift that using one format on both sides exists to
+    /// prevent.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        trunk = try container.decodeIfPresent(String.self, forKey: .trunk)
+        branch = try container.decodeIfPresent(String.self, forKey: .branch)
+        // Nothing recorded is nothing to withhold (`uploads_by_default` there).
+        upload = try container.decodeIfPresent(Bool.self, forKey: .upload) ?? true
     }
 }
 
@@ -179,20 +165,22 @@ struct SetupCacheCommandService {
             )
         }
 
-        // Read every other project's row back: this rewrites the whole file, so
-        // anything dropped here is a project silently losing its policy.
+        // Read every other project back: this rewrites the whole file, so anything
+        // lost here is a project silently losing its policy. A registry we cannot
+        // decode therefore fails the command rather than being written over with
+        // just this project, which would erase every other one's.
         var entries: [String: RegisteredSource] = [:]
         if try await fileSystem.exists(sourcesPath) {
-            for row in try await fileSystem.readTextFile(at: sourcesPath).split(separator: "\n") {
-                guard let (instance, source) = RegisteredSource.from(row: row) else { continue }
-                entries[instance] = source
-            }
+            let contents = try await fileSystem.readTextFile(at: sourcesPath)
+            entries = try JSONDecoder().decode([String: RegisteredSource].self, from: Data(contents.utf8))
         }
         entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
 
-        let body = entries.sorted { $0.key < $1.key }
-            .map { $0.value.row(instance: $0.key) }
-            .joined(separator: "\n") + "\n"
+        let encoder = JSONEncoder()
+        // Sorted so a rewrite that changes nothing produces the same bytes, and
+        // unescaped because every key here is an `account/project`.
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+        let body = String(decoding: try encoder.encode(entries), as: UTF8.self)
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
         }

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -204,6 +204,7 @@ struct SetupCacheCommandService {
                 )
             }
         } else if kuraEnabled {
+            let proxySocketPath = Environment.current.casProxySocketPathString()
             Logger.current.info(
                 """
                 Xcode Cache setup is almost complete!
@@ -212,10 +213,13 @@ struct SetupCacheCommandService {
                 COMPILATION_CACHE_ENABLE_CACHING=YES
                 COMPILATION_CACHE_ENABLE_PLUGIN=YES
                 COMPILATION_CACHE_PLUGIN_PATH=<path to libtuist_cas_plugin.dylib>
+                COMPILATION_CACHE_REMOTE_SERVICE_PATH=\(proxySocketPath)
                 COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES
                 OTHER_SWIFT_FLAGS=$(inherited) -cas-plugin-option tuist-instance=\(fullHandle)
 
-                `COMPILATION_CACHE_ENABLE_PLUGIN` and `COMPILATION_CACHE_PLUGIN_PATH` are not directly exposed by Xcode; add them as user-defined build settings. See the docs for the plugin path: https://tuist.dev/en/docs/guides/features/cache/xcode-cache
+                `COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what lets C, Objective-C and precompiled modules be shared too — without it only Swift is, and a machine with a cold cache recompiles the rest.
+
+                `COMPILATION_CACHE_ENABLE_PLUGIN`, `COMPILATION_CACHE_PLUGIN_PATH` and `COMPILATION_CACHE_REMOTE_SERVICE_PATH` are not directly exposed by Xcode; add them as user-defined build settings. See the docs for the plugin path: https://tuist.dev/en/docs/guides/features/cache/xcode-cache
                 """
             )
         } else {

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -36,6 +36,11 @@ private struct RegisteredSource {
     let trunk: String?
     /// Recorded only on CI. See `ciBranch`.
     let branch: String?
+    /// The project's `xcodeCache.upload`. The proxy is the only place that can
+    /// enforce this: the plugin reads it as a compiler option, which reaches
+    /// Swift, while the build system's Clang caching runs in its own process
+    /// with no plugin options at all. Recorded here so one answer covers both.
+    let upload: Bool
 }
 
 struct SetupCacheCommandService {
@@ -126,7 +131,8 @@ struct SetupCacheCommandService {
         fullHandle: String,
         sourceRoot: AbsolutePath,
         trunk: String?,
-        branch: String?
+        branch: String?,
+        upload: Bool
     ) async throws {
         // Derived from the proxy's OWN socket, not from `stateDirectory`. The two
         // agree by default and diverge under `XDG_STATE_HOME`, which the socket
@@ -167,12 +173,20 @@ struct SetupCacheCommandService {
                     entries[parts[0]] = RegisteredSource(
                         root: parts[1],
                         trunk: column(2),
-                        branch: column(3)
+                        branch: column(3),
+                        // Absent means a registry written before this column, and
+                        // uploading is what that machine already does.
+                        upload: column(4) != "0"
                     )
                 }
             }
         }
-        entries[fullHandle] = RegisteredSource(root: sourceRoot.pathString, trunk: trunk, branch: branch)
+        entries[fullHandle] = RegisteredSource(
+            root: sourceRoot.pathString,
+            trunk: trunk,
+            branch: branch,
+            upload: upload
+        )
 
         let body = entries.sorted { $0.key < $1.key }
             .map { key, value in
@@ -180,6 +194,12 @@ struct SetupCacheCommandService {
                 // still has to leave the trunk's place empty.
                 let trunk = value.trunk.flatMap { $0.isEmpty ? nil : $0 }
                 let branch = value.branch.flatMap { $0.isEmpty ? nil : $0 }
+                // Only written when it says something. Uploading is the default,
+                // so a row that omits it means the same thing, and rows written
+                // before this column survive a rewrite byte-identical.
+                if !value.upload {
+                    return "\(key)\t\(value.root)\t\(trunk ?? "")\t\(branch ?? "")\t0"
+                }
                 if let branch {
                     return "\(key)\t\(value.root)\t\(trunk ?? "")\t\(branch)"
                 }
@@ -232,7 +252,8 @@ struct SetupCacheCommandService {
                 fullHandle: fullHandle,
                 sourceRoot: path,
                 trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL),
-                branch: await ciBranch(sourceRoot: path)
+                branch: await ciBranch(sourceRoot: path),
+                upload: config.xcodeCache.upload
             )
             try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
         } else {

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -17,6 +17,7 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     case missingFullHandle
     case notAuthenticated
     case registryNotReplaced(String, Int32)
+    case registryNotLocked(String, Int32)
 
     var errorDescription: String? {
         switch self {
@@ -28,6 +29,8 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
                 "You must be authenticated to set up the cache. Run `tuist auth login` (or set the `TUIST_TOKEN` environment variable) and run `tuist setup cache` again."
         case let .registryNotReplaced(path, code):
             return "Could not update the cache proxy's registry at \(path) (errno \(code))."
+        case let .registryNotLocked(path, code):
+            return "Could not lock the cache proxy's registry at \(path) (errno \(code))."
         }
     }
 }
@@ -165,43 +168,77 @@ struct SetupCacheCommandService {
             )
         }
 
-        // Read every other project back: this rewrites the whole file, so anything
-        // lost here is a project silently losing its policy. A registry we cannot
-        // decode therefore fails the command rather than being written over with
-        // just this project, which would erase every other one's.
-        var entries: [String: RegisteredSource] = [:]
-        if try await fileSystem.exists(sourcesPath) {
-            let contents = try await fileSystem.readTextFile(at: sourcesPath)
-            entries = try JSONDecoder().decode([String: RegisteredSource].self, from: Data(contents.utf8))
-        }
-        entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
-
-        let encoder = JSONEncoder()
-        // Sorted so a rewrite that changes nothing produces the same bytes, and
-        // unescaped because every key here is an `account/project`.
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-        let body = String(decoding: try encoder.encode(entries), as: UTF8.self)
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
         }
-        // Swapped in, never rewritten in place, and `rename` rather than a remove
-        // followed by a write or a move: it is the only one of the three that
-        // leaves no instant where the file is missing or half-written.
-        //
-        // The proxy re-reads this on a timer while we write it, and it carries
-        // the upload policy. A reader that finds no file sees no projects, and an
-        // unknown project has to be allowed to upload, so any gap here hands an
-        // opted-out project a window in which its Clang outputs are published.
-        // `rename` gives every reader either the whole old file or the whole new
-        // one, and both are answers we can live with.
-        let staged = sourcesPath.parentDirectory
-            .appending(component: "\(sourcesPath.basename).\(UUID().uuidString)")
-        try await fileSystem.writeText(body, at: staged)
-        guard rename(staged.pathString, sourcesPath.pathString) == 0 else {
-            let code = errno
-            try? await fileSystem.remove(staged)
-            throw SetupCacheCommandServiceError.registryNotReplaced(sourcesPath.pathString, code)
+
+        // The whole read-modify-write is serialized across processes. Atomic
+        // rename gives a READER the old file or the new one, never a torn one,
+        // but it does nothing for two setups racing: both read the registry
+        // before either renames, and the later rename drops the project the
+        // earlier one added, silently losing its trunk and upload policy. An
+        // exclusive lock on a sidecar file makes the second setup wait for the
+        // first, so it reads the already-updated registry and upserts onto it.
+        let lockPath = sourcesPath.parentDirectory
+            .appending(component: "\(sourcesPath.basename).lock")
+        try await withRegistryLock(at: lockPath) {
+            // Read every other project back: this rewrites the whole file, so
+            // anything lost here is a project silently losing its policy. A
+            // registry we cannot decode therefore fails the command rather than
+            // being written over with just this project, which would erase every
+            // other one's.
+            var entries: [String: RegisteredSource] = [:]
+            if try await fileSystem.exists(sourcesPath) {
+                let contents = try await fileSystem.readTextFile(at: sourcesPath)
+                entries = try JSONDecoder().decode([String: RegisteredSource].self, from: Data(contents.utf8))
+            }
+            entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
+
+            let encoder = JSONEncoder()
+            // Sorted so a rewrite that changes nothing produces the same bytes,
+            // and unescaped because every key here is an `account/project`.
+            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+            let body = String(decoding: try encoder.encode(entries), as: UTF8.self)
+
+            // Swapped in, never rewritten in place, and `rename` rather than a
+            // remove followed by a write or a move: it is the only one of the
+            // three that leaves no instant where the file is missing or
+            // half-written.
+            //
+            // The proxy re-reads this on a timer while we write it, and it
+            // carries the upload policy. A reader that finds no file sees no
+            // projects, and an unknown project has to be allowed to upload, so
+            // any gap here hands an opted-out project a window in which its Clang
+            // outputs are published. `rename` gives every reader either the whole
+            // old file or the whole new one, and both are answers we can live
+            // with.
+            let staged = sourcesPath.parentDirectory
+                .appending(component: "\(sourcesPath.basename).\(UUID().uuidString)")
+            try await fileSystem.writeText(body, at: staged)
+            guard rename(staged.pathString, sourcesPath.pathString) == 0 else {
+                let code = errno
+                try? await fileSystem.remove(staged)
+                throw SetupCacheCommandServiceError.registryNotReplaced(sourcesPath.pathString, code)
+            }
         }
+    }
+
+    /// Runs `body` while holding an exclusive advisory lock on `lockPath`, so two
+    /// `tuist setup cache` processes cannot interleave a read-modify-write of the
+    /// registry. The lock file is created on demand and never removed: deleting
+    /// it would reopen the race it closes. `flock` is released when the descriptor
+    /// closes, including on a crash, so a killed setup cannot wedge the next one.
+    private func withRegistryLock(at lockPath: AbsolutePath, _ body: () async throws -> Void) async throws {
+        let descriptor = open(lockPath.pathString, O_CREAT | O_RDWR, 0o644)
+        guard descriptor >= 0 else {
+            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+        }
+        defer { close(descriptor) }
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        try await body()
     }
 
     func run(

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -34,19 +34,59 @@ struct SetupCacheCommandService {
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let manifestLoader: ManifestLoading
+    private let fileSystem: FileSysteming
 
     init(
         launchAgentService: LaunchAgentServicing = LaunchAgentService(),
         configLoader: ConfigLoading = ConfigLoader(),
         serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
         serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
-        manifestLoader: ManifestLoading = ManifestLoader.current
+        manifestLoader: ManifestLoading = ManifestLoader.current,
+        fileSystem: FileSysteming = FileSystem()
     ) {
         self.launchAgentService = launchAgentService
         self.configLoader = configLoader
         self.serverEnvironmentService = serverEnvironmentService
         self.serverAuthenticationController = serverAuthenticationController
         self.manifestLoader = manifestLoader
+        self.fileSystem = fileSystem
+    }
+
+    /// Records `fullHandle -> sourceRoot` in the proxy's sources registry
+    /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). The proxy derives
+    /// the branch and trunk of every publish live from this repo's git HEAD, so
+    /// nothing branch-specific is baked into a build setting. Upserts so setting
+    /// up a second project does not clobber the first.
+    private func registerSourceRoot(fullHandle: String, sourceRoot: AbsolutePath) async throws {
+        let sourcesPath: AbsolutePath
+        if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
+            sourcesPath = try AbsolutePath(validating: registry + ".sources")
+        } else {
+            sourcesPath = Environment.current.stateDirectory
+                .appending(component: "cas-proxy.sock.registry.sources")
+        }
+
+        var entries: [String: String] = [:]
+        if try await fileSystem.exists(sourcesPath) {
+            let contents = try await fileSystem.readTextFile(at: sourcesPath)
+            for line in contents.split(separator: "\n") {
+                let parts = line.split(separator: "\t", maxSplits: 1).map(String.init)
+                if parts.count == 2 { entries[parts[0]] = parts[1] }
+            }
+        }
+        entries[fullHandle] = sourceRoot.pathString
+
+        let body = entries.sorted { $0.key < $1.key }
+            .map { "\($0.key)\t\($0.value)" }
+            .joined(separator: "\n") + "\n"
+        if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
+            try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
+        }
+        if try await fileSystem.exists(sourcesPath) {
+            try await fileSystem.remove(sourcesPath)
+        }
+        try await fileSystem.writeText(body, at: sourcesPath)
     }
 
     func run(
@@ -74,6 +114,7 @@ struct SetupCacheCommandService {
         let kuraEnabled = ClientFeatureFlags.contains("kura")
         if kuraEnabled {
             try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
+            try await registerSourceRoot(fullHandle: fullHandle, sourceRoot: path)
         } else {
             try await installLegacyDaemon(
                 fullHandle: fullHandle,

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -405,10 +405,14 @@ struct SetupCacheCommandService {
         // start together, so ingestion would race the build it is meant to help
         // and compete for the bandwidth that build's own demand fetches need. Our
         // runners have less use for it still: their CAS arrives warm on an
-        // attached volume, which is the mechanism there. The key cache (one round
-        // trip, orders of magnitude lighter) still applies on CI.
+        // attached volume, which is the mechanism there.
+        //
+        // `keys` and not `0`: the key cache is one round trip and orders of
+        // magnitude lighter than the bytes, and it is what gives a cold CI
+        // machine its breadth. Turning it off too would make every resolve a
+        // per-key round trip.
         if Environment.current.isCI {
-            environmentVariables["TUIST_CAS_INGEST_TRUNK"] = "0"
+            environmentVariables["TUIST_CAS_PREFETCH"] = "keys"
         }
 
         // One proxy per machine. Boot out any legacy per-project cache daemon so

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -128,12 +128,19 @@ struct SetupCacheCommandService {
         trunk: String?,
         branch: String?
     ) async throws {
+        // Derived from the proxy's OWN socket, not from `stateDirectory`. The two
+        // agree by default and diverge under `XDG_STATE_HOME`, which the socket
+        // deliberately ignores (see `casProxySocketPath`) because the plugin must
+        // resolve it from HOME alone. Writing this file where the proxy is not
+        // reading loses the source root and trunk silently: unscoped snapshots and
+        // untagged publishes, with nothing to show for it.
         let sourcesPath: AbsolutePath
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
             sourcesPath = try AbsolutePath(validating: registry + ".sources")
         } else {
-            sourcesPath = Environment.current.stateDirectory
-                .appending(component: "cas-proxy.sock.registry.sources")
+            sourcesPath = try AbsolutePath(
+                validating: Environment.current.casProxySocketPath().pathString + ".registry.sources"
+            )
         }
 
         // instance -> (source root, trunk, branch). Both trailing columns are
@@ -337,6 +344,11 @@ struct SetupCacheCommandService {
         // endpoint at launch.
         if let cacheEndpoint = Environment.current.variables["TUIST_CACHE_ENDPOINT"] {
             environmentVariables["TUIST_CACHE_ENDPOINT"] = cacheEndpoint
+        }
+        // Without this the agent falls back to `<socket>.registry` and never reads
+        // the sources file written beside the override above.
+        if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
+            environmentVariables["TUIST_CAS_PROXY_REGISTRY"] = registry
         }
 
         // One proxy per machine. Boot out any legacy per-project cache daemon so

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -156,12 +156,18 @@ struct SetupCacheCommandService {
         // they rely on today, until they are migrated to kura.
         let kuraEnabled = ClientFeatureFlags.contains("kura")
         if kuraEnabled {
-            try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
+            // Register the source root BEFORE starting the proxy. The proxy
+            // prefetches a snapshot for every instance it already knows as soon as
+            // it boots, and it keys that snapshot by instance alone: if it starts
+            // first, an upgraded machine prefetches an unscoped view and keeps
+            // serving it until the next full refresh, however promptly the mapping
+            // lands afterwards.
             try await registerSourceRoot(
                 fullHandle: fullHandle,
                 sourceRoot: path,
                 trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL)
             )
+            try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
         } else {
             try await installLegacyDaemon(
                 fullHandle: fullHandle,

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -151,12 +151,23 @@ struct SetupCacheCommandService {
         if try await fileSystem.exists(sourcesPath) {
             let contents = try await fileSystem.readTextFile(at: sourcesPath)
             for line in contents.split(separator: "\n") {
-                let parts = line.split(separator: "\t", maxSplits: 3).map(String.init)
-                if parts.count >= 2 {
+                // `omittingEmptySubsequences: false` is load-bearing: the columns
+                // are positional, and a branch known without a trunk writes the
+                // trunk's place empty. Dropping empty fields would shift the
+                // branch into the trunk's column and silently rewrite it that way
+                // for every OTHER project, since this rewrites the whole file.
+                let parts = line
+                    .split(separator: "\t", maxSplits: 3, omittingEmptySubsequences: false)
+                    .map(String.init)
+                if parts.count >= 2, !parts[0].isEmpty, !parts[1].isEmpty {
+                    let column = { (index: Int) -> String? in
+                        guard parts.count > index, !parts[index].isEmpty else { return nil }
+                        return parts[index]
+                    }
                     entries[parts[0]] = RegisteredSource(
                         root: parts[1],
-                        trunk: parts.count > 2 ? parts[2] : nil,
-                        branch: parts.count > 3 ? parts[3] : nil
+                        trunk: column(2),
+                        branch: column(3)
                     )
                 }
             }

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -32,10 +32,13 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     }
 }
 
-/// A row of the CAS proxy's sources registry, whose columns the proxy parses in
-/// this order (see `load_sources` in cas-plugin).
+/// What setup knows about a project that the proxy cannot work out for itself
+/// (see `load_sources` in cas-plugin).
 private struct RegisteredSource {
-    let root: String
+    /// The project's configured default branch, which is a server-side decision.
+    /// The proxy would otherwise have to guess it from the local clone's
+    /// `origin/HEAD`, a property of how this machine cloned rather than of the
+    /// project.
     let trunk: String?
     /// Recorded only on CI. See `ciBranch`.
     let branch: String?
@@ -76,31 +79,30 @@ struct SetupCacheCommandService {
         self.gitController = gitController
     }
 
-    /// The project's default branch, which is what a trunk-scoped cache snapshot
-    /// is anchored to. Best-effort: a setup that cannot reach the server still
-    /// installs a working cache, and the proxy falls back to deriving the trunk
-    /// from the checkout's `origin/HEAD`.
+    /// The project's default branch, which is what a trunk-scoped cache snapshot is
+    /// anchored to. Best-effort: a setup that cannot reach the server still installs
+    /// a working cache, and an unscoped snapshot is what this branch improves on
+    /// rather than a regression.
     private func trunkBranch(fullHandle: String, serverURL: URL) async -> String? {
         do {
             return try await getProjectService.getProject(fullHandle: fullHandle, serverURL: serverURL)
                 .defaultBranch
         } catch {
             Logger.current.debug(
-                "Could not resolve \(fullHandle)'s default branch for the cache proxy: \(error). The proxy will derive the trunk from the checkout instead."
+                "Could not resolve \(fullHandle)'s default branch for the cache proxy: \(error). Its snapshot will not be trunk-scoped."
             )
             return nil
         }
     }
 
-    /// The branch to record for a CI checkout, whose HEAD is detached and so tells
-    /// the proxy's `git rev-parse` nothing. Every provider exposes it in the
-    /// environment instead, which `GitController` already knows how to read, but
-    /// only this command runs inside the job and can see it: the proxy is a launchd
-    /// agent and does not inherit the job's environment.
+    /// The branch to record for a CI checkout. Only this command runs inside the
+    /// job and can see it: the proxy is a launchd agent and does not inherit the
+    /// job's environment, and a CI checkout's HEAD is detached, so nothing it
+    /// could read from the repository would answer either.
     ///
-    /// `nil` off CI on purpose. A developer's HEAD is attached, so the proxy
-    /// derives the branch live and stays correct across a `git checkout`, where a
-    /// value recorded once at setup would rot into mis-tagging every later publish.
+    /// `nil` off CI on purpose, which leaves a developer's publishes untagged and
+    /// therefore outside the trunk view. CI is the only publisher that view is
+    /// built from, so it is the only one whose branch has to be right.
     private func ciBranch(sourceRoot: AbsolutePath) async -> String? {
         guard Environment.current.isCI else { return nil }
         do {
@@ -113,26 +115,23 @@ struct SetupCacheCommandService {
         }
     }
 
-    /// Records `fullHandle -> sourceRoot, trunk, branch` in the proxy's sources
-    /// registry (`<state>/cas-proxy.sock.registry.sources`, honoring the same
-    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). Three things the proxy
-    /// cannot know on its own:
+    /// Records what the proxy cannot work out for itself in its sources registry
+    /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads): the project's trunk,
+    /// the branch when this is CI, and the upload policy.
     ///
-    /// - The source root, from which it derives the branch of every publish live
-    ///   off this repo's git HEAD. Nothing branch-specific is baked into a build
-    ///   setting, which would enter the compiler's cache key and split the cache
-    ///   per branch.
-    /// - The trunk, which is the *project's* configured default branch and hence
-    ///   a server-side decision. The proxy would otherwise have to guess it from
-    ///   the local clone's `origin/HEAD`, which is a property of how the machine
-    ///   cloned rather than of the project.
-    /// - The branch, but only on CI. See `ciBranch`: the proxy prefers its live
-    ///   git reading and only falls back to this when HEAD is detached.
+    /// A row is `instance` followed by `key=value` fields, tab separated. The
+    /// fields are named rather than positional because every value here is
+    /// optional, and a positional row has to hold an absent one's place: a branch
+    /// recorded without a trunk leaves an empty column, and anything that drops
+    /// empties reads the branch as the trunk. Naming them also means a field
+    /// added later cannot shift the ones already there, and that a reader can
+    /// ignore what it does not know. Git forbids tabs in a ref, so no value here
+    /// can contain the separator.
     ///
     /// Upserts, so setting up a second project does not clobber the first.
-    private func registerSourceRoot(
+    private func registerSource(
         fullHandle: String,
-        sourceRoot: AbsolutePath,
         trunk: String?,
         branch: String?,
         upload: Bool
@@ -141,8 +140,8 @@ struct SetupCacheCommandService {
         // agree by default and diverge under `XDG_STATE_HOME`, which the socket
         // deliberately ignores (see `casProxySocketPath`) because the plugin must
         // resolve it from HOME alone. Writing this file where the proxy is not
-        // reading loses the source root and trunk silently: unscoped snapshots and
-        // untagged publishes, with nothing to show for it.
+        // reading loses the trunk silently: unscoped snapshots and untagged
+        // publishes, with nothing to show for it.
         let sourcesPath: AbsolutePath
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
             sourcesPath = try AbsolutePath(validating: registry + ".sources")
@@ -152,64 +151,38 @@ struct SetupCacheCommandService {
             )
         }
 
-        // instance -> (source root, trunk, branch). Both trailing columns are
-        // optional: a registry written before either shipped, or by a setup that
-        // could not reach the server, still parses and leaves the proxy on its
-        // git-derived fallback.
+        // Read every other project's row back: this rewrites the whole file, so
+        // anything dropped here is a project silently losing its policy.
         var entries: [String: RegisteredSource] = [:]
         if try await fileSystem.exists(sourcesPath) {
             let contents = try await fileSystem.readTextFile(at: sourcesPath)
             for line in contents.split(separator: "\n") {
-                // `omittingEmptySubsequences: false` is load-bearing: the columns
-                // are positional, and a branch known without a trunk writes the
-                // trunk's place empty. Dropping empty fields would shift the
-                // branch into the trunk's column and silently rewrite it that way
-                // for every OTHER project, since this rewrites the whole file.
-                let parts = line
-                    .split(separator: "\t", maxSplits: 3, omittingEmptySubsequences: false)
-                    .map(String.init)
-                if parts.count >= 2, !parts[0].isEmpty, !parts[1].isEmpty {
-                    let column = { (index: Int) -> String? in
-                        guard parts.count > index, !parts[index].isEmpty else { return nil }
-                        return parts[index]
-                    }
-                    entries[parts[0]] = RegisteredSource(
-                        root: parts[1],
-                        trunk: column(2),
-                        branch: column(3),
-                        // Absent means a registry written before this column, and
-                        // uploading is what that machine already does.
-                        upload: column(4) != "0"
-                    )
+                var fields = line.split(separator: "\t").map(String.init)
+                guard !fields.isEmpty, !fields[0].isEmpty else { continue }
+                let instance = fields.removeFirst()
+                var values: [String: String] = [:]
+                for field in fields {
+                    guard let separator = field.firstIndex(of: "=") else { continue }
+                    // A ref may contain `=`, so only the first one separates.
+                    values[String(field[..<separator])] = String(field[field.index(after: separator)...])
                 }
+                entries[instance] = RegisteredSource(
+                    trunk: values["trunk"],
+                    branch: values["branch"],
+                    upload: values["upload"] != "0"
+                )
             }
         }
-        entries[fullHandle] = RegisteredSource(
-            root: sourceRoot.pathString,
-            trunk: trunk,
-            branch: branch,
-            upload: upload
-        )
+        entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
 
         let body = entries.sorted { $0.key < $1.key }
-            .map { key, value in
-                // The branch column is positional, so a branch without a trunk
-                // still has to leave the trunk's place empty.
-                let trunk = value.trunk.flatMap { $0.isEmpty ? nil : $0 }
-                let branch = value.branch.flatMap { $0.isEmpty ? nil : $0 }
-                // Only written when it says something. Uploading is the default,
-                // so a row that omits it means the same thing, and rows written
-                // before this column survive a rewrite byte-identical.
-                if !value.upload {
-                    return "\(key)\t\(value.root)\t\(trunk ?? "")\t\(branch ?? "")\t0"
-                }
-                if let branch {
-                    return "\(key)\t\(value.root)\t\(trunk ?? "")\t\(branch)"
-                }
-                if let trunk {
-                    return "\(key)\t\(value.root)\t\(trunk)"
-                }
-                return "\(key)\t\(value.root)"
+            .map { instance, source in
+                var fields = [instance]
+                if let trunk = source.trunk, !trunk.isEmpty { fields.append("trunk=\(trunk)") }
+                if let branch = source.branch, !branch.isEmpty { fields.append("branch=\(branch)") }
+                // Uploading is the default, so this only appears when it says no.
+                if !source.upload { fields.append("upload=0") }
+                return fields.joined(separator: "\t")
             }
             .joined(separator: "\n") + "\n"
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
@@ -259,15 +232,14 @@ struct SetupCacheCommandService {
         // they rely on today, until they are migrated to kura.
         let kuraEnabled = ClientFeatureFlags.contains("kura")
         if kuraEnabled {
-            // Register the source root BEFORE starting the proxy. The proxy
+            // Register BEFORE starting the proxy. The proxy
             // prefetches a snapshot for every instance it already knows as soon as
             // it boots, and it keys that snapshot by instance alone: if it starts
             // first, an upgraded machine prefetches an unscoped view and keeps
             // serving it until the next full refresh, however promptly the mapping
             // lands afterwards.
-            try await registerSourceRoot(
+            try await registerSource(
                 fullHandle: fullHandle,
-                sourceRoot: path,
                 trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL),
                 branch: await ciBranch(sourceRoot: path),
                 upload: config.xcodeCache.upload

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -350,6 +350,17 @@ struct SetupCacheCommandService {
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
             environmentVariables["TUIST_CAS_PROXY_REGISTRY"] = registry
         }
+        // Trunk ingestion pays for itself only where the machine can warm the CAS
+        // BEFORE a build: it pulls the trunk closure in the background so the next
+        // build finds it local. CI has no such window. The proxy and the build
+        // start together, so ingestion would race the build it is meant to help
+        // and compete for the bandwidth that build's own demand fetches need. Our
+        // runners have less use for it still: their CAS arrives warm on an
+        // attached volume, which is the mechanism there. The key cache (one round
+        // trip, orders of magnitude lighter) still applies on CI.
+        if Environment.current.isCI {
+            environmentVariables["TUIST_CAS_INGEST_TRUNK"] = "0"
+        }
 
         // One proxy per machine. Boot out any legacy per-project cache daemon so
         // the two do not both run.

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -34,6 +34,14 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
 
 /// What setup knows about a project that the proxy cannot work out for itself
 /// (see `load_sources` in cas-plugin).
+///
+/// A row is the instance followed by `key=value` fields, tab separated. The
+/// fields are named rather than positional because every value here is optional,
+/// and a positional row has to hold an absent one's place: a branch recorded
+/// without a trunk leaves an empty column, and anything that drops empties reads
+/// the branch as the trunk. Naming them also means a field added later cannot
+/// shift the ones already there, and that a reader can ignore what it does not
+/// know. Git forbids tabs in a ref, so no value can contain the separator.
 private struct RegisteredSource {
     /// The project's configured default branch, which is a server-side decision.
     /// The proxy would otherwise have to guess it from the local clone's
@@ -47,6 +55,36 @@ private struct RegisteredSource {
     /// Swift, while the build system's Clang caching runs in its own process
     /// with no plugin options at all. Recorded here so one answer covers both.
     let upload: Bool
+
+    static func from(row: Substring) -> (instance: String, source: RegisteredSource)? {
+        let fields = row.split(separator: "\t")
+        guard let instance = fields.first, !instance.isEmpty else { return nil }
+        var values: [String: String] = [:]
+        for field in fields.dropFirst() {
+            // A ref may contain `=`, so only the first one separates.
+            let pair = field.split(separator: "=", maxSplits: 1)
+            guard pair.count == 2 else { continue }
+            values[String(pair[0])] = String(pair[1])
+        }
+        return (
+            String(instance),
+            RegisteredSource(
+                trunk: values["trunk"],
+                branch: values["branch"],
+                // Nothing recorded is nothing to withhold.
+                upload: values["upload"] != "0"
+            )
+        )
+    }
+
+    func row(instance: String) -> String {
+        var fields = [instance]
+        if let trunk, !trunk.isEmpty { fields.append("trunk=\(trunk)") }
+        if let branch, !branch.isEmpty { fields.append("branch=\(branch)") }
+        // Uploading is the default, so this only appears when it says no.
+        if !upload { fields.append("upload=0") }
+        return fields.joined(separator: "\t")
+    }
 }
 
 struct SetupCacheCommandService {
@@ -115,19 +153,9 @@ struct SetupCacheCommandService {
         }
     }
 
-    /// Records what the proxy cannot work out for itself in its sources registry
-    /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
-    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads): the project's trunk,
-    /// the branch when this is CI, and the upload policy.
-    ///
-    /// A row is `instance` followed by `key=value` fields, tab separated. The
-    /// fields are named rather than positional because every value here is
-    /// optional, and a positional row has to hold an absent one's place: a branch
-    /// recorded without a trunk leaves an empty column, and anything that drops
-    /// empties reads the branch as the trunk. Naming them also means a field
-    /// added later cannot shift the ones already there, and that a reader can
-    /// ignore what it does not know. Git forbids tabs in a ref, so no value here
-    /// can contain the separator.
+    /// Records a `RegisteredSource` for this project in the proxy's sources
+    /// registry (`<state>/cas-proxy.sock.registry.sources`, honoring the same
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads).
     ///
     /// Upserts, so setting up a second project does not clobber the first.
     private func registerSource(
@@ -155,35 +183,15 @@ struct SetupCacheCommandService {
         // anything dropped here is a project silently losing its policy.
         var entries: [String: RegisteredSource] = [:]
         if try await fileSystem.exists(sourcesPath) {
-            let contents = try await fileSystem.readTextFile(at: sourcesPath)
-            for line in contents.split(separator: "\n") {
-                var fields = line.split(separator: "\t").map(String.init)
-                guard !fields.isEmpty, !fields[0].isEmpty else { continue }
-                let instance = fields.removeFirst()
-                var values: [String: String] = [:]
-                for field in fields {
-                    guard let separator = field.firstIndex(of: "=") else { continue }
-                    // A ref may contain `=`, so only the first one separates.
-                    values[String(field[..<separator])] = String(field[field.index(after: separator)...])
-                }
-                entries[instance] = RegisteredSource(
-                    trunk: values["trunk"],
-                    branch: values["branch"],
-                    upload: values["upload"] != "0"
-                )
+            for row in try await fileSystem.readTextFile(at: sourcesPath).split(separator: "\n") {
+                guard let (instance, source) = RegisteredSource.from(row: row) else { continue }
+                entries[instance] = source
             }
         }
         entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
 
         let body = entries.sorted { $0.key < $1.key }
-            .map { instance, source in
-                var fields = [instance]
-                if let trunk = source.trunk, !trunk.isEmpty { fields.append("trunk=\(trunk)") }
-                if let branch = source.branch, !branch.isEmpty { fields.append("branch=\(branch)") }
-                // Uploading is the default, so this only appears when it says no.
-                if !source.upload { fields.append("upload=0") }
-                return fields.joined(separator: "\t")
-            }
+            .map { $0.value.row(instance: $0.key) }
             .joined(separator: "\n") + "\n"
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -16,6 +16,7 @@ import TuistSupport
 enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     case missingFullHandle
     case notAuthenticated
+    case registryNotReplaced(String, Int32)
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +26,8 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
         case .notAuthenticated:
             return
                 "You must be authenticated to set up the cache. Run `tuist auth login` (or set the `TUIST_TOKEN` environment variable) and run `tuist setup cache` again."
+        case let .registryNotReplaced(path, code):
+            return "Could not update the cache proxy's registry at \(path) (errno \(code))."
         }
     }
 }
@@ -212,10 +215,24 @@ struct SetupCacheCommandService {
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
         }
-        if try await fileSystem.exists(sourcesPath) {
-            try await fileSystem.remove(sourcesPath)
+        // Swapped in, never rewritten in place, and `rename` rather than a remove
+        // followed by a write or a move: it is the only one of the three that
+        // leaves no instant where the file is missing or half-written.
+        //
+        // The proxy re-reads this on a timer while we write it, and it carries
+        // the upload policy. A reader that finds no file sees no projects, and an
+        // unknown project has to be allowed to upload, so any gap here hands an
+        // opted-out project a window in which its Clang outputs are published.
+        // `rename` gives every reader either the whole old file or the whole new
+        // one, and both are answers we can live with.
+        let staged = sourcesPath.parentDirectory
+            .appending(component: "\(sourcesPath.basename).\(UUID().uuidString)")
+        try await fileSystem.writeText(body, at: staged)
+        guard rename(staged.pathString, sourcesPath.pathString) == 0 else {
+            let code = errno
+            try? await fileSystem.remove(staged)
+            throw SetupCacheCommandServiceError.registryNotReplaced(sourcesPath.pathString, code)
         }
-        try await fileSystem.writeText(body, at: sourcesPath)
     }
 
     func run(

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -35,6 +35,7 @@ struct SetupCacheCommandService {
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let manifestLoader: ManifestLoading
     private let fileSystem: FileSysteming
+    private let getProjectService: GetProjectServicing
 
     init(
         launchAgentService: LaunchAgentServicing = LaunchAgentService(),
@@ -42,7 +43,8 @@ struct SetupCacheCommandService {
         serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
         serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         manifestLoader: ManifestLoading = ManifestLoader.current,
-        fileSystem: FileSysteming = FileSystem()
+        fileSystem: FileSysteming = FileSystem(),
+        getProjectService: GetProjectServicing = GetProjectService()
     ) {
         self.launchAgentService = launchAgentService
         self.configLoader = configLoader
@@ -50,15 +52,45 @@ struct SetupCacheCommandService {
         self.serverAuthenticationController = serverAuthenticationController
         self.manifestLoader = manifestLoader
         self.fileSystem = fileSystem
+        self.getProjectService = getProjectService
     }
 
-    /// Records `fullHandle -> sourceRoot` in the proxy's sources registry
+    /// The project's default branch, which is what a trunk-scoped cache snapshot
+    /// is anchored to. Best-effort: a setup that cannot reach the server still
+    /// installs a working cache, and the proxy falls back to deriving the trunk
+    /// from the checkout's `origin/HEAD`.
+    private func trunkBranch(fullHandle: String, serverURL: URL) async -> String? {
+        do {
+            return try await getProjectService.getProject(fullHandle: fullHandle, serverURL: serverURL)
+                .defaultBranch
+        } catch {
+            Logger.current.debug(
+                "Could not resolve \(fullHandle)'s default branch for the cache proxy: \(error). The proxy will derive the trunk from the checkout instead."
+            )
+            return nil
+        }
+    }
+
+    /// Records `fullHandle -> sourceRoot, trunk` in the proxy's sources registry
     /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
-    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). The proxy derives
-    /// the branch and trunk of every publish live from this repo's git HEAD, so
-    /// nothing branch-specific is baked into a build setting. Upserts so setting
-    /// up a second project does not clobber the first.
-    private func registerSourceRoot(fullHandle: String, sourceRoot: AbsolutePath) async throws {
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). Two things the proxy
+    /// cannot know on its own:
+    ///
+    /// - The source root, from which it derives the branch of every publish live
+    ///   off this repo's git HEAD. Nothing branch-specific is baked into a build
+    ///   setting, which would enter the compiler's cache key and split the cache
+    ///   per branch.
+    /// - The trunk, which is the *project's* configured default branch and hence
+    ///   a server-side decision. The proxy would otherwise have to guess it from
+    ///   the local clone's `origin/HEAD`, which is a property of how the machine
+    ///   cloned rather than of the project.
+    ///
+    /// Upserts, so setting up a second project does not clobber the first.
+    private func registerSourceRoot(
+        fullHandle: String,
+        sourceRoot: AbsolutePath,
+        trunk: String?
+    ) async throws {
         let sourcesPath: AbsolutePath
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
             sourcesPath = try AbsolutePath(validating: registry + ".sources")
@@ -67,18 +99,29 @@ struct SetupCacheCommandService {
                 .appending(component: "cas-proxy.sock.registry.sources")
         }
 
-        var entries: [String: String] = [:]
+        // instance -> (source root, trunk). The trunk column is optional: a
+        // registry written before this shipped, or by a setup that could not
+        // reach the server, still parses and leaves the proxy on its git-derived
+        // fallback.
+        var entries: [String: (root: String, trunk: String?)] = [:]
         if try await fileSystem.exists(sourcesPath) {
             let contents = try await fileSystem.readTextFile(at: sourcesPath)
             for line in contents.split(separator: "\n") {
-                let parts = line.split(separator: "\t", maxSplits: 1).map(String.init)
-                if parts.count == 2 { entries[parts[0]] = parts[1] }
+                let parts = line.split(separator: "\t", maxSplits: 2).map(String.init)
+                if parts.count >= 2 {
+                    entries[parts[0]] = (root: parts[1], trunk: parts.count > 2 ? parts[2] : nil)
+                }
             }
         }
-        entries[fullHandle] = sourceRoot.pathString
+        entries[fullHandle] = (root: sourceRoot.pathString, trunk: trunk)
 
         let body = entries.sorted { $0.key < $1.key }
-            .map { "\($0.key)\t\($0.value)" }
+            .map { key, value in
+                if let trunk = value.trunk, !trunk.isEmpty {
+                    return "\(key)\t\(value.root)\t\(trunk)"
+                }
+                return "\(key)\t\(value.root)"
+            }
             .joined(separator: "\n") + "\n"
         if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
@@ -114,7 +157,11 @@ struct SetupCacheCommandService {
         let kuraEnabled = ClientFeatureFlags.contains("kura")
         if kuraEnabled {
             try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
-            try await registerSourceRoot(fullHandle: fullHandle, sourceRoot: path)
+            try await registerSourceRoot(
+                fullHandle: fullHandle,
+                sourceRoot: path,
+                trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL)
+            )
         } else {
             try await installLegacyDaemon(
                 fullHandle: fullHandle,

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -6,6 +6,7 @@ import TuistConfigLoader
 import TuistConstants
 import TuistCore
 import TuistEnvironment
+import TuistGit
 import TuistLaunchctl
 import TuistLoader
 import TuistLogging
@@ -28,6 +29,15 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     }
 }
 
+/// A row of the CAS proxy's sources registry, whose columns the proxy parses in
+/// this order (see `load_sources` in cas-plugin).
+private struct RegisteredSource {
+    let root: String
+    let trunk: String?
+    /// Recorded only on CI. See `ciBranch`.
+    let branch: String?
+}
+
 struct SetupCacheCommandService {
     private let launchAgentService: LaunchAgentServicing
     private let configLoader: ConfigLoading
@@ -36,6 +46,7 @@ struct SetupCacheCommandService {
     private let manifestLoader: ManifestLoading
     private let fileSystem: FileSysteming
     private let getProjectService: GetProjectServicing
+    private let gitController: GitControlling
 
     init(
         launchAgentService: LaunchAgentServicing = LaunchAgentService(),
@@ -44,7 +55,8 @@ struct SetupCacheCommandService {
         serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         manifestLoader: ManifestLoading = ManifestLoader.current,
         fileSystem: FileSysteming = FileSystem(),
-        getProjectService: GetProjectServicing = GetProjectService()
+        getProjectService: GetProjectServicing = GetProjectService(),
+        gitController: GitControlling = GitController()
     ) {
         self.launchAgentService = launchAgentService
         self.configLoader = configLoader
@@ -53,6 +65,7 @@ struct SetupCacheCommandService {
         self.manifestLoader = manifestLoader
         self.fileSystem = fileSystem
         self.getProjectService = getProjectService
+        self.gitController = gitController
     }
 
     /// The project's default branch, which is what a trunk-scoped cache snapshot
@@ -71,9 +84,30 @@ struct SetupCacheCommandService {
         }
     }
 
-    /// Records `fullHandle -> sourceRoot, trunk` in the proxy's sources registry
-    /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
-    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). Two things the proxy
+    /// The branch to record for a CI checkout, whose HEAD is detached and so tells
+    /// the proxy's `git rev-parse` nothing. Every provider exposes it in the
+    /// environment instead, which `GitController` already knows how to read, but
+    /// only this command runs inside the job and can see it: the proxy is a launchd
+    /// agent and does not inherit the job's environment.
+    ///
+    /// `nil` off CI on purpose. A developer's HEAD is attached, so the proxy
+    /// derives the branch live and stays correct across a `git checkout`, where a
+    /// value recorded once at setup would rot into mis-tagging every later publish.
+    private func ciBranch(sourceRoot: AbsolutePath) async -> String? {
+        guard Environment.current.isCI else { return nil }
+        do {
+            return try await gitController.gitInfo(workingDirectory: sourceRoot).branch
+        } catch {
+            Logger.current.debug(
+                "Could not resolve the CI branch for the cache proxy: \(error). Publishes from this job will be untagged."
+            )
+            return nil
+        }
+    }
+
+    /// Records `fullHandle -> sourceRoot, trunk, branch` in the proxy's sources
+    /// registry (`<state>/cas-proxy.sock.registry.sources`, honoring the same
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads). Three things the proxy
     /// cannot know on its own:
     ///
     /// - The source root, from which it derives the branch of every publish live
@@ -84,12 +118,15 @@ struct SetupCacheCommandService {
     ///   a server-side decision. The proxy would otherwise have to guess it from
     ///   the local clone's `origin/HEAD`, which is a property of how the machine
     ///   cloned rather than of the project.
+    /// - The branch, but only on CI. See `ciBranch`: the proxy prefers its live
+    ///   git reading and only falls back to this when HEAD is detached.
     ///
     /// Upserts, so setting up a second project does not clobber the first.
     private func registerSourceRoot(
         fullHandle: String,
         sourceRoot: AbsolutePath,
-        trunk: String?
+        trunk: String?,
+        branch: String?
     ) async throws {
         let sourcesPath: AbsolutePath
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
@@ -99,25 +136,36 @@ struct SetupCacheCommandService {
                 .appending(component: "cas-proxy.sock.registry.sources")
         }
 
-        // instance -> (source root, trunk). The trunk column is optional: a
-        // registry written before this shipped, or by a setup that could not
-        // reach the server, still parses and leaves the proxy on its git-derived
-        // fallback.
-        var entries: [String: (root: String, trunk: String?)] = [:]
+        // instance -> (source root, trunk, branch). Both trailing columns are
+        // optional: a registry written before either shipped, or by a setup that
+        // could not reach the server, still parses and leaves the proxy on its
+        // git-derived fallback.
+        var entries: [String: RegisteredSource] = [:]
         if try await fileSystem.exists(sourcesPath) {
             let contents = try await fileSystem.readTextFile(at: sourcesPath)
             for line in contents.split(separator: "\n") {
-                let parts = line.split(separator: "\t", maxSplits: 2).map(String.init)
+                let parts = line.split(separator: "\t", maxSplits: 3).map(String.init)
                 if parts.count >= 2 {
-                    entries[parts[0]] = (root: parts[1], trunk: parts.count > 2 ? parts[2] : nil)
+                    entries[parts[0]] = RegisteredSource(
+                        root: parts[1],
+                        trunk: parts.count > 2 ? parts[2] : nil,
+                        branch: parts.count > 3 ? parts[3] : nil
+                    )
                 }
             }
         }
-        entries[fullHandle] = (root: sourceRoot.pathString, trunk: trunk)
+        entries[fullHandle] = RegisteredSource(root: sourceRoot.pathString, trunk: trunk, branch: branch)
 
         let body = entries.sorted { $0.key < $1.key }
             .map { key, value in
-                if let trunk = value.trunk, !trunk.isEmpty {
+                // The branch column is positional, so a branch without a trunk
+                // still has to leave the trunk's place empty.
+                let trunk = value.trunk.flatMap { $0.isEmpty ? nil : $0 }
+                let branch = value.branch.flatMap { $0.isEmpty ? nil : $0 }
+                if let branch {
+                    return "\(key)\t\(value.root)\t\(trunk ?? "")\t\(branch)"
+                }
+                if let trunk {
                     return "\(key)\t\(value.root)\t\(trunk)"
                 }
                 return "\(key)\t\(value.root)"
@@ -165,7 +213,8 @@ struct SetupCacheCommandService {
             try await registerSourceRoot(
                 fullHandle: fullHandle,
                 sourceRoot: path,
-                trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL)
+                trunk: await trunkBranch(fullHandle: fullHandle, serverURL: serverURL),
+                branch: await ciBranch(sourceRoot: path)
             )
             try await installProxy(fullHandle: fullHandle, serverURL: serverURL)
         } else {

--- a/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
@@ -128,7 +128,14 @@ struct XcodeCacheSettingsProjectMapperTests {
         #expect(baseSettings["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] == .string("YES"))
         #expect(baseSettings["COMPILATION_CACHE_ENABLE_PLUGIN"] == .string("YES"))
         #expect(baseSettings["COMPILATION_CACHE_PLUGIN_PATH"] == .string(casPluginPath.pathString))
-        #expect(baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] == nil)
+
+        // The proxy's socket is what makes C, Objective-C and precompiled modules
+        // shareable: the build system only runs its caching for those when a remote
+        // service is configured. Without it, only Swift compilations are shared.
+        #expect(
+            baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"]
+                == .string(Environment.current.casProxySocketPathString())
+        )
 
         // The account/project is delivered to the plugin as a compiler option so
         // it reaches every frontend, including Xcode ⌘B builds.
@@ -256,7 +263,10 @@ struct XcodeCacheSettingsProjectMapperTests {
         #expect(baseSettings["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] == .string("YES"))
         #expect(baseSettings["COMPILATION_CACHE_ENABLE_PLUGIN"] == .string("YES"))
         #expect(baseSettings["COMPILATION_CACHE_PLUGIN_PATH"] == .string(casPluginPath.pathString))
-        #expect(baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] == nil)
+        #expect(
+            baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"]
+                == .string(Environment.current.casProxySocketPathString())
+        )
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistGitTests/GitControllerTests.swift
+++ b/cli/Tests/TuistGitTests/GitControllerTests.swift
@@ -235,6 +235,80 @@ struct GitControllerTests {
 
     // MARK: - gitInfo() tests
 
+    /// `GITHUB_HEAD_REF` is a pull-request variable, so a push falls through to
+    /// git, and a workflow that checks out an explicit SHA is detached, where git
+    /// cannot name the branch either. CI on the default branch is where most of a
+    /// project's cache comes from, so reporting no branch there is the whole
+    /// point of the branch being reported at all.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func gitInfo_when_github_actions_pushes_to_a_branch_with_a_detached_head() async throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        let mockEnvironment = try #require(Environment.mocked)
+        mockEnvironment.variables = [
+            "GITHUB_REF": "refs/heads/main",
+            "GITHUB_REF_NAME": "main",
+            "GITHUB_REF_TYPE": "branch",
+        ]
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "rev-parse"])
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "log", "-1"])
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "rev-parse", "HEAD"],
+            output: "some-sha\n"
+        )
+        // Detached: git reports no current branch.
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "branch", "--show-current"],
+            output: "\n"
+        )
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "remote"], output: "origin")
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "remote", "get-url", "origin"],
+            output: "https://github.com/tuist/tuist"
+        )
+
+        // When
+        let gitInfo = try await subject.gitInfo(workingDirectory: path)
+
+        // Then
+        #expect(gitInfo.branch == "main")
+    }
+
+    /// A tag push sets `GITHUB_REF_NAME` to the tag. Reporting it as the branch
+    /// would attribute the build to a ref no branch ever matches.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func gitInfo_when_github_actions_pushes_a_tag() async throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        let mockEnvironment = try #require(Environment.mocked)
+        mockEnvironment.variables = [
+            "GITHUB_REF": "refs/tags/4.1.0",
+            "GITHUB_REF_NAME": "4.1.0",
+            "GITHUB_REF_TYPE": "tag",
+        ]
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "rev-parse"])
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "log", "-1"])
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "rev-parse", "HEAD"],
+            output: "some-sha\n"
+        )
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "branch", "--show-current"],
+            output: "\n"
+        )
+        commandRunner.succeedCommand(["git", "-C", path.pathString, "remote"], output: "origin")
+        commandRunner.succeedCommand(
+            ["git", "-C", path.pathString, "remote", "get-url", "origin"],
+            output: "https://github.com/tuist/tuist"
+        )
+
+        // When
+        let gitInfo = try await subject.gitInfo(workingDirectory: path)
+
+        // Then
+        #expect(gitInfo.branch == nil, "a tag is not a branch")
+    }
+
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func gitInfo_when_github_actions() async throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -492,10 +492,10 @@ struct SetupCacheCommandServiceTests {
             .called(1)
     }
 
-    /// The registry the proxy reads to derive the branch and trunk of every publish.
-    /// Its columns are positional and parsed by `load_sources` in cas-plugin, so the
-    /// two sides have to agree exactly; these pin our half of that contract.
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheSourceRootAndTrunk() async throws {
+    /// The registry the proxy reads for the trunk, branch and upload policy of every
+    /// publish. Its `key=value` fields are parsed by `load_sources` in cas-plugin, so
+    /// the two sides have to agree; these pin our half of that contract.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheTrunk() async throws {
         // Given
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
@@ -507,23 +507,20 @@ struct SetupCacheCommandServiceTests {
         // When
         try await subject.run(path: nil)
 
-        // Then: off CI the branch column is omitted on purpose. HEAD is attached, so
-        // the proxy reads the branch live and a value recorded here would rot.
-        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        // Then: off CI no branch is recorded, which leaves this project's publishes
+        // untagged and so outside the trunk view. CI is the only publisher it is
+        // built from.
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\t\(root.pathString)\tmain\n")
+        #expect(sources == "tuist/tuist\ttrunk=main\n")
     }
 
     /// The registry is machine-wide, and setting one project up rewrites the whole
-    /// file, so every other project's row has to survive being read and written
-    /// back untouched. The columns are positional and a branch known without a
-    /// trunk leaves the trunk's place empty, which is exactly the shape a default
-    /// `split` drops: the branch would shift into the trunk's column and be
-    /// written back that way, and the proxy would then scope that project's
-    /// snapshot to its branch.
+    /// file, so every other project's row has to survive being read and written back
+    /// untouched. A row carrying a branch but no trunk is the case that a positional
+    /// format got wrong, and the one this format has to keep getting right.
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupCache_keepsAnotherProjectsColumnsWhenItsTrunkIsEmpty() async throws {
+    func setupCache_keepsAnotherProjectsFieldsWhenItsTrunkIsUnknown() async throws {
         // Given
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
@@ -534,10 +531,7 @@ struct SetupCacheCommandServiceTests {
         let sources = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
         let fileSystem = FileSystem()
         // Another project, on CI, whose trunk was never resolved.
-        try await fileSystem.writeText(
-            "other/project\t/src/other\t\tfeature/theirs\n",
-            at: sources
-        )
+        try await fileSystem.writeText("other/project\tbranch=feature/theirs\n", at: sources)
 
         // When: this project's setup rewrites the file.
         try await subject.run(path: nil)
@@ -545,7 +539,7 @@ struct SetupCacheCommandServiceTests {
         // Then
         let contents = try await fileSystem.readTextFile(at: sources)
         #expect(
-            contents.contains("other/project\t/src/other\t\tfeature/theirs\n"),
+            contents.contains("other/project\tbranch=feature/theirs\n"),
             "another project's row round-trips byte for byte: \(contents)"
         )
     }
@@ -563,18 +557,17 @@ struct SetupCacheCommandServiceTests {
         // When
         try await subject.run(path: nil)
 
-        // Then: all four columns, in the order the proxy parses them.
-        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        // Then
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\t\(root.pathString)\tmain\tfeature/tags\n")
+        #expect(sources == "tuist/tuist\ttrunk=main\tbranch=feature/tags\n")
     }
 
-    /// A branch with no trunk still has to leave the trunk's place empty: the proxy
-    /// reads the columns positionally, so a collapsed row would hand it the branch
-    /// as the trunk and scope every snapshot to a branch that is not the trunk.
+    /// A setup that cannot reach the server knows the branch but not the trunk. The
+    /// branch has to stay the branch: read back as a trunk it would scope every
+    /// snapshot to a branch that is not trunk.
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupCache_keepsTheTrunkColumnWhenOnlyTheBranchIsKnown() async throws {
+    func setupCache_recordsTheBranchWhenTheTrunkIsUnknown() async throws {
         // Given
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
@@ -594,14 +587,14 @@ struct SetupCacheCommandServiceTests {
         try await subject.run(path: nil)
 
         // Then
-        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\t\(root.pathString)\t\tfeature/tags\n")
+        #expect(sources == "tuist/tuist\tbranch=feature/tags\n")
     }
 
-    /// Setting up a second project must not clobber the first, and rows written by an
-    /// older setup (two columns, no trunk) have to survive the rewrite intact.
+    /// Setting up a second project must not clobber the first, and a row that carries
+    /// nothing but its instance (a setup that could not reach the server) has to
+    /// survive the rewrite intact.
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_upsertsIntoAnExistingRegistry() async throws {
         // Given
         let environment = try #require(Environment.mocked)
@@ -612,15 +605,14 @@ struct SetupCacheCommandServiceTests {
         environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
         let sourcesPath = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
         let fileSystem = FileSystem()
-        try await fileSystem.writeText("tuist/legacy\t/src/legacy\n", at: sourcesPath)
+        try await fileSystem.writeText("tuist/legacy\n", at: sourcesPath)
 
         // When
         try await subject.run(path: nil)
 
         // Then
-        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
         let sources = try await fileSystem.readTextFile(at: sourcesPath)
-        #expect(sources == "tuist/legacy\t/src/legacy\ntuist/tuist\t\(root.pathString)\tmain\n")
+        #expect(sources == "tuist/legacy\ntuist/tuist\ttrunk=main\n")
     }
 }
 

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -507,7 +507,7 @@ struct SetupCacheCommandServiceTests {
         // When
         try await subject.run(path: nil)
 
-        // Then: off CI the branch column is omitted on purpose — HEAD is attached, so
+        // Then: off CI the branch column is omitted on purpose. HEAD is attached, so
         // the proxy reads the branch live and a value recorded here would rot.
         let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -493,8 +493,8 @@ struct SetupCacheCommandServiceTests {
     }
 
     /// The registry the proxy reads for the trunk, branch and upload policy of every
-    /// publish. Its `key=value` fields are parsed by `load_sources` in cas-plugin, so
-    /// the two sides have to agree; these pin our half of that contract.
+    /// publish. It is decoded by `load_sources` in cas-plugin, so the two sides have
+    /// to agree; these pin our half of that contract by asserting the bytes.
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheTrunk() async throws {
         // Given
         let environment = try #require(Environment.mocked)
@@ -512,7 +512,14 @@ struct SetupCacheCommandServiceTests {
         // built from.
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\ttrunk=main\n")
+        #expect(sources == """
+        {
+          "tuist/tuist" : {
+            "trunk" : "main",
+            "upload" : true
+          }
+        }
+        """)
     }
 
     /// The registry is machine-wide, and setting one project up rewrites the whole
@@ -531,7 +538,10 @@ struct SetupCacheCommandServiceTests {
         let sources = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
         let fileSystem = FileSystem()
         // Another project, on CI, whose trunk was never resolved.
-        try await fileSystem.writeText("other/project\tbranch=feature/theirs\n", at: sources)
+        try await fileSystem.writeText(
+            #"{"other/project":{"branch":"feature/theirs","upload":true}}"#,
+            at: sources
+        )
 
         // When: this project's setup rewrites the file.
         try await subject.run(path: nil)
@@ -539,8 +549,13 @@ struct SetupCacheCommandServiceTests {
         // Then
         let contents = try await fileSystem.readTextFile(at: sources)
         #expect(
-            contents.contains("other/project\tbranch=feature/theirs\n"),
-            "another project's row round-trips byte for byte: \(contents)"
+            contents.contains("""
+              "other/project" : {
+                "branch" : "feature/theirs",
+                "upload" : true
+              }
+            """),
+            "another project round-trips: \(contents)"
         )
     }
 
@@ -560,7 +575,15 @@ struct SetupCacheCommandServiceTests {
         // Then
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\ttrunk=main\tbranch=feature/tags\n")
+        #expect(sources == """
+        {
+          "tuist/tuist" : {
+            "branch" : "feature/tags",
+            "trunk" : "main",
+            "upload" : true
+          }
+        }
+        """)
     }
 
     /// A setup that cannot reach the server knows the branch but not the trunk. The
@@ -589,7 +612,14 @@ struct SetupCacheCommandServiceTests {
         // Then
         let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
             .appending(component: "cas-proxy.registry.sources"))
-        #expect(sources == "tuist/tuist\tbranch=feature/tags\n")
+        #expect(sources == """
+        {
+          "tuist/tuist" : {
+            "branch" : "feature/tags",
+            "upload" : true
+          }
+        }
+        """)
     }
 
     /// Setting up a second project must not clobber the first, and a row that carries
@@ -605,14 +635,24 @@ struct SetupCacheCommandServiceTests {
         environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
         let sourcesPath = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
         let fileSystem = FileSystem()
-        try await fileSystem.writeText("tuist/legacy\n", at: sourcesPath)
+        try await fileSystem.writeText(#"{"tuist/legacy":{}}"#, at: sourcesPath)
 
         // When
         try await subject.run(path: nil)
 
         // Then
         let sources = try await fileSystem.readTextFile(at: sourcesPath)
-        #expect(sources == "tuist/legacy\ntuist/tuist\ttrunk=main\n")
+        #expect(sources == """
+        {
+          "tuist/legacy" : {
+            "upload" : true
+          },
+          "tuist/tuist" : {
+            "trunk" : "main",
+            "upload" : true
+          }
+        }
+        """)
     }
 }
 

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -10,6 +10,7 @@ import TuistConfigLoader
 import TuistConstants
 import TuistCore
 import TuistEnvironment
+import TuistGit
 import TuistLaunchctl
 import TuistLoader
 import TuistLoggerTesting
@@ -26,6 +27,8 @@ struct SetupCacheCommandServiceTests {
     private let serverEnvironmentService = MockServerEnvironmentServicing()
     private let serverAuthenticationController = MockServerAuthenticationControlling()
     private let manifestLoader = MockManifestLoading()
+    private let getProjectService = MockGetProjectServicing()
+    private let gitController = MockGitControlling()
 
     init() {
         subject = SetupCacheCommandService(
@@ -33,9 +36,23 @@ struct SetupCacheCommandServiceTests {
             configLoader: configLoader,
             serverEnvironmentService: serverEnvironmentService,
             serverAuthenticationController: serverAuthenticationController,
-            manifestLoader: manifestLoader
+            manifestLoader: manifestLoader,
+            getProjectService: getProjectService,
+            gitController: gitController
         )
 
+        // Every kura-path setup resolves the project's default branch to record the
+        // trunk. Left to the real service these tests would reach the production
+        // server: `trunkBranch` swallows the error, so the only symptom would be a
+        // network round trip per test and a silently missing trunk column.
+        given(getProjectService)
+            .getProject(fullHandle: .any, serverURL: .any)
+            .willReturn(.test(defaultBranch: "main"))
+
+        // Only read on CI, where the proxy cannot see the job's branch itself.
+        given(gitController)
+            .gitInfo(workingDirectory: .any)
+            .willReturn(GitInfo(ref: nil, branch: "feature/tags", sha: nil, remoteURLOrigin: nil))
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
@@ -474,4 +491,105 @@ struct SetupCacheCommandServiceTests {
             )
             .called(1)
     }
+
+    /// The registry the proxy reads to derive the branch and trunk of every publish.
+    /// Its columns are positional and parsed by `load_sources` in cas-plugin, so the
+    /// two sides have to agree exactly; these pin our half of that contract.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheSourceRootAndTrunk() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: off CI the branch column is omitted on purpose — HEAD is attached, so
+        // the proxy reads the branch live and a value recorded here would rot.
+        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
+            .appending(component: "cas-proxy.registry.sources"))
+        #expect(sources == "tuist/tuist\t\(root.pathString)\tmain\n")
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheBranchOnCI() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        environment.variables["CI"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: all four columns, in the order the proxy parses them.
+        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
+            .appending(component: "cas-proxy.registry.sources"))
+        #expect(sources == "tuist/tuist\t\(root.pathString)\tmain\tfeature/tags\n")
+    }
+
+    /// A branch with no trunk still has to leave the trunk's place empty: the proxy
+    /// reads the columns positionally, so a collapsed row would hand it the branch
+    /// as the trunk and scope every snapshot to a branch that is not the trunk.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupCache_keepsTheTrunkColumnWhenOnlyTheBranchIsKnown() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        environment.variables["CI"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        // A setup that cannot reach the server records no trunk.
+        getProjectService.reset()
+        given(getProjectService)
+            .getProject(fullHandle: .any, serverURL: .any)
+            .willThrow(TestError("unreachable"))
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        let sources = try await FileSystem().readTextFile(at: registry.parentDirectory
+            .appending(component: "cas-proxy.registry.sources"))
+        #expect(sources == "tuist/tuist\t\(root.pathString)\t\tfeature/tags\n")
+    }
+
+    /// Setting up a second project must not clobber the first, and rows written by an
+    /// older setup (two columns, no trunk) have to survive the rewrite intact.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_upsertsIntoAnExistingRegistry() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+        let sourcesPath = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        let fileSystem = FileSystem()
+        try await fileSystem.writeText("tuist/legacy\t/src/legacy\n", at: sourcesPath)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        let root = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        let sources = try await fileSystem.readTextFile(at: sourcesPath)
+        #expect(sources == "tuist/legacy\t/src/legacy\ntuist/tuist\t\(root.pathString)\tmain\n")
+    }
+}
+
+private struct TestError: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
 }

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -515,6 +515,41 @@ struct SetupCacheCommandServiceTests {
         #expect(sources == "tuist/tuist\t\(root.pathString)\tmain\n")
     }
 
+    /// The registry is machine-wide, and setting one project up rewrites the whole
+    /// file, so every other project's row has to survive being read and written
+    /// back untouched. The columns are positional and a branch known without a
+    /// trunk leaves the trunk's place empty, which is exactly the shape a default
+    /// `split` drops: the branch would shift into the trunk's column and be
+    /// written back that way, and the proxy would then scope that project's
+    /// snapshot to its branch.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupCache_keepsAnotherProjectsColumnsWhenItsTrunkIsEmpty() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+        let sources = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        let fileSystem = FileSystem()
+        // Another project, on CI, whose trunk was never resolved.
+        try await fileSystem.writeText(
+            "other/project\t/src/other\t\tfeature/theirs\n",
+            at: sources
+        )
+
+        // When: this project's setup rewrites the file.
+        try await subject.run(path: nil)
+
+        // Then
+        let contents = try await fileSystem.readTextFile(at: sources)
+        #expect(
+            contents.contains("other/project\t/src/other\t\tfeature/theirs\n"),
+            "another project's row round-trips byte for byte: \(contents)"
+        )
+    }
+
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_recordsTheBranchOnCI() async throws {
         // Given
         let environment = try #require(Environment.mocked)

--- a/kura/src/artifact/manifest.rs
+++ b/kura/src/artifact/manifest.rs
@@ -22,6 +22,8 @@ pub struct ArtifactManifest {
     pub size: u64,
     pub version_ms: u64,
     pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
 }
 
 impl ArtifactManifest {
@@ -77,6 +79,8 @@ pub struct PersistedManifestRecord {
     pub size: u64,
     pub version_ms: u64,
     pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
 }
 
 impl PersistedManifestRecord {
@@ -93,6 +97,7 @@ impl PersistedManifestRecord {
             size: manifest.size,
             version_ms: manifest.version_ms,
             created_at_ms: manifest.created_at_ms,
+            branch: manifest.branch.clone(),
         }
     }
 
@@ -110,6 +115,7 @@ impl PersistedManifestRecord {
             size: self.size,
             version_ms: self.version_ms,
             created_at_ms: self.created_at_ms,
+            branch: self.branch,
         })
     }
 }
@@ -135,6 +141,7 @@ mod tests {
             size: 128,
             version_ms: 100,
             created_at_ms: 90,
+            branch: None,
         };
 
         let metadata = manifest.metadata("acme");
@@ -164,6 +171,7 @@ mod tests {
             size: 64,
             version_ms: 200,
             created_at_ms: 150,
+            branch: None,
         };
 
         let restored = PersistedManifestRecord::from_manifest(&manifest)

--- a/kura/src/artifact/segment_location_record.rs
+++ b/kura/src/artifact/segment_location_record.rs
@@ -52,6 +52,7 @@ impl SegmentLocationRecord {
             size: self.size,
             version_ms: self.version_ms,
             created_at_ms: self.created_at_ms,
+            branch: None,
         })
     }
 
@@ -208,6 +209,7 @@ mod tests {
             size: 512,
             version_ms: 5678,
             created_at_ms: 1234,
+            branch: None,
         };
 
         let record = SegmentLocationRecord::from_manifest(&manifest)

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -52,12 +52,20 @@ pub const REAPI_ACTION_CACHE_EXPIRY_MAX_DELETES: usize = 100_000;
 // an identical re-publish only applies when the stored version has aged past
 // it — one refresh per entry per window fleet-wide.
 pub const REAPI_ACTION_CACHE_REFRESH_DAMPING_MS: u64 = 24 * 60 * 60 * 1000;
-// How many index rows a trunk-scoped snapshot build may examine per entry it is
-// allowed to keep. A trunk filter skips feature rows after paying their
-// point-read, so without a ceiling the walk is bounded by the namespace's size
-// rather than by the view's, on every periodic rebuild. Generous on purpose: it
-// is a backstop against a pathologically feature-heavy namespace, not a tuning
-// knob, and a namespace that trips it logs and wants a branch-keyed index.
+// How many manifest READS a trunk-scoped snapshot build may pay per entry it is
+// allowed to keep. Not rows examined: a row carrying its branch answers the trunk
+// filter from the key, so rejecting feature churn costs a sequential step over a
+// compact CF and is deliberately not counted here. What this bounds is the random
+// read into the manifests CF, which is the work, and which only rows written
+// before the branch was recorded (plus stale rows) still need.
+//
+// So the walk itself is bounded by the namespace's prefix rather than by this,
+// and that is the intended trade: bounding the walk would truncate the trunk view
+// under exactly the feature churn this scoping exists to see through, which is
+// the bug the branch-keyed rows fixed. The reads are what had to be bounded, and
+// they are. Generous on purpose: a backstop against a namespace with a large
+// pre-branch backlog, not a tuning knob, and one that trips it logs how far it
+// walked to get there.
 pub const ACTION_CACHE_TRUNK_SCAN_FACTOR: usize = 8;
 // Not a cap on total bootstrap runtime — it is the maximum time a bootstrap may
 // go *without forward progress* (a fetched page or applied artifact) before it

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -52,6 +52,13 @@ pub const REAPI_ACTION_CACHE_EXPIRY_MAX_DELETES: usize = 100_000;
 // an identical re-publish only applies when the stored version has aged past
 // it — one refresh per entry per window fleet-wide.
 pub const REAPI_ACTION_CACHE_REFRESH_DAMPING_MS: u64 = 24 * 60 * 60 * 1000;
+// How many index rows a trunk-scoped snapshot build may examine per entry it is
+// allowed to keep. A trunk filter skips feature rows after paying their
+// point-read, so without a ceiling the walk is bounded by the namespace's size
+// rather than by the view's, on every periodic rebuild. Generous on purpose: it
+// is a backstop against a pathologically feature-heavy namespace, not a tuning
+// knob, and a namespace that trips it logs and wants a branch-keyed index.
+pub const ACTION_CACHE_TRUNK_SCAN_FACTOR: usize = 8;
 // Not a cap on total bootstrap runtime — it is the maximum time a bootstrap may
 // go *without forward progress* (a fetched page or applied artifact) before it
 // is abandoned and retried. A large cold pull that keeps making progress runs to

--- a/kura/src/failpoints.rs
+++ b/kura/src/failpoints.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::Mutex, time::Duration};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum FailpointName {
     BeforeSegmentFsync,
+    AfterInlineManifestReadBeforeCommit,
     AfterArtifactBytesDurableBeforeMetadata,
     AfterMetadataCommitBeforeReturn,
     AfterReadArtifactBytesBeforeReturn,
@@ -17,6 +18,9 @@ impl FailpointName {
     fn as_str(self) -> &'static str {
         match self {
             Self::BeforeSegmentFsync => "before_segment_fsync",
+            Self::AfterInlineManifestReadBeforeCommit => {
+                "after_inline_manifest_read_before_commit"
+            }
             Self::AfterArtifactBytesDurableBeforeMetadata => {
                 "after_artifact_bytes_durable_before_metadata"
             }

--- a/kura/src/failpoints.rs
+++ b/kura/src/failpoints.rs
@@ -18,9 +18,7 @@ impl FailpointName {
     fn as_str(self) -> &'static str {
         match self {
             Self::BeforeSegmentFsync => "before_segment_fsync",
-            Self::AfterInlineManifestReadBeforeCommit => {
-                "after_inline_manifest_read_before_commit"
-            }
+            Self::AfterInlineManifestReadBeforeCommit => "after_inline_manifest_read_before_commit",
             Self::AfterArtifactBytesDurableBeforeMetadata => {
                 "after_artifact_bytes_durable_before_metadata"
             }

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -333,6 +333,12 @@ struct ReplicateArtifactQuery {
     key: String,
     content_type: String,
     version_ms: u64,
+    /// The origin's branch tag and the publishing build's trunk. Both optional:
+    /// a peer that predates them (or any untagged publish) omits them and the
+    /// entry applies untagged, which is what this node did for every replicated
+    /// entry before.
+    branch: Option<String>,
+    trunk: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -412,6 +418,8 @@ impl ReplicateArtifactQuery {
             key: required_param(params, "key")?,
             content_type: required_param(params, "content_type")?,
             version_ms: optional_u64_param(params, "version_ms")?.unwrap_or_default(),
+            branch: param_value(params, "branch").cloned(),
+            trunk: param_value(params, "trunk").cloned(),
         })
     }
 }
@@ -1296,6 +1304,7 @@ async fn put_keyvalue(
             &payload_bytes,
             &targets,
             None,
+            None,
         )
         .await
     {
@@ -1906,6 +1915,8 @@ async fn internal_replicate_artifact(
                 &query.content_type,
                 &bytes,
                 query.version_ms,
+                query.branch.as_deref(),
+                query.trunk.as_deref(),
             )
             .await
         {

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1295,6 +1295,7 @@ async fn put_keyvalue(
             "application/json",
             &payload_bytes,
             &targets,
+            None,
         )
         .await
     {

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1244,9 +1244,9 @@ impl ActionCache for ReapiService {
                 .iter()
                 .find_map(|hint| hint.strip_prefix(SNAPSHOT_AFTER_HINT)?.parse::<u64>().ok())
                 .unwrap_or(0);
-            // A trunk-branch filter scopes the snapshot to the trunk baseline
-            // (entries tagged with this branch plus untagged/legacy entries).
-            // Absent or empty means the unfiltered, whole-namespace snapshot.
+            // A trunk-branch filter scopes the snapshot to the trunk baseline:
+            // entries tagged with this branch, and only those. Absent or empty
+            // means the unfiltered snapshot of every branch in the namespace.
             let trunk = ref_metadata(&request, "x-tuist-trunk-branch", "x-tuist-trunk-branch-bin");
             let trunk = trunk.as_deref();
             let snapshot = self

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -570,6 +570,7 @@ impl ReapiService {
         // with no filter the key is just the namespace, preserving today's
         // behavior exactly.
         let cache_key = snapshot_cache_key(namespace_id, trunk);
+        let generation = self.state.store.action_cache_generation(namespace_id);
         // Serve the cached index immediately, kicking the reconcile in the
         // background once the view is older than the freshness window: a
         // reconcile costs a namespace scan (tens of seconds on a large
@@ -583,19 +584,24 @@ impl ReapiService {
                 .indexes
                 .lock()
                 .expect("snapshot cache lock poisoned");
-            // An index that built EMPTY does not get to answer, however fresh it
-            // is. The freshness window trades staleness for round trips, and that
-            // trade only makes sense when there is something to serve: a
-            // populated index that is 60s out of date costs its client a few
-            // keys, an empty one costs it every key it came for. And it does not
-            // come back to find out we were only a minute behind, because it
-            // fetches once per session. So a namespace that published its first
-            // entries just after an empty build would starve every client that
-            // arrived inside the window. Falling through builds and serves the
-            // real thing, which is what an absent index already does, and the
-            // build is shared so concurrent serves pay for one.
+            // An index that built EMPTY only answers while the namespace has not
+            // moved under it. The freshness window trades staleness for round
+            // trips, and that trade only makes sense when there is something to
+            // serve: a populated index 60s out of date costs its client a few
+            // keys, an empty one costs it every key it came for, and it does not
+            // come back to find out, because it fetches once per session.
+            //
+            // The generation is what makes that affordable. Rebuilding every
+            // empty index instead would be a namespace scan per build for every
+            // namespace whose trunk view is legitimately empty, which is all of
+            // them until the fleet re-tags. Equal generation means nothing has
+            // been published since the build, so empty is the answer, not a
+            // stale one.
+            let unchanged = indexes
+                .get(&cache_key)
+                .is_some_and(|index| index.built_at_generation == generation);
             if let Some(index) = indexes.get_mut(&cache_key)
-                && !index.entries.is_empty()
+                && (!index.entries.is_empty() || unchanged)
             {
                 let stale = index.reconciled_at.elapsed() >= SNAPSHOT_RECONCILE_INTERVAL;
                 index.last_used = Instant::now();
@@ -860,6 +866,10 @@ impl ReapiService {
         // `served_full` instead. Cloning the whole index to keep it in place
         // would copy an unbounded node table (the entry cap does not bound it);
         // the cached full encoding is bounded at the wire ceiling.
+        // Sampled BEFORE the scan: a publish landing mid-reconcile must leave the
+        // index looking out of date, not be stamped as included by a generation
+        // read after it.
+        let generation = state.store.action_cache_generation(&namespace);
         let index = cache
             .indexes
             .lock()
@@ -870,6 +880,7 @@ impl ReapiService {
             match reconcile_snapshot_index(&state, &namespace, trunk.as_deref(), index).await {
                 Ok(mut index) => {
                     index.reconciled_at = Instant::now();
+                    index.built_at_generation = generation;
                     (index, Ok(()))
                 }
                 Err((index, error)) => {
@@ -2349,6 +2360,11 @@ struct NamespaceSnapshotIndex {
     /// When the last successful reconcile finished. Serving reads this to
     /// decide whether the cached view is fresh enough to return as-is.
     reconciled_at: Instant,
+    /// The namespace's action-cache generation when this index was built. An
+    /// empty index is only worth serving while this still matches: equal means
+    /// nothing has been published since, so empty is the truth rather than a
+    /// stale answer.
+    built_at_generation: u64,
 }
 
 impl NamespaceSnapshotIndex {
@@ -2359,6 +2375,7 @@ impl NamespaceSnapshotIndex {
             entries: BTreeMap::new(),
             last_used: Instant::now(),
             reconciled_at: Instant::now(),
+            built_at_generation: 0,
         }
     }
 
@@ -2931,46 +2948,63 @@ mod tests {
         assert!(!should_refresh_snapshot_index(fresh, idle));
     }
 
-    /// A namespace that publishes its first entries just after an empty index was
-    /// built would otherwise serve nothing for the rest of the freshness window,
-    /// and a client fetches once per session, so "the rest of the window" is the
-    /// rest of its build. An empty index has to go back to the store instead of
-    /// answering, however recently it was reconciled.
+    /// An empty index is ambiguous: "nothing to show" and "built before anything
+    /// was published" look identical. The generation is what tells them apart,
+    /// and both answers matter. Serving a stale-empty view costs a client every
+    /// key it came for and it does not ask twice; rebuilding a correctly-empty
+    /// one costs a namespace scan per build, on every namespace whose trunk view
+    /// is empty, which is all of them until the fleet re-tags.
     #[tokio::test]
-    async fn a_fresh_but_empty_index_is_rebuilt_rather_than_served() {
+    async fn an_empty_index_answers_only_while_its_namespace_has_not_moved() {
         let context = test_context(|_| {}).await;
         let service = ReapiService {
             snapshot_cache: Default::default(),
             state: context.state.clone(),
         };
-        // Reconciled just now, and empty: the shape a namespace has when its
-        // first client prefetched before anything was published.
-        let stamped = Instant::now();
-        let mut index = NamespaceSnapshotIndex::new();
-        index.reconciled_at = stamped;
-        service
-            .snapshot_cache
-            .indexes
-            .lock()
-            .unwrap()
-            .insert(snapshot_cache_key("ios", None), index);
+        let insert = |generation: u64| {
+            let mut index = NamespaceSnapshotIndex::new();
+            index.reconciled_at = Instant::now();
+            index.built_at_generation = generation;
+            service
+                .snapshot_cache
+                .indexes
+                .lock()
+                .unwrap()
+                .insert(snapshot_cache_key("ios", None), index);
+            Instant::now()
+        };
+        let reconciled_at = || {
+            service
+                .snapshot_cache
+                .indexes
+                .lock()
+                .unwrap()
+                .get(&snapshot_cache_key("ios", None))
+                .map(|index| index.reconciled_at)
+        };
 
+        // Nothing published, so the store's generation is 0 and the index agrees:
+        // empty is the truth and answering costs nothing.
+        let stamped = insert(context.state.store.action_cache_generation("ios"));
         service
             .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("serve should succeed");
-
-        let reconciled_at = service
-            .snapshot_cache
-            .indexes
-            .lock()
-            .unwrap()
-            .get(&snapshot_cache_key("ios", None))
-            .map(|index| index.reconciled_at);
         assert!(
-            reconciled_at.is_some_and(|at| at > stamped),
-            "the serve went back to the store instead of answering from an empty \
-             index that happened to be fresh"
+            reconciled_at().is_some_and(|at| at < stamped),
+            "a correctly-empty index answers without rescanning the namespace"
+        );
+
+        // A generation the store has moved past: the index was built before
+        // something was published, so it has to go back and look.
+        let stamped = insert(context.state.store.action_cache_generation("ios") + 1);
+        service
+            .serve_actioncache_snapshot("ios", 0, None)
+            .await
+            .expect("serve should succeed");
+        assert!(
+            reconciled_at().is_some_and(|at| at > stamped),
+            "an index built before a publish is rebuilt rather than served empty"
         );
     }
 

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -37,6 +37,7 @@ use tonic::{
     codegen::{Body as HttpBody, Service, http},
 };
 use tower::Layer;
+use tracing::Instrument;
 
 use crate::{
     artifact::{manifest::ArtifactManifest, producer::ArtifactProducer},
@@ -91,6 +92,16 @@ struct SnapshotCache {
 
 type SharedIndexBuild = futures_util::future::Shared<BoxFuture<'static, Result<(), String>>>;
 
+/// What asked for an index build. Only a serve counts as USE: the background
+/// refresh must not renew an index's LRU standing, or a namespace served once
+/// would keep itself alive — and keep paying for a scan every window — for the
+/// life of the process, and never age out behind the namespaces still in use.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IndexBuildTrigger {
+    Serve,
+    Refresh,
+}
+
 #[derive(Clone)]
 struct GrpcExtensionSpec<'a> {
     route: &'a str,
@@ -110,12 +121,9 @@ type ReapiServers = (
     ByteStreamServer<ReapiService>,
 );
 
-// The four REAPI gRPC services with their shared decoding limits.
-fn reapi_servers(state: SharedState) -> ReapiServers {
-    let service = ReapiService {
-        state,
-        snapshot_cache: Default::default(),
-    };
+// The four REAPI gRPC services with their shared decoding limits, all backed by
+// the one service (and so the one snapshot cache).
+fn reapi_servers(service: ReapiService) -> ReapiServers {
     (
         CapabilitiesServer::new(service.clone())
             .max_decoding_message_size(REAPI_MAX_DECODING_MESSAGE_SIZE),
@@ -137,13 +145,45 @@ fn reapi_servers(state: SharedState) -> ReapiServers {
 // fallback (gRPC status 12) becomes the co-hosted router's fallback for
 // otherwise-unmatched paths.
 pub fn routes(state: SharedState) -> axum::Router {
-    let (capabilities, action_cache, cas, byte_stream) = reapi_servers(state.clone());
+    let service = ReapiService {
+        state: state.clone(),
+        snapshot_cache: Default::default(),
+    };
+    spawn_snapshot_refresh_task(service.clone());
+    let (capabilities, action_cache, cas, byte_stream) = reapi_servers(service);
     tonic::service::Routes::new(capabilities)
         .add_service(action_cache)
         .add_service(cas)
         .add_service(byte_stream)
         .into_axum_router()
         .layer(GrpcRequestAccountingLayer { state })
+}
+
+/// Keeps the snapshot indexes this node is already serving fresh, instead of
+/// waiting for a fetch to notice they are stale.
+///
+/// Reconciling only on demand made staleness a function of fetch arrivals, not
+/// of the window: a client fetches the full snapshot about once per session and
+/// keeps that view for its whole build, so on a namespace CI publishes to
+/// continuously the first fetch of a session was answered from a view minutes
+/// behind — and every miss it caused was recompiled work the cache already
+/// held. Refreshing on a tick makes the freshness window mean what it says.
+///
+/// Bounded by construction: it only reconciles indexes the cache already holds
+/// (LRU-capped at SNAPSHOT_CACHE_MAX_NAMESPACES) and only while they are still
+/// being served, so it never enumerates namespaces nobody asked for and a node
+/// serving nothing does no work. The existing dedup owns the rest — a refresh
+/// joins an in-flight build rather than starting a second one.
+fn spawn_snapshot_refresh_task(service: ReapiService) {
+    tokio::spawn(
+        async move {
+            loop {
+                tokio::time::sleep(SNAPSHOT_REFRESH_TICK).await;
+                service.refresh_snapshot_indexes();
+            }
+        }
+        .in_current_span(),
+    );
 }
 
 #[derive(Clone)]
@@ -551,7 +591,8 @@ impl ReapiService {
                 drop(indexes);
                 self.cache_full_view(&cache_key, after, entries, &bytes);
                 if stale {
-                    let _build = self.ensure_index_build(namespace_id, trunk);
+                    let _build =
+                        self.ensure_index_build(namespace_id, trunk, IndexBuildTrigger::Serve);
                 }
                 return Ok(bytes);
             }
@@ -571,7 +612,7 @@ impl ReapiService {
                 .get(&cache_key)
                 .cloned();
             if let Some(cached) = cached {
-                let _build = self.ensure_index_build(namespace_id, trunk);
+                let _build = self.ensure_index_build(namespace_id, trunk, IndexBuildTrigger::Serve);
                 return Ok((*cached).clone());
             }
         }
@@ -583,7 +624,7 @@ impl ReapiService {
         // every fetch for as long as the build ran). Past the bound the
         // client gets UNAVAILABLE, stays on the per-key path, and a later
         // fetch is served from the completed index.
-        let build = self.ensure_index_build(namespace_id, trunk);
+        let build = self.ensure_index_build(namespace_id, trunk, IndexBuildTrigger::Serve);
         match tokio::time::timeout(SNAPSHOT_COLD_SERVE_WAIT, build).await {
             Ok(result) => result.map_err(|error| {
                 Status::internal(format!(
@@ -644,7 +685,12 @@ impl ReapiService {
     /// progress survives request aborts and transient store errors alike.
     /// While the index is out, serves fall back to the cached full view
     /// (`served_full`) rather than the cold path.
-    fn ensure_index_build(&self, namespace_id: &str, trunk: Option<&str>) -> SharedIndexBuild {
+    fn ensure_index_build(
+        &self,
+        namespace_id: &str,
+        trunk: Option<&str>,
+        trigger: IndexBuildTrigger,
+    ) -> SharedIndexBuild {
         // Builds are keyed by the same compound cache key as the indexes they
         // produce, so a trunk-scoped build and the unscoped one run and cache
         // independently.
@@ -674,7 +720,7 @@ impl ReapiService {
         let cleanup_cache = cache.clone();
         let task = tokio::spawn(async move {
             let outcome = futures_util::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
-                Self::run_index_build(cache, state, namespace, trunk, build_key),
+                Self::run_index_build(cache, state, namespace, trunk, build_key, trigger),
             ))
             .await;
             cleanup_cache
@@ -703,6 +749,47 @@ impl ReapiService {
         build
     }
 
+    /// The cached indexes a background refresh should reconcile: stale by the
+    /// same window a serve applies, and still being served. Only indexes that
+    /// already exist are candidates — nothing here enumerates the store, so a
+    /// namespace nobody fetches is never built. An index currently being built
+    /// is not in the map at all (the build takes it out), so an in-flight
+    /// reconcile is naturally skipped rather than raced.
+    fn refreshable_snapshot_indexes(&self) -> Vec<(String, Option<String>)> {
+        let indexes = self
+            .snapshot_cache
+            .indexes
+            .lock()
+            .expect("snapshot cache lock poisoned");
+        indexes
+            .iter()
+            .filter(|(_, index)| {
+                should_refresh_snapshot_index(
+                    index.reconciled_at.elapsed(),
+                    index.last_used.elapsed(),
+                )
+            })
+            .map(|(cache_key, _)| {
+                let (namespace_id, trunk) = snapshot_cache_key_parts(cache_key);
+                (namespace_id.to_owned(), trunk.map(str::to_owned))
+            })
+            .collect()
+    }
+
+    /// Reconciles every stale-but-live cached index once. Kicks the shared
+    /// build and drops it: the build is detached and caches its own result, and
+    /// awaiting them here would serialize a slow namespace's scan in front of
+    /// the rest.
+    fn refresh_snapshot_indexes(&self) {
+        for (namespace_id, trunk) in self.refreshable_snapshot_indexes() {
+            let _build = self.ensure_index_build(
+                &namespace_id,
+                trunk.as_deref(),
+                IndexBuildTrigger::Refresh,
+            );
+        }
+    }
+
     /// The build task's body: permit, reconcile, reinsert. The caller owns
     /// the builds-map entry cleanup, which must run whether this returns or
     /// panics.
@@ -712,6 +799,7 @@ impl ReapiService {
         namespace: String,
         trunk: Option<String>,
         cache_key: String,
+        trigger: IndexBuildTrigger,
     ) -> Result<(), String> {
         tracing::info!(
             namespace_id = namespace.as_str(),
@@ -775,7 +863,11 @@ impl ReapiService {
                     (index, Err(error))
                 }
             };
-        index.last_used = Instant::now();
+        // A background refresh leaves `last_used` alone so it keeps meaning
+        // "last served": the refresh selects on it, and the LRU evicts on it.
+        if trigger == IndexBuildTrigger::Serve {
+            index.last_used = Instant::now();
+        }
         {
             let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
             indexes.insert(cache_key.clone(), index);
@@ -2134,6 +2226,25 @@ fn snapshot_cache_key(namespace_id: &str, trunk: Option<&str>) -> String {
     }
 }
 
+/// Whether the background refresh should reconcile a cached index, given how
+/// long ago it was reconciled and how long ago it was last served. Stale by the
+/// same window a serve applies, and not yet idle: refreshing a namespace whose
+/// clients have all gone home buys nothing and costs a scan every window.
+fn should_refresh_snapshot_index(reconciled_ago: Duration, idle_for: Duration) -> bool {
+    reconciled_ago >= SNAPSHOT_RECONCILE_INTERVAL && idle_for < SNAPSHOT_REFRESH_IDLE_AFTER
+}
+
+/// The inverse of [`snapshot_cache_key`], for callers that hold a cached key
+/// and need the namespace and trunk it was built from. Exact: a namespace id is
+/// NUL-free (the store already uses NUL to terminate it in its own index key
+/// prefixes), so the first NUL is always the separator this wrote.
+fn snapshot_cache_key_parts(cache_key: &str) -> (&str, Option<&str>) {
+    match cache_key.split_once('\u{0}') {
+        Some((namespace_id, trunk)) => (namespace_id, Some(trunk)),
+        None => (cache_key, None),
+    }
+}
+
 /// The transient memory a bounded index build is budgeted for, held as a
 /// response-materialization-pool permit for the build's duration (adapted
 /// down on nodes whose pool is smaller). Matches SNAPSHOT_INDEX_MAX_ENTRIES
@@ -2146,11 +2257,25 @@ const SNAPSHOT_BUILD_BUDGET_BYTES: usize = 192 << 20;
 /// pinned at capacity for this entire window.
 const SNAPSHOT_BUILD_PERMIT_WAIT: Duration = Duration::from_secs(600);
 
-/// How old a cached snapshot index may grow before a serve kicks a
-/// background reconcile. Requests never wait on it — they get the cached
-/// view — so this bounds staleness, not latency; it composes with the
-/// client's ~2-minute delta cadence.
+/// How old a cached snapshot index may grow before it is reconciled. Requests
+/// never wait on it — they get the cached view — so this bounds staleness, not
+/// latency; it composes with the client's delta cadence.
 const SNAPSHOT_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How often the background refresh looks for cached indexes that have gone
+/// stale. Shorter than the freshness window so a stale index is picked up
+/// within it rather than a window later; a tick that finds nothing is a lock,
+/// a walk of at most SNAPSHOT_CACHE_MAX_NAMESPACES entries, and an instant
+/// comparison each.
+const SNAPSHOT_REFRESH_TICK: Duration = Duration::from_secs(15);
+
+/// How long after its last serve an index stops being refreshed in the
+/// background. Reconciling costs a namespace scan, so it is only worth paying
+/// on a namespace something is actually building against; past this the index
+/// simply goes cold and is served (and reconciled on demand) by the next fetch
+/// exactly as before. Generously above any client's delta cadence, so an idle
+/// gap between a session's fetches never drops it out of the refresh.
+const SNAPSHOT_REFRESH_IDLE_AFTER: Duration = Duration::from_secs(30 * 60);
 
 /// How long a COLD serve (no cached index) waits for the build before
 /// answering UNAVAILABLE. Long enough that an already-indexed namespace's
@@ -2747,6 +2872,79 @@ mod tests {
         // The rebuilt table keeps serving: the full view carries the live key.
         let full = index.encode_body(0, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(u64::from_le_bytes(full[5..13].try_into().unwrap()), 100);
+    }
+
+    #[test]
+    fn snapshot_cache_keys_round_trip_through_their_parts() {
+        for (namespace_id, trunk) in [
+            ("ios", None),
+            ("ios", Some("main")),
+            // A branch name carries slashes and dots; only NUL is reserved.
+            ("ios", Some("release/4.2.x")),
+        ] {
+            let key = snapshot_cache_key(namespace_id, trunk);
+            assert_eq!(snapshot_cache_key_parts(&key), (namespace_id, trunk));
+        }
+    }
+
+    #[test]
+    fn only_stale_and_still_served_indexes_are_refreshed() {
+        let fresh = SNAPSHOT_RECONCILE_INTERVAL / 2;
+        let stale = SNAPSHOT_RECONCILE_INTERVAL * 2;
+        let served = SNAPSHOT_REFRESH_IDLE_AFTER / 2;
+        let idle = SNAPSHOT_REFRESH_IDLE_AFTER * 2;
+
+        assert!(
+            should_refresh_snapshot_index(stale, served),
+            "a stale index a client is still fetching is exactly what this exists for"
+        );
+        assert!(
+            !should_refresh_snapshot_index(fresh, served),
+            "a fresh index costs nothing to leave alone"
+        );
+        assert!(
+            !should_refresh_snapshot_index(stale, idle),
+            "a namespace nobody fetches must not keep paying for a scan every window"
+        );
+        assert!(!should_refresh_snapshot_index(fresh, idle));
+    }
+
+    #[tokio::test]
+    async fn the_refresh_pass_picks_stale_indexes_out_of_the_cache_only() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        let insert = |cache_key: String, reconciled_at: Instant| {
+            let mut index = NamespaceSnapshotIndex::new();
+            index.reconciled_at = reconciled_at;
+            service
+                .snapshot_cache
+                .indexes
+                .lock()
+                .unwrap()
+                .insert(cache_key, index);
+        };
+        insert(
+            snapshot_cache_key("ios", Some("main")),
+            Instant::now() - 2 * SNAPSHOT_RECONCILE_INTERVAL,
+        );
+        insert(snapshot_cache_key("android", None), Instant::now());
+
+        assert_eq!(
+            service.refreshable_snapshot_indexes(),
+            vec![("ios".to_owned(), Some("main".to_owned()))],
+            "the stale index is selected, split back into its namespace and trunk"
+        );
+        // A namespace with no cached index is never a candidate: the refresh
+        // keeps what is being served warm, it does not go looking for work.
+        assert!(
+            !service
+                .refreshable_snapshot_indexes()
+                .iter()
+                .any(|(namespace_id, _)| namespace_id == "watch")
+        );
     }
 
     /// Marks a cached index stale so the next serve kicks a reconcile

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -523,7 +523,13 @@ impl ReapiService {
         &self,
         namespace_id: &str,
         after: u64,
+        trunk: Option<&str>,
     ) -> Result<Vec<u8>, Status> {
+        // A trunk filter keeps its own cached index and full view under a
+        // compound key so a scoped snapshot and the unscoped one never collide;
+        // with no filter the key is just the namespace, preserving today's
+        // behavior exactly.
+        let cache_key = snapshot_cache_key(namespace_id, trunk);
         // Serve the cached index immediately, kicking the reconcile in the
         // background once the view is older than the freshness window: a
         // reconcile costs a namespace scan (tens of seconds on a large
@@ -537,14 +543,15 @@ impl ReapiService {
                 .indexes
                 .lock()
                 .expect("snapshot cache lock poisoned");
-            if let Some(index) = indexes.get_mut(namespace_id) {
+            if let Some(index) = indexes.get_mut(&cache_key) {
                 let stale = index.reconciled_at.elapsed() >= SNAPSHOT_RECONCILE_INTERVAL;
                 index.last_used = Instant::now();
+                let entries = index.entries.len();
                 let bytes = index.encode(after);
                 drop(indexes);
-                self.cache_full_view(namespace_id, after, &bytes);
+                self.cache_full_view(&cache_key, after, entries, &bytes);
                 if stale {
-                    let _build = self.ensure_index_build(namespace_id);
+                    let _build = self.ensure_index_build(namespace_id, trunk);
                 }
                 return Ok(bytes);
             }
@@ -561,10 +568,10 @@ impl ReapiService {
                 .served_full
                 .lock()
                 .expect("snapshot served_full lock poisoned")
-                .get(namespace_id)
+                .get(&cache_key)
                 .cloned();
             if let Some(cached) = cached {
-                let _build = self.ensure_index_build(namespace_id);
+                let _build = self.ensure_index_build(namespace_id, trunk);
                 return Ok((*cached).clone());
             }
         }
@@ -576,7 +583,7 @@ impl ReapiService {
         // every fetch for as long as the build ran). Past the bound the
         // client gets UNAVAILABLE, stays on the per-key path, and a later
         // fetch is served from the completed index.
-        let build = self.ensure_index_build(namespace_id);
+        let build = self.ensure_index_build(namespace_id, trunk);
         match tokio::time::timeout(SNAPSHOT_COLD_SERVE_WAIT, build).await {
             Ok(result) => result.map_err(|error| {
                 Status::internal(format!(
@@ -594,13 +601,14 @@ impl ReapiService {
             .indexes
             .lock()
             .expect("snapshot cache lock poisoned");
-        let Some(index) = indexes.get_mut(namespace_id) else {
+        let Some(index) = indexes.get_mut(&cache_key) else {
             return Err(Status::internal("snapshot index missing after build"));
         };
         index.last_used = Instant::now();
+        let entries = index.entries.len();
         let bytes = index.encode(after);
         drop(indexes);
-        self.cache_full_view(namespace_id, after, &bytes);
+        self.cache_full_view(&cache_key, after, entries, &bytes);
         Ok(bytes)
     }
 
@@ -609,15 +617,24 @@ impl ReapiService {
     /// reconcile returns it instead of shedding to UNAVAILABLE. A delta is
     /// relative to a client's watermark and cannot be replayed, so it is not
     /// cached.
-    fn cache_full_view(&self, namespace_id: &str, after: u64, bytes: &[u8]) {
+    fn cache_full_view(&self, cache_key: &str, after: u64, entries: usize, bytes: &[u8]) {
         if after != 0 {
+            return;
+        }
+        // Never cache an empty view as stale-servable: a namespace's first
+        // request often lands before anything is published (a client's startup
+        // prefetch), and serving that cached emptiness to later cold clients
+        // starves them of a real index that finished building moments later —
+        // the client fetches once per session, so an empty answer sticks for
+        // its whole build.
+        if entries == 0 {
             return;
         }
         self.snapshot_cache
             .served_full
             .lock()
             .expect("snapshot served_full lock poisoned")
-            .insert(namespace_id.to_owned(), std::sync::Arc::new(bytes.to_vec()));
+            .insert(cache_key.to_owned(), std::sync::Arc::new(bytes.to_vec()));
     }
 
     /// The namespace's in-flight index build, starting one when none is
@@ -627,18 +644,24 @@ impl ReapiService {
     /// progress survives request aborts and transient store errors alike.
     /// While the index is out, serves fall back to the cached full view
     /// (`served_full`) rather than the cold path.
-    fn ensure_index_build(&self, namespace_id: &str) -> SharedIndexBuild {
+    fn ensure_index_build(&self, namespace_id: &str, trunk: Option<&str>) -> SharedIndexBuild {
+        // Builds are keyed by the same compound cache key as the indexes they
+        // produce, so a trunk-scoped build and the unscoped one run and cache
+        // independently.
+        let cache_key = snapshot_cache_key(namespace_id, trunk);
         let mut builds = self
             .snapshot_cache
             .builds
             .lock()
             .expect("snapshot builds lock poisoned");
-        if let Some(build) = builds.get(namespace_id) {
+        if let Some(build) = builds.get(&cache_key) {
             return build.clone();
         }
         let cache = self.snapshot_cache.clone();
         let state = self.state.clone();
         let namespace = namespace_id.to_owned();
+        let trunk = trunk.map(str::to_owned);
+        let build_key = cache_key.clone();
         // Spawned while holding the builds lock, so the task's terminal
         // removal (which takes the same lock) cannot run before the insert
         // below — the entry it removes is always its own. The body is
@@ -646,18 +669,19 @@ impl ReapiService {
         // that leaked the entry left a dead shared future in the map, and
         // every later build request for the namespace resolved to that
         // corpse — snapshots stayed bricked until the pod restarted.
+        let cleanup_key = cache_key.clone();
         let cleanup_namespace = namespace.clone();
         let cleanup_cache = cache.clone();
         let task = tokio::spawn(async move {
             let outcome = futures_util::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
-                Self::run_index_build(cache, state, namespace),
+                Self::run_index_build(cache, state, namespace, trunk, build_key),
             ))
             .await;
             cleanup_cache
                 .builds
                 .lock()
                 .expect("snapshot builds lock poisoned")
-                .remove(&cleanup_namespace);
+                .remove(&cleanup_key);
             match outcome {
                 Ok(result) => result,
                 Err(_panic) => {
@@ -675,7 +699,7 @@ impl ReapiService {
         }
         .boxed()
         .shared();
-        builds.insert(namespace_id.to_owned(), build.clone());
+        builds.insert(cache_key, build.clone());
         build
     }
 
@@ -686,6 +710,8 @@ impl ReapiService {
         cache: std::sync::Arc<SnapshotCache>,
         state: SharedState,
         namespace: String,
+        trunk: Option<String>,
+        cache_key: String,
     ) -> Result<(), String> {
         tracing::info!(
             namespace_id = namespace.as_str(),
@@ -728,30 +754,31 @@ impl ReapiService {
             .indexes
             .lock()
             .expect("snapshot cache lock poisoned")
-            .remove(&namespace)
+            .remove(&cache_key)
             .unwrap_or_else(NamespaceSnapshotIndex::new);
-        let (mut index, result) = match reconcile_snapshot_index(&state, &namespace, index).await {
-            Ok(mut index) => {
-                index.reconciled_at = Instant::now();
-                (index, Ok(()))
-            }
-            Err((index, error)) => {
-                // The reconcile hands the index back so accumulated progress
-                // survives a transient store error; reinsert it. Background
-                // kicks drop the shared future without awaiting it, so this is
-                // the only place a repeated reconcile failure becomes visible.
-                tracing::warn!(
-                    namespace_id = namespace.as_str(),
-                    error = error.as_str(),
-                    "action-cache snapshot reconcile failed"
-                );
-                (index, Err(error))
-            }
-        };
+        let (mut index, result) =
+            match reconcile_snapshot_index(&state, &namespace, trunk.as_deref(), index).await {
+                Ok(mut index) => {
+                    index.reconciled_at = Instant::now();
+                    (index, Ok(()))
+                }
+                Err((index, error)) => {
+                    // The reconcile hands the index back so accumulated progress
+                    // survives a transient store error; reinsert it. Background
+                    // kicks drop the shared future without awaiting it, so this is
+                    // the only place a repeated reconcile failure becomes visible.
+                    tracing::warn!(
+                        namespace_id = namespace.as_str(),
+                        error = error.as_str(),
+                        "action-cache snapshot reconcile failed"
+                    );
+                    (index, Err(error))
+                }
+            };
         index.last_used = Instant::now();
         {
             let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
-            indexes.insert(namespace.clone(), index);
+            indexes.insert(cache_key.clone(), index);
             while indexes.len() > SNAPSHOT_CACHE_MAX_NAMESPACES {
                 let oldest = indexes
                     .iter()
@@ -780,21 +807,23 @@ impl ReapiService {
 async fn reconcile_snapshot_index(
     state: &SharedState,
     namespace_id: &str,
+    trunk: Option<&str>,
     mut index: NamespaceSnapshotIndex,
 ) -> Result<NamespaceSnapshotIndex, (NamespaceSnapshotIndex, String)> {
     let started = Instant::now();
-    let manifests = match state
-        .store
-        .action_cache_manifests(namespace_id, SNAPSHOT_INDEX_MAX_ENTRIES)
-    {
-        Ok(manifests) => manifests,
-        Err(error) => {
-            return Err((
-                index,
-                format!("failed to enumerate the action cache: {error}"),
-            ));
-        }
-    };
+    let manifests =
+        match state
+            .store
+            .action_cache_manifests(namespace_id, snapshot_index_max_entries(), trunk)
+        {
+            Ok(manifests) => manifests,
+            Err(error) => {
+                return Err((
+                    index,
+                    format!("failed to enumerate the action cache: {error}"),
+                ));
+            }
+        };
     let scan_ms = started.elapsed().as_millis() as u64;
     // Diff the cached entries against the manifest keyspace: load only
     // new-or-changed entries, drop entries whose artifacts are gone.
@@ -1066,7 +1095,17 @@ impl ActionCache for ReapiService {
                 .iter()
                 .find_map(|hint| hint.strip_prefix(SNAPSHOT_AFTER_HINT)?.parse::<u64>().ok())
                 .unwrap_or(0);
-            let snapshot = self.serve_actioncache_snapshot(namespace_id, after).await?;
+            // A trunk-branch filter scopes the snapshot to the trunk baseline
+            // (entries tagged with this branch plus untagged/legacy entries).
+            // Absent or empty means the unfiltered, whole-namespace snapshot.
+            let trunk = request
+                .metadata()
+                .get("x-tuist-trunk-branch")
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| !value.is_empty());
+            let snapshot = self
+                .serve_actioncache_snapshot(namespace_id, after, trunk)
+                .await?;
             let served = snapshot.len() as u64;
             let action_result = reapi::ActionResult {
                 output_files: vec![reapi::OutputFile {
@@ -1293,6 +1332,22 @@ impl ActionCache for ReapiService {
             artifact_hash: Some(digest.hash.clone()),
         };
         let principal = self.authorize_request(&request, extension.clone()).await?;
+        // The publishing client tags the entry with its git branch so a
+        // trunk-scoped snapshot can later exclude feature-branch results.
+        let branch = request
+            .metadata()
+            .get("x-tuist-branch")
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        // The trunk rides the write too so the store can keep trunk-baseline
+        // keys sticky against feature republishes (see the damped persist).
+        let trunk = request
+            .metadata()
+            .get("x-tuist-trunk-branch")
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
         let bytes = action_result.encode_to_vec();
         let targets = replication_targets(&self.state).await;
         let (manifest, applied) = self
@@ -1305,6 +1360,8 @@ impl ActionCache for ReapiService {
                 "application/x-protobuf",
                 &bytes,
                 &targets,
+                branch.as_deref(),
+                trunk.as_deref(),
             )
             .await
             .map_err(|error| Status::internal(format!("failed to store action result: {error}")))?;
@@ -2053,8 +2110,29 @@ const SNAPSHOT_CACHE_MAX_NAMESPACES: usize = 32;
 /// in memory at once, and a namespace with weeks of un-expired CI churn
 /// OOM-killed the pod on its first serve. With the cap, the scan buffer
 /// (≤2x cap of manifests) plus the moved `current` map dominate the build's
-/// transient memory — roughly cap x ~1KB.
+/// transient memory — roughly cap x ~1KB. The default; a local bench can lower
+/// it through `KURA_SNAPSHOT_INDEX_MAX_ENTRIES` to force the cap to bind.
 const SNAPSHOT_INDEX_MAX_ENTRIES: usize = 100_000;
+
+/// The snapshot index cap, `KURA_SNAPSHOT_INDEX_MAX_ENTRIES` when it parses and
+/// `SNAPSHOT_INDEX_MAX_ENTRIES` otherwise.
+fn snapshot_index_max_entries() -> usize {
+    std::env::var("KURA_SNAPSHOT_INDEX_MAX_ENTRIES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(SNAPSHOT_INDEX_MAX_ENTRIES)
+}
+
+/// The snapshot-cache key for a namespace and optional trunk filter. With no
+/// filter it is the bare namespace id, so the unscoped snapshot keeps today's
+/// cache entries; a trunk filter appends the branch behind a NUL separator so a
+/// scoped snapshot never collides with the unscoped one.
+fn snapshot_cache_key(namespace_id: &str, trunk: Option<&str>) -> String {
+    match trunk {
+        Some(trunk) => format!("{namespace_id}\u{0}{trunk}"),
+        None => namespace_id.to_owned(),
+    }
+}
 
 /// The transient memory a bounded index build is budgeted for, held as a
 /// response-materialization-pool permit for the build's duration (adapted
@@ -2788,7 +2866,7 @@ mod tests {
         .await;
 
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("first serve should succeed");
         assert_eq!(
@@ -2815,7 +2893,7 @@ mod tests {
 
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("second serve should succeed");
         wait_for_snapshot_index(&service, "ios", |index| index.entries.len() == 1).await;
@@ -2995,7 +3073,7 @@ mod tests {
         // keep running and cache the index anyway. Dropping it with the
         // request meant every retry rebuilt from scratch, and a gateway
         // timeout made the snapshot permanently unservable.
-        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0));
+        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0, None));
         let first = futures_util::future::poll_immediate(serve.as_mut()).await;
         assert!(first.is_none(), "the first poll leaves the build in flight");
         drop(serve);
@@ -3022,7 +3100,7 @@ mod tests {
             "the finished build removed itself from the in-flight map"
         );
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("the follow-up request serves from the cached index");
         assert_eq!(&bytes[..4], b"TSNZ");
@@ -3046,7 +3124,7 @@ mod tests {
             .expect("late entry should persist");
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("the post-publish serve succeeds");
         wait_for_snapshot_index(&service, "ios", |index| {
@@ -3122,7 +3200,7 @@ mod tests {
         }
 
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("serve should succeed on the large namespace");
         assert_eq!(&bytes[..4], b"TSNZ");
@@ -3203,7 +3281,7 @@ mod tests {
             .expect("pool should be acquirable when idle");
         let serve = tokio::spawn({
             let service = service.clone();
-            async move { service.serve_actioncache_snapshot("ios", 0).await }
+            async move { service.serve_actioncache_snapshot("ios", 0, None).await }
         });
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         assert!(
@@ -3271,7 +3349,7 @@ mod tests {
 
         // A full serve builds the index and caches the full view.
         let first = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect("first serve builds the index");
         assert_eq!(&first[..4], b"TSNZ");
@@ -3301,7 +3379,7 @@ mod tests {
         // the rebuild runs. Before `served_full`, this fell to the cold path.
         let stale = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            service.serve_actioncache_snapshot("ios", 0),
+            service.serve_actioncache_snapshot("ios", 0, None),
         )
         .await
         .expect("serve must not block on the stalled rebuild")
@@ -3327,7 +3405,7 @@ mod tests {
             .try_acquire_reapi_materialization(pool)
             .expect("pool should be acquirable when idle");
         let status = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, None)
             .await
             .expect_err("cold serve should shed while the build is stuck");
         assert_eq!(status.code(), tonic::Code::Unavailable);
@@ -3336,7 +3414,7 @@ mod tests {
         drop(hog);
         let bytes = tokio::time::timeout(
             std::time::Duration::from_secs(120),
-            service.serve_actioncache_snapshot("ios", 0),
+            service.serve_actioncache_snapshot("ios", 0, None),
         )
         .await
         .expect("serve should not hang once the pool frees")

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -255,6 +255,30 @@ where
     }
 }
 
+/// A git ref carried as request metadata, preferring the binary header.
+///
+/// Git allows any UTF-8 in a ref name, and an ASCII metadata value takes visible
+/// ASCII only, so a client cannot send `feature/café` that way at all. It sends
+/// the bytes in the `-bin` header and, when the ref happens to be ASCII, the
+/// plain one as well, which is what a node too old to read this understands.
+/// Preferring the binary one costs nothing and is the only one that can be
+/// trusted to carry what the client actually meant.
+fn ref_metadata<T>(request: &Request<T>, header: &str, binary_header: &str) -> Option<String> {
+    request
+        .metadata()
+        .get_bin(binary_header)
+        .and_then(|value| value.to_bytes().ok())
+        .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok())
+        .or_else(|| {
+            request
+                .metadata()
+                .get(header)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned)
+        })
+        .filter(|value| !value.is_empty())
+}
+
 impl ReapiService {
     async fn authorize_request<T>(
         &self,
@@ -1223,11 +1247,8 @@ impl ActionCache for ReapiService {
             // A trunk-branch filter scopes the snapshot to the trunk baseline
             // (entries tagged with this branch plus untagged/legacy entries).
             // Absent or empty means the unfiltered, whole-namespace snapshot.
-            let trunk = request
-                .metadata()
-                .get("x-tuist-trunk-branch")
-                .and_then(|value| value.to_str().ok())
-                .filter(|value| !value.is_empty());
+            let trunk = ref_metadata(&request, "x-tuist-trunk-branch", "x-tuist-trunk-branch-bin");
+            let trunk = trunk.as_deref();
             let snapshot = self
                 .serve_actioncache_snapshot(namespace_id, after, trunk)
                 .await?;
@@ -1459,20 +1480,10 @@ impl ActionCache for ReapiService {
         let principal = self.authorize_request(&request, extension.clone()).await?;
         // The publishing client tags the entry with its git branch so a
         // trunk-scoped snapshot can later exclude feature-branch results.
-        let branch = request
-            .metadata()
-            .get("x-tuist-branch")
-            .and_then(|value| value.to_str().ok())
-            .filter(|value| !value.is_empty())
-            .map(str::to_owned);
+        let branch = ref_metadata(&request, "x-tuist-branch", "x-tuist-branch-bin");
         // The trunk rides the write too so the store can keep trunk-baseline
         // keys sticky against feature republishes (see the damped persist).
-        let trunk = request
-            .metadata()
-            .get("x-tuist-trunk-branch")
-            .and_then(|value| value.to_str().ok())
-            .filter(|value| !value.is_empty())
-            .map(str::to_owned);
+        let trunk = ref_metadata(&request, "x-tuist-trunk-branch", "x-tuist-trunk-branch-bin");
         let bytes = action_result.encode_to_vec();
         let targets = replication_targets(&self.state).await;
         let (manifest, applied) = self
@@ -3005,6 +3016,44 @@ mod tests {
         assert!(
             reconciled_at().is_some_and(|at| at > stamped),
             "an index built before a publish is rebuilt rather than served empty"
+        );
+    }
+
+    /// Git allows any UTF-8 in a ref name, and an ASCII metadata value takes
+    /// visible ASCII only, so a client cannot send one that way. It could not
+    /// even report the failure usefully: the publish just went out untagged and
+    /// the entry sat outside a trunk view nobody could see it was excluded from.
+    #[test]
+    fn a_ref_carrying_unicode_survives_the_metadata() {
+        let mut request = Request::new(());
+        request.metadata_mut().insert_bin(
+            "x-tuist-branch-bin",
+            tonic::metadata::MetadataValue::from_bytes("feature/café-au-lait".as_bytes()),
+        );
+        assert_eq!(
+            ref_metadata(&request, "x-tuist-branch", "x-tuist-branch-bin").as_deref(),
+            Some("feature/café-au-lait")
+        );
+    }
+
+    /// The header a node too old to send the binary one uses. Dropping it would
+    /// untag every ASCII ref through a rolling deploy.
+    #[test]
+    fn an_ascii_only_client_is_still_understood() {
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "x-tuist-branch",
+            tonic::metadata::MetadataValue::from_static("main"),
+        );
+        assert_eq!(
+            ref_metadata(&request, "x-tuist-branch", "x-tuist-branch-bin").as_deref(),
+            Some("main")
+        );
+        // And an absent ref stays absent rather than becoming an empty tag.
+        let empty: Request<()> = Request::new(());
+        assert_eq!(
+            ref_metadata(&empty, "x-tuist-branch", "x-tuist-branch-bin"),
+            None
         );
     }
 

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -668,7 +668,16 @@ impl ReapiService {
         // starves them of a real index that finished building moments later —
         // the client fetches once per session, so an empty answer sticks for
         // its whole build.
+        //
+        // Dropping any view already cached under this key is part of that:
+        // leaving it would serve an obsolete non-empty view to a request landing
+        // during a later reconcile, long after the namespace emptied.
         if entries == 0 {
+            self.snapshot_cache
+                .served_full
+                .lock()
+                .expect("snapshot served_full lock poisoned")
+                .remove(cache_key);
             return;
         }
         self.snapshot_cache

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -583,7 +583,20 @@ impl ReapiService {
                 .indexes
                 .lock()
                 .expect("snapshot cache lock poisoned");
-            if let Some(index) = indexes.get_mut(&cache_key) {
+            // An index that built EMPTY does not get to answer, however fresh it
+            // is. The freshness window trades staleness for round trips, and that
+            // trade only makes sense when there is something to serve: a
+            // populated index that is 60s out of date costs its client a few
+            // keys, an empty one costs it every key it came for. And it does not
+            // come back to find out we were only a minute behind, because it
+            // fetches once per session. So a namespace that published its first
+            // entries just after an empty build would starve every client that
+            // arrived inside the window. Falling through builds and serves the
+            // real thing, which is what an absent index already does, and the
+            // build is shared so concurrent serves pay for one.
+            if let Some(index) = indexes.get_mut(&cache_key)
+                && !index.entries.is_empty()
+            {
                 let stale = index.reconciled_at.elapsed() >= SNAPSHOT_RECONCILE_INTERVAL;
                 index.last_used = Instant::now();
                 let entries = index.entries.len();
@@ -2916,6 +2929,49 @@ mod tests {
             "a namespace nobody fetches must not keep paying for a scan every window"
         );
         assert!(!should_refresh_snapshot_index(fresh, idle));
+    }
+
+    /// A namespace that publishes its first entries just after an empty index was
+    /// built would otherwise serve nothing for the rest of the freshness window,
+    /// and a client fetches once per session, so "the rest of the window" is the
+    /// rest of its build. An empty index has to go back to the store instead of
+    /// answering, however recently it was reconciled.
+    #[tokio::test]
+    async fn a_fresh_but_empty_index_is_rebuilt_rather_than_served() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        // Reconciled just now, and empty: the shape a namespace has when its
+        // first client prefetched before anything was published.
+        let stamped = Instant::now();
+        let mut index = NamespaceSnapshotIndex::new();
+        index.reconciled_at = stamped;
+        service
+            .snapshot_cache
+            .indexes
+            .lock()
+            .unwrap()
+            .insert(snapshot_cache_key("ios", None), index);
+
+        service
+            .serve_actioncache_snapshot("ios", 0, None)
+            .await
+            .expect("serve should succeed");
+
+        let reconciled_at = service
+            .snapshot_cache
+            .indexes
+            .lock()
+            .unwrap()
+            .get(&snapshot_cache_key("ios", None))
+            .map(|index| index.reconciled_at);
+        assert!(
+            reconciled_at.is_some_and(|at| at > stamped),
+            "the serve went back to the store instead of answering from an empty \
+             index that happened to be fresh"
+        );
     }
 
     #[tokio::test]

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -84,6 +84,8 @@ pub async fn enqueue_replication_for_artifact(state: &SharedState, manifest: &Ar
                 artifact_id: manifest.artifact_id.clone(),
                 version_ms: manifest.version_ms,
                 inline: manifest.inline,
+                branch: manifest.branch.clone(),
+                trunk: None,
             },
         }) {
             warn!("failed to enqueue artifact replication for {peer}: {error}");
@@ -667,6 +669,13 @@ async fn bootstrap_artifact_from_peer(
                 &manifest.content_type,
                 bytes.as_ref(),
                 manifest.version_ms,
+                // The peer's manifest page carries the tag (an old peer's page
+                // simply omits it), so a bootstrapped entry keeps the branch it
+                // was published on instead of landing untagged in this node's
+                // trunk baseline. No trunk: bootstrap copies the peer's view
+                // rather than arbitrating between publishes.
+                manifest.branch.as_deref(),
+                None,
             )
             .await;
     }
@@ -1135,6 +1144,8 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
             artifact_id,
             version_ms,
             inline,
+            branch,
+            trunk,
         } => {
             let manifest = match state.store.manifest(artifact_id)? {
                 Some(manifest) => manifest,
@@ -1149,7 +1160,7 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                     format!("failed to open local artifact for replication: {error}")
                 })?;
 
-            let url = format!(
+            let mut url = format!(
                 "{}/_internal/replicate/artifact?producer={}&inline={}&namespace_id={}&key={}&content_type={}&version_ms={}",
                 message.target,
                 producer.as_str(),
@@ -1159,6 +1170,19 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                 url_encode(content_type),
                 version_ms,
             );
+            // Appended only when tagged, so an untagged publish puts the exact
+            // URL today's nodes send. An old peer ignores query params it does
+            // not read, which leaves it applying the entry untagged — its
+            // behavior before this field existed.
+            if let Some(branch) = branch {
+                url.push_str("&branch=");
+                url.push_str(&url_encode(branch));
+            }
+            if let Some(trunk) = trunk {
+                url.push_str("&trunk=");
+                url.push_str(&url_encode(trunk));
+            }
+            let url = url;
             let bandwidth_limiter = state.replication_bandwidth_limiter.clone();
             let body_stream = ReaderStream::new(file).then(move |item| {
                 let bandwidth_limiter = bandwidth_limiter.clone();
@@ -1577,6 +1601,8 @@ mod tests {
                         .expect("artifact should exist")
                         .version_ms,
                     inline: false,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("upsert should enqueue");
@@ -1890,6 +1916,8 @@ mod tests {
                     artifact_id: artifact.artifact_id,
                     version_ms: artifact.version_ms,
                     inline: false,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("upsert should enqueue");
@@ -1962,6 +1990,8 @@ mod tests {
                     artifact_id: artifact.artifact_id,
                     version_ms: artifact.version_ms,
                     inline: false,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("upsert should enqueue");
@@ -2055,6 +2085,8 @@ mod tests {
                     artifact_id: manifest.artifact_id.clone(),
                     version_ms: manifest.version_ms,
                     inline: false,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("outbox message should enqueue");
@@ -2572,6 +2604,8 @@ mod tests {
                     "application/octet-stream",
                     b"payload",
                     100,
+                    None,
+                    None,
                 )
                 .await
                 .expect("remote applies artifact");
@@ -2594,6 +2628,8 @@ mod tests {
                         "application/octet-stream",
                         b"payload",
                         100,
+                        None,
+                        None,
                     )
                     .await
                     .expect("local applies artifact");
@@ -2732,6 +2768,8 @@ mod tests {
                     "application/octet-stream",
                     b"payload",
                     100,
+                    None,
+                    None,
                 )
                 .await
                 .expect("remote applies artifact");
@@ -2787,6 +2825,8 @@ mod tests {
                 "application/octet-stream",
                 b"payload",
                 100,
+                None,
+                None,
             )
             .await
             .expect("remote applies artifact");

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -1344,6 +1344,7 @@ mod tests {
             size: 0,
             version_ms: 0,
             created_at_ms: 0,
+            branch: None,
         }
     }
 
@@ -1462,6 +1463,7 @@ mod tests {
             size,
             version_ms,
             created_at_ms: version_ms,
+            branch: None,
         }
     }
 

--- a/kura/src/replication/operation.rs
+++ b/kura/src/replication/operation.rs
@@ -15,6 +15,18 @@ pub enum ReplicationOperation {
         inline: bool,
         #[serde(default)]
         version_ms: u64,
+        /// The publishing client's git branch, carried so a replicated
+        /// action-cache entry keeps its tag. Without it every entry arrived at
+        /// the peer untagged, and untagged entries sit in the trunk baseline —
+        /// so a feature entry re-polluted the very view the tag exists to
+        /// scope. Additive: an old peer's message decodes to `None` (today's
+        /// behavior), and an old peer drops the field it does not know.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+        /// The publishing client's trunk, carried so the receiving node can
+        /// re-run the trunk-sticky rule against its own view of the key.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trunk: Option<String>,
     },
     DeleteNamespace {
         namespace_id: String,
@@ -46,6 +58,71 @@ mod tests {
 
     use super::ReplicationOperation;
 
+    /// The outbox is JSON on disk and the peer protocol is derived from it, so
+    /// both directions of a one-version skew must decode: an old node's message
+    /// (no branch/trunk) yields `None` — the untagged trunk-baseline entry
+    /// today's fleet already produces — and an old node reading a new message
+    /// ignores the fields it does not know rather than failing the drain.
+    #[test]
+    fn upsert_artifact_branch_is_additive_across_a_version_skew() {
+        let old_format = r#"{
+            "type": "upsert_artifact",
+            "producer": "reapi",
+            "namespace_id": "ios",
+            "key": "action_cache/aa/10",
+            "content_type": "application/x-protobuf",
+            "artifact_id": "artifact-id",
+            "inline": true,
+            "version_ms": 123
+        }"#;
+        let decoded: ReplicationOperation =
+            serde_json::from_str(old_format).expect("an old peer's message should decode");
+        assert!(matches!(
+            decoded,
+            ReplicationOperation::UpsertArtifact {
+                branch: None,
+                trunk: None,
+                ..
+            }
+        ));
+
+        let tagged = ReplicationOperation::UpsertArtifact {
+            producer: ArtifactProducer::Reapi,
+            namespace_id: "ios".into(),
+            key: "action_cache/aa/10".into(),
+            content_type: "application/x-protobuf".into(),
+            artifact_id: "artifact-id".into(),
+            inline: true,
+            version_ms: 123,
+            branch: Some("main".into()),
+            trunk: Some("main".into()),
+        };
+        let encoded = serde_json::to_string(&tagged).expect("message should encode");
+        assert_eq!(
+            serde_json::from_str::<ReplicationOperation>(&encoded).expect("round trip should hold"),
+            tagged
+        );
+        // An untagged publish keeps the fields off the wire entirely, so what
+        // an old node receives is byte-identical to what it sends today.
+        let untagged = ReplicationOperation::UpsertArtifact {
+            producer: ArtifactProducer::Reapi,
+            namespace_id: "ios".into(),
+            key: "action_cache/aa/10".into(),
+            content_type: "application/x-protobuf".into(),
+            artifact_id: "artifact-id".into(),
+            inline: true,
+            version_ms: 123,
+            branch: None,
+            trunk: None,
+        };
+        let encoded = serde_json::to_string(&untagged).expect("message should encode");
+        assert!(
+            !encoded.contains("branch"),
+            "absent fields stay off the wire"
+        );
+        assert!(!encoded.contains("trunk"));
+    }
+
     #[test]
     fn replication_operation_names_match_routes() {
         assert_eq!(
@@ -57,6 +134,8 @@ mod tests {
                 artifact_id: "artifact-id".into(),
                 inline: false,
                 version_ms: 123,
+                branch: None,
+                trunk: None,
             }
             .name(),
             "upsert_artifact"

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -219,6 +219,10 @@ struct PersistArtifactSpec<'a> {
     version_ms: u64,
     replication_targets: &'a [String],
     branch: Option<&'a str>,
+    /// Rides the replication messages this persist enqueues so a peer can
+    /// re-run the trunk-sticky rule against its own view. Not stored: the
+    /// trunk is a property of the publishing build, not of the artifact.
+    trunk: Option<&'a str>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -642,6 +646,7 @@ impl Store {
             version_ms: now_ms(),
             replication_targets,
             branch: None,
+            trunk: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_path_with_version(spec, source_path)
@@ -666,6 +671,7 @@ impl Store {
             version_ms,
             replication_targets: &[],
             branch: None,
+            trunk: None,
         };
         Ok(self
             .persist_artifact_from_path_with_version(spec, source_path)
@@ -787,7 +793,12 @@ impl Store {
                 [],
             );
         }
-        self.append_artifact_replication_messages(&mut batch, &manifest, spec.replication_targets)?;
+        self.append_artifact_replication_messages(
+            &mut batch,
+            &manifest,
+            spec.replication_targets,
+            spec.trunk,
+        )?;
 
         self.write_batch_sync(batch, "manifest batch")?;
         self.hit_failpoint(FailpointName::AfterMetadataCommitBeforeReturn)
@@ -1346,7 +1357,12 @@ impl Store {
                 artifact_id.as_bytes(),
             );
         }
-        self.append_artifact_replication_messages(&mut batch, &manifest, spec.replication_targets)?;
+        self.append_artifact_replication_messages(
+            &mut batch,
+            &manifest,
+            spec.replication_targets,
+            spec.trunk,
+        )?;
 
         self.write_batch_sync(batch, "keyvalue batch")?;
         self.maybe_cache_manifest(manifest.clone());
@@ -1872,6 +1888,7 @@ impl Store {
             version_ms: now_ms(),
             replication_targets: &[],
             branch: None,
+            trunk: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -1898,6 +1915,7 @@ impl Store {
             version_ms: now_ms(),
             replication_targets,
             branch: None,
+            trunk: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -1922,6 +1940,7 @@ impl Store {
             version_ms: now_ms(),
             replication_targets: &[],
             branch: None,
+            trunk: None,
         };
         match self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -1965,20 +1984,7 @@ impl Store {
         {
             return Ok((existing.clone(), false));
         }
-        // Trunk-sticky tagging: a key already in the trunk baseline (tagged
-        // with the trunk branch, or untagged/legacy) stays there. A feature
-        // build recomputing the same action republishes it — often with byte
-        // wobble that defeats the damping above — and must not steal the key
-        // from the trunk view. A publish FROM the trunk always (re)claims it.
-        let branch = match (&existing, trunk) {
-            (Some(existing), Some(trunk))
-                if branch != Some(trunk)
-                    && existing.branch.as_deref().is_none_or(|tag| tag == trunk) =>
-            {
-                existing.branch.as_deref()
-            }
-            _ => branch,
-        };
+        let branch = sticky_branch(existing.as_ref(), branch, trunk);
         self.persist_inline_artifact_from_bytes_and_enqueue(
             producer,
             namespace_id,
@@ -1987,6 +1993,7 @@ impl Store {
             bytes,
             replication_targets,
             branch,
+            trunk,
         )
         .await
         .map(|manifest| (manifest, true))
@@ -2002,6 +2009,7 @@ impl Store {
         bytes: &[u8],
         replication_targets: &[String],
         branch: Option<&str>,
+        trunk: Option<&str>,
     ) -> Result<ArtifactManifest, String> {
         let spec = PersistArtifactSpec {
             producer,
@@ -2011,6 +2019,7 @@ impl Store {
             version_ms: now_ms(),
             replication_targets,
             branch,
+            trunk,
         };
         match self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -2042,6 +2051,7 @@ impl Store {
             version_ms,
             replication_targets: &[],
             branch: None,
+            trunk: None,
         };
         Ok(self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -2050,6 +2060,11 @@ impl Store {
             .apply_outcome())
     }
 
+    /// Apply an inline artifact replicated from a peer. `branch` is the tag the
+    /// origin resolved and `trunk` the publishing build's trunk; a peer that
+    /// sends neither (an older node, or any non-REAPI write) applies untagged,
+    /// exactly as before.
+    #[allow(clippy::too_many_arguments)]
     pub async fn apply_replicated_inline_artifact_from_bytes(
         &self,
         producer: ArtifactProducer,
@@ -2058,7 +2073,25 @@ impl Store {
         content_type: &str,
         bytes: &[u8],
         version_ms: u64,
+        branch: Option<&str>,
+        trunk: Option<&str>,
     ) -> Result<ArtifactApplyOutcome, String> {
+        // Re-run the trunk-sticky rule against THIS node's view. The origin
+        // could only apply it against its own: a feature build publishing a
+        // trunk key to a peer that does not hold it yet resolves the tag to
+        // `feature`, and applying that verbatim would steal the key out of the
+        // trunk baseline here — the same theft the rule prevents locally, just
+        // arriving over replication. Only a trunk-carrying publish reaches the
+        // lookup, so a peer that sends none costs no read.
+        let existing = match trunk {
+            Some(_) => self.manifest_from_db(&artifact_storage_id(
+                producer,
+                &self.tenant_id,
+                namespace_id,
+                key,
+            ))?,
+            None => None,
+        };
         let spec = PersistArtifactSpec {
             producer,
             namespace_id,
@@ -2066,7 +2099,8 @@ impl Store {
             content_type,
             version_ms,
             replication_targets: &[],
-            branch: None,
+            branch: sticky_branch(existing.as_ref(), branch, trunk),
+            trunk: None,
         };
         Ok(self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -3072,6 +3106,7 @@ impl Store {
         batch: &mut WriteBatch,
         manifest: &ArtifactManifest,
         replication_targets: &[String],
+        trunk: Option<&str>,
     ) -> Result<(), String> {
         for target in replication_targets {
             self.append_outbox_message(
@@ -3086,6 +3121,10 @@ impl Store {
                         artifact_id: manifest.artifact_id.clone(),
                         inline: manifest.inline,
                         version_ms: manifest.version_ms,
+                        // The tag as resolved here, so the peer does not have to
+                        // infer it from a request header it never saw.
+                        branch: manifest.branch.clone(),
+                        trunk: trunk.map(str::to_owned),
                     },
                 },
             )?;
@@ -3964,6 +4003,29 @@ fn outbox_message_key(message: &OutboxMessage) -> String {
     format!("{lane}-{:020}-{}", now_ms(), Uuid::now_v7())
 }
 
+/// The branch tag a publish should land with, honoring trunk-stickiness: a key
+/// already in the trunk baseline (tagged with the trunk branch, or
+/// untagged/legacy) keeps its tag. A feature build recomputing the same action
+/// republishes it — often with byte wobble that defeats the refresh damping —
+/// and must not steal the key from the trunk view. A publish FROM the trunk
+/// always (re)claims it, and with no trunk to compare against the publish's own
+/// tag stands.
+fn sticky_branch<'a>(
+    existing: Option<&'a ArtifactManifest>,
+    branch: Option<&'a str>,
+    trunk: Option<&str>,
+) -> Option<&'a str> {
+    match (existing, trunk) {
+        (Some(existing), Some(trunk))
+            if branch != Some(trunk)
+                && existing.branch.as_deref().is_none_or(|tag| tag == trunk) =>
+        {
+            existing.branch.as_deref()
+        }
+        _ => branch,
+    }
+}
+
 /// Whether a manifest belongs in a trunk-scoped snapshot: entries tagged with
 /// the trunk branch and untagged/legacy entries (no branch) form the trunk
 /// baseline; entries tagged with a different branch are excluded. `None` keeps
@@ -4241,6 +4303,8 @@ mod tests {
                 "application/x-protobuf",
                 b"graph",
                 now_ms() - 2 * day,
+                None,
+                None,
             )
             .await
             .expect("seed should persist");
@@ -4401,6 +4465,133 @@ mod tests {
             ],
             "trunk keys stay in (or return to) the trunk baseline"
         );
+    }
+
+    #[tokio::test]
+    async fn replicated_entries_carry_their_branch_across_the_mesh() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn apply(store: &Store, key: &str, version_ms: u64, branch: Option<&str>) {
+            store
+                .apply_replicated_inline_artifact_from_bytes(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    key,
+                    "application/x-protobuf",
+                    b"graph",
+                    version_ms,
+                    branch,
+                    None,
+                )
+                .await
+                .expect("replicated entry should apply");
+        }
+        // A peer's feature entry keeps its tag instead of landing untagged in
+        // this node's trunk baseline — the pollution the branch tag exists to
+        // prevent, arriving over replication rather than from a client.
+        apply(&store, "action_cache/aa/10", 1_000, Some("feature")).await;
+        // A message from a node that predates the field carries no branch; it
+        // applies untagged, which is what every replicated entry did before.
+        apply(&store, "action_cache/bb/10", 1_000, None).await;
+        apply(&store, "action_cache/cc/10", 1_000, Some("main")).await;
+
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        let mut keys: Vec<&str> = trunk.iter().map(|manifest| manifest.key.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["action_cache/bb/10", "action_cache/cc/10"],
+            "a replicated feature entry stays out of the trunk view; an untagged one stays in"
+        );
+    }
+
+    #[tokio::test]
+    async fn replicated_feature_entries_cannot_steal_a_trunk_baseline_key() {
+        let (_temp_dir, _config, store) = temp_store();
+        // The origin resolves the tag against ITS OWN view, so a feature build
+        // publishing a trunk key to a peer that does not hold it yet resolves
+        // `feature` and replicates that. This node holds the key in its trunk
+        // baseline and must not hand it over.
+        store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                &[],
+                Some("main"),
+                Some("main"),
+            )
+            .await
+            .expect("trunk entry should persist");
+        let seeded = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        assert_eq!(seeded.len(), 1, "the key starts in the trunk baseline");
+
+        store
+            .apply_replicated_inline_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph-wobble",
+                seeded[0].version_ms + 1_000,
+                Some("feature"),
+                Some("main"),
+            )
+            .await
+            .expect("replicated republish should apply");
+
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        assert_eq!(
+            trunk.len(),
+            1,
+            "the key stays in the trunk view against a replicated feature republish"
+        );
+        assert_eq!(trunk[0].branch.as_deref(), Some("main"));
+
+        // A replicated publish FROM the trunk still reclaims the key.
+        store
+            .apply_replicated_inline_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/bb/10",
+                "application/x-protobuf",
+                b"graph",
+                1_000,
+                Some("feature"),
+                Some("main"),
+            )
+            .await
+            .expect("replicated feature entry should apply");
+        store
+            .apply_replicated_inline_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/bb/10",
+                "application/x-protobuf",
+                b"graph-wobble",
+                2_000,
+                Some("main"),
+                Some("main"),
+            )
+            .await
+            .expect("replicated trunk entry should apply");
+        let reclaimed = store
+            .manifest_from_db(&artifact_storage_id(
+                ArtifactProducer::Reapi,
+                &store.tenant_id,
+                "ios",
+                "action_cache/bb/10",
+            ))
+            .expect("manifest read should succeed")
+            .expect("entry should exist");
+        assert_eq!(reclaimed.branch.as_deref(), Some("main"));
     }
 
     #[tokio::test]
@@ -5170,6 +5361,8 @@ mod tests {
                 "application/octet-stream",
                 bytes,
                 version_ms,
+                None,
+                None,
             )
             .await
             .expect("failed to apply replicated inline artifact");
@@ -6277,6 +6470,8 @@ mod tests {
                     artifact_id: "blob-artifact".into(),
                     inline: false,
                     version_ms: 1,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("failed to enqueue bulk message");
@@ -6291,6 +6486,8 @@ mod tests {
                     artifact_id: "entry-artifact".into(),
                     inline: true,
                     version_ms: 2,
+                    branch: None,
+                    trunk: None,
                 },
             })
             .expect("failed to enqueue metadata message");
@@ -6370,6 +6567,7 @@ mod tests {
                 br#"{"ok":true}"#,
                 &targets,
                 None,
+                None,
             )
             .await
             .expect("artifact should persist");
@@ -6395,6 +6593,8 @@ mod tests {
                     artifact_id: manifest.artifact_id.clone(),
                     version_ms: manifest.version_ms,
                     inline: true,
+                    branch: None,
+                    trunk: None,
                 }
             );
         }
@@ -6610,6 +6810,7 @@ mod tests {
                 "application/json",
                 br#"{"value":"ok"}"#,
                 &["http://peer-a".to_string()],
+                None,
                 None,
             )
             .await

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1977,22 +1977,31 @@ impl Store {
     ) -> Result<(ArtifactManifest, bool), String> {
         let artifact_id = artifact_storage_id(producer, &self.tenant_id, namespace_id, key);
         let existing = self.manifest_from_db(&artifact_id)?;
-        let branch = sticky_branch(existing.as_ref(), branch, trunk);
-        // Damp only when the write would change nothing, INCLUDING the tag. An
-        // entry a feature branch published first is tagged `feature`, so trunk
-        // republishing the identical bytes must still write: damping it would
-        // leave the key tagged `feature` and therefore outside the trunk
-        // snapshot, for the whole damping window, for a key trunk demonstrably
-        // builds. That is the pollution this scoping exists to remove.
+        // Damping deliberately outranks the tag, and does NOT compare it.
+        //
+        // Making the tag part of this condition looks right (it would let trunk
+        // reclaim a key a feature branch published first with identical bytes)
+        // and is a trap: `refresh_view_keys` re-publishes cached manifests with
+        // no branch and no trunk, so a tag comparison sees `Some("feature")` vs
+        // `None`, declines to damp, and writes the entry UNTAGGED. Untagged is
+        // the trunk baseline, so every refreshed feature entry would land in the
+        // very view this scoping keeps clean. Reverted for that reason; the
+        // reclaim it bought was mostly unreachable anyway, because the client
+        // dedupes a re-publish whose value digest already matches and so never
+        // sends the tag-only update.
+        //
+        // Reclaiming a feature-tagged key for trunk needs the refresh path to
+        // carry branch/trunk (the instance is not threaded into `view_refresh`
+        // today) AND the client-side dedupe to allow a tag-only update.
         if let Some(existing) = &existing
             && existing.inline
-            && existing.branch.as_deref() == branch
             && manifest_version_ms(existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
                 > now_ms()
             && self.inline_bytes(&artifact_id)?.as_deref() == Some(bytes)
         {
             return Ok((existing.clone(), false));
         }
+        let branch = sticky_branch(existing.as_ref(), branch, trunk);
         self.persist_inline_artifact_from_bytes_and_enqueue(
             producer,
             namespace_id,
@@ -4539,67 +4548,8 @@ mod tests {
         );
     }
 
-    // Damping must not outrank the tag. A feature build publishes a key first, so
-    // it is tagged `feature`; trunk then builds the same action and republishes
-    // the IDENTICAL bytes well inside the damping window. Damping the write would
-    // leave the key `feature`-tagged and therefore missing from the trunk view for
-    // up to a day, for a key trunk provably builds — the exact pollution this
-    // scoping removes.
-    #[tokio::test]
-    async fn trunk_reclaims_an_identical_entry_a_feature_branch_published_first() {
-        let (_temp_dir, _config, store) = temp_store();
-        store
-            .persist_inline_artifact_from_bytes_damped_and_enqueue(
-                ArtifactProducer::Reapi,
-                "ios",
-                "action_cache/aa/10",
-                "application/x-protobuf",
-                b"graph",
-                &[],
-                Some("feature"),
-                Some("main"),
-            )
-            .await
-            .expect("feature entry should persist");
-        assert!(
-            store
-                .action_cache_manifests("ios", 10, Some("main"))
-                .expect("trunk scan should succeed")
-                .is_empty(),
-            "the feature build's key starts outside the trunk view"
-        );
-
-        let (_manifest, applied) = store
-            .persist_inline_artifact_from_bytes_damped_and_enqueue(
-                ArtifactProducer::Reapi,
-                "ios",
-                "action_cache/aa/10",
-                "application/x-protobuf",
-                b"graph", // byte-identical, and inside the damping window
-                &[],
-                Some("main"),
-                Some("main"),
-            )
-            .await
-            .expect("trunk republish should persist");
-
-        assert!(applied, "the tag changes, so the write must not be damped");
-        let keys: Vec<String> = store
-            .action_cache_manifests("ios", 10, Some("main"))
-            .expect("trunk scan should succeed")
-            .into_iter()
-            .map(|manifest| manifest.key)
-            .collect();
-        assert_eq!(
-            keys,
-            vec!["action_cache/aa/10"],
-            "trunk reclaims the key it demonstrably builds"
-        );
-    }
-
-    // The mirror of the above: once the tag already matches, an identical
-    // re-publish inside the window is still damped, which is what keeps a fleet
-    // of cold machines from stampeding version bumps for the same entry.
+    // An identical re-publish inside the window is damped, which is what keeps a
+    // fleet of cold machines from stampeding version bumps for the same entry.
     #[tokio::test]
     async fn identical_trunk_republish_stays_damped_when_the_tag_already_matches() {
         let (_temp_dir, _config, store) = temp_store();

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2836,12 +2836,18 @@ impl Store {
         // one.
         let read_budget = max_entries.saturating_mul(ACTION_CACHE_TRUNK_SCAN_FACTOR);
         let mut read = 0usize;
+        // Not a budget, an observation: rejecting a row is free now, so the walk
+        // is bounded by the namespace rather than by `read_budget`. Reporting it
+        // is what makes a namespace whose walk dwarfs its view visible instead of
+        // something to infer.
+        let mut scanned = 0usize;
         for item in iter {
             let (index_key, artifact_id) =
                 item.map_err(|error| format!("failed to iterate action-cache index: {error}"))?;
             if !index_key.starts_with(&prefix) {
                 break;
             }
+            scanned += 1;
             if manifests.len() >= max_entries {
                 break;
             }
@@ -2863,6 +2869,7 @@ impl Store {
                 tracing::warn!(
                     namespace_id,
                     read,
+                    scanned,
                     kept = manifests.len(),
                     "action-cache trunk scan hit its read budget; view truncated"
                 );

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -218,6 +218,7 @@ struct PersistArtifactSpec<'a> {
     content_type: &'a str,
     version_ms: u64,
     replication_targets: &'a [String],
+    branch: Option<&'a str>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -640,6 +641,7 @@ impl Store {
             content_type,
             version_ms: now_ms(),
             replication_targets,
+            branch: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_path_with_version(spec, source_path)
@@ -663,6 +665,7 @@ impl Store {
             content_type,
             version_ms,
             replication_targets: &[],
+            branch: None,
         };
         Ok(self
             .persist_artifact_from_path_with_version(spec, source_path)
@@ -730,6 +733,7 @@ impl Store {
             size,
             version_ms: persisted_version_ms,
             created_at_ms: persisted_version_ms,
+            branch: spec.branch.map(str::to_owned),
         };
         let metadata = manifest.metadata(&self.tenant_id);
 
@@ -1303,6 +1307,7 @@ impl Store {
             size: bytes.len() as u64,
             version_ms: persisted_version_ms,
             created_at_ms: persisted_version_ms,
+            branch: spec.branch.map(str::to_owned),
         };
         let metadata = manifest.metadata(&self.tenant_id);
 
@@ -1866,6 +1871,7 @@ impl Store {
             content_type,
             version_ms: now_ms(),
             replication_targets: &[],
+            branch: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -1891,6 +1897,7 @@ impl Store {
             content_type,
             version_ms: now_ms(),
             replication_targets,
+            branch: None,
         };
         let (outcome, already_present) = self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -1914,6 +1921,7 @@ impl Store {
             content_type,
             version_ms: now_ms(),
             replication_targets: &[],
+            branch: None,
         };
         match self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -1935,6 +1943,7 @@ impl Store {
     /// manifests; without damping, every cold machine in a fleet would bump
     /// the same entries' versions (and replicate the rewrites) on the same
     /// day.
+    #[allow(clippy::too_many_arguments)]
     pub async fn persist_inline_artifact_from_bytes_damped_and_enqueue(
         &self,
         producer: ArtifactProducer,
@@ -1943,16 +1952,33 @@ impl Store {
         content_type: &str,
         bytes: &[u8],
         replication_targets: &[String],
+        branch: Option<&str>,
+        trunk: Option<&str>,
     ) -> Result<(ArtifactManifest, bool), String> {
         let artifact_id = artifact_storage_id(producer, &self.tenant_id, namespace_id, key);
-        if let Some(existing) = self.manifest_from_db(&artifact_id)?
+        let existing = self.manifest_from_db(&artifact_id)?;
+        if let Some(existing) = &existing
             && existing.inline
-            && manifest_version_ms(&existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
+            && manifest_version_ms(existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
                 > now_ms()
             && self.inline_bytes(&artifact_id)?.as_deref() == Some(bytes)
         {
-            return Ok((existing, false));
+            return Ok((existing.clone(), false));
         }
+        // Trunk-sticky tagging: a key already in the trunk baseline (tagged
+        // with the trunk branch, or untagged/legacy) stays there. A feature
+        // build recomputing the same action republishes it — often with byte
+        // wobble that defeats the damping above — and must not steal the key
+        // from the trunk view. A publish FROM the trunk always (re)claims it.
+        let branch = match (&existing, trunk) {
+            (Some(existing), Some(trunk))
+                if branch != Some(trunk)
+                    && existing.branch.as_deref().is_none_or(|tag| tag == trunk) =>
+            {
+                existing.branch.as_deref()
+            }
+            _ => branch,
+        };
         self.persist_inline_artifact_from_bytes_and_enqueue(
             producer,
             namespace_id,
@@ -1960,11 +1986,13 @@ impl Store {
             content_type,
             bytes,
             replication_targets,
+            branch,
         )
         .await
         .map(|manifest| (manifest, true))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn persist_inline_artifact_from_bytes_and_enqueue(
         &self,
         producer: ArtifactProducer,
@@ -1973,6 +2001,7 @@ impl Store {
         content_type: &str,
         bytes: &[u8],
         replication_targets: &[String],
+        branch: Option<&str>,
     ) -> Result<ArtifactManifest, String> {
         let spec = PersistArtifactSpec {
             producer,
@@ -1981,6 +2010,7 @@ impl Store {
             content_type,
             version_ms: now_ms(),
             replication_targets,
+            branch,
         };
         match self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -2011,6 +2041,7 @@ impl Store {
             content_type,
             version_ms,
             replication_targets: &[],
+            branch: None,
         };
         Ok(self
             .persist_artifact_from_bytes_with_version(spec, bytes)
@@ -2035,6 +2066,7 @@ impl Store {
             content_type,
             version_ms,
             replication_targets: &[],
+            branch: None,
         };
         Ok(self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -2668,13 +2700,19 @@ impl Store {
     /// entries a thousand to one, which starved every snapshot fetch into a
     /// client timeout. Namespaces written before the index existed are
     /// backfilled with one legacy scan on first use.
+    ///
+    /// When `trunk` is `Some`, only entries whose manifest carries that branch
+    /// or no branch at all (untagged/legacy entries stay in the trunk baseline)
+    /// are returned; the cap counts kept entries only. `None` returns every
+    /// action-cache entry regardless of branch.
     pub fn action_cache_manifests(
         &self,
         namespace_id: &str,
         max_entries: usize,
+        trunk: Option<&str>,
     ) -> Result<Vec<ArtifactManifest>, String> {
         if !self.action_cache_index_backfilled(namespace_id)? {
-            return self.backfill_action_cache_index(namespace_id, max_entries);
+            return self.backfill_action_cache_index(namespace_id, max_entries, trunk);
         }
         let prefix = action_cache_index_prefix(namespace_id);
         let iter = self.db.iterator_cf(
@@ -2708,7 +2746,11 @@ impl Store {
                         && manifest.key.starts_with("action_cache/")
                         && row_version == Some(manifest.version_ms) =>
                 {
-                    manifests.push(manifest);
+                    // A valid entry outside the trunk filter is skipped, not
+                    // deleted: it is a live entry for another branch.
+                    if manifest_in_trunk(&manifest, trunk) {
+                        manifests.push(manifest);
+                    }
                 }
                 _ => stale_rows.push(index_key.to_vec()),
             }
@@ -2749,6 +2791,7 @@ impl Store {
         &self,
         namespace_id: &str,
         max_entries: usize,
+        trunk: Option<&str>,
     ) -> Result<Vec<ArtifactManifest>, String> {
         let started = std::time::Instant::now();
         let prefix = format!("{namespace_id}\0");
@@ -2782,6 +2825,12 @@ impl Store {
                 manifest.artifact_id.as_bytes(),
             );
             rows += 1;
+            // The index row is written for every entry regardless of the trunk
+            // filter, so the built index stays complete; only the returned set
+            // is branch-scoped.
+            if !manifest_in_trunk(&manifest, trunk) {
+                continue;
+            }
             manifests.push(manifest);
             // Keep the working set bounded while scanning: shed the
             // oldest half whenever the buffer doubles the cap.
@@ -3915,6 +3964,17 @@ fn outbox_message_key(message: &OutboxMessage) -> String {
     format!("{lane}-{:020}-{}", now_ms(), Uuid::now_v7())
 }
 
+/// Whether a manifest belongs in a trunk-scoped snapshot: entries tagged with
+/// the trunk branch and untagged/legacy entries (no branch) form the trunk
+/// baseline; entries tagged with a different branch are excluded. `None` keeps
+/// every entry.
+fn manifest_in_trunk(manifest: &ArtifactManifest, trunk: Option<&str>) -> bool {
+    match trunk {
+        Some(trunk) => manifest.branch.as_deref() == Some(trunk) || manifest.branch.is_none(),
+        None => true,
+    }
+}
+
 fn encode_manifest_record(manifest: &ArtifactManifest) -> Result<Vec<u8>, String> {
     if manifest.is_segment_backed() {
         return SegmentLocationRecord::from_manifest(manifest).map(|record| record.encode());
@@ -4193,6 +4253,8 @@ mod tests {
                 "application/x-protobuf",
                 b"graph",
                 &[],
+                None,
+                None,
             )
             .await
             .expect("aged refresh should persist");
@@ -4206,6 +4268,8 @@ mod tests {
                 "application/x-protobuf",
                 b"graph",
                 &[],
+                None,
+                None,
             )
             .await
             .expect("damped refresh should succeed");
@@ -4223,11 +4287,120 @@ mod tests {
                 "application/x-protobuf",
                 b"graph-v2",
                 &[],
+                None,
+                None,
             )
             .await
             .expect("changed publish should persist");
         assert!(applied, "changed content always applies");
         assert!(changed.version_ms >= refreshed.version_ms);
+    }
+
+    #[tokio::test]
+    async fn action_cache_manifests_scope_to_the_trunk_branch() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn publish(store: &Store, key: &str, branch: Option<&str>) {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    key,
+                    "application/x-protobuf",
+                    b"graph",
+                    &[],
+                    branch,
+                    None,
+                )
+                .await
+                .expect("action-cache entry should persist");
+        }
+        publish(&store, "action_cache/aa/10", Some("main")).await;
+        publish(&store, "action_cache/bb/10", Some("feature")).await;
+
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        assert_eq!(trunk.len(), 1, "the trunk snapshot excludes other branches");
+        assert_eq!(trunk[0].key, "action_cache/aa/10");
+        assert_eq!(trunk[0].branch.as_deref(), Some("main"));
+
+        let all = store
+            .action_cache_manifests("ios", 10, None)
+            .expect("unfiltered scan should succeed");
+        assert_eq!(all.len(), 2, "the unfiltered snapshot keeps every branch");
+
+        // An untagged (legacy) entry stays in the trunk baseline.
+        publish(&store, "action_cache/cc/10", None).await;
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        let keys: Vec<&str> = trunk.iter().map(|manifest| manifest.key.as_str()).collect();
+        assert!(keys.contains(&"action_cache/aa/10"));
+        assert!(keys.contains(&"action_cache/cc/10"));
+        assert!(!keys.contains(&"action_cache/bb/10"));
+    }
+
+    #[tokio::test]
+    async fn trunk_baseline_tags_stick_against_feature_republishes() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn publish(store: &Store, key: &str, bytes: &[u8], branch: Option<&str>) {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    key,
+                    "application/x-protobuf",
+                    bytes,
+                    &[],
+                    branch,
+                    Some("main"),
+                )
+                .await
+                .expect("action-cache entry should persist");
+        }
+        // Distinct version_ms per publish: a same-millisecond republish is
+        // dropped as stale before any tagging logic runs.
+        let tick = || tokio::time::sleep(std::time::Duration::from_millis(2));
+        // A feature build recomputing a trunk key (even with byte wobble that
+        // defeats damping) must not steal it from the trunk baseline.
+        publish(&store, "action_cache/aa/10", b"graph", Some("main")).await;
+        tick().await;
+        publish(
+            &store,
+            "action_cache/aa/10",
+            b"graph-wobble",
+            Some("feature"),
+        )
+        .await;
+        // Same for untagged/legacy baseline entries.
+        publish(&store, "action_cache/bb/10", b"graph", None).await;
+        tick().await;
+        publish(
+            &store,
+            "action_cache/bb/10",
+            b"graph-wobble",
+            Some("feature"),
+        )
+        .await;
+        // A trunk publish reclaims a feature-tagged key.
+        publish(&store, "action_cache/cc/10", b"graph", Some("feature")).await;
+        tick().await;
+        publish(&store, "action_cache/cc/10", b"graph-wobble", Some("main")).await;
+
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        let mut keys: Vec<&str> = trunk.iter().map(|manifest| manifest.key.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "action_cache/aa/10",
+                "action_cache/bb/10",
+                "action_cache/cc/10"
+            ],
+            "trunk keys stay in (or return to) the trunk baseline"
+        );
     }
 
     #[tokio::test]
@@ -4299,7 +4472,7 @@ mod tests {
         assert!(exists(ArtifactProducer::Gradle, "artifact"));
         assert!(
             store
-                .action_cache_manifests("ios", 1_000)
+                .action_cache_manifests("ios", 1_000, None)
                 .expect("namespace scan should succeed")
                 .iter()
                 .all(|manifest| manifest.key != "action_cache/aa/10"),
@@ -4366,7 +4539,7 @@ mod tests {
         write(&store, &config, "action_cache/cc/10", 2_000).await;
 
         let manifests = store
-            .action_cache_manifests("ios", 2)
+            .action_cache_manifests("ios", 2, None)
             .expect("scan should succeed");
         let mut keys: Vec<&str> = manifests.iter().map(|m| m.key.as_str()).collect();
         keys.sort_unstable();
@@ -4377,7 +4550,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .action_cache_manifests("ios", 10)
+                .action_cache_manifests("ios", 10, None)
                 .expect("scan should succeed")
                 .len(),
             3
@@ -4405,7 +4578,7 @@ mod tests {
         // Five entries against a cap of two crosses the in-scan shed
         // threshold (2x cap) as well as the final truncation.
         let manifests = store
-            .action_cache_manifests("ios", 2)
+            .action_cache_manifests("ios", 2, None)
             .expect("scan should succeed");
         let mut versions: Vec<u64> = manifests.iter().map(|m| m.version_ms).collect();
         versions.sort_unstable();
@@ -4430,7 +4603,10 @@ mod tests {
             .expect("artifact should persist");
         // First scan backfills the index; later writes must land in it
         // through the persist path rather than re-scanning the namespace.
-        assert_eq!(store.action_cache_manifests("ios", 10).unwrap().len(), 1);
+        assert_eq!(
+            store.action_cache_manifests("ios", 10, None).unwrap().len(),
+            1
+        );
         std::fs::write(&source, b"payload").expect("source should write");
         store
             .apply_replicated_artifact_from_path(
@@ -4444,7 +4620,7 @@ mod tests {
             .await
             .expect("artifact should persist");
         let manifests = store
-            .action_cache_manifests("ios", 10)
+            .action_cache_manifests("ios", 10, None)
             .expect("indexed scan should succeed");
         let mut keys: Vec<&str> = manifests.iter().map(|m| m.key.as_str()).collect();
         keys.sort_unstable();
@@ -4469,7 +4645,10 @@ mod tests {
             .expect("artifact should persist");
         // Backfill, then overwrite the same key at a newer version: the old
         // row must go, or capped indexed scans would double-count the key.
-        assert_eq!(store.action_cache_manifests("ios", 10).unwrap().len(), 1);
+        assert_eq!(
+            store.action_cache_manifests("ios", 10, None).unwrap().len(),
+            1
+        );
         std::fs::write(&source, b"payload").expect("source should write");
         store
             .apply_replicated_artifact_from_path(
@@ -4483,7 +4662,7 @@ mod tests {
             .await
             .expect("overwrite should persist");
         let manifests = store
-            .action_cache_manifests("ios", 10)
+            .action_cache_manifests("ios", 10, None)
             .expect("indexed scan should succeed");
         assert_eq!(manifests.len(), 1, "one row per live key");
         assert_eq!(manifests[0].version_ms, 5_000);
@@ -4507,13 +4686,16 @@ mod tests {
                 .await
                 .expect("artifact should persist");
         }
-        assert_eq!(store.action_cache_manifests("ios", 10).unwrap().len(), 2);
+        assert_eq!(
+            store.action_cache_manifests("ios", 10, None).unwrap().len(),
+            2
+        );
         let expired = store
             .expire_stale_action_cache_entries(1_500, 10)
             .expect("expiry should succeed");
         assert_eq!(expired, 1);
         let manifests = store
-            .action_cache_manifests("ios", 10)
+            .action_cache_manifests("ios", 10, None)
             .expect("indexed scan should succeed");
         assert_eq!(manifests.len(), 1);
         assert_eq!(manifests[0].key, "action_cache/bb/10");
@@ -5289,6 +5471,7 @@ mod tests {
             size: b"legacy-blob-payload".len() as u64,
             version_ms: 100,
             created_at_ms: 100,
+            branch: None,
         };
 
         store
@@ -6186,6 +6369,7 @@ mod tests {
                 "application/json",
                 br#"{"ok":true}"#,
                 &targets,
+                None,
             )
             .await
             .expect("artifact should persist");
@@ -6426,6 +6610,7 @@ mod tests {
                 "application/json",
                 br#"{"value":"ok"}"#,
                 &["http://peer-a".to_string()],
+                None,
             )
             .await
             .expect_err("write should fail after the durable commit");

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -55,7 +55,8 @@ use crate::{
     },
     usage::UsageRollup,
     utils::{
-        action_cache_index_key, action_cache_index_prefix, action_cache_manifest_hash,
+        action_cache_index_key, action_cache_index_prefix, action_cache_index_value,
+        action_cache_manifest_hash, decode_action_cache_index_value, IndexRowBranch,
         artifact_storage_id, ensure_tmp_dir_capacity, module_key, namespace_artifact_index_key,
         now_ms, segment_artifact_index_key, segment_artifact_index_prefix, segment_path,
         temp_file_path,
@@ -775,7 +776,7 @@ impl Store {
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
                 action_cache_index_key(&manifest.namespace_id, manifest.version_ms, action_hash),
-                artifact_id.as_bytes(),
+                action_cache_index_value(manifest.branch.as_deref(), &artifact_id),
             );
         }
         if let Some(previous_manifest) = &existing
@@ -1371,7 +1372,7 @@ impl Store {
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
                 action_cache_index_key(&manifest.namespace_id, manifest.version_ms, action_hash),
-                artifact_id.as_bytes(),
+                action_cache_index_value(manifest.branch.as_deref(), &artifact_id),
             );
         }
         self.append_artifact_replication_messages(
@@ -2786,17 +2787,18 @@ impl Store {
         // a crashed batch or a pre-fix overwrite can linger — drop it here so
         // the index converges instead of paying the dead point-read forever.
         let mut stale_rows: Vec<Vec<u8>> = Vec::new();
-        // Bound the WORK, not only the output. Untrunked, the two were the same:
-        // every live row counted toward `max_entries`, so the walk stopped after
-        // `max_entries` point-reads. Filtering by trunk breaks that, because a
-        // skipped feature row still costs its point-read and never advances the
-        // cap — so a namespace whose newest entries are feature churn would be
-        // read end to end on every view rebuild, and the rebuild is periodic.
-        // Newest-first ordering means the rows examined first are the ones worth
-        // keeping, so stopping early yields a smaller but still current trunk
-        // view rather than a wrong one.
-        let scan_budget = max_entries.saturating_mul(ACTION_CACHE_TRUNK_SCAN_FACTOR);
-        let mut scanned = 0usize;
+        // Bounds the point-reads, which are the work: each is a random read into
+        // the manifests CF, where advancing the iterator is a sequential step over
+        // a compact CF. A row that carries its branch answers the trunk filter
+        // without being read at all, so feature churn no longer costs anything to
+        // reject and no longer eats this budget. What remains under it is rows
+        // written before the branch was recorded, plus stale rows: both have to
+        // ask the manifest, and both are finite and self-clearing. Newest-first
+        // means the rows examined first are the ones worth keeping, so stopping
+        // early yields a smaller but still current trunk view rather than a wrong
+        // one.
+        let read_budget = max_entries.saturating_mul(ACTION_CACHE_TRUNK_SCAN_FACTOR);
+        let mut read = 0usize;
         for item in iter {
             let (index_key, artifact_id) =
                 item.map_err(|error| format!("failed to iterate action-cache index: {error}"))?;
@@ -2806,17 +2808,25 @@ impl Store {
             if manifests.len() >= max_entries {
                 break;
             }
-            scanned += 1;
-            if trunk.is_some() && scanned > scan_budget {
+            let (row_branch, artifact_id) = decode_action_cache_index_value(&artifact_id)?;
+            // The row's own tag settles the filter for every entry indexed since
+            // the branch was recorded, which is the whole point of carrying it.
+            if let IndexRowBranch::Known(branch) = row_branch
+                && !branch_in_trunk(branch, trunk)
+            {
+                continue;
+            }
+            read += 1;
+            if trunk.is_some() && read > read_budget {
                 // Say so rather than quietly return a short view: a namespace
                 // that trips this is telling us its trunk entries are buried
                 // under feature churn, which is what a branch-keyed index would
                 // fix at the source.
                 tracing::warn!(
                     namespace_id,
-                    scanned,
+                    read,
                     kept = manifests.len(),
-                    "action-cache trunk scan hit its budget; view truncated"
+                    "action-cache trunk scan hit its read budget; view truncated"
                 );
                 break;
             }
@@ -2824,8 +2834,6 @@ impl Store {
                 .get(prefix.len()..prefix.len() + 8)
                 .and_then(|bytes| <[u8; 8]>::try_from(bytes).ok())
                 .map(|bytes| !u64::from_be_bytes(bytes));
-            let artifact_id = std::str::from_utf8(&artifact_id)
-                .map_err(|error| format!("invalid action-cache index value: {error}"))?;
             match self.manifest_from_db(artifact_id)? {
                 Some(manifest)
                     if manifest.producer == ArtifactProducer::Reapi
@@ -2851,8 +2859,23 @@ impl Store {
         Ok(manifests)
     }
 
+    /// Versioned: the rows now carry their branch, and a namespace indexed before
+    /// that would otherwise keep its pre-branch rows forever and go on paying a
+    /// point-read to reject every feature entry. Bumping the version re-runs the
+    /// one-time backfill per namespace, which rewrites every row in the new
+    /// format. Correct either way, since a pre-branch row still reads its tag
+    /// from the manifest; this is what makes it stop being slow.
+    ///
+    /// This index is local derived state and is never replicated, so a rolling
+    /// deploy needs nothing from it: each node reads only rows it wrote. A
+    /// DOWNGRADE is the one direction that costs anything. The older binary takes
+    /// a row value to be the whole artifact id, fails to find that manifest, and
+    /// retires the row as stale, so it walks back to an empty index and serves
+    /// short views until ordinary publishes refill it. Slow, bounded, and
+    /// self-healing rather than wrong: an entry missing from a view is fetched
+    /// per key.
     fn action_cache_index_marker_key(namespace_id: &str) -> String {
-        format!("action_cache_index/backfilled/{namespace_id}")
+        format!("action_cache_index/backfilled/v2/{namespace_id}")
     }
 
     fn action_cache_index_backfilled(&self, namespace_id: &str) -> Result<bool, String> {
@@ -2908,7 +2931,7 @@ impl Store {
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
                 action_cache_index_key(namespace_id, manifest.version_ms, action_hash),
-                manifest.artifact_id.as_bytes(),
+                action_cache_index_value(manifest.branch.as_deref(), &manifest.artifact_id),
             );
             rows += 1;
             // The index row is written for every entry regardless of the trunk
@@ -4083,8 +4106,14 @@ fn sticky_branch<'a>(
 /// baseline; entries tagged with a different branch are excluded. `None` keeps
 /// every entry.
 fn manifest_in_trunk(manifest: &ArtifactManifest, trunk: Option<&str>) -> bool {
+    branch_in_trunk(manifest.branch.as_deref(), trunk)
+}
+
+/// The same rule against a bare tag, so an index row and a manifest cannot drift
+/// apart on what belongs in a trunk view.
+fn branch_in_trunk(branch: Option<&str>, trunk: Option<&str>) -> bool {
     match trunk {
-        Some(trunk) => manifest.branch.as_deref() == Some(trunk) || manifest.branch.is_none(),
+        Some(trunk) => branch == Some(trunk) || branch.is_none(),
         None => true,
     }
 }
@@ -4454,6 +4483,55 @@ mod tests {
         assert!(keys.contains(&"action_cache/aa/10"));
         assert!(keys.contains(&"action_cache/cc/10"));
         assert!(!keys.contains(&"action_cache/bb/10"));
+    }
+
+    /// Trunk entries have to be reachable when they are buried under feature
+    /// churn, which is the whole situation this scoping exists for. Rejecting a
+    /// feature row costs nothing now that the row carries its own tag, so the
+    /// churn cannot exhaust the budget that bounds reads before the walk reaches
+    /// the trunk entries underneath it.
+    #[tokio::test]
+    async fn action_cache_manifests_reach_trunk_entries_buried_under_feature_churn() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn publish(store: &Store, key: &str, branch: Option<&str>) {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    key,
+                    "application/x-protobuf",
+                    b"graph",
+                    &[],
+                    branch,
+                    None,
+                )
+                .await
+                .expect("action-cache entry should persist");
+        }
+        // Oldest, and last in the index under either ordering: it loses the
+        // newest-first comparison on version, and `zzz` loses the action-hash tie
+        // that a same-millisecond publish falls back on.
+        publish(&store, "action_cache/zzz", Some("main")).await;
+        // Enough feature rows ahead of it to exceed `max_entries * FACTOR`, which
+        // is what used to end the walk before it ever arrived.
+        for index in 0..(ACTION_CACHE_TRUNK_SCAN_FACTOR * 2) {
+            publish(&store, &format!("action_cache/f{index:02}"), Some("feature")).await;
+        }
+
+        // The first call backfills and sets the marker; only after it does the
+        // indexed path (the one with the budget) run at all.
+        store
+            .action_cache_manifests("ios", 1, Some("main"))
+            .expect("backfill should succeed");
+        let trunk = store
+            .action_cache_manifests("ios", 1, Some("main"))
+            .expect("indexed trunk scan should succeed");
+        assert_eq!(
+            trunk.len(),
+            1,
+            "the trunk entry is found under the feature churn instead of the view being truncated"
+        );
+        assert_eq!(trunk[0].key, "action_cache/zzz");
     }
 
     #[tokio::test]

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1291,7 +1291,19 @@ impl Store {
         let artifact_id =
             artifact_storage_id(spec.producer, &self.tenant_id, spec.namespace_id, spec.key);
 
+        // Hold the per-artifact write lock across the read, the sticky-tag
+        // decision and the commit. The tag is a read-modify-write over the
+        // stored manifest, so computing it from a read taken outside the lock
+        // lets a feature build that observed "no entry" resume after a trunk
+        // build committed `main`, and overwrite it with the `feature` tag it
+        // precomputed, and with a newer version, so nothing downstream rejects
+        // it. The key then leaves the trunk baseline it had just joined.
+        let _write_guard = self.artifact_write_lock_for(&artifact_id).lock().await;
+
         let existing = self.manifest_from_db(&artifact_id)?;
+        // Widens the read-to-commit window a racing writer would have to hit.
+        self.hit_failpoint(FailpointName::AfterInlineManifestReadBeforeCommit)
+            .await?;
         if let Some(existing) = &existing
             && existing.inline
             && self.inline_bytes(&artifact_id)?.is_some()
@@ -1300,6 +1312,10 @@ impl Store {
             self.note_artifact_exists(&artifact_id);
             return Ok(PersistArtifactOutcome::IgnoredStale(existing.clone()));
         }
+        // Resolved here, under the lock, from the read above: every inline
+        // writer goes through this function, so this is the one place where the
+        // tag decision and the write it feeds cannot be split by a racing peer.
+        let branch = sticky_branch(existing.as_ref(), spec.branch, spec.trunk);
         if self.namespace_tombstone_blocks(spec.namespace_id, spec.version_ms)? {
             return Ok(PersistArtifactOutcome::IgnoredTombstone);
         }
@@ -1319,7 +1335,7 @@ impl Store {
             size: bytes.len() as u64,
             version_ms: persisted_version_ms,
             created_at_ms: persisted_version_ms,
-            branch: spec.branch.map(str::to_owned),
+            branch: branch.map(str::to_owned),
         };
         let metadata = manifest.metadata(&self.tenant_id);
 
@@ -2001,7 +2017,9 @@ impl Store {
         {
             return Ok((existing.clone(), false));
         }
-        let branch = sticky_branch(existing.as_ref(), branch, trunk);
+        // The tag is resolved by the persist below, under the per-artifact write
+        // lock. Deciding it from `existing` here would race: this read is only
+        // the damping probe, and a peer can commit between it and the write.
         self.persist_inline_artifact_from_bytes_and_enqueue(
             producer,
             namespace_id,
@@ -2093,22 +2111,14 @@ impl Store {
         branch: Option<&str>,
         trunk: Option<&str>,
     ) -> Result<ArtifactApplyOutcome, String> {
-        // Re-run the trunk-sticky rule against THIS node's view. The origin
-        // could only apply it against its own: a feature build publishing a
-        // trunk key to a peer that does not hold it yet resolves the tag to
-        // `feature`, and applying that verbatim would steal the key out of the
-        // trunk baseline here — the same theft the rule prevents locally, just
-        // arriving over replication. Only a trunk-carrying publish reaches the
-        // lookup, so a peer that sends none costs no read.
-        let existing = match trunk {
-            Some(_) => self.manifest_from_db(&artifact_storage_id(
-                producer,
-                &self.tenant_id,
-                namespace_id,
-                key,
-            ))?,
-            None => None,
-        };
+        // The trunk-sticky rule is re-run against THIS node's view by the persist
+        // below (under the per-artifact write lock, from its own read). The origin
+        // could only apply the rule against its own view: a feature build
+        // publishing a trunk key to a peer that does not hold it yet resolves the
+        // tag to `feature`, and applying that verbatim would steal the key out of
+        // the trunk baseline here: the same theft the rule prevents locally, just
+        // arriving over replication. Forwarding `trunk` is what asks for the
+        // re-run; a peer that sends none applies untagged, exactly as before.
         let spec = PersistArtifactSpec {
             producer,
             namespace_id,
@@ -2116,8 +2126,8 @@ impl Store {
             content_type,
             version_ms,
             replication_targets: &[],
-            branch: sticky_branch(existing.as_ref(), branch, trunk),
-            trunk: None,
+            branch,
+            trunk,
         };
         Ok(self
             .persist_inline_artifact_with_version(spec, bytes)
@@ -4506,6 +4516,74 @@ mod tests {
                 "action_cache/cc/10"
             ],
             "trunk keys stay in (or return to) the trunk baseline"
+        );
+    }
+
+    // The tag is a read-modify-write over the stored manifest, so it is only as
+    // sound as the serialization around it. Two builds publishing the same shared
+    // action concurrently (routine: one namespace, many machines) must not be able
+    // to interleave their read and their commit, or the feature build writes the
+    // `feature` tag it decided on when the key looked absent, over the `main` the
+    // trunk build committed meanwhile, and with a version nothing downstream
+    // rejects. The failpoint pins that interleaving instead of racing for it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_concurrent_feature_publish_cannot_overwrite_the_trunk_tag() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+        store.failpoints().set_once(
+            FailpointName::AfterInlineManifestReadBeforeCommit,
+            FailpointAction::Sleep(std::time::Duration::from_millis(300)),
+        );
+
+        let feature_store = Arc::clone(&store);
+        // Reads first (and stalls on the failpoint holding nothing but its own
+        // read), so it is the one whose decision is stale by the time it writes.
+        let feature = tokio::spawn(async move {
+            feature_store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    "action_cache/aa/10",
+                    "application/x-protobuf",
+                    b"graph-from-feature",
+                    &[],
+                    Some("feature"),
+                    Some("main"),
+                )
+                .await
+                .expect("feature publish should persist");
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let trunk_store = Arc::clone(&store);
+        let trunk = tokio::spawn(async move {
+            trunk_store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    "action_cache/aa/10",
+                    "application/x-protobuf",
+                    b"graph-from-trunk",
+                    &[],
+                    Some("main"),
+                    Some("main"),
+                )
+                .await
+                .expect("trunk publish should persist");
+        });
+        feature.await.expect("feature task");
+        trunk.await.expect("trunk task");
+
+        let trunk_view = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        let keys: Vec<&str> = trunk_view
+            .iter()
+            .map(|manifest| manifest.key.as_str())
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["action_cache/aa/10"],
+            "the key stays in the trunk baseline whichever publish commits first"
         );
     }
 

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -31,10 +31,10 @@ use crate::{
     },
     config::Config,
     constants::{
-        CAS_CAPACITY_DEFAULT_DISK_PERCENT, CAS_CAPACITY_MAX_DISK_PERCENT, DESIRED_CURRENT_SEGMENTS,
-        DESIRED_NEW_SEGMENTS, DESIRED_OLD_SEGMENTS, MAX_DESIRED_SEGMENTS, MAX_MODULE_TOTAL_BYTES,
-        ACTION_CACHE_TRUNK_SCAN_FACTOR, MAX_SEGMENT_BYTES, REAPI_ACTION_CACHE_REFRESH_DAMPING_MS,
-        ROCKSDB_BYTES_PER_SYNC,
+        ACTION_CACHE_TRUNK_SCAN_FACTOR, CAS_CAPACITY_DEFAULT_DISK_PERCENT,
+        CAS_CAPACITY_MAX_DISK_PERCENT, DESIRED_CURRENT_SEGMENTS, DESIRED_NEW_SEGMENTS,
+        DESIRED_OLD_SEGMENTS, MAX_DESIRED_SEGMENTS, MAX_MODULE_TOTAL_BYTES, MAX_SEGMENT_BYTES,
+        REAPI_ACTION_CACHE_REFRESH_DAMPING_MS, ROCKSDB_BYTES_PER_SYNC,
         ROCKSDB_CF_ACTION_CACHE_INDEX, ROCKSDB_CF_KEY_VALUE, ROCKSDB_CF_MANIFESTS,
         ROCKSDB_CF_MULTIPART_UPLOADS, ROCKSDB_CF_NAMESPACE_ARTIFACTS,
         ROCKSDB_CF_NAMESPACE_TOMBSTONES, ROCKSDB_CF_OUTBOX, ROCKSDB_CF_SEGMENT_ARTIFACTS,
@@ -55,11 +55,10 @@ use crate::{
     },
     usage::UsageRollup,
     utils::{
-        action_cache_index_key, action_cache_index_key_branch, action_cache_index_prefix,
-        action_cache_manifest_hash, IndexRowBranch,
-        artifact_storage_id, ensure_tmp_dir_capacity, module_key, namespace_artifact_index_key,
-        now_ms, segment_artifact_index_key, segment_artifact_index_prefix, segment_path,
-        temp_file_path,
+        IndexRowBranch, action_cache_index_key, action_cache_index_key_branch,
+        action_cache_index_prefix, action_cache_manifest_hash, artifact_storage_id,
+        ensure_tmp_dir_capacity, module_key, namespace_artifact_index_key, now_ms,
+        segment_artifact_index_key, segment_artifact_index_prefix, segment_path, temp_file_path,
     },
 };
 
@@ -2853,7 +2852,8 @@ impl Store {
             }
             // The row's own tag settles the filter for every entry indexed since
             // the branch was recorded, which is the whole point of carrying it.
-            if let IndexRowBranch::Known(branch) = action_cache_index_key_branch(&index_key, prefix.len())
+            if let IndexRowBranch::Known(branch) =
+                action_cache_index_key_branch(&index_key, prefix.len())
                 && !branch_in_trunk(branch, trunk)
             {
                 continue;
@@ -4162,8 +4162,7 @@ fn sticky_branch<'a>(
 ) -> Option<&'a str> {
     match (existing, trunk) {
         (Some(existing), Some(trunk))
-            if branch != Some(trunk)
-                && existing.branch.as_deref() == Some(trunk) =>
+            if branch != Some(trunk) && existing.branch.as_deref() == Some(trunk) =>
         {
             existing.branch.as_deref()
         }
@@ -4585,7 +4584,10 @@ mod tests {
         let prefix = action_cache_index_prefix("ios");
         for branch in [None, Some("main"), Some("feature/some-long-name")] {
             let key = action_cache_index_key("ios", 1_234, "abc123", branch);
-            assert!(key.starts_with(&prefix), "namespace prefix scan still matches");
+            assert!(
+                key.starts_with(&prefix),
+                "namespace prefix scan still matches"
+            );
             let version = key
                 .get(prefix.len()..prefix.len() + 8)
                 .expect("version sits at a fixed offset");
@@ -4648,7 +4650,12 @@ mod tests {
         // Enough feature rows ahead of it to exceed `max_entries * FACTOR`, which
         // is what used to end the walk before it ever arrived.
         for index in 0..(ACTION_CACHE_TRUNK_SCAN_FACTOR * 2) {
-            publish(&store, &format!("action_cache/f{index:02}"), Some("feature")).await;
+            publish(
+                &store,
+                &format!("action_cache/f{index:02}"),
+                Some("feature"),
+            )
+            .await;
         }
 
         // The first call backfills and sets the marker; only after it does the

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -33,7 +33,8 @@ use crate::{
     constants::{
         CAS_CAPACITY_DEFAULT_DISK_PERCENT, CAS_CAPACITY_MAX_DISK_PERCENT, DESIRED_CURRENT_SEGMENTS,
         DESIRED_NEW_SEGMENTS, DESIRED_OLD_SEGMENTS, MAX_DESIRED_SEGMENTS, MAX_MODULE_TOTAL_BYTES,
-        MAX_SEGMENT_BYTES, REAPI_ACTION_CACHE_REFRESH_DAMPING_MS, ROCKSDB_BYTES_PER_SYNC,
+        ACTION_CACHE_TRUNK_SCAN_FACTOR, MAX_SEGMENT_BYTES, REAPI_ACTION_CACHE_REFRESH_DAMPING_MS,
+        ROCKSDB_BYTES_PER_SYNC,
         ROCKSDB_CF_ACTION_CACHE_INDEX, ROCKSDB_CF_KEY_VALUE, ROCKSDB_CF_MANIFESTS,
         ROCKSDB_CF_MULTIPART_UPLOADS, ROCKSDB_CF_NAMESPACE_ARTIFACTS,
         ROCKSDB_CF_NAMESPACE_TOMBSTONES, ROCKSDB_CF_OUTBOX, ROCKSDB_CF_SEGMENT_ARTIFACTS,
@@ -1976,15 +1977,22 @@ impl Store {
     ) -> Result<(ArtifactManifest, bool), String> {
         let artifact_id = artifact_storage_id(producer, &self.tenant_id, namespace_id, key);
         let existing = self.manifest_from_db(&artifact_id)?;
+        let branch = sticky_branch(existing.as_ref(), branch, trunk);
+        // Damp only when the write would change nothing, INCLUDING the tag. An
+        // entry a feature branch published first is tagged `feature`, so trunk
+        // republishing the identical bytes must still write: damping it would
+        // leave the key tagged `feature` and therefore outside the trunk
+        // snapshot, for the whole damping window, for a key trunk demonstrably
+        // builds. That is the pollution this scoping exists to remove.
         if let Some(existing) = &existing
             && existing.inline
+            && existing.branch.as_deref() == branch
             && manifest_version_ms(existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
                 > now_ms()
             && self.inline_bytes(&artifact_id)?.as_deref() == Some(bytes)
         {
             return Ok((existing.clone(), false));
         }
-        let branch = sticky_branch(existing.as_ref(), branch, trunk);
         self.persist_inline_artifact_from_bytes_and_enqueue(
             producer,
             namespace_id,
@@ -2759,6 +2767,17 @@ impl Store {
         // a crashed batch or a pre-fix overwrite can linger — drop it here so
         // the index converges instead of paying the dead point-read forever.
         let mut stale_rows: Vec<Vec<u8>> = Vec::new();
+        // Bound the WORK, not only the output. Untrunked, the two were the same:
+        // every live row counted toward `max_entries`, so the walk stopped after
+        // `max_entries` point-reads. Filtering by trunk breaks that, because a
+        // skipped feature row still costs its point-read and never advances the
+        // cap — so a namespace whose newest entries are feature churn would be
+        // read end to end on every view rebuild, and the rebuild is periodic.
+        // Newest-first ordering means the rows examined first are the ones worth
+        // keeping, so stopping early yields a smaller but still current trunk
+        // view rather than a wrong one.
+        let scan_budget = max_entries.saturating_mul(ACTION_CACHE_TRUNK_SCAN_FACTOR);
+        let mut scanned = 0usize;
         for item in iter {
             let (index_key, artifact_id) =
                 item.map_err(|error| format!("failed to iterate action-cache index: {error}"))?;
@@ -2766,6 +2785,20 @@ impl Store {
                 break;
             }
             if manifests.len() >= max_entries {
+                break;
+            }
+            scanned += 1;
+            if trunk.is_some() && scanned > scan_budget {
+                // Say so rather than quietly return a short view: a namespace
+                // that trips this is telling us its trunk entries are buried
+                // under feature churn, which is what a branch-keyed index would
+                // fix at the source.
+                tracing::warn!(
+                    namespace_id,
+                    scanned,
+                    kept = manifests.len(),
+                    "action-cache trunk scan hit its budget; view truncated"
+                );
                 break;
             }
             let row_version = index_key
@@ -4504,6 +4537,101 @@ mod tests {
             vec!["action_cache/bb/10", "action_cache/cc/10"],
             "a replicated feature entry stays out of the trunk view; an untagged one stays in"
         );
+    }
+
+    // Damping must not outrank the tag. A feature build publishes a key first, so
+    // it is tagged `feature`; trunk then builds the same action and republishes
+    // the IDENTICAL bytes well inside the damping window. Damping the write would
+    // leave the key `feature`-tagged and therefore missing from the trunk view for
+    // up to a day, for a key trunk provably builds — the exact pollution this
+    // scoping removes.
+    #[tokio::test]
+    async fn trunk_reclaims_an_identical_entry_a_feature_branch_published_first() {
+        let (_temp_dir, _config, store) = temp_store();
+        store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                &[],
+                Some("feature"),
+                Some("main"),
+            )
+            .await
+            .expect("feature entry should persist");
+        assert!(
+            store
+                .action_cache_manifests("ios", 10, Some("main"))
+                .expect("trunk scan should succeed")
+                .is_empty(),
+            "the feature build's key starts outside the trunk view"
+        );
+
+        let (_manifest, applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph", // byte-identical, and inside the damping window
+                &[],
+                Some("main"),
+                Some("main"),
+            )
+            .await
+            .expect("trunk republish should persist");
+
+        assert!(applied, "the tag changes, so the write must not be damped");
+        let keys: Vec<String> = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed")
+            .into_iter()
+            .map(|manifest| manifest.key)
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["action_cache/aa/10"],
+            "trunk reclaims the key it demonstrably builds"
+        );
+    }
+
+    // The mirror of the above: once the tag already matches, an identical
+    // re-publish inside the window is still damped, which is what keeps a fleet
+    // of cold machines from stampeding version bumps for the same entry.
+    #[tokio::test]
+    async fn identical_trunk_republish_stays_damped_when_the_tag_already_matches() {
+        let (_temp_dir, _config, store) = temp_store();
+        for _ in 0..1 {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    "action_cache/aa/10",
+                    "application/x-protobuf",
+                    b"graph",
+                    &[],
+                    Some("main"),
+                    Some("main"),
+                )
+                .await
+                .expect("trunk entry should persist");
+        }
+        let (_manifest, applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                &[],
+                Some("main"),
+                Some("main"),
+            )
+            .await
+            .expect("identical republish should succeed");
+        assert!(!applied, "nothing changes, so the write is damped");
     }
 
     #[tokio::test]

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -81,6 +81,14 @@ pub struct Store {
     rocksdb_block_cache: Cache,
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
+    /// Bumped whenever a namespace's action cache changes, so a snapshot index
+    /// that came back EMPTY can tell "nothing to show" from "out of date". An
+    /// empty index is otherwise indistinguishable from a stale one and has to be
+    /// rebuilt on every serve to find out, which is a namespace scan per build
+    /// for every namespace whose trunk view is legitimately empty. In memory and
+    /// per node: it only ever gates a local cache, a fresh process rebuilds once,
+    /// and the apply path bumps it too so a peer's write is not missed.
+    action_cache_generations: StdMutex<HashMap<String, u64>>,
     // Counts segment fsyncs so tests can assert durability is batched across
     // concurrent writers rather than one fsync per write under the global lock.
     segment_fsync_count: Arc<AtomicU64>,
@@ -469,6 +477,7 @@ impl Store {
             rocksdb_block_cache,
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
+            action_cache_generations: StdMutex::new(HashMap::new()),
             segment_fsync_count: Arc::new(AtomicU64::new(0)),
             pending_seq: AtomicU64::new(0),
             durable_seq: AtomicU64::new(0),
@@ -786,6 +795,7 @@ impl Store {
                 ),
                 artifact_id.as_bytes(),
             );
+            self.bump_action_cache_generation(&manifest.namespace_id);
         }
         if let Some(previous_manifest) = &existing
             && let Some(previous_segment_id) = &previous_manifest.segment_id
@@ -1390,6 +1400,7 @@ impl Store {
                 ),
                 artifact_id.as_bytes(),
             );
+            self.bump_action_cache_generation(&manifest.namespace_id);
         }
         self.append_artifact_replication_messages(
             &mut batch,
@@ -2884,6 +2895,27 @@ impl Store {
             self.write_batch_sync(batch, "action-cache index stale rows")?;
         }
         Ok(manifests)
+    }
+
+    /// The namespace's action-cache generation. A snapshot index records this at
+    /// build time; if it has not moved, the index still describes the namespace,
+    /// including when the index is empty.
+    pub fn action_cache_generation(&self, namespace_id: &str) -> u64 {
+        self.action_cache_generations
+            .lock()
+            .expect("action-cache generations lock poisoned")
+            .get(namespace_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn bump_action_cache_generation(&self, namespace_id: &str) {
+        *self
+            .action_cache_generations
+            .lock()
+            .expect("action-cache generations lock poisoned")
+            .entry(namespace_id.to_owned())
+            .or_insert(0) += 1;
     }
 
     /// Deliberately NOT versioned to force a rebuild when the branch joined the

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1370,6 +1370,7 @@ impl Store {
             namespace_artifact_index_key(&metadata.namespace_id, &artifact_id).as_bytes(),
             [],
         );
+        let mut wrote_action_cache_index = false;
         if manifest.producer == ArtifactProducer::Reapi
             && let Some(action_hash) = action_cache_manifest_hash(&manifest.key)
         {
@@ -1399,7 +1400,7 @@ impl Store {
                 ),
                 artifact_id.as_bytes(),
             );
-            self.bump_action_cache_generation(&manifest.namespace_id);
+            wrote_action_cache_index = true;
         }
         self.append_artifact_replication_messages(
             &mut batch,
@@ -1409,6 +1410,14 @@ impl Store {
         )?;
 
         self.write_batch_sync(batch, "keyvalue batch")?;
+        // Only after the batch commits: the generation is what a snapshot serve
+        // reads to decide its cached view is current, and the new index row is
+        // not visible to that scan until the write lands. Bumping before the
+        // commit lets a concurrent serve stamp the pre-commit (row-less) view
+        // with the new generation and then answer later requests from it.
+        if wrote_action_cache_index {
+            self.bump_action_cache_generation(&manifest.namespace_id);
+        }
         self.maybe_cache_manifest(manifest.clone());
         self.note_artifact_exists(&artifact_id);
 
@@ -4176,10 +4185,10 @@ fn sticky_branch<'a>(
     }
 }
 
-/// Whether a manifest belongs in a trunk-scoped snapshot: entries tagged with
-/// the trunk branch and untagged/legacy entries (no branch) form the trunk
-/// baseline; entries tagged with a different branch are excluded. `None` keeps
-/// every entry.
+/// Whether a manifest belongs in a trunk-scoped snapshot: only entries tagged
+/// with the trunk branch form the scoped baseline. An untagged entry is NOT in
+/// it, and neither is one tagged with a different branch. `None` (no trunk
+/// asked for) keeps every entry.
 fn manifest_in_trunk(manifest: &ArtifactManifest, trunk: Option<&str>) -> bool {
     branch_in_trunk(manifest.branch.as_deref(), trunk)
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2010,25 +2010,30 @@ impl Store {
     ) -> Result<(ArtifactManifest, bool), String> {
         let artifact_id = artifact_storage_id(producer, &self.tenant_id, namespace_id, key);
         let existing = self.manifest_from_db(&artifact_id)?;
-        // Damping deliberately outranks the tag, and does NOT compare it.
+        // Damping compares the TAG as well as the bytes, because an entry is no
+        // longer identified by its bytes alone. Without it, a trunk build that
+        // recomputes a result a feature branch published first is damped on the
+        // bytes and its tag never lands, so the entry stays feature-scoped and
+        // stays out of the trunk view: the reclaim the client is asking for is
+        // dropped here, silently, by the one check it has to pass.
         //
-        // This was tried once and reverted, for reasons that no longer hold: the
-        // refresh path then re-published with no branch and no trunk, so a tag
-        // comparison declined to damp and wrote the entry untagged, and the
-        // client's dedupe meant a tag-only update never arrived anyway. Both are
-        // fixed, and untagged is no longer the trunk baseline, so the trap it was
-        // reverted for is gone.
+        // This was tried once and reverted, for reasons that no longer hold. The
+        // refresh path then re-published with no branch, so comparing tags saw
+        // `Some("feature")` against `None`, declined to damp, and wrote the entry
+        // untagged into what was then the trunk baseline. That path now carries
+        // its tags, `sticky_branch` no longer lets an absent branch overwrite a
+        // present one, and untagged is no longer the baseline. Three reasons the
+        // old shape was a trap, all gone.
         //
-        // It stays out because it is no longer needed here. A byte-identical
-        // publish now carries its tags to the server, and a per-key hit refreshes
-        // under the tags of the build that took it, so reclaim happens on those
-        // paths with the manifest in hand. Comparing tags here would only add a
-        // way for the damping probe (a read taken outside the write lock) to
-        // disagree with the tag the persist resolves under it.
+        // Resolving the tag here is a probe, not the decision: the persist below
+        // re-resolves it under the per-artifact write lock. A peer committing in
+        // between can only cost a damp we should have taken, or a write we did
+        // not need, and the next publish settles it either way.
         if let Some(existing) = &existing
             && existing.inline
             && manifest_version_ms(existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
                 > now_ms()
+            && sticky_branch(Some(existing), branch, trunk) == existing.branch.as_deref()
             && self.inline_bytes(&artifact_id)?.as_deref() == Some(bytes)
         {
             return Ok((existing.clone(), false));
@@ -4123,6 +4128,12 @@ fn sticky_branch<'a>(
         {
             existing.branch.as_deref()
         }
+        // A publisher that names no branch is not asserting that the entry has
+        // none; it is saying it cannot tell. It must not overwrite what a
+        // publisher that could tell recorded, or a node too old to send the
+        // header would untag a trunk key and drop it out of the trunk view by
+        // republishing it.
+        (Some(existing), _) if branch.is_none() => existing.branch.as_deref(),
         _ => branch,
     }
 }
@@ -4615,6 +4626,78 @@ mod tests {
             "the trunk entry is found under the feature churn instead of the view being truncated"
         );
         assert_eq!(trunk[0].key, "action_cache/zzz");
+    }
+
+    /// The reclaim the whole scoping depends on, in the shape it actually happens:
+    /// two builds computing the same action produce the SAME bytes, so nothing
+    /// about the value changes and only the tag does. Damping is the one check
+    /// that stands between the client's tag-only update and the entry.
+    #[tokio::test]
+    async fn trunk_reclaims_an_identical_result_a_feature_published_first() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn publish(store: &Store, branch: Option<&str>) -> ArtifactManifest {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    "action_cache/aa/10",
+                    "application/x-protobuf",
+                    b"identical",
+                    &[],
+                    branch,
+                    Some("main"),
+                )
+                .await
+                .expect("action-cache entry should persist")
+                .0
+        }
+        // A feature build gets there first.
+        publish(&store, Some("feature")).await;
+        // Trunk recomputes it: same bytes, well inside the damping window.
+        let reclaimed = publish(&store, Some("main")).await;
+        assert_eq!(
+            reclaimed.branch.as_deref(),
+            Some("main"),
+            "a tag-only update is not a no-op, so damping must not swallow it"
+        );
+        let trunk = store
+            .action_cache_manifests("ios", 10, Some("main"))
+            .expect("trunk scan should succeed");
+        assert_eq!(trunk.len(), 1, "and the entry is back in the trunk view");
+    }
+
+    /// A node too old to send the header, or a publisher whose checkout it could
+    /// not resolve, says nothing about provenance. Letting that erase a tag would
+    /// evict a trunk key from the trunk view by republishing it.
+    #[tokio::test]
+    async fn a_publish_that_names_no_branch_does_not_erase_one() {
+        let (_temp_dir, _config, store) = temp_store();
+        async fn publish(store: &Store, bytes: &[u8], branch: Option<&str>) -> ArtifactManifest {
+            store
+                .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    "action_cache/aa/10",
+                    "application/x-protobuf",
+                    bytes,
+                    &[],
+                    branch,
+                    // No trunk either: an older client sends neither header.
+                    None,
+                )
+                .await
+                .expect("action-cache entry should persist")
+                .0
+        }
+        publish(&store, b"graph", Some("main")).await;
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        // Different bytes, so damping cannot be what saves the tag.
+        let after = publish(&store, b"graph-wobble", None).await;
+        assert_eq!(
+            after.branch.as_deref(),
+            Some("main"),
+            "an untagged republish keeps the tag someone who knew it recorded"
+        );
     }
 
     #[tokio::test]

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -55,8 +55,8 @@ use crate::{
     },
     usage::UsageRollup,
     utils::{
-        action_cache_index_key, action_cache_index_prefix, action_cache_index_value,
-        action_cache_manifest_hash, decode_action_cache_index_value, IndexRowBranch,
+        action_cache_index_key, action_cache_index_key_branch, action_cache_index_prefix,
+        action_cache_manifest_hash, IndexRowBranch,
         artifact_storage_id, ensure_tmp_dir_capacity, module_key, namespace_artifact_index_key,
         now_ms, segment_artifact_index_key, segment_artifact_index_prefix, segment_path,
         temp_file_path,
@@ -770,13 +770,21 @@ impl Store {
                         &manifest.namespace_id,
                         previous_manifest.version_ms,
                         previous_hash,
+                        // The row was keyed under the tag it held then, not the
+                        // one being written now.
+                        previous_manifest.branch.as_deref(),
                     ),
                 );
             }
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
-                action_cache_index_key(&manifest.namespace_id, manifest.version_ms, action_hash),
-                action_cache_index_value(manifest.branch.as_deref(), &artifact_id),
+                action_cache_index_key(
+                    &manifest.namespace_id,
+                    manifest.version_ms,
+                    action_hash,
+                    manifest.branch.as_deref(),
+                ),
+                artifact_id.as_bytes(),
             );
         }
         if let Some(previous_manifest) = &existing
@@ -1366,13 +1374,21 @@ impl Store {
                         &manifest.namespace_id,
                         previous_manifest.version_ms,
                         previous_hash,
+                        // The row was keyed under the tag it held then, not the
+                        // one being written now.
+                        previous_manifest.branch.as_deref(),
                     ),
                 );
             }
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
-                action_cache_index_key(&manifest.namespace_id, manifest.version_ms, action_hash),
-                action_cache_index_value(manifest.branch.as_deref(), &artifact_id),
+                action_cache_index_key(
+                    &manifest.namespace_id,
+                    manifest.version_ms,
+                    action_hash,
+                    manifest.branch.as_deref(),
+                ),
+                artifact_id.as_bytes(),
             );
         }
         self.append_artifact_replication_messages(
@@ -2230,7 +2246,12 @@ impl Store {
                 {
                     batch.delete_cf(
                         self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
-                        action_cache_index_key(namespace_id, manifest.version_ms, action_hash),
+                        action_cache_index_key(
+                            namespace_id,
+                            manifest.version_ms,
+                            action_hash,
+                            manifest.branch.as_deref(),
+                        ),
                     );
                 }
                 if let Some(blob_path) = manifest.blob_path {
@@ -2687,6 +2708,7 @@ impl Store {
                         &manifest.namespace_id,
                         manifest.version_ms,
                         action_hash,
+                        manifest.branch.as_deref(),
                     ),
                 );
             }
@@ -2807,14 +2829,15 @@ impl Store {
             if manifests.len() >= max_entries {
                 break;
             }
-            let (row_branch, artifact_id) = decode_action_cache_index_value(&artifact_id)?;
             // The row's own tag settles the filter for every entry indexed since
             // the branch was recorded, which is the whole point of carrying it.
-            if let IndexRowBranch::Known(branch) = row_branch
+            if let IndexRowBranch::Known(branch) = action_cache_index_key_branch(&index_key, prefix.len())
                 && !branch_in_trunk(branch, trunk)
             {
                 continue;
             }
+            let artifact_id = std::str::from_utf8(&artifact_id)
+                .map_err(|error| format!("invalid action-cache index value: {error}"))?;
             read += 1;
             if trunk.is_some() && read > read_budget {
                 // Say so rather than quietly return a short view: a namespace
@@ -2858,23 +2881,19 @@ impl Store {
         Ok(manifests)
     }
 
-    /// Versioned: the rows now carry their branch, and a namespace indexed before
-    /// that would otherwise keep its pre-branch rows forever and go on paying a
-    /// point-read to reject every feature entry. Bumping the version re-runs the
-    /// one-time backfill per namespace, which rewrites every row in the new
-    /// format. Correct either way, since a pre-branch row still reads its tag
-    /// from the manifest; this is what makes it stop being slow.
+    /// Deliberately NOT versioned to force a rebuild when the branch joined the
+    /// key. The branch is part of the key, so rewriting a row under the new
+    /// format writes a second row rather than overwriting the old one, and a
+    /// forced rebuild would leave every entry indexed twice.
     ///
-    /// This index is local derived state and is never replicated, so a rolling
-    /// deploy needs nothing from it: each node reads only rows it wrote. A
-    /// DOWNGRADE is the one direction that costs anything. The older binary takes
-    /// a row value to be the whole artifact id, fails to find that manifest, and
-    /// retires the row as stale, so it walks back to an empty index and serves
-    /// short views until ordinary publishes refill it. Slow, bounded, and
-    /// self-healing rather than wrong: an entry missing from a view is fetched
-    /// per key.
+    /// It needs no rebuild. A row written before the branch reports its tag as
+    /// unknown and asks the manifest, exactly as it did before, and the next
+    /// publish of that entry supersedes it: the new row carries the tag, and the
+    /// old one is left pointing at a stale version, which the scan already
+    /// retires. The migration therefore rides along with the republishes that
+    /// re-tagging needs anyway.
     fn action_cache_index_marker_key(namespace_id: &str) -> String {
-        format!("action_cache_index/backfilled/v2/{namespace_id}")
+        format!("action_cache_index/backfilled/{namespace_id}")
     }
 
     fn action_cache_index_backfilled(&self, namespace_id: &str) -> Result<bool, String> {
@@ -2929,8 +2948,13 @@ impl Store {
             };
             batch.put_cf(
                 self.cf(ROCKSDB_CF_ACTION_CACHE_INDEX),
-                action_cache_index_key(namespace_id, manifest.version_ms, action_hash),
-                action_cache_index_value(manifest.branch.as_deref(), &manifest.artifact_id),
+                action_cache_index_key(
+                    namespace_id,
+                    manifest.version_ms,
+                    action_hash,
+                    manifest.branch.as_deref(),
+                ),
+                manifest.artifact_id.as_bytes(),
             );
             rows += 1;
             // The index row is written for every entry regardless of the trunk
@@ -4499,6 +4523,49 @@ mod tests {
             .action_cache_manifests("ios", 10, None)
             .expect("unfiltered scan should succeed");
         assert_eq!(all.len(), 3, "an unscoped view still keeps every entry");
+    }
+
+    /// The rollback contract, pinned. A node that predates the branch reads the
+    /// version out of the key at a fixed offset and the artifact id out of the
+    /// value, and never parses what sits between them. Both have to survive the
+    /// branch being appended, or that node retires every row it cannot read and
+    /// deletes the index out from under itself.
+    #[test]
+    fn an_index_key_keeps_its_version_where_an_older_node_looks_for_it() {
+        let prefix = action_cache_index_prefix("ios");
+        for branch in [None, Some("main"), Some("feature/some-long-name")] {
+            let key = action_cache_index_key("ios", 1_234, "abc123", branch);
+            assert!(key.starts_with(&prefix), "namespace prefix scan still matches");
+            let version = key
+                .get(prefix.len()..prefix.len() + 8)
+                .expect("version sits at a fixed offset");
+            let version = !u64::from_be_bytes(version.try_into().expect("8 bytes"));
+            assert_eq!(version, 1_234, "an older node still reads the version");
+        }
+    }
+
+    #[test]
+    fn an_index_row_reports_its_branch_and_a_pre_branch_row_admits_it_cannot() {
+        let prefix_len = action_cache_index_prefix("ios").len();
+        let tagged = action_cache_index_key("ios", 1, "abc123", Some("main"));
+        assert!(matches!(
+            action_cache_index_key_branch(&tagged, prefix_len),
+            IndexRowBranch::Known(Some("main"))
+        ));
+        // Untagged is known, and distinct from unknown: it answers the filter.
+        let untagged = action_cache_index_key("ios", 1, "abc123", None);
+        assert!(matches!(
+            action_cache_index_key_branch(&untagged, prefix_len),
+            IndexRowBranch::Known(None)
+        ));
+        // A row written before the branch: no separator after the action hash.
+        let mut legacy = action_cache_index_prefix("ios");
+        legacy.extend_from_slice(&(!1u64).to_be_bytes());
+        legacy.extend_from_slice(b"abc123");
+        assert!(matches!(
+            action_cache_index_key_branch(&legacy, prefix_len),
+            IndexRowBranch::Unknown
+        ));
     }
 
     /// Trunk entries have to be reachable when they are buried under feature

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -4653,6 +4653,9 @@ mod tests {
         }
         // A feature build gets there first.
         publish(&store, Some("feature")).await;
+        // Distinct version_ms: a same-millisecond republish is dropped as stale
+        // before any tagging runs, which makes this pass or fail on the clock.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         // Trunk recomputes it: same bytes, well inside the damping window.
         let reclaimed = publish(&store, Some("main")).await;
         assert_eq!(

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1996,20 +1996,19 @@ impl Store {
         let existing = self.manifest_from_db(&artifact_id)?;
         // Damping deliberately outranks the tag, and does NOT compare it.
         //
-        // Making the tag part of this condition looks right (it would let trunk
-        // reclaim a key a feature branch published first with identical bytes)
-        // and is a trap: `refresh_view_keys` re-publishes cached manifests with
-        // no branch and no trunk, so a tag comparison sees `Some("feature")` vs
-        // `None`, declines to damp, and writes the entry UNTAGGED. Untagged is
-        // the trunk baseline, so every refreshed feature entry would land in the
-        // very view this scoping keeps clean. Reverted for that reason; the
-        // reclaim it bought was mostly unreachable anyway, because the client
-        // dedupes a re-publish whose value digest already matches and so never
-        // sends the tag-only update.
+        // This was tried once and reverted, for reasons that no longer hold: the
+        // refresh path then re-published with no branch and no trunk, so a tag
+        // comparison declined to damp and wrote the entry untagged, and the
+        // client's dedupe meant a tag-only update never arrived anyway. Both are
+        // fixed, and untagged is no longer the trunk baseline, so the trap it was
+        // reverted for is gone.
         //
-        // Reclaiming a feature-tagged key for trunk needs the refresh path to
-        // carry branch/trunk (the instance is not threaded into `view_refresh`
-        // today) AND the client-side dedupe to allow a tag-only update.
+        // It stays out because it is no longer needed here. A byte-identical
+        // publish now carries its tags to the server, and a per-key hit refreshes
+        // under the tags of the build that took it, so reclaim happens on those
+        // paths with the manifest in hand. Comparing tags here would only add a
+        // way for the damping probe (a read taken outside the write lock) to
+        // disagree with the tag the persist resolves under it.
         if let Some(existing) = &existing
             && existing.inline
             && manifest_version_ms(existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
@@ -2764,7 +2763,7 @@ impl Store {
     /// backfilled with one legacy scan on first use.
     ///
     /// When `trunk` is `Some`, only entries whose manifest carries that branch
-    /// or no branch at all (untagged/legacy entries stay in the trunk baseline)
+    /// only (an untagged entry is not in the baseline: see `branch_in_trunk`)
     /// are returned; the cap counts kept entries only. `None` returns every
     /// action-cache entry regardless of branch.
     pub fn action_cache_manifests(
@@ -4079,12 +4078,15 @@ fn outbox_message_key(message: &OutboxMessage) -> String {
 }
 
 /// The branch tag a publish should land with, honoring trunk-stickiness: a key
-/// already in the trunk baseline (tagged with the trunk branch, or
-/// untagged/legacy) keeps its tag. A feature build recomputing the same action
-/// republishes it — often with byte wobble that defeats the refresh damping —
-/// and must not steal the key from the trunk view. A publish FROM the trunk
-/// always (re)claims it, and with no trunk to compare against the publish's own
-/// tag stands.
+/// already in the trunk baseline (tagged with the trunk branch) keeps its tag. A
+/// feature build recomputing the same action republishes it, often with byte
+/// wobble that defeats the refresh damping, and must not steal the key from the
+/// trunk view. A publish FROM the trunk always (re)claims it, and with no trunk
+/// to compare against the publish's own tag stands.
+///
+/// An untagged entry has nothing to protect: it is not in the baseline, so the
+/// first publisher to name a branch may claim it, which is how the fleet retags
+/// what it inherited.
 fn sticky_branch<'a>(
     existing: Option<&'a ArtifactManifest>,
     branch: Option<&'a str>,
@@ -4093,7 +4095,7 @@ fn sticky_branch<'a>(
     match (existing, trunk) {
         (Some(existing), Some(trunk))
             if branch != Some(trunk)
-                && existing.branch.as_deref().is_none_or(|tag| tag == trunk) =>
+                && existing.branch.as_deref() == Some(trunk) =>
         {
             existing.branch.as_deref()
         }
@@ -4111,9 +4113,16 @@ fn manifest_in_trunk(manifest: &ArtifactManifest, trunk: Option<&str>) -> bool {
 
 /// The same rule against a bare tag, so an index row and a manifest cannot drift
 /// apart on what belongs in a trunk view.
+///
+/// An untagged entry is NOT in the trunk baseline. `None` means the publisher
+/// could not tell us which branch produced it (no registered checkout, a moved
+/// or renamed one, a node older than the tag), and treating "unknown" as "trunk"
+/// resolves every one of those the least safe way: silently, into the one view
+/// this scoping exists to keep clean. Excluded, an unknown entry costs a per-key
+/// round trip and gets re-tagged by the refresh path the first time it is read.
 fn branch_in_trunk(branch: Option<&str>, trunk: Option<&str>) -> bool {
     match trunk {
-        Some(trunk) => branch == Some(trunk) || branch.is_none(),
+        Some(trunk) => branch == Some(trunk),
         None => true,
     }
 }
@@ -4474,15 +4483,22 @@ mod tests {
             .expect("unfiltered scan should succeed");
         assert_eq!(all.len(), 2, "the unfiltered snapshot keeps every branch");
 
-        // An untagged (legacy) entry stays in the trunk baseline.
+        // An untagged entry is not in the trunk baseline: its publisher could not
+        // say which branch produced it, and a trunk view is the wrong place to
+        // resolve that doubt. It is still served per key, and the first publisher
+        // to name a branch claims it.
         publish(&store, "action_cache/cc/10", None).await;
         let trunk = store
             .action_cache_manifests("ios", 10, Some("main"))
             .expect("trunk scan should succeed");
         let keys: Vec<&str> = trunk.iter().map(|manifest| manifest.key.as_str()).collect();
         assert!(keys.contains(&"action_cache/aa/10"));
-        assert!(keys.contains(&"action_cache/cc/10"));
+        assert!(!keys.contains(&"action_cache/cc/10"));
         assert!(!keys.contains(&"action_cache/bb/10"));
+        let all = store
+            .action_cache_manifests("ios", 10, None)
+            .expect("unfiltered scan should succeed");
+        assert_eq!(all.len(), 3, "an unscoped view still keeps every entry");
     }
 
     /// Trunk entries have to be reachable when they are buried under feature
@@ -4566,7 +4582,8 @@ mod tests {
             Some("feature"),
         )
         .await;
-        // Same for untagged/legacy baseline entries.
+        // An untagged entry is NOT in the baseline, so it has nothing to protect:
+        // the feature publish below claims it, and it leaves the trunk view.
         publish(&store, "action_cache/bb/10", b"graph", None).await;
         tick().await;
         publish(
@@ -4588,12 +4605,9 @@ mod tests {
         keys.sort_unstable();
         assert_eq!(
             keys,
-            vec![
-                "action_cache/aa/10",
-                "action_cache/bb/10",
-                "action_cache/cc/10"
-            ],
-            "trunk keys stay in (or return to) the trunk baseline"
+            vec!["action_cache/aa/10", "action_cache/cc/10"],
+            "a trunk key survives a feature republish (aa) and is reclaimed by a \
+             trunk one (cc); an untagged key is claimed by whoever names a branch (bb)"
         );
     }
 
@@ -4687,8 +4701,9 @@ mod tests {
         // this node's trunk baseline — the pollution the branch tag exists to
         // prevent, arriving over replication rather than from a client.
         apply(&store, "action_cache/aa/10", 1_000, Some("feature")).await;
-        // A message from a node that predates the field carries no branch; it
-        // applies untagged, which is what every replicated entry did before.
+        // A message from a node that predates the field carries no branch. It
+        // applies untagged, and untagged is not the trunk baseline: an older
+        // node's entries do not get to claim trunk by omission.
         apply(&store, "action_cache/bb/10", 1_000, None).await;
         apply(&store, "action_cache/cc/10", 1_000, Some("main")).await;
 
@@ -4699,8 +4714,8 @@ mod tests {
         keys.sort_unstable();
         assert_eq!(
             keys,
-            vec!["action_cache/bb/10", "action_cache/cc/10"],
-            "a replicated feature entry stays out of the trunk view; an untagged one stays in"
+            vec!["action_cache/cc/10"],
+            "only a replicated entry tagged with the trunk is in the trunk view"
         );
     }
 

--- a/kura/src/utils.rs
+++ b/kura/src/utils.rs
@@ -278,6 +278,54 @@ pub fn action_cache_index_key(namespace_id: &str, version_ms: u64, action_hash: 
     key
 }
 
+/// What an index row knows about its entry's branch, so a trunk-scoped scan can
+/// answer the filter from the row itself.
+pub enum IndexRowBranch<'a> {
+    /// Written before the branch was recorded in the row. Only the manifest
+    /// knows, and reading it is the cost the tag exists to avoid.
+    Unknown,
+    /// The entry's tag, `None` for an untagged (trunk-baseline) entry.
+    Known(Option<&'a str>),
+}
+
+/// Row value in the action-cache index CF: `{branch}\0{artifact_id}`, with an
+/// empty branch for an untagged entry.
+///
+/// The branch is duplicated out of the manifest on purpose. The scan is
+/// newest-first over a whole namespace, and a trunk-scoped view has to reject
+/// every entry belonging to another branch. Reading the tag from the manifest
+/// means a random point-read per rejected row, so a namespace whose recent
+/// history is feature churn paid a full random read for every entry it then
+/// threw away. Carrying it here makes the rejection cost one sequential step.
+pub fn action_cache_index_value(branch: Option<&str>, artifact_id: &str) -> Vec<u8> {
+    let branch = branch.unwrap_or_default();
+    let mut value = Vec::with_capacity(branch.len() + 1 + artifact_id.len());
+    value.extend_from_slice(branch.as_bytes());
+    value.push(0);
+    value.extend_from_slice(artifact_id.as_bytes());
+    value
+}
+
+/// Reads a row value written by either format. A value with no separator is a
+/// pre-branch row: a bare artifact id, whose branch only the manifest knows.
+pub fn decode_action_cache_index_value(
+    value: &[u8],
+) -> Result<(IndexRowBranch<'_>, &str), String> {
+    let invalid = |error| format!("invalid action-cache index value: {error}");
+    match value.iter().position(|byte| *byte == 0) {
+        Some(split) => {
+            let branch = std::str::from_utf8(&value[..split]).map_err(invalid)?;
+            let artifact_id = std::str::from_utf8(&value[split + 1..]).map_err(invalid)?;
+            let branch = (!branch.is_empty()).then_some(branch);
+            Ok((IndexRowBranch::Known(branch), artifact_id))
+        }
+        None => Ok((
+            IndexRowBranch::Unknown,
+            std::str::from_utf8(value).map_err(invalid)?,
+        )),
+    }
+}
+
 pub fn action_cache_index_prefix(namespace_id: &str) -> Vec<u8> {
     let mut prefix = Vec::with_capacity(namespace_id.len() + 1);
     prefix.extend_from_slice(namespace_id.as_bytes());

--- a/kura/src/utils.rs
+++ b/kura/src/utils.rs
@@ -269,60 +269,56 @@ pub fn segment_artifact_index_prefix(segment_id: &str) -> String {
 /// big-endian so a forward prefix scan yields entries newest-first and can
 /// stop at the snapshot's entry cap without sorting. The action hash keeps
 /// same-millisecond rows distinct; the row value is the artifact id.
-pub fn action_cache_index_key(namespace_id: &str, version_ms: u64, action_hash: &str) -> Vec<u8> {
-    let mut key = Vec::with_capacity(namespace_id.len() + 1 + 8 + action_hash.len());
+pub fn action_cache_index_key(
+    namespace_id: &str,
+    version_ms: u64,
+    action_hash: &str,
+    branch: Option<&str>,
+) -> Vec<u8> {
+    let branch = branch.unwrap_or_default();
+    let mut key =
+        Vec::with_capacity(namespace_id.len() + 1 + 8 + action_hash.len() + 1 + branch.len());
     key.extend_from_slice(namespace_id.as_bytes());
     key.push(0);
     key.extend_from_slice(&(!version_ms).to_be_bytes());
     key.extend_from_slice(action_hash.as_bytes());
+    // Always written, so an untagged row is distinguishable from one written
+    // before the branch was recorded at all.
+    key.push(0);
+    key.extend_from_slice(branch.as_bytes());
     key
 }
 
 /// What an index row knows about its entry's branch, so a trunk-scoped scan can
 /// answer the filter from the row itself.
 pub enum IndexRowBranch<'a> {
-    /// Written before the branch was recorded in the row. Only the manifest
+    /// Written before the branch was recorded in the key. Only the manifest
     /// knows, and reading it is the cost the tag exists to avoid.
     Unknown,
-    /// The entry's tag, `None` for an untagged (trunk-baseline) entry.
+    /// The entry's tag, `None` for an untagged entry.
     Known(Option<&'a str>),
 }
 
-/// Row value in the action-cache index CF: `{branch}\0{artifact_id}`, with an
-/// empty branch for an untagged entry.
+/// The branch a row carries, read out of its key.
 ///
-/// The branch is duplicated out of the manifest on purpose. The scan is
-/// newest-first over a whole namespace, and a trunk-scoped view has to reject
-/// every entry belonging to another branch. Reading the tag from the manifest
-/// means a random point-read per rejected row, so a namespace whose recent
-/// history is feature churn paid a full random read for every entry it then
-/// threw away. Carrying it here makes the rejection cost one sequential step.
-pub fn action_cache_index_value(branch: Option<&str>, artifact_id: &str) -> Vec<u8> {
-    let branch = branch.unwrap_or_default();
-    let mut value = Vec::with_capacity(branch.len() + 1 + artifact_id.len());
-    value.extend_from_slice(branch.as_bytes());
-    value.push(0);
-    value.extend_from_slice(artifact_id.as_bytes());
-    value
-}
-
-/// Reads a row value written by either format. A value with no separator is a
-/// pre-branch row: a bare artifact id, whose branch only the manifest knows.
-pub fn decode_action_cache_index_value(
-    value: &[u8],
-) -> Result<(IndexRowBranch<'_>, &str), String> {
-    let invalid = |error| format!("invalid action-cache index value: {error}");
-    match value.iter().position(|byte| *byte == 0) {
-        Some(split) => {
-            let branch = std::str::from_utf8(&value[..split]).map_err(invalid)?;
-            let artifact_id = std::str::from_utf8(&value[split + 1..]).map_err(invalid)?;
-            let branch = (!branch.is_empty()).then_some(branch);
-            Ok((IndexRowBranch::Known(branch), artifact_id))
-        }
-        None => Ok((
-            IndexRowBranch::Unknown,
-            std::str::from_utf8(value).map_err(invalid)?,
-        )),
+/// It rides in the KEY rather than the value, which is what makes it invisible to
+/// a node that predates it: that reader takes only `[prefix .. prefix + 8]` (the
+/// version) out of the key and never parses the rest, and reads the artifact id
+/// from the value, which is unchanged. So an older binary reading these rows finds
+/// them intact. Putting it in the value instead would make every row look like a
+/// dangling artifact id to that binary, which retires unreadable rows as stale, so
+/// a rollback would delete the index it was meant to keep working against.
+pub fn action_cache_index_key_branch(index_key: &[u8], prefix_len: usize) -> IndexRowBranch<'_> {
+    let Some(tail) = index_key.get(prefix_len + 8..) else {
+        return IndexRowBranch::Unknown;
+    };
+    // The action hash is hex, so the first NUL after it opens the branch.
+    let Some(split) = tail.iter().position(|byte| *byte == 0) else {
+        return IndexRowBranch::Unknown;
+    };
+    match std::str::from_utf8(&tail[split + 1..]) {
+        Ok(branch) => IndexRowBranch::Known((!branch.is_empty()).then_some(branch)),
+        Err(_) => IndexRowBranch::Unknown,
     }
 }
 

--- a/server/data-export.md
+++ b/server/data-export.md
@@ -123,6 +123,7 @@ The following data is stored in ClickHouse for analytics purposes:
 
 All uploaded files associated with the account are included:
 - **Cache artifacts**: Build caches and compiled binaries, including Xcode, legacy CAS, module, and Gradle artifacts
+  - **Xcode cache branch tags**: each Xcode cache action-cache entry may additionally carry the name of the git branch that produced it, stored on the entry's manifest in the account's Kura RocksDB store and replicated to that account's other Kura nodes. It is recorded so a cache view can be scoped to the project's trunk (entries from feature branches are kept out of the trunk view), and it is supplied by the client with the publication rather than read from the customer's repository. It has no retention of its own: it lives and dies with the entry it tags, under the same cache eviction, and is exported alongside that entry. Branch names routinely carry ticket ids or people's names, so they are treated as customer content rather than operational metadata.
 - **App previews**: iOS app bundles (.app/.ipa files) and icons  
 - **Run artifacts**: uploaded result bundles, invocation records, result-bundle objects, and session archives stored under `{account}/{project}/runs/{run_id}/`
 - **Shard bundles**: Shared `.xctestproducts` bundles stored at `{account_id}/{project_id}/shards/{shard_plan_id}/`

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -16,6 +16,15 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 >
 > The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs during the build.
 
+> [!IMPORTANT]
+> **Swift compilations are shared; C, Objective-C and modules are cached locally only**
+>
+> Xcode keeps two separate caches under `DerivedData/CompilationCache.noindex`. Swift compilations go through Tuist's CAS plugin and are the ones shared with your team through the remote cache. C and Objective-C compilations, precompiled modules (`.pcm`) and precompiled headers go to Xcode's built-in cache instead, because clang does not load a compilation cache plugin. Those are still cached, but only on the machine that produced them.
+>
+> This is a limitation of Xcode rather than a configuration issue — no build setting changes it. It means a machine that has never built your project (a fresh CI runner, or a colleague's first build) reuses your team's Swift compilations but still compiles C, Objective-C and modules itself.
+>
+> Both caches live inside `DerivedData`, so deleting it discards them together. **If you clean, prefer deleting only the build products and keeping `CompilationCache.noindex`** — a rebuild then reuses everything, including the local C, Objective-C and module compilations.
+
 
 ## Setup {#setup}
 

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -63,7 +63,7 @@ Note that `COMPILATION_CACHE_REMOTE_SERVICE_PATH` and `COMPILATION_CACHE_ENABLE_
 > [!NOTE]
 > **Socket Path**
 >
-> The socket path will be displayed when you run `tuist setup cache` — copy it from there rather than assembling it by hand, since it differs depending on how your account's cache is served.
+> The socket path will be displayed when you run `tuist setup cache`. Copy it from there rather than assembling it by hand, since it differs depending on how your account's cache is served.
 
 > [!IMPORTANT]
 > **`COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what shares C and Objective-C**

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -16,14 +16,10 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 >
 > The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs during the build.
 
-> [!IMPORTANT]
-> **Swift compilations are shared; C, Objective-C and modules are cached locally only**
+> [!TIP]
+> **If you clean, keep `CompilationCache.noindex`**
 >
-> Xcode keeps two separate caches under `DerivedData/CompilationCache.noindex`. Swift compilations go through Tuist's CAS plugin and are the ones shared with your team through the remote cache. C and Objective-C compilations, precompiled modules (`.pcm`) and precompiled headers go to Xcode's built-in cache instead, because clang does not load a compilation cache plugin. Those are still cached, but only on the machine that produced them.
->
-> This is a limitation of Xcode rather than a configuration issue — no build setting changes it. It means a machine that has never built your project (a fresh CI runner, or a colleague's first build) reuses your team's Swift compilations but still compiles C, Objective-C and modules itself.
->
-> Both caches live inside `DerivedData`, so deleting it discards them together. **If you clean, prefer deleting only the build products and keeping `CompilationCache.noindex`** — a rebuild then reuses everything, including the local C, Objective-C and module compilations.
+> The compilation cache lives inside `DerivedData`, so deleting `DerivedData` throws it away along with the build products. Prefer deleting only the build products: the rebuild then replays from the cache on disk, without fetching anything.
 
 
 ## Setup {#setup}
@@ -67,7 +63,12 @@ Note that `COMPILATION_CACHE_REMOTE_SERVICE_PATH` and `COMPILATION_CACHE_ENABLE_
 > [!NOTE]
 > **Socket Path**
 >
-> The socket path will be displayed when you run `tuist setup cache`. It's based on your project's full handle with slashes replaced by underscores.
+> The socket path will be displayed when you run `tuist setup cache` — copy it from there rather than assembling it by hand, since it differs depending on how your account's cache is served.
+
+> [!IMPORTANT]
+> **`COMPILATION_CACHE_REMOTE_SERVICE_PATH` is what shares C and Objective-C**
+>
+> It is easy to read this setting as "where the cache service lives" and treat it as optional. It is also the switch that decides whether C, Objective-C, precompiled modules and precompiled headers are shared at all: the build system only runs its caching for those when a remote cache service is configured. Leave it out and you still get Swift compilations shared, but every C/Objective-C file and every module is recompiled on any machine that has not built the project before.
 
 
 You can also specify these settings when running `xcodebuild` by adding the following flags, such as:

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -8,6 +8,11 @@ defmodule TuistWeb.RunnersLiveTest do
   alias Tuist.Runners.Jobs
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
+  # render_async/2 is LiveViewTest's first-party hook for waiting on async assigns.
+  # The runners widgets cross analytics-backed async work that can be slower on CI,
+  # so keep an explicit timeout until we have a deterministic non-time-based drain.
+  @render_async_timeout 1_000
+
   setup %{conn: conn} do
     user = AccountsFixtures.user_fixture()
 
@@ -49,7 +54,7 @@ defmodule TuistWeb.RunnersLiveTest do
     {:ok, _} = Jobs.complete(70_001, "success")
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
-    html = render_async(lv)
+    html = render_async(lv, @render_async_timeout)
 
     assert html =~ "Total jobs"
     assert html =~ "Avg. job duration"
@@ -72,7 +77,7 @@ defmodule TuistWeb.RunnersLiveTest do
 
   test "shows empty state when the account has no jobs", %{conn: conn, account: account} do
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
-    html = render_async(lv)
+    html = render_async(lv, @render_async_timeout)
 
     assert html =~ "Workflows"
     assert html =~ "Concurrency"
@@ -84,7 +89,7 @@ defmodule TuistWeb.RunnersLiveTest do
     {:ok, lv, _html} =
       live(conn, ~p"/#{account.name}/runners?concurrency-platform=linux")
 
-    html = render_async(lv)
+    html = render_async(lv, @render_async_timeout)
 
     assert html =~ "32 vCPU limit"
     assert html =~ "64 GB limit"


### PR DESCRIPTION
The action-cache snapshot kura serves is a size-capped, newest-first view of a whole namespace. Feature-branch churn evicts trunk entries from it, and because a resolve answers from that snapshot, a fresh trunk build does not just get slower: it **loses hits outright and recompiles work the cache already holds** (measured: 464 of ~930 tasks lost this way under pollution).

This makes the snapshot mean one thing (**what trunk looks like, as CI built it**) and adds a layer that materializes that trunk closure into the local CAS off the build's critical path. It also fixes a separate regression that had been keeping C and Objective-C out of the cache entirely.

### The two decisions everything else follows from

**The snapshot is trunk-only.** An entry tagged with another branch is not in it, and neither is an untagged one. `None` used to mean "in the trunk baseline", for backward compatibility with entries published before the tag existed. That made every way of *not knowing* resolve itself the least safe way: silently, into the one view this scoping exists to keep clean. And there are more of those ways than the legacy one it was chosen for. An untagged entry is still stored, still served per key, and the first publisher to name a branch claims it.

**The branch comes from CI, and only from CI.** Not from the checkout. That makes CI the only publisher whose branch has to be right, and CI is exactly where a checkout cannot answer anyway, its HEAD being detached.

The second decision deleted more code than it added, and deleted a class of bug rather than fixing it: a registered source root could be moved, renamed, replaced by a different repository, or shared by two worktrees of one project, and every one of those quietly attributed a build to the wrong branch. None of it is reachable from a value the CI job told us about itself.

**The trade, stated plainly:** a project that publishes locally rather than from CI gets a permanently empty trunk view. It keeps per-key resolves and its local CAS; it loses the snapshot's breadth. That is the cost of the snapshot meaning one thing.

### What changed

**kura: a branch per action-cache entry, and a trunk-scoped snapshot**
- `ArtifactManifest` gains a `branch: Option<String>` (`serde(default, skip_serializing_if)`), threaded through `PersistedManifestRecord`/`PersistArtifactSpec`. Additive on purpose: manifests are serde_json, so an old node ignores the field and a new node defaults it, which is what the mixed-version overlap of a rolling deploy needs.
- `UpdateActionResult` stores the branch from request metadata; the snapshot serve filters by the trunk, under a compound `(namespace, trunk)` cache key. **No trunk asked for = today's behavior, byte for byte.**
- **Trunk-sticky tags, under the artifact lock.** A feature build recomputing an action shared with trunk republishes an identical-but-byte-wobbled result, and must not steal the key. The decision is a read-modify-write, so it happens inside the persist, under the lock, from a read taken there: an unlocked probe let a feature publish resume with a precomputed tag and overwrite a trunk publish that landed in between.
- **A publisher that names no branch cannot erase one.** An older node, or one whose context could not be resolved, is saying it cannot tell, not that the entry has none.
- **Damping compares the tag it would resolve, not just the bytes.** Two builds computing the same action produce the same bytes and differ only in the tag, so damping on the value alone silently dropped exactly the reclaim this design depends on.
- **An index row carries its branch in its KEY**, so a trunk-scoped scan rejects feature churn without a point-read. In the key rather than the value because a node that predates it reads the version from a fixed offset and the artifact id from the value, and never parses what sits between: its rows survive a rollback intact, which the README validates on the same persistent volumes.
- **An empty index is told apart from a stale one** by a per-namespace write generation. Empty is ambiguous, because "nothing to show" and "built before anything was published" look identical, and both wrong answers are expensive: serving a stale-empty view costs a client every key it came for (it fetches once per session), and rebuilding a correctly-empty one is a namespace scan per build.
- Branch survives mesh replication; trunk indexes are maintained eagerly.

**cas-plugin: CI's branch, the project's trunk, and the proxy as the enforcer**
- The branch **never touches a build setting**. Anything baked into the compiler invocation risks entering the `-cache-compile-job` key, which would split the cache per branch and stop a feature build ever hitting trunk: the exact opposite of the goal.
- Trunk is a **server decision**, taken from the project's configured default branch. Which branch is trunk is a property of the project, not of how this machine cloned it: a fork, a mirror, or a clone whose remote head was never set all get it wrong locally.
- **The upload policy is enforced at the proxy**, because it is the only place that sees the whole build. The plugin checks it too, but from a compiler option, and swift-build's `CASOptions` carries a plugin path and **no plugin options**: the CAS it creates for Clang caching never sees the project's answer and defaults to uploading. Every publication crosses `enqueue_publish`, from either lane and from the sweeper, so that is where `upload: false` is made to mean it. A refused record is deleted rather than left for the next sweep.
- **Tags are bound when a record is accepted**, not when it is uploaded. Publishing is asynchronous and durable, and the upload runs after the queue wait, the existence probe and the closure's transfers, which is typically after the producing build has exited. A sidecar carries the answer forward so a sweeper cannot re-tag it with whatever the registry says by then.
- **A refresh is distinct per (instance, action, branch, trunk)**, and a claim that does not become work is released. Keyed on the action alone, a feature job's refresh permanently suppressed the later trunk hit for that key, disabling the reclaim path outright on a shared runner.
- **The CAS handle is restatted before a demand fetch**, not only on a resolve. Nothing orders those, so after a DerivedData wipe a fetch is often the first thing to touch a handle bound to the deleted store, and clang does not survive `missing object`.
- **Background refreshes hold off while the machine is busy**, and a demand fetch counts as busy: the resolves all land during planning, so a long compile phase is nothing but fetches, and the machine would otherwise read as idle exactly when it is most bandwidth-bound.
- **No trunk ingestion on CI.** Ingestion pays for itself only where the machine can warm before a build; CI has no such window, and our runners get a warm CAS from an attached volume.

**cli**
- Generation sets `COMPILATION_CACHE_REMOTE_SERVICE_PATH` on the kura path. See the measurement below for why this is not cosmetic.
- `tuist setup cache` records the project's trunk, the CI job's branch, and the upload policy, and swaps the file in with `rename`. The proxy re-reads it on a timer, and any instant where it is missing reads as "no projects", which in turn reads as "upload".
- The branch is reported on GitHub pushes, not just pull requests: `GITHUB_HEAD_REF` is a PR-only variable, and a detached checkout left CI, the publisher the trunk view is built from, untagged.

### Measured: the clang regression

The gap that made this worth chasing was attributed before it was fixed: of an ingested build's 378 misses, **100% were clang** and **Swift was 0**. Two earlier readings of that were wrong: first "key drift", then "an Apple limitation" (documented in a3405d68d2 and superseded here). The keys are stable and it is not Apple's to fix.

clang does not load a CAS plugin, so left alone it caches only into Xcode's local builtin CAS. The build system covers clang itself, but only where it considers a remote cache present, and it decides that purely by `remoteServicePath != nil` (`CASOptions.hasRemoteCache`). That one flag gates uploading a clang or module output (`ClangCompileTaskAction`, `PrecompileClangModuleTaskAction`) and requesting the materialize-key task that fetches one back (`maybeRequestCachingKeyMaterialization`). We never set it on the kura path. **The legacy daemon always did**, so this was a regression the plugin path introduced, not a wall.

Isolated A/B, own socket/registry/kura port, fresh kura per arm, full DerivedData wipe before each build, both populate runs at 0 hit / 930 miss with `snapshot_hits=0` (proving the kura really was fresh):

| Replay after a full DerivedData wipe | Cached | Missed | Wall |
|---|---|---|---|
| Without `COMPILATION_CACHE_REMOTE_SERVICE_PATH` | 259 | 671 | 35.4s |
| With it | **930** | **0** | **28.3s** |

2,136 keys resolved with 2,136 remote hits and 0 misses: a complete replay from remote onto an empty CAS. The first attempt at this A/B varied two settings at once; the table is the single-variable re-run.

Our plugin *consumes* the matching `remote-service-path` option rather than forwarding it, so the flag flips without Xcode's own remote client, the slow path this plugin replaced, ever taking the socket.

### Measured: trunk scoping and ingestion

With the trunk closure ingested, the build stops talking to the network at all. From the proxy's own counters, at 50ms RTT, after a full DerivedData wipe:

```
resolves=2136  snapshot_hits=2136  remote_hits=0  demand_fetched=0  misses=0
```

Every resolve answered from the snapshot already in memory, no object fetched on demand, and the compiler reporting 930 hits / 0 misses. No compiles and no network: that is a local CAS replay, which is the floor by construction rather than by measurement.

Counters rather than a stopwatch, deliberately. An earlier version of this section quoted wall times (32.0–34.5s against a 17.4–17.5s floor) from a harness I no longer trust: re-running it produced 22.0s and 38.6s for the *same* floor arm, a 75% swing on unchanged code, and in one run the floor came out slower than a cold build. Two flaws explain it, and both invalidate the comparison rather than just adding noise:

- **The "pre-ingested" arm never was.** `pending=6437` objects were still queued when the build started. The build did not wait for them, but the proxy saturated disk and network in the background while it ran. Lifting the node budget to force a fuller ingest made that arm *slower*, which is the tell.
- **The floor arm is a different workload.** It reports 687 hit remarks against the ingested build's 930, consistently. Dropping `Build` products does not reproduce the same task set, so the two were never comparable.

**The honest cost, since the counters do not show it:** ingestion competes with the machine while it runs. It is off the build's critical path in the sense that the build never blocks on it, but it is not free, and a build that starts while it drains pays for the contention. Background refreshes are gated on the machine being idle; the initial ingest is not.

**No CI numbers are claimed.** Every measurement here populated and replayed on the same machine. That is the real shape of a DerivedData wipe, not of a fresh one. `<Module>_vers.c` stubs and Swift keys embed the DerivedData path, so CI likely wants a pinned `derivedDataPath` before any of this is worth measuring there.

### Why this shape

Keys are orders of magnitude lighter than bytes: ~100k of them ride one round trip in a ≤48MB frame, where the equivalent bytes are GBs. The key cache is the breadth layer (cold-start coverage in one fetch), scoping keeps that capped budget spent on entries a trunk build can actually hit, and ingestion buys the last gap to floor, affordable *only* because it is trunk-scoped. None substitutes for another.

### Rollout

Every entry published before this is untagged, so the first trunk-scoped views come back empty and those builds run cold. They refill themselves: a per-key hit queues a refresh under the tags of the build that took it, so a namespace re-tags over its next few builds with nothing re-uploaded. The kura side is header-gated and additive, so it can go out ahead of any client that sets them.

### Testing

kura 362 tests, cas-plugin 50, clippy clean on both. The CLI's mapper, setup-cache and GitController suites pass.

Each fix here is verified by mutation rather than by a green suite: the change is reverted, the test must fail, and it must be the right test. That is how several of these were found to be testing nothing, including one case where `-only-testing` with a Swift Testing function name ran zero tests and reported success.

### Reviewer notes

- The kura changes are header-gated and additive; absent headers preserve today's behavior exactly.
- Two mapper tests that asserted `COMPILATION_CACHE_REMOTE_SERVICE_PATH == nil` on the kura path are inverted here on purpose: they were pinning the regression as intended behavior.
- Setup still writes the source root into the registry's second column and the proxy steps over it. Dropping the column would shift every column after it, and a long-lived agent from before this change would read the trunk out of the branch's position.
- The index needs no backfill. A row from before the branch reports it as unknown and asks the manifest, as it always did, and the next publish supersedes it, so the migration rides along with the republishes that re-tagging needs anyway.

