### PR TITLE
chore(kura): drop debug info for dependencies in dev builds

### DIFF
--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -59,3 +59,9 @@ tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 [dev-dependencies]
 tempfile = "3.23.0"
 tokio = { version = "1.48.0", features = ["test-util"] }
+
+[profile.dev.package."*"]
+debug = false
+
+[profile.dev.build-override]
+debug = false


### PR DESCRIPTION
Cuts a clean Kura dev build from 4.5 GiB to 2.0 GiB by dropping debug info for dependencies, while leaving Kura's own debuggability and production binaries untouched.

### Why

`kura/Cargo.toml` had no `[profile]` section at all, so every dev build ran on cargo's defaults: `debug = 2` applied uniformly across the entire dependency graph. That means full DWARF for all 418 crates in the lockfile, plus the vendored C/C++ (RocksDB, aws-lc, mlua, jemalloc).

The dominant cost is RocksDB. `librocksdb-sys 0.17.3+10.4.2` vendors RocksDB 10.4.2 and compiles all 720 of its `.cc` files from source. Cargo passes the profile's `debug` setting to build scripts through the `DEBUG` env var, and the `cc` crate turns that into `-g`, so we were carrying full debug symbols for a C++ codebase nobody steps into. That single dependency was 1.6 GiB of a 4.5 GiB build.

`build-override` is included because the `package."*"` glob does not reach build scripts and proc macros.

### Measured impact

Both builds were clean, from scratch, into fresh target directories:

| | before | after |
|---|---|---|
| **total** | **4.5 GiB** | **2.0 GiB** |
| `deps/` | 2.3G | 1.2G |
| `build/` (vendored C/C++) | 1.7G | 348M |
| ⌞ `librocksdb-sys` | 1.6G | 198M |
| `incremental/` | 163M | 162M |
| `libkura.rlib` | 208M | **208M** |
| `kura` binary | 99M | 86M |

`libkura.rlib` is unchanged byte-for-byte. Kura's own code keeps `debug = 2`, so stepping through it in a debugger works exactly as before. The only thing lost is stepping into dependency internals (tokio, rustls, RocksDB).

Production is unaffected: the `release` profile already defaults to `debug = 0`, and this change only touches `dev`. `[profile.test]` inherits from `dev`, so tests are covered too.

### Why not link a prebuilt RocksDB

`librocksdb-sys` supports skipping the source build via `ROCKSDB_LIB_DIR` (with `ROCKSDB_INCLUDE_DIR` and `ROCKSDB_STATIC`), which would remove the RocksDB build entirely rather than merely shrinking it. It was rejected as a bad trade:

- The crate pins RocksDB **10.4.2**; Homebrew's current stable is **11.1.2**, a major version apart. `bindgen` generates bindings from whatever `ROCKSDB_INCLUDE_DIR` points at, so this risks generating 11.x bindings for a crate written against 10.4.2 and linking an 11.x library. For the storage engine behind a cache, that is an ABI-mismatch class of bug.
- A system build would also have to match our `lz4` feature, and it would introduce local/production divergence on exactly the component where we least want it.
- Making it safe means building and pinning our own 10.4.2 for every dev machine and CI image, which is real infrastructure to save something this change already gets for free (an 8x cut on RocksDB, zero risk, one line).

### How to test locally

From `kura/`, build into a scratch target directory and check the size:

```
CARGO_TARGET_DIR=/tmp/kura-check cargo build
du -sh /tmp/kura-check
```

This should report roughly 2.0G rather than 4.5G. To confirm debuggability is preserved, `du -sh /tmp/kura-check/debug/libkura.rlib` should still report 208M.

### Not addressed here

This change halves the cost of each build, but it is not the whole disk story. A `target/` directory observed at 23 GiB is roughly 5x a single clean build; the excess is accumulation, since cargo never garbage-collects `target/` (stale artifacts under multiple hashes, a parallel `release/` tree, incremental caches). Two follow-ups are worth considering separately:

- A shared `CARGO_TARGET_DIR`. The kura lockfiles are byte-identical across worktrees, so the dependency set and the RocksDB build would be compiled and stored once instead of per-worktree. RocksDB is already cached per target directory rather than rebuilt per compile, so the cost today is one RocksDB build per target directory.
- Periodic reclamation (`cargo-sweep` or `cargo clean`), since nothing in cargo will reclaim the accumulated space on its own.
