### PR TITLE
fix(registry): preserve archive content type across redirects

### DIFF
--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -38,8 +38,9 @@ managed environments that expose the registry service directly.
 
 ## Serving model
 - **Source archives** are served as `303` redirects to presigned Tigris
-  URLs. SE-0292 §4.4 explicitly permits this shape for signed archive
-  URLs.
+  URLs. The signed request overrides the object response content type with
+  `application/zip`, including for existing objects with generic metadata.
+  SE-0292 §4.4 explicitly permits this shape for signed archive URLs.
 - **Default `Package.swift`** is loaded from Tigris into memory and
   served in-process with an alternate-manifest `Link` header attached.
 - **Version-specific manifests** are also loaded from Tigris and served

--- a/registry/lib/tuist_registry/s3.ex
+++ b/registry/lib/tuist_registry/s3.ex
@@ -32,6 +32,7 @@ defmodule TuistRegistry.S3 do
   ## Options
 
     * `:type` - The storage type. Only `:registry` is supported.
+    * `:content_type` - Overrides the content type returned by object storage.
 
   Returns `{:ok, url}` on success or `{:error, reason}` on failure.
   Returns `{:error, :registry_disabled}` if type is `:registry` and registry storage is not configured.
@@ -45,7 +46,17 @@ defmodule TuistRegistry.S3 do
 
       bucket ->
         config = ExAws.Config.new(:s3)
-        ExAws.S3.presigned_url(config, :get, bucket, key, expires_in: 600)
+
+        presign_opts =
+          case Keyword.fetch(opts, :content_type) do
+            {:ok, content_type} ->
+              [expires_in: 600, query_params: [{"response-content-type", content_type}]]
+
+            :error ->
+              [expires_in: 600]
+          end
+
+        ExAws.S3.presigned_url(config, :get, bucket, key, presign_opts)
     end
   end
 

--- a/registry/lib/tuist_registry_web/controllers/swift/registry_controller.ex
+++ b/registry/lib/tuist_registry_web/controllers/swift/registry_controller.ex
@@ -226,7 +226,7 @@ defmodule TuistRegistryWeb.Swift.RegistryController do
         })
       end
 
-      case S3.presign_download_url(key, type: :registry) do
+      case S3.presign_download_url(key, type: :registry, content_type: "application/zip") do
         {:ok, url} ->
           conn
           |> put_resp_header("content-version", "1")

--- a/registry/test/tuist_registry/s3_test.exs
+++ b/registry/test/tuist_registry/s3_test.exs
@@ -12,6 +12,26 @@ defmodule TuistRegistry.S3Test do
     :ok
   end
 
+  describe "presign_download_url/2" do
+    test "signs the requested response content type" do
+      key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+
+      expect(ExAws.Config, :new, fn :s3 -> :config end)
+
+      expect(ExAws.S3, :presigned_url, fn :config, :get, "test-registry-bucket", ^key, opts ->
+        assert opts == [
+                 expires_in: 600,
+                 query_params: [{"response-content-type", "application/zip"}]
+               ]
+
+        {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
+      end)
+
+      assert S3.presign_download_url(key, type: :registry, content_type: "application/zip") ==
+               {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
+    end
+  end
+
   describe "exists?/2" do
     test "does not cache positive results" do
       key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"

--- a/registry/test/tuist_registry_web/controllers/swift/registry_controller_test.exs
+++ b/registry/test/tuist_registry_web/controllers/swift/registry_controller_test.exs
@@ -172,7 +172,9 @@ defmodule TuistRegistryWeb.Swift.RegistryControllerTest do
     test "redirects with See Other to presigned S3 URL when artifact exists", %{conn: conn} do
       expect(S3, :exists?, fn _key, _opts -> true end)
 
-      expect(S3, :presign_download_url, fn _key, _opts ->
+      expect(S3, :presign_download_url, fn _key, opts ->
+        assert opts == [type: :registry, content_type: "application/zip"]
+
         {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
       end)
 


### PR DESCRIPTION
## What changed

The standalone registry now signs source archive redirects with `response-content-type=application/zip`. The storage helper accepts the response content type explicitly, and focused tests cover both the controller request and the signed query parameters.

## Why

After production traffic moved to the standalone registry frontend, the Linux release job began rejecting package downloads because their final response did not identify the payload as a zip archive.

## Root cause

The previous cache service set `application/zip` explicitly when serving both local and object-storage archives. The standalone registry instead returns a `303 See Other` redirect to Tigris. Existing archive objects have the generic `binary/octet-stream` media type, which Swift Package Manager rejects for registry archives.

## Approach

The signed Tigris request now uses the standard response content type override. Applying the correction at the serving boundary fixes existing and future objects without rewriting stored metadata or proxying archive bytes through the registry application.

## Impact

Once the registry service is deployed, redirected package archives will return `application/zip`. No data migration or object rewrite is required.

## Validation

- `mise run test` passed all 43 registry tests.
- `mise run credo` found no issues.
- `mix format --check-formatted` and `git diff --check` passed.

### How to test locally

Run the registry test suite and code checks from `registry/`:

```sh
mise run test
mise run credo
mix format --check-formatted
```
