### PR TITLE
fix(cli): backport nested xcframework module map discovery to 4.202.x

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -117,29 +117,36 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
             }
 
             if !staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.isEmpty {
-                settings["OTHER_SWIFT_FLAGS"] = .array(
-                    staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
-                        [
-                            "-Xcc",
-                            moduleMapFlag(
-                                for: xcframework,
-                                derivedDirectory: derivedDirectory,
-                                project: project
-                            ),
-                        ]
-                    }
-                )
-                settings["OTHER_C_FLAGS"] = .array(
-                    staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
-                        [
-                            moduleMapFlag(
-                                for: xcframework,
-                                derivedDirectory: derivedDirectory,
-                                project: project
-                            ),
-                        ]
-                    }
-                )
+                // Only flat layouts point at a module map. Nested ones are left for clang to
+                // discover from whichever `Headers` root wins the search path, so that the module
+                // and the headers its umbrella imports always come from the same directory.
+                let flatXCFrameworks = staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies
+                    .filter { Self.nestedModuleMap(for: $0) == nil }
+                if !flatXCFrameworks.isEmpty {
+                    settings["OTHER_SWIFT_FLAGS"] = .array(
+                        flatXCFrameworks.flatMap { xcframework -> [String] in
+                            [
+                                "-Xcc",
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    )
+                    settings["OTHER_C_FLAGS"] = .array(
+                        flatXCFrameworks.flatMap { xcframework -> [String] in
+                            [
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    )
+                }
                 settings["HEADER_SEARCH_PATHS"] = .array(
                     staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies
                         .compactMap { xcframework -> String? in
@@ -202,23 +209,31 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
     /// root (the subdirectory's parent) on the search path so those prefixed imports resolve;
     /// "flat" xcframeworks keep their headers directly next to the module map. Returns the
     /// xcframework's module map when the layout is nested.
+    ///
+    /// Nested layouts are deliberately *not* passed to clang with `-fmodule-map-file`. Whenever
+    /// anything else still references the xcframework, Xcode's `ProcessXCFramework` copies the
+    /// same headers into `$(BUILT_PRODUCTS_DIR)/include/<ModuleName>/`, which is searched ahead of
+    /// `HEADER_SEARCH_PATHS`. Naming a module map here would define the module over one copy of
+    /// the headers while `#import <ModuleName/Header.h>` resolved to the other, which clang
+    /// reports as `umbrella header for module 'X' does not include header 'Y.h'` or, once that
+    /// copy makes a second module map reachable, `import of shadowed module`. Leaving the module
+    /// map out lets clang discover it next to whichever headers actually win the search path, so
+    /// the module is always defined over the copy its umbrella imports.
     private static func nestedModuleMap(for xcframework: GraphDependency.XCFramework) -> AbsolutePath? {
         guard let moduleMap = xcframework.moduleMaps.first else { return nil }
         return moduleMap.parentDirectory.basename == xcframework.path.basenameWithoutExt ? moduleMap : nil
     }
 
+    /// Only called for flat layouts, which point at the derived module map whose umbrella header was
+    /// rewritten to drop the `<ModuleName/...>` prefix so it resolves against the module map's own
+    /// directory.
     private func moduleMapFlag(
         for xcframework: GraphDependency.XCFramework,
         derivedDirectory: AbsolutePath,
         project: Project
     ) -> String {
         let name = xcframework.path.basenameWithoutExt
-        // Nested layouts point at the xcframework's own module map: its umbrella imports the
-        // headers with the `<ModuleName/...>` prefix, which resolves against the `Headers` root.
-        // Flat layouts point at the derived module map, whose umbrella header was rewritten to
-        // drop the prefix so it resolves against the module map's own directory.
-        let moduleMapPath = Self.nestedModuleMap(for: xcframework)
-            ?? derivedDirectory.appending(components: name, "Headers", "module.modulemap")
+        let moduleMapPath = derivedDirectory.appending(components: name, "Headers", "module.modulemap")
         return "-fmodule-map-file=\"$(SRCROOT)/\(moduleMapPath.relative(to: project.path).pathString)\""
     }
 

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -369,6 +369,60 @@ struct TuistCacheEEAcceptanceTests {
         )
     }
 
+    /// Same nested-header xcframeworks as above, but `ToolLinkingXCFrameworksDirectly` also links
+    /// them directly, so they stay referenced once `Library` is replaced by its cached xcframework.
+    /// Xcode then runs `ProcessXCFramework` and copies each slice's headers into
+    /// `$(BUILT_PRODUCTS_DIR)/include/<Module>/`, which is searched ahead of `HEADER_SEARCH_PATHS`.
+    /// Pointing the module map at the xcframework's own headers therefore defined the module over
+    /// one copy of the headers while `#import <NestedObjC/Anchor.h>` resolved to another, which
+    /// clang reports as `umbrella header for module 'NestedObjC' does not include header ...` and,
+    /// once a second module map became reachable through that copy, `import of shadowed module
+    /// 'Anchor'`. The module map and the search path must name the same headers, so the mapper
+    /// consumes these through `$(BUILT_PRODUCTS_DIR)/include`, which is where the prefixed imports
+    /// resolve.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_nested_header_xcframework")
+    ) func generated_macos_tool_linking_cached_nested_header_xcframework_directly() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "NestedHeaderXCFramework.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["Library", "--path", fixtureDirectory.pathString]
+        )
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            ["--no-open", "--path", fixtureDirectory.pathString, "ToolLinkingXCFrameworksDirectly"]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "Library",
+            by: "ToolLinkingXCFrameworksDirectly",
+            xcodeprojPath: xcodeprojPath
+        )
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "-project",
+                xcodeprojPath.pathString,
+                "-scheme",
+                "ToolLinkingXCFrameworksDirectly",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -186,9 +186,13 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
 
     /// Some static Objective-C xcframeworks keep their module map and headers in a `Headers/<ModuleName>/`
     /// subdirectory and re-import each other with the `<ModuleName/...>` prefix. Such a "nested"
-    /// layout is consumed through the xcframework's own module map with the `Headers` root (the
-    /// parent of the module subdirectory) on the search path, not a derived/rewritten copy, so
-    /// both the umbrella's and the headers' prefixed imports resolve and the module is defined once.
+    /// layout gets only the `Headers` root (the parent of the module subdirectory) on the search
+    /// path, so the prefixed imports resolve, and no `-fmodule-map-file`: clang discovers the module
+    /// map next to whichever headers win the search path. Naming one here would define the module
+    /// over the xcframework's headers even when Xcode's `ProcessXCFramework` has copied the same
+    /// headers into `$(BUILT_PRODUCTS_DIR)/include/<ModuleName>/`, which is searched first — the
+    /// module and its umbrella's imports would then come from two different copies, which clang
+    /// rejects as an incomplete umbrella or a shadowed module.
     func test_map_when_static_xcframework_library_with_nested_module_headers_linked_via_dynamic_xcframework() async throws {
         // Given
         let projectPath = try temporaryPath()
@@ -267,13 +271,6 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         name: "App",
                         settings: .test(
                             base: [
-                                "OTHER_SWIFT_FLAGS": [
-                                    "-Xcc",
-                                    "-fmodule-map-file=\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers/NestedObjC/module.modulemap\"",
-                                ],
-                                "OTHER_C_FLAGS": [
-                                    "-fmodule-map-file=\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers/NestedObjC/module.modulemap\"",
-                                ],
                                 "HEADER_SEARCH_PATHS": ["\"$(SRCROOT)/../NestedObjC.xcframework/ios-arm64/Headers\""],
                             ]
                         )

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
@@ -5,7 +5,7 @@ import ProjectDescription
 // re-import each other with the `<NestedObjC/...>` prefix, linked by a dynamic
 // framework (`Library`). When `Library` is cached, `Library.xcframework` becomes
 // a dynamic dependency that links `NestedObjC` behind it, so `Tool` consumes
-// `NestedObjC` as a static-objc-xcframework-behind-a-dynamic-xcframework — the
+// `NestedObjC` as a static-objc-xcframework-behind-a-dynamic-xcframework, the
 // path handled by `StaticXCFrameworkModuleMapGraphMapper`.
 let project = Project(
     name: "NestedHeaderXCFramework",
@@ -23,6 +23,29 @@ let project = Project(
             sources: ["Tool/Sources/**"],
             dependencies: [
                 .target(name: "Library"),
+            ]
+        ),
+        // Same as `Tool`, but the xcframeworks are *also* linked directly. Once
+        // `Library` is replaced by its cached xcframework, `Tool` no longer
+        // references `NestedObjC.xcframework` at all, so Xcode never processes it.
+        // Here the direct link keeps it referenced, so Xcode runs
+        // `ProcessXCFramework` and copies each slice's headers into
+        // `$(BUILT_PRODUCTS_DIR)/include/<Module>/`. That directory is searched
+        // before `HEADER_SEARCH_PATHS`, so `#import <NestedObjC/Anchor.h>` resolves
+        // to Xcode's copy rather than to the headers the module map was pointed at.
+        // A real project reaches the same state whenever anything else in the graph
+        // still references the xcframework.
+        .target(
+            name: "ToolLinkingXCFrameworksDirectly",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "io.tuist.NestedHeaderXCFramework.ToolLinkingXCFrameworksDirectly",
+            infoPlist: .default,
+            sources: ["Tool/Sources/**"],
+            dependencies: [
+                .target(name: "Library"),
+                .xcframework(path: "NestedObjC.xcframework"),
+                .xcframework(path: "NestedObjCKit.xcframework"),
             ]
         ),
         .target(


### PR DESCRIPTION
## What changed

- Backport [#11872](https://github.com/tuist/tuist/pull/11872) to the `releases/4.202.x` stable line.
- Stop passing nested static Objective-C xcframework layouts through an explicit `-fmodule-map-file`.
- Keep the xcframework's `Headers` root on `HEADER_SEARCH_PATHS` so clang discovers the module map beside whichever header copy wins search order.
- Leave flat header layouts unchanged and continue pointing them at their derived, rewritten module map.
- Include the focused mapper expectations and the direct-linking acceptance fixture that reproduces Xcode's `ProcessXCFramework` copy.

## Why

Tuist 4.202.0 regressed cached builds that consume nested-layout static Objective-C xcframeworks behind a dynamic xcframework while another graph edge still references the original binary. This was reported with Google Maps and commonly fails projects that promote warnings to errors.

The failure appears as incomplete umbrella diagnostics such as `umbrella header for module 'GoogleMapsBase' does not include header ...`, and can escalate to `import of shadowed module`.

## Root cause and approach

The mapper explicitly defined the module over the xcframework's original headers. At the same time, Xcode's workspace-level `ProcessXCFramework` task could copy the same headers and module map into `$(BUILT_PRODUCTS_DIR)/include/<Module>/`, a directory searched before project-controlled header search paths. The umbrella's prefixed imports then resolved to Xcode's copy while clang considered the module to be defined over the original files.

The backport removes the explicit module-map flag only for nested layouts. Clang now discovers the module map next to the header directory that actually wins search order, so module definition and umbrella imports always refer to the same files. This avoids predicting Xcode's task graph or duplicating slice-selection logic.

## Impact

Cached builds on the 4.202 stable line can consume nested-layout static Objective-C xcframeworks without incomplete-umbrella or shadowed-module failures. Projects treating warnings as errors no longer need `-Wno-error=incomplete-umbrella` as a workaround. Flat xcframework layouts retain their existing behavior.

## Validation

- `mise run cli:lint --fix` — completed with zero files reformatted.
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` — 19 tests passed.
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -destination 'platform=macOS' -derivedDataPath /tmp/tuist-backport-11872-acceptance-derived-data '-only-testing:TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests/generated_macos_tool_linking_cached_nested_header_xcframework_directly()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` — the Xcode result bundle records the regression test as `Passed`.
- `git diff --check` — clean.

The remote module cache returned 503 during local validation, so Xcode compiled the selected graphs locally.