### PR TITLE
fix(server): pin the Kura CAS budget to the region's declared storage size

### DIFF
--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -56,10 +56,11 @@ server:
       # `kura-dedibox` pool (the eu-central cutover). `scw-fr-par-runners` is the
       # macOS-serving private runner-cache region: a Scaleway fr-par Linux node
       # pool next to the Mac mini fleet, on its own `kura-scw-fr-par` pool, so
-      # the Macs' cache traffic never crosses the WAN. The former Linux
-      # runner-cache region `hetzner-staging-runners` is dropped: it lived on the
-      # Hetzner ccx13 `kura` pool that the cutover deletes, and no customers use
-      # the staging Linux runner cache. `ca-east` (Canada East / OVHcloud BHS) is
+      # the Macs' cache traffic never crosses the WAN. Linux runners have no
+      # private cache region: the former `hetzner-staging-runners` lived on the
+      # Hetzner ccx13 `kura` pool the cutover deleted, no customers used the
+      # staging Linux runner cache, and the region spec is gone with the pool.
+      # `ca-east` (Canada East / OVHcloud BHS) is
       # the OVH bare-metal validation region — a geographic id; OVH is an
       # implementation detail behind it (ovhFleet below, replicas 1).
       value: eu-central,scw-fr-par-runners,ca-east

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -410,16 +410,26 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # single node over-commit it (2 replicas x 50% of the disk = 100% of it). The
   # box then crosses kubelet's imagefs eviction threshold long before any replica
   # reaches its own budget, so Kura's ring rotation never gets to evict and the
-  # node evicts the whole region instead. Pin the budget to the volume the region
-  # actually asked for so the ring stays inside the PVC contract on any backing.
+  # node evicts the whole region instead.
+  #
+  # Budget from the size the region declares. That is normally storage_size, so
+  # the ring stays inside the claim on a class that enforces it; a region whose
+  # claim bounds nothing (local-path) can override with cas_capacity_size rather
+  # than inflate storage_size, which the controller would try to apply to the
+  # live PVCs.
   defp cas_capacity_env(%Regions{} = region) do
-    with size when is_binary(size) <- storage_size(region),
+    with size when is_binary(size) <- cas_capacity_source(region),
          {:ok, bytes} <- parse_storage_quantity(size) do
       [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(cas_capacity_bytes(bytes)))]
     else
       _ -> []
     end
   end
+
+  defp cas_capacity_source(%Regions{provisioner_config: %{cas_capacity_size: size}}) when is_binary(size) and size != "",
+    do: size
+
+  defp cas_capacity_source(%Regions{} = region), do: storage_size(region)
 
   # Kura appends a new segment before evicting the oldest one, so a ring sized to
   # the entire volume can still run it full mid-rotation. Kura reserves the same

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -19,7 +19,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   alias Tuist.Kura.Server
 
   @namespace "kura"
-  @manifest_revision "2026-07-09-mesh-peers-sync-v1"
+  @manifest_revision "2026-07-16-cas-capacity-v1"
   @manifest_revision_annotation "tuist.dev/kura-manifest-revision"
   @impl true
   def provision(%{name: handle}, %Regions{} = region, %Server{}) do
@@ -397,9 +397,55 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
         "KURA_CONTROL_PLANE_CLIENT_ID",
         Environment.kura_control_plane_client_id()
       ) ++
+      cas_capacity_env(region) ++
       mesh_peers_sync_env(region) ++
       telemetry_env(region)
   end
+
+  # With KURA_CAS_CAPACITY_BYTES unset, Kura sizes its CAS segment ring from
+  # statvfs() on the data dir. Every managed region is backed by the local-path
+  # provisioner, where a volume is a plain directory on the node's shared disk,
+  # so statvfs reports the whole box instead of the PVC's declared size: each
+  # replica budgets a fraction of the box, and replicas co-located on a region's
+  # single node over-commit it (2 replicas x 50% of the disk = 100% of it). The
+  # box then crosses kubelet's imagefs eviction threshold long before any replica
+  # reaches its own budget, so Kura's ring rotation never gets to evict and the
+  # node evicts the whole region instead. Pin the budget to the volume the region
+  # actually asked for so the ring stays inside the PVC contract on any backing.
+  defp cas_capacity_env(%Regions{} = region) do
+    with size when is_binary(size) <- storage_size(region),
+         {:ok, bytes} <- parse_storage_quantity(size) do
+      [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(cas_capacity_bytes(bytes)))]
+    else
+      _ -> []
+    end
+  end
+
+  # Kura appends a new segment before evicting the oldest one, so a ring sized to
+  # the entire volume can still run it full mid-rotation. Kura reserves the same
+  # headroom itself (CAS_CAPACITY_MAX_DISK_PERCENT); apply it here against the
+  # volume size, which is the denominator it cannot infer on a local-path volume.
+  defp cas_capacity_bytes(storage_bytes), do: div(storage_bytes * 80, 100)
+
+  defp parse_storage_quantity(value) do
+    case Integer.parse(value) do
+      {quantity, suffix} when quantity > 0 ->
+        case storage_multiplier(String.trim(suffix)) do
+          nil -> :error
+          multiplier -> {:ok, quantity * multiplier}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp storage_multiplier(""), do: 1
+  defp storage_multiplier("Ki"), do: 1024
+  defp storage_multiplier("Mi"), do: 1024 * 1024
+  defp storage_multiplier("Gi"), do: 1024 * 1024 * 1024
+  defp storage_multiplier("Ti"), do: 1024 * 1024 * 1024 * 1024
+  defp storage_multiplier(_), do: nil
 
   # Managed pods fetch the account's self-hosted peer list from the control
   # plane at boot and on cadence, so a self-hosted peer joining or leaving

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -21,6 +21,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   @namespace "kura"
   @manifest_revision "2026-07-16-cas-capacity-v1"
   @manifest_revision_annotation "tuist.dev/kura-manifest-revision"
+  # Mirrors Kura's DEFAULT_TMP_DIR_MAX_BYTES (kura/src/constants.rs): 4 x
+  # MAX_REPLICATION_BODY_BYTES, itself 4 x MAX_SEGMENT_BYTES. We never set
+  # KURA_TMP_DIR_MAX_BYTES, so this default is what upload staging can reach
+  # inside the data volume. Keep in sync if either constant moves.
+  @kura_tmp_dir_max_bytes 8 * 1024 * 1024 * 1024
+  # Kura's MAX_SEGMENT_BYTES: the one extra segment a ring rotation appends
+  # before evicting the oldest one.
+  @kura_max_segment_bytes 512 * 1024 * 1024
   @impl true
   def provision(%{name: handle}, %Regions{} = region, %Server{}) do
     {:ok, instance_name(handle, region)}
@@ -419,8 +427,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # live PVCs.
   defp cas_capacity_env(%Regions{} = region) do
     with size when is_binary(size) <- cas_capacity_source(region),
-         {:ok, bytes} <- parse_storage_quantity(size) do
-      [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(cas_capacity_bytes(bytes)))]
+         {:ok, bytes} <- parse_storage_quantity(size),
+         capacity when is_integer(capacity) <- cas_capacity_bytes(bytes) do
+      [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(capacity))]
     else
       _ -> []
     end
@@ -431,11 +440,27 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   defp cas_capacity_source(%Regions{} = region), do: storage_size(region)
 
-  # Kura appends a new segment before evicting the oldest one, so a ring sized to
-  # the entire volume can still run it full mid-rotation. Kura reserves the same
-  # headroom itself (CAS_CAPACITY_MAX_DISK_PERCENT); apply it here against the
-  # volume size, which is the denominator it cannot infer on a local-path volume.
-  defp cas_capacity_bytes(storage_bytes), do: div(storage_bytes * 80, 100)
+  # KURA_CAS_CAPACITY_BYTES budgets the CAS segment ring only, but the ring is
+  # not the only thing in the data dir: the controller points KURA_TMP_DIR at
+  # <data dir>/tmp, so upload staging shares the volume, and RocksDB's index sits
+  # beside it with no budget of its own. Size the ring against what is left after
+  # them rather than taking a flat percentage — the tmp budget is a fixed 8 GiB,
+  # so a percentage that fits a 50Gi volume overruns a 20Gi one.
+  #
+  # Reserves, in order: the tmp dir's own ceiling; one extra segment, which a
+  # rotation appends before it evicts the oldest one; and a few percent for the
+  # RocksDB index, which tracks entry count rather than bytes (measured ~1.2% of
+  # resident segment bytes on a production instance, so 3% is slack).
+  defp cas_capacity_bytes(storage_bytes) do
+    usable = storage_bytes - @kura_tmp_dir_max_bytes - @kura_max_segment_bytes
+
+    if usable > 0 do
+      div(usable * 97, 100)
+      # Too small to carve a ring out of once staging is reserved. Emit nothing
+      # and let Kura fall back to its own statvfs default, which on a volume this
+      # size is both enforced and more conservative than anything derived here.
+    end
+  end
 
   defp parse_storage_quantity(value) do
     case Integer.parse(value) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -29,6 +29,12 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # Kura's MAX_SEGMENT_BYTES: the one extra segment a ring rotation appends
   # before evicting the oldest one.
   @kura_max_segment_bytes 512 * 1024 * 1024
+  # Kura's SegmentRingLimits::legacy_floor (DESIRED_OLD + DESIRED_CURRENT +
+  # DESIRED_NEW = 1 + 2 + 2 segments), which resolve_segment_ring_limits clamps
+  # the ring count up to. A budget below this is not honoured, so it is the
+  # smallest ring Kura will run and the floor any derived budget has to clear.
+  @kura_segment_ring_floor_segments 5
+  @kura_segment_ring_floor_bytes @kura_segment_ring_floor_segments * @kura_max_segment_bytes
   @impl true
   def provision(%{name: handle}, %Regions{} = region, %Server{}) do
     {:ok, instance_name(handle, region)}
@@ -422,20 +428,30 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   #
   # Budget from the size the region declares. That is normally storage_size, so
   # the ring stays inside the claim on a class that enforces it; a region whose
-  # claim bounds nothing (local-path) can override with cas_capacity_size rather
+  # claim bounds nothing (local-path) can override with disk_envelope_size rather
   # than inflate storage_size, which the controller would try to apply to the
   # live PVCs.
   defp cas_capacity_env(%Regions{} = region) do
-    with size when is_binary(size) <- cas_capacity_source(region),
-         {:ok, bytes} <- parse_storage_quantity(size),
-         capacity when is_integer(capacity) <- cas_capacity_bytes(bytes) do
-      [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(capacity))]
-    else
-      _ -> []
+    case cas_capacity_source(region) do
+      size when is_binary(size) and size != "" ->
+        size
+        |> parse_storage_quantity!(region)
+        |> cas_capacity_bytes()
+        |> cas_capacity_env_var()
+
+      # The region declares no size at all (self-hosted peers carry their own
+      # disk), so there is nothing to derive a budget from.
+      _ ->
+        []
     end
   end
 
-  defp cas_capacity_source(%Regions{provisioner_config: %{cas_capacity_size: size}}) when is_binary(size) and size != "",
+  defp cas_capacity_env_var(capacity) when is_integer(capacity),
+    do: [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(capacity))]
+
+  defp cas_capacity_env_var(nil), do: []
+
+  defp cas_capacity_source(%Regions{provisioner_config: %{disk_envelope_size: size}}) when is_binary(size) and size != "",
     do: size
 
   defp cas_capacity_source(%Regions{} = region), do: storage_size(region)
@@ -455,10 +471,33 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     usable = storage_bytes - @kura_tmp_dir_max_bytes - @kura_max_segment_bytes
 
     if usable > 0 do
-      div(usable * 97, 100)
-      # Too small to carve a ring out of once staging is reserved. Emit nothing
-      # and let Kura fall back to its own statvfs default, which on a volume this
-      # size is both enforced and more conservative than anything derived here.
+      budget = div(usable * 97, 100)
+
+      # Kura sizes the ring in whole segments and clamps the count up to a legacy
+      # floor of @kura_segment_ring_floor_segments, so a budget under that floor
+      # is silently raised to it and the runtime uses more disk than we derived.
+      # Emitting a value we know will be overridden would make the reserves above
+      # a fiction, so emit only what Kura honours verbatim.
+      if budget >= @kura_segment_ring_floor_bytes, do: budget
+      # Too small to carve a ring out of once staging and the floor are reserved.
+      # Nothing this volume can hold satisfies the invariant, so emit nothing:
+      # there is no honest budget to declare, and a region this small is a
+      # misconfiguration to notice rather than a number to paper over.
+    end
+  end
+
+  # Region specs are compile-time constants, so an unparseable size is a typo
+  # that would otherwise degrade to exactly the statvfs behaviour this
+  # derivation exists to prevent. Fail loudly instead of silently regressing.
+  defp parse_storage_quantity!(value, %Regions{} = region) do
+    case parse_storage_quantity(value) do
+      {:ok, bytes} ->
+        bytes
+
+      :error ->
+        raise ArgumentError,
+              "region #{region.id} declares an unparseable storage quantity #{inspect(value)}; " <>
+                "expected an integer with an optional Ki/Mi/Gi/Ti suffix"
     end
   end
 

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -198,19 +198,22 @@ defmodule Tuist.Kura.Regions do
       # installed on the pool out-of-band).
       storage_class: "scw-local-nvme",
       storage_size: "50Gi",
-      # A local-path volume is a directory on the node's shared NVMe, so the
-      # claim above bounds nothing and this pool's cache has been running near
-      # 150Gi per account off Kura's statvfs default. Budget it against the box
-      # it actually shares rather than shrinking a healthy cache ~3.5x to a
-      # number that never applied; three accounts at 80% of this still leave the
-      # ~900G node about half free. Kept separate from storage_size because
-      # raising the claim is not a no-op: the controller patches existing PVCs up
-      # to spec.storageSize on every reconcile, and scw-local-nvme sets
-      # allowVolumeExpansion: false, so the API would reject each resize and wedge
-      # the instances that already exist. Only meaningful where the claim is a
-      # fiction — leave it unset on a class that enforces the claim, so the ring
-      # stays inside the volume.
-      cas_capacity_size: "200Gi",
+      # A local-path volume is a directory on the node's shared NVMe, so the claim
+      # above bounds nothing and this pool has been running near 137Gi per account
+      # off Kura's statvfs default. This is the whole per-account disk envelope
+      # (ring + index + upload staging), so it lands the ring back on roughly what
+      # the pool already holds rather than shrinking a healthy cache to a claim
+      # that never applied. Three accounts leave the ~900G node about half free;
+      # the box tops out near five, so raising this or adding accounts past that
+      # needs a second box, not a bigger number.
+      #
+      # Kept separate from storage_size because raising the claim is not a no-op:
+      # the controller patches existing PVCs up to spec.storageSize on every
+      # reconcile, and scw-local-nvme sets allowVolumeExpansion: false, so the API
+      # would reject each resize and wedge the instances that already exist. Only
+      # meaningful where the claim is a fiction — leave it unset on a class that
+      # enforces the claim, so the ring stays inside the volume.
+      cas_capacity_size: "150Gi",
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -175,16 +175,18 @@ defmodule Tuist.Kura.Regions do
   #
   #   * `scw-fr-par-runners` is pinned to Scaleway fr-par capacity next
   #     to the Apple-Silicon Mac mini fleet, so it serves `:macos` only —
-  #     handing its URL to a Hetzner Linux runner would route cache
-  #     traffic across the WAN, which is worse than the public ingress
-  #     it's meant to replace.
-  #   * `hetzner-staging-runners` lives in the staging umbrella
-  #     cluster's Hetzner (Falkenstein) node pool next to the Linux
-  #     kata Pods, so it serves `:linux` only. The staging Mac minis
-  #     CAN reach it over the tailnet, but they sit in Scaleway fr-par
-  #     — their cache lives in `scw-fr-par-runners`, the same region
-  #     spec production uses, so staging exercises the co-located
-  #     topology rather than a WAN-crossing one.
+  #     handing its URL to a Linux runner would route cache traffic
+  #     across the WAN, which is worse than the public ingress it's
+  #     meant to replace.
+  #
+  # Linux runners have no private cache region. `hetzner-staging-runners`
+  # was one, on the staging cluster's Hetzner node pool, but that pool is
+  # gone: the Kura fleet is bare metal (Dedibox/OVH/Scaleway Elastic
+  # Metal) and staging's Linux runners moved to the `runners-linux` pool.
+  # The spec outlived the pool and kept minting instances that could
+  # never schedule, so it was removed rather than repointed — staging's
+  # Mac minis already exercise the co-located topology through
+  # `scw-fr-par-runners`, the same spec production uses.
   @private_region_specs [
     %{
       id: "scw-fr-par-runners",
@@ -238,15 +240,6 @@ defmodule Tuist.Kura.Regions do
       tolerations: [
         %{"key" => "tuist.dev/runner-cache", "operator" => "Exists", "effect" => "NoSchedule"}
       ]
-    },
-    %{
-      id: "hetzner-staging-runners",
-      display_name: "Hetzner staging (runner cache)",
-      cluster_id: "staging",
-      node_pool: "kura",
-      storage_class: @managed_region_storage_class,
-      storage_size: "20Gi",
-      runner_platforms: [:linux]
     }
   ]
 

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -197,17 +197,20 @@ defmodule Tuist.Kura.Regions do
       # via the local-path provisioner (`scw-local-nvme` StorageClass,
       # installed on the pool out-of-band).
       storage_class: "scw-local-nvme",
-      # Sized against the box, not the old nominal 50Gi: this is what the CAS
-      # budget is derived from, and the runner cache had been running at roughly
-      # 150Gi per account off the statvfs default long before that default was
-      # pinned. Three accounts at 80% of this still leave the ~900G node close to
-      # half free. Only the CAS budget moves for instances that already exist —
-      # a StatefulSet's volumeClaimTemplates are immutable and the controller
-      # recreates on a storage *class* change, not a size one, so their PVCs keep
-      # reading 50Gi. Nothing enforces that number on a local-path volume (it is
-      # a directory on the shared disk), so the claim is cosmetic; the budget
-      # below is the real limit.
-      storage_size: "200Gi",
+      storage_size: "50Gi",
+      # A local-path volume is a directory on the node's shared NVMe, so the
+      # claim above bounds nothing and this pool's cache has been running near
+      # 150Gi per account off Kura's statvfs default. Budget it against the box
+      # it actually shares rather than shrinking a healthy cache ~3.5x to a
+      # number that never applied; three accounts at 80% of this still leave the
+      # ~900G node about half free. Kept separate from storage_size because
+      # raising the claim is not a no-op: the controller patches existing PVCs up
+      # to spec.storageSize on every reconcile, and scw-local-nvme sets
+      # allowVolumeExpansion: false, so the API would reject each resize and wedge
+      # the instances that already exist. Only meaningful where the claim is a
+      # fiction — leave it unset on a class that enforces the claim, so the ring
+      # stays inside the volume.
+      cas_capacity_size: "200Gi",
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS
@@ -397,6 +400,7 @@ defmodule Tuist.Kura.Regions do
         # + a bounded storage_size.
         replicas: Map.get(spec, :replicas),
         storage_size: Map.get(spec, :storage_size),
+        cas_capacity_size: Map.get(spec, :cas_capacity_size),
         tuist_base_url: Tuist.Environment.kura_tuist_base_url(),
         node_selector: %{@managed_region_node_pool_label => spec.node_pool},
         # Tolerate the customer-facing cache nodes' taint so the cache pod
@@ -465,6 +469,7 @@ defmodule Tuist.Kura.Regions do
         node_selector: %{@managed_region_node_pool_label => spec.node_pool},
         storage_class: spec.storage_class,
         storage_size: spec.storage_size,
+        cas_capacity_size: Map.get(spec, :cas_capacity_size),
         replicas: 1,
         tuist_base_url: Tuist.Environment.kura_tuist_base_url(),
         # The runner-cache node replicates with the account's other nodes

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -197,7 +197,17 @@ defmodule Tuist.Kura.Regions do
       # via the local-path provisioner (`scw-local-nvme` StorageClass,
       # installed on the pool out-of-band).
       storage_class: "scw-local-nvme",
-      storage_size: "50Gi",
+      # Sized against the box, not the old nominal 50Gi: this is what the CAS
+      # budget is derived from, and the runner cache had been running at roughly
+      # 150Gi per account off the statvfs default long before that default was
+      # pinned. Three accounts at 80% of this still leave the ~900G node close to
+      # half free. Only the CAS budget moves for instances that already exist —
+      # a StatefulSet's volumeClaimTemplates are immutable and the controller
+      # recreates on a storage *class* change, not a size one, so their PVCs keep
+      # reading 50Gi. Nothing enforces that number on a local-path volume (it is
+      # a directory on the shared disk), so the claim is cosmetic; the budget
+      # below is the real limit.
+      storage_size: "200Gi",
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -203,9 +203,11 @@ defmodule Tuist.Kura.Regions do
       # A local-path volume is a directory on the node's shared NVMe, so the claim
       # above bounds nothing and this pool has been running near 137Gi per account
       # off Kura's statvfs default. This is the whole per-account disk envelope
-      # (ring + index + upload staging), so it lands the ring back on roughly what
-      # the pool already holds rather than shrinking a healthy cache to a claim
-      # that never applied. Three accounts leave the ~900G node about half free;
+      # (ring + index + upload staging) rather than the ring itself — the ring is
+      # what is left after the reserves, ~137GiB here — so it lands the ring back
+      # on roughly what the pool already holds rather than shrinking a healthy
+      # cache to a claim that never applied. Three accounts leave the ~900G node
+      # about half free;
       # the box tops out near five, so raising this or adding accounts past that
       # needs a second box, not a bigger number.
       #
@@ -215,7 +217,7 @@ defmodule Tuist.Kura.Regions do
       # would reject each resize and wedge the instances that already exist. Only
       # meaningful where the claim is a fiction — leave it unset on a class that
       # enforces the claim, so the ring stays inside the volume.
-      cas_capacity_size: "150Gi",
+      disk_envelope_size: "150Gi",
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS
@@ -396,7 +398,7 @@ defmodule Tuist.Kura.Regions do
         # + a bounded storage_size.
         replicas: Map.get(spec, :replicas),
         storage_size: Map.get(spec, :storage_size),
-        cas_capacity_size: Map.get(spec, :cas_capacity_size),
+        disk_envelope_size: Map.get(spec, :disk_envelope_size),
         tuist_base_url: Tuist.Environment.kura_tuist_base_url(),
         node_selector: %{@managed_region_node_pool_label => spec.node_pool},
         # Tolerate the customer-facing cache nodes' taint so the cache pod
@@ -465,7 +467,7 @@ defmodule Tuist.Kura.Regions do
         node_selector: %{@managed_region_node_pool_label => spec.node_pool},
         storage_class: spec.storage_class,
         storage_size: spec.storage_size,
-        cas_capacity_size: Map.get(spec, :cas_capacity_size),
+        disk_envelope_size: Map.get(spec, :disk_envelope_size),
         replicas: 1,
         tuist_base_url: Tuist.Environment.kura_tuist_base_url(),
         # The runner-cache node replicates with the account's other nodes
@@ -495,7 +497,15 @@ defmodule Tuist.Kura.Regions do
         otlp_traces_endpoint: "http://127.0.0.1:4318/v1/traces",
         public_url: "http://localhost:#{@local_controller_kura_base_port + suffix}",
         replicas: 1,
-        storage_size: "10Gi"
+        storage_size: "10Gi",
+        # kind's local-path volumes bound nothing, so without an envelope Kura
+        # would fall back to statvfs and size the ring at half the developer's
+        # own disk. 10Gi cannot carry one: the reserves plus Kura's ring floor
+        # need ~11GiB, so a budget derived from it would be raised to the floor
+        # and silently overrun the claim. Declare the envelope the dev cache is
+        # actually allowed instead, on the claim rather than in it, since
+        # local-path rejects the expansion a bigger storage_size would trigger.
+        disk_envelope_size: "12Gi"
       }
     }
   end

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -441,6 +441,65 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert env["KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL"] == "https://tuist.dev"
     end
 
+    test "pins the CAS capacity to the region's declared storage size" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "50Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      # 80% of 50Gi, leaving the headroom a ring rotation needs. Without this the
+      # runtime would size the ring from the node's whole disk instead.
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "42949672960"
+    end
+
+    test "scales the CAS capacity with a smaller declared storage size" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-scw-fr-par-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "10Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "8589934592"
+    end
+
+    test "omits the CAS capacity when the region declares no storage size" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      refute Map.has_key?(env, "KURA_CAS_CAPACITY_BYTES")
+    end
+
     test "renders local controller overrides for kind testing" do
       stub(Tuist.Environment, :app_url, fn -> "http://localhost:8080" end)
 

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -481,6 +481,31 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert env["KURA_CAS_CAPACITY_BYTES"] == "8589934592"
     end
 
+    test "budgets the CAS from cas_capacity_size without moving the declared storage size" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-scw-fr-par-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "50Gi", cas_capacity_size: "200Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      # 80% of the 200Gi override, not of the 50Gi claim.
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "171798691840"
+
+      # storageSize must stay at the claim: the controller patches live PVCs up to
+      # spec.storageSize on every reconcile, and scw-local-nvme is not expandable,
+      # so raising it would wedge every instance that already exists.
+      assert manifest["spec"]["storageSize"] == "50Gi"
+    end
+
     test "omits the CAS capacity when the region declares no storage size" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
       stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -898,24 +898,28 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         "00000000-0000-0000-0000-000000000001"
       end)
 
+      # Synthetic: no catalog region is cluster-DNS private today (the one that
+      # was went with its node pool), but a private region that omits
+      # `data_plane` still falls back to it, so the manifest builder has to keep
+      # handling it.
       region = %Regions{
-        id: "hetzner-staging-runners",
+        id: "cluster-dns-runners",
         provisioner_config: %{
-          cluster_id: "staging",
+          cluster_id: "cluster-dns",
           private: true,
           private_url_template: "http://{instance}.kura.svc.cluster.local:4000",
           data_plane: :cluster_dns,
           client_cidrs: [],
           pod_annotations: %{},
-          node_selector: %{"node.cluster.x-k8s.io/pool" => "kura"},
-          storage_class: "hcloud-volumes",
+          node_selector: %{"node.cluster.x-k8s.io/pool" => "kura-cluster-dns"},
+          storage_class: "scw-local-nvme",
           replicas: 1
         }
       }
 
       spec =
         KubernetesController.manifest(
-          "kura-tuist-staging",
+          "kura-tuist-cluster-dns",
           "0.5.2",
           %{name: "tuist"},
           region,

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -490,6 +490,112 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert capacity + tmp + segment < 20 * 1024 * 1024 * 1024
     end
 
+    test "every registered region derives a budget Kura can honour" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      segment = 512 * 1024 * 1024
+      tmp = 8 * 1024 * 1024 * 1024
+      floor = 5 * segment
+
+      for region <- Enum.filter(Regions.all(), &(&1.provisioner == KubernetesController)) do
+        # Building the manifest at all is the assertion for the sizes: an
+        # unparseable quantity raises, so a typo in a spec fails here rather than
+        # degrading to the statvfs budget in production.
+        manifest =
+          KubernetesController.manifest(
+            "kura-tuist-#{region.id}-1",
+            "0.5.2",
+            %{name: "tuist"},
+            region,
+            %Server{},
+            "return true"
+          )
+
+        env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+        case env["KURA_CAS_CAPACITY_BYTES"] do
+          nil ->
+            :ok
+
+          value ->
+            capacity = String.to_integer(value)
+            envelope = envelope_bytes(region)
+
+            assert capacity < Integer.pow(2, 64), "#{region.id} declares a capacity Kura's u64 config rejects"
+            assert capacity >= floor, "#{region.id} budgets under Kura's ring floor, which the runtime raises"
+
+            assert div(capacity, segment) * segment + tmp + segment <= envelope,
+                   "#{region.id} overruns its declared envelope once staging and a rotation are reserved"
+        end
+      end
+    end
+
+    test "omits the CAS capacity when the budget would land under Kura's ring floor" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      # 10Gi clears the reserves, so a budget is derivable, but it comes to
+      # ~1.4GiB and Kura clamps the ring up to its 2.5GiB floor. Emitting the
+      # derived value would promise a ring the runtime does not honour, and the
+      # floor plus the reserves overruns the volume.
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-under-floor-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "10Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      refute Map.has_key?(env, "KURA_CAS_CAPACITY_BYTES")
+    end
+
+    test "emits a budget that Kura's ring floor does not raise" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-above-floor-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "12Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      capacity = String.to_integer(env["KURA_CAS_CAPACITY_BYTES"])
+
+      segment = 512 * 1024 * 1024
+      floor = 5 * segment
+
+      # Above the floor the clamp is a no-op, so the ring Kura resolves is the
+      # segment count this budget buys and the reserves still hold.
+      assert capacity >= floor
+      assert div(capacity, segment) * segment + 8 * 1024 * 1024 * 1024 + segment < 12 * 1024 * 1024 * 1024
+    end
+
+    test "raises rather than falling back to statvfs when a region's size cannot be parsed" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      assert_raise ArgumentError, ~r/unparseable storage quantity/, fn ->
+        KubernetesController.manifest(
+          "kura-tuist-typo-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "1.5Ti"}),
+          %Server{},
+          "return true"
+        )
+      end
+    end
+
     test "omits the CAS capacity when the declared size cannot fit staging" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
       stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
@@ -509,7 +615,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(env, "KURA_CAS_CAPACITY_BYTES")
     end
 
-    test "budgets the CAS from cas_capacity_size without moving the declared storage size" do
+    test "budgets the CAS from disk_envelope_size without moving the declared storage size" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
       stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
 
@@ -518,7 +624,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
           "kura-tuist-scw-fr-par-1",
           "0.5.2",
           %{name: "tuist"},
-          eu_region(%{storage_size: "50Gi", cas_capacity_size: "200Gi"}),
+          eu_region(%{storage_size: "50Gi", disk_envelope_size: "200Gi"}),
           %Server{},
           "return true"
         )
@@ -795,6 +901,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     test "does not expose per-account Kubernetes resources" do
       assert KubernetesController.resources_for(%Server{}) == %{}
     end
+  end
+
+  # The size the region's budget is derived against: the envelope override where
+  # the claim is a fiction, the claim itself otherwise.
+  defp envelope_bytes(%Regions{provisioner_config: config}) do
+    size = config[:disk_envelope_size] || config[:storage_size]
+    {quantity, "Gi"} = Integer.parse(size)
+    quantity * 1024 * 1024 * 1024
   end
 
   defp eu_region(extra_config \\ %{}) do

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -457,28 +457,56 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
 
-      # 80% of 50Gi, leaving the headroom a ring rotation needs. Without this the
-      # runtime would size the ring from the node's whole disk instead.
-      assert env["KURA_CAS_CAPACITY_BYTES"] == "42949672960"
+      # 50Gi less the 8Gi tmp ceiling and one 512Mi segment, less 3% for the
+      # index. Without this the runtime would size the ring from the node's whole
+      # disk instead.
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "43223477125"
     end
 
-    test "scales the CAS capacity with a smaller declared storage size" do
+    test "leaves a 20Gi volume room for staging and index alongside the ring" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
       stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
 
       manifest =
         KubernetesController.manifest(
-          "kura-tuist-scw-fr-par-1",
+          "kura-tuist-staging-runners-1",
           "0.5.2",
           %{name: "tuist"},
-          eu_region(%{storage_size: "10Gi"}),
+          eu_region(%{storage_size: "20Gi"}),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      capacity = String.to_integer(env["KURA_CAS_CAPACITY_BYTES"])
+
+      assert capacity == 11_977_590_046
+
+      # The reserves are fixed sizes, not a share, so the ring plus the tmp
+      # ceiling plus a rotation has to stay inside the volume. A flat percentage
+      # passes at 50Gi and overruns here, which on an enforced class is ENOSPC.
+      tmp = 8 * 1024 * 1024 * 1024
+      segment = 512 * 1024 * 1024
+      assert capacity + tmp + segment < 20 * 1024 * 1024 * 1024
+    end
+
+    test "omits the CAS capacity when the declared size cannot fit staging" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn -> nil end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-tiny-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{storage_size: "8Gi"}),
           %Server{},
           "return true"
         )
 
       env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
 
-      assert env["KURA_CAS_CAPACITY_BYTES"] == "8589934592"
+      refute Map.has_key?(env, "KURA_CAS_CAPACITY_BYTES")
     end
 
     test "budgets the CAS from cas_capacity_size without moving the declared storage size" do
@@ -497,8 +525,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
 
-      # 80% of the 200Gi override, not of the 50Gi claim.
-      assert env["KURA_CAS_CAPACITY_BYTES"] == "171798691840"
+      # Budgeted from the 200Gi override, not the 50Gi claim.
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "199452912517"
 
       # storageSize must stay at the claim: the controller patches live PVCs up to
       # spec.storageSize on every reconcile, and scw-local-nvme is not expandable,

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -244,12 +244,12 @@ defmodule Tuist.Kura.RegionsTest do
       assert scw_config.storage_class == "scw-local-nvme"
       assert scw_config.replicas == 1
 
-      # The cache budget rides cas_capacity_size, and the claim stays put:
+      # The cache budget rides disk_envelope_size, and the claim stays put:
       # scw-local-nvme is not expandable, and the controller patches live PVCs up
       # to spec.storageSize on every reconcile, so raising the claim would wedge
       # every runner-cache instance that already exists.
       assert scw_config.storage_size == "50Gi"
-      assert scw_config.cas_capacity_size == "150Gi"
+      assert scw_config.disk_envelope_size == "150Gi"
       assert scw_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura-scw-fr-par"}
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -97,7 +97,7 @@ defmodule Tuist.Kura.RegionsTest do
     end
 
     test "enables the per-account peer mesh on managed and private regions" do
-      for id <- ["us-east", "us-west", "eu-central", "scw-fr-par-runners", "hetzner-staging-runners"] do
+      for id <- ["us-east", "us-west", "eu-central", "ca-east", "scw-fr-par-runners"] do
         assert Regions.get(id).provisioner_config.mesh == true,
                "expected region #{id} to enable the peer mesh"
       end
@@ -108,8 +108,11 @@ defmodule Tuist.Kura.RegionsTest do
                %{"key" => "tuist.dev/runner-cache", "operator" => "Exists", "effect" => "NoSchedule"}
              ]
 
-      # The Hetzner runner-cache pool isn't tainted, so its region carries no toleration.
-      assert Regions.get("hetzner-staging-runners").provisioner_config.tolerations == []
+      # The customer-facing cache pools carry their own taint, not the
+      # runner-cache one, so their regions never tolerate it.
+      assert Regions.get("eu-central").provisioner_config.tolerations == [
+               %{"key" => "tuist.dev/kura-cache", "operator" => "Exists", "effect" => "NoSchedule"}
+             ]
     end
 
     test "exposes a local controller-backed region for kind smoke tests" do
@@ -235,7 +238,7 @@ defmodule Tuist.Kura.RegionsTest do
   end
 
   describe "private runner-cache regions" do
-    test "scaleway and hetzner-staging runner regions are registered as private" do
+    test "the scaleway runner region is registered as private" do
       assert %Regions{provisioner_config: scw_config} = Regions.get("scw-fr-par-runners")
       assert scw_config.private == true
       assert scw_config.storage_class == "scw-local-nvme"
@@ -251,18 +254,15 @@ defmodule Tuist.Kura.RegionsTest do
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)
 
-      assert %Regions{provisioner_config: hetzner_config} = Regions.get("hetzner-staging-runners")
-      assert hetzner_config.private == true
-      assert hetzner_config.storage_class == "hcloud-volumes"
-      assert hetzner_config.replicas == 1
-      assert hetzner_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura"}
+      # The only private region. Linux runners have no cache region of their
+      # own: the Hetzner-backed staging one was removed with its node pool.
+      assert Regions.all() |> Enum.filter(&Regions.private?/1) |> Enum.map(& &1.id) == ["scw-fr-par-runners"]
     end
   end
 
   describe "private?/1" do
     test "is true only for private regions" do
       assert Regions.private?(Regions.get("scw-fr-par-runners"))
-      assert Regions.private?(Regions.get("hetzner-staging-runners"))
       refute Regions.private?(Regions.get("eu-central"))
       refute Regions.private?(Regions.get("local-controller"))
       refute Regions.private?(nil)
@@ -278,17 +278,14 @@ defmodule Tuist.Kura.RegionsTest do
       refute Regions.serves_runner_platform?(scw, :linux)
     end
 
-    test "staging hetzner region serves only the co-located linux fleet" do
-      staging = Regions.get("hetzner-staging-runners")
-
-      assert staging.runner_platforms == [:linux]
-      assert Regions.serves_runner_platform?(staging, :linux)
-      refute Regions.serves_runner_platform?(staging, :macos)
+    test "no region serves the linux fleet" do
+      # The Hetzner-backed staging region was the only :linux one, and it went
+      # with its node pool. Linux runners fall back to the public endpoint.
+      refute Enum.any?(Regions.all(), &Regions.serves_runner_platform?(&1, :linux))
     end
 
-    test "scw region uses the node-port data plane; hetzner stays on cluster DNS" do
+    test "scw region uses the node-port data plane; customer regions stay on cluster DNS" do
       assert Regions.node_port_data_plane?(Regions.get("scw-fr-par-runners"))
-      refute Regions.node_port_data_plane?(Regions.get("hetzner-staging-runners"))
       refute Regions.node_port_data_plane?(Regions.get("eu-central"))
       refute Regions.node_port_data_plane?(nil)
     end
@@ -304,13 +301,13 @@ defmodule Tuist.Kura.RegionsTest do
     test "excludes private regions a customer cannot pick" do
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
-      stub(Tuist.Environment, :kura_available_region_ids, fn -> ["eu-central", "hetzner-staging-runners"] end)
+      stub(Tuist.Environment, :kura_available_region_ids, fn -> ["eu-central", "scw-fr-par-runners"] end)
 
       available_ids = Enum.map(Regions.available(), & &1.id)
       selectable_ids = Enum.map(Regions.selectable(), & &1.id)
 
-      assert "hetzner-staging-runners" in available_ids
-      refute "hetzner-staging-runners" in selectable_ids
+      assert "scw-fr-par-runners" in available_ids
+      refute "scw-fr-par-runners" in selectable_ids
       assert "eu-central" in selectable_ids
     end
   end

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -240,6 +240,13 @@ defmodule Tuist.Kura.RegionsTest do
       assert scw_config.private == true
       assert scw_config.storage_class == "scw-local-nvme"
       assert scw_config.replicas == 1
+
+      # The cache budget rides cas_capacity_size, and the claim stays put:
+      # scw-local-nvme is not expandable, and the controller patches live PVCs up
+      # to spec.storageSize on every reconcile, so raising the claim would wedge
+      # every runner-cache instance that already exists.
+      assert scw_config.storage_size == "50Gi"
+      assert scw_config.cas_capacity_size == "200Gi"
       assert scw_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura-scw-fr-par"}
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -246,7 +246,7 @@ defmodule Tuist.Kura.RegionsTest do
       # to spec.storageSize on every reconcile, so raising the claim would wedge
       # every runner-cache instance that already exists.
       assert scw_config.storage_size == "50Gi"
-      assert scw_config.cas_capacity_size == "200Gi"
+      assert scw_config.cas_capacity_size == "150Gi"
       assert scw_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura-scw-fr-par"}
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)

--- a/server/test/tuist/kura/runner_cache_test.exs
+++ b/server/test/tuist/kura/runner_cache_test.exs
@@ -11,18 +11,18 @@ defmodule Tuist.Kura.RunnerCacheTest do
 
   setup :set_mimic_from_context
 
-  # Drive Regions.available/0 to the real private-region catalog
-  # entries: `scw-fr-par-runners` serves [:macos] only,
-  # `hetzner-staging-runners` serves [:linux] only. Both provision
-  # through KubernetesController whose `provision/3` is pure (builds
-  # the instance name), and `destroy_server/1` only flips DB state —
-  # so reconcile runs for real against the sandbox.
+  # Drive Regions.available/0 to the real private-region catalog:
+  # `scw-fr-par-runners` serves [:macos] and is the only private region
+  # (Linux runners have none). It provisions through KubernetesController
+  # whose `provision/3` is pure (builds the instance name), and
+  # `destroy_server/1` only flips DB state — so reconcile runs for real
+  # against the sandbox.
   setup do
     stub(Tuist.Environment, :dev?, fn -> false end)
     stub(Tuist.Environment, :test?, fn -> false end)
 
     stub(Tuist.Environment, :kura_available_region_ids, fn ->
-      ["scw-fr-par-runners", "hetzner-staging-runners"]
+      ["scw-fr-par-runners"]
     end)
 
     stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.2" end)
@@ -75,12 +75,12 @@ defmodule Tuist.Kura.RunnerCacheTest do
 
     assert :ok = RunnerCache.reconcile()
 
-    # Each fleet's cache lives next to it: Linux profiles get the
-    # Hetzner node, macOS profiles the Scaleway fr-par one. A
-    # Linux-only account never gets a node in the macOS-serving
-    # region — its URL would route cache traffic across the WAN.
-    assert server_regions(linux_only) == ["hetzner-staging-runners"]
-    assert server_regions(macos_too) == ["hetzner-staging-runners", "scw-fr-par-runners"]
+    # A region's cache only serves the fleet it sits next to. macOS
+    # profiles get the Scaleway fr-par node; there is no Linux-serving
+    # region, so a Linux-only account gets nothing rather than a node in
+    # the macOS region, whose URL would route cache traffic across the WAN.
+    assert server_regions(linux_only) == []
+    assert server_regions(macos_too) == ["scw-fr-par-runners"]
   end
 
   test "accounts without the runners flag get no nodes" do
@@ -97,15 +97,15 @@ defmodule Tuist.Kura.RunnerCacheTest do
     enable_runners_for([account.id])
 
     assert :ok = RunnerCache.reconcile()
-    assert server_regions(account) == ["hetzner-staging-runners", "scw-fr-par-runners"]
+    assert server_regions(account) == ["scw-fr-par-runners"]
 
-    # Dropping the macOS profile frees the macOS-serving node but
-    # keeps the node in the region that still serves the remaining
-    # Linux profile.
+    # Dropping the macOS profile leaves nothing the region serves, so its
+    # node is torn down. The remaining Linux profile has no region of its
+    # own to keep a node in.
     Repo.delete_all(from(p in Profile, where: p.account_id == ^account.id and p.platform == :macos))
 
     assert :ok = RunnerCache.reconcile()
-    assert server_regions(account) == ["hetzner-staging-runners"]
+    assert server_regions(account) == []
   end
 
   test "an enabled account beyond the first candidate page still gets a node" do
@@ -133,8 +133,8 @@ defmodule Tuist.Kura.RunnerCacheTest do
       for %{id: account_id} <- filler_accounts do
         %{
           account_id: account_id,
-          name: "linux",
-          platform: :linux,
+          name: "macos",
+          platform: :macos,
           vcpus: 4,
           memory_gb: 16,
           inserted_at: now_utc,
@@ -144,15 +144,15 @@ defmodule Tuist.Kura.RunnerCacheTest do
 
     Repo.insert_all(Profile, profile_rows)
 
-    enabled = account_with_profiles([:linux])
+    enabled = account_with_profiles([:macos])
     enable_runners_for([enabled.id])
 
     assert :ok = RunnerCache.reconcile()
 
-    assert server_regions(enabled) == ["hetzner-staging-runners"]
+    assert server_regions(enabled) == ["scw-fr-par-runners"]
   end
 
-  test "macOS-only accounts get no node in the linux-serving region" do
+  test "macOS-only accounts get a node in the macOS-serving region" do
     account = account_with_profiles([:macos])
     enable_runners_for([account.id])
 

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -581,7 +581,7 @@ defmodule Tuist.KuraTest do
       stub(Tuist.Environment, :test?, fn -> false end)
 
       stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["scw-fr-par-runners", "hetzner-staging-runners"]
+        ["eu-central", "scw-fr-par-runners"]
       end)
 
       :ok
@@ -637,7 +637,7 @@ defmodule Tuist.KuraTest do
       stub(Tuist.Environment, :test?, fn -> false end)
 
       stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["scw-fr-par-runners", "hetzner-staging-runners"]
+        ["eu-central", "scw-fr-par-runners"]
       end)
 
       user = AccountsFixtures.user_fixture()
@@ -704,14 +704,16 @@ defmodule Tuist.KuraTest do
       assert DateTime.compare(refreshed.last_ready_at, stamp) == :eq
     end
 
-    test "is a no-op for cluster-DNS private servers" do
+    test "is a no-op outside a node-port region" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
+      # Only a node-port region carries an endpoint worth refreshing; anywhere
+      # else the URL is Service DNS and never moves.
       {:ok, server} =
         Kura.create_server(%{
           account_id: account.id,
-          region: "hetzner-staging-runners",
+          region: "eu-central",
           image_tag: "0.5.2"
         })
 
@@ -733,7 +735,7 @@ defmodule Tuist.KuraTest do
       stub(Tuist.Environment, :test?, fn -> false end)
 
       stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["scw-fr-par-runners", "hetzner-staging-runners"]
+        ["eu-central", "scw-fr-par-runners"]
       end)
 
       user = AccountsFixtures.user_fixture()
@@ -773,34 +775,10 @@ defmodule Tuist.KuraTest do
       assert Kura.runner_cache_endpoint_url(account, :macos) == nil
     end
 
-    test "cluster-DNS private servers serve regardless of the heartbeat" do
-      stub(Tuist.Environment, :dev?, fn -> false end)
-      stub(Tuist.Environment, :test?, fn -> false end)
-
-      stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["scw-fr-par-runners", "hetzner-staging-runners"]
-      end)
-
-      user = AccountsFixtures.user_fixture()
-      account = Accounts.get_account_from_user(user)
-
-      {:ok, server} =
-        Kura.create_server(%{
-          account_id: account.id,
-          region: "hetzner-staging-runners",
-          image_tag: "0.5.2"
-        })
-
-      stub(Provisioner, :public_url, fn _account, %Server{} -> "http://kura-tuist.kura.svc.cluster.local" end)
-      {:ok, active} = Kura.activate_server(server, "0.5.2")
-
-      # The node-port heartbeat path never runs for cluster-DNS, so last_ready_at
-      # stays ancient — it must still serve (the in-cluster Service gates readiness).
-      ancient = ~U[2020-01-01 00:00:00Z]
-      Server |> Repo.get!(active.id) |> Ecto.Changeset.change(last_ready_at: ancient) |> Repo.update!()
-
-      assert Kura.runner_cache_endpoint_url(account, :linux) == active.url
-    end
+    # The heartbeat-exempt path for cluster-DNS private servers has no test:
+    # every private region is node-port today, so the configuration cannot be
+    # built. `private_runner_cache_url/2` keeps the branch because it is what a
+    # private region that omits `data_plane` would fall back to.
   end
 
   describe "runner_cache_endpoint_url/2 public in-cluster fallback" do
@@ -920,22 +898,17 @@ defmodule Tuist.KuraTest do
     end
 
     test "prefers a serving private runner-cache node over the public fallback", %{account: account} do
-      stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["eu-central", "hetzner-staging-runners"]
-      end)
-
       activate_public_server!(account, "eu-central")
 
       {:ok, private} =
-        Kura.create_server(%{account_id: account.id, region: "hetzner-staging-runners", image_tag: "0.5.2"})
+        Kura.create_server(%{account_id: account.id, region: "scw-fr-par-runners", image_tag: "0.5.2"})
 
-      stub(Provisioner, :public_url, fn _account, %Server{} ->
-        "http://kura-private.kura.svc.cluster.local"
-      end)
-
+      expect(Provisioner, :external_endpoint, fn %Server{} -> {:ok, "http://172.16.0.2:30815"} end)
       {:ok, active_private} = Kura.activate_server(private, "0.5.2")
 
-      assert Kura.runner_cache_endpoint_url(account, :linux) == active_private.url
+      # activate_server/2 stamps last_ready_at, so the node serves at once and
+      # wins over the public server's in-cluster URL.
+      assert Kura.runner_cache_endpoint_url(account, :macos) == active_private.url
     end
 
     test "requires an active, CLI-visible public server", %{account: account} do

--- a/server/test/tuist_web/controllers/runners_controller_test.exs
+++ b/server/test/tuist_web/controllers/runners_controller_test.exs
@@ -139,33 +139,29 @@ defmodule TuistWeb.RunnersControllerTest do
       account = account_fixture()
 
       # The endpoint lookup goes through `Regions.available/0`, which
-      # in test sees only the local controller region — surface both
-      # private regions the way a managed runtime would.
+      # in test sees only the local controller region — surface the
+      # private region the way a managed runtime would.
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
 
       stub(Tuist.Environment, :kura_available_region_ids, fn ->
-        ["scw-fr-par-runners", "hetzner-staging-runners"]
+        ["scw-fr-par-runners"]
       end)
 
-      # Active runner-cache nodes in both private regions: the
-      # macOS-serving Scaleway one and the linux+macos staging one.
+      # The only private runner-cache region, serving macOS. Linux has none.
       scw_url = "http://kura-#{account.name}-scw-fr-par.kura.svc.cluster.local:4000"
-      staging_url = "http://kura-#{account.name}-staging.kura.svc.cluster.local:4000"
 
-      for {region, url} <- [{"scw-fr-par-runners", scw_url}, {"hetzner-staging-runners", staging_url}] do
-        Tuist.Repo.insert!(%Tuist.Kura.Server{
-          account_id: account.id,
-          region: region,
-          status: :active,
-          url: url,
-          # Fresh readiness heartbeat so the node-port server is served
-          # rather than failed over to the public cache (see
-          # Kura.runner_cache_endpoint_url/2).
-          last_ready_at: DateTime.truncate(DateTime.utc_now(), :second),
-          provisioner_node_ref: "kura-#{account.name}-#{region}"
-        })
-      end
+      Tuist.Repo.insert!(%Tuist.Kura.Server{
+        account_id: account.id,
+        region: "scw-fr-par-runners",
+        status: :active,
+        url: scw_url,
+        # Fresh readiness heartbeat so the node-port server is served
+        # rather than failed over to the public cache (see
+        # Kura.runner_cache_endpoint_url/2).
+        last_ready_at: DateTime.truncate(DateTime.utc_now(), :second),
+        provisioner_node_ref: "kura-#{account.name}-scw-fr-par-runners"
+      })
 
       stub(K8sClient, :create_token_review, fn "valid-token" ->
         {:ok, %{namespace: "tuist-runners", name: "pod-1"}}
@@ -190,11 +186,11 @@ defmodule TuistWeb.RunnersControllerTest do
         |> json_response(200)
       end
 
-      # Locality: each platform only ever sees a region that serves
-      # it. The Linux fleet must never receive the Scaleway URL —
-      # that node is co-located with the macOS fleet on the other
-      # side of a WAN.
-      assert dispatch.(true, :linux)["cache_endpoint_url"] == staging_url
+      # Locality: each platform only ever sees a region that serves it. The
+      # Linux fleet must never receive the Scaleway URL — that node is
+      # co-located with the macOS fleet on the other side of a WAN — and since
+      # no region serves Linux, it gets no URL rather than the wrong one.
+      refute Map.has_key?(dispatch.(true, :linux), "cache_endpoint_url")
       assert dispatch.(true, :macos)["cache_endpoint_url"] == scw_url
 
       # Reachability: a fleet off the cluster network gets no URL at


### PR DESCRIPTION
## What changed

`KURA_CAS_CAPACITY_BYTES` is now derived from the disk envelope each Kura region declares and injected through `extension_env/1`. That envelope is normally `storage_size`; a region whose claim bounds nothing can override it with the new `cas_capacity_size`, which the runner-cache region uses to keep the ~137Gi per account it already holds. `@manifest_revision` is bumped so the rollout worker re-applies the manifest to instances that already exist.

## Why

Found while investigating a live eu-central outage (2026-07-16): the single Dedibox node backing the region sat at `DiskPressure=True`, which evicts running pods **and** blocks rescheduling. Because it is a one-node fleet nothing could move, so the region lost its demux, its ingress and every tenant instance. The `platform-kura-eu-central-ingress-nginx-controller` DaemonSet could then never go Ready, so `helm --wait` on the Platform chart failed and the whole production deploy cascade died with it.

## Root cause

When `KURA_CAS_CAPACITY_BYTES` is unset, Kura sizes its CAS segment ring from `libc::statvfs()` on the data dir (`kura/src/store.rs`, `resolve_segment_ring_limits`), defaulting to `CAS_CAPACITY_DEFAULT_DISK_PERCENT` (50%). Nothing in the server or the kura-controller ever set it.

Every managed region is backed by the local-path provisioner, where a volume is a plain directory on the node's shared disk. `statvfs` therefore reports **the whole box**, not the PVC's declared size — and on ext4 nothing enforces the PVC's capacity either, so the `50Gi` claim was never more than a label. Each replica budgeted 50% of the entire node, and the two replicas a region runs on its single node over-committed it two to one.

The node's own confirmation, straight from a replica's startup log:

```
"resolved CAS segment ring limits" ... "capacity_bytes":491773755392
```

That is 458 GiB — exactly 50% of the 984 GB filesystem — per replica, times two replicas, on one disk.

The box crosses kubelet's `imagefs.available<15%` eviction threshold long before either replica reaches its budget, so Kura's ring rotation never gets to evict anything and kubelet evicts the region instead. Two details worth recording:

- The filesystem hosting the volumes also hosts `/data/containerd` and `/var/lib/kubelet` (all bind mounts of one `md2p1`), which is why a cache-sizing bug surfaces as *imagefs* pressure.
- The `FreeDiskSpaceFailed` / `ImageGCFailed` events on the node are a red herring. The node had 4 images totalling 0.34 GB and reported `only found 0 bytes eligible to free`; the "attempted to free 49.4 GB" figure is just 5.022% of the filesystem, the default 85%→80% image-GC band.

Measured on the box: 732G of the 733G in use was Kura's segment data, and 733G of that belonged to Tuist's own two dogfooding replicas (379G + 354G). The four paying tenants co-located in the region were using ~12MB each and were evicted anyway.

## How the budget is derived

`KURA_CAS_CAPACITY_BYTES` bounds the **segment ring only**, not the data dir. The ring shares its volume with two things the cap does not cover: the controller points `KURA_TMP_DIR` at `<data dir>/tmp`, so upload staging is inside the claim, and RocksDB's index sits beside it with no budget of its own.

So the declared size is treated as the whole envelope and the fixed reserves are subtracted from it:

- the tmp dir's ceiling (`KURA_TMP_DIR_MAX_BYTES`, never set by us, so Kura's 8 GiB default applies)
- one `MAX_SEGMENT_BYTES` (512 MiB), which a rotation appends before evicting the oldest segment
- 3% for the index, which tracks entry count rather than bytes (measured ~1.2% of resident segment bytes on a production instance)

Subtracting rather than taking a percentage matters, and an earlier revision of this PR got it wrong: the reserves are **fixed sizes, not a share**, so any percentage that fits a large volume overruns a small one. Subtracting also makes the declared number mean something useful on a local-path volume — the envelope *is* the per-replica footprint, which is exactly what the box arithmetic below needs. The flat 80% quietly understated it (a 40Gi ring, but ~49Gi actually on disk once staging and the index are counted). When what remains is not worth a ring, the env is omitted entirely and Kura's own default applies.

To be precise about the stakes: today this changes nothing for a live region, because every region that actually runs is local-path, where the claim is unenforced and only the box total binds. The one region declaring an enforced 20Gi claim, `hetzner-staging-runners`, is dead config — its Hetzner `kura` node pool no longer exists, so its pods have been unschedulable and its PVCs unbound for over a month (see below). The subtraction is what keeps the rule correct rather than accidentally correct.

## Why this fix

The declared envelope is what the region already asks for, so deriving the budget from it makes actual usage match the stated contract instead of silently tracking whatever box the volume landed on. It is also correct on a CSI-backed volume, where the claim is enforced.

**Why `cas_capacity_size` rather than just raising `storage_size`.** The first revision carried the runner-cache budget by setting `storage_size: 200Gi`, on the reading that a size change is inert for existing instances (`reconcileStatefulSet` preserves `existingVolumeClaimTemplates`, and `staleDataStorageReason` recreates on a storage *class* change, not a size one). That reading was incomplete and the approach was wrong: `reconcileStatefulSet` also calls `reconcileDataPersistentVolumeClaims` on every pass, which patches each live data PVC up to `spec.storageSize` whenever the desired size is larger. `scw-local-nvme` sets `allowVolumeExpansion: false` (verified in the chart and live in production), so the API would reject every resize and leave all three existing runner-cache instances failing to reconcile. Keeping the budget on its own field leaves the claim untouched. The budget still defaults to `storage_size`, so the safe behaviour is the default and the override is only for regions where the claim is a fiction.

Other alternatives considered:

- **Setting the env by hand on the CR.** Rejected: the server writes `"extraEnv" => extension_env(region)` wholesale and the kura-controller owns the StatefulSet, so any manual edit is reconciled away.
- **Dividing the disk by co-located replicas inside Kura.** Rejected: a replica cannot see how many peers share its filesystem, and it would keep the budget coupled to the box instead of to the declared volume.
- **Capping only the 2-replica regions.** Rejected: it leaves the budget silently box-derived everywhere else, so the same bug returns the moment a region gains a replica or moves to a smaller box.
- **Cutting the runner cache to the nominal 50Gi.** Rejected: at 1 replica the 50%-of-disk default was never over-committed, and that region has been running near 137Gi per account for a long time. Enforcing a number that never applied would shrink a healthy cache ~3.5x for no reason. `150Gi` reproduces roughly what it already holds; `200Gi` would have grown it and left the box unable to take a fourth account.

## Resulting headroom

| Region | budget source | ring/replica | envelope/replica | replicas | tenants | total on box | box | used | tenant ceiling |
|---|---|---|---|---|---|---|---|---|---|
| `eu-central` | storage_size 50Gi | 40Gi | 50Gi | 2 | 5 | 537GB | 984GB | **54.6%** | ~8 |
| `scw-fr-par-runners` | cas_capacity_size 150Gi | 137Gi | 150Gi | 1 | 3 | 483GB | 909GB | **53.2%** | ~5 |
| `us-east` | storage_size 50Gi | 40Gi | 50Gi | 2 | 2 | 215GB | 942GB | **22.8%** | ~7 |
| `us-west` | storage_size 50Gi | 40Gi | 50Gi | 2 | 2 | 215GB | 942GB | **22.8%** | ~7 |

Against 85% at the time of the incident. These are worst case: the envelope assumes every replica holds a full ring *and* hits its staging ceiling at once, so steady state sits lower (eu-central ~45%). Every region keeps `storage_size: 50Gi`, so no PVC resize is attempted anywhere.

## Impact

- eu-central stops evicting itself, and us-east / us-west / ca-east carry the same latent bug today — they simply have not taken enough traffic to trip it yet. `scw-fr-par-runners` is the natural experiment: 1 replica, so 50% of the disk was always a safe plateau, and it sits stably at 48% with rotation working.
- Tuist's eu-central cache is bounded at 40Gi per replica instead of growing to 458 GiB, so its dogfooding traffic can no longer evict paying tenants off the box.

## Residual risk (not addressed here)

- **The cap is per instance, so the box total scales with tenant count** — see the ceiling column. eu-central is fine at 5 tenants and would approach the eviction line near ~8; `scw-fr-par-runners` tops out near ~5 accounts. That is now linear and predictable rather than a fixed 200% over-commit, but adding accounts past a region's ceiling needs a second box, not a bigger envelope. Each region also remains a **single node** with no failover, so a full box is still a full-region outage.
- `reconcileDataPersistentVolumeClaims` patches a PVC without checking whether the storage class allows expansion. That is a latent footgun independent of this PR: any future `storage_size` increase on a local-path region wedges its instances the same way. Worth fixing in the controller separately.
- The 8 GiB staging reserve mirrors Kura's `DEFAULT_TMP_DIR_MAX_BYTES` rather than reading it, because we never set `KURA_TMP_DIR_MAX_BYTES`. If that default moves, this constant has to move with it.
- **`hetzner-staging-runners` is dead and should be deleted**, separately from this PR. Its `kura` node pool (Hetzner Falkenstein) is gone — staging's Linux runners moved to bare metal (`runners-linux`) — but the region spec stayed behind and keeps minting instances that can never schedule: 12 KuraInstances on staging, 33-35 days old, pods `FailedScheduling` against a `node.cluster.x-k8s.io/pool: kura` that does not exist, PVCs stuck Pending. Nothing is provisioned so it costs nothing, but it is the last region pinning `hcloud-volumes` into the region table; removing it makes every Kura region bare-metal (OVH/Dedibox/Scaleway EM) and drops the only enforced-claim case from this code path. Left out here because it touches `kura_test.exs` fixtures and needs the orphaned staging instances reaped.

## Validation

- `mix test test/tuist/kura/` — 191 passed. New cases cover the derived value, the override path, omission when a region declares none, a regression test asserting the runner region budgets from `cas_capacity_size` while `storageSize` stays `50Gi`, an assertion that a 20Gi enforced volume still fits ring + staging + rotation, and omission when the envelope is too small to carve a ring from.
- `mix format --check-formatted` and `mix credo` clean on the changed files.
- Verified against the live fleet: caps rendered from the real region configs and checked against each box's actual disk size (table above); `allowVolumeExpansion: false` confirmed on the live `scw-local-nvme` StorageClass; the three live runner-cache PVCs confirmed still at 50Gi; `KURA_TMP_DIR=/var/cache/kura/tmp` confirmed inside `KURA_DATA_DIR`.
- The incident itself was resolved by reclaiming the 733G (Tuist's own cache only); `DiskPressure` cleared after kubelet's 5-minute transition period, the demux, the regional ingress and all four tenant instances rescheduled, and the eu-central hosts serve again behind a valid certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
