### PR TITLE
fix(infra): release runner Pods orphaned on deleted Nodes

### DIFF
--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -36,12 +36,31 @@ independent workqueues:
   is neither alive nor DeletionTimestamp-free. Upstream PodGC can't
   break the tie either, since it only issues a Delete. This is a real
   production failure (Pods surviving 22h+ on released minis), and
-  orphaned Pods on deleted Nodes have wedged `helm --wait` before. The
-  sweep no-ops unless the Node view is usable — an unsynced Node
-  informer reads as zero Nodes, not as an error, and acting on that
-  would delete the fleet mid-job — and it only ever strips
-  tart-kubelet's own finalizer, never a foreign one whose owner may
-  still be alive.
+  orphaned Pods on deleted Nodes have wedged `helm --wait` before.
+
+  The sweep runs on **both** the steady-state path and `reconcileDelete`.
+  The drain needs it just as much: an orphan that still carries its
+  claim-time owner label reads as `running` forever, holding the CR in
+  Terminating and wedging the `helm --wait` behind a pool rename, and
+  deleting the CR is the one path where nothing reconciles again later to
+  catch up.
+
+  Three guards bound the blast radius, all load-bearing — **every live
+  macOS runner Pod carries the `vm-cleanup` finalizer and no
+  deletionTimestamp**, so Node existence is the only thing separating a
+  busy runner from a wedged orphan, and a wrong answer deletes a job:
+  - A cached Node miss is a suspicion, not a verdict. Pod and Node
+    informers are independent watch streams with no atomic cross-type
+    view, so a live Node can be transiently absent from the Node cache
+    while a Pod already bound to it is visible. Every suspect is
+    re-checked against the apiserver through the uncached `APIReader`,
+    and only a definite NotFound counts as gone.
+  - No `APIReader` means no sweep. Unwired plumbing should cost cleanup,
+    never jobs.
+  - It no-ops unless the cached Node view is usable (an unsynced informer
+    reads as zero Nodes, not as an error), and only ever strips
+    tart-kubelet's own finalizer, never a foreign one whose owner may
+    still be alive.
 
 - **`AutoscalerReconciler`** — on a 5-second cadence, calls the
   server's `/api/internal/runners/desired_replicas` endpoint and

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -17,10 +17,31 @@ independent workqueues:
   finalizer holds the CR Terminating, reaps only idle Pods, and waits
   for mid-job Pods to finish their single-shot job before releasing.
   When it reaps a terminal Pod it logs the `runner` container's
-  `exitCode`/`reason` first — the durable, image-independent post-mortem
-  fingerprint for a runner that "lost communication" (0 = clean,
-  137+OOMKilled = host OOM, 137+Error = guest OOM / in-VM kill, signal
-  15 = SIGTERM, other = crash), captured before the Pod is gone.
+  `exitCode`/`reason` first — the durable post-mortem fingerprint for a
+  runner that "lost communication" (0 = clean, 137+OOMKilled = host OOM,
+  137+Error = guest OOM / in-VM kill, signal 15 = SIGTERM, other =
+  crash), captured before the Pod is gone. Note this fires for Linux
+  Pods only: tart-kubelet never publishes a terminated container state
+  (it only ever synthesizes *running* statuses), so `runnerTerminated`
+  returns nil for the whole macOS fleet and those Pods reap silently.
+
+  **Orphan sweep.** A Pod bound to a Node that no longer exists is
+  released: tart-kubelet's `vm-cleanup` finalizer is stripped, then the
+  Pod + SA are reaped. That finalizer is node-local — only the podagent
+  on the Pod's *own* host removes it — so once the CAPI provider
+  releases a Mac mini and deletes its Node object, nothing is left alive
+  to clean up Pods still bound to it. Without the sweep such a Pod is
+  immortal: the reap's Delete sets a deletionTimestamp, the finalizer
+  blocks collection, and every later reconcile skips the Pod because it
+  is neither alive nor DeletionTimestamp-free. Upstream PodGC can't
+  break the tie either, since it only issues a Delete. This is a real
+  production failure (Pods surviving 22h+ on released minis), and
+  orphaned Pods on deleted Nodes have wedged `helm --wait` before. The
+  sweep no-ops unless the Node view is usable — an unsynced Node
+  informer reads as zero Nodes, not as an error, and acting on that
+  would delete the fleet mid-job — and it only ever strips
+  tart-kubelet's own finalizer, never a foreign one whose owner may
+  still be alive.
 
 - **`AutoscalerReconciler`** — on a 5-second cadence, calls the
   server's `/api/internal/runners/desired_replicas` endpoint and

--- a/infra/runners-controller/cmd/manager/main.go
+++ b/infra/runners-controller/cmd/manager/main.go
@@ -107,6 +107,7 @@ func main() {
 
 	if err := (&controllers.RunnerPoolReconciler{
 		Client:              mgr.GetClient(),
+		APIReader:           mgr.GetAPIReader(),
 		Scheme:              mgr.GetScheme(),
 		DispatchURL:         dispatchURL,
 		DispatchInternalURL: dispatchInternalURL,

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -69,6 +69,25 @@ type RunnerPoolReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
+	// APIReader is an uncached, direct-to-apiserver reader used to
+	// confirm a Node is really gone before the orphan sweep deletes
+	// anything bound to it. Set from `mgr.GetAPIReader()`.
+	//
+	// The cached client cannot answer this question safely. Pod and Node
+	// informers are independent watch streams with no atomic cross-type
+	// view, so a Node that exists can be transiently absent from the Node
+	// cache while a Pod already bound to it is visible in the Pod cache —
+	// exactly the shape of a fleet where minis join and are released
+	// continuously. Believing the cache there means deleting a healthy
+	// runner mid-job: every live macOS runner Pod carries tart-kubelet's
+	// finalizer and no deletionTimestamp, so Node existence is the ONLY
+	// thing separating "busy runner" from "wedged orphan" — there is no
+	// second signal to fall back on.
+	//
+	// nil disables the sweep entirely (see confirmedOrphans). Failing
+	// closed on unwired plumbing loses cleanup; failing open loses jobs.
+	APIReader client.Reader
+
 	// DispatchURL is the customer-server's runner dispatch endpoint
 	// threaded into every Pod via env. Set from the manager's
 	// --dispatch-url flag. Used as-is for macOS pools (Tart VMs
@@ -168,16 +187,15 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("list pods: %w", err)
 	}
 
-	// Live Node view for the orphan sweep below. Gathered once per
-	// reconcile and shared with the phase-count loop so a Pod stranded on
-	// a deleted Node isn't reported as warm capacity it can no longer
-	// provide.
-	liveNodes, nodesUsable := r.liveNodeNames(ctx)
+	// Orphan verdict for the sweep below. Resolved once per reconcile and
+	// shared with the phase-count loop so a Pod stranded on a deleted Node
+	// isn't reported as warm capacity it can no longer provide.
+	orphans := r.confirmedOrphans(ctx, pods.Items)
 
 	phaseReplicas := podPhaseReplicaCounts{}
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		if isAlive(p) && !(nodesUsable && isOrphaned(p, liveNodes)) {
+		if isAlive(p) && !orphans[p.Name] {
 			phaseReplicas.add(p)
 		}
 	}
@@ -209,7 +227,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// upstream PodGC's orphan collection only issues a Delete, which
 		// a finalizer blocks. Release it before the branches below, which
 		// all assume a Pod whose host is still around to act on it.
-		if nodesUsable && isOrphaned(p, liveNodes) {
+		if orphans[p.Name] {
 			if err := r.releaseOrphanedRunner(ctx, p); err != nil {
 				logger.Error(err, "release orphaned runner; will retry next tick",
 					"pod", p.Name, "node", p.Spec.NodeName)
@@ -398,7 +416,9 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // are left to finish their single-shot lifecycle. The CR stays
 // Terminating until no live Pod remains, so GC never cascade-deletes
 // a mid-job runner. Terminal Pods and the per-Pod SAs are collected
-// by GC alongside the CR once the finalizer clears.
+// by GC alongside the CR once the finalizer clears — except for
+// orphans, which the sweep has to release explicitly because a held
+// finalizer blocks the GC this path otherwise leans on.
 func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv1.RunnerPool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("pool", client.ObjectKeyFromObject(pool))
 
@@ -415,11 +435,32 @@ func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv
 		return ctrl.Result{}, fmt.Errorf("list pods: %w", err)
 	}
 
+	// The drain needs the same orphan sweep as the steady-state path, and
+	// needs it first. A Pod whose host is gone is neither draining nor
+	// collectable, and both of the branches below get it wrong: a busy-
+	// looking orphan counts as `running` forever, holding the CR in
+	// Terminating and wedging the `helm --wait` that a pool rename or
+	// removal triggers; a terminal one is left to a GC that a held
+	// finalizer blocks, stranding exactly the Pod this controller exists
+	// to release. Deleting the CR is also the one path where nothing ever
+	// reconciles again to catch up later.
+	orphans := r.confirmedOrphans(ctx, pods.Items)
+
 	running := 0
 	drainedIdle := 0
+	orphaned := 0
 	for i := range pods.Items {
 		p := &pods.Items[i]
 		switch {
+		case orphans[p.Name]:
+			if err := r.releaseOrphanedRunner(ctx, p); err != nil {
+				logger.Error(err, "release orphaned runner while draining; will retry",
+					"pod", p.Name, "node", p.Spec.NodeName)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			logger.Info("released orphaned runner while draining",
+				"pod", p.Name, "node", p.Spec.NodeName, "phase", string(p.Status.Phase))
+			orphaned++
 		case !isAlive(p):
 			// Terminal or already deleting — GC takes it with the CR.
 		case isIdle(p):
@@ -438,7 +479,7 @@ func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv
 		// re-check; single-shot Pods turn over to terminal on exit.
 		// Bounded in practice by the GitHub Actions job timeout.
 		logger.Info("draining pool; waiting on in-flight runners",
-			"running", running, "drainedIdle", drainedIdle)
+			"running", running, "drainedIdle", drainedIdle, "orphaned", orphaned)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
@@ -446,7 +487,8 @@ func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv
 	if err := r.Update(ctx, pool); err != nil {
 		return ctrl.Result{}, fmt.Errorf("remove drain finalizer: %w", err)
 	}
-	logger.Info("pool drained; finalizer released", "drainedIdle", drainedIdle)
+	logger.Info("pool drained; finalizer released",
+		"drainedIdle", drainedIdle, "orphaned", orphaned)
 	return ctrl.Result{}, nil
 }
 
@@ -535,16 +577,72 @@ func (r *RunnerPoolReconciler) liveNodeNames(ctx context.Context) (map[string]st
 	return names, true
 }
 
-// isOrphaned reports whether pod is bound to a Node that no longer
-// exists. An unscheduled Pod (no nodeName yet) is not orphaned — it is
-// waiting for a host, which is the normal Pending state for a warm
-// poller that hasn't been placed.
+// isOrphaned reports whether pod is bound to a Node absent from the
+// cached Node view. An unscheduled Pod (no nodeName yet) is not orphaned
+// — it is waiting for a host, which is the normal Pending state for a
+// warm poller that hasn't been placed.
+//
+// This is only the cheap first pass. A cached miss is a suspicion, not a
+// verdict: see confirmedOrphans, which re-checks every hit against the
+// apiserver before anything is deleted.
 func isOrphaned(pod *corev1.Pod, liveNodes map[string]struct{}) bool {
 	if pod.Spec.NodeName == "" {
 		return false
 	}
 	_, live := liveNodes[pod.Spec.NodeName]
 	return !live
+}
+
+// confirmedOrphans returns, by Pod name, the Pods bound to a Node that
+// really is gone. Computed once per reconcile and shared by every loop
+// that needs the verdict, so the apiserver sees at most one Get per
+// suspect Node however many Pods were stranded on it.
+//
+// Two-pass on purpose. The cached NodeList is the cheap filter that keeps
+// the steady state (no orphans) free; every Pod it flags is then confirmed
+// against the apiserver, whose Get is authoritative and linearizable where
+// the informer's absence is merely "nothing delivered yet". Only a definite
+// NotFound counts as gone: a transient error, an RBAC regression, or a
+// timeout all leave the Pod alone, because the cost of waiting a tick is a
+// Pod cleaned up late, and the cost of guessing wrong is a job killed.
+//
+// Returns empty (sweep disabled) when the Node view is unusable or the
+// APIReader is unwired.
+func (r *RunnerPoolReconciler) confirmedOrphans(ctx context.Context, pods []corev1.Pod) map[string]bool {
+	orphans := map[string]bool{}
+	if r.APIReader == nil {
+		return orphans
+	}
+	liveNodes, ok := r.liveNodeNames(ctx)
+	if !ok {
+		return orphans
+	}
+
+	gone := map[string]bool{}
+	for i := range pods {
+		p := &pods[i]
+		if !isOrphaned(p, liveNodes) {
+			continue
+		}
+		node := p.Spec.NodeName
+		verdict, checked := gone[node]
+		if !checked {
+			verdict = r.nodeConfirmedGone(ctx, node)
+			gone[node] = verdict
+		}
+		if verdict {
+			orphans[p.Name] = true
+		}
+	}
+	return orphans
+}
+
+// nodeConfirmedGone asks the apiserver directly whether a Node exists.
+// Only an explicit NotFound is treated as gone; every other outcome
+// (including errors) reports "still there" so callers leave the Pod be.
+func (r *RunnerPoolReconciler) nodeConfirmedGone(ctx context.Context, name string) bool {
+	err := r.APIReader.Get(ctx, client.ObjectKey{Name: name}, &corev1.Node{})
+	return apierrors.IsNotFound(err)
 }
 
 // releaseOrphanedRunner force-completes the removal of a Pod whose Node

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -43,6 +43,23 @@ const drainEligibleLabel = "tuist.dev/drain-eligible"
 // spec.rollout.maxConcurrentPercent.
 const defaultRollMaxConcurrentPercent = 5
 
+// tartKubeletVMCleanupFinalizer is tart-kubelet's Pod finalizer, which
+// gates the Pod object's removal on the host tearing its Tart VM down.
+// Source of truth is `podagent.PodFinalizer` in infra/tart-kubelet;
+// redeclared here because the two live in separate Go modules.
+//
+// It is node-local: the only code that removes it is the podagent's
+// DeletionTimestamp branch, and each podagent filters the Pod informer
+// down to its OWN `spec.nodeName`. So when a Node disappears — the CAPI
+// provider deletes the Node object after releasing the Mac mini, and
+// MachineHealthCheck remediation churns them routinely — every Pod still
+// bound to it keeps this finalizer with no agent left alive to remove it.
+// The apiserver then holds the Pod object open forever, and the terminal
+// reap below can't help: the Pod is neither alive nor
+// DeletionTimestamp-free, so it matches no branch. See
+// releaseOrphanedRunner.
+const tartKubeletVMCleanupFinalizer = "tart-kubelet.tuist.dev/vm-cleanup"
+
 // RunnerPoolReconciler maintains a fleet of runner Pods + per-Pod
 // ServiceAccounts. Pods are owned directly by the RunnerPool (no
 // RunnerAssignment intermediate). When a Pod hits a terminal
@@ -151,10 +168,16 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("list pods: %w", err)
 	}
 
+	// Live Node view for the orphan sweep below. Gathered once per
+	// reconcile and shared with the phase-count loop so a Pod stranded on
+	// a deleted Node isn't reported as warm capacity it can no longer
+	// provide.
+	liveNodes, nodesUsable := r.liveNodeNames(ctx)
+
 	phaseReplicas := podPhaseReplicaCounts{}
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		if isAlive(p) {
+		if isAlive(p) && !(nodesUsable && isOrphaned(p, liveNodes)) {
 			phaseReplicas.add(p)
 		}
 	}
@@ -164,6 +187,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	alive := 0
 	reaped := 0
+	orphaned := 0
 	staleAlive := 0
 	markedStale := 0
 	newNotReady := 0
@@ -177,6 +201,28 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var stalePendingCandidates []*corev1.Pod
 	for i := range pods.Items {
 		p := &pods.Items[i]
+
+		// Pod stranded on a Node that no longer exists. Its VM died with
+		// the host, so it is neither doing work nor capacity we can fill
+		// a job with, whatever phase it last published. Nothing else will
+		// ever clean it up: tart-kubelet's finalizer is node-local, and
+		// upstream PodGC's orphan collection only issues a Delete, which
+		// a finalizer blocks. Release it before the branches below, which
+		// all assume a Pod whose host is still around to act on it.
+		if nodesUsable && isOrphaned(p, liveNodes) {
+			if err := r.releaseOrphanedRunner(ctx, p); err != nil {
+				logger.Error(err, "release orphaned runner; will retry next tick",
+					"pod", p.Name, "node", p.Spec.NodeName)
+				continue
+			}
+			logger.Info("released orphaned runner",
+				"pod", p.Name,
+				"node", p.Spec.NodeName,
+				"phase", string(p.Status.Phase),
+			)
+			orphaned++
+			continue
+		}
 
 		switch {
 		case isAlive(p):
@@ -300,6 +346,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		"target", pool.Spec.Replicas,
 		"observed", alive,
 		"reaped", reaped,
+		"orphaned", orphaned,
 		"gap", gap,
 		"overflow", overflow,
 		"idleAlive", len(idleAlive),
@@ -460,6 +507,74 @@ func (r *RunnerPoolReconciler) reapRunner(ctx context.Context, pod *corev1.Pod) 
 		return fmt.Errorf("delete sa %s: %w", pod.Name, err)
 	}
 	return nil
+}
+
+// liveNodeNames returns the names of every Node currently registered in
+// the cluster.
+//
+// ok is false when the view is unusable, and callers must then skip the
+// orphan sweep entirely rather than treat what they have as authoritative.
+// Both failure modes collapse to "every Pod looks orphaned", and acting on
+// that would delete the whole fleet mid-job: a List error is the obvious
+// one, and an empty list is the subtle one (a Node informer that hasn't
+// synced yet reads as zero Nodes, not as an error). A cluster with no Nodes
+// at all has no runner Pods to sweep, so refusing to act on an empty view
+// costs nothing.
+func (r *RunnerPoolReconciler) liveNodeNames(ctx context.Context) (map[string]struct{}, bool) {
+	nodes := &corev1.NodeList{}
+	if err := r.List(ctx, nodes); err != nil {
+		return nil, false
+	}
+	if len(nodes.Items) == 0 {
+		return nil, false
+	}
+	names := make(map[string]struct{}, len(nodes.Items))
+	for i := range nodes.Items {
+		names[nodes.Items[i].Name] = struct{}{}
+	}
+	return names, true
+}
+
+// isOrphaned reports whether pod is bound to a Node that no longer
+// exists. An unscheduled Pod (no nodeName yet) is not orphaned — it is
+// waiting for a host, which is the normal Pending state for a warm
+// poller that hasn't been placed.
+func isOrphaned(pod *corev1.Pod, liveNodes map[string]struct{}) bool {
+	if pod.Spec.NodeName == "" {
+		return false
+	}
+	_, live := liveNodes[pod.Spec.NodeName]
+	return !live
+}
+
+// releaseOrphanedRunner force-completes the removal of a Pod whose Node
+// is gone, by stripping tart-kubelet's node-local finalizer before the
+// usual reap. Removing the finalizer is safe precisely because the host
+// is gone: the finalizer exists to keep the Pod object visible until the
+// VM is torn down, and a released Mac mini takes its VMs with it, so
+// there is nothing left to wait for. We strip only tart-kubelet's own
+// finalizer and leave any other intact, so this can't bulldoze a
+// finalizer whose owner is still alive to honour it.
+//
+// Ordering matters: the finalizer patch has to land before the Delete,
+// or the Pod just re-enters the same wedged state (deletionTimestamp
+// set, finalizer held, no agent to remove it) that stranded it here. The
+// Delete is what the apiserver needs to actually collect the object; on
+// a Pod already carrying a deletionTimestamp, dropping the finalizer
+// completes the deletion on its own and reapRunner's Delete no-ops on
+// NotFound while still collecting the sibling ServiceAccount.
+func (r *RunnerPoolReconciler) releaseOrphanedRunner(ctx context.Context, pod *corev1.Pod) error {
+	if controllerutil.ContainsFinalizer(pod, tartKubeletVMCleanupFinalizer) {
+		// Optimistic lock: a blind merge patch rewrites the whole
+		// finalizer array, which would silently drop a finalizer added
+		// concurrently. Conflict just means re-read and retry next tick.
+		patch := client.MergeFromWithOptions(pod.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		controllerutil.RemoveFinalizer(pod, tartKubeletVMCleanupFinalizer)
+		if err := r.Patch(ctx, pod, patch); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("strip vm-cleanup finalizer from %s: %w", pod.Name, err)
+		}
+	}
+	return r.reapRunner(ctx, pod)
 }
 
 // reapAlivePod is the scale-down path. Same shape as

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -701,6 +701,181 @@ func TestReconcile_DrainsPoolOnDeleteWithoutKillingRunningPod(t *testing.T) {
 	}
 }
 
+// newNode returns a registered cluster Node. Tests that exercise the
+// orphan sweep need at least one, because an empty Node view is
+// deliberately treated as unusable rather than as "every Pod is
+// orphaned" (see liveNodeNames).
+func newNode(name string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+// wedgedOrphanPod builds a runner Pod in the exact shape that survived
+// in production: terminal, bound to a Node that no longer exists, and
+// already carrying both tart-kubelet's node-local finalizer and the
+// deletionTimestamp left by a reap that could never complete.
+func wedgedOrphanPod(name, image, poolName, nodeName string) *corev1.Pod {
+	pod := newRunnerPod(name, image, corev1.PodFailed, poolName)
+	pod.Spec.NodeName = nodeName
+	pod.Finalizers = []string{tartKubeletVMCleanupFinalizer}
+	deleted := metav1.NewTime(time.Now().Add(-22 * time.Hour))
+	pod.DeletionTimestamp = &deleted
+	return pod
+}
+
+// TestReconcile_ReleasesRunnerOrphanedOnDeletedNode is the regression for
+// runner Pods outliving the Mac minis they ran on. tart-kubelet's
+// `vm-cleanup` finalizer is removed only by the podagent on the Pod's own
+// host, so once the CAPI provider released the mini and deleted its Node
+// object, the Pod became immortal: the reap's Delete set a
+// deletionTimestamp, the finalizer blocked collection, and every later
+// reconcile skipped the Pod because it was neither alive nor
+// DeletionTimestamp-free. Upstream PodGC can't help either — it only
+// issues a Delete, which the same finalizer blocks. Four such Pods
+// accumulated in production, two of them on deleted Nodes, and Pods
+// orphaned this way have wedged `helm --wait` before.
+func TestReconcile_ReleasesRunnerOrphanedOnDeletedNode(t *testing.T) {
+	scheme := mustScheme(t)
+	const image = "ghcr.io/tuist/tuist-runner@sha256:new"
+	pool := newPool("p", image, 1)
+	orphan := wedgedOrphanPod("p-runner-orphan", image, "p", "mini-released")
+	orphanSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-runner-orphan", Namespace: "tuist-runners"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, newNode("mini-live"), orphan, orphanSA).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pods := &corev1.PodList{}
+	if err := c.List(context.Background(), pods); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	for _, p := range pods.Items {
+		if p.Name == "p-runner-orphan" {
+			t.Fatalf("expected orphaned pod to be released, still present with finalizers %v", p.Finalizers)
+		}
+	}
+
+	// The orphan never counted as alive, so the pool refills the gap it
+	// left rather than sitting a replica short behind a dead host.
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected 1 replacement pod, got %d: %+v", len(pods.Items), podNames(pods.Items))
+	}
+
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(context.Background(), nn("tuist-runners", "p-runner-orphan"), sa); err == nil {
+		t.Fatalf("expected orphaned pod's sibling SA to be deleted, still present")
+	}
+}
+
+// TestReconcile_SkipsOrphanSweepWhenNodeViewUnusable guards the sweep's
+// blast radius. An unsynced Node informer reads as zero Nodes rather than
+// as an error, and every Pod would then look orphaned — so an unusable
+// view must delete nothing at all. The Pod here is in the wedged shape,
+// which no other branch touches, so the sweep is the only thing that could
+// remove it.
+func TestReconcile_SkipsOrphanSweepWhenNodeViewUnusable(t *testing.T) {
+	scheme := mustScheme(t)
+	const image = "ghcr.io/tuist/tuist-runner@sha256:new"
+	pool := newPool("p", image, 1)
+	orphan := wedgedOrphanPod("p-runner-orphan", image, "p", "mini-released")
+
+	// No Node objects at all: the view is unusable.
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, orphan).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &corev1.Pod{}
+	if err := c.Get(context.Background(), nn("tuist-runners", "p-runner-orphan"), got); err != nil {
+		t.Fatalf("expected pod to survive an unusable node view, got: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, tartKubeletVMCleanupFinalizer) {
+		t.Fatalf("expected vm-cleanup finalizer to be left intact when the node view is unusable")
+	}
+}
+
+// TestReconcile_OrphanSweepPreservesForeignFinalizers pins the sweep to
+// tart-kubelet's own finalizer. Stripping it is only safe because the host
+// that would honour it is gone; a finalizer belonging to anything else has
+// an owner that may well still be alive, so the sweep must leave it (and
+// therefore the Pod) alone.
+func TestReconcile_OrphanSweepPreservesForeignFinalizers(t *testing.T) {
+	scheme := mustScheme(t)
+	const foreign = "example.com/some-other-controller"
+	const image = "ghcr.io/tuist/tuist-runner@sha256:new"
+	pool := newPool("p", image, 1)
+	orphan := newRunnerPod("p-runner-orphan", image, corev1.PodRunning, "p")
+	orphan.Spec.NodeName = "mini-released"
+	orphan.Finalizers = []string{tartKubeletVMCleanupFinalizer, foreign}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, newNode("mini-live"), orphan).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &corev1.Pod{}
+	if err := c.Get(context.Background(), nn("tuist-runners", "p-runner-orphan"), got); err != nil {
+		t.Fatalf("expected pod held open by a foreign finalizer to still exist, got: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, tartKubeletVMCleanupFinalizer) {
+		t.Fatalf("expected vm-cleanup finalizer to be stripped, finalizers = %v", got.Finalizers)
+	}
+	if !controllerutil.ContainsFinalizer(got, foreign) {
+		t.Fatalf("expected foreign finalizer %q to be preserved, finalizers = %v", foreign, got.Finalizers)
+	}
+}
+
+func TestIsOrphaned(t *testing.T) {
+	live := map[string]struct{}{"mini-live": {}}
+
+	cases := []struct {
+		name     string
+		nodeName string
+		want     bool
+	}{
+		{"bound to a live node", "mini-live", false},
+		{"bound to a deleted node", "mini-released", true},
+		// A Pod the scheduler hasn't placed yet is the normal Pending
+		// state for a warm poller, not an orphan.
+		{"not yet scheduled", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := newRunnerPod("p-runner-x", "img", corev1.PodPending, "p")
+			pod.Spec.NodeName = tc.nodeName
+			if got := isOrphaned(pod, live); got != tc.want {
+				t.Fatalf("isOrphaned(nodeName=%q) = %v, want %v", tc.nodeName, got, tc.want)
+			}
+		})
+	}
+}
+
 func podNames(pods []corev1.Pod) []string {
 	out := make([]string, len(pods))
 	for i, p := range pods {

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -748,7 +748,7 @@ func TestReconcile_ReleasesRunnerOrphanedOnDeletedNode(t *testing.T) {
 		WithStatusSubresource(&tuistv1.RunnerPool{}).
 		Build()
 
-	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	r := &RunnerPoolReconciler{Client: c, APIReader: c, Scheme: scheme, DispatchURL: "http://dispatch"}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: nn(pool.Namespace, pool.Name),
 	}); err != nil {
@@ -796,7 +796,7 @@ func TestReconcile_SkipsOrphanSweepWhenNodeViewUnusable(t *testing.T) {
 		WithStatusSubresource(&tuistv1.RunnerPool{}).
 		Build()
 
-	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	r := &RunnerPoolReconciler{Client: c, APIReader: c, Scheme: scheme, DispatchURL: "http://dispatch"}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: nn(pool.Namespace, pool.Name),
 	}); err != nil {
@@ -832,7 +832,7 @@ func TestReconcile_OrphanSweepPreservesForeignFinalizers(t *testing.T) {
 		WithStatusSubresource(&tuistv1.RunnerPool{}).
 		Build()
 
-	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	r := &RunnerPoolReconciler{Client: c, APIReader: c, Scheme: scheme, DispatchURL: "http://dispatch"}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: nn(pool.Namespace, pool.Name),
 	}); err != nil {
@@ -848,6 +848,166 @@ func TestReconcile_OrphanSweepPreservesForeignFinalizers(t *testing.T) {
 	}
 	if !controllerutil.ContainsFinalizer(got, foreign) {
 		t.Fatalf("expected foreign finalizer %q to be preserved, finalizers = %v", foreign, got.Finalizers)
+	}
+}
+
+// TestReconcileDelete_ReleasesOrphansWedgingTerminatingPool is the
+// regression for the drain path skipping the orphan sweep. Reconcile
+// returns through reconcileDelete before ever reaching the steady-state
+// sweep, and neither of the drain's own branches can handle an orphan: the
+// busy-looking one below counts as `running` forever, holding the CR in
+// Terminating so the `helm --wait` behind a pool rename never returns, and
+// the terminal one is left to a GC that its held finalizer blocks. This is
+// the motivating scenario for the whole fix, so it has to work on the exact
+// path a helm pool-topology change takes.
+func TestReconcileDelete_ReleasesOrphansWedgingTerminatingPool(t *testing.T) {
+	scheme := mustScheme(t)
+	const image = "ghcr.io/tuist/tuist-runner@sha256:current"
+	pool := newPool("p", image, 1)
+
+	// Mid-job runner: the server stamped the owner label at claim time, so
+	// the drain waits for it rather than killing it. Its host is still alive
+	// at this point.
+	busy := newRunnerPod("p-runner-busy", image, corev1.PodRunning, "p")
+	busy.Labels["tuist.dev/runner-pool-owner"] = "acme"
+	busy.Spec.NodeName = "mini-doomed"
+	busy.Finalizers = []string{tartKubeletVMCleanupFinalizer}
+	busySA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-runner-busy", Namespace: "tuist-runners"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, newNode("mini-live"), newNode("mini-doomed"), busy, busySA).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, APIReader: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &tuistv1.RunnerPool{}
+	if err := c.Get(ctx, nn(pool.Namespace, pool.Name), got); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+
+	// helm-style delete: the drain finalizer holds the CR Terminating while
+	// the mid-job runner finishes.
+	if err := c.Delete(ctx, got); err != nil {
+		t.Fatalf("delete pool: %v", err)
+	}
+
+	// The mini is released mid-drain, taking the VM with it. Everything the
+	// orphan sweep reacts to happens strictly AFTER the pool went
+	// Terminating, so only reconcileDelete can clean this up — the
+	// steady-state sweep is never reached again for this pool.
+	if err := c.Delete(ctx, newNode("mini-doomed")); err != nil {
+		t.Fatalf("delete node: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("drain reconcile: %v", err)
+	}
+
+	p := &corev1.Pod{}
+	if err := c.Get(ctx, nn("tuist-runners", "p-runner-busy"), p); err == nil {
+		t.Fatalf("expected orphan to be released during drain, still present with finalizers %v", p.Finalizers)
+	}
+	if err := c.Get(ctx, nn("tuist-runners", "p-runner-busy"), &corev1.ServiceAccount{}); err == nil {
+		t.Fatalf("expected released orphan's sibling SA to be deleted, still present")
+	}
+
+	// Nothing live is left, so the drain must complete rather than block on
+	// a runner that no longer has a host to run on. A held finalizer here is
+	// what wedges `helm --wait`.
+	if err := c.Get(ctx, nn(pool.Namespace, pool.Name), got); err == nil &&
+		controllerutil.ContainsFinalizer(got, runnerPoolFinalizer) {
+		t.Fatalf("expected drain finalizer to be released once only orphans remained")
+	}
+}
+
+// TestReconcile_KeepsRunnerWhenNodeMissingOnlyFromCache guards the sweep's
+// blast radius against informer skew. Pod and Node informers are separate
+// watch streams with no atomic cross-type view, so a Node that exists can be
+// briefly absent from the Node cache while a Pod already bound to it is
+// visible — routine on a fleet where minis join and are released constantly.
+// Believing the cache there deletes a healthy runner mid-job: the Pod below
+// is busy and carries the vm-cleanup finalizer, which is exactly what every
+// live macOS runner looks like, so nothing but the Node read distinguishes it
+// from a wedged orphan. The authoritative Get is the only thing standing
+// between a stale cache and a killed job.
+func TestReconcile_KeepsRunnerWhenNodeMissingOnlyFromCache(t *testing.T) {
+	scheme := mustScheme(t)
+	const image = "ghcr.io/tuist/tuist-runner@sha256:current"
+	pool := newPool("p", image, 1)
+
+	busy := newRunnerPod("p-runner-busy", image, corev1.PodRunning, "p")
+	busy.Labels["tuist.dev/runner-pool-owner"] = "acme"
+	busy.Spec.NodeName = "mini-joining"
+	busy.Finalizers = []string{tartKubeletVMCleanupFinalizer}
+	busySA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-runner-busy", Namespace: "tuist-runners"},
+	}
+
+	// Cached view: synced enough to be usable (it has a Node), but the Pod's
+	// own Node hasn't been delivered yet.
+	cached := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, newNode("mini-live"), busy, busySA).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	// The apiserver knows better: mini-joining is real.
+	authoritative := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(newNode("mini-live"), newNode("mini-joining")).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: cached, APIReader: authoritative, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &corev1.Pod{}
+	if err := cached.Get(context.Background(), nn("tuist-runners", "p-runner-busy"), got); err != nil {
+		t.Fatalf("expected mid-job pod on a cache-missing but live node to survive, got: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, tartKubeletVMCleanupFinalizer) {
+		t.Fatalf("expected vm-cleanup finalizer to be left intact on a live node's pod")
+	}
+	if err := cached.Get(context.Background(), nn("tuist-runners", "p-runner-busy"), &corev1.ServiceAccount{}); err != nil {
+		t.Fatalf("expected mid-job pod's sibling SA to survive, got: %v", err)
+	}
+}
+
+// TestReconcile_SkipsOrphanSweepWithoutAPIReader pins the fail-closed
+// default. Without an authoritative reader the sweep cannot tell a released
+// mini from an unsynced cache, and it must then do nothing: unwired plumbing
+// should cost cleanup, never jobs.
+func TestReconcile_SkipsOrphanSweepWithoutAPIReader(t *testing.T) {
+	scheme := mustScheme(t)
+	const image = "ghcr.io/tuist/tuist-runner@sha256:new"
+	pool := newPool("p", image, 1)
+	orphan := wedgedOrphanPod("p-runner-orphan", image, "p", "mini-released")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, newNode("mini-live"), orphan).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if err := c.Get(context.Background(), nn("tuist-runners", "p-runner-orphan"), &corev1.Pod{}); err != nil {
+		t.Fatalf("expected pod to survive a reconciler with no APIReader, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Runner Pods could survive indefinitely on Mac minis that had already been released, and Pods orphaned this way have wedged `helm --wait` before. This adds an orphan sweep to the `RunnerPoolReconciler` so they are collected automatically instead of hand-deleted.

## Root cause

tart-kubelet's `tart-kubelet.tuist.dev/vm-cleanup` finalizer is **node-local**. The only code that removes it is the podagent's DeletionTimestamp branch (`infra/tart-kubelet/internal/podagent/reconciler.go`), and each podagent filters the Pod informer down to its own `spec.nodeName`. When the CAPI provider releases a Mac mini it deletes the Node object (`ScalewayAppleSiliconMachine` reconcileDelete, Stage 4) with no pod handling, and by then the host is gone.

Any Pod still bound to that Node is then immortal:

1. The reap issues a Delete, so the apiserver stamps a `deletionTimestamp` but cannot collect the object while the finalizer is held.
2. Every later reconcile skips the Pod: it is neither alive (terminal phase) nor `DeletionTimestamp`-free, so it matches no branch of the pod loop.
3. Upstream PodGC's orphan collection cannot break the tie either. It only issues a Delete, which the same finalizer blocks.

The reap path itself is healthy, which is what made this subtle: the macOS pools were reaping other Pods successfully in the same window.

Note `reconciler.go` already documents a sibling of this bug ("We shipped exactly that bug for several days"). That earlier fix corrected the branch **ordering** for the case where the podagent is alive. It does nothing when the agent's host no longer exists, which is this case.

## Observed in production

Four runner Pods stranded for 21-22h, two of them on Nodes absent from `kubectl get nodes`. The correlation is the signature: Pods on live nodes get their finalizer removed normally, Pods on dead nodes never do.

## What changed

A Pod bound to a Node that no longer exists gets tart-kubelet's finalizer stripped, then the Pod and its sibling ServiceAccount are reaped. The sweep runs ahead of the alive/terminal switch, since every branch there assumes a Pod whose host is still around to act on it. Orphans are also excluded from the pool's phase-replica metric, because a Pod stranded on a dead host is not warm capacity it can still provide.

It runs on **both** the steady-state path and `reconcileDelete`. The drain needs it just as much, and needs it first: an orphan that still carries its claim-time owner label reads as `running` forever, holding the CR in Terminating so the `helm --wait` behind a pool rename or removal never returns; a terminal one is left to a GC that its held finalizer blocks. Deleting the CR is also the one path where nothing ever reconciles again to catch up later.

No RBAC change is needed. The controller already holds the cluster-scoped `nodes` read (`get, list, watch`) the autoscaler uses, and Pods already carry `patch`, which is what finalizer removal goes through (there is no `update` verb, so a `Patch` with an optimistic lock is both required and the existing idiom, matching `markDrainEligible`).

## Why the runners-controller and not the CAPI provider

The provider's Node-delete path is the other obvious home, and there is precedent for it: the Linux machine controller already does this exact shape of cleanup via `deleteNodeLocalPVCs`. It was rejected as the *only* fix for two reasons:

- It covers just provider-driven deletes. The sweep covers every way a Node can vanish, including MachineHealthCheck remediation and manual deletes.
- A one-shot cleanup at delete time fails silently if the controller restarts mid-delete. A continuously reconciling sweep self-heals.

Adding it to the provider as well is reasonable follow-up, but it should not stand alone.

## Guards on the blast radius

All three are load-bearing. **Every live macOS runner Pod carries the vm-cleanup finalizer and no deletionTimestamp** (verified against production), so Node existence is the only signal separating a busy runner from a wedged orphan. There is no second signal to fall back on, and a wrong answer deletes a job.

- **A cached Node miss is a suspicion, not a verdict.** Pod and Node informers are independent watch streams with no atomic cross-type view, so a live Node can be transiently absent from the Node cache while a Pod already bound to it is visible. That is routine on a fleet where minis join and are released continuously. Every suspect is re-checked against the apiserver through an uncached `APIReader`, memoized per Node so the steady state stays free and a dead mini costs one Get however many Pods it stranded. Only a definite NotFound counts as gone; a transient error, an RBAC regression, or a timeout all leave the Pod alone, because a Pod cleaned up a tick late is cheap and a job killed is not.
- **No `APIReader` means no sweep.** Failing closed on unwired plumbing loses cleanup; failing open loses jobs.
- **An unusable cached view no-ops, and only tart-kubelet's own finalizer is stripped.** A List error and an empty list both collapse to "every Pod looks orphaned", and an unsynced Node informer reads as zero Nodes rather than as an error. A foreign finalizer may still have a live owner, so it (and its Pod) is left alone.

## Validation

- `go test ./...`, `go vet ./...` and `gofmt -l .` all clean, which is exactly what `runners-controller-image.yml` runs in CI.
- **Every behavioural test was confirmed to fail without its fix**, by disabling that fix and re-running. The orphan-release test reproduces the production symptom verbatim (`still present with finalizers [tart-kubelet.tuist.dev/vm-cleanup]`); the drain test reproduces it on the terminating-pool path; the cache-skew test deletes the busy runner outright (`pods "p-runner-busy" not found`); removing the fail-closed guard panics. This caught a genuinely vacuous first draft of the drain test, where the steady-state sweep cleaned the orphans before the pool was ever Terminating, so the drain path was never exercised. It now deletes the Node mid-drain, strictly after the CR goes Terminating.

### How to test locally

```
cd infra/runners-controller
go test ./controllers/ -run 'Orphan|TestIsOrphaned' -v
```

To confirm the tests actually catch the bugs rather than passing vacuously, revert a guard and re-run. For example, make `nodeConfirmedGone` `return true` (trusting the cache, as the first revision did) and `TestReconcile_KeepsRunnerWhenNodeMissingOnlyFromCache` fails by deleting a mid-job runner.

## Reviewer notes

The reconciler does not watch Nodes, so a Node deletion does not itself trigger a reconcile. In practice the sweep still fires within seconds: the autoscaler patches `spec.replicas` every 5s, and prod logs confirm the macOS pools reconcile that often. A genuinely static, non-autoscaled pool would wait on the 10h resync. The Node watch was left out to keep the change tight, but it is a one-line `Watches` if preferred.

One residual, deliberately not handled: a Node deleted and recreated under the same name makes the authoritative Get return the new Node, so a Pod stranded on the old incarnation is not swept. That is a false negative (cleaned up late, never a job killed) and closing it would mean recording Node UID on the Pod, which is not worth it here.

Separately, while investigating this I found that tart-kubelet never publishes a terminated container state (it only ever synthesizes *running* statuses), so the controller's exit-code post-mortem fingerprint never fires for the macOS fleet. `AGENTS.md` is updated here to describe that accurately rather than overclaim; closing the gap is follow-up work, since it means touching tart-kubelet's status publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)