### PR TITLE
fix(server): keep suite shard plans from collapsing to a single catch-all shard

### DIFF
--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -423,13 +423,27 @@ defmodule Tuist.Shards do
     branches = suite_inventory_branches(project, params)
     suites_by_branch_module = latest_branch_module_suite_units(project, branches, modules)
 
-    modules
-    |> Enum.flat_map(fn module ->
-      branches
-      |> Enum.find_value(fn branch -> Map.get(suites_by_branch_module, {branch, module}) end)
-      |> List.wrap()
-    end)
-    |> Enum.uniq()
+    units_by_module =
+      Map.new(modules, fn module ->
+        {module, Enum.find_value(branches, fn branch -> Map.get(suites_by_branch_module, {branch, module}) end)}
+      end)
+
+    # A module with no suite history on the preferred branches falls back to its most recent CI run
+    # on any branch. The preferred branches can come up empty for reasons that have nothing to do
+    # with the module: a project that only runs tests on pull-request branches has no history on its
+    # default branch, and the build run the branch is read from is written through an async
+    # ingestion buffer, so it is usually still unflushed when the plan is created. Without the
+    # fallback every module resolves no suites, and a plan with nothing to pack collapses to a
+    # single catch-all shard that runs the whole suite serially.
+    fallback_units =
+      units_by_module
+      |> Enum.filter(fn {_module, units} -> is_nil(units) end)
+      |> Enum.map(fn {module, _units} -> module end)
+      |> then(&latest_module_suite_units(project, &1))
+
+    branch_units = units_by_module |> Map.values() |> Enum.reject(&is_nil/1) |> List.flatten()
+
+    Enum.uniq(branch_units ++ fallback_units)
   end
 
   defp suite_inventory_branches(project, params) do
@@ -494,6 +508,44 @@ defmodule Tuist.Shards do
     )
     |> ClickHouseRepo.all()
     |> Enum.group_by(fn row -> {row.branch, row.module} end, & &1.name)
+  end
+
+  # Suite inventory for modules that have no history on any of the preferred branches, taken from
+  # each module's most recent CI run regardless of branch. Suites that exist only on the branch
+  # being built still run: they are absent from the plan, and the catch-all shard picks them up.
+  defp latest_module_suite_units(_project, []), do: []
+
+  defp latest_module_suite_units(project, modules) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@timing_lookback_days, :day)
+
+    latest_module_runs_query =
+      from(mr in TestModuleRun,
+        where: mr.project_id == ^project.id,
+        where: mr.is_ci == true,
+        where: mr.ran_at >= ^cutoff,
+        where: mr.name in ^modules,
+        where: mr.test_suite_count > 0,
+        group_by: mr.name,
+        select: %{
+          module_name: mr.name,
+          test_run_id: fragment("argMax(?, ?)", mr.test_run_id, mr.ran_at)
+        }
+      )
+
+    ClickHouseRepo.all(
+      from(sr in TestSuiteRun,
+        join: mr in TestModuleRun,
+        on: sr.test_module_run_id == mr.id,
+        join: latest in subquery(latest_module_runs_query),
+        on: latest.test_run_id == sr.test_run_id and latest.module_name == mr.name,
+        where: sr.project_id == ^project.id,
+        where: sr.is_ci == true,
+        where: sr.ran_at >= ^cutoff,
+        where: mr.name in ^modules,
+        group_by: [latest.module_name, sr.name],
+        select: fragment("concat(?, '/', ?)", latest.module_name, sr.name)
+      )
+    )
   end
 
   defp blank?(nil), do: true

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -337,6 +337,122 @@ defmodule Tuist.ShardsTest do
       assert MapSet.equal?(planned, MapSet.new(["AppTests/LoginSuite", "AppTests/SignupSuite"]))
     end
 
+    test "derives suite units from history on other branches when no preferred branch has any" do
+      project = ProjectsFixtures.project_fixture(default_branch: "main")
+
+      # Tests only ever run on pull-request branches, so the default branch has no history. The
+      # build run the current branch would be read from is unresolvable here (it is written through
+      # an async ingestion buffer in production and is typically still unflushed at plan time), so
+      # neither preferred branch resolves anything.
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: "feature/only-branch-with-history",
+        test_modules: [
+          %{
+            name: "AppTests",
+            status: "success",
+            duration: 10_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "LoginSuite", status: "success", duration: 6_000},
+              %{name: "SignupSuite", status: "success", duration: 4_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      params = %{
+        reference: "history-derived-other-branch",
+        modules: ["AppTests"],
+        test_suites: nil,
+        granularity: "suite",
+        shard_total: 2
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      assert result.shard_count == 2
+
+      planned =
+        result.shard_assignments
+        |> Enum.flat_map(fn a -> a["test_targets"] end)
+        |> MapSet.new()
+
+      assert MapSet.equal?(planned, MapSet.new(["AppTests/LoginSuite", "AppTests/SignupSuite"]))
+    end
+
+    test "prefers the linked build branch inventory over history on unrelated branches" do
+      project = ProjectsFixtures.project_fixture(default_branch: "main")
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: "feature/unrelated",
+        ran_at: NaiveDateTime.utc_now(),
+        test_modules: [
+          %{
+            name: "AppTests",
+            status: "success",
+            duration: 7_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "UnrelatedSuite", status: "success", duration: 7_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: "feature/some-branch",
+        ran_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -1, :day),
+        test_modules: [
+          %{
+            name: "AppTests",
+            status: "success",
+            duration: 3_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "BranchOnlySuite", status: "success", duration: 3_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      {:ok, build} =
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          is_ci: true,
+          git_branch: "feature/some-branch"
+        )
+
+      params = %{
+        reference: "linked-branch-beats-fallback",
+        modules: ["AppTests"],
+        test_suites: nil,
+        granularity: "suite",
+        shard_total: 2,
+        build_run_id: build.id
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      planned =
+        result.shard_assignments
+        |> Enum.flat_map(fn a -> a["test_targets"] end)
+        |> MapSet.new()
+
+      # The fallback must not pull in the newer run from the unrelated branch when the build's own
+      # branch has history.
+      assert MapSet.equal?(planned, MapSet.new(["AppTests/BranchOnlySuite"]))
+    end
+
     test "prefers suite inventory from the linked build branch" do
       project = ProjectsFixtures.project_fixture(default_branch: "main")
       older_ran_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -2, :day)


### PR DESCRIPTION
Suite-granularity shard plans could collapse to a single empty catch-all shard that ran the whole test suite serially, silently disabling sharding:

```
Creating shard plan with 43 test module(s)
Shard plan created: 1 shards
  Shard 0:  (~0ms)
```

## What changed

Modules with no suite history on any of the preferred branches now fall back to their most recent CI run regardless of branch (`latest_module_suite_units/2`). Branch preference still wins whenever it resolves.

## Why

Since #11581 the client no longer enumerates suites by booting every test bundle. It sends `test_suites: nil` plus the deterministic `.xctestrun` module universe, and the server derives the suite inventory from history via `latest_branch_suite_units/3`. That lookup is scoped to a preferred branch list: the request's git branch, the linked build run's branch, and the project's default branch.

### Root cause

All three entries can be empty at the same time:

1. **The request has no `git_branch` field.** `ShardsController.create` never puts `:git_branch` into params, so `Map.get(params, :git_branch)` is always nil. The parameter has been dead since it was introduced.
2. **The linked build run is usually not readable yet.** `Builds.create_build` writes through `Build.Buffer.insert`, an async `GenServer.cast` whose default flush interval is 5s. The client creates the build run and requests the shard plan roughly a second later, so `Builds.get_build` returns `{:error, :not_found}`. The `build_runs.inserted_at` column hides this, because it is stamped in `Build.to_buffer_map` when `create_build` runs rather than when the row is flushed, so the build looks like it already existed at plan time.
3. **The default branch has no history** on projects that only run tests on pull-request branches.

With no branch resolving, no suite units are found. `BinPacker.determine_shard_count` returns 1 for an empty unit list, and `pack([], 1)` yields a single empty shard, which is by definition the catch-all (`index == shard_count - 1`). The catch-all downloads the full module inventory and runs everything.

The database tell is a plan with 0 rows in `shard_plan_test_suites` while `shard_plan_modules` has one row per built module. In the CLI output, an empty `Shard 0:  (~0ms)` means zero units resolved rather than an imbalanced plan.

### Why this fix

Replaying the inventory query point-in-time against production for an affected plan returned 763 suite units for the build's real branch, while the plan itself recorded 0. That isolates branch resolution, not missing data, as the failure.

`fetch_timing_data` already runs with no branch filter, so the inventory being the only branch-scoped lookup was the inconsistency. Falling back to each module's most recent CI run keeps the plan populated regardless of how branch resolution goes.

Alternatives considered:

- **Having the client send `git_branch`.** This is the right long-term fix for inventory freshness and is worth a follow-up, but it needs an OpenAPI regeneration and a CLI release, so it would not help affected projects until they upgrade. The fix here is server-side and takes effect on deploy.
- **Reading the build run around the ingestion buffer.** The buffer is deliberate, since it keeps `create_build` non-blocking on ClickHouse health, so making the planner depend on a synchronous read would trade one fragility for another.

Correctness is unaffected either way: a suite that exists only on the branch being built is absent from the plan, and the catch-all shard runs it.

## Impact

Projects on a CLI >= 4.202.0-canary.23 using suite granularity, whose default branch has no CI test history (common when tests only run on pull requests), get working shard plans again instead of one shard running the full suite. An affected project went from 4 shards to 1 after upgrading past that version.

## Why tests missed it

`config/test.exs` sets `sync_writes: true` and `Bufferable write_through_repo: true`, so buffered rows are written through synchronously and `build_run_git_branch` always resolves under ExUnit. The production buffer delay is not reproducible there. Existing tests also seeded history on `project.default_branch`, so a preferred branch always matched.

### How to test locally

Two tests were added to `server/test/tuist/shards_test.exs`:

- "derives suite units from history on other branches when no preferred branch has any" reproduces the bug. With the fix reverted it fails with `shard_count` 1 instead of 2, the exact production symptom.
- "prefers the linked build branch inventory over history on unrelated branches" guards the fallback against overriding a resolvable branch preference.

```
cd server
mix test test/tuist/shards_test.exs
mix test test/tuist_web/controllers/api/shards_controller_test.exs
```

Validation run: 36 shards tests and 24 shards controller tests pass, `mix credo lib/tuist/shards.ex` reports no issues, and the new test was confirmed to fail without the fix applied.
