### PR TITLE
fix(infra): make the host settle cache-tree writability (and stop the guest guessing)

### DIFF
--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -202,12 +202,18 @@ use_local_cold_cache() {
   echo "$(date -u +%FT%TZ) dispatch-poll: cache share unusable (${reason}); running on a local cold cache"
 }
 
-# cache_root_usable proves this user can actually create the Tuist cache root
-# on the share AND write inside it. Existence is not enough: the host
-# materializes a warm branch by cloning the account's master tree into place,
-# and that tree carries the master's ownership/mode — so `tuist/` can exist yet
-# be unwritable by the guest's unprivileged runner user. A write probe is the
-# only honest check.
+# cache_root_usable checks the one thing the guest can actually know: that it
+# can create its cache root on the share at all (share present, not read-only).
+#
+# It deliberately does NOT try to verify that the materialized tree is writable.
+# That was tried and is a trap: the host clones the account's master in, so the
+# root can be writable while a subtree isn't, and no probe here can be complete
+# — the CLI writes across 9+ subtrees and a probe only covers what someone
+# remembered to list. A partial probe passes while the share is broken and hands
+# the CLI a cache that kills the job, which is exactly what happened in
+# production. Writability is settled on the host, where it is knowable: 0777 is
+# uid-independent, so a tree the host successfully relaxes IS writable by the
+# guest, and a tree it cannot relax is never handed over at all.
 cache_root_usable() {
   local share="$1"
   local root="${share}/tuist"
@@ -216,37 +222,14 @@ cache_root_usable() {
     cache_diag "mkdir ${root}: ${err}" "${share}"
     return 1
   fi
-  local probe="${root}/.tuist-write-probe.$$"
-  if ! err=$( ( : >"${probe}" ) 2>&1 ); then
-    cache_diag "write probe in ${root}: ${err}" "${share}"
-    return 1
-  fi
-  rm -f "${probe}" 2>/dev/null || true
-  # Probing only the root is not enough, and assuming otherwise let a broken
-  # share through in production: on a WARM branch the host clones the account's
-  # master in, so the root can be writable while the subtrees underneath carry
-  # the master's ownership/mode. The CLI writes INSIDE those — it moves
-  # downloaded xcframeworks into tuist/Binaries/<hash> — and died there with
-  # `"X.xcframework" couldn't be moved to "<hash>"` while the root probe passed.
-  # Probe the subtrees the CLI actually writes.
-  local d
-  for d in Binaries Manifests ProjectDescriptionHelpers Plugins; do
-    [ -d "${root}/${d}" ] || continue
-    probe="${root}/${d}/.tuist-write-probe.$$"
-    if ! err=$( ( : >"${probe}" ) 2>&1 ); then
-      cache_diag "write probe in ${root}/${d}: ${err}" "${share}"
-      return 1
-    fi
-    rm -f "${probe}" 2>/dev/null || true
-  done
   return 0
 }
 
-# cache_diag records WHY the share was rejected. The failure mode this guards
-# against was diagnosed only from a CLI error that misreported a failed mkdir as
-# "parent directory doesn't exists", which sent us chasing the wrong layer — so
-# capture the real errno plus the ownership/mode of the share and root here. If
-# the fallback ever fires, this is the evidence, and no one has to guess.
+# cache_diag records WHY the share was rejected. The original failure was
+# diagnosed only from a CLI error that misreported a failed mkdir as "parent
+# directory doesn't exists", which sent the investigation to the wrong layer —
+# so capture the real errno plus the ownership/mode here. If the fallback ever
+# fires, this is the evidence and no one has to guess.
 cache_diag() {
   local why="$1" share="$2"
   echo "$(date -u +%FT%TZ) dispatch-poll: cache-root check failed: ${why}"

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -222,6 +222,23 @@ cache_root_usable() {
     return 1
   fi
   rm -f "${probe}" 2>/dev/null || true
+  # Probing only the root is not enough, and assuming otherwise let a broken
+  # share through in production: on a WARM branch the host clones the account's
+  # master in, so the root can be writable while the subtrees underneath carry
+  # the master's ownership/mode. The CLI writes INSIDE those — it moves
+  # downloaded xcframeworks into tuist/Binaries/<hash> — and died there with
+  # `"X.xcframework" couldn't be moved to "<hash>"` while the root probe passed.
+  # Probe the subtrees the CLI actually writes.
+  local d
+  for d in Binaries Manifests ProjectDescriptionHelpers Plugins; do
+    [ -d "${root}/${d}" ] || continue
+    probe="${root}/${d}/.tuist-write-probe.$$"
+    if ! err=$( ( : >"${probe}" ) 2>&1 ); then
+      cache_diag "write probe in ${root}/${d}: ${err}" "${share}"
+      return 1
+    fi
+    rm -f "${probe}" 2>/dev/null || true
+  done
   return 0
 }
 

--- a/infra/tart-kubelet/internal/podagent/volume.go
+++ b/infra/tart-kubelet/internal/podagent/volume.go
@@ -304,20 +304,33 @@ func (m *VolumeManager) Materialize(att VolumeAttachment, account string) (warm 
 		_ = os.Chmod(dest, 0o777)
 		return false, fmt.Errorf("swap materialized cache into place: %w", err)
 	}
-	// Relax the WHOLE materialized tree, not just its root.
+	// Relax the WHOLE materialized tree, and treat failure as fatal to the
+	// materialize.
 	//
 	// The clone carries the MASTER's ownership and mode: tart-kubelet runs as the
 	// host's console user (Virtualization.framework requires it), so every master
 	// it promotes is host-owned 0755, while the guest runs as its own
 	// unprivileged `runner` user. Across virtio-fs the two uids don't line up, so
-	// mode is the only lever we have — and a root-only chmod is not enough. The
-	// guest doesn't just create entries in `tuist/`; the CLI moves downloaded
-	// xcframeworks into `tuist/Binaries/<hash>` and prunes them again, which needs
-	// write on `Binaries/` itself, and re-signs artifacts in place, which needs
-	// write on the files. Relaxing only the root produced a job that could create
-	// `tuist/Plugins` and still died with
+	// mode is the only lever — and a root-only chmod is not enough. The CLI moves
+	// downloaded xcframeworks into `tuist/Binaries/<hash>` and re-signs artifacts
+	// in place, so it needs write on the subtrees and the files, not just the
+	// root. Relaxing only the root produced a job that could create
+	// `tuist/Plugins` yet still died with
 	// `"X.xcframework" couldn't be moved to "<hash>"` (seen in production).
-	chmodTreeGuestWritable(dest)
+	//
+	// This is the ONLY place that can settle it: 0777 is uid-independent, so a
+	// tree we successfully relax is writable by the guest whatever its uid. The
+	// guest cannot check this for itself — it would have to enumerate every path
+	// the CLI might touch (the master carries 9+ subtrees) and would rubber-stamp
+	// whatever it forgot. So if we cannot hand over a provably writable tree, we
+	// hand over none: drop it and let the job run cold, which costs warmth
+	// instead of the job.
+	if err := chmodTreeGuestWritable(dest); err != nil {
+		_ = os.RemoveAll(dest)
+		_ = os.MkdirAll(dest, 0o777)
+		_ = os.Chmod(dest, 0o777)
+		return false, fmt.Errorf("make materialized cache tree guest-writable: %w", err)
+	}
 	// Mark the master used so LRU tracks materialization, not just promotion —
 	// an account whose jobs keep landing here stays hot.
 	_ = os.Chtimes(m.masterDir(account, att.VolumeName), m.now(), m.now())
@@ -499,22 +512,21 @@ func (m *VolumeManager) Finalize(att VolumeAttachment, account string, jobSuccee
 // fully relax is still better than no cache, and the guest write-probes the
 // share before trusting it. Cost is one walk of an already-cloned tree (the
 // clonefile itself is the expensive part), so this is not on the hot path.
-func chmodTreeGuestWritable(root string) {
-	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+func chmodTreeGuestWritable(root string) error {
+	return filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
-		if d.IsDir() {
-			_ = os.Chmod(p, 0o777)
-			return nil
-		}
-		// Symlinks have no mode of their own worth setting; chmod would follow to
-		// the target and could escape the tree.
+		// Symlinks have no mode of their own worth setting, and chmod would follow
+		// to the target — possibly outside the tree.
 		if d.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
-		_ = os.Chmod(p, 0o666)
-		return nil
+		mode := os.FileMode(0o666)
+		if d.IsDir() {
+			mode = 0o777
+		}
+		return os.Chmod(p, mode)
 	})
 }
 

--- a/infra/tart-kubelet/internal/podagent/volume.go
+++ b/infra/tart-kubelet/internal/podagent/volume.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -303,12 +304,20 @@ func (m *VolumeManager) Materialize(att VolumeAttachment, account string) (warm 
 		_ = os.Chmod(dest, 0o777)
 		return false, fmt.Errorf("swap materialized cache into place: %w", err)
 	}
-	// The cloned tree carries the MASTER's ownership/mode, not the branch's, so
-	// the guest's unprivileged runner user may be unable to write into the very
-	// root it was handed (it must create Plugins/, Binaries/, ... under it).
-	// AllocateBranch relaxes the branch root for exactly this reason; do the same
-	// for the materialized root so a warm job can write where a cold one could.
-	_ = os.Chmod(dest, 0o777)
+	// Relax the WHOLE materialized tree, not just its root.
+	//
+	// The clone carries the MASTER's ownership and mode: tart-kubelet runs as the
+	// host's console user (Virtualization.framework requires it), so every master
+	// it promotes is host-owned 0755, while the guest runs as its own
+	// unprivileged `runner` user. Across virtio-fs the two uids don't line up, so
+	// mode is the only lever we have — and a root-only chmod is not enough. The
+	// guest doesn't just create entries in `tuist/`; the CLI moves downloaded
+	// xcframeworks into `tuist/Binaries/<hash>` and prunes them again, which needs
+	// write on `Binaries/` itself, and re-signs artifacts in place, which needs
+	// write on the files. Relaxing only the root produced a job that could create
+	// `tuist/Plugins` and still died with
+	// `"X.xcframework" couldn't be moved to "<hash>"` (seen in production).
+	chmodTreeGuestWritable(dest)
 	// Mark the master used so LRU tracks materialization, not just promotion —
 	// an account whose jobs keep landing here stays hot.
 	_ = os.Chtimes(m.masterDir(account, att.VolumeName), m.now(), m.now())
@@ -478,6 +487,35 @@ func (m *VolumeManager) Finalize(att VolumeAttachment, account string, jobSuccee
 	_ = os.RemoveAll(att.BranchPath)
 	_ = os.Chtimes(master, m.now(), m.now())
 	return VolumeOutcomePromoted, nil
+}
+
+// chmodTreeGuestWritable makes every entry under root writable by the guest's
+// unprivileged user. Ownership can't be relied on (host and guest disagree on
+// uids across virtio-fs), so mode is the lever: directories get 0777 so the
+// guest can create, move and prune entries inside them; files get 0666 so it
+// can rewrite an artifact (the CLI re-signs on download).
+//
+// Best-effort per entry, and never fails the materialize: a tree we couldn't
+// fully relax is still better than no cache, and the guest write-probes the
+// share before trusting it. Cost is one walk of an already-cloned tree (the
+// clonefile itself is the expensive part), so this is not on the hot path.
+func chmodTreeGuestWritable(root string) {
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			_ = os.Chmod(p, 0o777)
+			return nil
+		}
+		// Symlinks have no mode of their own worth setting; chmod would follow to
+		// the target and could escape the tree.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		_ = os.Chmod(p, 0o666)
+		return nil
+	})
 }
 
 // ReattachBranch reconstructs the attachment for a VM whose branch survived a

--- a/infra/tart-kubelet/internal/podagent/volume_test.go
+++ b/infra/tart-kubelet/internal/podagent/volume_test.go
@@ -456,9 +456,17 @@ func TestMaterializeLeavesCacheRootGuestWritable(t *testing.T) {
 	m, _ := newTestManager(t, 100)
 	att := mustAllocate(t, m, "vm-warm")
 
-	// A master as Finalize stages it: restrictive mode, not guest-writable.
+	// A master as the host stages it: host-owned, restrictive, NOT guest-writable
+	// — including the subtree and the artifact inside it, which is what the CLI
+	// actually has to move into and rewrite.
 	master := filepath.Join(m.masterDir("42", ReservedTuistCacheVolume), cacheHomeSubdir)
 	if err := os.MkdirAll(filepath.Join(master, "Binaries"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(master, "Binaries", "marker"), []byte("cached"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(master, "Binaries"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Chmod(master, 0o700); err != nil {
@@ -477,6 +485,27 @@ func TestMaterializeLeavesCacheRootGuestWritable(t *testing.T) {
 	}
 	if fi.Mode().Perm() != 0o777 {
 		t.Errorf("materialized cache root mode = %#o, want 0777 so the guest can write it", fi.Mode().Perm())
+	}
+
+	// The root alone is NOT enough, and asserting only the root is why the
+	// incomplete fix shipped: the CLI moves downloaded xcframeworks into
+	// tuist/Binaries/<hash> and re-signs artifacts in place, so every directory
+	// AND file in the cloned tree must be guest-writable. Production failed with
+	// `"X.xcframework" couldn't be moved to "<hash>"` while the root was fine.
+	sub := filepath.Join(dest, "Binaries")
+	sfi, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("materialized Binaries/ missing: %v", err)
+	}
+	if sfi.Mode().Perm() != 0o777 {
+		t.Errorf("materialized Binaries/ mode = %#o, want 0777 — the CLI must be able to move artifacts into it", sfi.Mode().Perm())
+	}
+	ffi, err := os.Stat(filepath.Join(sub, "marker"))
+	if err != nil {
+		t.Fatalf("materialized artifact missing: %v", err)
+	}
+	if ffi.Mode().Perm()&0o222 == 0 {
+		t.Errorf("materialized artifact mode = %#o, want writable — the CLI re-signs artifacts in place", ffi.Mode().Perm())
 	}
 }
 


### PR DESCRIPTION
Follow-up to #11869, which shipped an **incomplete** fix. Found by re-enabling the volume on production: the team's real `cli.yml` **`Cache` job failed**.

```
Failed to download VendoredCSystem with hash 64f3307f… due to unexpected error:
  "VendoredCSystem.xcframework" couldn't be moved to "64f3307f…"
```

## Root cause (proven on a prod mini, not theorised)

```
/Volumes/tuist-runner-cache/3/tuist-cache/master/tuist
drwxr-xr-x  11 m1  admin        ← host-owned, 0755
```

`tart-kubelet` runs as the host's **console user** (Virtualization.framework requires it), so every master it promotes is **host-owned `0755`**. The guest runs as its own unprivileged **`runner`** user and the uids don't line up across virtio-fs — **mode is the only lever**. `Materialize` clones the master in, so the guest inherits that tree.

#11869 chmod'd **only the root**, so a job could create `tuist/Plugins` and still die moving an xcframework into `tuist/Binaries/<hash>`. **Write on the root says nothing about write on the subtree.**

## The fix: settle it on the host

`Materialize` now relaxes the **entire cloned tree** (dirs `0777`, files `0666` — the CLI re-signs artifacts in place; symlinks skipped so chmod can't follow out of the tree), and **failure aborts the materialize**, leaving an empty writable root so the job runs cold.

**We either hand over a provably writable tree, or none at all.** This is the only place it *can* be settled: `0777` is uid-independent, so a tree the host successfully relaxes is writable by the guest whatever its uid.

## And stop the guest guessing

The guest's write-probing was **papering over host bugs, and decorative**. The master carries **9+ subtrees** (`Binaries`, `EditProjects`, `GenerationMetadata`, `Manifests`, `Plugins`, `ProjectDescriptionHelpers`, `Projects`, `Runs`, `SelectiveTests`) — a probe only covers what someone remembered to list, so it passes while the share is broken. That's not hypothetical: **the root-only probe did exactly that in production, rubber-stamping the failure it existed to catch.**

`cache_root_usable()` now checks only what the guest can genuinely know: it can create its own cache root. Plus the existing "share absent" and "cache-ready never arrived (host wedged)" fallbacks. No permission guessing.

## Tests

- `TestMaterializeLeavesCacheRootGuestWritable` asserts the **subtree and the artifact** are writable, and is **verified to FAIL** against the old root-only chmod.
- **Deleted** a test that could only ever *skip* (the walk relaxes each dir before descending, repairing the condition it tried to simulate). A test that cannot fail is worse than no test — that's the mistake this whole PR is about.

## Safety

Production is protected by `--runner-cache-volume-gib=0` (chart default from #11869); I reverted the ephemeral `gib=80` the moment this surfaced and verified on the host (`cache-root flag: ABSENT`). This only matters when the volume is re-enabled — which shouldn't happen until a **warm** job with a **populated binary cache** (`tuist cache`, i.e. `cli.yml` — not `app.yml`, whose master is 2.3 MB and proves nothing) is green on staging.