### PR TITLE
docs(chore): reposition landing page around build toolchains

### DIFF
--- a/server/assets/docs/css/components/overview.css
+++ b/server/assets/docs/css/components/overview.css
@@ -405,6 +405,145 @@
     }
   }
 
+  /* Starting paths */
+  & [data-part="start"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--noora-spacing-6);
+    padding-top: var(--noora-spacing-6);
+  }
+
+  & [data-part="start-heading"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--noora-spacing-3);
+
+    & h2 {
+      color: var(--noora-surface-label-primary);
+      font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
+    }
+
+    & p {
+      max-width: 720px;
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-body-large);
+    }
+  }
+
+  & [data-part="journey-cards"] {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--noora-spacing-5);
+  }
+
+  & [data-part="journey-card"],
+  & [data-part="journey-card"]:link,
+  & [data-part="journey-card"]:visited {
+    display: flex;
+    position: relative;
+    flex-direction: column;
+    gap: var(--noora-spacing-5);
+    transition:
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+    box-sizing: border-box;
+    box-shadow: var(--noora-light-border-default);
+    border-radius: var(--noora-radius-6);
+    background: radial-gradient(
+        circle at top right,
+        color-mix(in oklch, var(--noora-purple-200) 45%, transparent),
+        transparent 48%
+      ),
+      var(--noora-surface-background-primary);
+    padding: var(--noora-spacing-6);
+    min-height: 260px;
+    overflow: hidden;
+    color: var(--noora-surface-label-primary);
+    text-decoration: none;
+  }
+
+  & [data-part="journey-card"]:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--noora-light-border-focus);
+  }
+
+  & [data-part="journey-card"]:focus-visible {
+    outline: none;
+    box-shadow: var(--noora-light-border-focus);
+  }
+
+  & [data-part="journey-icon"] {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: var(--noora-radius-4);
+    background: color-mix(in oklch, var(--noora-purple-200) 52%, transparent);
+    width: 44px;
+    height: 44px;
+    color: var(--noora-purple-600);
+
+    & svg {
+      width: var(--noora-icon-size-medium);
+      height: var(--noora-icon-size-medium);
+    }
+  }
+
+  & [data-part="journey-content"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--noora-spacing-3);
+
+    & h3 {
+      color: var(--noora-surface-label-primary);
+      font: var(--noora-font-weight-medium) var(--noora-font-heading-large);
+    }
+
+    & p {
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-body-medium);
+    }
+  }
+
+  & [data-part="journey-link"] {
+    display: flex;
+    align-items: center;
+    gap: var(--noora-spacing-2);
+    margin-top: auto;
+    color: var(--noora-purple-600);
+    font: var(--noora-font-weight-medium) var(--noora-font-body-small);
+
+    & svg {
+      width: var(--noora-icon-size-small);
+      height: var(--noora-icon-size-small);
+    }
+  }
+
+  & [data-part="secondary-actions"] {
+    display: flex;
+    align-items: center;
+    gap: var(--noora-spacing-6);
+
+    & a,
+    & a:link,
+    & a:visited {
+      display: flex;
+      align-items: center;
+      gap: var(--noora-spacing-2);
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-weight-medium) var(--noora-font-body-small);
+      text-decoration: none;
+    }
+
+    & a:hover {
+      color: var(--noora-purple-600);
+    }
+
+    & svg {
+      width: var(--noora-icon-size-small);
+      height: var(--noora-icon-size-small);
+    }
+  }
+
   /* Section intros */
   & [data-part="section-intro"] {
     display: flex;
@@ -656,6 +795,22 @@
   }
 
   #docs-overview {
+    & [data-part="journey-cards"] {
+      grid-template-columns: 1fr;
+    }
+
+    & [data-part="journey-card"],
+    & [data-part="journey-card"]:link,
+    & [data-part="journey-card"]:visited {
+      min-height: 0;
+    }
+
+    & [data-part="secondary-actions"] {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--noora-spacing-3);
+    }
+
     & [data-part="hero-cards"] {
       flex-direction: column;
     }

--- a/server/assets/docs/css/components/overview.css
+++ b/server/assets/docs/css/components/overview.css
@@ -432,7 +432,7 @@
 
   & [data-part="journey-cards"] {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--noora-spacing-5);
   }
 
@@ -740,6 +740,18 @@
 }
 
 /* Responsive */
+@media (min-width: 1281px) {
+  #docs-overview [data-part="journey-cards"] [data-part="title"] {
+    font: var(--noora-font-weight-medium) var(--noora-font-heading-large);
+  }
+}
+
+@media (min-width: 1025px) and (max-width: 1280px) {
+  #docs-overview [data-part="journey-cards"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 1024px) {
   #docs-page-layout:has(#docs-overview) #docs-layout {
     grid-template-columns: 1fr;

--- a/server/assets/docs/css/components/overview.css
+++ b/server/assets/docs/css/components/overview.css
@@ -436,74 +436,6 @@
     gap: var(--noora-spacing-5);
   }
 
-  & [data-part="journey-card"],
-  & [data-part="journey-card"]:link,
-  & [data-part="journey-card"]:visited {
-    display: flex;
-    position: relative;
-    flex-direction: column;
-    gap: var(--noora-spacing-5);
-    transition:
-      transform 0.15s ease,
-      box-shadow 0.15s ease;
-    box-sizing: border-box;
-    box-shadow: var(--noora-light-border-default);
-    border-radius: var(--noora-radius-6);
-    background: radial-gradient(
-        circle at top right,
-        color-mix(in oklch, var(--noora-purple-200) 45%, transparent),
-        transparent 48%
-      ),
-      var(--noora-surface-background-primary);
-    padding: var(--noora-spacing-6);
-    min-height: 260px;
-    overflow: hidden;
-    color: var(--noora-surface-label-primary);
-    text-decoration: none;
-  }
-
-  & [data-part="journey-card"]:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--noora-light-border-focus);
-  }
-
-  & [data-part="journey-card"]:focus-visible {
-    outline: none;
-    box-shadow: var(--noora-light-border-focus);
-  }
-
-  & [data-part="journey-icon"] {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: var(--noora-radius-4);
-    background: color-mix(in oklch, var(--noora-purple-200) 52%, transparent);
-    width: 44px;
-    height: 44px;
-    color: var(--noora-purple-600);
-
-    & svg {
-      width: var(--noora-icon-size-medium);
-      height: var(--noora-icon-size-medium);
-    }
-  }
-
-  & [data-part="journey-content"] {
-    display: flex;
-    flex-direction: column;
-    gap: var(--noora-spacing-3);
-
-    & h3 {
-      color: var(--noora-surface-label-primary);
-      font: var(--noora-font-weight-medium) var(--noora-font-heading-large);
-    }
-
-    & p {
-      color: var(--noora-surface-label-secondary);
-      font: var(--noora-font-body-medium);
-    }
-  }
-
   & [data-part="journey-link"] {
     display: flex;
     align-items: center;
@@ -661,6 +593,25 @@
     }
   }
 
+  & [data-part="journey-cards"] > [data-part="feature-card"] {
+    width: 100%;
+    min-width: 0;
+  }
+
+  & [data-part="journey-cards"] [data-part="image"] {
+    box-sizing: border-box;
+    padding: var(--noora-spacing-5);
+    height: 160px;
+    text-align: center;
+  }
+
+  & [data-part="journey-cards"] [data-part="body"] {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--noora-spacing-4);
+  }
+
   /* Video cards */
   & [data-part="video-cards"] {
     display: flex;
@@ -797,12 +748,6 @@
   #docs-overview {
     & [data-part="journey-cards"] {
       grid-template-columns: 1fr;
-    }
-
-    & [data-part="journey-card"],
-    & [data-part="journey-card"]:link,
-    & [data-part="journey-card"]:visited {
-      min-height: 0;
     }
 
     & [data-part="secondary-actions"] {

--- a/server/lib/tuist_web/live/docs_live.ex
+++ b/server/lib/tuist_web/live/docs_live.ex
@@ -133,7 +133,7 @@ defmodule TuistWeb.DocsLive do
             <.link id="docs-xcode-path" patch={@xcode_path} data-part="feature-card">
               <div data-part="image">
                 <span data-part="icon"><.brand_apple /></span>
-                <span data-part="title">{dgettext("docs", "Existing Xcode project")}</span>
+                <span data-part="title">{dgettext("docs", "Xcode project")}</span>
               </div>
               <div data-part="body">
                 <p>
@@ -171,13 +171,13 @@ defmodule TuistWeb.DocsLive do
             <.link id="docs-runners-path" patch={@runners_path} data-part="feature-card">
               <div data-part="image">
                 <span data-part="icon"><.server /></span>
-                <span data-part="title">{dgettext("docs", "Tuist Runners")}</span>
+                <span data-part="title">{dgettext("docs", "CI runners")}</span>
               </div>
               <div data-part="body">
                 <p>
                   {dgettext(
                     "docs",
-                    "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
+                    "Run continuous integration workflows with GitHub Actions on managed macOS and Linux infrastructure next to your cache."
                   )}
                 </p>
                 <span data-part="journey-link">
@@ -585,7 +585,7 @@ defmodule TuistWeb.DocsLive do
           "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
         ),
         "",
-        "- #{markdown_link(dgettext("docs", "Existing Xcode project"), xcode_path)}: " <>
+        "- #{markdown_link(dgettext("docs", "Xcode project"), xcode_path)}: " <>
           dgettext(
             "docs",
             "Add compilation caching and insights without adopting project generation."
@@ -595,10 +595,10 @@ defmodule TuistWeb.DocsLive do
             "docs",
             "Connect remote caching, build insights, and test insights to your existing project."
           ),
-        "- #{markdown_link(dgettext("docs", "Tuist Runners"), runners_path)}: " <>
+        "- #{markdown_link(dgettext("docs", "CI runners"), runners_path)}: " <>
           dgettext(
             "docs",
-            "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
+            "Run continuous integration workflows with GitHub Actions on managed macOS and Linux infrastructure next to your cache."
           ),
         "",
         markdown_link(dgettext("docs", "Install Tuist"), install_path),

--- a/server/lib/tuist_web/live/docs_live.ex
+++ b/server/lib/tuist_web/live/docs_live.ex
@@ -9,10 +9,9 @@ defmodule TuistWeb.DocsLive do
   alias Tuist.Docs.Paths
   alias TuistWeb.Errors.NotFoundError
 
-  @noora_icons_path Path.expand("../noora/lib/noora/icons", File.cwd!())
-  @copy_check_icon @noora_icons_path |> Path.join("copy-check.svg") |> File.read!() |> String.trim()
   @overview_headings [
-    %{id: "learn-more", text: "Learn more about what Tuist offers", level: 2},
+    %{id: "start-with-your-setup", text: "Start with your setup", level: 2},
+    %{id: "learn-more", text: "Explore Tuist's capabilities", level: 2},
     %{id: "builds", text: "Builds", level: 2},
     %{id: "tests", text: "Tests", level: 2},
     %{id: "artifacts", text: "Artifacts", level: 2},
@@ -52,7 +51,10 @@ defmodule TuistWeb.DocsLive do
      |> assign(:markdown, overview_markdown(socket.assigns.locale, videos))
      |> assign(:page_title, "Docs · Tuist")
      |> assign(:head_title, "Docs · Tuist")
-     |> assign(:head_description, "Learn how to use Tuist to make mobile your competitive advantage.")}
+     |> assign(
+       :head_description,
+       "Build, test, and run Xcode and Gradle projects faster with Tuist's shared build infrastructure."
+     )}
   end
 
   defp handle_show(params, socket) do
@@ -90,7 +92,9 @@ defmodule TuistWeb.DocsLive do
     assigns =
       assigns
       |> assign(:install_path, docs_path("/#{assigns.locale}/guides/install-tuist"))
-      |> assign(:copy_check_icon, @copy_check_icon)
+      |> assign(:xcode_path, docs_path("/#{assigns.locale}/guides/features/cache/xcode-cache"))
+      |> assign(:gradle_path, docs_path("/#{assigns.locale}/guides/install-gradle-plugin"))
+      |> assign(:runners_path, docs_path("/#{assigns.locale}/guides/features/runners/getting-started"))
       |> assign(:headings, @overview_headings)
 
     ~H"""
@@ -104,115 +108,99 @@ defmodule TuistWeb.DocsLive do
       <div id="docs-overview">
         <%!-- Hero --%>
         <section data-part="hero">
-          <h1>{dgettext("docs", "Your mobile platform team, as a service")}</h1>
+          <h1>{dgettext("docs", "One platform for faster build toolchains")}</h1>
           <p>
             {dgettext(
               "docs",
-              "Let us be your virtual companion that continuously optimizes and observes your setup, so you can focus on shipping."
+              "Connect local development, continuous integration, and coding agents through shared caching, actionable insights, test optimization, and managed runners for Xcode and Gradle."
             )}
           </p>
         </section>
 
-        <%!-- Hero cards --%>
-        <section data-part="hero-cards">
-          <div
-            id="docs-install-card"
-            data-part="hero-card"
-            data-clickable
-            phx-click={JS.patch(@install_path)}
-            phx-key="Enter"
-            role="link"
-            tabindex="0"
-            aria-label={dgettext("docs", "Install Tuist CLI")}
-          >
-            <div data-part="hero-card-bg"></div>
-            <h3>{dgettext("docs", "Install Tuist CLI")}</h3>
-            <div data-part="terminal-group" id="docs-install-terminal" phx-hook="DocsInstallTabs">
-              <div data-part="terminal">
-                <div data-part="terminal-header">
-                  <div data-part="terminal-tabs">
-                    <span
-                      data-part="terminal-tab"
-                      data-selected
-                      phx-click={JS.exec("event.stopPropagation()", to: "window")}
-                    >
-                      mise
-                    </span>
-                    <span
-                      data-part="terminal-tab"
-                      phx-click={JS.exec("event.stopPropagation()", to: "window")}
-                    >
-                      homebrew
-                    </span>
-                  </div>
-                  <button
-                    data-part="terminal-copy"
-                    aria-label={dgettext("docs", "Copy command")}
-                    phx-click={JS.exec("event.stopPropagation()", to: "window")}
-                  >
-                    <span data-part="copy-icon"><.copy /></span>
-                    <span data-part="copy-check-icon">{raw(@copy_check_icon)}</span>
-                  </button>
-                </div>
-                <div data-part="terminal-body">
-                  <code>mise install tuist</code>
-                </div>
-              </div>
-              <p data-part="hero-card-hint">
-                {dgettext("docs", "or follow the instructions to")}
-                <.link patch={@install_path} data-part="hero-card-link">
-                  {dgettext("docs", "install specific version of tuist")}
-                </.link>
-              </p>
-            </div>
+        <%!-- Starting paths --%>
+        <section data-part="start">
+          <div data-part="start-heading">
+            <h2 id="start-with-your-setup">{dgettext("docs", "Start with your setup")}</h2>
+            <p>
+              {dgettext(
+                "docs",
+                "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
+              )}
+            </p>
           </div>
-          <.link navigate="/tuist/tuist" data-part="hero-card" data-variant="dashboard">
-            <div data-part="hero-card-bg"></div>
-            <h3>{dgettext("docs", "Explore dashboard")}</h3>
-            <div data-part="browser-mockup">
-              <div data-part="browser-bar">
-                <span data-part="browser-dot" data-color="red"></span>
-                <span data-part="browser-dot" data-color="yellow"></span>
-                <span data-part="browser-dot" data-color="green"></span>
+
+          <div data-part="journey-cards">
+            <.link id="docs-xcode-path" patch={@xcode_path} data-part="journey-card">
+              <span data-part="journey-icon"><.brand_apple /></span>
+              <div data-part="journey-content">
+                <h3>{dgettext("docs", "Existing Xcode project")}</h3>
+                <p>
+                  {dgettext(
+                    "docs",
+                    "Add compilation caching and insights without adopting project generation."
+                  )}
+                </p>
               </div>
-              <div data-part="browser-content">
-                <div data-part="browser-sidebar">
-                  <div data-part="browser-sidebar-items">
-                    <div data-part="sidebar-line"></div>
-                    <div data-part="sidebar-line"></div>
-                    <div data-part="sidebar-line"></div>
-                    <div data-part="sidebar-line"></div>
-                  </div>
-                </div>
-                <div data-part="browser-main">
-                  <div data-part="main-row" data-cols="4">
-                    <div data-part="main-block"></div>
-                    <div data-part="main-block"></div>
-                    <div data-part="main-block"></div>
-                    <div data-part="main-block"></div>
-                  </div>
-                  <div data-part="main-row" data-cols="2-wide">
-                    <div data-part="main-block" data-wide></div>
-                    <div data-part="main-block" data-narrow></div>
-                  </div>
-                  <div data-part="main-row" data-cols="2-equal">
-                    <div data-part="main-block" data-equal></div>
-                    <div data-part="main-block" data-equal></div>
-                  </div>
-                  <div data-part="sidebar-line" data-short></div>
-                </div>
+              <span data-part="journey-link">
+                {dgettext("docs", "Explore Xcode")}
+                <.arrow_right />
+              </span>
+            </.link>
+
+            <.link id="docs-gradle-path" patch={@gradle_path} data-part="journey-card">
+              <span data-part="journey-icon"><.settings /></span>
+              <div data-part="journey-content">
+                <h3>{dgettext("docs", "Gradle project")}</h3>
+                <p>
+                  {dgettext(
+                    "docs",
+                    "Connect remote caching, build insights, and test insights to your existing project."
+                  )}
+                </p>
               </div>
-            </div>
-          </.link>
+              <span data-part="journey-link">
+                {dgettext("docs", "Start with Gradle")}
+                <.arrow_right />
+              </span>
+            </.link>
+
+            <.link id="docs-runners-path" patch={@runners_path} data-part="journey-card">
+              <span data-part="journey-icon"><.server /></span>
+              <div data-part="journey-content">
+                <h3>{dgettext("docs", "Tuist Runners")}</h3>
+                <p>
+                  {dgettext(
+                    "docs",
+                    "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
+                  )}
+                </p>
+              </div>
+              <span data-part="journey-link">
+                {dgettext("docs", "Start with runners")}
+                <.arrow_right />
+              </span>
+            </.link>
+          </div>
+
+          <div data-part="secondary-actions">
+            <.link patch={@install_path}>
+              {dgettext("docs", "Install Tuist")}
+              <.arrow_right />
+            </.link>
+            <.link navigate="/tuist/tuist">
+              {dgettext("docs", "Explore dashboard")}
+              <.arrow_right />
+            </.link>
+          </div>
         </section>
 
         <%!-- What Tuist offers --%>
         <section data-part="section-intro">
-          <h1 id="learn-more">{dgettext("docs", "Learn more about what Tuist offers")}</h1>
+          <h1 id="learn-more">{dgettext("docs", "Explore Tuist's capabilities")}</h1>
           <p>
             {dgettext(
               "docs",
-              "Learn how to generate projects, automate your workflows, and scale your app development efficiently with Tuist."
+              "Speed up builds, improve test reliability, understand performance, and run workflows on infrastructure designed for your toolchain."
             )}
           </p>
         </section>
@@ -223,12 +211,13 @@ defmodule TuistWeb.DocsLive do
           <p>
             {dgettext(
               "docs",
-              "Skip the manual steps, auto-generate projects, speeds up builds, and explore insights with built-in analytics."
+              "Share build work across developer machines, continuous integration, runners, and coding agents, then use insights to find regressions."
             )}
           </p>
           <div data-part="feature-cards">
             <.link
-              patch={docs_path("/#{@locale}/guides/features/cache/module-cache")}
+              id="docs-cache-card"
+              patch={docs_path("/#{@locale}/guides/features/cache")}
               data-part="feature-card"
             >
               <div data-part="image">
@@ -239,7 +228,7 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Speeds up builds by caching compiled modules, cutting down load times in both local development and CI workflows."
+                    "Reuse build artifacts across Xcode and Gradle so work completed in one environment speeds up every other environment."
                   )}
                 </p>
               </div>
@@ -256,7 +245,7 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Monitor build performance across your CI infrastructure to catch slowdowns before they impact development."
+                    "Understand build performance across local and continuous integration environments before slowdowns affect your team."
                   )}
                 </p>
               </div>
@@ -270,7 +259,7 @@ defmodule TuistWeb.DocsLive do
           <p>
             {dgettext(
               "docs",
-              "Run only impacted tests based on your changes, faster feedback loops, less waiting, both locally and on CI."
+              "Run the tests that matter, detect flaky behavior, and understand test performance locally and in continuous integration."
             )}
           </p>
           <div data-part="feature-cards">
@@ -286,7 +275,7 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Run only the tests that matter by detecting changes since your last successful run, cutting down test times both locally and on CI."
+                    "Run only impacted tests by detecting changes since your last successful run, both locally and in continuous integration."
                   )}
                 </p>
               </div>
@@ -320,7 +309,7 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Track test performance, catch slow tests early, and debug CI failures through real-time logs."
+                    "Track test performance, catch slow tests early, and debug continuous integration failures through real-time logs."
                   )}
                 </p>
               </div>
@@ -334,7 +323,7 @@ defmodule TuistWeb.DocsLive do
           <p>
             {dgettext(
               "docs",
-              "From code to feedback in minutes. Instant previews and AI-powered testing close the loop between building and validating."
+              "Move from a successful build to useful feedback with shareable previews and bundle-size insights."
             )}
           </p>
           <div data-part="feature-cards">
@@ -347,7 +336,7 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Share your app instantly with a URL, no TestFlight or setup needed, so others can run it on their device or simulator in seconds."
+                    "Share your app with a link so others can run it on their device or simulator without TestFlight setup."
                   )}
                 </p>
               </div>
@@ -545,13 +534,16 @@ defmodule TuistWeb.DocsLive do
   end
 
   defp overview_markdown(locale, videos) do
-    module_cache_path = docs_path("/#{locale}/guides/features/cache/module-cache")
+    cache_path = docs_path("/#{locale}/guides/features/cache")
     build_insights_path = docs_path("/#{locale}/guides/features/build-insights")
     selective_testing_path = docs_path("/#{locale}/guides/features/selective-testing")
     flaky_tests_path = docs_path("/#{locale}/guides/features/test-insights/flaky-tests")
     test_insights_path = docs_path("/#{locale}/guides/features/test-insights")
     previews_path = docs_path("/#{locale}/guides/features/previews")
     install_path = docs_path("/#{locale}/guides/install-tuist")
+    xcode_path = docs_path("/#{locale}/guides/features/cache/xcode-cache")
+    gradle_path = docs_path("/#{locale}/guides/install-gradle-plugin")
+    runners_path = docs_path("/#{locale}/guides/features/runners/getting-started")
 
     video_lines =
       if videos == [] do
@@ -573,59 +565,75 @@ defmodule TuistWeb.DocsLive do
 
     Enum.join(
       [
-        "# " <> dgettext("docs", "Your mobile platform team, as a service"),
+        "# " <> dgettext("docs", "One platform for faster build toolchains"),
         "",
         dgettext(
           "docs",
-          "Let us be your virtual companion that continuously optimizes and observes your setup, so you can focus on shipping."
+          "Connect local development, continuous integration, and coding agents through shared caching, actionable insights, test optimization, and managed runners for Xcode and Gradle."
         ),
         "",
-        "## " <> dgettext("docs", "Install Tuist CLI"),
-        "",
-        "```sh",
-        "mise install tuist",
-        "```",
-        "",
-        markdown_link(dgettext("docs", "install specific version of tuist"), install_path),
-        "",
-        markdown_link(dgettext("docs", "Explore dashboard"), "/tuist/tuist"),
-        "",
-        "## " <> dgettext("docs", "Learn more about what Tuist offers"),
+        "## " <> dgettext("docs", "Start with your setup"),
         "",
         dgettext(
           "docs",
-          "Learn how to generate projects, automate your workflows, and scale your app development efficiently with Tuist."
+          "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
+        ),
+        "",
+        "- #{markdown_link(dgettext("docs", "Existing Xcode project"), xcode_path)}: " <>
+          dgettext(
+            "docs",
+            "Add compilation caching and insights without adopting project generation."
+          ),
+        "- #{markdown_link(dgettext("docs", "Gradle project"), gradle_path)}: " <>
+          dgettext(
+            "docs",
+            "Connect remote caching, build insights, and test insights to your existing project."
+          ),
+        "- #{markdown_link(dgettext("docs", "Tuist Runners"), runners_path)}: " <>
+          dgettext(
+            "docs",
+            "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
+          ),
+        "",
+        markdown_link(dgettext("docs", "Install Tuist"), install_path),
+        markdown_link(dgettext("docs", "Explore dashboard"), "/tuist/tuist"),
+        "",
+        "## " <> dgettext("docs", "Explore Tuist's capabilities"),
+        "",
+        dgettext(
+          "docs",
+          "Speed up builds, improve test reliability, understand performance, and run workflows on infrastructure designed for your toolchain."
         ),
         "",
         "## " <> dgettext("docs", "Builds"),
         "",
         dgettext(
           "docs",
-          "Skip the manual steps, auto-generate projects, speeds up builds, and explore insights with built-in analytics."
+          "Share build work across developer machines, continuous integration, runners, and coding agents, then use insights to find regressions."
         ),
         "",
-        "- #{markdown_link(dgettext("docs", "Cache"), module_cache_path)}: " <>
+        "- #{markdown_link(dgettext("docs", "Cache"), cache_path)}: " <>
           dgettext(
             "docs",
-            "Speeds up builds by caching compiled modules, cutting down load times in both local development and CI workflows."
+            "Reuse build artifacts across Xcode and Gradle so work completed in one environment speeds up every other environment."
           ),
         "- #{markdown_link(dgettext("docs", "Insights"), build_insights_path)}: " <>
           dgettext(
             "docs",
-            "Monitor build performance across your CI infrastructure to catch slowdowns before they impact development."
+            "Understand build performance across local and continuous integration environments before slowdowns affect your team."
           ),
         "",
         "## " <> dgettext("docs", "Tests"),
         "",
         dgettext(
           "docs",
-          "Run only impacted tests based on your changes, faster feedback loops, less waiting, both locally and on CI."
+          "Run the tests that matter, detect flaky behavior, and understand test performance locally and in continuous integration."
         ),
         "",
         "- #{markdown_link(dgettext("docs", "Selective Testing"), selective_testing_path)}: " <>
           dgettext(
             "docs",
-            "Run only the tests that matter by detecting changes since your last successful run, cutting down test times both locally and on CI."
+            "Run only impacted tests by detecting changes since your last successful run, both locally and in continuous integration."
           ),
         "- #{markdown_link(dgettext("docs", "Flaky Tests"), flaky_tests_path)}: " <>
           dgettext(
@@ -635,20 +643,20 @@ defmodule TuistWeb.DocsLive do
         "- #{markdown_link(dgettext("docs", "Insights"), test_insights_path)}: " <>
           dgettext(
             "docs",
-            "Track test performance, catch slow tests early, and debug CI failures through real-time logs."
+            "Track test performance, catch slow tests early, and debug continuous integration failures through real-time logs."
           ),
         "",
         "## " <> dgettext("docs", "Artifacts"),
         "",
         dgettext(
           "docs",
-          "From code to feedback in minutes. Instant previews and AI-powered testing close the loop between building and validating."
+          "Move from a successful build to useful feedback with shareable previews and bundle-size insights."
         ),
         "",
         "- #{markdown_link(dgettext("docs", "Previews"), previews_path)}: " <>
           dgettext(
             "docs",
-            "Share your app instantly with a URL, no TestFlight or setup needed, so others can run it on their device or simulator in seconds."
+            "Share your app with a link so others can run it on their device or simulator without TestFlight setup."
           ),
         ""
       ] ++

--- a/server/lib/tuist_web/live/docs_live.ex
+++ b/server/lib/tuist_web/live/docs_live.ex
@@ -92,6 +92,10 @@ defmodule TuistWeb.DocsLive do
     assigns =
       assigns
       |> assign(:install_path, docs_path("/#{assigns.locale}/guides/install-tuist"))
+      |> assign(
+        :generated_xcode_path,
+        docs_path("/#{assigns.locale}/tutorials/xcode/create-a-generated-project")
+      )
       |> assign(:xcode_path, docs_path("/#{assigns.locale}/guides/features/cache/xcode-cache"))
       |> assign(:gradle_path, docs_path("/#{assigns.locale}/guides/install-gradle-plugin"))
       |> assign(:runners_path, docs_path("/#{assigns.locale}/guides/features/runners/getting-started"))
@@ -121,15 +125,32 @@ defmodule TuistWeb.DocsLive do
         <section data-part="start">
           <div data-part="start-heading">
             <h2 id="start-with-your-setup">{dgettext("docs", "Start with your setup")}</h2>
-            <p>
-              {dgettext(
-                "docs",
-                "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
-              )}
-            </p>
           </div>
 
           <div data-part="journey-cards">
+            <.link
+              id="docs-generated-xcode-path"
+              patch={@generated_xcode_path}
+              data-part="feature-card"
+            >
+              <div data-part="image">
+                <span data-part="icon"><.brand_tuist /></span>
+                <span data-part="title">{dgettext("docs", "Generated Xcode project")}</span>
+              </div>
+              <div data-part="body">
+                <p>
+                  {dgettext(
+                    "docs",
+                    "Generate and maintain your Xcode project with module caching and selective testing."
+                  )}
+                </p>
+                <span data-part="journey-link">
+                  {dgettext("docs", "Start generating")}
+                  <.arrow_right />
+                </span>
+              </div>
+            </.link>
+
             <.link id="docs-xcode-path" patch={@xcode_path} data-part="feature-card">
               <div data-part="image">
                 <span data-part="icon"><.brand_apple /></span>
@@ -139,11 +160,11 @@ defmodule TuistWeb.DocsLive do
                 <p>
                   {dgettext(
                     "docs",
-                    "Add compilation caching and insights without adopting project generation."
+                    "Connect compilation caching and insights to an existing Xcode project."
                   )}
                 </p>
                 <span data-part="journey-link">
-                  {dgettext("docs", "Explore Xcode")}
+                  {dgettext("docs", "Start with Xcode")}
                   <.arrow_right />
                 </span>
               </div>
@@ -547,6 +568,10 @@ defmodule TuistWeb.DocsLive do
     test_insights_path = docs_path("/#{locale}/guides/features/test-insights")
     previews_path = docs_path("/#{locale}/guides/features/previews")
     install_path = docs_path("/#{locale}/guides/install-tuist")
+
+    generated_xcode_path =
+      docs_path("/#{locale}/tutorials/xcode/create-a-generated-project")
+
     xcode_path = docs_path("/#{locale}/guides/features/cache/xcode-cache")
     gradle_path = docs_path("/#{locale}/guides/install-gradle-plugin")
     runners_path = docs_path("/#{locale}/guides/features/runners/getting-started")
@@ -580,15 +605,15 @@ defmodule TuistWeb.DocsLive do
         "",
         "## " <> dgettext("docs", "Start with your setup"),
         "",
-        dgettext(
-          "docs",
-          "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
-        ),
-        "",
+        "- #{markdown_link(dgettext("docs", "Generated Xcode project"), generated_xcode_path)}: " <>
+          dgettext(
+            "docs",
+            "Generate and maintain your Xcode project with module caching and selective testing."
+          ),
         "- #{markdown_link(dgettext("docs", "Xcode project"), xcode_path)}: " <>
           dgettext(
             "docs",
-            "Add compilation caching and insights without adopting project generation."
+            "Connect compilation caching and insights to an existing Xcode project."
           ),
         "- #{markdown_link(dgettext("docs", "Gradle project"), gradle_path)}: " <>
           dgettext(

--- a/server/lib/tuist_web/live/docs_live.ex
+++ b/server/lib/tuist_web/live/docs_live.ex
@@ -130,55 +130,61 @@ defmodule TuistWeb.DocsLive do
           </div>
 
           <div data-part="journey-cards">
-            <.link id="docs-xcode-path" patch={@xcode_path} data-part="journey-card">
-              <span data-part="journey-icon"><.brand_apple /></span>
-              <div data-part="journey-content">
-                <h3>{dgettext("docs", "Existing Xcode project")}</h3>
+            <.link id="docs-xcode-path" patch={@xcode_path} data-part="feature-card">
+              <div data-part="image">
+                <span data-part="icon"><.brand_apple /></span>
+                <span data-part="title">{dgettext("docs", "Existing Xcode project")}</span>
+              </div>
+              <div data-part="body">
                 <p>
                   {dgettext(
                     "docs",
                     "Add compilation caching and insights without adopting project generation."
                   )}
                 </p>
+                <span data-part="journey-link">
+                  {dgettext("docs", "Explore Xcode")}
+                  <.arrow_right />
+                </span>
               </div>
-              <span data-part="journey-link">
-                {dgettext("docs", "Explore Xcode")}
-                <.arrow_right />
-              </span>
             </.link>
 
-            <.link id="docs-gradle-path" patch={@gradle_path} data-part="journey-card">
-              <span data-part="journey-icon"><.settings /></span>
-              <div data-part="journey-content">
-                <h3>{dgettext("docs", "Gradle project")}</h3>
+            <.link id="docs-gradle-path" patch={@gradle_path} data-part="feature-card">
+              <div data-part="image">
+                <span data-part="icon"><.settings /></span>
+                <span data-part="title">{dgettext("docs", "Gradle project")}</span>
+              </div>
+              <div data-part="body">
                 <p>
                   {dgettext(
                     "docs",
                     "Connect remote caching, build insights, and test insights to your existing project."
                   )}
                 </p>
+                <span data-part="journey-link">
+                  {dgettext("docs", "Start with Gradle")}
+                  <.arrow_right />
+                </span>
               </div>
-              <span data-part="journey-link">
-                {dgettext("docs", "Start with Gradle")}
-                <.arrow_right />
-              </span>
             </.link>
 
-            <.link id="docs-runners-path" patch={@runners_path} data-part="journey-card">
-              <span data-part="journey-icon"><.server /></span>
-              <div data-part="journey-content">
-                <h3>{dgettext("docs", "Tuist Runners")}</h3>
+            <.link id="docs-runners-path" patch={@runners_path} data-part="feature-card">
+              <div data-part="image">
+                <span data-part="icon"><.server /></span>
+                <span data-part="title">{dgettext("docs", "Tuist Runners")}</span>
+              </div>
+              <div data-part="body">
                 <p>
                   {dgettext(
                     "docs",
                     "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
                   )}
                 </p>
+                <span data-part="journey-link">
+                  {dgettext("docs", "Start with runners")}
+                  <.arrow_right />
+                </span>
               </div>
-              <span data-part="journey-link">
-                {dgettext("docs", "Start with runners")}
-                <.arrow_right />
-              </span>
             </.link>
           </div>
 

--- a/server/priv/gettext/docs.pot
+++ b/server/priv/gettext/docs.pot
@@ -11,14 +11,14 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:322
-#: lib/tuist_web/live/docs_live.ex:649
+#: lib/tuist_web/live/docs_live.ex:328
+#: lib/tuist_web/live/docs_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:293
-#: lib/tuist_web/live/docs_live.ex:639
+#: lib/tuist_web/live/docs_live.ex:299
+#: lib/tuist_web/live/docs_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Automatically detect flaky tests that fail without code changes and save time spent investigating false failures."
 msgstr ""
@@ -28,32 +28,32 @@ msgstr ""
 msgid "Bluesky"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:210
-#: lib/tuist_web/live/docs_live.ex:608
+#: lib/tuist_web/live/docs_live.ex:216
+#: lib/tuist_web/live/docs_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Builds"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:225
-#: lib/tuist_web/live/docs_live.ex:615
+#: lib/tuist_web/live/docs_live.ex:231
+#: lib/tuist_web/live/docs_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:410
-#: lib/tuist_web/live/docs_live.ex:674
+#: lib/tuist_web/live/docs_live.ex:416
+#: lib/tuist_web/live/docs_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Chat with the Tuist community in real-time."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:380
-#: lib/tuist_web/live/docs_live.ex:667
+#: lib/tuist_web/live/docs_live.ex:386
+#: lib/tuist_web/live/docs_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "Connect with thousands of developers who are shipping better apps with Tuist. Get help, share wins, and shape the future of app development tooling."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:398
-#: lib/tuist_web/live/docs_live.ex:673
+#: lib/tuist_web/live/docs_live.ex:404
+#: lib/tuist_web/live/docs_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Contribute or report issues to our open source repository."
 msgstr ""
@@ -79,32 +79,32 @@ msgstr ""
 msgid "Documentation navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:191
-#: lib/tuist_web/live/docs_live.ex:599
+#: lib/tuist_web/live/docs_live.ex:197
+#: lib/tuist_web/live/docs_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Explore dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:289
-#: lib/tuist_web/live/docs_live.ex:638
+#: lib/tuist_web/live/docs_live.ex:295
+#: lib/tuist_web/live/docs_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:475
-#: lib/tuist_web/live/docs_live.ex:684
+#: lib/tuist_web/live/docs_live.ex:481
+#: lib/tuist_web/live/docs_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Follow Tuist on LinkedIn for news and updates."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:451
-#: lib/tuist_web/live/docs_live.ex:680
+#: lib/tuist_web/live/docs_live.ex:457
+#: lib/tuist_web/live/docs_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Follow us on Bluesky to stay up to date with our work."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:463
-#: lib/tuist_web/live/docs_live.ex:682
+#: lib/tuist_web/live/docs_live.ex:469
+#: lib/tuist_web/live/docs_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Follow us on Mastodon to stay up to date with our work."
 msgstr ""
@@ -119,22 +119,22 @@ msgstr ""
 msgid "Guides"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:242
-#: lib/tuist_web/live/docs_live.ex:306
-#: lib/tuist_web/live/docs_live.ex:620
-#: lib/tuist_web/live/docs_live.ex:643
+#: lib/tuist_web/live/docs_live.ex:248
+#: lib/tuist_web/live/docs_live.ex:312
+#: lib/tuist_web/live/docs_live.ex:626
+#: lib/tuist_web/live/docs_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Insights"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:351
-#: lib/tuist_web/live/docs_live.ex:555
+#: lib/tuist_web/live/docs_live.ex:357
+#: lib/tuist_web/live/docs_live.ex:561
 #, elixir-autogen, elixir-format
 msgid "Learn from real implementations and get inspired by what's possible when your toolchain just works."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:439
-#: lib/tuist_web/live/docs_live.ex:678
+#: lib/tuist_web/live/docs_live.ex:445
+#: lib/tuist_web/live/docs_live.ex:684
 #, elixir-autogen, elixir-format
 msgid "Learn from videos from the Tuist team and the community."
 msgstr ""
@@ -160,8 +160,8 @@ msgstr ""
 msgid "On this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:378
-#: lib/tuist_web/live/docs_live.ex:665
+#: lib/tuist_web/live/docs_live.ex:384
+#: lib/tuist_web/live/docs_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Open source and community"
 msgstr ""
@@ -171,8 +171,8 @@ msgstr ""
 msgid "Page navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:333
-#: lib/tuist_web/live/docs_live.ex:656
+#: lib/tuist_web/live/docs_live.ex:339
+#: lib/tuist_web/live/docs_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Previews"
 msgstr ""
@@ -197,20 +197,20 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:349
-#: lib/tuist_web/live/docs_live.ex:553
+#: lib/tuist_web/live/docs_live.ex:355
+#: lib/tuist_web/live/docs_live.ex:559
 #, elixir-autogen, elixir-format
 msgid "See Tuist in action"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:272
-#: lib/tuist_web/live/docs_live.ex:633
+#: lib/tuist_web/live/docs_live.ex:278
+#: lib/tuist_web/live/docs_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:423
-#: lib/tuist_web/live/docs_live.ex:676
+#: lib/tuist_web/live/docs_live.ex:429
+#: lib/tuist_web/live/docs_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Share your ideas, report issues, and discuss with other community members."
 msgstr ""
@@ -231,8 +231,8 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:258
-#: lib/tuist_web/live/docs_live.ex:626
+#: lib/tuist_web/live/docs_live.ex:264
+#: lib/tuist_web/live/docs_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Tests"
 msgstr ""
@@ -242,8 +242,8 @@ msgstr ""
 msgid "Toggle sidebar"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:437
-#: lib/tuist_web/live/docs_live.ex:677
+#: lib/tuist_web/live/docs_live.ex:443
+#: lib/tuist_web/live/docs_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr ""
@@ -290,22 +290,22 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:509
+#: lib/tuist_web/live/docs_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Edit this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:519
+#: lib/tuist_web/live/docs_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Last updated on %{date}"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:497
+#: lib/tuist_web/live/docs_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:499
+#: lib/tuist_web/live/docs_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "as Markdown"
 msgstr ""
@@ -328,143 +328,143 @@ msgstr ""
 msgid "Toggle theme"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:138
-#: lib/tuist_web/live/docs_live.ex:583
+#: lib/tuist_web/live/docs_live.ex:140
+#: lib/tuist_web/live/docs_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "Add compilation caching and insights without adopting project generation."
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:125
-#: lib/tuist_web/live/docs_live.ex:577
+#: lib/tuist_web/live/docs_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:113
-#: lib/tuist_web/live/docs_live.ex:570
+#: lib/tuist_web/live/docs_live.ex:576
 #, elixir-autogen, elixir-format
 msgid "Connect local development, continuous integration, and coding agents through shared caching, actionable insights, test optimization, and managed runners for Xcode and Gradle."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:155
-#: lib/tuist_web/live/docs_live.ex:588
+#: lib/tuist_web/live/docs_live.ex:159
+#: lib/tuist_web/live/docs_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Connect remote caching, build insights, and test insights to your existing project."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:136
-#: lib/tuist_web/live/docs_live.ex:582
-#, elixir-autogen, elixir-format
-msgid "Existing Xcode project"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:199
-#: lib/tuist_web/live/docs_live.ex:601
+#: lib/tuist_web/live/docs_live.ex:205
+#: lib/tuist_web/live/docs_live.ex:607
 #, elixir-autogen, elixir-format
 msgid "Explore Tuist's capabilities"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:145
+#: lib/tuist_web/live/docs_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Explore Xcode"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:153
-#: lib/tuist_web/live/docs_live.ex:587
+#: lib/tuist_web/live/docs_live.ex:155
+#: lib/tuist_web/live/docs_live.ex:593
 #, elixir-autogen, elixir-format
 msgid "Gradle project"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:187
-#: lib/tuist_web/live/docs_live.ex:598
+#: lib/tuist_web/live/docs_live.ex:193
+#: lib/tuist_web/live/docs_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Install Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:324
-#: lib/tuist_web/live/docs_live.ex:651
+#: lib/tuist_web/live/docs_live.ex:330
+#: lib/tuist_web/live/docs_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Move from a successful build to useful feedback with shareable previews and bundle-size insights."
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:111
-#: lib/tuist_web/live/docs_live.ex:568
+#: lib/tuist_web/live/docs_live.ex:574
 #, elixir-autogen, elixir-format
 msgid "One platform for faster build toolchains"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:229
-#: lib/tuist_web/live/docs_live.ex:616
+#: lib/tuist_web/live/docs_live.ex:235
+#: lib/tuist_web/live/docs_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Reuse build artifacts across Xcode and Gradle so work completed in one environment speeds up every other environment."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:172
-#: lib/tuist_web/live/docs_live.ex:593
-#, elixir-autogen, elixir-format
-msgid "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:276
-#: lib/tuist_web/live/docs_live.ex:634
+#: lib/tuist_web/live/docs_live.ex:282
+#: lib/tuist_web/live/docs_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Run only impacted tests by detecting changes since your last successful run, both locally and in continuous integration."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:260
-#: lib/tuist_web/live/docs_live.ex:628
+#: lib/tuist_web/live/docs_live.ex:266
+#: lib/tuist_web/live/docs_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Run the tests that matter, detect flaky behavior, and understand test performance locally and in continuous integration."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:212
-#: lib/tuist_web/live/docs_live.ex:610
+#: lib/tuist_web/live/docs_live.ex:218
+#: lib/tuist_web/live/docs_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "Share build work across developer machines, continuous integration, runners, and coding agents, then use insights to find regressions."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:337
-#: lib/tuist_web/live/docs_live.ex:657
+#: lib/tuist_web/live/docs_live.ex:343
+#: lib/tuist_web/live/docs_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Share your app with a link so others can run it on their device or simulator without TestFlight setup."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:201
-#: lib/tuist_web/live/docs_live.ex:603
+#: lib/tuist_web/live/docs_live.ex:207
+#: lib/tuist_web/live/docs_live.ex:609
 #, elixir-autogen, elixir-format
 msgid "Speed up builds, improve test reliability, understand performance, and run workflows on infrastructure designed for your toolchain."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:162
+#: lib/tuist_web/live/docs_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Start with Gradle"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:179
+#: lib/tuist_web/live/docs_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Start with runners"
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:123
-#: lib/tuist_web/live/docs_live.ex:575
+#: lib/tuist_web/live/docs_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Start with your setup"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:310
-#: lib/tuist_web/live/docs_live.ex:644
+#: lib/tuist_web/live/docs_live.ex:316
+#: lib/tuist_web/live/docs_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Track test performance, catch slow tests early, and debug continuous integration failures through real-time logs."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:170
-#: lib/tuist_web/live/docs_live.ex:592
-#, elixir-autogen, elixir-format
-msgid "Tuist Runners"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:246
-#: lib/tuist_web/live/docs_live.ex:621
+#: lib/tuist_web/live/docs_live.ex:252
+#: lib/tuist_web/live/docs_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Understand build performance across local and continuous integration environments before slowdowns affect your team."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:136
+#: lib/tuist_web/live/docs_live.ex:588
+#, elixir-autogen, elixir-format
+msgid "Xcode project"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:174
+#: lib/tuist_web/live/docs_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "CI runners"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:178
+#: lib/tuist_web/live/docs_live.ex:599
+#, elixir-autogen, elixir-format
+msgid "Run continuous integration workflows with GitHub Actions on managed macOS and Linux infrastructure next to your cache."
 msgstr ""

--- a/server/priv/gettext/docs.pot
+++ b/server/priv/gettext/docs.pot
@@ -11,14 +11,14 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:333
-#: lib/tuist_web/live/docs_live.ex:641
+#: lib/tuist_web/live/docs_live.ex:322
+#: lib/tuist_web/live/docs_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:304
-#: lib/tuist_web/live/docs_live.ex:631
+#: lib/tuist_web/live/docs_live.ex:293
+#: lib/tuist_web/live/docs_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Automatically detect flaky tests that fail without code changes and save time spent investigating false failures."
 msgstr ""
@@ -28,39 +28,34 @@ msgstr ""
 msgid "Bluesky"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:222
-#: lib/tuist_web/live/docs_live.ex:600
+#: lib/tuist_web/live/docs_live.ex:210
+#: lib/tuist_web/live/docs_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Builds"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:236
-#: lib/tuist_web/live/docs_live.ex:607
+#: lib/tuist_web/live/docs_live.ex:225
+#: lib/tuist_web/live/docs_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:421
-#: lib/tuist_web/live/docs_live.ex:666
+#: lib/tuist_web/live/docs_live.ex:410
+#: lib/tuist_web/live/docs_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "Chat with the Tuist community in real-time."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:391
-#: lib/tuist_web/live/docs_live.ex:659
+#: lib/tuist_web/live/docs_live.ex:380
+#: lib/tuist_web/live/docs_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Connect with thousands of developers who are shipping better apps with Tuist. Get help, share wins, and shape the future of app development tooling."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:409
-#: lib/tuist_web/live/docs_live.ex:665
+#: lib/tuist_web/live/docs_live.ex:398
+#: lib/tuist_web/live/docs_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "Contribute or report issues to our open source repository."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:150
-#, elixir-autogen, elixir-format
-msgid "Copy command"
 msgstr ""
 
 #: lib/tuist_web/docs/components/page_layout.html.heex:71
@@ -84,40 +79,34 @@ msgstr ""
 msgid "Documentation navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:171
-#: lib/tuist_web/live/docs_live.ex:591
+#: lib/tuist_web/live/docs_live.ex:191
+#: lib/tuist_web/live/docs_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "Explore dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:300
-#: lib/tuist_web/live/docs_live.ex:630
+#: lib/tuist_web/live/docs_live.ex:289
+#: lib/tuist_web/live/docs_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:486
-#: lib/tuist_web/live/docs_live.ex:676
+#: lib/tuist_web/live/docs_live.ex:475
+#: lib/tuist_web/live/docs_live.ex:684
 #, elixir-autogen, elixir-format
 msgid "Follow Tuist on LinkedIn for news and updates."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:462
-#: lib/tuist_web/live/docs_live.ex:672
+#: lib/tuist_web/live/docs_live.ex:451
+#: lib/tuist_web/live/docs_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Follow us on Bluesky to stay up to date with our work."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:474
-#: lib/tuist_web/live/docs_live.ex:674
+#: lib/tuist_web/live/docs_live.ex:463
+#: lib/tuist_web/live/docs_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Follow us on Mastodon to stay up to date with our work."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:335
-#: lib/tuist_web/live/docs_live.ex:643
-#, elixir-autogen, elixir-format
-msgid "From code to feedback in minutes. Instant previews and AI-powered testing close the loop between building and validating."
 msgstr ""
 
 #: lib/tuist_web/docs/layouts/root.html.heex:146
@@ -130,43 +119,24 @@ msgstr ""
 msgid "Guides"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:253
-#: lib/tuist_web/live/docs_live.ex:317
-#: lib/tuist_web/live/docs_live.ex:612
-#: lib/tuist_web/live/docs_live.ex:635
+#: lib/tuist_web/live/docs_live.ex:242
+#: lib/tuist_web/live/docs_live.ex:306
+#: lib/tuist_web/live/docs_live.ex:620
+#: lib/tuist_web/live/docs_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Insights"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:126
-#: lib/tuist_web/live/docs_live.ex:129
-#: lib/tuist_web/live/docs_live.ex:583
-#, elixir-autogen, elixir-format
-msgid "Install Tuist CLI"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:362
-#: lib/tuist_web/live/docs_live.ex:563
+#: lib/tuist_web/live/docs_live.ex:351
+#: lib/tuist_web/live/docs_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Learn from real implementations and get inspired by what's possible when your toolchain just works."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:450
-#: lib/tuist_web/live/docs_live.ex:670
+#: lib/tuist_web/live/docs_live.ex:439
+#: lib/tuist_web/live/docs_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Learn from videos from the Tuist team and the community."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:213
-#: lib/tuist_web/live/docs_live.ex:595
-#, elixir-autogen, elixir-format
-msgid "Learn how to generate projects, automate your workflows, and scale your app development efficiently with Tuist."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:211
-#: lib/tuist_web/live/docs_live.ex:593
-#, elixir-autogen, elixir-format
-msgid "Learn more about what Tuist offers"
 msgstr ""
 
 #: lib/tuist_web/docs/layouts/root.html.heex:86
@@ -184,20 +154,14 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:257
-#: lib/tuist_web/live/docs_live.ex:613
-#, elixir-autogen, elixir-format
-msgid "Monitor build performance across your CI infrastructure to catch slowdowns before they impact development."
-msgstr ""
-
 #: lib/tuist_web/docs/components/toc.html.heex:39
 #: lib/tuist_web/docs/layouts/root.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "On this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:389
-#: lib/tuist_web/live/docs_live.ex:657
+#: lib/tuist_web/live/docs_live.ex:378
+#: lib/tuist_web/live/docs_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Open source and community"
 msgstr ""
@@ -207,8 +171,8 @@ msgstr ""
 msgid "Page navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:344
-#: lib/tuist_web/live/docs_live.ex:648
+#: lib/tuist_web/live/docs_live.ex:333
+#: lib/tuist_web/live/docs_live.ex:656
 #, elixir-autogen, elixir-format
 msgid "Previews"
 msgstr ""
@@ -228,51 +192,27 @@ msgstr ""
 msgid "Return to top"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:271
-#: lib/tuist_web/live/docs_live.ex:620
-#, elixir-autogen, elixir-format
-msgid "Run only impacted tests based on your changes, faster feedback loops, less waiting, both locally and on CI."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:287
-#: lib/tuist_web/live/docs_live.ex:626
-#, elixir-autogen, elixir-format
-msgid "Run only the tests that matter by detecting changes since your last successful run, cutting down test times both locally and on CI."
-msgstr ""
-
 #: lib/tuist_web/docs/layouts/root.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:360
-#: lib/tuist_web/live/docs_live.ex:561
+#: lib/tuist_web/live/docs_live.ex:349
+#: lib/tuist_web/live/docs_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "See Tuist in action"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:283
-#: lib/tuist_web/live/docs_live.ex:625
+#: lib/tuist_web/live/docs_live.ex:272
+#: lib/tuist_web/live/docs_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:348
-#: lib/tuist_web/live/docs_live.ex:649
-#, elixir-autogen, elixir-format
-msgid "Share your app instantly with a URL, no TestFlight or setup needed, so others can run it on their device or simulator in seconds."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:434
-#: lib/tuist_web/live/docs_live.ex:668
+#: lib/tuist_web/live/docs_live.ex:423
+#: lib/tuist_web/live/docs_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Share your ideas, report issues, and discuss with other community members."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:224
-#: lib/tuist_web/live/docs_live.ex:602
-#, elixir-autogen, elixir-format
-msgid "Skip the manual steps, auto-generate projects, speeds up builds, and explore insights with built-in analytics."
 msgstr ""
 
 #: lib/tuist_web/docs/layouts/root.html.heex:84
@@ -285,20 +225,14 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:240
-#: lib/tuist_web/live/docs_live.ex:608
-#, elixir-autogen, elixir-format
-msgid "Speeds up builds by caching compiled modules, cutting down load times in both local development and CI workflows."
-msgstr ""
-
 #: lib/tuist_web/docs/components/page_layout.html.heex:12
 #: lib/tuist_web/docs/components/toc.html.heex:1
 #, elixir-autogen, elixir-format
 msgid "Table of contents"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:269
-#: lib/tuist_web/live/docs_live.ex:618
+#: lib/tuist_web/live/docs_live.ex:258
+#: lib/tuist_web/live/docs_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Tests"
 msgstr ""
@@ -308,14 +242,8 @@ msgstr ""
 msgid "Toggle sidebar"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:321
-#: lib/tuist_web/live/docs_live.ex:636
-#, elixir-autogen, elixir-format
-msgid "Track test performance, catch slow tests early, and debug CI failures through real-time logs."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:448
-#: lib/tuist_web/live/docs_live.ex:669
+#: lib/tuist_web/live/docs_live.ex:437
+#: lib/tuist_web/live/docs_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr ""
@@ -330,29 +258,6 @@ msgstr ""
 #: lib/tuist_web/docs/components/toc.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "View this page as plain text"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:164
-#: lib/tuist_web/live/docs_live.ex:589
-#, elixir-autogen, elixir-format
-msgid "install specific version of tuist"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:162
-#, elixir-autogen, elixir-format
-msgid "or follow the instructions to"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:109
-#: lib/tuist_web/live/docs_live.ex:578
-#, elixir-autogen, elixir-format
-msgid "Let us be your virtual companion that continuously optimizes and observes your setup, so you can focus on shipping."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:107
-#: lib/tuist_web/live/docs_live.ex:576
-#, elixir-autogen, elixir-format
-msgid "Your mobile platform team, as a service"
 msgstr ""
 
 #: lib/tuist_web/docs/layouts/root.html.heex:105
@@ -385,22 +290,22 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:520
+#: lib/tuist_web/live/docs_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Edit this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:530
+#: lib/tuist_web/live/docs_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Last updated on %{date}"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:508
+#: lib/tuist_web/live/docs_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:510
+#: lib/tuist_web/live/docs_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "as Markdown"
 msgstr ""
@@ -421,4 +326,145 @@ msgstr ""
 #: lib/tuist_web/docs/layouts/root.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Toggle theme"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:138
+#: lib/tuist_web/live/docs_live.ex:583
+#, elixir-autogen, elixir-format
+msgid "Add compilation caching and insights without adopting project generation."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:125
+#: lib/tuist_web/live/docs_live.ex:577
+#, elixir-autogen, elixir-format
+msgid "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:113
+#: lib/tuist_web/live/docs_live.ex:570
+#, elixir-autogen, elixir-format
+msgid "Connect local development, continuous integration, and coding agents through shared caching, actionable insights, test optimization, and managed runners for Xcode and Gradle."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:155
+#: lib/tuist_web/live/docs_live.ex:588
+#, elixir-autogen, elixir-format
+msgid "Connect remote caching, build insights, and test insights to your existing project."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:136
+#: lib/tuist_web/live/docs_live.ex:582
+#, elixir-autogen, elixir-format
+msgid "Existing Xcode project"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:199
+#: lib/tuist_web/live/docs_live.ex:601
+#, elixir-autogen, elixir-format
+msgid "Explore Tuist's capabilities"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:145
+#, elixir-autogen, elixir-format
+msgid "Explore Xcode"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:153
+#: lib/tuist_web/live/docs_live.ex:587
+#, elixir-autogen, elixir-format
+msgid "Gradle project"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:187
+#: lib/tuist_web/live/docs_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "Install Tuist"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:324
+#: lib/tuist_web/live/docs_live.ex:651
+#, elixir-autogen, elixir-format
+msgid "Move from a successful build to useful feedback with shareable previews and bundle-size insights."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:111
+#: lib/tuist_web/live/docs_live.ex:568
+#, elixir-autogen, elixir-format
+msgid "One platform for faster build toolchains"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:229
+#: lib/tuist_web/live/docs_live.ex:616
+#, elixir-autogen, elixir-format
+msgid "Reuse build artifacts across Xcode and Gradle so work completed in one environment speeds up every other environment."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:172
+#: lib/tuist_web/live/docs_live.ex:593
+#, elixir-autogen, elixir-format
+msgid "Run GitHub Actions workflows on managed macOS and Linux infrastructure next to your cache."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:276
+#: lib/tuist_web/live/docs_live.ex:634
+#, elixir-autogen, elixir-format
+msgid "Run only impacted tests by detecting changes since your last successful run, both locally and in continuous integration."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:260
+#: lib/tuist_web/live/docs_live.ex:628
+#, elixir-autogen, elixir-format
+msgid "Run the tests that matter, detect flaky behavior, and understand test performance locally and in continuous integration."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:212
+#: lib/tuist_web/live/docs_live.ex:610
+#, elixir-autogen, elixir-format
+msgid "Share build work across developer machines, continuous integration, runners, and coding agents, then use insights to find regressions."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:337
+#: lib/tuist_web/live/docs_live.ex:657
+#, elixir-autogen, elixir-format
+msgid "Share your app with a link so others can run it on their device or simulator without TestFlight setup."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:201
+#: lib/tuist_web/live/docs_live.ex:603
+#, elixir-autogen, elixir-format
+msgid "Speed up builds, improve test reliability, understand performance, and run workflows on infrastructure designed for your toolchain."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:162
+#, elixir-autogen, elixir-format
+msgid "Start with Gradle"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:179
+#, elixir-autogen, elixir-format
+msgid "Start with runners"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:123
+#: lib/tuist_web/live/docs_live.ex:575
+#, elixir-autogen, elixir-format
+msgid "Start with your setup"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:310
+#: lib/tuist_web/live/docs_live.ex:644
+#, elixir-autogen, elixir-format
+msgid "Track test performance, catch slow tests early, and debug continuous integration failures through real-time logs."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:170
+#: lib/tuist_web/live/docs_live.ex:592
+#, elixir-autogen, elixir-format
+msgid "Tuist Runners"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:246
+#: lib/tuist_web/live/docs_live.ex:621
+#, elixir-autogen, elixir-format
+msgid "Understand build performance across local and continuous integration environments before slowdowns affect your team."
 msgstr ""

--- a/server/priv/gettext/docs.pot
+++ b/server/priv/gettext/docs.pot
@@ -11,14 +11,14 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:328
-#: lib/tuist_web/live/docs_live.ex:655
+#: lib/tuist_web/live/docs_live.ex:349
+#: lib/tuist_web/live/docs_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:299
-#: lib/tuist_web/live/docs_live.ex:645
+#: lib/tuist_web/live/docs_live.ex:320
+#: lib/tuist_web/live/docs_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Automatically detect flaky tests that fail without code changes and save time spent investigating false failures."
 msgstr ""
@@ -28,32 +28,32 @@ msgstr ""
 msgid "Bluesky"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:216
-#: lib/tuist_web/live/docs_live.ex:614
+#: lib/tuist_web/live/docs_live.ex:237
+#: lib/tuist_web/live/docs_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Builds"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:231
-#: lib/tuist_web/live/docs_live.ex:621
+#: lib/tuist_web/live/docs_live.ex:252
+#: lib/tuist_web/live/docs_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:416
-#: lib/tuist_web/live/docs_live.ex:680
+#: lib/tuist_web/live/docs_live.ex:437
+#: lib/tuist_web/live/docs_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Chat with the Tuist community in real-time."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:386
-#: lib/tuist_web/live/docs_live.ex:673
+#: lib/tuist_web/live/docs_live.ex:407
+#: lib/tuist_web/live/docs_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "Connect with thousands of developers who are shipping better apps with Tuist. Get help, share wins, and shape the future of app development tooling."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:404
-#: lib/tuist_web/live/docs_live.ex:679
+#: lib/tuist_web/live/docs_live.ex:425
+#: lib/tuist_web/live/docs_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Contribute or report issues to our open source repository."
 msgstr ""
@@ -79,32 +79,32 @@ msgstr ""
 msgid "Documentation navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:197
-#: lib/tuist_web/live/docs_live.ex:605
+#: lib/tuist_web/live/docs_live.ex:218
+#: lib/tuist_web/live/docs_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Explore dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:295
-#: lib/tuist_web/live/docs_live.ex:644
+#: lib/tuist_web/live/docs_live.ex:316
+#: lib/tuist_web/live/docs_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:481
-#: lib/tuist_web/live/docs_live.ex:690
+#: lib/tuist_web/live/docs_live.ex:502
+#: lib/tuist_web/live/docs_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Follow Tuist on LinkedIn for news and updates."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:457
-#: lib/tuist_web/live/docs_live.ex:686
+#: lib/tuist_web/live/docs_live.ex:478
+#: lib/tuist_web/live/docs_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Follow us on Bluesky to stay up to date with our work."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:469
-#: lib/tuist_web/live/docs_live.ex:688
+#: lib/tuist_web/live/docs_live.ex:490
+#: lib/tuist_web/live/docs_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Follow us on Mastodon to stay up to date with our work."
 msgstr ""
@@ -119,22 +119,22 @@ msgstr ""
 msgid "Guides"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:248
-#: lib/tuist_web/live/docs_live.ex:312
-#: lib/tuist_web/live/docs_live.ex:626
-#: lib/tuist_web/live/docs_live.ex:649
+#: lib/tuist_web/live/docs_live.ex:269
+#: lib/tuist_web/live/docs_live.ex:333
+#: lib/tuist_web/live/docs_live.ex:651
+#: lib/tuist_web/live/docs_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "Insights"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:357
-#: lib/tuist_web/live/docs_live.ex:561
+#: lib/tuist_web/live/docs_live.ex:378
+#: lib/tuist_web/live/docs_live.ex:586
 #, elixir-autogen, elixir-format
 msgid "Learn from real implementations and get inspired by what's possible when your toolchain just works."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:445
-#: lib/tuist_web/live/docs_live.ex:684
+#: lib/tuist_web/live/docs_live.ex:466
+#: lib/tuist_web/live/docs_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Learn from videos from the Tuist team and the community."
 msgstr ""
@@ -160,8 +160,8 @@ msgstr ""
 msgid "On this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:384
-#: lib/tuist_web/live/docs_live.ex:671
+#: lib/tuist_web/live/docs_live.ex:405
+#: lib/tuist_web/live/docs_live.ex:696
 #, elixir-autogen, elixir-format
 msgid "Open source and community"
 msgstr ""
@@ -171,8 +171,8 @@ msgstr ""
 msgid "Page navigation"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:339
-#: lib/tuist_web/live/docs_live.ex:662
+#: lib/tuist_web/live/docs_live.ex:360
+#: lib/tuist_web/live/docs_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Previews"
 msgstr ""
@@ -197,20 +197,20 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:355
-#: lib/tuist_web/live/docs_live.ex:559
+#: lib/tuist_web/live/docs_live.ex:376
+#: lib/tuist_web/live/docs_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "See Tuist in action"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:278
-#: lib/tuist_web/live/docs_live.ex:639
+#: lib/tuist_web/live/docs_live.ex:299
+#: lib/tuist_web/live/docs_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:429
-#: lib/tuist_web/live/docs_live.ex:682
+#: lib/tuist_web/live/docs_live.ex:450
+#: lib/tuist_web/live/docs_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Share your ideas, report issues, and discuss with other community members."
 msgstr ""
@@ -231,8 +231,8 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:264
-#: lib/tuist_web/live/docs_live.ex:632
+#: lib/tuist_web/live/docs_live.ex:285
+#: lib/tuist_web/live/docs_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Tests"
 msgstr ""
@@ -242,8 +242,8 @@ msgstr ""
 msgid "Toggle sidebar"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:443
-#: lib/tuist_web/live/docs_live.ex:683
+#: lib/tuist_web/live/docs_live.ex:464
+#: lib/tuist_web/live/docs_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr ""
@@ -290,22 +290,22 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:515
+#: lib/tuist_web/live/docs_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "Edit this page"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:525
+#: lib/tuist_web/live/docs_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Last updated on %{date}"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:503
+#: lib/tuist_web/live/docs_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:505
+#: lib/tuist_web/live/docs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "as Markdown"
 msgstr ""
@@ -328,143 +328,154 @@ msgstr ""
 msgid "Toggle theme"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:140
-#: lib/tuist_web/live/docs_live.ex:589
-#, elixir-autogen, elixir-format
-msgid "Add compilation caching and insights without adopting project generation."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:125
-#: lib/tuist_web/live/docs_live.ex:583
-#, elixir-autogen, elixir-format
-msgid "Choose the path that matches how your team builds today. You can adopt Tuist without changing how your projects are generated."
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:113
-#: lib/tuist_web/live/docs_live.ex:576
+#: lib/tuist_web/live/docs_live.ex:117
+#: lib/tuist_web/live/docs_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Connect local development, continuous integration, and coding agents through shared caching, actionable insights, test optimization, and managed runners for Xcode and Gradle."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:159
-#: lib/tuist_web/live/docs_live.ex:594
+#: lib/tuist_web/live/docs_live.ex:180
+#: lib/tuist_web/live/docs_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Connect remote caching, build insights, and test insights to your existing project."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:205
-#: lib/tuist_web/live/docs_live.ex:607
+#: lib/tuist_web/live/docs_live.ex:226
+#: lib/tuist_web/live/docs_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Explore Tuist's capabilities"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:146
-#, elixir-autogen, elixir-format
-msgid "Explore Xcode"
-msgstr ""
-
-#: lib/tuist_web/live/docs_live.ex:155
-#: lib/tuist_web/live/docs_live.ex:593
+#: lib/tuist_web/live/docs_live.ex:176
+#: lib/tuist_web/live/docs_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "Gradle project"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:193
-#: lib/tuist_web/live/docs_live.ex:604
+#: lib/tuist_web/live/docs_live.ex:214
+#: lib/tuist_web/live/docs_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Install Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:330
-#: lib/tuist_web/live/docs_live.ex:657
+#: lib/tuist_web/live/docs_live.ex:351
+#: lib/tuist_web/live/docs_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Move from a successful build to useful feedback with shareable previews and bundle-size insights."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:111
-#: lib/tuist_web/live/docs_live.ex:574
+#: lib/tuist_web/live/docs_live.ex:115
+#: lib/tuist_web/live/docs_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "One platform for faster build toolchains"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:235
-#: lib/tuist_web/live/docs_live.ex:622
+#: lib/tuist_web/live/docs_live.ex:256
+#: lib/tuist_web/live/docs_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Reuse build artifacts across Xcode and Gradle so work completed in one environment speeds up every other environment."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:282
-#: lib/tuist_web/live/docs_live.ex:640
+#: lib/tuist_web/live/docs_live.ex:303
+#: lib/tuist_web/live/docs_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Run only impacted tests by detecting changes since your last successful run, both locally and in continuous integration."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:266
-#: lib/tuist_web/live/docs_live.ex:634
+#: lib/tuist_web/live/docs_live.ex:287
+#: lib/tuist_web/live/docs_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "Run the tests that matter, detect flaky behavior, and understand test performance locally and in continuous integration."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:218
-#: lib/tuist_web/live/docs_live.ex:616
+#: lib/tuist_web/live/docs_live.ex:239
+#: lib/tuist_web/live/docs_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Share build work across developer machines, continuous integration, runners, and coding agents, then use insights to find regressions."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:343
-#: lib/tuist_web/live/docs_live.ex:663
+#: lib/tuist_web/live/docs_live.ex:364
+#: lib/tuist_web/live/docs_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Share your app with a link so others can run it on their device or simulator without TestFlight setup."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:207
-#: lib/tuist_web/live/docs_live.ex:609
+#: lib/tuist_web/live/docs_live.ex:228
+#: lib/tuist_web/live/docs_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Speed up builds, improve test reliability, understand performance, and run workflows on infrastructure designed for your toolchain."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:165
+#: lib/tuist_web/live/docs_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Start with Gradle"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:184
+#: lib/tuist_web/live/docs_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Start with runners"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:123
-#: lib/tuist_web/live/docs_live.ex:581
+#: lib/tuist_web/live/docs_live.ex:127
+#: lib/tuist_web/live/docs_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "Start with your setup"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:316
-#: lib/tuist_web/live/docs_live.ex:650
+#: lib/tuist_web/live/docs_live.ex:337
+#: lib/tuist_web/live/docs_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Track test performance, catch slow tests early, and debug continuous integration failures through real-time logs."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:252
-#: lib/tuist_web/live/docs_live.ex:627
+#: lib/tuist_web/live/docs_live.ex:273
+#: lib/tuist_web/live/docs_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Understand build performance across local and continuous integration environments before slowdowns affect your team."
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:136
-#: lib/tuist_web/live/docs_live.ex:588
+#: lib/tuist_web/live/docs_live.ex:157
+#: lib/tuist_web/live/docs_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Xcode project"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:174
-#: lib/tuist_web/live/docs_live.ex:598
+#: lib/tuist_web/live/docs_live.ex:195
+#: lib/tuist_web/live/docs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "CI runners"
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:178
-#: lib/tuist_web/live/docs_live.ex:599
+#: lib/tuist_web/live/docs_live.ex:199
+#: lib/tuist_web/live/docs_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "Run continuous integration workflows with GitHub Actions on managed macOS and Linux infrastructure next to your cache."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:161
+#: lib/tuist_web/live/docs_live.ex:614
+#, elixir-autogen, elixir-format
+msgid "Connect compilation caching and insights to an existing Xcode project."
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:138
+#: lib/tuist_web/live/docs_live.ex:608
+#, elixir-autogen, elixir-format
+msgid "Generated Xcode project"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:148
+#, elixir-autogen, elixir-format
+msgid "Start generating"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Start with Xcode"
+msgstr ""
+
+#: lib/tuist_web/live/docs_live.ex:142
+#: lib/tuist_web/live/docs_live.ex:609
+#, elixir-autogen, elixir-format
+msgid "Generate and maintain your Xcode project with module caching and selective testing."
 msgstr ""

--- a/server/priv/gettext/errors.pot
+++ b/server/priv/gettext/errors.pot
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:63
+#: lib/tuist_web/live/docs_live.ex:65
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "Page not found"

--- a/server/test/tuist_web/live/docs_live_test.exs
+++ b/server/test/tuist_web/live/docs_live_test.exs
@@ -24,6 +24,12 @@ defmodule TuistWeb.DocsLiveTest do
 
       assert has_element?(
                lv,
+               ~s(a#docs-generated-xcode-path[href="/en/docs/tutorials/xcode/create-a-generated-project"]),
+               "Generated Xcode project"
+             )
+
+      assert has_element?(
+               lv,
                ~s(a#docs-xcode-path[href="/en/docs/guides/features/cache/xcode-cache"]),
                "Xcode project"
              )

--- a/server/test/tuist_web/live/docs_live_test.exs
+++ b/server/test/tuist_web/live/docs_live_test.exs
@@ -19,13 +19,44 @@ defmodule TuistWeb.DocsLiveTest do
   end
 
   describe "docs overview" do
-    test "renders the install card as a clickable link target", %{conn: conn} do
+    test "renders setup-specific starting paths", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/en/docs")
 
       assert has_element?(
                lv,
-               ~s([data-part="hero-card"]#docs-install-card[phx-click][role="link"][tabindex="0"])
+               ~s(a#docs-xcode-path[href="/en/docs/guides/features/cache/xcode-cache"]),
+               "Existing Xcode project"
              )
+
+      assert has_element?(
+               lv,
+               ~s(a#docs-gradle-path[href="/en/docs/guides/install-gradle-plugin"]),
+               "Gradle project"
+             )
+
+      assert has_element?(
+               lv,
+               ~s(a#docs-runners-path[href="/en/docs/guides/features/runners/getting-started"]),
+               "Tuist Runners"
+             )
+    end
+
+    test "routes the generic cache card to the cache overview", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/en/docs")
+
+      assert has_element?(
+               lv,
+               ~s(a#docs-cache-card[href="/en/docs/guides/features/cache"]),
+               "Cache"
+             )
+    end
+
+    test "positions Tuist as build infrastructure for Xcode and Gradle", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/en/docs")
+
+      assert has_element?(lv, "h1", "One platform for faster build toolchains")
+      assert has_element?(lv, "#start-with-your-setup", "Start with your setup")
+      assert has_element?(lv, "#learn-more", "Explore Tuist's capabilities")
     end
 
     test "shows a Log in button with return_to when the user is not authenticated", %{

--- a/server/test/tuist_web/live/docs_live_test.exs
+++ b/server/test/tuist_web/live/docs_live_test.exs
@@ -25,7 +25,7 @@ defmodule TuistWeb.DocsLiveTest do
       assert has_element?(
                lv,
                ~s(a#docs-xcode-path[href="/en/docs/guides/features/cache/xcode-cache"]),
-               "Existing Xcode project"
+               "Xcode project"
              )
 
       assert has_element?(
@@ -37,7 +37,7 @@ defmodule TuistWeb.DocsLiveTest do
       assert has_element?(
                lv,
                ~s(a#docs-runners-path[href="/en/docs/guides/features/runners/getting-started"]),
-               "Tuist Runners"
+               "CI runners"
              )
     end
 

--- a/server/test/tuist_web/plugs/legacy_redirects_plug_test.exs
+++ b/server/test/tuist_web/plugs/legacy_redirects_plug_test.exs
@@ -17,22 +17,22 @@ defmodule TuistWeb.Plugs.LegacyRedirectsPlugTest do
     end
 
     test "redirects docs locale paths to locale-first docs paths" do
-      conn = %{build_conn() | request_path: "/docs/ja/guides/features/cache"}
+      conn = %{build_conn() | request_path: "/docs/en/guides/features/cache"}
 
       conn = LegacyRedirectsPlug.call(conn, [])
 
       assert conn.status == 301
-      assert redirected_to(conn, 301) == "/ja/docs/guides/features/cache"
+      assert redirected_to(conn, 301) == "/en/docs/guides/features/cache"
       assert conn.halted
     end
 
     test "preserves query strings when redirecting docs locale paths" do
-      conn = %{build_conn() | request_path: "/docs/ja/guides/features/cache", query_string: "tab=setup"}
+      conn = %{build_conn() | request_path: "/docs/en/guides/features/cache", query_string: "tab=setup"}
 
       conn = LegacyRedirectsPlug.call(conn, [])
 
       assert conn.status == 301
-      assert redirected_to(conn, 301) == "/ja/docs/guides/features/cache?tab=setup"
+      assert redirected_to(conn, 301) == "/en/docs/guides/features/cache?tab=setup"
       assert conn.halted
     end
 


### PR DESCRIPTION
## What changed

The documentation home now presents Tuist as shared build infrastructure for Xcode and Gradle while retaining generated Xcode projects as a first-class entry point.

Four prominent starting paths route visitors to the generated Xcode project tutorial, existing Xcode cache, Gradle plugin, and Tuist Runners guides. The generic Cache capability now opens the cache overview, while installation and the dashboard remain available as secondary actions. The machine-readable Markdown output, responsive presentation, translation templates, and focused tests were updated to match.

## Why

Tuist has evolved from an Xcode project-generation tool into a platform for caching, build and test insights, and managed runners. The previous landing page still taught the older product model, which made Gradle engineers, teams with existing Xcode projects, and runner evaluators work through unrelated project-generation concepts before finding the relevant guides.

Generated projects and module caching remain central to Tuist, so broadening the landing page should not make them appear secondary. The starting taxonomy needs to represent both the established generated-project workflow and the newer build-infrastructure paths.

## Approach

This is the first incremental slice of the documentation revamp. It corrects the most misleading entry points while leaving the broader sidebar and existing documentation addresses intact.

The new starting cards compose canonical guides instead of duplicating setup instructions. The generated Xcode path starts with the project tutorial and highlights module caching and selective testing. The existing Xcode path routes to compilation-cache setup, the Gradle path starts with the plugin installation guide, and the runner path goes directly to the getting-started guide. Existing legacy address normalization continues to redirect in one hop and preserves query strings.

## Impact

Teams interested in generated projects can reach that workflow immediately and see its connection to module caching. Gradle visitors can reach remote-cache setup without encountering generated-project requirements. Existing Xcode teams can adopt caching and insights without changing project generation. Runner evaluators now have a direct path from the documentation home.

There is no migration for existing users, and no documentation addresses were moved or removed.

## Validation

- `mise run format -c`
- `mix test test/tuist_web/live/docs_live_test.exs test/tuist/docs/redirects_test.exs test/tuist_web/plugs/legacy_redirects_plug_test.exs test/tuist_web/router_test.exs`
- 35 focused tests passed.
- Ran the server locally with `mise run dev`.
- Verified successful responses for the documentation home, generated Xcode project tutorial, cache overview, Xcode cache, Gradle plugin, and runners getting-started guides.
- Verified permanent redirects from `/docs`, `/docs/en/guides/features/cache`, and the former generated-project quick-start address, including query-string preservation where applicable.
- Captured and inspected wide desktop, intermediate two-column, and narrow single-column layouts with Google Chrome 150 in headless mode.

## Screenshots

### Desktop

![Documentation home at desktop width](https://raw.githubusercontent.com/pepicrft/tuist/0879d26ee5c55660be64c085413c77ececb193b5/tuist-docs-home-desktop.png)

### Narrow width

<img src="https://raw.githubusercontent.com/pepicrft/tuist/0879d26ee5c55660be64c085413c77ececb193b5/tuist-docs-home-narrow.png" alt="Documentation home at narrow width" width="430">
