### PR TITLE
feat(kura): make membership churn and discarded bootstrap completions observable

### DIFF
--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -129,6 +129,9 @@ pub struct Metrics {
     traffic_state: Gauge,
     ready_state: Gauge,
     drain_state: Gauge,
+    membership_generation: Gauge,
+    membership_peer_changes: Family<MembershipChangeLabels, Counter>,
+    bootstrap_completions_discarded: Counter,
     initial_discovery_completed: Gauge,
     writer_lock_owned: Gauge,
     writer_lock_acquire_failures: Counter,
@@ -285,6 +288,9 @@ impl Metrics {
         let traffic_state = Gauge::default();
         let ready_state = Gauge::default();
         let drain_state = Gauge::default();
+        let membership_generation = Gauge::default();
+        let membership_peer_changes = Family::<MembershipChangeLabels, Counter>::default();
+        let bootstrap_completions_discarded = Counter::default();
         let initial_discovery_completed = Gauge::default();
         let writer_lock_owned = Gauge::default();
         let writer_lock_acquire_failures = Counter::default();
@@ -780,6 +786,21 @@ impl Metrics {
             ready_state.clone(),
         );
         registry.register(
+            "kura_membership_generation",
+            "Membership view generation; increments on every peer topology change, so a climbing value means the peer set is flapping",
+            membership_generation.clone(),
+        );
+        registry.register(
+            "kura_membership_peer_changes_total",
+            "Peers that entered (change=discovered) or left (change=lost) the membership view",
+            membership_peer_changes.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_completions_discarded_total",
+            "Completed bootstrap passes discarded because the peer left the membership view or the bootstrap epoch was reset mid-pass",
+            bootstrap_completions_discarded.clone(),
+        );
+        registry.register(
             "kura_drain_state",
             "Current drain state for this node: 1=draining, 0=not draining",
             drain_state.clone(),
@@ -922,6 +943,9 @@ impl Metrics {
             traffic_state,
             ready_state,
             drain_state,
+            membership_generation,
+            membership_peer_changes,
+            bootstrap_completions_discarded,
             initial_discovery_completed,
             writer_lock_owned,
             writer_lock_acquire_failures,
@@ -1580,6 +1604,26 @@ impl Metrics {
             .set(if writer_lock_owned { 1 } else { 0 });
     }
 
+    pub fn update_membership_generation(&self, generation: u64) {
+        self.membership_generation
+            .set(i64::try_from(generation).unwrap_or(i64::MAX));
+    }
+
+    pub fn record_membership_peer_changes(&self, change: &str, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.membership_peer_changes
+            .get_or_create(&MembershipChangeLabels {
+                change: change.to_owned(),
+            })
+            .inc_by(count as u64);
+    }
+
+    pub fn record_bootstrap_completion_discarded(&self) {
+        self.bootstrap_completions_discarded.inc();
+    }
+
     pub fn record_writer_lock_acquire_failure(&self) {
         self.writer_lock_acquire_failures.inc();
     }
@@ -1833,6 +1877,11 @@ struct GeoIpRefreshLabels {
     result: String,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct MembershipChangeLabels {
+    change: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1926,6 +1975,10 @@ mod tests {
         metrics.update_background_work_paused("outbox", true);
         metrics.record_memory_action("manifest_cache_trim");
         metrics.update_runtime_state(1, true, false, true, true);
+        metrics.update_membership_generation(7);
+        metrics.record_membership_peer_changes("lost", 1);
+        metrics.record_membership_peer_changes("discovered", 2);
+        metrics.record_bootstrap_completion_discarded();
         metrics.record_writer_lock_acquire_failure();
         metrics.record_node_geo(&NodeLocation {
             country: Some("US".into()),
@@ -2039,6 +2092,11 @@ mod tests {
         assert!(rendered.contains("kura_memory_actions_total"));
         assert!(rendered.contains("kura_traffic_state"));
         assert!(rendered.contains("kura_ready_state"));
+        assert!(rendered.contains("kura_membership_generation"));
+        assert!(rendered.contains("kura_membership_peer_changes_total"));
+        assert!(rendered.contains("change=\"lost\""));
+        assert!(rendered.contains("change=\"discovered\""));
+        assert!(rendered.contains("kura_bootstrap_completions_discarded_total"));
         assert!(rendered.contains("kura_drain_state"));
         assert!(rendered.contains("kura_initial_discovery_completed"));
         assert!(rendered.contains("kura_writer_lock_owned"));

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -787,7 +787,7 @@ impl Metrics {
         );
         registry.register(
             "kura_membership_generation",
-            "Membership view generation; increments on every peer topology change, so a climbing value means the peer set is flapping",
+            "Membership view generation; increments on every peer topology change",
             membership_generation.clone(),
         );
         registry.register(
@@ -797,7 +797,7 @@ impl Metrics {
         );
         registry.register(
             "kura_bootstrap_completions_discarded_total",
-            "Completed bootstrap passes discarded because the peer left the membership view or the bootstrap epoch was reset mid-pass",
+            "Completed bootstrap passes that did not count toward the readiness gate",
             bootstrap_completions_discarded.clone(),
         );
         registry.register(

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -786,6 +786,11 @@ impl Metrics {
             ready_state.clone(),
         );
         registry.register(
+            "kura_drain_state",
+            "Current drain state for this node: 1=draining, 0=not draining",
+            drain_state.clone(),
+        );
+        registry.register(
             "kura_membership_generation",
             "Membership view generation; increments on every peer topology change",
             membership_generation.clone(),
@@ -799,11 +804,6 @@ impl Metrics {
             "kura_bootstrap_completions_discarded_total",
             "Completed bootstrap passes that did not count toward the readiness gate",
             bootstrap_completions_discarded.clone(),
-        );
-        registry.register(
-            "kura_drain_state",
-            "Current drain state for this node: 1=draining, 0=not draining",
-            drain_state.clone(),
         );
         registry.register(
             "kura_initial_discovery_completed",
@@ -2094,8 +2094,8 @@ mod tests {
         assert!(rendered.contains("kura_ready_state"));
         assert!(rendered.contains("kura_membership_generation"));
         assert!(rendered.contains("kura_membership_peer_changes_total"));
-        assert!(rendered.contains("change=\"lost\""));
-        assert!(rendered.contains("change=\"discovered\""));
+        assert!(rendered.contains("change=\"lost\"} 1"));
+        assert!(rendered.contains("change=\"discovered\"} 2"));
         assert!(rendered.contains("kura_bootstrap_completions_discarded_total"));
         assert!(rendered.contains("kura_drain_state"));
         assert!(rendered.contains("kura_initial_discovery_completed"));

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -11,6 +11,8 @@ use tokio::{
     time::{Duration, Instant},
 };
 
+use tracing::{info, warn};
+
 use crate::{
     analytics::Analytics,
     bandwidth::BandwidthLimiter,
@@ -255,13 +257,16 @@ impl ReadinessState {
         true
     }
 
-    fn note_bootstrap_succeeded(&mut self, peer: &str, epoch: u64) {
+    fn note_bootstrap_succeeded(&mut self, peer: &str, epoch: u64) -> bool {
         self.bootstrap_inflight_peers.remove(peer);
         // A completion from a pass started before the last progress reset does
         // not count as bootstrapped; the peer re-enters peers_needing_bootstrap
         // and gets a fresh pass.
         if epoch == self.bootstrap_epoch && self.known_peers.contains(peer) {
             self.bootstrapped_peers.insert(peer.to_string());
+            true
+        } else {
+            false
         }
     }
 
@@ -358,7 +363,7 @@ impl AppState {
     ) -> MembershipUpdate {
         let known_peers = peer_nodes.keys().cloned().collect::<BTreeSet<_>>();
 
-        {
+        let membership_update = {
             let mut readiness = self.readiness.lock().await;
             let membership_update = readiness.apply_membership(
                 members,
@@ -370,7 +375,27 @@ impl AppState {
                 self.runtime.clear_serving();
             }
             membership_update
+        };
+        // A lost peer silently drops its bootstrapped mark and re-enters the
+        // bootstrap gate when it returns, so topology changes must be loud:
+        // a flapping peer set is the difference between a 30-minute bootstrap
+        // and one that never converges.
+        if !membership_update.lost_peers.is_empty() {
+            warn!(
+                "membership changed: lost peers {:?} (discovered {:?}); their bootstrapped state is forgotten until they are re-bootstrapped",
+                membership_update.lost_peers, membership_update.discovered_peers
+            );
+        } else if !membership_update.discovered_peers.is_empty() {
+            info!(
+                "membership changed: discovered peers {:?}",
+                membership_update.discovered_peers
+            );
         }
+        self.metrics
+            .record_membership_peer_changes("discovered", membership_update.discovered_peers.len());
+        self.metrics
+            .record_membership_peer_changes("lost", membership_update.lost_peers.len());
+        membership_update
     }
 
     pub async fn peers_needing_bootstrap(&self) -> Vec<String> {
@@ -413,10 +438,22 @@ impl AppState {
     }
 
     pub async fn note_bootstrap_succeeded(&self, peer: &str, epoch: u64) {
-        self.readiness
+        let recorded = self
+            .readiness
             .lock()
             .await
             .note_bootstrap_succeeded(peer, epoch);
+        if !recorded {
+            // The pass ran to completion but no longer counts toward the
+            // readiness gate — the peer flapped out of the membership view or
+            // the bootstrap epoch was reset mid-pass. The peer gets a fresh
+            // pass, so repeated discards are how a bootstrap loops forever
+            // without ever logging a failure.
+            warn!(
+                "bootstrap completion for {peer} discarded (membership changed or epoch reset mid-pass); the peer will be re-bootstrapped"
+            );
+            self.metrics.record_bootstrap_completion_discarded();
+        }
     }
 
     #[cfg(test)]
@@ -603,6 +640,7 @@ impl AppState {
             report.initial_discovery_completed,
             report.writer_lock_owned,
         );
+        self.metrics.update_membership_generation(report.generation);
         self.metrics.update_bootstrap_peers(
             report.known_peers.len(),
             report.bootstrapped_peers.len(),

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -377,11 +377,13 @@ impl AppState {
             membership_update
         };
         // A lost peer silently drops its bootstrapped mark and re-enters the
-        // bootstrap gate when it returns, so topology changes must be loud:
-        // a flapping peer set is the difference between a 30-minute bootstrap
-        // and one that never converges.
+        // bootstrap gate when it returns; a flapping peer set is the difference
+        // between a 30-minute bootstrap and one that never converges. Lost
+        // peers are routine on rolling deploys and scale-downs, so this logs at
+        // info and the kura_membership_peer_changes_total{change="lost"} counter
+        // carries the alerting signal.
         if !membership_update.lost_peers.is_empty() {
-            warn!(
+            info!(
                 "membership changed: lost peers {:?} (discovered {:?}); their bootstrapped state is forgotten until they are re-bootstrapped",
                 membership_update.lost_peers, membership_update.discovered_peers
             );
@@ -749,13 +751,14 @@ mod tests {
         // must not mark the peer bootstrapped.
         let stale_epoch = readiness.bootstrap_epoch;
         readiness.reset_bootstrap_progress(now);
-        readiness.note_bootstrap_succeeded(&peer, stale_epoch);
+        assert!(!readiness.note_bootstrap_succeeded(&peer, stale_epoch));
 
         assert_eq!(readiness.peers_needing_bootstrap(), vec![peer.clone()]);
 
         // A fresh pass under the current epoch counts.
         assert!(readiness.note_bootstrap_started(&peer));
-        readiness.note_bootstrap_succeeded(&peer, readiness.bootstrap_epoch);
+        let fresh_epoch = readiness.bootstrap_epoch;
+        assert!(readiness.note_bootstrap_succeeded(&peer, fresh_epoch));
         assert!(readiness.peers_needing_bootstrap().is_empty());
     }
 
@@ -907,6 +910,78 @@ mod tests {
                 .reasons
                 .iter()
                 .any(|reason| reason.contains("discovery settling"))
+        );
+    }
+
+    fn rendered_metric_value(rendered: &str, selector: &str) -> Option<u64> {
+        rendered
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .find(|line| line.contains(selector))
+            .and_then(|line| line.split_whitespace().last())
+            .and_then(|value| value.parse().ok())
+    }
+
+    #[tokio::test]
+    async fn app_state_records_membership_peer_change_metrics() {
+        let context = test_context(|_| {}).await;
+        let peer_a = "http://peer-a.kura.internal:7443".to_string();
+        let peer_b = "http://peer-b.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote-a".to_string()]),
+                BTreeMap::from([(peer_a.clone(), "remote-a".to_string())]),
+                true,
+            )
+            .await;
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote-b".to_string()]),
+                BTreeMap::from([(peer_b.clone(), "remote-b".to_string())]),
+                true,
+            )
+            .await;
+
+        let rendered = context.state.metrics.render();
+        assert_eq!(
+            rendered_metric_value(&rendered, "change=\"discovered\"}"),
+            Some(2)
+        );
+        assert_eq!(
+            rendered_metric_value(&rendered, "change=\"lost\"}"),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn app_state_records_discarded_bootstrap_completion_metric() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote".to_string()]),
+                BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
+            )
+            .await;
+
+        let stale_epoch = context.state.current_bootstrap_epoch().await;
+        context.state.note_bootstrap_started(&peer).await;
+        // A recovery re-enrollment resets progress while the pass is in flight,
+        // so the completion arrives under a stale epoch and is discarded.
+        context.state.reset_bootstrap_progress().await;
+        context
+            .state
+            .note_bootstrap_succeeded(&peer, stale_epoch)
+            .await;
+
+        let rendered = context.state.metrics.render();
+        assert_eq!(
+            rendered_metric_value(&rendered, "kura_bootstrap_completions_discarded"),
+            Some(1)
         );
     }
 }


### PR DESCRIPTION
## What

Makes the silent membership/bootstrap transitions observable, three instruments plus logs:

- **`kura_membership_generation`** (gauge) — the membership view generation, exported every second by `sync_runtime_metrics`. A climbing value means the peer set is flapping.
- **`kura_membership_peer_changes_total{change="discovered"|"lost"}`** (counter) — peers entering/leaving the membership view.
- **`kura_bootstrap_completions_discarded_total`** (counter) — completed bootstrap passes that didn't count toward the readiness gate because the peer left the view or the epoch was reset mid-pass.
- **Logs at the same sites**: `info!` on discovered and lost peers — membership changes are routine (peers drop on every rolling deploy/scale-down), so the `{change="lost"}` counter is the alerting primitive; `warn!` on discarded pass completions, which is the actual anomaly.

## Why

During the 2026-07-16 production incident, `kura-tuist-eu-central-1` sat at 0/2 ready for 4+ hours while both replicas re-downloaded the legacy scw peer's **static** ~2 GB / 85k-artifact dataset **~16 times** (1.38M bootstrap fetches served, all 200s) — and emitted **zero log lines** doing it. Every loud failure path (`bootstrap from … incomplete/failed … will retry`) was ruled out via Loki; what remained were the silent paths in the heartbeat-driven membership machinery (#11725):

- `apply_membership` (`src/state.rs`) rebuilds `known_peers` from each 2.5s `/status` poll and applies it unconditionally — **one missed poll** deletes the peer's `bootstrapped` mark and re-enters it into the bootstrap gate when it answers again;
- `note_bootstrap_succeeded` discards a finished pass if the peer isn't in `known_peers` at completion time (or the epoch was reset);
- neither path logged, and `generation` — the one value that directly reveals the churn — was not exported.

This is self-sustaining under load: a peer busy serving ~100 req/s of bootstrap fetches occasionally misses a poll → flap → marks dropped, fresh passes spawn → sustained load → more misses. Rolling updates never trigger it (one pod bootstraps at a time); a simultaneous cold boot of both replicas (taint eviction after a node flap) did.

Full diagnosis: [incident report](https://artifacts.nunes.dev/a/019f6c40-269d-739b-9deb-40b56d13969c/kura-incident-report.html) (tuist.dev domain access).

## Why logs *and* metrics

During the incident the reliable signal for the stuck replicas was their **container logs** (verified flowing through Loki), so these log lines make the diagnosis available the moment an instrumented image reaches even one stuck replica:

```
{cluster="tuist-production", namespace="kura", service_name="kura"}
  | pod=~"kura-tuist-eu-central-1-.*" |~ "membership changed|completion.*discarded"
```

The `kura_membership_generation` gauge also enables an alert on sustained generation growth.

## Rollout safety

Additive only: new metrics, new log lines, one internal function now returns `bool`. No wire-format, on-disk, or protocol changes; safe under one version skew.

## Validation

- `cargo test --lib` — 346 passed (includes new state-path tests for the membership counters and the discarded-completion path, plus render assertions with exact metric values)
- `cargo clippy --all-targets -- -D warnings` — clean
- `mise run format -- --check` (rules_rust rustfmt aspect) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
