### PR TITLE
fix(cli): retry Linux release bundles after cache cleanup

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -190,7 +190,21 @@ jobs:
           sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
 
       - name: Bundle CLI
-        run: ./mise/tasks/cli/bundle-linux.sh
+        run: |
+          for attempt in 1 2 3; do
+            if ./mise/tasks/cli/bundle-linux.sh; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Linux CLI bundle failed after ${attempt} attempts."
+              exit 1
+            fi
+
+            echo "::warning::Linux CLI bundle attempt ${attempt} failed; clearing SwiftPM state before retrying."
+            rm -rf "${BUILD_PATH:-.build}" build "$HOME/.cache/org.swift.swiftpm" "$HOME/.swiftpm"
+            sleep $((attempt * 10))
+          done
 
       - name: Upload CLI Linux artifacts
         id: upload


### PR DESCRIPTION
## What changed

The Linux CLI release jobs now make up to three bounded bundle attempts. After a failed attempt, the workflow clears:

- the configured Swift build path
- generated release artifacts
- SwiftPM's download/cache state
- the installed Swift SDK state

The next attempt therefore starts from clean SwiftPM and SDK state, with short incremental backoff between attempts.

## Why

The 4.202.4 backport release failed twice before compilation while SwiftPM was fetching dependencies. FoundationNetworking crashed in libcurl with error code 43 during the Linux x86_64 bundle, and the matrix fail-fast behavior cancelled the other artifacts and publishing.

The previous 4.202.3 release completed with the same Swift Docker image and Swift toolchain. That points to transient or corrupted dependency-fetch state rather than a source or toolchain incompatibility. A bounded retry with cache cleanup lets the release recover without changing the immutable release ref or silently accepting a partial build.

## Buggy behavior

A single transient SwiftPM/libcurl fetch failure aborted the entire Linux matrix. Because the publishing job requires every platform artifact, no CLI release was produced even though the backported CLI change itself had already passed its targeted validation.

## Validation

- `git diff --check`
- Focused three-attempt shell simulation that fails twice, verifies all four cache/build locations are absent before each retry, then succeeds on the third attempt
- `actionlint .github/workflows/cli-build-publish.yml` parsed the modified block successfully; its reported findings are existing custom-runner labels and unrelated shell warnings elsewhere in the workflow