### PR TITLE
fix(infra): make the runner cache volume fail safe instead of killing the job

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -383,8 +383,17 @@ macosFleet:
   # path rather than risking ENOSPC. A real Tuist cache master is ~2.4 GB
   # (the 20 GiB masterCapGib is a sparse per-master ceiling), so 40 GiB
   # holds ~16 masters — ample for canary's single replica.
+  # DISABLED (2026-07-16): rolling this to the prod fleet broke every
+  # macOS CI job — the guest mounts the virtio-fs cache share and exports
+  # TUIST_XDG_CACHE_HOME at it, but `mkdir -p $CACHE_MOUNT/tuist` in
+  # dispatch-poll.sh fails silently (`2>/dev/null || true`) while the env
+  # var is exported regardless, so the CLI dies with "Couldn't create the
+  # directory at /Volumes/My Shared Files/cache/tuist/... because its
+  # parent directory doesn't exists". Re-enable only once a real CI job
+  # is verified green on a cache-volume host (host-side provisioning
+  # checks are NOT sufficient — that gap is what let this reach prod).
   runnerCacheVolume:
-    gib: 40
+    gib: 0
   # Canary runs on the production tailnet (single shared tailnet
   # across canary + production — same Grafana, same admin console).
   # Staging has its own tailnet so a leaked staging key can't add

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -546,8 +546,17 @@ macosFleet:
   # a single host keeps hot once affinity spreads them across the fleet.
   # Kept well under the 512 GB disk, which is dominated by the ~85 GB
   # golden VM image(s) (two during a digest roll) + per-job DerivedData.
+  # DISABLED (2026-07-16): rolling this to the prod fleet broke every
+  # macOS CI job — the guest mounts the virtio-fs cache share and exports
+  # TUIST_XDG_CACHE_HOME at it, but `mkdir -p $CACHE_MOUNT/tuist` in
+  # dispatch-poll.sh fails silently (`2>/dev/null || true`) while the env
+  # var is exported regardless, so the CLI dies with "Couldn't create the
+  # directory at /Volumes/My Shared Files/cache/tuist/... because its
+  # parent directory doesn't exists". Re-enable only once a real CI job
+  # is verified green on a cache-volume host (host-side provisioning
+  # checks are NOT sufficient — that gap is what let this reach prod).
   runnerCacheVolume:
-    gib: 80
+    gib: 0
   # Production tailnet — alloy-metrics scrapes PromEx (xcresult VM)
   # + node_exporter (host) over the tailnet. The pre-auth key lives
   # in the production 1Password vault under TAILSCALE/auth-key.

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -462,8 +462,17 @@ macosFleet:
   # 40 GiB holds ~16 masters — ample for the 1-2 accounts staging runs.
   # Operator-wide, so it also provisions a (harmless, unused) volume on the
   # xcresult host.
+  # DISABLED (2026-07-16): rolling this to the prod fleet broke every
+  # macOS CI job — the guest mounts the virtio-fs cache share and exports
+  # TUIST_XDG_CACHE_HOME at it, but `mkdir -p $CACHE_MOUNT/tuist` in
+  # dispatch-poll.sh fails silently (`2>/dev/null || true`) while the env
+  # var is exported regardless, so the CLI dies with "Couldn't create the
+  # directory at /Volumes/My Shared Files/cache/tuist/... because its
+  # parent directory doesn't exists". Re-enable only once a real CI job
+  # is verified green on a cache-volume host (host-side provisioning
+  # checks are NOT sufficient — that gap is what let this reach prod).
   runnerCacheVolume:
-    gib: 40
+    gib: 0
   # Share the pre-ordered pool with runnersFleet (same prefix
   # below). Both MachineDeployments draw from one Scaleway-side
   # pool of `tuist-pool-*` hosts; the controller claims the first


### PR DESCRIPTION
## The bug

The cache volume broke **every macOS CI job** on a cache-volume host (confirmed on prod at 08:11 and again at 09:04):

```
Fatal error: Couldn't create the directory at path
/Volumes/My Shared Files/cache/tuist/Plugins because its parent directory doesn't exists.
exit 133
```

The defect is that the guest trusts the share **unconditionally**:

```sh
mkdir -p "${CACHE_MOUNT}/tuist" 2>/dev/null || true   # failure swallowed
export TUIST_XDG_CACHE_HOME="${CACHE_MOUNT}"          # exported regardless
```

Any share the guest can't create/write in is handed to the CLI anyway, and the CLI aborts the run on its first cache write. **A cache is an optimization — it must never be able to fail a job.** That's the bug fixed here, independent of *why* the `mkdir` fails.

## The fix

**Guest (`dispatch-poll.sh`)**
- `cache_root_usable()` — proves this user can create `tuist/` **and write inside it** (a write probe; existence isn't enough, since a warm branch carries the master's ownership/mode).
- On failure → fall back to a private **local cold cache** instead of exporting `TUIST_XDG_CACHE_HOME` at an unusable root. Worst case a job runs cold; it can no longer die.
- **Re-check after `cache-ready`**, not just at boot — the host swaps the master tree in between, so the root validated at boot may no longer be usable.
- `cache_diag()` logs the **real errno + the share's ownership/mode** when the fallback fires.

**Host (`VolumeManager.Materialize`)**
- A failed swap no longer strands the branch without a cache root (the guest has already exported `TUIST_XDG_CACHE_HOME` at it) — it restores an empty, writable one, so a failed materialize costs *warmth*, not the job.
- The materialized root is relaxed to `0777` like `AllocateBranch` does, so a warm job can write where a cold one could.

Tests: `TestMaterializeLeavesCacheRootGuestWritable`, `TestMaterializeFailureStillLeavesACacheRoot`.

## Honesty about the root cause

**The reason the `mkdir` fails is not yet proven.** The CLI misreported a failed `mkdir` as "parent doesn't exist," which sent the investigation to the wrong layer. Rather than ship a third confident-but-unverified theory, this PR makes the failure **non-fatal** and **self-diagnosing** — the next staging enable will name the cause in the runner log.

## Sequencing (why the chart stays at `gib: 0` here)

The guest half ships **in the runner image**, and every image in the field still has the unsafe script — so enabling the volume before the rebake would still break jobs. Order:

1. Land this → rebake the runner image → roll tart-kubelet.
2. Re-enable on **staging**, confirm a **real CI job green** on a cache-volume host (and read `cache_diag` if it falls back).
3. Canary → prod.

Host-side checks (volume provisioned, config converged) are **not** sufficient evidence — trusting them is exactly what let this reach production.

Live mitigation already applied: prod operator patched to `--runner-cache-volume-gib=0`, all 9 minis rolled to the disabled config. That patch is ephemeral, which is why the chart values are pinned to 0 here until step 2 passes.