### PR TITLE
fix(infra): reclaim macOS host slots and detect wedged runner jobs

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -1501,7 +1501,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "How long each pool's oldest un-booted Pod has been waiting. A Pod is Pending from creation until tart-kubelet has its VM up, so this is the boot path's queue age: normally tens of seconds, unbounded when a host stalls mid image-pull. Neither neighbouring signal sees that. The Pending count reads the same whether a pool is steadily replacing single-shot runners or has one Pod wedged for hours, and tart-kubelet's provision histogram is observed only when a VM finally starts, so a Pod that never boots is absent from it entirely. The node stays Ready throughout and `kube_pod_status_unschedulable` stays 0 \u2014 these Pods are scheduled, just not booted.",
+        "description": "How long each macOS pool's oldest un-booted Pod has been waiting. On a Tart pool a Pod is Pending from creation until tart-kubelet has its VM up, so this is the boot path's queue age: normally tens of seconds, unbounded when a host stalls mid image-pull. Neither neighbouring signal sees that. The Pending count reads the same whether a pool is steadily replacing single-shot runners or has one Pod wedged for hours, and tart-kubelet's provision histogram is observed only when a VM finally starts, so a Pod that never boots is absent from it entirely. The node stays Ready throughout and `kube_pod_status_unschedulable` stays 0 \u2014 these Pods are scheduled, just not booted. macOS only, and not filtered by $platform: on Linux, Pending is the healthy steady state (the dispatch poller is an init container), so an idle Linux pool would sit at its warm-pool age here and read as wedged.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1552,7 +1552,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "max by (pool) (tuist_runners_pool_oldest_pending_pod_age_seconds{pool=~\".*$platform.*\", env=\"$env\"})",
+            "expr": "max by (pool) (tuist_runners_pool_oldest_pending_pod_age_seconds{pool=~\".*runner-pool-macos.*\", env=\"$env\"})",
             "legendFormat": "{{pool}}",
             "refId": "A"
           }

--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -1498,6 +1498,67 @@
         ],
         "title": "Autoscaler target vs allocated by platform",
         "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "How long each pool's oldest un-booted Pod has been waiting. A Pod is Pending from creation until tart-kubelet has its VM up, so this is the boot path's queue age: normally tens of seconds, unbounded when a host stalls mid image-pull. Neither neighbouring signal sees that. The Pending count reads the same whether a pool is steadily replacing single-shot runners or has one Pod wedged for hours, and tart-kubelet's provision histogram is observed only when a VM finally starts, so a Pod that never boots is absent from it entirely. The node stays Ready throughout and `kube_pod_status_unschedulable` stays 0 \u2014 these Pods are scheduled, just not booted.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 1800 }
+              ]
+            },
+            "unit": "s"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 58
+        },
+        "id": 133,
+        "options": {
+          "legend": {
+            "calcs": ["max"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (pool) (tuist_runners_pool_oldest_pending_pod_age_seconds{pool=~\".*$platform.*\", env=\"$env\"})",
+            "legendFormat": "{{pool}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Oldest un-booted Pod age by pool",
+        "type": "timeseries"
       }
     ]
   }

--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -694,6 +694,67 @@
         "type": "timeseries"
       },
       {
+        "datasource": "$datasource",
+        "description": "Age of the oldest still-queued job per fleet, polled from ClickHouse `runner_jobs` every 30s (0 when nothing is queued). Read it against \"Queue time\" above: that histogram is recorded on claim, so a job that is never claimed never appears in it, and its top bucket is 300s \u2014 a 4h wait and a 6m wait plot identically. This gauge is what moves while a job is stuck. A fleet climbing here while its Pods sit idle points at allocation or boot rather than capacity. Backs the `Runner queue age` alert, which fires past 30m.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 1800 }
+              ]
+            },
+            "unit": "s"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 40
+        },
+        "id": 313,
+        "options": {
+          "legend": {
+            "calcs": ["max"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (fleet) (tuist_runners_queue_oldest_age_seconds{fleet=~\".*$platform.*\", env=\"$env\"})",
+            "legendFormat": "{{fleet}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Oldest queued job age by fleet",
+        "type": "timeseries"
+      },
+      {
         "collapsed": false,
         "gridPos": {
           "h": 1,

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -627,17 +627,29 @@ runnersFleet:
   # fleet under skewed demand and the allocator caps the joint sum
   # so the pools don't double-book.
   #
-  # Floors sum to 3 of the 9-slot budget; the remaining 6 slots are
-  # dynamically apportioned by queue depth across the pools.
-  # The default (26.6) keeps the warm baseline since most traffic
-  # lands there; older Xcodes sit cold (floor 0) so an unused runner
-  # doesn't tie up a host. Revisit once we open the runners to
-  # general signups where the pool mix is unpredictable in advance.
+  # Floors sum to 1 of the 9-slot budget; the remaining 8 slots are
+  # dynamically apportioned by queue depth across the pools. Keep the
+  # sum small: 9 hosts across 5 pools means every reserved slot is one
+  # the allocator cannot hand to a pool with real queued work.
+  #
+  # Note that a floor does NOT follow the catalog default. `tuist-macos`
+  # resolves through each account's protected `macos` profile, whose
+  # `xcode_version` is pinned at account-creation time, so moving
+  # `default: true` in the catalog does not move where existing accounts'
+  # jobs land — they stay on the Xcode they were created with (26.5
+  # today; see the `20260602145000_backfill_protected_macos_profile`
+  # migration). 26.6 therefore carries a warm slot for *new* accounts
+  # only, not for the bulk of traffic. Size floors from measured demand
+  # per pool (`tuist_runners_autoscaler_target_replicas`), never from
+  # which version is tagged default. Older Xcodes sit cold (floor 0) so
+  # an unused runner doesn't tie up a host. Revisit once we open the
+  # runners to general signups where the pool mix is unpredictable in
+  # advance.
   xcodeOverrides:
     "26.6":
       autoscaling:
         enabled: true
-        minWarmPoolFloor: 3
+        minWarmPoolFloor: 1
         maxReplicas: 9
     "26.5":
       autoscaling:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -631,15 +631,14 @@ runnersFleet:
   # dynamically apportioned by queue depth across the pools. Older
   # Xcodes sit cold (floor 0) so an unused runner doesn't tie up a host.
   #
-  # Floors do not follow the catalog default: `tuist-macos` resolves
-  # through each account's protected `macos` profile, whose
-  # `xcode_version` is pinned at account creation (26.5 for existing
-  # accounts — see the `20260602145000_backfill_protected_macos_profile`
-  # migration), so 26.6 warms new accounts only. Size floors from
-  # measured demand (`tuist_runners_autoscaler_target_replicas`), not
-  # from which version is tagged default. Revisit once we open the
-  # runners to general signups where the pool mix is unpredictable in
-  # advance.
+  # The default (26.6) carries the warm floor, since `tuist-macos`
+  # resolves there. That resolution goes through each account's
+  # protected `macos` profile, which stores `xcode_version` at account
+  # creation — so bumping the catalog default only redirects new
+  # accounts. Move existing accounts' profile in the same change, or
+  # their traffic stays on the old pool while the floor warms an idle
+  # one. Revisit once we open the runners to general signups where the
+  # pool mix is unpredictable in advance.
   xcodeOverrides:
     "26.6":
       autoscaling:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -628,21 +628,16 @@ runnersFleet:
   # so the pools don't double-book.
   #
   # Floors sum to 1 of the 9-slot budget; the remaining 8 slots are
-  # dynamically apportioned by queue depth across the pools. Keep the
-  # sum small: 9 hosts across 5 pools means every reserved slot is one
-  # the allocator cannot hand to a pool with real queued work.
+  # dynamically apportioned by queue depth across the pools. Older
+  # Xcodes sit cold (floor 0) so an unused runner doesn't tie up a host.
   #
-  # Note that a floor does NOT follow the catalog default. `tuist-macos`
-  # resolves through each account's protected `macos` profile, whose
-  # `xcode_version` is pinned at account-creation time, so moving
-  # `default: true` in the catalog does not move where existing accounts'
-  # jobs land — they stay on the Xcode they were created with (26.5
-  # today; see the `20260602145000_backfill_protected_macos_profile`
-  # migration). 26.6 therefore carries a warm slot for *new* accounts
-  # only, not for the bulk of traffic. Size floors from measured demand
-  # per pool (`tuist_runners_autoscaler_target_replicas`), never from
-  # which version is tagged default. Older Xcodes sit cold (floor 0) so
-  # an unused runner doesn't tie up a host. Revisit once we open the
+  # Floors do not follow the catalog default: `tuist-macos` resolves
+  # through each account's protected `macos` profile, whose
+  # `xcode_version` is pinned at account creation (26.5 for existing
+  # accounts — see the `20260602145000_backfill_protected_macos_profile`
+  # migration), so 26.6 warms new accounts only. Size floors from
+  # measured demand (`tuist_runners_autoscaler_target_replicas`), not
+  # from which version is tagged default. Revisit once we open the
   # runners to general signups where the pool mix is unpredictable in
   # advance.
   xcodeOverrides:

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -88,14 +88,21 @@ independent workqueues:
 
   Alongside it, `tuist_runners_pool_oldest_pending_pod_age_seconds{pool}`
   is how long the pool's oldest un-`Running` Pod has been waiting (0 when
-  none). A Pod is `Pending` from creation until tart-kubelet has its VM
-  up, so this is the boot path's queue age. The phase count above can't
-  stand in: a pool steadily replacing single-shot runners and a pool with
-  one Pod wedged for hours both read `Pending=1`. Neither can
-  tart-kubelet's `tart_kubelet_pod_provision_delay_seconds`, which is
-  observed when a VM finally starts and so omits Pods that never boot
-  entirely — the failure this gauge exists to catch, and one that leaves
-  the Node `Ready` and `kube_pod_status_unschedulable` at 0 throughout.
+  none). **darwin pools only.** On a Tart pool a Pod is `Pending` from
+  creation until tart-kubelet has its VM up, so this is the boot path's
+  queue age. On a Linux pool `Pending` is the *healthy steady state* —
+  the dispatch poller is an init container and kubelet holds a Pod in
+  `Pending` for as long as any init container runs — so publishing it
+  there would peg every idle pool at its warm-pool age. A Linux
+  equivalent has to read the poller's own lifecycle, not the Pod phase.
+
+  The phase count above can't stand in: a pool steadily replacing
+  single-shot runners and a pool with one Pod wedged for hours both read
+  `Pending=1`. Neither can tart-kubelet's
+  `tart_kubelet_pod_provision_delay_seconds`, which is observed when a VM
+  finally starts and so omits Pods that never boot entirely — the failure
+  this gauge exists to catch, and one that leaves the Node `Ready` and
+  `kube_pod_status_unschedulable` at 0 throughout.
 
   Pod-level autoscaling only — bare-metal Host count is operator-
   managed via the CAPI cluster topology, since Hetzner Robot hosts

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -86,6 +86,17 @@ independent workqueues:
   runner dashboard's macOS ready vs cold-booting split without relying
   on pod-scoped kube-state-metrics series.
 
+  Alongside it, `tuist_runners_pool_oldest_pending_pod_age_seconds{pool}`
+  is how long the pool's oldest un-`Running` Pod has been waiting (0 when
+  none). A Pod is `Pending` from creation until tart-kubelet has its VM
+  up, so this is the boot path's queue age. The phase count above can't
+  stand in: a pool steadily replacing single-shot runners and a pool with
+  one Pod wedged for hours both read `Pending=1`. Neither can
+  tart-kubelet's `tart_kubelet_pod_provision_delay_seconds`, which is
+  observed when a VM finally starts and so omits Pods that never boot
+  entirely — the failure this gauge exists to catch, and one that leaves
+  the Node `Ready` and `kube_pod_status_unschedulable` at 0 throughout.
+
   Pod-level autoscaling only — bare-metal Host count is operator-
   managed via the CAPI cluster topology, since Hetzner Robot hosts
   are monthly-billed and can't be auto-ordered. To grow capacity,

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -143,14 +143,28 @@ type RunnerPoolSpec struct {
 // its own struct so an absent block (the v1 default) keeps
 // `RunnerPoolSpec` byte-identical to its pre-autoscaling shape on
 // the wire — no `autoscaling: null` noise on every macOS pool.
-// A field here may carry `omitempty` only when its CRD default equals
-// its Go zero value. `omitempty` drops the zero value from the
-// serialized spec, which the apiserver cannot tell from "unset" and so
+// CRD defaults for the two optional fields whose zero value is
+// meaningful. Kept in sync with the `default:` markers in
+// crds/tuist.dev_runnerpools.yaml; the accessors below apply them when a
+// field is unset so the apiserver default and the in-process default
+// never disagree.
+const (
+	defaultMinWarmPoolFloor         int32 = 1
+	defaultScaleDownCooldownSeconds int32 = 300
+)
+
+// A field here may keep the plain `int32` + `omitempty` only when its
+// CRD default equals its Go zero value; `enabled` (default false) and
+// `maxReplicas` (default 0) qualify. The two fields whose default is
+// non-zero use `*int32` instead: `omitempty` on a plain `int32` drops a
+// deliberate 0, which the apiserver cannot tell from "unset" and so
 // replaces with the CRD default — and the controller serializes the
-// whole spec whenever it adds the drain finalizer (runnerpool_controller.go).
-// `enabled` (default false) and `maxReplicas` (default 0) are safe;
-// the fields below that declare `minimum: 0` with a non-zero default
-// are not.
+// whole spec whenever it adds the drain finalizer
+// (runnerpool_controller.go). A pointer keeps the distinction: nil
+// serializes to nothing (so the apiserver default applies, and a typed
+// client that never set the field gets it), while a non-nil 0 serializes
+// as 0 (so a deliberate zero survives the round-trip). Read them through
+// the OrDefault accessors, never the raw pointer.
 type RunnerPoolAutoscaling struct {
 	// Enabled flips the autoscaling reconciler on for this pool.
 	// When false, the controller leaves `spec.replicas` alone.
@@ -167,10 +181,11 @@ type RunnerPoolAutoscaling struct {
 	// and uncontended Linux pools honor it as a floor; real load
 	// (claimed + queued) is always funded above it.
 	//
-	// No `omitempty`: 0 ("this pool holds no warm capacity") is a valid
-	// and useful setting, and the CRD default is 1.
+	// Pointer so a deliberate 0 ("this pool holds no warm capacity")
+	// survives serialization; nil means unset and defaults to 1. Read
+	// via MinWarmPoolFloorOrDefault.
 	// +optional
-	MinWarmPoolFloor int32 `json:"minWarmPoolFloor"`
+	MinWarmPoolFloor *int32 `json:"minWarmPoolFloor,omitempty"`
 
 	// MaxReplicas is the hard ceiling on the autoscaler-driven
 	// `spec.replicas` value. 0 disables autoscaling-driven scale
@@ -182,10 +197,32 @@ type RunnerPoolAutoscaling struct {
 	// waits between successive scale-down actions for this pool.
 	// Anti-thrash guard.
 	//
-	// No `omitempty`: 0 ("scale down as soon as demand drops") is a
-	// valid setting, and the CRD default is 300.
+	// Pointer so a deliberate 0 ("scale down as soon as demand drops")
+	// survives serialization; nil means unset and defaults to 300. Read
+	// via ScaleDownCooldownSecondsOrDefault.
 	// +optional
-	ScaleDownCooldownSeconds int32 `json:"scaleDownCooldownSeconds"`
+	ScaleDownCooldownSeconds *int32 `json:"scaleDownCooldownSeconds,omitempty"`
+}
+
+// MinWarmPoolFloorOrDefault returns the configured floor, or the CRD
+// default when the field is unset (nil). The apiserver normally fills
+// the default in on admission, so nil is the belt-and-suspenders path —
+// but reading through this accessor means a nil never reaches the
+// allocator as a 0 and silently zeroes a pool's warm floor.
+func (a *RunnerPoolAutoscaling) MinWarmPoolFloorOrDefault() int32 {
+	if a == nil || a.MinWarmPoolFloor == nil {
+		return defaultMinWarmPoolFloor
+	}
+	return *a.MinWarmPoolFloor
+}
+
+// ScaleDownCooldownSecondsOrDefault returns the configured cooldown, or
+// the CRD default when unset (nil).
+func (a *RunnerPoolAutoscaling) ScaleDownCooldownSecondsOrDefault() int32 {
+	if a == nil || a.ScaleDownCooldownSeconds == nil {
+		return defaultScaleDownCooldownSeconds
+	}
+	return *a.ScaleDownCooldownSeconds
 }
 
 // RunnerPoolRollout carries the image-roll throttle knob. Its own

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -143,6 +143,19 @@ type RunnerPoolSpec struct {
 // its own struct so an absent block (the v1 default) keeps
 // `RunnerPoolSpec` byte-identical to its pre-autoscaling shape on
 // the wire — no `autoscaling: null` noise on every macOS pool.
+// A note on `omitempty` in this struct: a field may only carry it when
+// its CRD default equals its Go zero value. `omitempty` drops the zero
+// value from the serialized spec, which is indistinguishable from "unset"
+// — so the apiserver's structural-schema defaulting fills the CRD default
+// back in, and a deliberately-configured zero silently becomes the
+// default. That is not theoretical: the controller Updates the whole
+// typed object when it adds the drain finalizer (see
+// runnerpool_controller.go), so any zero-valued field with a non-zero
+// default is rewritten on a pool's first reconcile and stays wrong for
+// the pool's lifetime. `enabled` (default false) and `maxReplicas`
+// (default 0) default to their zero values, so they are safe; the two
+// fields that declare `minimum: 0` with a non-zero default must not be
+// omitted.
 type RunnerPoolAutoscaling struct {
 	// Enabled flips the autoscaling reconciler on for this pool.
 	// When false, the controller leaves `spec.replicas` alone.
@@ -158,8 +171,11 @@ type RunnerPoolAutoscaling struct {
 	// contention to admit another shape's real queued work. macOS pools
 	// and uncontended Linux pools honor it as a floor; real load
 	// (claimed + queued) is always funded above it.
+	//
+	// No `omitempty`: 0 ("this pool holds no warm capacity") is a valid
+	// and useful setting, and the CRD default is 1.
 	// +optional
-	MinWarmPoolFloor int32 `json:"minWarmPoolFloor,omitempty"`
+	MinWarmPoolFloor int32 `json:"minWarmPoolFloor"`
 
 	// MaxReplicas is the hard ceiling on the autoscaler-driven
 	// `spec.replicas` value. 0 disables autoscaling-driven scale
@@ -170,8 +186,11 @@ type RunnerPoolAutoscaling struct {
 	// ScaleDownCooldownSeconds is the minimum time the controller
 	// waits between successive scale-down actions for this pool.
 	// Anti-thrash guard.
+	//
+	// No `omitempty`: 0 ("scale down as soon as demand drops") is a
+	// valid setting, and the CRD default is 300.
 	// +optional
-	ScaleDownCooldownSeconds int32 `json:"scaleDownCooldownSeconds,omitempty"`
+	ScaleDownCooldownSeconds int32 `json:"scaleDownCooldownSeconds"`
 }
 
 // RunnerPoolRollout carries the image-roll throttle knob. Its own

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -143,19 +143,14 @@ type RunnerPoolSpec struct {
 // its own struct so an absent block (the v1 default) keeps
 // `RunnerPoolSpec` byte-identical to its pre-autoscaling shape on
 // the wire — no `autoscaling: null` noise on every macOS pool.
-// A note on `omitempty` in this struct: a field may only carry it when
-// its CRD default equals its Go zero value. `omitempty` drops the zero
-// value from the serialized spec, which is indistinguishable from "unset"
-// — so the apiserver's structural-schema defaulting fills the CRD default
-// back in, and a deliberately-configured zero silently becomes the
-// default. That is not theoretical: the controller Updates the whole
-// typed object when it adds the drain finalizer (see
-// runnerpool_controller.go), so any zero-valued field with a non-zero
-// default is rewritten on a pool's first reconcile and stays wrong for
-// the pool's lifetime. `enabled` (default false) and `maxReplicas`
-// (default 0) default to their zero values, so they are safe; the two
-// fields that declare `minimum: 0` with a non-zero default must not be
-// omitted.
+// A field here may carry `omitempty` only when its CRD default equals
+// its Go zero value. `omitempty` drops the zero value from the
+// serialized spec, which the apiserver cannot tell from "unset" and so
+// replaces with the CRD default — and the controller serializes the
+// whole spec whenever it adds the drain finalizer (runnerpool_controller.go).
+// `enabled` (default false) and `maxReplicas` (default 0) are safe;
+// the fields below that declare `minimum: 0` with a non-zero default
+// are not.
 type RunnerPoolAutoscaling struct {
 	// Enabled flips the autoscaling reconciler on for this pool.
 	// When false, the controller leaves `spec.replicas` alone.

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
@@ -4,15 +4,20 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
-// Guards the autoscaling fields whose CRD default is non-zero while
-// `minimum: 0` makes zero a valid setting. A zero dropped by `omitempty`
-// is indistinguishable from "unset", so the apiserver replaces it with
-// the CRD default — and the controller serializes the whole spec every
-// time it adds the drain finalizer.
-func TestAutoscalingZeroValuesReachTheWire(t *testing.T) {
-	payload, err := json.Marshal(RunnerPoolAutoscaling{Enabled: true})
+// An explicit 0 on the two pointer fields must reach the wire. A zero
+// dropped from the serialized spec is indistinguishable from "unset", so
+// the apiserver replaces it with the CRD default — and the controller
+// serializes the whole spec every time it adds the drain finalizer.
+func TestAutoscalingExplicitZeroReachesTheWire(t *testing.T) {
+	payload, err := json.Marshal(RunnerPoolAutoscaling{
+		Enabled:                  true,
+		MinWarmPoolFloor:         ptr.To[int32](0),
+		ScaleDownCooldownSeconds: ptr.To[int32](0),
+	})
 	if err != nil {
 		t.Fatalf("marshal autoscaling: %v", err)
 	}
@@ -26,25 +31,88 @@ func TestAutoscalingZeroValuesReachTheWire(t *testing.T) {
 		{`"scaleDownCooldownSeconds":0`, "300"},
 	} {
 		if !strings.Contains(got, field.json) {
-			t.Errorf("zero value dropped from the serialized spec: want %s in %s\n"+
-				"the apiserver will re-default this field to %s; drop `omitempty` from its json tag",
-				field.json, got, field.crdDefault)
+			t.Errorf("explicit zero dropped from the serialized spec: want %s in %s\n"+
+				"the apiserver will re-default this field to %s", field.json, got, field.crdDefault)
 		}
 	}
 }
 
-// Fields whose CRD default equals their Go zero value keep `omitempty`,
-// preserving the wire shape the RunnerPoolSpec doc comment describes.
-func TestAutoscalingDefaultZeroFieldsStayOmitted(t *testing.T) {
-	payload, err := json.Marshal(RunnerPoolAutoscaling{MinWarmPoolFloor: 1})
+// An unset (nil) pointer field must be omitted, so a typed client that
+// never set it sends nothing and the apiserver's CRD default applies —
+// the distinction `*int32` exists to preserve.
+func TestAutoscalingUnsetFieldsAreOmitted(t *testing.T) {
+	payload, err := json.Marshal(RunnerPoolAutoscaling{Enabled: true, MaxReplicas: 9})
 	if err != nil {
 		t.Fatalf("marshal autoscaling: %v", err)
 	}
 	got := string(payload)
 
-	for _, field := range []string{`"enabled"`, `"maxReplicas"`} {
-		if strings.Contains(got, field) {
-			t.Errorf("expected %s to be omitted at its zero value, got %s", field, got)
+	for _, field := range []string{
+		`"minWarmPoolFloor"`,
+		`"scaleDownCooldownSeconds"`,
+		`"maxReplicas":9`, // sanity: a set value is present
+	} {
+		want := field == `"maxReplicas":9`
+		if strings.Contains(got, field) != want {
+			t.Errorf("field %s present=%v, want present=%v in %s", field, !want, want, got)
 		}
+	}
+}
+
+// The decode side of the round-trip: helm renders `minWarmPoolFloor: 0`,
+// and it must land as a non-nil pointer to 0 (a deliberate floor), while
+// an absent field lands as nil (apiserver default applies). This is the
+// exact case the pointer switch fixes.
+func TestAutoscalingDecodePreservesZeroVsUnset(t *testing.T) {
+	var withZero RunnerPoolAutoscaling
+	if err := json.Unmarshal([]byte(`{"minWarmPoolFloor":0}`), &withZero); err != nil {
+		t.Fatalf("unmarshal explicit zero: %v", err)
+	}
+	if withZero.MinWarmPoolFloor == nil || *withZero.MinWarmPoolFloor != 0 {
+		t.Errorf("explicit zero decoded to %v, want non-nil 0", withZero.MinWarmPoolFloor)
+	}
+
+	var absent RunnerPoolAutoscaling
+	if err := json.Unmarshal([]byte(`{"maxReplicas":9}`), &absent); err != nil {
+		t.Fatalf("unmarshal absent: %v", err)
+	}
+	if absent.MinWarmPoolFloor != nil {
+		t.Errorf("absent minWarmPoolFloor decoded to %v, want nil", absent.MinWarmPoolFloor)
+	}
+}
+
+// The accessors return the CRD default for an unset field and the
+// configured value otherwise, including a deliberate 0. They are how the
+// controller reads these fields, so a nil never reaches the allocator as
+// a raw 0.
+func TestAutoscalingOrDefaultAccessors(t *testing.T) {
+	unset := &RunnerPoolAutoscaling{}
+	if got := unset.MinWarmPoolFloorOrDefault(); got != 1 {
+		t.Errorf("unset MinWarmPoolFloor = %d, want CRD default 1", got)
+	}
+	if got := unset.ScaleDownCooldownSecondsOrDefault(); got != 300 {
+		t.Errorf("unset ScaleDownCooldownSeconds = %d, want CRD default 300", got)
+	}
+
+	zero := &RunnerPoolAutoscaling{
+		MinWarmPoolFloor:         ptr.To[int32](0),
+		ScaleDownCooldownSeconds: ptr.To[int32](0),
+	}
+	if got := zero.MinWarmPoolFloorOrDefault(); got != 0 {
+		t.Errorf("explicit-zero MinWarmPoolFloor = %d, want 0", got)
+	}
+	if got := zero.ScaleDownCooldownSecondsOrDefault(); got != 0 {
+		t.Errorf("explicit-zero ScaleDownCooldownSeconds = %d, want 0", got)
+	}
+
+	set := &RunnerPoolAutoscaling{MinWarmPoolFloor: ptr.To[int32](3)}
+	if got := set.MinWarmPoolFloorOrDefault(); got != 3 {
+		t.Errorf("set MinWarmPoolFloor = %d, want 3", got)
+	}
+
+	// A nil receiver (autoscaling block absent) must not panic.
+	var nilAuto *RunnerPoolAutoscaling
+	if got := nilAuto.MinWarmPoolFloorOrDefault(); got != 1 {
+		t.Errorf("nil-receiver MinWarmPoolFloor = %d, want CRD default 1", got)
 	}
 }

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
@@ -1,0 +1,58 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The controller serializes the whole typed RunnerPool when it adds the
+// drain finalizer (runnerpool_controller.go). Any field dropped by
+// `omitempty` is indistinguishable from "unset" on that write, so the
+// apiserver's structural-schema defaulting fills the CRD default back in
+// and a deliberately-configured zero silently becomes the default for the
+// pool's lifetime.
+//
+// This regression-guards the two autoscaling fields whose CRD default is
+// non-zero while `minimum: 0` makes zero a valid setting. It caught a live
+// production bug: three macOS pools configured `minWarmPoolFloor: 0` ran at
+// the CRD default of 1, each reserving a Mac mini nobody asked for on a
+// 9-host fleet.
+func TestAutoscalingZeroValuesReachTheWire(t *testing.T) {
+	payload, err := json.Marshal(RunnerPoolAutoscaling{Enabled: true})
+	if err != nil {
+		t.Fatalf("marshal autoscaling: %v", err)
+	}
+	got := string(payload)
+
+	for _, field := range []struct {
+		json       string
+		crdDefault string
+	}{
+		{`"minWarmPoolFloor":0`, "1"},
+		{`"scaleDownCooldownSeconds":0`, "300"},
+	} {
+		if !strings.Contains(got, field.json) {
+			t.Errorf("zero value dropped from the serialized spec: want %s in %s\n"+
+				"the apiserver will re-default this field to %s; drop `omitempty` from its json tag",
+				field.json, got, field.crdDefault)
+		}
+	}
+}
+
+// Guards the inverse: fields whose CRD default equals their Go zero value
+// are safe to omit, and keeping `omitempty` on them preserves the
+// pre-autoscaling wire shape the RunnerPoolSpec doc comment describes.
+func TestAutoscalingDefaultZeroFieldsStayOmitted(t *testing.T) {
+	payload, err := json.Marshal(RunnerPoolAutoscaling{MinWarmPoolFloor: 1})
+	if err != nil {
+		t.Fatalf("marshal autoscaling: %v", err)
+	}
+	got := string(payload)
+
+	for _, field := range []string{`"enabled"`, `"maxReplicas"`} {
+		if strings.Contains(got, field) {
+			t.Errorf("expected %s to be omitted at its zero value, got %s", field, got)
+		}
+	}
+}

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
@@ -6,18 +6,11 @@ import (
 	"testing"
 )
 
-// The controller serializes the whole typed RunnerPool when it adds the
-// drain finalizer (runnerpool_controller.go). Any field dropped by
-// `omitempty` is indistinguishable from "unset" on that write, so the
-// apiserver's structural-schema defaulting fills the CRD default back in
-// and a deliberately-configured zero silently becomes the default for the
-// pool's lifetime.
-//
-// This regression-guards the two autoscaling fields whose CRD default is
-// non-zero while `minimum: 0` makes zero a valid setting. It caught a live
-// production bug: three macOS pools configured `minWarmPoolFloor: 0` ran at
-// the CRD default of 1, each reserving a Mac mini nobody asked for on a
-// 9-host fleet.
+// Guards the autoscaling fields whose CRD default is non-zero while
+// `minimum: 0` makes zero a valid setting. A zero dropped by `omitempty`
+// is indistinguishable from "unset", so the apiserver replaces it with
+// the CRD default — and the controller serializes the whole spec every
+// time it adds the drain finalizer.
 func TestAutoscalingZeroValuesReachTheWire(t *testing.T) {
 	payload, err := json.Marshal(RunnerPoolAutoscaling{Enabled: true})
 	if err != nil {
@@ -40,9 +33,8 @@ func TestAutoscalingZeroValuesReachTheWire(t *testing.T) {
 	}
 }
 
-// Guards the inverse: fields whose CRD default equals their Go zero value
-// are safe to omit, and keeping `omitempty` on them preserves the
-// pre-autoscaling wire shape the RunnerPoolSpec doc comment describes.
+// Fields whose CRD default equals their Go zero value keep `omitempty`,
+// preserving the wire shape the RunnerPoolSpec doc comment describes.
 func TestAutoscalingDefaultZeroFieldsStayOmitted(t *testing.T) {
 	payload, err := json.Marshal(RunnerPoolAutoscaling{MinWarmPoolFloor: 1})
 	if err != nil {

--- a/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -89,6 +89,16 @@ func (in *RunnerPoolSpec) DeepCopyInto(out *RunnerPoolSpec) {
 
 func (in *RunnerPoolAutoscaling) DeepCopyInto(out *RunnerPoolAutoscaling) {
 	*out = *in
+	if in.MinWarmPoolFloor != nil {
+		in, out := &in.MinWarmPoolFloor, &out.MinWarmPoolFloor
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ScaleDownCooldownSeconds != nil {
+		in, out := &in.ScaleDownCooldownSeconds, &out.ScaleDownCooldownSeconds
+		*out = new(int32)
+		**out = **in
+	}
 }
 
 func (in *RunnerPoolRollout) DeepCopyInto(out *RunnerPoolRollout) {

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -137,7 +137,7 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	knobs := scaling.PolicyKnobs{
-		MinWarmPoolFloor: pool.Spec.Autoscaling.MinWarmPoolFloor,
+		MinWarmPoolFloor: pool.Spec.Autoscaling.MinWarmPoolFloorOrDefault(),
 		MaxReplicas:      pool.Spec.Autoscaling.MaxReplicas,
 	}
 	desired := r.desiredForPool(ctx, pool, *signals, knobs, logger)
@@ -160,7 +160,7 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// desired < current — scale down candidate. Cooldown gate
 		// stops us from oscillating: a single brief idle window
 		// shouldn't drop warm capacity that's about to be reused.
-		cooldown := time.Duration(pool.Spec.Autoscaling.ScaleDownCooldownSeconds) * time.Second
+		cooldown := time.Duration(pool.Spec.Autoscaling.ScaleDownCooldownSecondsOrDefault()) * time.Second
 		if cooldown < 0 {
 			cooldown = 0
 		}
@@ -342,7 +342,7 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 			}
 			sig = *fetched
 			k = scaling.PolicyKnobs{
-				MinWarmPoolFloor: p.Spec.Autoscaling.MinWarmPoolFloor,
+				MinWarmPoolFloor: p.Spec.Autoscaling.MinWarmPoolFloorOrDefault(),
 				MaxReplicas:      p.Spec.Autoscaling.MaxReplicas,
 			}
 		}

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -114,9 +115,9 @@ func TestAutoscaler_DisabledPoolIsNoOp(t *testing.T) {
 func TestAutoscaler_ScalesUp(t *testing.T) {
 	pool := newAutoscalerPool("linux", 1, &tuistv1.RunnerPoolAutoscaling{
 		Enabled:                  true,
-		MinWarmPoolFloor:         1,
+		MinWarmPoolFloor:         ptr.To[int32](1),
 		MaxReplicas:              30,
-		ScaleDownCooldownSeconds: 300,
+		ScaleDownCooldownSeconds: ptr.To[int32](300),
 	})
 	r, server := setupReconciler(t, pool, scaling.Signals{
 		Fleet:                 "linux",
@@ -145,9 +146,9 @@ func TestAutoscaler_ScalesUp(t *testing.T) {
 func TestAutoscaler_ScalesDownAfterCooldown(t *testing.T) {
 	pool := newAutoscalerPool("linux", 10, &tuistv1.RunnerPoolAutoscaling{
 		Enabled:                  true,
-		MinWarmPoolFloor:         1,
+		MinWarmPoolFloor:         ptr.To[int32](1),
 		MaxReplicas:              30,
-		ScaleDownCooldownSeconds: 60,
+		ScaleDownCooldownSeconds: ptr.To[int32](60),
 	})
 	r, server := setupReconciler(t, pool, scaling.Signals{
 		Fleet:                 "linux",
@@ -179,9 +180,9 @@ func TestAutoscaler_DefersScaleDownDuringCooldown(t *testing.T) {
 	tenSecondsAgo := metav1.NewTime(time.Date(2026, 5, 14, 11, 59, 50, 0, time.UTC))
 	pool := newAutoscalerPool("linux", 10, &tuistv1.RunnerPoolAutoscaling{
 		Enabled:                  true,
-		MinWarmPoolFloor:         1,
+		MinWarmPoolFloor:         ptr.To[int32](1),
 		MaxReplicas:              30,
-		ScaleDownCooldownSeconds: 300,
+		ScaleDownCooldownSeconds: ptr.To[int32](300),
 	})
 	pool.Status.LastScaleDownAt = &tenSecondsAgo
 
@@ -210,9 +211,9 @@ func TestAutoscaler_DefersScaleDownDuringCooldown(t *testing.T) {
 func TestAutoscaler_NoOpAtTarget(t *testing.T) {
 	pool := newAutoscalerPool("linux", 6, &tuistv1.RunnerPoolAutoscaling{
 		Enabled:                  true,
-		MinWarmPoolFloor:         1,
+		MinWarmPoolFloor:         ptr.To[int32](1),
 		MaxReplicas:              30,
-		ScaleDownCooldownSeconds: 300,
+		ScaleDownCooldownSeconds: ptr.To[int32](300),
 	})
 	r, server := setupReconciler(t, pool, scaling.Signals{
 		Fleet:                 "linux",
@@ -237,9 +238,9 @@ func TestAutoscaler_NoOpAtTarget(t *testing.T) {
 func TestAutoscaler_ServerErrorLeavesReplicasUnchanged(t *testing.T) {
 	pool := newAutoscalerPool("linux", 5, &tuistv1.RunnerPoolAutoscaling{
 		Enabled:                  true,
-		MinWarmPoolFloor:         1,
+		MinWarmPoolFloor:         ptr.To[int32](1),
 		MaxReplicas:              30,
-		ScaleDownCooldownSeconds: 300,
+		ScaleDownCooldownSeconds: ptr.To[int32](300),
 	})
 
 	scheme := runtime.NewScheme()
@@ -293,9 +294,9 @@ func linuxFleetPool(name string, replicas int32, podMemMB int32, floor, maxRepl 
 			PodMemoryMB:   podMemMB,
 			Autoscaling: &tuistv1.RunnerPoolAutoscaling{
 				Enabled:                  true,
-				MinWarmPoolFloor:         floor,
+				MinWarmPoolFloor:         ptr.To(floor),
 				MaxReplicas:              maxRepl,
-				ScaleDownCooldownSeconds: 0,
+				ScaleDownCooldownSeconds: ptr.To[int32](0),
 			},
 		},
 	}
@@ -392,9 +393,9 @@ func macosFleetPool(name, fleetSelector string, replicas, floor, maxRepl int32) 
 			DispatchLabel: name + "-label",
 			Autoscaling: &tuistv1.RunnerPoolAutoscaling{
 				Enabled:                  true,
-				MinWarmPoolFloor:         floor,
+				MinWarmPoolFloor:         ptr.To(floor),
 				MaxReplicas:              maxRepl,
-				ScaleDownCooldownSeconds: 0,
+				ScaleDownCooldownSeconds: ptr.To[int32](0),
 			},
 		},
 	}

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -170,7 +170,17 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	defer func() {
 		metrics.RecordPodPhases(pool.Name, phaseReplicas.pending, phaseReplicas.running, phaseReplicas.unknown)
-		metrics.RecordOldestPendingPodAge(pool.Name, phaseReplicas.oldestPendingAge(r.now()))
+		// darwin only: Pending means "no VM yet" for a Tart pool, but it
+		// is the healthy steady state for a Linux one. Linux warm-standby
+		// Pods run their dispatch poller as an init container and kubelet
+		// holds a Pod in Pending for as long as any init container runs,
+		// so an idle Linux runner reports Pending for its whole life —
+		// hours, by design. Publishing this for Linux would peg every
+		// idle pool at its warm-pool age. A Linux equivalent has to read
+		// the poller's own lifecycle, not the Pod phase.
+		if pool.Spec.OS == "darwin" {
+			metrics.RecordOldestPendingPodAge(pool.Name, phaseReplicas.oldestPendingAge(r.now()))
+		}
 	}()
 
 	alive := 0

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -88,6 +88,16 @@ type RunnerPoolReconciler struct {
 	// DNS and never need these. Empty disables the env injection.
 	ClusterDNSIP  string
 	ClusterDomain string
+
+	// Now is overridable in tests; defaults to time.Now.
+	Now func() time.Time
+}
+
+func (r *RunnerPoolReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
 }
 
 // +kubebuilder:rbac:groups=tuist.dev,resources=runnerpools,verbs=get;list;watch;update;patch
@@ -160,6 +170,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	defer func() {
 		metrics.RecordPodPhases(pool.Name, phaseReplicas.pending, phaseReplicas.running, phaseReplicas.unknown)
+		metrics.RecordOldestPendingPodAge(pool.Name, phaseReplicas.oldestPendingAge(r.now()))
 	}()
 
 	alive := 0
@@ -475,17 +486,42 @@ type podPhaseReplicaCounts struct {
 	pending int
 	running int
 	unknown int
+
+	// Creation timestamps of the Pods counted in `pending`, keyed by Pod
+	// name so `remove` can drop the right one. A running max can't be
+	// maintained through the reconcile's add/remove churn — reaping the
+	// oldest Pod has to reveal the next-oldest, not leave a stale peak.
+	// Pods this tick creates are deliberately absent: they're
+	// milliseconds old, so they can never be the oldest, and tracking
+	// them would mean threading a clock through createRunner.
+	pendingSince map[string]time.Time
 }
 
 func (c *podPhaseReplicaCounts) add(pod *corev1.Pod) {
 	switch pod.Status.Phase {
 	case corev1.PodPending:
 		c.pending++
+		if c.pendingSince == nil {
+			c.pendingSince = map[string]time.Time{}
+		}
+		c.pendingSince[pod.Name] = pod.CreationTimestamp.Time
 	case corev1.PodRunning:
 		c.running++
 	default:
 		c.unknown++
 	}
+}
+
+// oldestPendingAge is how long the least-recently-created Pending Pod
+// has been waiting as of `now`, or 0 when the pool has none.
+func (c *podPhaseReplicaCounts) oldestPendingAge(now time.Time) time.Duration {
+	var oldest time.Duration
+	for _, since := range c.pendingSince {
+		if age := now.Sub(since); age > oldest {
+			oldest = age
+		}
+	}
+	return oldest
 }
 
 func (c *podPhaseReplicaCounts) remove(pod *corev1.Pod) {
@@ -494,6 +530,7 @@ func (c *podPhaseReplicaCounts) remove(pod *corev1.Pod) {
 		if c.pending > 0 {
 			c.pending--
 		}
+		delete(c.pendingSince, pod.Name)
 	case corev1.PodRunning:
 		if c.running > 0 {
 			c.running--

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -708,3 +708,44 @@ func podNames(pods []corev1.Pod) []string {
 	}
 	return out
 }
+
+func TestOldestPendingAgeTracksTheOldest(t *testing.T) {
+	now := time.Date(2026, 7, 17, 3, 0, 0, 0, time.UTC)
+
+	newest := newRunnerPod("p-newest", "img", corev1.PodPending, "p")
+	newest.CreationTimestamp = metav1.NewTime(now.Add(-30 * time.Second))
+	oldest := newRunnerPod("p-oldest", "img", corev1.PodPending, "p")
+	oldest.CreationTimestamp = metav1.NewTime(now.Add(-4 * time.Hour))
+	running := newRunnerPod("p-running", "img", corev1.PodRunning, "p")
+	running.CreationTimestamp = metav1.NewTime(now.Add(-8 * time.Hour))
+
+	counts := podPhaseReplicaCounts{}
+	counts.add(newest)
+	counts.add(oldest)
+	// A Pod that booted long ago is not waiting on anything, so its age
+	// must not leak into the gauge.
+	counts.add(running)
+
+	if got := counts.oldestPendingAge(now); got != 4*time.Hour {
+		t.Fatalf("oldest pending age = %v, want 4h", got)
+	}
+
+	// Reaping the oldest has to reveal the next-oldest. A running max
+	// would keep reporting 4h here.
+	counts.remove(oldest)
+	if got := counts.oldestPendingAge(now); got != 30*time.Second {
+		t.Fatalf("oldest pending age after reaping the oldest = %v, want 30s", got)
+	}
+
+	counts.remove(newest)
+	if got := counts.oldestPendingAge(now); got != 0 {
+		t.Fatalf("oldest pending age with nothing pending = %v, want 0", got)
+	}
+}
+
+func TestOldestPendingAgeEmpty(t *testing.T) {
+	counts := podPhaseReplicaCounts{}
+	if got := counts.oldestPendingAge(time.Now()); got != 0 {
+		t.Fatalf("oldest pending age on an empty pool = %v, want 0", got)
+	}
+}

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -13,8 +13,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
+	"github.com/tuist/tuist/infra/runners-controller/internal/metrics"
 )
 
 func nn(ns, name string) types.NamespacedName {
@@ -747,5 +749,88 @@ func TestOldestPendingAgeEmpty(t *testing.T) {
 	counts := podPhaseReplicaCounts{}
 	if got := counts.oldestPendingAge(time.Now()); got != 0 {
 		t.Fatalf("oldest pending age on an empty pool = %v, want 0", got)
+	}
+}
+
+// oldestPendingGauge reads the published gauge out of the shared
+// controller-runtime registry: the metric is unexported in its own
+// package, and the registry is the same surface Prometheus scrapes.
+// Returns the value for `pool` and the total number of series.
+func oldestPendingGauge(t *testing.T, pool string) (float64, int) {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var value float64
+	var series int
+	for _, f := range families {
+		if f.GetName() != "tuist_runners_pool_oldest_pending_pod_age_seconds" {
+			continue
+		}
+		series = len(f.GetMetric())
+		for _, m := range f.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "pool" && l.GetValue() == pool {
+					value = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return value, series
+}
+
+// A Linux warm-standby Pod runs its dispatch poller as an init container,
+// and kubelet holds a Pod in Pending for as long as any init container
+// runs — so an idle Linux runner reports Pending for hours by design.
+// Publishing the un-booted age for Linux would peg every idle pool at its
+// warm-pool age and read as wedged. Tart pools have no such state.
+func TestOldestPendingPodAgeIsDarwinOnly(t *testing.T) {
+	now := time.Date(2026, 7, 17, 3, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		os         string
+		pool       string
+		wantAge    float64
+		wantSeries int
+	}{
+		{os: "darwin", pool: "p-darwin", wantAge: 3600, wantSeries: 1},
+		{os: "linux", pool: "p-linux", wantAge: 0, wantSeries: 0},
+	} {
+		t.Run(tc.os, func(t *testing.T) {
+			metrics.ClearRunnerPool(tc.pool)
+			t.Cleanup(func() { metrics.ClearRunnerPool(tc.pool) })
+
+			scheme := mustScheme(t)
+			pool := newPool(tc.pool, "img", 1)
+			pool.Spec.OS = tc.os
+
+			pending := newRunnerPod(tc.pool+"-runner-a", "img", corev1.PodPending, tc.pool)
+			pending.CreationTimestamp = metav1.NewTime(now.Add(-time.Hour))
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pool, pending).
+				WithStatusSubresource(&tuistv1.RunnerPool{}).
+				Build()
+
+			r := &RunnerPoolReconciler{
+				Client:      c,
+				Scheme:      scheme,
+				DispatchURL: "http://dispatch",
+				Now:         func() time.Time { return now },
+			}
+			if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			gotAge, gotSeries := oldestPendingGauge(t, tc.pool)
+			if gotAge != tc.wantAge {
+				t.Errorf("%s pool oldest pending age = %v, want %v", tc.os, gotAge, tc.wantAge)
+			}
+			if gotSeries != tc.wantSeries {
+				t.Errorf("%s pool published %d series, want %d", tc.os, gotSeries, tc.wantSeries)
+			}
+		})
 	}
 }

--- a/infra/runners-controller/go.mod
+++ b/infra/runners-controller/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.0
 )
 
@@ -59,7 +60,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -100,10 +100,13 @@ var (
 	}, []string{poolLabel, phaseLabel})
 
 	// oldestPendingPodAge is how long the pool's least-recently-created
-	// un-Running Pod has been waiting. A Pod is Pending from creation
-	// until tart-kubelet has its VM up, so this is the boot path's
-	// equivalent of queue age: normally tens of seconds, and unbounded
-	// when a host stalls mid image-pull.
+	// un-Running Pod has been waiting. **darwin pools only** — see the
+	// caller in runnerpool_controller.go. On a Tart pool, Pending means
+	// the VM isn't up, so this is the boot path's equivalent of queue
+	// age: tens of seconds normally, unbounded when a host stalls mid
+	// image-pull. On a Linux pool, Pending is the healthy steady state
+	// (the dispatch poller is an init container), so the same reading
+	// would peg every idle pool at its warm-pool age.
 	//
 	// The count in phaseReplicas cannot substitute. A pool that keeps
 	// one Pod Pending because it is steadily replacing single-shot
@@ -113,7 +116,7 @@ var (
 	// that never boots is absent from it entirely.
 	oldestPendingPodAge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "tuist_runners_pool_oldest_pending_pod_age_seconds",
-		Help: "Age of the pool's oldest alive Pod that has not reached Running (0 when none).",
+		Help: "Age of a darwin pool's oldest alive Pod that has not reached Running (0 when none).",
 	}, []string{poolLabel})
 )
 

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -12,6 +12,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -96,10 +98,27 @@ var (
 		Name: "tuist_runners_pool_phase_replicas",
 		Help: "Alive runner Pods per pool and Kubernetes phase.",
 	}, []string{poolLabel, phaseLabel})
+
+	// oldestPendingPodAge is how long the pool's least-recently-created
+	// un-Running Pod has been waiting. A Pod is Pending from creation
+	// until tart-kubelet has its VM up, so this is the boot path's
+	// equivalent of queue age: normally tens of seconds, and unbounded
+	// when a host stalls mid image-pull.
+	//
+	// The count in phaseReplicas cannot substitute. A pool that keeps
+	// one Pod Pending because it is steadily replacing single-shot
+	// runners reads the same as a pool with one Pod wedged for hours —
+	// only the age separates them. tart-kubelet's provision histogram
+	// cannot either: it is observed when a VM finally starts, so a Pod
+	// that never boots is absent from it entirely.
+	oldestPendingPodAge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_pool_oldest_pending_pod_age_seconds",
+		Help: "Age of the pool's oldest alive Pod that has not reached Running (0 when none).",
+	}, []string{poolLabel})
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas)
+	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge)
 }
 
 // RecordAllocation publishes one pool's allocation outcome for this
@@ -133,6 +152,18 @@ func RecordPodPhases(pool string, pending, running, unknown int) {
 	phaseReplicas.WithLabelValues(pool, "Unknown").Set(float64(unknown))
 }
 
+// RecordOldestPendingPodAge publishes how long the pool's oldest
+// un-Running Pod has been waiting. Callers pass 0 when the pool has
+// none, rather than skipping the call, so the gauge drains instead of
+// holding its last non-zero sample forever.
+func RecordOldestPendingPodAge(pool string, age time.Duration) {
+	seconds := age.Seconds()
+	if seconds < 0 {
+		seconds = 0
+	}
+	oldestPendingPodAge.WithLabelValues(pool).Set(seconds)
+}
+
 // ClearAutoscaler drops the autoscaler-owned series for a pool. Safe
 // to call for an unknown pool.
 func ClearAutoscaler(pool string) {
@@ -148,6 +179,7 @@ func ClearRunnerPool(pool string) {
 	rollingPods.DeleteLabelValues(pool)
 	stalePods.DeleteLabelValues(pool)
 	rollCap.DeleteLabelValues(pool)
+	oldestPendingPodAge.DeleteLabelValues(pool)
 	for _, phase := range podPhaseLabels {
 		phaseReplicas.DeleteLabelValues(pool, phase)
 	}

--- a/infra/runners-controller/internal/metrics/metrics_test.go
+++ b/infra/runners-controller/internal/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -92,5 +93,49 @@ func TestClearDropsRunnerPoolPhaseReplicas(t *testing.T) {
 
 	if got := testutil.CollectAndCount(phaseReplicas); got != 0 {
 		t.Fatalf("phase replica metric count after Clear = %d, want 0", got)
+	}
+}
+
+func TestRecordOldestPendingPodAge(t *testing.T) {
+	const pool = "p"
+
+	oldestPendingPodAge.Reset()
+
+	RecordOldestPendingPodAge(pool, 90*time.Second)
+	if got := testutil.ToFloat64(oldestPendingPodAge.WithLabelValues(pool)); got != 90 {
+		t.Fatalf("oldest pending pod age = %v, want 90", got)
+	}
+
+	// Drains rather than holding its last non-zero sample: a pool whose
+	// Pods have all booted must not keep reporting the old peak.
+	RecordOldestPendingPodAge(pool, 0)
+	if got := testutil.ToFloat64(oldestPendingPodAge.WithLabelValues(pool)); got != 0 {
+		t.Fatalf("oldest pending pod age after drain = %v, want 0", got)
+	}
+}
+
+// A clock skewed backwards must not publish a negative age, which would
+// plot below every threshold and read as a healthy pool.
+func TestRecordOldestPendingPodAgeClampsNegative(t *testing.T) {
+	const pool = "p"
+
+	oldestPendingPodAge.Reset()
+
+	RecordOldestPendingPodAge(pool, -5*time.Second)
+	if got := testutil.ToFloat64(oldestPendingPodAge.WithLabelValues(pool)); got != 0 {
+		t.Fatalf("negative age = %v, want clamped to 0", got)
+	}
+}
+
+func TestClearDropsOldestPendingPodAge(t *testing.T) {
+	const pool = "p"
+
+	oldestPendingPodAge.Reset()
+
+	RecordOldestPendingPodAge(pool, 30*time.Second)
+	Clear(pool)
+
+	if got := testutil.CollectAndCount(oldestPendingPodAge); got != 0 {
+		t.Fatalf("oldest pending pod age count after Clear = %d, want 0", got)
 	}
 }

--- a/infra/runners-controller/internal/scaling/desired.go
+++ b/infra/runners-controller/internal/scaling/desired.go
@@ -40,12 +40,10 @@ type PolicyKnobs struct {
 //   - `+ MinWarmPoolFloor` adds operator-configured slack on top
 //     of whichever (current load OR predicted peak) won, so a
 //     fresh arrival lands on a warm Pod instead of waiting for a
-//     newly-claimed Pod to start polling. Because it is additive,
-//     `desired >= MinWarmPoolFloor` always holds — the warm
-//     guarantee needs no separate lower-bound clamp, and applying
-//     one would double-count it (an idle pool would size to
-//     2 * MinWarmPoolFloor and hold twice the hosts its operator
-//     asked for; on the 9-slot macOS fleet a floor of 3 reserved 6).
+//     newly-claimed Pod to start polling. It is additive only:
+//     `desired >= MinWarmPoolFloor` already holds, so clamping the
+//     floor as a lower bound as well would double-count it and size
+//     an idle pool to twice its configured floor.
 //   - `MaxReplicas == 0` returns 0, which the caller treats as
 //     "autoscaling disabled" — the static spec.Replicas is left
 //     alone. This matches the CRD default; a pool that didn't

--- a/infra/runners-controller/internal/scaling/desired.go
+++ b/infra/runners-controller/internal/scaling/desired.go
@@ -27,21 +27,25 @@ type PolicyKnobs struct {
 // DesiredReplicas computes the autoscaler's target replica count
 // from server signals and CRD knobs:
 //
-//	floor    = max(MinWarmPoolFloor, P95ConcurrentLastHour)
-//	desired  = max(Claimed + Queued, floor) + MinWarmPoolFloor
+//	desired  = max(Claimed + Queued, P95ConcurrentLastHour) + MinWarmPoolFloor
 //	clamped  = min(MaxReplicas, max(0, desired))
 //
 // Intuition:
 //   - `Claimed + Queued` is what's in flight or wanting a Pod right
 //     now. The fleet must be at least this big.
-//   - `floor` lifts the size to the typical peak observed in the
-//     last hour even when current load is below it — that's the
-//     "lead the demand" behavior that keeps the next peak from
-//     paying cold-start.
+//   - `P95ConcurrentLastHour` lifts the size to the typical peak
+//     observed in the last hour even when current load is below it —
+//     that's the "lead the demand" behavior that keeps the next peak
+//     from paying cold-start.
 //   - `+ MinWarmPoolFloor` adds operator-configured slack on top
 //     of whichever (current load OR predicted peak) won, so a
 //     fresh arrival lands on a warm Pod instead of waiting for a
-//     newly-claimed Pod to start polling.
+//     newly-claimed Pod to start polling. Because it is additive,
+//     `desired >= MinWarmPoolFloor` always holds — the warm
+//     guarantee needs no separate lower-bound clamp, and applying
+//     one would double-count it (an idle pool would size to
+//     2 * MinWarmPoolFloor and hold twice the hosts its operator
+//     asked for; on the 9-slot macOS fleet a floor of 3 reserved 6).
 //   - `MaxReplicas == 0` returns 0, which the caller treats as
 //     "autoscaling disabled" — the static spec.Replicas is left
 //     alone. This matches the CRD default; a pool that didn't
@@ -51,10 +55,7 @@ func DesiredReplicas(s Signals, k PolicyKnobs) int32 {
 		return 0
 	}
 
-	floor := k.MinWarmPoolFloor
-	if s.P95ConcurrentLastHour > floor {
-		floor = s.P95ConcurrentLastHour
-	}
+	floor := s.P95ConcurrentLastHour
 
 	load := s.Claimed + s.Queued
 

--- a/infra/runners-controller/internal/scaling/desired_test.go
+++ b/infra/runners-controller/internal/scaling/desired_test.go
@@ -25,7 +25,17 @@ func TestDesiredReplicas(t *testing.T) {
 			name:    "idle with no history uses MinWarmPoolFloor",
 			signals: Signals{Claimed: 0, Queued: 0, P95ConcurrentLastHour: 0},
 			knobs:   PolicyKnobs{MinWarmPoolFloor: 3, MaxReplicas: 30},
-			want:    6, // floor=3 (no p95), target=max(0,3)=3, desired=3+3=6
+			want:    3, // target=max(0,0)=0, desired=0+3=3 — the floor, not twice it
+		},
+		{
+			// Regression: MinWarmPoolFloor is additive slack only. Counting it
+			// as a lower bound *and* adding it sized an idle pool to 2 * floor,
+			// so a zero-traffic pool reserved twice the hosts it was configured
+			// for and starved the pools serving real work.
+			name:    "MinWarmPoolFloor is not double-counted when it exceeds p95",
+			signals: Signals{Claimed: 0, Queued: 0, P95ConcurrentLastHour: 1},
+			knobs:   PolicyKnobs{MinWarmPoolFloor: 3, MaxReplicas: 30},
+			want:    4, // target=max(0,1)=1, desired=1+3=4
 		},
 		{
 			name:    "steady load matching p95",

--- a/infra/runners-controller/internal/scaling/desired_test.go
+++ b/infra/runners-controller/internal/scaling/desired_test.go
@@ -25,13 +25,9 @@ func TestDesiredReplicas(t *testing.T) {
 			name:    "idle with no history uses MinWarmPoolFloor",
 			signals: Signals{Claimed: 0, Queued: 0, P95ConcurrentLastHour: 0},
 			knobs:   PolicyKnobs{MinWarmPoolFloor: 3, MaxReplicas: 30},
-			want:    3, // target=max(0,0)=0, desired=0+3=3 — the floor, not twice it
+			want:    3, // target=max(0,0)=0, desired=0+3=3
 		},
 		{
-			// Regression: MinWarmPoolFloor is additive slack only. Counting it
-			// as a lower bound *and* adding it sized an idle pool to 2 * floor,
-			// so a zero-traffic pool reserved twice the hosts it was configured
-			// for and starved the pools serving real work.
 			name:    "MinWarmPoolFloor is not double-counted when it exceeds p95",
 			signals: Signals{Claimed: 0, Queued: 0, P95ConcurrentLastHour: 1},
 			knobs:   PolicyKnobs{MinWarmPoolFloor: 3, MaxReplicas: 30},

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -96,11 +96,22 @@ var guestDiskUsagePercent = prometheus.NewGaugeVec(
 //
 // Pool label from the Pod's `tuist.dev/runner-pool` label, same as the
 // boot histogram, for per-pool breakdowns.
+//
+// Buckets run to an hour: a cold pull of a tens-of-GB image behind the
+// single-concurrency reconcile puts real observations well past ten
+// minutes, and prod p99 sits on the top bucket through every busy hour.
+// Anything censored at the ceiling reads as "10 minutes" no matter how
+// much worse it is, which defeats the rising-p90 signal above.
+//
+// This only measures Pods that eventually run — it is observed on the
+// path to Run, so a Pod that never provisions contributes nothing here
+// and no quantile will show it. Detection of that case belongs on a
+// gauge over live Pods, not on this histogram.
 var podProvisionDelaySeconds = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "tart_kubelet_pod_provision_delay_seconds",
 		Help:    "Wall-clock from Pod creation to tart run start (scheduling + image pull + clone).",
-		Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 180, 300, 600},
+		Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 1800, 3600},
 	},
 	[]string{"pool"},
 )
@@ -114,11 +125,13 @@ var podProvisionDelaySeconds = prometheus.NewHistogramVec(
 // materialized) makes the cold-pull tail explicit, so a high
 // podProvisionDelaySeconds can be attributed to queue wait vs. a genuine
 // re-pull at a glance rather than guessed at.
+// Buckets match podProvisionDelaySeconds so the two are comparable at a
+// glance; a cold pull is exactly the case that exceeds ten minutes.
 var vmProvisionWorkSeconds = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "tart_kubelet_vm_provision_work_seconds",
 		Help:    "Wall-clock for on-host provisioning work (ensureGolden + runner clone), per pool and path (warm=clonefile, cold=pull).",
-		Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 180, 300, 600},
+		Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 1800, 3600},
 	},
 	[]string{"pool", "path"},
 )

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -62,6 +62,16 @@ defmodule Tuist.Runners.PromExPlugin do
   # after a RunnerPool is deleted.
   @pool_replicas_seen_key :tuist_runners_pool_replicas_seen_fleets
 
+  # Same idea for the queue poll. `universe_fleets/1` keeps a fleet
+  # emitting zeros while it is either an active RunnerPool or still has
+  # queued rows, but a fleet that loses both at once (pool deleted while
+  # a row is queued, then that row leaves `queued`) is in neither set,
+  # so nothing is emitted and `last_value` holds the fleet's last
+  # non-zero `queue_length` / `queue_oldest_age_seconds` forever — a
+  # growing age that keeps the queue-age alert firing after the queue
+  # has cleared. Emit one final zero for such fleets.
+  @queue_seen_key :tuist_runners_queue_seen_fleets
+
   # Buckets cover the realistic wall-clock range for each duration.
   # `queue_time` and `queue_to_running` are sub-minute on the happy
   # path; `run_time` / `total_time` span seconds to the GH-side
@@ -294,10 +304,9 @@ defmodule Tuist.Runners.PromExPlugin do
     if PoolMetrics.running?(ClickHouseRepo) do
       now = DateTime.utc_now()
       stats = fetch_queue_stats(now)
+      current_fleets = stats |> universe_fleets() |> MapSet.new()
 
-      stats
-      |> universe_fleets()
-      |> Enum.each(fn fleet ->
+      Enum.each(current_fleets, fn fleet ->
         %{count: count, oldest_age_seconds: age} =
           Map.get(stats, fleet, %{count: 0, oldest_age_seconds: 0})
 
@@ -307,6 +316,19 @@ defmodule Tuist.Runners.PromExPlugin do
           %{fleet: fleet}
         )
       end)
+
+      @queue_seen_key
+      |> Process.get(MapSet.new())
+      |> MapSet.difference(current_fleets)
+      |> Enum.each(fn fleet ->
+        :telemetry.execute(
+          Telemetry.event_name_queue_length(),
+          %{count: 0, oldest_age_seconds: 0},
+          %{fleet: fleet}
+        )
+      end)
+
+      Process.put(@queue_seen_key, current_fleets)
     end
   end
 

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -231,13 +231,10 @@ defmodule Tuist.Runners.PromExPlugin do
             measurement: :count,
             tags: [:fleet]
           ),
-          # Rides the same event as `queue_length` because both come out
-          # of one ClickHouse scan — depth and age answer different
-          # questions and neither substitutes for the other. Depth alone
-          # can't tell "jobs arriving and being served promptly, queue
-          # never empty" from "one job wedged for hours": both sit at 1.
-          # Age is the only signal that separates them, and it's the one
-          # a stuck job trips.
+          # Rides the `queue_length` event: both values come out of one
+          # ClickHouse scan. Depth alone can't distinguish a queue that
+          # is never empty because arrivals are served promptly from one
+          # job wedged for hours — both sit at 1.
           last_value(
             @metric_prefix ++ [:queue, :oldest, :age, :seconds],
             event_name: Telemetry.event_name_queue_length(),
@@ -355,9 +352,8 @@ defmodule Tuist.Runners.PromExPlugin do
   end
 
   # Clamped at 0 so clock skew between the pod that wrote `enqueued_at`
-  # and the pod polling can't report a negative age — which would read
-  # as a healthy queue and suppress the alert this gauge exists to
-  # raise. `nil` means the fleet has nothing queued.
+  # and the pod polling can't report a negative age, which would read as
+  # a healthy queue. `nil` means the fleet has nothing queued.
   defp age_seconds(_now, nil), do: 0
 
   defp age_seconds(now, %DateTime{} = enqueued_at) do

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -230,6 +230,20 @@ defmodule Tuist.Runners.PromExPlugin do
             description: "Queued workflow jobs per fleet (ClickHouse runner_jobs).",
             measurement: :count,
             tags: [:fleet]
+          ),
+          # Rides the same event as `queue_length` because both come out
+          # of one ClickHouse scan — depth and age answer different
+          # questions and neither substitutes for the other. Depth alone
+          # can't tell "jobs arriving and being served promptly, queue
+          # never empty" from "one job wedged for hours": both sit at 1.
+          # Age is the only signal that separates them, and it's the one
+          # a stuck job trips.
+          last_value(
+            @metric_prefix ++ [:queue, :oldest, :age, :seconds],
+            event_name: Telemetry.event_name_queue_length(),
+            description: "Age of the oldest still-queued workflow job per fleet, in seconds (0 when the queue is empty).",
+            measurement: :oldest_age_seconds,
+            tags: [:fleet]
           )
         ]
       ),
@@ -281,14 +295,18 @@ defmodule Tuist.Runners.PromExPlugin do
   @doc false
   def execute_queue_length_telemetry_event do
     if PoolMetrics.running?(ClickHouseRepo) do
-      counts = fetch_queue_counts()
+      now = DateTime.utc_now()
+      stats = fetch_queue_stats(now)
 
-      counts
+      stats
       |> universe_fleets()
       |> Enum.each(fn fleet ->
+        %{count: count, oldest_age_seconds: age} =
+          Map.get(stats, fleet, %{count: 0, oldest_age_seconds: 0})
+
         :telemetry.execute(
           Telemetry.event_name_queue_length(),
-          %{count: Map.get(counts, fleet, 0)},
+          %{count: count, oldest_age_seconds: age},
           %{fleet: fleet}
         )
       end)
@@ -310,8 +328,8 @@ defmodule Tuist.Runners.PromExPlugin do
   # of our problems.
   @queue_lookback_days 7
 
-  defp fetch_queue_counts do
-    cutoff = DateTime.add(DateTime.utc_now(), -@queue_lookback_days, :day)
+  defp fetch_queue_stats(now) do
+    cutoff = DateTime.add(now, -@queue_lookback_days, :day)
 
     latest =
       from(j in Job,
@@ -320,17 +338,34 @@ defmodule Tuist.Runners.PromExPlugin do
         select: %{
           workflow_job_id: j.workflow_job_id,
           fleet_name: fragment("argMax(?, ?)", j.fleet_name, j.updated_at),
-          status: fragment("argMax(?, ?)", j.status, j.updated_at)
+          status: fragment("argMax(?, ?)", j.status, j.updated_at),
+          enqueued_at: min(j.enqueued_at)
         }
       )
 
     from(s in subquery(latest),
       where: s.status == "queued",
       group_by: s.fleet_name,
-      select: {s.fleet_name, count(s.workflow_job_id)}
+      select: {s.fleet_name, count(s.workflow_job_id), min(s.enqueued_at)}
     )
     |> ClickHouseRepo.all()
-    |> Map.new(fn {fleet, count} -> {fleet || "", count} end)
+    |> Map.new(fn {fleet, count, oldest_enqueued_at} ->
+      {fleet || "", %{count: count, oldest_age_seconds: age_seconds(now, oldest_enqueued_at)}}
+    end)
+  end
+
+  # Clamped at 0 so clock skew between the pod that wrote `enqueued_at`
+  # and the pod polling can't report a negative age — which would read
+  # as a healthy queue and suppress the alert this gauge exists to
+  # raise. `nil` means the fleet has nothing queued.
+  defp age_seconds(_now, nil), do: 0
+
+  defp age_seconds(now, %DateTime{} = enqueued_at) do
+    now |> DateTime.diff(enqueued_at, :second) |> max(0)
+  end
+
+  defp age_seconds(now, %NaiveDateTime{} = enqueued_at) do
+    age_seconds(now, DateTime.from_naive!(enqueued_at, "Etc/UTC"))
   end
 
   @doc false

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -137,6 +137,48 @@ defmodule Tuist.Runners.PromExPluginTest do
                       %{fleet: "fleet-empty-age"}},
                      500
     end
+
+    test "emits a final zero when a queued fleet's pool is gone and its queue clears",
+         %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+
+      # The fleet has a queued row but no active RunnerPool — the "pool
+      # deleted while a job was still queued" case. It's visible this
+      # tick only because it has a queued row.
+      stub_pool_list([])
+
+      account = account_fixture()
+
+      :ok =
+        Jobs.enqueue(%{
+          workflow_job_id: 999_020,
+          account_id: account.id,
+          fleet_name: "fleet-gone",
+          repository: "acme/cli",
+          workflow_run_id: 9020,
+          run_attempt: 1,
+          job_name: "build",
+          head_branch: "main",
+          head_sha: "deadbeef"
+        })
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 1}, %{fleet: "fleet-gone"}},
+                     500
+
+      # The queued row leaves `queued` and the pool is still gone, so the
+      # fleet is now in neither the queue stats nor the active pool list.
+      # Without the seen-set drain, this tick would emit nothing and
+      # last_value would hold the stale non-zero age forever.
+      {:ok, _} = Jobs.complete(999_020, "success")
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0, oldest_age_seconds: 0},
+                      %{fleet: "fleet-gone"}},
+                     500
+    end
   end
 
   describe "execute_claims_telemetry_event/0" do

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -91,10 +91,17 @@ defmodule Tuist.Runners.PromExPluginTest do
 
       account = account_fixture()
 
+      # Relative to now, not fixed dates: the poll only scans back
+      # `@queue_lookback_days`, so absolute timestamps would age out of
+      # the window and silently drop the expected count.
+      now = DateTime.utc_now()
+      oldest_enqueued_at = DateTime.add(now, -4 * 60 * 60, :second)
+      newer_enqueued_at = DateTime.add(now, -30 * 60, :second)
+
       # Two queued jobs on one fleet: the gauge tracks the oldest.
       for {id, enqueued_at} <- [
-            {999_010, ~U[2026-07-16 22:39:43.000000Z]},
-            {999_011, ~U[2026-07-17 02:00:00.000000Z]}
+            {999_010, oldest_enqueued_at},
+            {999_011, newer_enqueued_at}
           ] do
         :ok =
           Jobs.enqueue(%{
@@ -117,8 +124,7 @@ defmodule Tuist.Runners.PromExPluginTest do
                       %{count: 2, oldest_age_seconds: oldest_age_seconds}, %{fleet: "fleet-age"}},
                      500
 
-      expected = DateTime.diff(DateTime.utc_now(), ~U[2026-07-16 22:39:43.000000Z], :second)
-      assert_in_delta oldest_age_seconds, expected, 60
+      assert_in_delta oldest_age_seconds, 4 * 60 * 60, 60
     end
 
     test "reports zero age for a fleet with an empty queue", %{handler_id: handler_id} do

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -84,6 +84,57 @@ defmodule Tuist.Runners.PromExPluginTest do
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0}, %{fleet: "fleet-empty"}},
                      500
     end
+
+    test "reports the age of the oldest queued job", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+      stub_pool_list(["fleet-age"])
+
+      account = account_fixture()
+
+      # Two queued jobs on one fleet: the gauge must track the *oldest*,
+      # since that's the one whose wait a queue-age alert has to catch.
+      # A fleet steadily serving new arrivals keeps depth at 1 forever
+      # without anything being wrong; only the head's age separates that
+      # from a wedged job.
+      for {id, enqueued_at} <- [
+            {999_010, ~U[2026-07-16 22:39:43.000000Z]},
+            {999_011, ~U[2026-07-17 02:00:00.000000Z]}
+          ] do
+        :ok =
+          Jobs.enqueue(%{
+            workflow_job_id: id,
+            account_id: account.id,
+            fleet_name: "fleet-age",
+            repository: "acme/cli",
+            workflow_run_id: 9010,
+            run_attempt: 1,
+            job_name: "build",
+            head_branch: "main",
+            head_sha: "deadbeef",
+            enqueued_at: enqueued_at
+          })
+      end
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length],
+                      %{count: 2, oldest_age_seconds: oldest_age_seconds}, %{fleet: "fleet-age"}},
+                     500
+
+      expected = DateTime.diff(DateTime.utc_now(), ~U[2026-07-16 22:39:43.000000Z], :second)
+      assert_in_delta oldest_age_seconds, expected, 60
+    end
+
+    test "reports zero age for a fleet with an empty queue", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+      stub_pool_list(["fleet-empty-age"])
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{oldest_age_seconds: 0},
+                      %{fleet: "fleet-empty-age"}},
+                     500
+    end
   end
 
   describe "execute_claims_telemetry_event/0" do

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -91,11 +91,7 @@ defmodule Tuist.Runners.PromExPluginTest do
 
       account = account_fixture()
 
-      # Two queued jobs on one fleet: the gauge must track the *oldest*,
-      # since that's the one whose wait a queue-age alert has to catch.
-      # A fleet steadily serving new arrivals keeps depth at 1 forever
-      # without anything being wrong; only the head's age separates that
-      # from a wedged job.
+      # Two queued jobs on one fleet: the gauge tracks the oldest.
       for {id, enqueued_at} <- [
             {999_010, ~U[2026-07-16 22:39:43.000000Z]},
             {999_011, ~U[2026-07-17 02:00:00.000000Z]}


### PR DESCRIPTION
Found while investigating a `tuist-macos` job that stayed queued on GitHub for **4h08m** while macOS runners sat Running and idle. Two detection gaps that let it run unnoticed, and three defects wasting host slots on the 9-slot macOS fleet.

## What actually caused the 4h

Not the floor defects — those are capacity hygiene, and they're fixed here because they're real, not because they caused this. The allocator gave 26-5 `desired = 1` for the entire four hours and total desired was 8 of 9, so **a host was spare**. `claims_count` stayed 0. The job was never starved of an allocation or of capacity.

The wait happened between `spec.replicas = 1` and a booted VM, and **every signal was green throughout**:

- `tart_kubelet_pod_provision_delay_seconds` logged **zero provisions at 01:00 and 02:00, then exactly one at 03:00** — 26-5's Pod finally starting at 02:48 after ~4h. It's observed on the path to `Run`, so a Pod that never boots contributes nothing.
- Its top bucket was **600s**, and prod p99 sits on that ceiling through every busy hour — the "rising p90 = pull wave" signal it was added for cannot rise past its own ceiling.
- The Node kept heartbeating **Ready**, and `kube_pod_status_unschedulable` stayed **0**: the Pod *was* scheduled. It just never booted.

It was **not** a dropped webhook. A JIT config is minted only after `pick_queued` returns a candidate read from ClickHouse, so no row would mean the runner never registers and the job never starts — yet it did start, on a 26-5 runner. Its sibling, created in the same webhook batch, dispatched in 15s.

## 1. Two gauges for the states nothing could see

**`tuist_runners_queue_oldest_age_seconds{fleet}`** (server) — age of the oldest still-queued job. `queue_length` measures depth: a fleet steadily serving arrivals sits at 1 forever and looks identical to one job wedged for hours. `job_queue_time_milliseconds` is emitted **on claim**, so an unclaimed job emits nothing, and it tops out at 300s — even retrospectively a 4h wait and a 6m wait are indistinguishable (p99 pins at exactly 300). Rides the existing `queue_length` event and poll, so no extra ClickHouse query per tick.

**`tuist_runners_pool_oldest_pending_pod_age_seconds{pool}`** (controller) — age of the oldest un-`Running` Pod, the boot path's equivalent. Rides the reconciler's existing Pod list and its metrics defer, so no extra API call. Timestamps are tracked per Pod name rather than as a running max: reaping the oldest has to reveal the next-oldest, not leave a stale peak.

Both clamp negatives so a backwards clock can't read as healthy, and both report 0 rather than skipping so they drain instead of holding a stale peak.

**Alert "Runner queue age"** (folder Alerts, group Runners, uid `afsd33dx5fhmoc`): `max by (fleet) (tuist_runners_queue_oldest_age_seconds{env="production"}) > 1800` for 5m. `max by (fleet)` is required, not stylistic — polling gauges are emitted by every server replica and prod runs 3, so a bare aggregate triple-counts. Threshold from measured behaviour: healthy waits peak at ~3.3m, the worst day's p90 was ~11m, the incident ran 106m then 248m. It would have fired at ~23:15 instead of never. Sits NoData → OK until this ships, then activates on its own.

Also widens `tart_kubelet_pod_provision_delay_seconds` and `..._vm_provision_work_seconds` to 1200/1800/3600 so observations past ten minutes stop being censored. Nothing queries them today, so no dashboard or alert changes.

## 2. `minWarmPoolFloor` was double-counted

`DesiredReplicas` counted it twice: as a lower bound inside `floor = max(MinWarmPoolFloor, P95ConcurrentLastHour)`, and again as additive slack in `desired = max(load, floor) + MinWarmPoolFloor`. An idle pool sized to `2 * MinWarmPoolFloor`.

Dropping it from the max is enough — because the slack is additive, `desired >= MinWarmPoolFloor` already holds unconditionally. Every other documented behaviour is preserved. The only changed test is the case whose name already said what it should be: *"idle with no history uses MinWarmPoolFloor"* now wants 3, not 6.

## 3. `minWarmPoolFloor: 0` was silently becoming 1

`omitempty` on a field whose CRD default is `1`, so an explicit `0` was dropped from the serialized spec and re-defaulted by the apiserver. Not latent: `RunnerPoolReconciler` Updates the **whole typed object** when it adds the drain finalizer, so the flip lands on a pool's first reconcile and sticks for its lifetime.

The chart renders `0` for 26.5/26.4.1/26.3/26.0.1; production reported **1** for three of them, flat across 16h and several deploys. The pattern is what the mechanism predicts: 26.5 escaped because its `0` arrived after its finalizer already existed, and 26.6 kept its `3` because non-zero values aren't dropped. Only `0` is affected.

`scaleDownCooldownSeconds` has the same shape (default 300, `minimum: 0`) and is fixed alongside. `enabled` and `maxReplicas` default to their zero values and keep `omitempty`. The rule is documented on the struct and pinned by a test that fails with the old tag. No CRD regeneration needed — `omitempty` is a Go serialization concern and optionality comes from the explicit `+optional` markers.

## 4. The 26.6 floor was sized on a false premise

A floor doesn't follow the catalog default on its own: `tuist-macos` resolves through each account's protected `macos` profile, which stores `xcode_version` at account creation. Moving `default: true` to 26.6 in #11822 didn't move where existing accounts' jobs landed — 143 of 147 macOS jobs in a 10-hour window went to **26-5**, none to 26-6. The floor was warming a pool nothing dispatched to.

Dropped to **1** (canary and staging already use 1). The tuist account's profile has since been moved to 26.6 and dispatch followed within the hour, so the default now genuinely carries the traffic and the floor is correctly placed. The comment records the ordering constraint: bumping the catalog default only redirects *new* accounts, so existing profiles have to move in the same change.

## Fleet budget impact

| pool | configured floor | effective floor | target | allocated |
|---|---|---|---|---|
| macos-26-6 | 3 | 3 | **6** | **4** |
| macos-26-0-1 | 0 | **1** (drift) | 2 | 1 |
| macos-26-3 | 0 | **1** (drift) | 2 | 1 |
| macos-26-4-1 | 0 | **1** (drift) | 2 | 1 |
| macos-26-5 | 0 | 0 | 1 | 1 |

Targets summed to **13 against 9 hosts**. Reserved floors go from an effective **12 of 9 slots** to **1**, leaving 8 for the allocator.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` pass across the controller and tart-kubelet.
- `mix test test/tuist/runners/prom_ex_plugin_test.exs` — 10 passed, including the oldest-of-two-jobs case and the empty-queue zero.
- `helm template` with production values renders 26.6=1 and the rest 0.
- Two tests were verified to **fail** against the bug they guard, not merely pass against the fix: the `omitempty` serialization test, and the reap-reveals-next-oldest test (which reports `4h0m0s, want 30s` against a running max).

## Known gap

`tuist_runners_pool_replicas_observed` has its `fleet` label aggregated away in Grafana Cloud (`fleet: "<aggregated>"`), so desired-vs-observed per pool isn't queryable. The new Pod-age gauge covers the case that mattered here, but that aggregation is worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
