### PR TITLE
fix(cli): run the Copy Module Map script phase before Compile Sources

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -92,10 +92,15 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                         // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift#L76-L108
                         // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift#L1197-L1200
                         let escapedModuleMapPath = Self.shellEscaped(moduleMapPath.pathString)
+                        // The copy must run before Compile Sources: clang records the framework's
+                        // module map as a discovered dependency of the target's own compile steps,
+                        // so producing it in a phase ordered after compilation makes the build
+                        // system detect a dependency cycle on incremental builds ("Cycle inside
+                        // <target>; building could produce unreliable results").
                         target.scripts.append(
                             TargetScript(
                                 name: "Copy Module Map",
-                                order: .post,
+                                order: .pre,
                                 script: .embedded(
                                     // -f: with Xcode compilation caching enabled, the destination can
                                     // pre-exist as a read-only CAS-materialized file that plain cp

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -423,7 +423,7 @@ struct ModuleMapMapperTests {
             [
                 TargetScript(
                     name: "Copy Module Map",
-                    order: .post,
+                    order: .pre,
                     script: .embedded(
                         """
                         set -eu


### PR DESCRIPTION
### Problem

Since the "Copy Module Map" script phase was introduced in #11135, projects that consume an external dynamic framework with a custom module map (in our case geos, pulled in through GEOSwift) hit a dependency cycle on every incremental build:

```
error: Cycle inside geos; building could produce unreliable results.
Cycle details:
 That command depends on command in Target 'geos': script phase 'Copy Module Map'
 Target 'geos' has compile command with input '.../Sources/geos/src/deps/ryu/d2s.c'
```

### Cause

The phase is added with `order: .post`, so it runs after Compile Sources, and its declared output is the framework's own `Modules/module.modulemap`. The first build after generating is fine, but clang reads that module map while compiling the target and records it in the discovered dependencies, so from the second build on, the build system sees compile steps that depend on a file produced by a phase scheduled after compilation. That's the cycle.

### Fix

Add the script with `order: .pre` instead, so the module map is in place before anything compiles. The copy only reads a file from the source tree, so running it first is always safe, and it puts the module map where the build system expects it from the start. 

### How to test locally

1. Generate a project that has an external dynamic framework with a `MODULEMAP_FILE` setting (anything that triggers the "Copy Module Map" phase; GEOSwift's geos is a convenient real-world case).
2. Build twice on `main`: the second, incremental build reports "Cycle inside <target>; building could produce unreliable results".
3. Build twice on this branch: no cycle, and the phase shows up before Compile Sources in the generated pbxproj.

Unit tests: `TuistGeneratorTests/ModuleMapMapperTests`.
