### PR TITLE
fix(cli): serialize Linux release downloads

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -214,6 +214,11 @@ jobs:
               "$ACCOUNT_HOME/.swiftpm"
             sleep $((attempt * 10))
           done
+        env:
+          # Swift 6.2.4's registry client otherwise downloads up to one package
+          # per CPU concurrently, which can trigger FoundationNetworking's
+          # redirect handling crash before the CLI starts compiling.
+          SWIFTPM_MAX_CONCURRENT_OPERATIONS: 1
 
       - name: Upload CLI Linux artifacts
         id: upload


### PR DESCRIPTION
## What changed

Set `SWIFTPM_MAX_CONCURRENT_OPERATIONS=1` for the Linux CLI bundle step in the reusable release workflow. The existing bounded retries and cache cleanup remain in place.

## Why

The `4.202.4` backport release repeatedly failed before compilation while SwiftPM downloaded registry archives in the `swift:6.2` container. Every clean attempt terminated in FoundationNetworking's `EasyHandle.swift` with libcurl code 43. The cache cleanup added in the preceding workflow fix worked as intended—subsequent attempts reinstalled the SDK and started from empty SwiftPM state—but the downloader still crashed.

SwiftPM 6.2.4 creates its registry `HTTPClient` with a token count derived from `Concurrency.maxOperations`, which defaults to the container's active CPU count. That lets many redirected registry downloads run at once and exposes the concurrent redirect bug in the FoundationNetworking version shipped by this pinned toolchain.

## Approach

Use SwiftPM's supported `SWIFTPM_MAX_CONCURRENT_OPERATIONS` control to serialize registry network operations in the affected Linux bundle jobs. This is applied at the workflow step rather than changing an older release branch's build script, so current release infrastructure remains compatible with supported backport lines.

The build's compiler-worker count is configured independently from this environment value, so compilation still uses the runner's normal parallelism. This avoids the broader compatibility risk of changing the release compiler/toolchain solely to pick up a newer FoundationNetworking implementation.

## Buggy behavior and impact

On both x86_64 and aarch64 Linux release jobs, SwiftPM began fetching dozens of registry packages concurrently and aborted in `FoundationNetworking/EasyHandle.swift:293` with `libcurl.Easy Code=43`. No Linux archives were uploaded, which prevented the backport release from being published even though the release source itself was valid.

With the environment override, SwiftPM's HTTP token bucket contains one token, preventing the concurrent redirected requests that trigger the crash while leaving the remainder of the release build unchanged.

## Validation

- Confirmed three clean attempts in backport release run `29523927918` all reproduced the same libcurl code 43 failure, ruling out stale cache state.
- Inspected the exact SwiftPM `swift-6.2.4-RELEASE` source: `Concurrency.maxOperations` reads `SWIFTPM_MAX_CONCURRENT_OPERATIONS`, and the registry HTTP client uses that value for its request token bucket.
- Confirmed SwiftPM build workers are independently derived from `--jobs` or active processor count.
- Ran `git diff --check`.
- Ran `actionlint .github/workflows/cli-build-publish.yml`; the edited block parsed successfully. Existing warnings remain for repository-specific runner labels and unrelated shell code around line 100.
