### PR TITLE
fix(cli): let clang discover module maps for nested static xcframework headers

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -117,29 +117,36 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
             }
 
             if !staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.isEmpty {
-                settings["OTHER_SWIFT_FLAGS"] = .array(
-                    staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
-                        [
-                            "-Xcc",
-                            moduleMapFlag(
-                                for: xcframework,
-                                derivedDirectory: derivedDirectory,
-                                project: project
-                            ),
-                        ]
-                    }
-                )
-                settings["OTHER_C_FLAGS"] = .array(
-                    staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
-                        [
-                            moduleMapFlag(
-                                for: xcframework,
-                                derivedDirectory: derivedDirectory,
-                                project: project
-                            ),
-                        ]
-                    }
-                )
+                // Only flat layouts point at a module map. Nested ones are left for clang to
+                // discover from whichever `Headers` root wins the search path, so that the module
+                // and the headers its umbrella imports always come from the same directory.
+                let flatXCFrameworks = staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies
+                    .filter { Self.nestedModuleMap(for: $0) == nil }
+                if !flatXCFrameworks.isEmpty {
+                    settings["OTHER_SWIFT_FLAGS"] = .array(
+                        flatXCFrameworks.flatMap { xcframework -> [String] in
+                            [
+                                "-Xcc",
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    )
+                    settings["OTHER_C_FLAGS"] = .array(
+                        flatXCFrameworks.flatMap { xcframework -> [String] in
+                            [
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    )
+                }
                 settings["HEADER_SEARCH_PATHS"] = .array(
                     staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies
                         .compactMap { xcframework -> String? in
@@ -202,23 +209,31 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
     /// root (the subdirectory's parent) on the search path so those prefixed imports resolve;
     /// "flat" xcframeworks keep their headers directly next to the module map. Returns the
     /// xcframework's module map when the layout is nested.
+    ///
+    /// Nested layouts are deliberately *not* passed to clang with `-fmodule-map-file`. Whenever
+    /// anything else still references the xcframework, Xcode's `ProcessXCFramework` copies the
+    /// same headers into `$(BUILT_PRODUCTS_DIR)/include/<ModuleName>/`, which is searched ahead of
+    /// `HEADER_SEARCH_PATHS`. Naming a module map here would define the module over one copy of
+    /// the headers while `#import <ModuleName/Header.h>` resolved to the other, which clang
+    /// reports as `umbrella header for module 'X' does not include header 'Y.h'` or, once that
+    /// copy makes a second module map reachable, `import of shadowed module`. Leaving the module
+    /// map out lets clang discover it next to whichever headers actually win the search path, so
+    /// the module is always defined over the copy its umbrella imports.
     private static func nestedModuleMap(for xcframework: GraphDependency.XCFramework) -> AbsolutePath? {
         guard let moduleMap = xcframework.moduleMaps.first else { return nil }
         return moduleMap.parentDirectory.basename == xcframework.path.basenameWithoutExt ? moduleMap : nil
     }
 
+    /// Only called for flat layouts, which point at the derived module map whose umbrella header was
+    /// rewritten to drop the `<ModuleName/...>` prefix so it resolves against the module map's own
+    /// directory.
     private func moduleMapFlag(
         for xcframework: GraphDependency.XCFramework,
         derivedDirectory: AbsolutePath,
         project: Project
     ) -> String {
         let name = xcframework.path.basenameWithoutExt
-        // Nested layouts point at the xcframework's own module map: its umbrella imports the
-        // headers with the `<ModuleName/...>` prefix, which resolves against the `Headers` root.
-        // Flat layouts point at the derived module map, whose umbrella header was rewritten to
-        // drop the prefix so it resolves against the module map's own directory.
-        let moduleMapPath = Self.nestedModuleMap(for: xcframework)
-            ?? derivedDirectory.appending(components: name, "Headers", "module.modulemap")
+        let moduleMapPath = derivedDirectory.appending(components: name, "Headers", "module.modulemap")
         return "-fmodule-map-file=\"$(SRCROOT)/\(moduleMapPath.relative(to: project.path).pathString)\""
     }
 

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -369,6 +369,60 @@ struct TuistCacheEEAcceptanceTests {
         )
     }
 
+    /// Same nested-header xcframeworks as above, but `ToolLinkingXCFrameworksDirectly` also links
+    /// them directly, so they stay referenced once `Library` is replaced by its cached xcframework.
+    /// Xcode then runs `ProcessXCFramework` and copies each slice's headers into
+    /// `$(BUILT_PRODUCTS_DIR)/include/<Module>/`, which is searched ahead of `HEADER_SEARCH_PATHS`.
+    /// Pointing the module map at the xcframework's own headers therefore defined the module over
+    /// one copy of the headers while `#import <NestedObjC/Anchor.h>` resolved to another, which
+    /// clang reports as `umbrella header for module 'NestedObjC' does not include header ...` and,
+    /// once a second module map became reachable through that copy, `import of shadowed module
+    /// 'Anchor'`. The module map and the search path must name the same headers, so the mapper
+    /// consumes these through `$(BUILT_PRODUCTS_DIR)/include`, which is where the prefixed imports
+    /// resolve.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_nested_header_xcframework")
+    ) func generated_macos_tool_linking_cached_nested_header_xcframework_directly() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "NestedHeaderXCFramework.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["Library", "--path", fixtureDirectory.pathString]
+        )
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            ["--no-open", "--path", fixtureDirectory.pathString, "ToolLinkingXCFrameworksDirectly"]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "Library",
+            by: "ToolLinkingXCFrameworksDirectly",
+            xcodeprojPath: xcodeprojPath
+        )
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "-project",
+                xcodeprojPath.pathString,
+                "-scheme",
+                "ToolLinkingXCFrameworksDirectly",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -186,9 +186,13 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
 
     /// Some static Objective-C xcframeworks keep their module map and headers in a `Headers/<ModuleName>/`
     /// subdirectory and re-import each other with the `<ModuleName/...>` prefix. Such a "nested"
-    /// layout is consumed through the xcframework's own module map with the `Headers` root (the
-    /// parent of the module subdirectory) on the search path, not a derived/rewritten copy, so
-    /// both the umbrella's and the headers' prefixed imports resolve and the module is defined once.
+    /// layout gets only the `Headers` root (the parent of the module subdirectory) on the search
+    /// path, so the prefixed imports resolve, and no `-fmodule-map-file`: clang discovers the module
+    /// map next to whichever headers win the search path. Naming one here would define the module
+    /// over the xcframework's headers even when Xcode's `ProcessXCFramework` has copied the same
+    /// headers into `$(BUILT_PRODUCTS_DIR)/include/<ModuleName>/`, which is searched first — the
+    /// module and its umbrella's imports would then come from two different copies, which clang
+    /// rejects as an incomplete umbrella or a shadowed module.
     func test_map_when_static_xcframework_library_with_nested_module_headers_linked_via_dynamic_xcframework() async throws {
         // Given
         let projectPath = try temporaryPath()
@@ -267,13 +271,6 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         name: "App",
                         settings: .test(
                             base: [
-                                "OTHER_SWIFT_FLAGS": [
-                                    "-Xcc",
-                                    "-fmodule-map-file=\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers/NestedObjC/module.modulemap\"",
-                                ],
-                                "OTHER_C_FLAGS": [
-                                    "-fmodule-map-file=\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers/NestedObjC/module.modulemap\"",
-                                ],
                                 "HEADER_SEARCH_PATHS": ["\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers\""],
                             ]
                         )

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
@@ -5,7 +5,7 @@ import ProjectDescription
 // re-import each other with the `<NestedObjC/...>` prefix, linked by a dynamic
 // framework (`Library`). When `Library` is cached, `Library.xcframework` becomes
 // a dynamic dependency that links `NestedObjC` behind it, so `Tool` consumes
-// `NestedObjC` as a static-objc-xcframework-behind-a-dynamic-xcframework — the
+// `NestedObjC` as a static-objc-xcframework-behind-a-dynamic-xcframework, the
 // path handled by `StaticXCFrameworkModuleMapGraphMapper`.
 let project = Project(
     name: "NestedHeaderXCFramework",
@@ -23,6 +23,29 @@ let project = Project(
             sources: ["Tool/Sources/**"],
             dependencies: [
                 .target(name: "Library"),
+            ]
+        ),
+        // Same as `Tool`, but the xcframeworks are *also* linked directly. Once
+        // `Library` is replaced by its cached xcframework, `Tool` no longer
+        // references `NestedObjC.xcframework` at all, so Xcode never processes it.
+        // Here the direct link keeps it referenced, so Xcode runs
+        // `ProcessXCFramework` and copies each slice's headers into
+        // `$(BUILT_PRODUCTS_DIR)/include/<Module>/`. That directory is searched
+        // before `HEADER_SEARCH_PATHS`, so `#import <NestedObjC/Anchor.h>` resolves
+        // to Xcode's copy rather than to the headers the module map was pointed at.
+        // A real project reaches the same state whenever anything else in the graph
+        // still references the xcframework.
+        .target(
+            name: "ToolLinkingXCFrameworksDirectly",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "io.tuist.NestedHeaderXCFramework.ToolLinkingXCFrameworksDirectly",
+            infoPlist: .default,
+            sources: ["Tool/Sources/**"],
+            dependencies: [
+                .target(name: "Library"),
+                .xcframework(path: "NestedObjC.xcframework"),
+                .xcframework(path: "NestedObjCKit.xcframework"),
             ]
         ),
         .target(


### PR DESCRIPTION
## What changed

Static Objective-C xcframeworks whose public headers live in a `Headers/<Module>/` subdirectory (the "nested" layout) are no longer consumed through an explicit `-fmodule-map-file`. They keep only the xcframework's `Headers` root on `HEADER_SEARCH_PATHS`, and clang discovers the module map itself. Flat layouts are untouched and still point at their derived, rewritten module map.

## Why

A user reported that updating to 4.202.0 broke their cached build of a nested-layout mapping SDK:

```
umbrella header for module 'GoogleMapsBase' does not include header 'GMSDeprecationMacros.h'
umbrella header for module 'GoogleMapsBase' does not include header 'GMSCompatabilityMacros.h'
umbrella header for module 'GoogleMapsBase' does not include header 'GMSCoordinateBounds.h'
```

They worked around it with `-Wno-error=incomplete-umbrella`, since they treat warnings as errors.

## Root cause

Two copies of the same headers end up on the search path, and clang identifies headers by file identity rather than by path text.

`StaticXCFrameworkModuleMapGraphMapper` emitted `-fmodule-map-file=<xcframework>/<slice>/Headers/<Module>/module.modulemap` for nested layouts. Independently, whenever anything else in the graph still references that xcframework, Xcode runs a workspace level `ProcessXCFramework` task (`builtin-process-xcframework --target-path <BUILT_PRODUCTS_DIR>`) which copies the same headers, module map included, into `$(BUILT_PRODUCTS_DIR)/include/<Module>/`, preserving the nested subdirectory. Xcode searches that directory ahead of `HEADER_SEARCH_PATHS`, and its position is not something a project can reorder.

So the module got defined over the xcframework's headers, while the umbrella's `#import <Module/Header.h>` resolved to Xcode's copy. Clang then walks the umbrella directory, finds that none of its headers were entered, and reports every one as uncovered. With warnings as errors that fails the build. Once the copy also makes a second module map reachable, it escalates to `import of shadowed module`.

The nested branch was only ever correct when nothing else referenced the xcframework, so Xcode made no copy. That is exactly the case the existing ARCore acceptance test covers, which is why this shipped green.

## Why this fix over the alternatives

Each of these was tried and rejected against real binaries, not reasoned about:

- **Selecting the SDK matching slice.** The mapper picks `moduleMaps.first`, which is the device slice even for simulator builds. Real, but not the cause: a copy of the *same* slice fails identically.
- **A hermetic derived copy with imports rewritten to quoted relative form.** Fixes the umbrella, but a consumer's or a sibling module's `<Module/Header.h>` still lands in Xcode's copy, reproducing `import of shadowed module`.
- **Always pointing at `$(BUILT_PRODUCTS_DIR)/include`.** That directory does not exist when nothing references the xcframework, so the module map file would be missing.
- **Populating `$(BUILT_PRODUCTS_DIR)/include` from a build phase.** Trigger independent, but it hand rolls slice selection and races the workspace level task already writing those files.
- **Conditioning on whether a target links the xcframework.** In the reported build nothing links the static library at all: it is referenced but never linked, so the condition would green the test and leave the user broken.

Not emitting the flag sidesteps the whole question. Whichever directory wins the search order both defines the module and supplies the headers its umbrella imports, so the two can never disagree. No build phase, no slice selection, and no need to predict Xcode's task graph.

## Impact

Cached builds that consume a nested-layout static Objective-C xcframework behind a dynamic xcframework, while anything else in the graph still references it, now compile. Projects treating warnings as errors no longer need `-Wno-error=incomplete-umbrella`. This is not fixed on main: the mapper is byte identical between 4.202.0 and HEAD.

## Validation

- New acceptance test `generated_macos_tool_linking_cached_nested_header_xcframework_directly`, driven by a new `ToolLinkingXCFrameworksDirectly` fixture target that keeps the xcframeworks referenced so Xcode processes them. Verified **red without the fix** with the reported symptom, then green with it:

```
[!] umbrella header for module 'NestedObjC' does not include header 'TrackingState.h'
[!] umbrella header for module 'NestedObjC' does not include header 'Anchor.h'
[x] import of shadowed module 'Anchor'
```

- The existing `generated_macos_tool_with_cached_nested_header_xcframework` (ARCore, no copy made) still passes, so both cases are covered.
- All 12 `StaticXCFrameworkModuleMapGraphMapperTests` pass; every flat test is unchanged.
- Reproduced and fixed against the real `GoogleMapsBase.xcframework` 8.4.0 binary, and confirmed on real `xcodebuild` runs with `SWIFT_ENABLE_EXPLICIT_MODULES` both **on** (the reported build's mode) and off.
- The fixture is red on 4.202.0 and on 4.203.0-canary.24, and green with this change.

## Follow ups, not addressed here

- Flat layouts have the same latent shadowing: their derived umbrella's `<Sub.h>` resolves to Xcode's `include/Sub.h`, giving `-Wincomplete-umbrella`. It is unreported, needs a different remedy (quoted relative rewrite), and would churn the flat tests.
- A repro shaped like the reported project (SPM `binaryTarget` plus a cached wrapper target) reproduced the `include/` copy but did not fire the mapper at all, which suggests cached external SPM targets may lose their graph edge to the binary xcframework. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
