### PR TITLE
docs(infra): document tuist.dev certificate issuance policy

### DIFF
--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -9,7 +9,7 @@ Platform-level Helm umbrella chart installed **once per Kubernetes cluster** tha
 | `cert-manager` | TLS certificate issuance via Let's Encrypt + Cloudflare DNS-01 |
 | `ingress-nginx` | Ingress controller backed by a cloud LoadBalancer |
 | `kura-*-ingress-nginx` | Optional region-local Kura ingress controllers backed by shared regional cloud LoadBalancers |
-| `external-dns` | Sync Ingress / Service hostnames into Cloudflare DNS |
+| `external-dns` | Sync Ingress / Service hostnames into Cloudflare Domain Name System records |
 | `external-secrets` | Pull secrets from external stores (1Password, SOPS, etc.) into the cluster |
 | `metrics-server` | Resource metrics API (`pods.metrics.k8s.io`) consumed by HPAs and `kubectl top` |
 | `ClusterIssuer` | Shared Let's Encrypt issuer wired to Cloudflare DNS-01 |
@@ -64,6 +64,40 @@ the hour, and the janitor follows at minute 20 as the in-cluster backstop.
 The janitor is disabled by default because it needs cluster-wide delete access
 to dynamic preview namespaces. Keep it enabled only for the managed preview
 cluster overlay.
+
+## Certificate issuance policy
+
+Manage the `tuist.dev`
+[Certification Authority Authorization](https://www.rfc-editor.org/info/rfc8659/)
+policy manually in Cloudflare. It is a zone-level policy shared by every
+cluster, so it does not belong to the platform chart or a cluster reconciliation
+loop.
+
+Create these records at the zone apex:
+
+| Flags | Tag | Value |
+|---|---|---|
+| `0` | `issue` | `letsencrypt.org` |
+| `0` | `iodef` | `mailto:contact@tuist.dev` |
+
+Let's Encrypt issues certificates for cluster-hosted endpoints. Cloudflare
+automatically adds the authorizations required by its managed edge-certificate
+providers when a user-managed policy exists, so do not remove those generated
+records. The reporting destination is advisory; certificate authorities are
+not required to send reports.
+
+After changing the policy, verify the public response through two independent
+resolvers:
+
+```bash
+dig +short CAA tuist.dev @1.1.1.1
+dig +short CAA tuist.dev @8.8.8.8
+```
+
+Review the policy when either the cluster issuer or Cloudflare certificate
+configuration changes. See Cloudflare's
+[Certification Authority Authorization records documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/)
+for its generated-record behavior.
 
 ## Local validation
 


### PR DESCRIPTION
## What changed

The platform runbook now documents the manual Cloudflare configuration for the `tuist.dev` [Certification Authority Authorization policy](https://www.rfc-editor.org/info/rfc8659/).

It records:

- the apex authorization for Let's Encrypt
- the optional policy-reporting destination
- verification through two independent public resolvers
- Cloudflare's generated edge-certificate authorizations, which must remain in place

The GitHub Actions workflow and reconciliation helper from the earlier draft have been removed.

## Why

An explicit issuance policy is a useful defense-in-depth control, although the absence of one is not by itself a high-severity vulnerability. The live zone currently has no explicit policy, so the desired configuration should be clear before it is applied.

## Root cause

The `tuist.dev` zone has no Certification Authority Authorization records. The repository also has no established infrastructure-as-code boundary for Cloudflare zone settings.

The earlier draft crossed ownership boundaries by reading a Cloudflare credential from a Kubernetes cluster and mutating a zone-level setting from GitHub Actions. That added ongoing workflow and secret coupling for a small, rarely changed policy.

## Approach

Keep the policy manual in Cloudflare and document the intended records next to the platform's Let's Encrypt issuer. This matches the resource owner: Cloudflare manages the global zone, while the Kubernetes clusters only request certificates for their endpoints.

Cloudflare automatically adds the authorizations needed by its managed edge-certificate providers once a user-managed policy exists. If the repository later adopts broader Cloudflare infrastructure as code, this policy can move into that boundary with the other zone settings.

## Impact

This pull request changes documentation only. It does not change the live Domain Name System configuration. An operator must add the documented records in Cloudflare after merge and verify the public response.

Application routing and existing certificates are unaffected.

## Validation

- `git diff --check origin/main...HEAD`
- confirmed the final pull request diff contains one documentation file
- queried `tuist.dev` through `1.1.1.1` and `8.8.8.8`; both currently return no Certification Authority Authorization records
- verified both external documentation links resolve successfully
