### PR TITLE
fix(server): keep the billing page up when Stripe is unreachable

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -16,6 +16,8 @@ defmodule Tuist.Billing do
   alias Tuist.CommandEvents
   alias Tuist.Repo
 
+  require Logger
+
   # Unfortunately, this data can't be obtained and cached
   # from the Stripe's API, so we have to make sure it's in sync
   # with the values on Stripe.
@@ -349,11 +351,19 @@ defmodule Tuist.Billing do
     end
   end
 
+  @doc """
+  Returns the end of the subscription's current period, or `nil` when Stripe can't be reached.
+  """
   def get_subscription_current_period_end(subscription_id) do
-    {:ok, %{current_period_end: current_period_end}} =
-      Stripe.Subscription.retrieve(subscription_id)
+    case Stripe.Subscription.retrieve(subscription_id) do
+      {:ok, %{current_period_end: current_period_end}} ->
+        DateTime.from_unix!(current_period_end)
 
-    DateTime.from_unix!(current_period_end)
+      {:error, error} ->
+        Logger.warning("Couldn't retrieve the subscription #{subscription_id} from Stripe: #{inspect(error)}")
+
+        nil
+    end
   end
 
   def get_payment_method_id_from_subscription_id(subscription_id) do
@@ -371,9 +381,22 @@ defmodule Tuist.Billing do
     end
   end
 
+  @doc """
+  Returns the payment method, or `nil` when Stripe can't be reached.
+  """
   def get_payment_method_by_id(payment_method_id) do
-    {:ok, payment_method} = Stripe.PaymentMethod.retrieve(payment_method_id)
+    case Stripe.PaymentMethod.retrieve(payment_method_id) do
+      {:ok, payment_method} ->
+        build_payment_method(payment_method)
 
+      {:error, error} ->
+        Logger.warning("Couldn't retrieve the payment method #{payment_method_id} from Stripe: #{inspect(error)}")
+
+        nil
+    end
+  end
+
+  defp build_payment_method(payment_method) do
     card =
       if is_nil(payment_method.card),
         do: nil,

--- a/server/lib/tuist_web/live/billing_live.ex
+++ b/server/lib/tuist_web/live/billing_live.ex
@@ -31,15 +31,17 @@ defmodule TuistWeb.BillingLive do
       |> Billing.get_estimated_next_payment_money()
       |> format_money()
 
+    current_period_end =
+      if is_nil(subscription),
+        do: nil,
+        else: Billing.get_subscription_current_period_end(subscription.subscription_id)
+
     next_charge_date =
-      if is_nil(subscription) do
+      if is_nil(current_period_end) do
         dgettext("dashboard_account", "charged /per month")
       else
         dgettext("dashboard_account", "charged on %{next_charge_date}",
-          next_charge_date:
-            subscription.subscription_id
-            |> Billing.get_subscription_current_period_end()
-            |> Timex.format!("{Mfull} {D}")
+          next_charge_date: Timex.format!(current_period_end, "{Mfull} {D}")
         )
       end
 

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist/billing.ex:59
-#: lib/tuist_web/live/billing_live.ex:218
+#: lib/tuist/billing.ex:61
+#: lib/tuist_web/live/billing_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "$0"
 msgstr ""
@@ -49,8 +49,8 @@ msgstr ""
 msgid "Admin"
 msgstr ""
 
-#: lib/tuist/billing.ex:37
-#: lib/tuist_web/live/billing_live.ex:188
+#: lib/tuist/billing.ex:39
+#: lib/tuist_web/live/billing_live.ex:190
 #: lib/tuist_web/live/billing_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Air"
@@ -61,8 +61,8 @@ msgstr ""
 msgid "All billing correspondence will go to this email"
 msgstr ""
 
-#: lib/tuist/billing.ex:46
-#: lib/tuist_web/live/billing_live.ex:193
+#: lib/tuist/billing.ex:48
+#: lib/tuist_web/live/billing_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "All features, no credit card required"
 msgstr ""
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Are you sure you want to remove %{name} from this organization?"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:72
+#: lib/tuist_web/live/billing_live.ex:74
 #: lib/tuist_web/live/billing_live.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Billing"
@@ -138,12 +138,12 @@ msgstr ""
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
 
-#: lib/tuist/billing.ex:47
+#: lib/tuist/billing.ex:49
 #, elixir-autogen, elixir-format
 msgid "Community support"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:194
+#: lib/tuist_web/live/billing_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Community support via forum"
 msgstr ""
@@ -168,8 +168,8 @@ msgstr ""
 msgid "Confirmation instructions"
 msgstr ""
 
-#: lib/tuist/billing.ex:79
-#: lib/tuist_web/live/billing_live.ex:255
+#: lib/tuist/billing.ex:81
+#: lib/tuist_web/live/billing_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Contact sales"
 msgstr ""
@@ -179,34 +179,34 @@ msgstr ""
 msgid "Create organization"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:245
+#: lib/tuist_web/live/billing_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Create your plan or self-host your instance"
 msgstr ""
 
-#: lib/tuist/billing.ex:77
+#: lib/tuist/billing.ex:79
 #: lib/tuist_web/live/billing_live.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Create your plan or self-host your instance."
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:200
-#: lib/tuist_web/live/billing_live.ex:229
+#: lib/tuist_web/live/billing_live.ex:202
+#: lib/tuist_web/live/billing_live.ex:231
 #: lib/tuist_web/live/billing_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Current plan"
 msgstr ""
 
-#: lib/tuist/billing.ex:78
-#: lib/tuist_web/live/billing_live.ex:246
+#: lib/tuist/billing.ex:80
+#: lib/tuist_web/live/billing_live.ex:248
 #: lib/tuist_web/live/billing_live.html.heex:67
 #: lib/tuist_web/live/webhook_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Custom"
 msgstr ""
 
-#: lib/tuist/billing.ex:81
-#: lib/tuist_web/live/billing_live.ex:248
+#: lib/tuist/billing.ex:83
+#: lib/tuist_web/live/billing_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Custom terms"
 msgstr ""
@@ -327,7 +327,7 @@ msgstr ""
 msgid "Did you request to reset your password?"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:206
+#: lib/tuist_web/live/billing_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Downgrade"
 msgstr ""
@@ -358,8 +358,8 @@ msgstr ""
 msgid "Enter your username to confirm"
 msgstr ""
 
-#: lib/tuist/billing.ex:75
-#: lib/tuist_web/live/billing_live.ex:244
+#: lib/tuist/billing.ex:77
+#: lib/tuist_web/live/billing_live.ex:246
 #: lib/tuist_web/live/billing_live.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Enterprise"
@@ -370,8 +370,8 @@ msgstr ""
 msgid "Europe"
 msgstr ""
 
-#: lib/tuist/billing.ex:40
-#: lib/tuist_web/live/billing_live.ex:190
+#: lib/tuist/billing.ex:42
+#: lib/tuist_web/live/billing_live.ex:192
 #: lib/tuist_web/live/billing_live.html.heex:64
 #: lib/tuist_web/live/billing_live.html.heex:65
 #, elixir-autogen, elixir-format
@@ -383,12 +383,12 @@ msgstr ""
 msgid "Free tier exceeded"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:192
+#: lib/tuist_web/live/billing_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Free under tier limits"
 msgstr ""
 
-#: lib/tuist/billing.ex:63
+#: lib/tuist/billing.ex:65
 #, elixir-autogen, elixir-format
 msgid "Generous base price"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Generous base price: Pay nothing if below free tier limits"
 msgstr ""
 
-#: lib/tuist/billing.ex:43
+#: lib/tuist/billing.ex:45
 #, elixir-autogen, elixir-format
 msgid "Generous free monthly tier"
 msgstr ""
@@ -408,18 +408,18 @@ msgstr ""
 msgid "Generous free monthly tier: Usage capped at free tier limits"
 msgstr ""
 
-#: lib/tuist/billing.ex:41
-#: lib/tuist/billing.ex:61
+#: lib/tuist/billing.ex:43
+#: lib/tuist/billing.ex:63
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:189
+#: lib/tuist_web/live/billing_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Get started with no credit card required"
 msgstr ""
 
-#: lib/tuist/billing.ex:39
+#: lib/tuist/billing.ex:41
 #: lib/tuist_web/live/billing_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Get started with no credit card required—try with no commitment."
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/tuist/billing.ex:45
+#: lib/tuist/billing.ex:47
 #, elixir-autogen, elixir-format
 msgid "Like, totally free"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:150
+#: lib/tuist_web/live/billing_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Most Popular"
 msgstr ""
@@ -520,7 +520,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist/billing.ex:51
+#: lib/tuist/billing.ex:53
 #, elixir-autogen, elixir-format
 msgid "No credit card required"
 msgstr ""
@@ -535,8 +535,8 @@ msgstr ""
 msgid "No members found"
 msgstr ""
 
-#: lib/tuist/billing.ex:83
-#: lib/tuist_web/live/billing_live.ex:249
+#: lib/tuist/billing.ex:85
+#: lib/tuist_web/live/billing_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "On-premise"
 msgstr ""
@@ -562,14 +562,14 @@ msgstr ""
 msgid "Passwords don't match"
 msgstr ""
 
-#: lib/tuist/billing.ex:64
-#: lib/tuist_web/live/billing_live.ex:221
+#: lib/tuist/billing.ex:66
+#: lib/tuist_web/live/billing_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Pay nothing if below free tier limits"
 msgstr ""
 
-#: lib/tuist/billing.ex:66
-#: lib/tuist_web/live/billing_live.ex:222
+#: lib/tuist/billing.ex:68
+#: lib/tuist_web/live/billing_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Pay only for what you use per feature"
 msgstr ""
@@ -607,12 +607,12 @@ msgstr ""
 msgid "Pricing details"
 msgstr ""
 
-#: lib/tuist/billing.ex:85
+#: lib/tuist/billing.ex:87
 #, elixir-autogen, elixir-format
 msgid "Priority support"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:250
+#: lib/tuist_web/live/billing_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Priority support via shared Slack channel"
 msgstr ""
@@ -622,8 +622,8 @@ msgstr ""
 msgid "Priority support: Via shared Slack channel"
 msgstr ""
 
-#: lib/tuist/billing.ex:56
-#: lib/tuist_web/live/billing_live.ex:216
+#: lib/tuist/billing.ex:58
+#: lib/tuist_web/live/billing_live.ex:218
 #: lib/tuist_web/live/billing_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Pro"
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Select region"
 msgstr ""
 
-#: lib/tuist/billing.ex:84
+#: lib/tuist/billing.ex:86
 #, elixir-autogen, elixir-format
 msgid "Self-host your instance of Tuist"
 msgstr ""
@@ -740,12 +740,12 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/tuist/billing.ex:67
+#: lib/tuist/billing.ex:69
 #, elixir-autogen, elixir-format
 msgid "Standard support"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:223
+#: lib/tuist_web/live/billing_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Standard support via Slack and email"
 msgstr ""
@@ -771,12 +771,12 @@ msgstr ""
 msgid "Storage region"
 msgstr ""
 
-#: lib/tuist/billing.ex:48
+#: lib/tuist/billing.ex:50
 #, elixir-autogen, elixir-format
 msgid "Support via community forum"
 msgstr ""
 
-#: lib/tuist/billing.ex:82
+#: lib/tuist/billing.ex:84
 #, elixir-autogen, elixir-format
 msgid "Tailored agreements to meet your specific needs"
 msgstr ""
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist/billing.ex:70
+#: lib/tuist/billing.ex:72
 #, elixir-autogen, elixir-format
 msgid "Unlimited projects"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Updating your username can have unintended consequences."
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:235
+#: lib/tuist_web/live/billing_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
@@ -868,7 +868,7 @@ msgstr ""
 msgid "Usage"
 msgstr ""
 
-#: lib/tuist/billing.ex:44
+#: lib/tuist/billing.ex:46
 #, elixir-autogen, elixir-format
 msgid "Usage capped at free tier limits"
 msgstr ""
@@ -883,17 +883,17 @@ msgstr ""
 msgid "Usage-based"
 msgstr ""
 
-#: lib/tuist/billing.ex:65
+#: lib/tuist/billing.ex:67
 #, elixir-autogen, elixir-format
 msgid "Usage-based pricing"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:217
+#: lib/tuist_web/live/billing_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Usage-based pricing after free tier"
 msgstr ""
 
-#: lib/tuist/billing.ex:58
+#: lib/tuist/billing.ex:60
 #: lib/tuist_web/live/billing_live.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Usage-based pricing after free tier."
@@ -921,12 +921,12 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: lib/tuist/billing.ex:67
+#: lib/tuist/billing.ex:69
 #, elixir-autogen, elixir-format
 msgid "Via Slack and email"
 msgstr ""
 
-#: lib/tuist/billing.ex:85
+#: lib/tuist/billing.ex:87
 #, elixir-autogen, elixir-format
 msgid "Via shared Slack channel"
 msgstr ""
@@ -985,18 +985,18 @@ msgstr ""
 msgid "above free tier"
 msgstr ""
 
-#: lib/tuist/billing.ex:60
-#: lib/tuist_web/live/billing_live.ex:219
+#: lib/tuist/billing.ex:62
+#: lib/tuist_web/live/billing_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "and up"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:36
+#: lib/tuist_web/live/billing_live.ex:41
 #, elixir-autogen, elixir-format
 msgid "charged /per month"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.ex:38
+#: lib/tuist_web/live/billing_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "charged on %{next_charge_date}"
 msgstr ""

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -110,6 +110,44 @@ defmodule Tuist.BillingTest do
     end
   end
 
+  describe "get_subscription_current_period_end/1" do
+    test "returns the current period end as a date time" do
+      # Given
+      subscription_id = "subscription_id"
+
+      stub(Stripe.Subscription, :retrieve, fn ^subscription_id ->
+        {:ok, %Stripe.Subscription{current_period_end: 1_705_329_000}}
+      end)
+
+      # When
+      got = Billing.get_subscription_current_period_end(subscription_id)
+
+      # Then
+      assert got == ~U[2024-01-15 14:30:00Z]
+    end
+
+    test "returns nil when the subscription can't be retrieved from Stripe" do
+      # Given
+      subscription_id = "subscription_id"
+
+      stub(Stripe.Subscription, :retrieve, fn ^subscription_id ->
+        {:error,
+         %Stripe.Error{
+           source: :network,
+           code: :network_error,
+           extra: %{hackney_reason: :protocol_error},
+           message: "An error occurred while making the network request."
+         }}
+      end)
+
+      # When
+      got = Billing.get_subscription_current_period_end(subscription_id)
+
+      # Then
+      assert got == nil
+    end
+  end
+
   describe "get_estimated_next_payment_money/1" do
     test "when current_month_remote_cache_hits_count is under the threshold" do
       # Given
@@ -553,6 +591,27 @@ defmodule Tuist.BillingTest do
                  exp_year: 2022
                }
              }
+    end
+
+    test "returns nil when the payment method can't be retrieved from Stripe" do
+      # Given
+      payment_method_id = "payment_method_id"
+
+      stub(Stripe.PaymentMethod, :retrieve, fn ^payment_method_id ->
+        {:error,
+         %Stripe.Error{
+           source: :network,
+           code: :network_error,
+           extra: %{hackney_reason: :protocol_error},
+           message: "An error occurred while making the network request."
+         }}
+      end)
+
+      # When
+      payment_method = Billing.get_payment_method_by_id(payment_method_id)
+
+      # Then
+      assert payment_method == nil
     end
   end
 

--- a/server/test/tuist_web/live/billing_live_test.exs
+++ b/server/test/tuist_web/live/billing_live_test.exs
@@ -167,6 +167,54 @@ defmodule TuistWeb.BillingLiveTest do
     end
   end
 
+  describe "when Stripe is unreachable" do
+    test "renders the billing page falling back to the generic charge period", %{
+      conn: conn,
+      account: account
+    } do
+      # Given
+      stub(Billing, :get_current_active_subscription, fn _ ->
+        %{
+          plan: :pro,
+          status: "active",
+          default_payment_method: "payment_method_id",
+          trial_end: nil,
+          subscription_id: "subscription_id"
+        }
+      end)
+
+      stub(Billing, :get_subscription_current_period_end, fn _ -> nil end)
+
+      # When
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/billing")
+
+      # Then
+      assert has_element?(lv, "[data-part='next-charge-date']", "charged /per month")
+    end
+
+    test "renders the billing page when the payment method can't be fetched", %{
+      conn: conn,
+      account: account
+    } do
+      # Given
+      stub(Billing, :get_current_active_subscription, fn _ ->
+        %{
+          plan: :pro,
+          status: "active",
+          default_payment_method: "payment_method_id",
+          trial_end: nil,
+          subscription_id: "subscription_id"
+        }
+      end)
+
+      stub(Billing, :get_payment_method_id_from_subscription_id, fn _ -> "payment_method_id" end)
+      stub(Billing, :get_payment_method_by_id, fn _ -> nil end)
+
+      # When/Then
+      assert {:ok, _lv, _html} = live(conn, ~p"/#{account.name}/billing")
+    end
+  end
+
   describe "when payment method card is nil" do
     @tag account_without_customer: true
     test "does not crash when payment method has nil card", %{conn: conn, account: account} do


### PR DESCRIPTION
Resolves <https://tuist.sentry.io/issues/TUIST-38W>

## What changed

`Tuist.Billing.get_subscription_current_period_end/1` and `Tuist.Billing.get_payment_method_by_id/1` no longer hard-match `{:ok, _}` on the Stripe API response. Both now return `nil` and log a warning when Stripe returns an error, and `TuistWeb.BillingLive` falls back to the existing "charged /per month" copy when the period end is missing.

## Why

An account's billing page started returning 500s in production. The culprit:

```elixir
def get_subscription_current_period_end(subscription_id) do
  {:ok, %{current_period_end: current_period_end}} =
    Stripe.Subscription.retrieve(subscription_id)

  DateTime.from_unix!(current_period_end)
end
```

Stripe returned a transient network error rather than a subscription:

```
{:error,
 %Stripe.Error{
   source: :network,
   code: :network_error,
   extra: %{hackney_reason: :protocol_error},
   ...
 }}
```

The failed match raised a `MatchError` inside `TuistWeb.BillingLive.mount/3`, so a momentary third-party network blip took the whole billing page down instead of degrading the single piece of information that could not be fetched.

`get_payment_method_by_id/1` had the identical hard match and is called on the same mount path, so fixing only the function named in the Sentry report would have left the page crashable by the very same blip. It is fixed here too.

## Why this solution

Returning `nil` matches the convention already used by the neighbouring `get_payment_method_id_from_subscription_id/1`, which returns `nil` when the payment method cannot be resolved. Tagged `{:ok, _}` / `{:error, _}` tuples were the obvious alternative, but with a single caller each that only pushes unwrapping into the LiveView for no real gain.

The LiveView reuses the existing "charged /per month" string instead of introducing new copy, so no new translatable strings are added: the `dashboard_account` msgid inventory is unchanged at 484 entries.

`priv/gettext/dashboard_account.pot` is still regenerated in a separate commit. Its `#:` source references encode exact line numbers, so shifting lines in `billing_live.ex` drifts every reference below the edit. That diff is 120 reference updates plus one msgid block reordering (the extractor orders entries by first source reference), with no strings added or removed. It was regenerated with `mix gettext.extract` without `--merge`, so no `.po` translation files are touched.

The `Logger.warning` is deliberate. Going from a loud crash to entirely silent degradation would trade a 500 for zero signal during a real Stripe outage, which is a bad trade for billing.

Write paths that also hard-match Stripe responses (`create_customer/1`, `create_session/1`, `update_plan/1`, `upgrade_to_enterprise/2`) are intentionally left alone. Failing loudly is more defensible there than on a read-only page render, and widening the diff to cover them would mix concerns.

## Impact

The billing page stays up through a transient Stripe failure. The next charge date falls back to "charged /per month" and the payment method section renders empty, rather than the entire page 500ing.

## Validation

Written test-first. Three tests were added and each was confirmed to fail for the right reason before any production code changed:

1. Stripe error to `get_subscription_current_period_end/1` raised `MatchError` at `billing.ex:353`, the exact frame from the Sentry stack trace.
2. Stripe error to `get_payment_method_by_id/1` raised the same `MatchError` at `billing.ex:375`.
3. The billing LiveView raised Timex `invalid_date` when the period end was missing, proving the caller could not take a `nil`.

Coverage is layered to match the existing architecture of these files: the unit tests stub at the Stripe boundary, and the LiveView tests stub at the `Billing` boundary, since the LiveView test `setup` block already stubs `Billing` wholesale.

Commands run:

- `mix test test/tuist/billing_test.exs test/tuist_web/live/billing_live_test.exs`: 43 passed
- Billing-adjacent sweep (`test/tuist/billing/`, subscription, runners billing, billing plug): 99 passed
- `mix credo` on both changed lib files: no issues
- `mix format`
- `mix gettext.extract`: verified idempotent (a second run produces no further diff, which is what the Gettext check asserts) and confirmed no `.po` files are modified

Not manually reproduced against a live Stripe outage. The regression tests encode the production scenario instead.

### How to test locally

Run the regression tests, which reproduce the Sentry crash at the Stripe boundary:

```sh
cd server
mix test test/tuist/billing_test.exs test/tuist_web/live/billing_live_test.exs
```

To confirm they are genuine regression tests, revert either function in `lib/tuist/billing.ex` to its `{:ok, ...} = Stripe...` form and the corresponding test fails with the `MatchError` from the Sentry report.
