### PR TITLE
fix(cli): don't deduplicate packages that share a manifest name

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -208,33 +208,33 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         //
         // If multiple candidates exist, the highest-precedence source wins and the others are discarded.
         //
+        // Packages are grouped by identity rather than by the `name` their manifest declares, since unrelated
+        // packages are free to declare the same name (e.g. both `danielgindi/Charts` and forks of it declare
+        // `DGCharts`) and merging those would silently drop one package's products.
+        //
         // References:
         // - https://github.com/tuist/tuist/pull/7518
+        // - https://github.com/tuist/tuist/issues/11867
         // - https://community.tuist.dev/t/swift-package-registry-overriding-local-dependency-in-tuist-generated-project/902
-        packageInfos = Dictionary(grouping: packageInfos, by: {
-            if $0.kind == "registry" {
-                // A package is uniquely identified by a scoped identifier in the form scope.package-name.
-                return String($0.name.split(separator: ".").last ?? "").lowercased()
-            } else {
-                return $0.name.lowercased()
+        packageInfos = Dictionary(grouping: packageInfos, by: \.canonicalIdentity)
+            .compactMap { _, groupedPackageInfos in
+                if let localPackage = groupedPackageInfos.first(where: {
+                    Self.isLocalDependencyKind($0.kind)
+                }) {
+                    return localPackage
+                } else if let registryPackage = groupedPackageInfos.first(where: { $0.kind == "registry" }) {
+                    return registryPackage
+                } else {
+                    return groupedPackageInfos.first
+                }
             }
-        })
-        .compactMap { _, groupedPackageInfos in
-            if let localPackage = groupedPackageInfos.first(where: {
-                Self.isLocalDependencyKind($0.kind)
-            }) {
-                return localPackage
-            } else if let registryPackage = groupedPackageInfos.first(where: { $0.kind == "registry" }) {
-                return registryPackage
-            } else {
-                return groupedPackageInfos.first
-            }
-        }
 
-        let packageInfoDictionary = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, $0.info) })
-        let packageToFolder = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, $0.folder) })
+        // Keyed by identity rather than by name: identities are unique across the deduplicated packages, while
+        // names are not. The key is only a handle to correlate these dictionaries with each other.
+        let packageInfoDictionary = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.id, $0.info) })
+        let packageToFolder = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.id, $0.folder) })
         let packageToTargetsToArtifactPaths = Dictionary(uniqueKeysWithValues: packageInfos.map {
-            ($0.name, $0.targetToArtifactPaths)
+            ($0.id, $0.targetToArtifactPaths)
         })
         let packagePrebuilts = try mapPackagePrebuilts(
             packageInfos: packageInfos,
@@ -276,10 +276,9 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             packageSettings: packageSettings
         )
 
-        let packageInfoDictionaryById = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.id, $0.info) })
         let enabledTraitsPerPackage = Self.enabledTraits(
             rootPackageInfo: rootPackage,
-            packageInfos: packageInfoDictionaryById
+            packageInfos: packageInfoDictionary
         )
 
         let packageModuleAliases = mutablePackageModuleAliases
@@ -292,7 +291,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     path: packageInfo.folder,
                     packageType: .external(
                         origin: Self.packageOrigin(for: packageInfo.kind),
-                        artifactPaths: packageToTargetsToArtifactPaths[packageInfo.name] ?? [:],
+                        artifactPaths: packageToTargetsToArtifactPaths[packageInfo.id] ?? [:],
                         packagePrebuilts: packagePrebuilts,
                         derivedXCFrameworksPath: scratchDirectory.appending(
                             components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
@@ -444,13 +443,25 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
 }
 
 private struct SwiftPackageManagerResolvedPackageInfo {
+    /// The Swift Package Manager identity of the package, lowercased.
     let id: String
+    /// The name the package's manifest declares. Not unique across packages.
     let name: String
     let folder: AbsolutePath
     let targetToArtifactPaths: [String: AbsolutePath]
     let info: PackageInfo
     let hash: String?
     let kind: String
+
+    /// The identity under which the same package resolved from different sources collapses into a single entry.
+    ///
+    /// Registry packages are identified by a scoped identifier in the form `scope.package-name`, while source
+    /// control and local packages are identified by the package name alone, so the scope is dropped to let the
+    /// two match.
+    var canonicalIdentity: String {
+        guard kind == "registry" else { return id }
+        return String(id.split(separator: ".").last ?? "")
+    }
 }
 
 private func mapPackagePrebuilts(

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -182,9 +182,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
     /// Resolves all SwiftPackageManager dependencies.
     /// - Parameters:
-    ///   - packageInfos: All available `PackageInfo`s
-    ///   - packageToFolder: Mapping from a package name to its local folder
-    ///   - packageToTargetsToArtifactPaths: Mapping from a package name its targets' names to artifacts' paths
+    ///   - packageInfos: All available `PackageInfo`s, keyed by package identity
+    ///   - packageToFolder: Mapping from a package identity to its local folder
+    ///   - packageToTargetsToArtifactPaths: Mapping from a package identity to its targets' names to artifacts' paths
     /// - Returns: Mapped project
     public func resolveExternalDependencies(
         path: AbsolutePath,

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -677,6 +677,131 @@ struct SwiftPackageManagerGraphLoaderTests {
     }
 
     @Test
+    func load_when_two_source_control_dependencies_declare_the_same_package_name() async throws {
+        // Unrelated packages are free to declare the same name in their manifest, which swifterpm writes to
+        // `packageRef.name`. They must not be deduplicated against each other, otherwise the discarded package's
+        // products are reported as not being valid configured external dependencies.
+        // https://github.com/tuist/tuist/issues/11867
+        try await withMockedDependencies {
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) {
+                temporaryDirectory in
+                // Given
+                let packageSettings = PackageSettings.test()
+
+                let workspacePath = temporaryDirectory.appending(components: [
+                    ".build", "workspace-state.json",
+                ])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : [
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Charts",
+                              "kind" : "remoteSourceControl",
+                              "location" : "https://github.com/danielgindi/Charts.git",
+                              "name" : "DGCharts"
+                            },
+                            "state" : {
+                              "checkoutState" : {
+                                "revision" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "version" : "5.1.0"
+                              },
+                              "name" : "sourceControlCheckout"
+                            },
+                            "subpath" : "Charts"
+                          },
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Charts-fork",
+                              "kind" : "remoteSourceControl",
+                              "location" : "https://github.com/acme/Charts-fork.git",
+                              "name" : "DGCharts"
+                            },
+                            "state" : {
+                              "checkoutState" : {
+                                "revision" : "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "version" : "6.0.0"
+                              },
+                              "name" : "sourceControlCheckout"
+                            },
+                            "subpath" : "Charts-fork"
+                          },
+                        ],
+                      }
+                    }
+                    """,
+                    at: workspacePath
+                )
+
+                try await fileSystem.makeDirectory(
+                    at: temporaryDirectory.appending(components: [".build", "Derived"])
+                )
+                try await fileSystem.touch(
+                    temporaryDirectory.appending(components: [
+                        ".build", "Derived", "Package.resolved",
+                    ])
+                )
+                try await fileSystem.touch(
+                    temporaryDirectory.appending(component: "Package.resolved")
+                )
+
+                given(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packagePath: .any,
+                        packageInfos: .any,
+                        packageToFolder: .any,
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any,
+                        packageSettings: .any
+                    )
+                    .willReturn([:])
+
+                // When
+                let (got, _) = try await subject.load(
+                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                    packageSettings: packageSettings,
+                    disableSandbox: true
+                )
+
+                // Then: both packages are kept, so both contribute their products.
+                #expect(
+                    got.externalProjects.values.map(\.hash).compactMap { $0 }.sorted() == [
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    ]
+                )
+
+                let checkoutsFolder = temporaryDirectory.appending(components: [".build", "checkouts"])
+                #expect(
+                    got.externalProjects.keys.map(\.pathString).sorted() == [
+                        checkoutsFolder.appending(component: "Charts").pathString,
+                        checkoutsFolder.appending(component: "Charts-fork").pathString,
+                    ]
+                )
+
+                verify(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packagePath: .any,
+                        packageInfos: .matching { $0.count == 2 },
+                        packageToFolder: .matching { $0.count == 2 },
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any,
+                        packageSettings: .any
+                    )
+                    .called(1)
+            }
+        }
+    }
+
+    @Test
     func load_whenWorkspaceStateContainsPrebuilts_sanitizesPathsAndPassesPackagePrebuiltsToMapper() async throws {
         try await withMockedDependencies {
             try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11867>

### What changed

External packages that resolve from multiple sources (local path, registry, source control) are deduplicated down to a single entry. That grouping was keyed by the **name the package's manifest declares**. It's now keyed by the package's **Swift Package Manager identity**.

The dictionaries handed to `PackageInfoMapper` (`packageInfos`, `packageToFolder`, `packageToTargetsToArtifactPaths`) are rekeyed from name to identity as part of this. That key is only a handle used to correlate the three dictionaries with each other (`PackageInfoMapper` never interprets it as a name), but it has to change: names are no longer unique across the deduplicated packages, so leaving them as keys would trap on `Dictionary(uniqueKeysWithValues:)`.

### Why, and the root cause

swifterpm writes each dependency's `packageRef` into `workspace-state.json`. For source-control dependencies it overwrites `name` with the manifest's `Package(name:)` (`Restore.swift`, `packageRef(_:packagePath:disableSandbox:)`), while `identity` stays the URL-derived identity. Two packages at completely different URLs are free to declare the same name — the reported case is the `danielgindi/Charts` → `ChartsOrg/Charts` migration, where both declare `name: "DGCharts"`.

Grouping on that name merged them, the precedence rules kept one, and the other's products were never registered as external dependencies, surfacing as:

```
`<ProductName>` is not a valid configured external dependency
```

Identity is what actually identifies a package, so it's the correct grouping key. Registry identities are scoped (`scope.package-name`) while source-control and local identities are the package name alone, so the scope is dropped to keep the registry-vs-SCM case introduced in #7518 collapsing into one entry.

### Why not the fix suggested in the issue

The issue proposed adding URL identity to the existing key (`"\(name)|\(id)"`). That would break #7518: within one resolution the registry and SCM variants of the same package have *different* identities (`alamofire.alamofire` vs `alamofire`), so including the identity alongside the name splits the very pair that dedup exists to merge, bringing back the unstable hash. Keying on identity alone (with the registry scope dropped) fixes the reported bug while keeping that pair merged.

Switching to identity also closes a latent hole in the original heuristic: it only merged registry and SCM when the registry package name matched the *manifest* name. For any package whose manifest name differs from its repository name (`apple/swift-protobuf` declares `SwiftProtobuf`; `danielgindi/Charts` declares `DGCharts`) the registry-vs-SCM dedup silently did nothing. Comparing identities matches those correctly.

### Impact

Projects depending on two packages that share a manifest name now get both, and both packages' products resolve. No change for any project that doesn't have such a pair — the same single entry is kept, chosen by the same local → registry → source control precedence.

### Validation

`xcodebuild test -only-testing TuistLoaderTests` — 215 tests across 10 suites pass, including the three pre-existing dedup tests that pin #7518 and the local-precedence behaviour (`load_when_dependency_via_scm_and_registry`, `load_when_dependency_via_local_registry_and_scm`, `load_when_dependency_via_local_and_registry_case_insensitive`).

Added `load_when_two_source_control_dependencies_declare_the_same_package_name`, which was verified red before the fix and green after. Against the unfixed loader it reports exactly the bug — only `Charts` survives and `Charts-fork` is dropped:

```
✘ Expectation failed:
  got.externalProjects.values.map(\.hash).compactMap { $0 }.sorted()
    → ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
```

`mise run lint` passes (includes `swiftformat --lint`).

### How to test locally

Depend on two packages at different URLs whose `Package.swift` declare the same `name:` (e.g. `danielgindi/Charts` v5 and a fork of it), each contributing a product to a different target, then run `tuist install && tuist generate`. Before this change one package's products fail with "is not a valid configured external dependency"; after it both resolve.
