### PR TITLE
fix(server): fold the runner concurrency "Limit reached" series into the peak bar

### DIFF
--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -498,24 +498,12 @@ defmodule TuistWeb.RunnersLive do
   limit as a dashed line.
   """
   def concurrency_chart_series(values, limit, usage_label) do
-    admitted_usage = Enum.map(values, &if(&1 < limit, do: &1))
-    at_limit = Enum.map(values, &if(&1 >= limit, do: &1))
-
     [
       %{
-        data: admitted_usage,
+        data: Enum.map(values, &concurrency_bar(&1, limit)),
         itemStyle: %{color: "var:noora-chart-primary"},
         name: usage_label,
         type: "bar",
-        stack: "admitted-usage",
-        barMaxWidth: 18
-      },
-      %{
-        data: at_limit,
-        itemStyle: %{color: "var:noora-chart-destructive"},
-        name: dgettext("dashboard_runners", "Limit reached"),
-        type: "bar",
-        stack: "admitted-usage",
         barMaxWidth: 18
       },
       %{
@@ -533,6 +521,12 @@ defmodule TuistWeb.RunnersLive do
       }
     ]
   end
+
+  defp concurrency_bar(value, limit) when value >= limit do
+    %{value: value, itemStyle: %{color: "var:noora-chart-destructive"}}
+  end
+
+  defp concurrency_bar(value, _limit), do: value
 
   @doc """
   Shared ECharts options for concurrency resource charts.

--- a/server/priv/gettext/dashboard_runners.pot
+++ b/server/priv/gettext/dashboard_runners.pot
@@ -74,7 +74,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:178
 #: lib/tuist_web/live/runner_workflow_live.ex:316
 #: lib/tuist_web/live/runners_live.ex:335
-#: lib/tuist_web/live/runners_live.ex:672
+#: lib/tuist_web/live/runners_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:517
 #: lib/tuist_web/live/runner_workflow_live.ex:174
 #: lib/tuist_web/live/runner_workflow_live.ex:309
-#: lib/tuist_web/live/runners_live.ex:665
+#: lib/tuist_web/live/runners_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "Claimed"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:519
 #: lib/tuist_web/live/runner_workflow_live.ex:311
-#: lib/tuist_web/live/runners_live.ex:667
+#: lib/tuist_web/live/runners_live.ex:661
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:177
 #: lib/tuist_web/live/runner_workflow_live.ex:315
 #: lib/tuist_web/live/runners_live.ex:334
-#: lib/tuist_web/live/runners_live.ex:671
+#: lib/tuist_web/live/runners_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Failure"
 msgstr ""
@@ -257,7 +257,7 @@ msgid "No jobs match the current filters"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.html.heex:684
-#: lib/tuist_web/live/runners_live.ex:687
+#: lib/tuist_web/live/runners_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "No jobs yet"
 msgstr ""
@@ -285,7 +285,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:489
 #: lib/tuist_web/live/runner_workflow_live.ex:173
 #: lib/tuist_web/live/runner_workflow_live.ex:308
-#: lib/tuist_web/live/runners_live.ex:664
+#: lib/tuist_web/live/runners_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Queued"
 msgstr ""
@@ -316,7 +316,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:472
 #: lib/tuist_web/live/runner_workflow_live.ex:175
 #: lib/tuist_web/live/runner_workflow_live.ex:310
-#: lib/tuist_web/live/runners_live.ex:666
+#: lib/tuist_web/live/runners_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -329,7 +329,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:179
 #: lib/tuist_web/live/runner_workflow_live.ex:317
 #: lib/tuist_web/live/runners_live.ex:336
-#: lib/tuist_web/live/runners_live.ex:673
+#: lib/tuist_web/live/runners_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -354,7 +354,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:176
 #: lib/tuist_web/live/runner_workflow_live.ex:314
 #: lib/tuist_web/live/runners_live.ex:333
-#: lib/tuist_web/live/runners_live.ex:670
+#: lib/tuist_web/live/runners_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Success"
 msgstr ""
@@ -432,7 +432,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflows_live.html.heex:360
 #: lib/tuist_web/live/runner_workflows_live.html.heex:368
 #: lib/tuist_web/live/runners_live.ex:337
-#: lib/tuist_web/live/runners_live.ex:668
+#: lib/tuist_web/live/runners_live.ex:662
 #: lib/tuist_web/live/runners_live.html.heex:460
 #: lib/tuist_web/live/runners_live.html.heex:479
 #: lib/tuist_web/live/runners_live.html.heex:615
@@ -1327,7 +1327,7 @@ msgstr ""
 msgid "%{limit} vCPU limit"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:523
+#: lib/tuist_web/live/runners_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Limit"
 msgstr ""
@@ -1340,11 +1340,6 @@ msgstr ""
 #: lib/tuist_web/live/runners_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "%{platform} vCPU"
-msgstr ""
-
-#: lib/tuist_web/live/runners_live.ex:516
-#, elixir-autogen, elixir-format
-msgid "Limit reached"
 msgstr ""
 
 #: lib/tuist_web/live/runners_live.ex:493

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -94,17 +94,16 @@ defmodule TuistWeb.RunnersLiveTest do
   end
 
   test "marks limit buckets and renders the configured threshold" do
-    [admitted_usage, at_limit, limit] =
-      TuistWeb.RunnersLive.concurrency_chart_series([6, 12, 18], 12, "Peak CPU")
+    [usage, limit] = TuistWeb.RunnersLive.concurrency_chart_series([6, 12, 18], 12, "Peak CPU")
 
-    assert admitted_usage.data == [6, nil, nil]
-    assert admitted_usage.name == "Peak CPU"
-    assert admitted_usage.itemStyle.color == "var:noora-chart-primary"
+    assert usage.name == "Peak CPU"
+    assert usage.itemStyle.color == "var:noora-chart-primary"
 
-    assert at_limit.data == [nil, 12, 18]
-    assert at_limit.name == "Limit reached"
-    assert at_limit.itemStyle.color == "var:noora-chart-destructive"
-    assert at_limit.stack == admitted_usage.stack
+    assert usage.data == [
+             6,
+             %{value: 12, itemStyle: %{color: "var:noora-chart-destructive"}},
+             %{value: 18, itemStyle: %{color: "var:noora-chart-destructive"}}
+           ]
 
     assert limit.data == [12, 12, 12]
     assert limit.itemStyle.color == "var:noora-chart-destructive"


### PR DESCRIPTION

<img width="1773" height="557" alt="image" src="https://github.com/user-attachments/assets/267b3a56-c498-491d-85ce-4946c6ef938c" />


### What changed

The Runners concurrency charts rendered peak usage as **two stacked bar series** — `admitted_usage` (values below the limit, `nil` elsewhere) and `at_limit` (values at or above the limit, `nil` elsewhere) — sharing a `stack`. A single visible bar was really whichever of the two was non-`nil` at that index, which meant three legend entries for what reads as one measurement.

This collapses them into a single `Peak CPU` / `Peak memory` bar series and moves the color onto the individual datum:

```elixir
defp concurrency_bar(value, limit) when value >= limit do
  %{value: value, itemStyle: %{color: "var:noora-chart-destructive"}}
end

defp concurrency_bar(value, _limit), do: value
```

Noora's chart hook already resolves `var:` tokens nested inside `series[].data[].itemStyle` (`noora/js/Chart.js:360`), and `tests_live.ex:320` is an existing precedent for per-datum colors, so no Noora change was needed. Values below the limit stay bare numbers — ECharts accepts a mixed array, and the series-level `itemStyle.color` keeps the legend swatch primary.

Behavior is unchanged from the user's point of view: a bucket that reached the limit is still a red bar, so the `2026.07.14-runner-concurrency-limits` changelog copy ("red bars for hours when a limit was reached") stays accurate. The legend now reads `Peak CPU` + `Limit` instead of three entries.

### Why

Feedback on the chart shipped in #11836: `Limit reached` isn't a separate quantity from `Peak CPU`, it's a property of the same bar, and modeling it as its own stacked series made the legend misrepresent that.

### Note for reviewers: over-limit bars in the dashboard are expected right now

This PR came out of asking why the chart shows peaks well above the dashed limit line when admission should make that impossible. It's not a bug in the admission path, and nothing here changes it:

- Resource limits only landed in #11836 (merged Jul 15). Before that, `runners.ex` stated plainly: "There's no concurrency cap." A 30-day chart is therefore ~29 days of unenforced history.
- The dashed line is **today's** limit read from Postgres and painted retroactively across the whole window. No per-bucket limit history exists, because no limit existed.
- The per-job `platform` / `vcpus` / `memory_gb` columns on `runner_jobs` were added in that same PR (`20260714120000_add_resources_to_runner_jobs`), so every row before Jul 15 has `vcpus = 0` and `active_intervals_query` backfills the catalog default shape. Pre-cutover bars are reconstructions, not recorded values.

The magnitudes corroborate this: the macOS shape is 6 vCPU / 14 GB, so a 32 vCPU / 64 GB budget admits 4 concurrent jobs (memory binds first at 64/14 = 4.57), while the chart peaks near 75 vCPU — about 12 concurrent jobs, i.e. exactly an uncapped account. These bars should stop appearing as the window rolls past the cutover.

One asymmetry worth a second opinion, not addressed here: `dispatch.ex:219` deletes the Postgres claim and *then* calls `Jobs.complete`. If the ClickHouse write fails, the slot is freed for admission while the CH row keeps `completed_at = NULL` — and `active_intervals_query` clamps a NULL completion to the window end, counting that job as active indefinitely. `orphaned_runners_worker.ex:289` has the same ordering and logs "CH row will resolve on next webhook", which it won't if no webhook is coming. Rare, but it's the one remaining path that could produce a genuinely over-limit bar after the cutover.

### How to test locally

```
cd server && mix test test/tuist_web/live/runners_live_test.exs
```

`4 passed`. The `marks limit buckets and renders the configured threshold` test was updated to assert the two-series shape and the per-datum color.

Visually: on the Runners dashboard's Concurrency card, bars at or above the dashed line render in the destructive color, bars below it in the primary color, and the legend shows two entries.

`mix credo` and `mix format` are clean. `mix gettext.extract` was rerun to drop the now-unused `Limit reached` msgid — only `dashboard_runners.pot` changed, no `.po` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
