### PR TITLE
fix(infra): repair registry Grafana dashboard queries

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -69,7 +69,7 @@ End-to-end runbook for the bare-metal Mac mini fleet that bakes our Tart VM imag
 ### `grafana-dashboards/` — Grafana Cloud dashboards (managed only)
 Dashboard definitions synced with Grafana Cloud via [Git Sync](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/). The `Tuist Dashboards` folder in Grafana Cloud is bound to this directory; changes propagate in both directions.
 
-Each file is a `dashboard.grafana.app/v1` resource. The raw dashboard JSON lives under `spec`; the wrapper (`apiVersion`, `kind`, `metadata.name`) is what Grafana Git Sync expects. `metadata.name` must match the dashboard UID.
+Each file is a `dashboard.grafana.app/v1` or `dashboard.grafana.app/v2` resource. The raw dashboard JSON lives under `spec`; the wrapper (`apiVersion`, `kind`, `metadata.name`) is what Grafana Git Sync expects. `metadata.name` must match the dashboard UID.
 
 **Editing workflow:**
 - Prefer editing dashboards in the Grafana UI. On save, Grafana opens a pull request against `tuist/tuist` with the updated file. Direct commits to `main` from Grafana are disabled, so every UI save goes through PR review.

--- a/infra/grafana-dashboards/registry-service.json
+++ b/infra/grafana-dashboards/registry-service.json
@@ -49,7 +49,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum by (method, path) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum by (method, path) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -174,7 +174,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -505,7 +505,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (env, result) (rate(tuist_registry_s3_head_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum by (env, result) (rate(tuist_registry_s3_head_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
                         "legendFormat": "{{env}} {{result}}",
                         "range": true
                       },
@@ -753,7 +753,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "100 * sum by (namespace, url) (tuist_registry_prom_ex_finch_pool_in_use_connections{namespace=~\"^($environment)$\", pod=~\"$pod\"}) / clamp_min(sum by (namespace, url) (tuist_registry_prom_ex_finch_pool_size{namespace=~\"^($environment)$\", pod=~\"$pod\"}), 1)",
+                        "expr": "100 * sum by (env, url) (tuist_registry_prom_ex_finch_pool_in_use_connections{env=~\"$environment\", pod=~\"$pod\"}) / clamp_min(sum by (env, url) (tuist_registry_prom_ex_finch_pool_size{env=~\"$environment\", pod=~\"$pod\"}), 1)",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -880,7 +880,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_response_size_bytes_bucket{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_response_size_bytes_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -1005,7 +1005,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "count(container_cpu_usage_seconds_total{namespace=~\"^($environment)$\", container=\"registry\", pod=~\"tuist-tuist-registry.*\"})",
+                        "expr": "sum(kube_deployment_status_replicas_ready{env=~\"$environment\", deployment=\"tuist-tuist-registry\"})",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -1091,14 +1091,38 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "tuist_registry_prom_ex_beam_memory_allocated_bytes{namespace=\"$environment\"}",
+                        "expr": "max by (env, pod) (tuist_registry_prom_ex_beam_memory_allocated_bytes{env=~\"$environment\", pod=~\"$pod\"})",
                         "instant": false,
+                        "legendFormat": "{{env}} {{pod}} total",
                         "queryType": "range",
                         "range": true
                       },
                       "version": "v0"
                     },
                     "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max by (env, pod) (tuist_registry_prom_ex_beam_memory_processes_total_bytes{env=~\"$environment\", pod=~\"$pod\"})",
+                        "instant": false,
+                        "legendFormat": "{{env}} {{pod}} processes",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
                   }
                 }
               ],
@@ -1216,7 +1240,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"^($environment)$\", pod=~\"$pod\", container=\"registry\"}[$__rate_interval]))",
+                        "expr": "sum by (env, pod) (rate(container_cpu_usage_seconds_total{env=~\"$environment\", pod=~\"$pod\", container=\"registry\"}[$__rate_interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -1341,7 +1365,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "tuist_registry_prom_ex_beam_stats_process_count{namespace=\"$environment\"}",
+                        "expr": "max by (env, pod) (tuist_registry_prom_ex_beam_stats_process_count{env=~\"$environment\", pod=~\"$pod\"})",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -1466,7 +1490,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"^($environment)$\", pod=~\"$pod\", container=\"registry\"}[$__range]))",
+                        "expr": "sum(increase(kube_pod_container_status_restarts_total{env=~\"$environment\", pod=~\"$pod\", container=\"registry\"}[$__range]))",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -1552,14 +1576,38 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "tuist_registry_prom_ex_beam_stats_active_task_count{namespace=\"$environment\", type=\"normal\"}",
+                        "expr": "max by (env, pod) (tuist_registry_prom_ex_beam_stats_active_task_count{env=~\"$environment\", pod=~\"$pod\", type=\"normal\"})",
                         "instant": false,
+                        "legendFormat": "{{env}} {{pod}} normal",
                         "queryType": "range",
                         "range": true
                       },
                       "version": "v0"
                     },
                     "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max by (env, pod) (tuist_registry_prom_ex_beam_stats_active_task_count{env=~\"$environment\", pod=~\"$pod\", type=\"dirty\"})",
+                        "instant": false,
+                        "legendFormat": "{{env}} {{pod}} dirty",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
                   }
                 }
               ],
@@ -1817,7 +1865,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum(rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -1900,7 +1948,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "100 * (sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\", status_class=\"5xx\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
+                        "expr": "100 * (sum(rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", status_class=\"5xx\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -1993,7 +2041,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -2084,7 +2132,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(tuist_registry_swift_download_total{env=~\"$environment\", pod=~\"$pod\"}[$__range]))",
+                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version\", status_class=\"3xx\"}[$__range])) or vector(0)",
                         "instant": true,
                         "range": false
                       },
@@ -2165,7 +2213,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(tuist_registry_swift_manifest_total{env=~\"$environment\", pod=~\"$pod\"}[$__range]))",
+                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version/Package[.]swift\", status_class=\"2xx\"}[$__range])) or vector(0)",
                         "instant": true,
                         "range": false
                       },
@@ -2246,7 +2294,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum by (namespace) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum by (env) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -2371,7 +2419,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum by (namespace, status_class) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{namespace=~\"^($environment)$\", pod=~\"$pod\", status_class=~\"4xx|5xx\"}[$__rate_interval]))",
+                        "expr": "sum by (env, status_class) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", status_class=~\"4xx|5xx\"}[$__rate_interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -2981,11 +3029,11 @@
           },
           "hide": "dontHide",
           "includeAll": true,
-          "label": "Namespace",
+          "label": "Environment",
           "multi": true,
           "name": "environment",
           "options": [],
-          "query": "tuist,tuist-canary,tuist-staging",
+          "query": "production,canary,staging",
           "skipUrlSync": false,
           "valuesFormat": "csv"
         }
@@ -2999,7 +3047,7 @@
             "text": "All",
             "value": "$__all"
           },
-          "definition": "label_values(container_cpu_usage_seconds_total{namespace=~\"^($environment)$\", container=\"registry\"}, pod)",
+          "definition": "label_values(container_cpu_usage_seconds_total{env=~\"$environment\", container=\"registry\"}, pod)",
           "hide": "dontHide",
           "includeAll": true,
           "label": "Pod",
@@ -3014,7 +3062,7 @@
             "kind": "DataQuery",
             "spec": {
               "qryType": 1,
-              "query": "label_values()",
+              "query": "label_values(container_cpu_usage_seconds_total{env=~\"$environment\", container=\"registry\"}, pod)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "version": "v0"


### PR DESCRIPTION
## What changed

This repairs the registry service dashboard so its visualizations query the telemetry that Grafana Cloud currently stores.

- Uses the shared `production`, `canary`, and `staging` environment values across metrics, logs, and traces.
- Replaces unavailable request counters with the request-duration histogram count series, including route, error, download, and manifest panels.
- Uses the object-storage duration histogram count for existence-check request rates.
- Fixes the pod variable's executable query.
- Restores the process-memory and dirty-runtime-task series that were lost during the dashboard version 2 conversion.
- Makes Erlang runtime gauges compatible with stored metric aggregations and restores per-environment, per-pod legends.
- Documents that Grafana Git Sync accepts both version 1 and version 2 dashboard resources in this repository.

## Why

The registry is serving traffic, but several dashboard panels showed no data or query-state warnings. That made the dashboard unreliable as the first place to investigate registry health, traffic, storage behavior, and runtime pressure.

## Root cause

The dashboard mixed Kubernetes namespace values with the `env` label used by the managed monitoring destinations. This broke cross-source filtering because logs and traces use `production`, `canary`, and `staging`, while the dashboard variable had been changed to `tuist`, `tuist-canary`, and `tuist-staging`.

The request counter is stored by Grafana Adaptive Metrics without the counter-aware aggregation required by `rate` and `increase`. The request-duration histogram count has the same request labels and supports those operations. The same issue affected the object-storage request counter.

The dashboard version 2 conversion also reduced two multi-query runtime panels to one query each and left the pod variable's executable query as an empty `label_values()` call.

## Approach

The dashboard now treats the environment label as the common boundary across Prometheus, Grafana Loki, and Grafana Tempo. Request totals come from the known-working histogram count series. Aggregate download and manifest totals are derived from normalized route, method, and response-class labels, while the top-package tables keep the package-level counters because those are the only series carrying scope and package name.

Runtime gauges use `max by (env, pod)` so Grafana can map them to compatible stored aggregations without changing their per-pod meaning. Empty download and manifest periods render as zero instead of no data.

## Impact

After merge, Grafana Git Sync will update the managed registry dashboard. Production, canary, and staging filtering will be consistent across all data sources, and the repaired panels will show available telemetry without changing the registry runtime, deployment, or collection pipeline.

Top-package tables remain empty when the selected time range contains no successful package downloads or manifest reads. This is an accurate no-activity state.

## Validation

- Parsed the dashboard resource successfully with `jq empty infra/grafana-dashboards/registry-service.json`.
- Checked all 24 Prometheus expressions with Prometheus 3.5.0 after substituting representative dashboard-variable values: `SUCCESS: 24 rules found`.
- Confirmed the runtime memory and active-task panels each contain query references `A` and `B`.
- Ran `git diff --check` successfully.
- Confirmed the production and canary registry pods are Ready on the currently deployed image.

Live Grafana screenshots are not available before merge because Git Sync only applies the dashboard resource from the target branch. Live visual verification remains the post-merge check.

### How to test locally

Run:

```sh
jq empty infra/grafana-dashboards/registry-service.json
git diff --check origin/main...HEAD
```

After merge, open the `Tuist Registry Service` dashboard in Grafana Cloud, select each environment, and verify the service health, registry traffic, storage, runtime, logs, and traces sections.
