### PR TITLE
fix(cli): backport non-overlapping test schemes to 4.202.x

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -461,12 +461,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             schemes = [scheme]
         } else {
             let workspaceSchemes = buildGraphInspector.workspaceSchemes(graphTraverser: graphTraverser)
-            let testableSchemes =
-                buildGraphInspector.testableSchemes(graphTraverser: graphTraverser)
-                    + workspaceSchemes
             schemes = defaultSchemes(
-                testableSchemes: testableSchemes,
                 workspaceSchemes: workspaceSchemes,
+                candidateTestSchemes: testableSchemes,
                 graphTraverser: graphTraverser,
                 testPlanConfiguration: testPlanConfiguration,
                 action: action
@@ -1175,6 +1172,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             uploadCacheStorage = cacheStorage
         }
 
+        let passthroughSkippedTargetNames = passthroughSkippedTestTargetNames(passthroughXcodeBuildArguments)
         let testSchemeRuns = schemes.compactMap { testScheme -> (scheme: Scheme, testTargets: [TestIdentifier])? in
             let testSchemeTargetNames = Set(
                 testActionTargetReferences(
@@ -1184,12 +1182,13 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
                 .map(\.name)
             )
-            if testSchemeTargetNames.isEmpty {
+            let runnableTestTargetNames = testSchemeTargetNames.subtracting(passthroughSkippedTargetNames)
+            if runnableTestTargetNames.isEmpty {
                 return nil
             }
 
             let testSchemeTestTargets = testTargets.filter {
-                testSchemeTargetNames.contains($0.target)
+                runnableTestTargetNames.contains($0.target)
             }
 
             if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
@@ -1258,10 +1257,20 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 }
 
                 if action != .build {
+                    let runTestTargetNames = testSchemeRun.testTargets.isEmpty
+                        ? Set(
+                            testActionTargetReferences(
+                                scheme: testScheme,
+                                testPlanConfiguration: testPlanConfiguration,
+                                action: action
+                            ).map(\.name)
+                        ).subtracting(passthroughSkippedTargetNames)
+                        : Set(testSchemeRun.testTargets.map(\.target))
                     try await storeSuccessfulTestHashes(
                         for: testActionTargets(
                             for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-                        ),
+                        )
+                        .filter { runTestTargetNames.contains($0.target.name) },
                         graph: graph,
                         mapperEnvironment: mapperEnvironment,
                         cacheStorage: uploadCacheStorage
@@ -1409,13 +1418,13 @@ public struct TestService { // swiftlint:disable:this type_body_length
     }
 
     private func defaultSchemes(
-        testableSchemes: [Scheme],
         workspaceSchemes: [Scheme],
+        candidateTestSchemes: [Scheme],
         graphTraverser: GraphTraversing,
         testPlanConfiguration: TestPlanConfiguration?,
         action: XcodeBuildTestAction
     ) -> [Scheme] {
-        guard action != .build,
+        guard action == .test,
               containsMixedHostedAndHostlessUnitTests(
                   schemes: workspaceSchemes,
                   graphTraverser: graphTraverser,
@@ -1427,7 +1436,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         let workspaceSchemeNames = Set(workspaceSchemes.map(\.name))
-        let workspaceTestTargets = Set(
+        let workspaceTargets = Set(
             workspaceSchemes.flatMap {
                 testActionTargetReferences(
                     scheme: $0,
@@ -1436,28 +1445,69 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
             }
         )
-        let projectSchemes = testableSchemes.filter {
-            guard !workspaceSchemeNames.contains($0.name) else {
-                return false
-            }
-
-            let schemeTestTargets = Set(
-                testActionTargetReferences(
-                    scheme: $0,
+        let schemesByTarget = Dictionary(
+            candidateTestSchemes.compactMap { scheme -> (TargetReference, Scheme)? in
+                guard !workspaceSchemeNames.contains(scheme.name) else { return nil }
+                let targets = testActionTargetReferences(
+                    scheme: scheme,
                     testPlanConfiguration: testPlanConfiguration,
                     action: action
                 )
-            )
-            return !schemeTestTargets.isDisjoint(with: workspaceTestTargets)
-        }
-        guard !projectSchemes.isEmpty else {
+                guard targets.count == 1,
+                      let target = targets.first,
+                      workspaceTargets.contains(target),
+                      !isHostlessUnitTest(target, graphTraverser: graphTraverser)
+                      || isCompatibleHostlessTestScheme(scheme, graphTraverser: graphTraverser)
+                else {
+                    return nil
+                }
+                return (target, scheme)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        guard workspaceTargets.allSatisfy({ schemesByTarget[$0] != nil }) else {
             return workspaceSchemes
         }
 
-        Logger.current.debug(
-            "Workspace schemes include hosted tests and host-less unit tests; running generated project schemes separately."
-        )
-        return projectSchemes
+        return workspaceTargets
+            .sorted {
+                ($0.name, $0.projectPath.pathString) < ($1.name, $1.projectPath.pathString)
+            }
+            .compactMap { schemesByTarget[$0] }
+    }
+
+    private func isCompatibleHostlessTestScheme(
+        _ scheme: Scheme,
+        graphTraverser: GraphTraversing
+    ) -> Bool {
+        let targetReferences = scheme.targetDependencies()
+        let schemeTargets = targetReferences.compactMap {
+            graphTraverser.target(path: $0.projectPath, name: $0.name)
+        }
+        guard schemeTargets.count == targetReferences.count else { return false }
+
+        let dependencies = graphTraverser.allTargetDependencies(traversingFromTargets: schemeTargets)
+        return (Set(schemeTargets).union(dependencies)).allSatisfy {
+            !$0.target.product.canHostTests()
+        }
+    }
+
+    private func isHostlessUnitTest(
+        _ targetReference: TargetReference,
+        graphTraverser: GraphTraversing
+    ) -> Bool {
+        guard let graphTarget = graphTraverser.target(
+            path: targetReference.projectPath,
+            name: targetReference.name
+        ), graphTarget.target.product == .unitTests
+        else {
+            return false
+        }
+
+        let dependencies = graphTraverser
+            .directTargetDependencies(path: graphTarget.path, name: graphTarget.target.name)
+        return !dependencies.isEmpty && !dependencies.contains(where: { $0.target.product.canHostTests() })
     }
 
     private func containsMixedHostedAndHostlessUnitTests(

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1,7 +1,10 @@
 import Command
+import FileSystem
+import FileSystemTesting
 import Foundation
 import Mockable
 import Path
+import Testing
 import struct TSCUtility.Version
 import TuistAlert
 import TuistAutomation
@@ -2848,110 +2851,6 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(testedSchemes, [])
-    }
-
-    func test_run_without_scheme_uses_project_schemes_when_workspace_scheme_contains_hostless_unit_tests() async throws {
-        // Given
-        let appProjectPath = try temporaryPath().appending(component: "App")
-        let featureProjectPath = try temporaryPath().appending(component: "Feature")
-        let app = Target.test(name: "App", product: .app)
-        let appTests = Target.test(name: "AppTests", product: .unitTests)
-        let feature = Target.test(name: "Feature", product: .framework)
-        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
-        let appTestsReference = TargetReference(projectPath: appProjectPath, name: appTests.name)
-        let featureTestsReference = TargetReference(projectPath: featureProjectPath, name: featureTests.name)
-        let appScheme = Scheme.test(
-            name: "App",
-            testAction: .test(targets: [.test(target: appTestsReference)])
-        )
-        let featureScheme = Scheme.test(
-            name: "Feature",
-            testAction: .test(targets: [.test(target: featureTestsReference)])
-        )
-        let workspaceScheme = Scheme.test(
-            name: "Sample-Workspace",
-            testAction: .test(
-                targets: [
-                    .test(target: appTestsReference),
-                    .test(target: featureTestsReference),
-                ]
-            )
-        )
-        let appProject = Project.test(
-            path: appProjectPath,
-            targets: [app, appTests],
-            schemes: [appScheme]
-        )
-        let featureProject = Project.test(
-            path: featureProjectPath,
-            targets: [feature, featureTests],
-            schemes: [featureScheme]
-        )
-        let workspace = Workspace.test(
-            name: "Sample",
-            projects: [appProjectPath, featureProjectPath],
-            schemes: [workspaceScheme]
-        )
-        let graph = Graph.test(
-            workspace: workspace,
-            projects: [
-                appProjectPath: appProject,
-                featureProjectPath: featureProject,
-            ],
-            dependencies: [
-                .target(name: appTests.name, path: appProjectPath): [
-                    .target(name: app.name, path: appProjectPath),
-                ],
-                .target(name: featureTests.name, path: featureProjectPath): [
-                    .target(name: feature.name, path: featureProjectPath),
-                ],
-            ]
-        )
-
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.test(project: .testGeneratedProject()))
-        given(generatorFactory)
-            .testing(
-                config: .any,
-                testPlan: .any,
-                includedTargets: .any,
-                excludedTargets: .any,
-                skipUITests: .any,
-                skipUnitTests: .any,
-                configuration: .any,
-                ignoreBinaryCache: .any,
-                ignoreSelectiveTesting: .any,
-                cacheStorage: .any,
-                destination: .any,
-                schemeName: .any
-            )
-            .willReturn(generator)
-        given(generator)
-            .generateWithGraph(path: .any, options: .any)
-            .willProduce { path, _ in (path, graph, MapperEnvironment()) }
-        given(buildGraphInspector)
-            .testableSchemes(graphTraverser: .any)
-            .willReturn([appScheme, featureScheme, workspaceScheme])
-        given(buildGraphInspector)
-            .workspaceSchemes(graphTraverser: .any)
-            .willReturn([workspaceScheme])
-
-        // When
-        try await testRun(path: try temporaryPath())
-
-        // Then
-        XCTAssertEqual(testedSchemes, ["App", "Feature"])
-
-        // When
-        testedSchemes = []
-        try await testRun(
-            path: try temporaryPath(),
-            testTargets: [try TestIdentifier(target: "FeatureTests", class: nil)]
-        )
-
-        // Then
-        XCTAssertEqual(testedSchemes, ["Feature"])
     }
 
     func test_run_skips_xcodebuild_when_passthrough_skip_testing_removes_all_selective_targets() async throws {
@@ -5844,6 +5743,505 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_inferPlatformDestination_returns_nil_for_empty_schemes() {
         let graphTraverser = MockGraphTraversing()
         XCTAssertNil(subject.inferPlatformDestination(schemes: [], graphTraverser: graphTraverser))
+    }
+}
+
+@Suite
+struct TestServiceSchemePlanningTests {
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_uses_non_overlapping_single_target_schemes_for_mixed_tests() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scenario = SchemePlanningScenario(rootDirectory: temporaryDirectory)
+        let fixture = TestServiceSchemePlanningFixture(scenario: scenario)
+        let resultBundlePath = temporaryDirectory.appending(component: "result.xcresult")
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            resultBundlePath: resultBundlePath,
+            derivedDataPath: derivedDataPath
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "AppSnapshotTests",
+                action: .test,
+                testTargets: [],
+                resultBundlePath: temporaryDirectory.appending(component: "result-AppSnapshotTests.xcresult"),
+                derivedDataPath: derivedDataPath
+            ),
+            CapturedTestRun(
+                scheme: "AppTests",
+                action: .test,
+                testTargets: [],
+                resultBundlePath: temporaryDirectory.appending(component: "result-AppTests.xcresult"),
+                derivedDataPath: derivedDataPath
+            ),
+            CapturedTestRun(
+                scheme: "FeatureTests",
+                action: .test,
+                testTargets: [],
+                resultBundlePath: temporaryDirectory.appending(
+                    component: "result-FeatureTests.xcresult"
+                ),
+                derivedDataPath: derivedDataPath
+            ),
+        ])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_without_building_preserves_the_workspace_build_layout() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scenario = SchemePlanningScenario(
+            rootDirectory: temporaryDirectory,
+            includeHostlessTargetWithoutScheme: true
+        )
+        let fixture = TestServiceSchemePlanningFixture(scenario: scenario)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            action: .testWithoutBuilding,
+            derivedDataPath: derivedDataPath
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "Sample-Workspace",
+                action: .testWithoutBuilding,
+                testTargets: [],
+                resultBundlePath: nil,
+                derivedDataPath: derivedDataPath
+            ),
+        ])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_excludes_passthrough_skips_from_invocations_and_hashes() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scenario = SchemePlanningScenario(rootDirectory: temporaryDirectory)
+        let fixture = TestServiceSchemePlanningFixture(scenario: scenario)
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            passthroughXcodeBuildArguments: [
+                "-skip-testing:AppSnapshotTests",
+                "-skip-testing:FeatureTests",
+            ]
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "AppTests",
+                action: .test,
+                testTargets: [],
+                resultBundlePath: nil,
+                derivedDataPath: nil
+            ),
+        ])
+        verify(fixture.cacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "AppTests", hash: "app-tests-hash"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
+        verify(fixture.cacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "AppSnapshotTests", hash: "app-snapshot-tests-hash"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(0)
+        verify(fixture.cacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "FeatureTests", hash: "feature-tests-hash"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(0)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_with_explicit_test_target_only_runs_its_matching_single_target_scheme() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scenario = SchemePlanningScenario(rootDirectory: temporaryDirectory)
+        let passthroughDerivedDataPath = temporaryDirectory.appending(component: "PassedDerivedData")
+        let fixture = TestServiceSchemePlanningFixture(scenario: scenario)
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            testTargets: [try TestIdentifier(target: "FeatureTests")],
+            passthroughXcodeBuildArguments: [
+                "-derivedDataPath", passthroughDerivedDataPath.pathString,
+            ]
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "FeatureTests",
+                action: .test,
+                testTargets: [try TestIdentifier(target: "FeatureTests")],
+                resultBundlePath: nil,
+                derivedDataPath: nil
+            ),
+        ])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_uses_the_workspace_scheme_when_single_target_scheme_coverage_is_incomplete() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scenario = SchemePlanningScenario(
+            rootDirectory: temporaryDirectory,
+            includeHostlessTargetWithoutScheme: true
+        )
+        let fixture = TestServiceSchemePlanningFixture(scenario: scenario)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            derivedDataPath: derivedDataPath
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "Sample-Workspace",
+                action: .test,
+                testTargets: [],
+                resultBundlePath: nil,
+                derivedDataPath: derivedDataPath
+            ),
+        ])
+    }
+}
+
+private struct SchemePlanningScenario {
+    let graph: Graph
+    let mapperEnvironment: MapperEnvironment
+    let rootDirectory: AbsolutePath
+    let testableSchemes: [Scheme]
+    let workspaceScheme: Scheme
+
+    init(
+        rootDirectory: AbsolutePath,
+        includeHostlessTargetWithoutScheme: Bool = false
+    ) {
+        self.rootDirectory = rootDirectory
+        let appProjectPath = rootDirectory.appending(component: "App")
+        let featureProjectPath = rootDirectory.appending(component: "Feature")
+        let orphanProjectPath = rootDirectory.appending(component: "Orphan")
+        let app = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let appSnapshotTests = Target.test(name: "AppSnapshotTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+        let orphan = Target.test(name: "Orphan", product: .framework)
+        let orphanTests = Target.test(name: "OrphanTests", product: .unitTests)
+        let appReference = TargetReference(projectPath: appProjectPath, name: app.name)
+        let featureReference = TargetReference(projectPath: featureProjectPath, name: feature.name)
+        let appTestsReference = TargetReference(projectPath: appProjectPath, name: appTests.name)
+        let appSnapshotTestsReference = TargetReference(projectPath: appProjectPath, name: appSnapshotTests.name)
+        let featureTestsReference = TargetReference(projectPath: featureProjectPath, name: featureTests.name)
+        let orphanTestsReference = TargetReference(projectPath: orphanProjectPath, name: orphanTests.name)
+        let appTestsScheme = Scheme.test(
+            name: "AppTests",
+            buildAction: .test(targets: [appReference]),
+            testAction: .test(targets: [.test(target: appTestsReference)])
+        )
+        let appSnapshotTestsScheme = Scheme.test(
+            name: "AppSnapshotTests",
+            buildAction: .test(targets: [appReference]),
+            testAction: .test(targets: [.test(target: appSnapshotTestsReference)])
+        )
+        let appAggregateScheme = Scheme.test(
+            name: "App-Aggregate",
+            testAction: .test(
+                targets: [
+                    .test(target: appTestsReference),
+                    .test(target: appSnapshotTestsReference),
+                ]
+            )
+        )
+        let featureScheme = Scheme.test(
+            name: "FeatureTests",
+            buildAction: .test(targets: [featureReference]),
+            testAction: .test(targets: [.test(target: featureTestsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let featureSchemeWithAppBuildContext = Scheme.test(
+            name: "FeatureTests-WithApp",
+            buildAction: .test(targets: [appReference]),
+            testAction: .test(targets: [.test(target: featureTestsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let allModulesScheme = Scheme.test(
+            name: "AllModules",
+            testAction: .test(
+                targets: [
+                    .test(target: appTestsReference),
+                    .test(target: appSnapshotTestsReference),
+                    .test(target: featureTestsReference),
+                ]
+            )
+        )
+        var workspaceTestTargets: [TestableTarget] = [
+            .test(target: appTestsReference),
+            .test(target: appSnapshotTestsReference),
+            .test(target: featureTestsReference),
+        ]
+        if includeHostlessTargetWithoutScheme {
+            workspaceTestTargets.append(.test(target: orphanTestsReference))
+        }
+        workspaceScheme = Scheme.test(
+            name: "Sample-Workspace",
+            testAction: .test(targets: workspaceTestTargets)
+        )
+        let appProject = Project.test(
+            path: appProjectPath,
+            targets: [app, appTests, appSnapshotTests],
+            schemes: [appTestsScheme, appSnapshotTestsScheme, appAggregateScheme, allModulesScheme]
+        )
+        let featureProject = Project.test(
+            path: featureProjectPath,
+            targets: [feature, featureTests],
+            schemes: [featureScheme]
+        )
+        let orphanProject = Project.test(
+            path: orphanProjectPath,
+            targets: [orphan, orphanTests]
+        )
+        let workspace = Workspace.test(
+            name: "Sample",
+            projects: [appProjectPath, featureProjectPath, orphanProjectPath],
+            schemes: [workspaceScheme]
+        )
+        graph = Graph.test(
+            workspace: workspace,
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+                orphanProjectPath: orphanProject,
+            ],
+            dependencies: [
+                .target(name: appTests.name, path: appProjectPath): [
+                    .target(name: app.name, path: appProjectPath),
+                ],
+                .target(name: appSnapshotTests.name, path: appProjectPath): [
+                    .target(name: app.name, path: appProjectPath),
+                ],
+                .target(name: featureTests.name, path: featureProjectPath): [
+                    .target(name: feature.name, path: featureProjectPath),
+                ],
+                .target(name: orphanTests.name, path: orphanProjectPath): [
+                    .target(name: orphan.name, path: orphanProjectPath),
+                ],
+            ]
+        )
+        var mapperEnvironment = MapperEnvironment()
+        mapperEnvironment.initialGraph = graph
+        mapperEnvironment.targetTestHashes = [
+            appProjectPath: [
+                "AppSnapshotTests": "app-snapshot-tests-hash",
+                "AppTests": "app-tests-hash",
+            ],
+            featureProjectPath: ["FeatureTests": "feature-tests-hash"],
+            orphanProjectPath: ["OrphanTests": "orphan-tests-hash"],
+        ]
+        self.mapperEnvironment = mapperEnvironment
+        testableSchemes = [
+            allModulesScheme,
+            appAggregateScheme,
+            appSnapshotTestsScheme,
+            appTestsScheme,
+            featureSchemeWithAppBuildContext,
+            featureScheme,
+            workspaceScheme,
+        ]
+    }
+}
+
+private struct CapturedTestRun: Equatable {
+    let scheme: String
+    let action: XcodeBuildTestAction
+    let testTargets: [TestIdentifier]
+    let resultBundlePath: AbsolutePath?
+    let derivedDataPath: AbsolutePath?
+}
+
+private final class TestRunCapture {
+    var runs: [CapturedTestRun] = []
+}
+
+private struct TestServiceSchemePlanningFixture {
+    let cacheStorage = MockCacheStoring()
+
+    private let capture: TestRunCapture
+    private let runMetadataStorage = RunMetadataStorage()
+    private let subject: TestService
+
+    var testRuns: [CapturedTestRun] {
+        capture.runs
+    }
+
+    init(scenario: SchemePlanningScenario) {
+        let capture = TestRunCapture()
+        self.capture = capture
+        let generator = MockGenerating()
+        let generatorFactory = MockGeneratorFactorying()
+        let cacheStorageFactory = MockCacheStorageFactorying()
+        let xcodebuildController = MockXcodeBuildControlling()
+        let buildGraphInspector = MockBuildGraphInspecting()
+        let simulatorController = MockSimulatorControlling()
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        let configLoader = MockConfigLoading()
+        let xcodeBuildArgumentParser = MockXcodeBuildArgumentParsing()
+        let derivedDataLocator = MockDerivedDataLocating()
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .willReturn(cacheStorage)
+        given(cacheStorage)
+            .store(.any, cacheCategory: .any)
+            .willReturn([])
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(scenario.rootDirectory)
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, scenario.graph, scenario.mapperEnvironment)
+            }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn(scenario.testableSchemes)
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scenario.workspaceScheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test())
+        given(buildGraphInspector)
+            .buildArguments(project: .any, target: .any, configuration: .any, skipSigning: .any)
+            .willReturn([])
+        given(simulatorController)
+            .findAvailableDevice(
+                platform: .any,
+                version: .any,
+                minVersion: .any,
+                deviceName: .any
+            )
+            .willReturn(.test())
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: nil, destination: nil))
+        given(derivedDataLocator)
+            .locate(for: .any)
+            .willReturn(scenario.rootDirectory.appending(component: "DerivedData"))
+        given(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, action, _, derivedDataPath, resultBundlePath, _, _, testTargets, _, _, _ in
+                capture.runs.append(
+                    CapturedTestRun(
+                        scheme: scheme,
+                        action: action,
+                        testTargets: testTargets,
+                        resultBundlePath: resultBundlePath,
+                        derivedDataPath: derivedDataPath
+                    )
+                )
+            }
+
+        subject = TestService(
+            generatorFactory: generatorFactory,
+            cacheStorageFactory: cacheStorageFactory,
+            xcodebuildController: xcodebuildController,
+            buildGraphInspector: buildGraphInspector,
+            simulatorController: simulatorController,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            configLoader: configLoader,
+            xcodeBuildArgumentParser: xcodeBuildArgumentParser,
+            derivedDataLocator: derivedDataLocator
+        )
+    }
+
+    func run(
+        path: AbsolutePath,
+        action: XcodeBuildTestAction = .test,
+        resultBundlePath: AbsolutePath? = nil,
+        derivedDataPath: AbsolutePath? = nil,
+        testTargets: [TestIdentifier] = [],
+        passthroughXcodeBuildArguments: [String] = []
+    ) async throws {
+        try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
+            try await subject.run(
+                runId: "run-id",
+                schemeName: nil,
+                clean: false,
+                noUpload: false,
+                configuration: nil,
+                path: path,
+                deviceName: nil,
+                platform: nil,
+                osVersion: nil,
+                action: action,
+                rosetta: false,
+                skipUITests: false,
+                skipUnitTests: false,
+                resultBundlePath: resultBundlePath,
+                derivedDataPath: derivedDataPath?.pathString,
+                retryCount: 0,
+                testTargets: testTargets,
+                skipTestTargets: [],
+                testPlanConfiguration: nil,
+                ignoreBinaryCache: false,
+                ignoreSelectiveTesting: false,
+                generateOnly: false,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
+                mode: .local
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Backport of #11821 to the `4.202.x` stable line.

- restore `Scheme`-only test execution instead of introducing per-run invocation models
- for a combined `tuist test`, replace a mixed hosted/hostless workspace scheme only when every workspace test target has a non-overlapping single-target scheme
- reject aggregate candidates and hostless candidates whose build/dependency closure contains a test-host product
- preserve the workspace scheme for `build-for-testing`, `test-without-building`, and any combined run without complete safe single-target scheme coverage
- drop schemes fully removed by passthrough `-skip-testing` arguments and persist selective-testing hashes only for targets that actually ran

The source PR's final effective diff is replayed here as one commit on top of `releases/4.202.x`, without pulling unrelated changes from `main`.

## Motivation

The stable branch contains the original hostless-test workaround for an Xcode 26.5 bootstrap crash: a workspace scheme containing both app-hosted and hostless unit-test bundles failed, while the narrower `App` and `Feature` schemes passed.

That workaround selected every project scheme whose test targets overlapped the workspace scheme. Overlap does not establish ownership. A broad aggregate scheme and narrower schemes can all be selected, causing the same tests to execute repeatedly, increasing runtime and producing result-bundle collisions. It also changed `test-without-building` to use a different scheme set from `build-for-testing`, even though both phases must share the same build-product layout.

## Root cause

The original bootstrap failure is specific to the mixed workspace scheme's build and launch context. Test filters and test plans decide which tests execute, but do not change that context.

The regression came from replacing the workspace scheme with all overlapping project schemes. Because aggregate schemes can overlap one another, that selection was neither exclusive nor complete and could duplicate large portions of the test suite.

## Approach

For default combined `tuist test` runs whose workspace scheme mixes hosted and hostless tests:

1. Collect the workspace scheme's test targets.
2. Consider only project schemes containing exactly one of those test targets.
3. For a hostless target, require the scheme's complete build/dependency closure to contain no product capable of hosting tests.
4. Use the narrow schemes only when every workspace target has one. Sort them deterministically and execute each target exactly once.
5. If coverage is incomplete, keep the workspace scheme unchanged and let `xcodebuild` report any genuine configuration or bootstrap failure.

`build-for-testing` and `test-without-building` always retain the workspace scheme, preserving their shared build layout. Explicitly requested schemes are unchanged.

This retains the existing `[Scheme]` execution pipeline. It does not add a filtered workspace invocation, invocation wrapper, derived-data isolation flag, or second resolution model. The narrow schemes share the caller's normal derived data, matching the passing `App`/`Feature` sequence from the original Xcode reproduction.

## Impact

- broad aggregate schemes are no longer selected alongside narrow schemes, so tests are not duplicated
- combined runs still avoid the mixed-scheme XCTest crash when complete safe narrow-scheme coverage exists
- split build/test workflows use the same workspace scheme and product layout again
- projects without complete narrow-scheme coverage retain their previous workspace behavior instead of receiving a new Tuist configuration error

## Validation

- regenerated the stable workspace with `tuist generate tuist TuistKit TuistKitTests ProjectDescription --no-open`
- ran `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistKitTests/TestServiceSchemePlanningTests -derivedDataPath /tmp/tuist-7d97-focused-derived-data -parallel-testing-enabled NO COMPILATION_CACHE_ENABLE_CACHING=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
  - 5 tests passed, 0 failed
  - covers complete single-target selection, aggregate and incompatible candidate rejection, split-workflow preservation, target filters, passthrough skips and hash persistence, and incomplete-coverage fallback
- `mise run cli:lint --fix` (no files changed)
- `git diff --cached --check`

