### PR TITLE
fix(cli): clean Swift account home before release retry

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -202,7 +202,14 @@ jobs:
             fi
 
             echo "::warning::Linux CLI bundle attempt ${attempt} failed; clearing SwiftPM state before retrying."
-            rm -rf "${BUILD_PATH:-.build}" build "$HOME/.cache/org.swift.swiftpm" "$HOME/.swiftpm"
+            ACCOUNT_HOME="$(getent passwd "$(id -u)" | cut -d: -f6)"
+            rm -rf \
+              "${BUILD_PATH:-.build}" \
+              build \
+              "$HOME/.cache/org.swift.swiftpm" \
+              "$HOME/.swiftpm" \
+              "$ACCOUNT_HOME/.cache/org.swift.swiftpm" \
+              "$ACCOUNT_HOME/.swiftpm"
             sleep $((attempt * 10))
           done
 


### PR DESCRIPTION
## What changed

The Linux release retry cleanup now clears SwiftPM and installed SDK state from both:

- the `HOME` environment directory configured by GitHub Actions
- the current Unix account's passwd-derived home directory

Build and artifact directories are still cleared between attempts.

## Why

The retry added in #11881 ran, but the release logs showed that attempts 2 and 3 failed while reinstalling the static SDK with:

`Swift SDK bundle ... is already installed`

Inside GitHub's Swift container, `HOME` is `/github/home`, while Swift resolves the root account home as `/root` and stores its SDK and network state there. Cleaning only `$HOME` therefore left the actual Swift state intact.

This also means the first clean retry did not clear SwiftPM's real network cache after the FoundationNetworking/libcurl error. Resolving the account home through `getent passwd` makes the cleanup match Swift's home-directory lookup without hard-coding `/root`.

## Buggy behavior

After the first SwiftPM/libcurl crash, the workflow announced a cache cleanup but removed the wrong home directory. Every subsequent attempt downloaded the SDK archive and then stopped because the existing SDK under `/root/.swiftpm` was still installed, so no real clean Swift build retry occurred.

## Validation

- `git diff --check`
- Dual-home shell simulation with distinct environment and account homes; verified both SwiftPM caches, both SDK directories, the configured build path, and artifact directory were removed
- `actionlint .github/workflows/cli-build-publish.yml` parsed the changed block successfully; reported findings remain the existing custom-runner labels and unrelated shell warnings elsewhere in the workflow