### PR TITLE
fix(cli): skip CAS setup on older release lines

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -74,8 +74,10 @@ jobs:
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       # Install the Rust toolchain the cas-plugin bundle needs, resolving its
       # version from cas-plugin/mise.toml rather than pinning it here (single
-      # source of truth, matching how kura pins its toolchain).
+      # source of truth, matching how kura pins its toolchain). Older release
+      # branches that predate cas-plugin do not need this toolchain.
       - uses: jdx/mise-action@v4.0.1
+        if: ${{ hashFiles('cas-plugin/mise.toml') != '' }}
         with:
           version: ${{ env.MISE_VERSION }}
           install_args: rust


### PR DESCRIPTION
## What changed

The reusable CLI release workflow now installs the Rust toolchain for the CAS plugin only when the checked-out release source contains `cas-plugin/mise.toml`.

Current release sources still run the existing CAS setup unchanged. Older stable lines that predate the CAS plugin skip only that toolchain setup step.

## Why

The backport workflow intentionally combines current release tooling from `main` with source from the selected stable branch. The current reusable workflow unconditionally configures mise with `working_directory: cas-plugin`, but `releases/4.202.x` predates that directory.

The 4.202.4 macOS job therefore failed during bootstrap with:

`The cwd: cas-plugin does not exist!`

It never reached authentication, dependency installation, or the source build.

## Root cause

CAS plugin toolchain setup was added for current CLI releases without a presence guard for historical source refs. Since reusable workflow steps run after checking out the requested source SHA, the working directory must be treated as optional across backport lines.

Using `hashFiles('cas-plugin/mise.toml')` ties the setup to the same file that supplies the Rust version and avoids hard-coding release versions or branch names.

## Impact

Backport releases from branches created before `cas-plugin` can complete their macOS bundle. Current releases continue installing Rust and bundling the CAS plugin as before.

## Validation

- Confirmed `cas-plugin` and `cas-plugin/mise.toml` are absent from `releases/4.202.x`
- Confirmed the failed macOS job selected version `4.202.4` and ref `9fc69a84dd34b7957bfc725d04e40f1c10639b6e` before failing at the missing working directory
- `git diff --check`
- `actionlint .github/workflows/cli-build-publish.yml` parsed the new `hashFiles` guard; reported findings remain the existing custom-runner labels and unrelated shell warnings