### PR TITLE
fix(infra): unstrand tart pods on macOS machine deletion (vm-cleanup finalizer)

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -347,6 +347,15 @@ eligible for the next adoption once Scaleway flips it back to
 operator-owned territory — you keep paying for capacity you already
 pre-ordered until you decide to release it via the Scaleway console.
 
+`reconcileDelete` also deletes the departing host's Node object and
+strips `tart-kubelet.tuist.dev/vm-cleanup` from every Pod bound to it.
+That finalizer is only ever removed by the tart-kubelet on the Pod's
+host after it tears the backing VM down; once the host is released and
+reinstalled there is no tart-kubelet left to do so and no VM to orphan,
+so without this strip PodGC-force-deleted Pods would wedge in
+`Terminating` forever (the manual fix was
+`kubectl patch pod … -p '{"metadata":{"finalizers":null}}'`).
+
 ### Replace a wedged host
 ```bash
 kubectl delete machine <machine-name>

--- a/infra/cluster-api-provider-tuist/cmd/manager/main.go
+++ b/infra/cluster-api-provider-tuist/cmd/manager/main.go
@@ -473,6 +473,7 @@ func main() {
 
 	if err := (&macos.ScalewayAppleSiliconMachineReconciler{
 		Client:               mgr.GetClient(),
+		APIReader:            mgr.GetAPIReader(),
 		Scheme:               mgr.GetScheme(),
 		ScalewayClient:       scwClient,
 		CredentialsManager:   credsManager,

--- a/infra/cluster-api-provider-tuist/config/rbac/role.yaml
+++ b/infra/cluster-api-provider-tuist/config/rbac/role.yaml
@@ -41,3 +41,9 @@ rules:
   - apiGroups: [""]
     resources: [persistentvolumeclaims]
     verbs: [get, list, watch, delete]
+  # On macOS Machine delete, strip tart-kubelet's vm-cleanup finalizer from Pods
+  # bound to the departing node (the host is gone, so its tart-kubelet can't) so
+  # PodGC-force-deleted Pods don't wedge in Terminating.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch, patch]

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -67,6 +67,15 @@ const (
 	// advertises for dashboard VNC sessions through the per-Mac Tailscale
 	// egress Service.
 	DashboardVNCRelayPort = 5900
+
+	// podFinalizerCleanupRetryBudget bounds how long reconcileDelete keeps
+	// retrying the Stage 4.5 stranded-Pod finalizer strip before it gives up
+	// and lets the machine delete proceed anyway. It exists so a transient API
+	// error — or a `pods … patch` RBAC grant that lands after the operator
+	// image rolls — gets several shots, without ever wedging the machine's
+	// deletion (and the owning MachineDeployment's rollout) forever. See
+	// stripStrandedPodFinalizers for why proceeding is safe.
+	podFinalizerCleanupRetryBudget = 5 * time.Minute
 )
 
 // ScalewayAppleSiliconMachineReconciler reconciles ScalewayAppleSiliconMachine objects.
@@ -1013,15 +1022,34 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	// Terminating (see podagent.PodFinalizer). Stage 1 already released and
 	// reinstalled the host, so there is no VM left for the finalizer to
 	// protect. Do it after the Node delete so we only ever strip Pods whose
-	// host we've confirmed gone. Blocking (requeue on error) like the other
-	// stages: a stranded Pod is precisely the failure this stage exists to
-	// prevent, so we don't drop the machine finalizer until the sweep runs
-	// clean.
+	// host we've confirmed gone.
+	//
+	// Best-effort, deliberately NOT fail-closed: while we're still within
+	// podFinalizerCleanupRetryBudget of the deletion, requeue on error so a
+	// transient API failure or a lagging `pods … patch` RBAC grant (the
+	// operator image can roll before the ClusterRole update lands) gets
+	// another shot. Once that budget is spent, event + log and PROCEED to drop
+	// the machine finalizer instead of retrying forever. Blocking here
+	// indefinitely would let a single un-patchable Pod wedge the machine's
+	// deletion — and with it the owning MachineDeployment's scale-down /
+	// rollout — which is a strictly worse failure than the bug this stage
+	// fixes. Proceeding leaks nothing (Stage 1 already released the host); the
+	// worst case degrades back to the original symptom, a Pod left in
+	// Terminating, now loudly evented for an operator / the periodic reclaim.
 	if err := r.stripStrandedPodFinalizers(ctx, machine.Name); err != nil {
-		logger.Error(err, "strip stranded pod finalizers; will retry")
-		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "PodFinalizerCleanupFailed",
-			"strip vm-cleanup finalizer from stranded pods on node %s: %v (will retry)", machine.Name, err)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		withinBudget := !machine.DeletionTimestamp.IsZero() &&
+			time.Since(machine.DeletionTimestamp.Time) < podFinalizerCleanupRetryBudget
+		if withinBudget {
+			logger.Error(err, "strip stranded pod finalizers; will retry")
+			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "PodFinalizerCleanupFailed",
+				"strip vm-cleanup finalizer from stranded pods on node %s: %v (will retry)", machine.Name, err)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		logger.Error(err, "strip stranded pod finalizers exhausted retry budget; proceeding with machine deletion",
+			"budget", podFinalizerCleanupRetryBudget)
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "PodFinalizerCleanupGaveUp",
+			"strip vm-cleanup finalizer from stranded pods on node %s still failing after %s; proceeding with machine deletion, pods may remain Terminating: %v",
+			machine.Name, podFinalizerCleanupRetryBudget, err)
 	}
 
 	// Stage 5: drop the per-machine Tailscale egress Service if the
@@ -1054,8 +1082,15 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 // The list goes through the uncached APIReader with a spec.nodeName field
 // selector, which the API server serves natively — a single scoped read that
 // returns only the doomed Pods, no cluster-wide Pods informer required. Each
-// match is patched (not Updated) to drop only the finalizer, so a concurrent
-// PodGC status write can't lose a resourceVersion race against us.
+// match is patched (not Updated) to drop the finalizer. The JSON merge patch
+// MergeFrom emits replaces the whole metadata.finalizers array, so this is
+// safe only because there is no concurrent finalizer writer — tart-kubelet,
+// the sole other actor that touches this Pod's finalizers, is gone with the
+// host. PodGC still races us, but only on the Pod's status/deletion, which the
+// merge patch doesn't carry, so it can't clobber or be clobbered here.
+//
+// Every match is attempted even if one fails; the per-Pod errors are joined so
+// a single un-patchable Pod can't hide progress on (or failures of) the rest.
 func (r *ScalewayAppleSiliconMachineReconciler) stripStrandedPodFinalizers(
 	ctx context.Context,
 	nodeName string,
@@ -1067,6 +1102,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) stripStrandedPodFinalizers(
 		return fmt.Errorf("list pods on node %q: %w", nodeName, err)
 	}
 
+	var errs []error
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		if !controllerutil.ContainsFinalizer(pod, PodVMCleanupFinalizer) {
@@ -1078,12 +1114,13 @@ func (r *ScalewayAppleSiliconMachineReconciler) stripStrandedPodFinalizers(
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return fmt.Errorf("strip vm-cleanup finalizer from pod %s/%s: %w", pod.Namespace, pod.Name, err)
+			errs = append(errs, fmt.Errorf("strip vm-cleanup finalizer from pod %s/%s: %w", pod.Namespace, pod.Name, err))
+			continue
 		}
 		logger.Info("stripped stranded vm-cleanup finalizer",
 			"pod", pod.Namespace+"/"+pod.Name, "node", nodeName)
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // reader returns the uncached APIReader when wired, else the cached client.

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -43,6 +43,22 @@ const (
 	// 24h floor means leaks cost money — this matters).
 	MachineFinalizer = "scalewayapplesilicon.cluster.x-k8s.io/finalizer"
 
+	// PodVMCleanupFinalizer is the finalizer tart-kubelet stamps on every
+	// Pod it runs so it can tear the backing Tart VM down before the Pod
+	// object disappears. The tart-kubelet on the Pod's host is the *only*
+	// actor that removes it. When a Mac mini is deleted the host — and its
+	// tart-kubelet — is gone, so nothing strips the finalizer: PodGC marks
+	// the orphaned Pods Failed and issues a grace-period-0 delete that then
+	// hangs on the finalizer forever. reconcileDelete strips it (Stage 4.5)
+	// once the host has been released, by which point there is no VM left
+	// to orphan.
+	//
+	// Duplicated from podagent.PodFinalizer in infra/tart-kubelet: capt is a
+	// separate Go module, and importing tart-kubelet only for this string
+	// would drag its whole dependency graph into this build. Keep the two
+	// values in sync.
+	PodVMCleanupFinalizer = "tart-kubelet.tuist.dev/vm-cleanup"
+
 	// BootstrappedCondition is macOS-specific (the tart-kubelet SSH bootstrap
 	// step); the cross-cutting shared.ProvisionedCondition lives in the shared package.
 	BootstrappedCondition clusterv1.ConditionType = "Bootstrapped"
@@ -56,7 +72,16 @@ const (
 // ScalewayAppleSiliconMachineReconciler reconciles ScalewayAppleSiliconMachine objects.
 type ScalewayAppleSiliconMachineReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
+	Scheme *runtime.Scheme
+
+	// APIReader is an uncached reader wired to mgr.GetAPIReader(). Used by
+	// reconcileDelete's stranded-Pod sweep to list Pods by spec.nodeName
+	// straight from the API server: the field selector is served natively
+	// there, so we avoid standing up a cluster-wide Pods informer just to
+	// clean up on delete. Falls back to the cached Client in tests where
+	// it's left unset.
+	APIReader client.Reader
+
 	ScalewayClient     *scaleway.Client
 	CredentialsManager *credentials.Manager
 
@@ -258,6 +283,7 @@ type ScalewayAppleSiliconMachineReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=cluster-info,verbs=get
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -978,6 +1004,26 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
+	// Stage 4.5: strip the tart-kubelet vm-cleanup finalizer from any Pods
+	// still bound to the Node we just deleted. Same reasoning that justifies
+	// Stage 4: the host is gone, so its tart-kubelet can neither deregister
+	// its Node nor clear the finalizer it stamped on every Pod it ran.
+	// Without this, PodGC marks those Pods Failed and force-deletes them, but
+	// the delete blocks on the finalizer forever and they wedge in
+	// Terminating (see podagent.PodFinalizer). Stage 1 already released and
+	// reinstalled the host, so there is no VM left for the finalizer to
+	// protect. Do it after the Node delete so we only ever strip Pods whose
+	// host we've confirmed gone. Blocking (requeue on error) like the other
+	// stages: a stranded Pod is precisely the failure this stage exists to
+	// prevent, so we don't drop the machine finalizer until the sweep runs
+	// clean.
+	if err := r.stripStrandedPodFinalizers(ctx, machine.Name); err != nil {
+		logger.Error(err, "strip stranded pod finalizers; will retry")
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "PodFinalizerCleanupFailed",
+			"strip vm-cleanup finalizer from stranded pods on node %s: %v (will retry)", machine.Name, err)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	// Stage 5: drop the per-machine Tailscale egress Service if the
 	// chart wired it up. Cross-namespace OwnerRef isn't allowed
 	// (Service lives in the tailscale-operator namespace, this CR
@@ -997,6 +1043,58 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 
 	controllerutil.RemoveFinalizer(machine, MachineFinalizer)
 	return ctrl.Result{}, nil
+}
+
+// stripStrandedPodFinalizers removes the tart-kubelet vm-cleanup finalizer
+// from every Pod bound to the given (now-deleted) Node. The host that ran
+// them is gone, so its tart-kubelet will never remove the finalizer itself
+// and the Pods would otherwise wedge in Terminating forever once PodGC
+// force-deletes them.
+//
+// The list goes through the uncached APIReader with a spec.nodeName field
+// selector, which the API server serves natively — a single scoped read that
+// returns only the doomed Pods, no cluster-wide Pods informer required. Each
+// match is patched (not Updated) to drop only the finalizer, so a concurrent
+// PodGC status write can't lose a resourceVersion race against us.
+func (r *ScalewayAppleSiliconMachineReconciler) stripStrandedPodFinalizers(
+	ctx context.Context,
+	nodeName string,
+) error {
+	logger := log.FromContext(ctx)
+
+	var pods corev1.PodList
+	if err := r.reader().List(ctx, &pods, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+		return fmt.Errorf("list pods on node %q: %w", nodeName, err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !controllerutil.ContainsFinalizer(pod, PodVMCleanupFinalizer) {
+			continue
+		}
+		patch := client.MergeFrom(pod.DeepCopy())
+		controllerutil.RemoveFinalizer(pod, PodVMCleanupFinalizer)
+		if err := r.Client.Patch(ctx, pod, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("strip vm-cleanup finalizer from pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		logger.Info("stripped stranded vm-cleanup finalizer",
+			"pod", pod.Namespace+"/"+pod.Name, "node", nodeName)
+	}
+	return nil
+}
+
+// reader returns the uncached APIReader when wired, else the cached client.
+// The stranded-Pod sweep uses it so a spec.nodeName field selector hits the
+// API server directly in production; tests leave APIReader unset and fall
+// back to the fake client (which registers the same field index).
+func (r *ScalewayAppleSiliconMachineReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // === helpers ================================================================

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/controllers/shared"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
@@ -276,6 +277,12 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMa
 		WithScheme(scheme).
 		WithRuntimeObjects(objs...).
 		WithStatusSubresource(&infrav1.ScalewayAppleSiliconMachine{}).
+		// Mirror the API server's native spec.nodeName Pod field selector so
+		// reconcileDelete's stranded-Pod sweep resolves against the fake client
+		// (which leaves APIReader unset and falls back to this Client).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).
 		Build()
 	return &ScalewayAppleSiliconMachineReconciler{
 		Client:   c,
@@ -795,6 +802,123 @@ func TestReconcileDelete_LegacyCRUsesDefaultPrefix(t *testing.T) {
 	}
 	if machine.Status.ServerID != "" {
 		t.Fatalf("Status.ServerID should be cleared after release, got %q", machine.Status.ServerID)
+	}
+}
+
+// strandedPod builds a Pod bound to nodeName carrying the given finalizers.
+// Used by the Stage 4.5 sweep tests.
+func strandedPod(namespace, name, nodeName string, finalizers ...string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  namespace,
+			Name:       name,
+			Finalizers: finalizers,
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+	}
+}
+
+// TestReconcileDelete_StripsStrandedPodFinalizers covers Stage 4.5: after the
+// Node is gone the sweep must strip tart-kubelet's vm-cleanup finalizer from
+// Pods on that node — and only those. Pods on other nodes and Pods without the
+// finalizer must be left untouched.
+func TestReconcileDelete_StripsStrandedPodFinalizers(t *testing.T) {
+	const node = "macos-fleet-7"
+	onNode := strandedPod("tuist-runners", "runner-on-node", node, PodVMCleanupFinalizer)
+	onNodeNoFinalizer := strandedPod("tuist-runners", "runner-no-finalizer", node)
+	onNodeOtherFinalizer := strandedPod("tuist-runners", "runner-other-finalizer", node, "example.com/keep-me")
+	otherNode := strandedPod("tuist-runners", "runner-other-node", "macos-fleet-99", PodVMCleanupFinalizer)
+
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       node,
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		// Empty ServerID: Stage 1 is skipped, so the delete flows straight
+		// through to the pod sweep without needing a Scaleway stub.
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{Zone: "fr-par-1"},
+	}
+
+	r := newReconciler(t, onNode, onNodeNoFinalizer, onNodeOtherFinalizer, otherNode)
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	assertFinalizer := func(pod *corev1.Pod, want bool) {
+		t.Helper()
+		var got corev1.Pod
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(pod), &got); err != nil {
+			t.Fatalf("get pod %s: %v", pod.Name, err)
+		}
+		has := false
+		for _, f := range got.Finalizers {
+			if f == PodVMCleanupFinalizer {
+				has = true
+			}
+		}
+		if has != want {
+			t.Fatalf("pod %s: vm-cleanup finalizer present=%v, want %v (finalizers=%v)", pod.Name, has, want, got.Finalizers)
+		}
+	}
+
+	assertFinalizer(onNode, false)
+	assertFinalizer(otherNode, true)
+
+	// The unrelated finalizer on a same-node pod must survive untouched.
+	var kept corev1.Pod
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(onNodeOtherFinalizer), &kept); err != nil {
+		t.Fatalf("get pod %s: %v", onNodeOtherFinalizer.Name, err)
+	}
+	if len(kept.Finalizers) != 1 || kept.Finalizers[0] != "example.com/keep-me" {
+		t.Fatalf("unrelated finalizer must be preserved, got %v", kept.Finalizers)
+	}
+
+	// The no-finalizer pod is a no-op; getting it must still succeed.
+	var untouched corev1.Pod
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(onNodeNoFinalizer), &untouched); err != nil {
+		t.Fatalf("get pod %s: %v", onNodeNoFinalizer.Name, err)
+	}
+}
+
+// TestReconcileDelete_UnwedgesTerminatingPod reproduces the production bug: a
+// Pod already force-deleted (DeletionTimestamp set) but held open by the
+// vm-cleanup finalizer wedges in Terminating forever. Stage 4.5 stripping the
+// finalizer must let the API object finalize and disappear.
+func TestReconcileDelete_UnwedgesTerminatingPod(t *testing.T) {
+	const node = "macos-fleet-8"
+	pod := strandedPod("tuist-runners", "runner-wedged", node, PodVMCleanupFinalizer)
+
+	r := newReconciler(t, pod)
+
+	// Delete blocks on the finalizer, leaving the Pod in Terminating —
+	// exactly the state PodGC leaves behind when the node vanishes.
+	if err := r.Delete(context.Background(), pod); err != nil {
+		t.Fatalf("delete pod: %v", err)
+	}
+	var terminating corev1.Pod
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pod), &terminating); err != nil {
+		t.Fatalf("pod should still exist while finalizer holds it: %v", err)
+	}
+	if terminating.DeletionTimestamp.IsZero() {
+		t.Fatalf("expected pod to be Terminating (DeletionTimestamp set)")
+	}
+
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       node,
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{Zone: "fr-par-1"},
+	}
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	var got corev1.Pod
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pod), &got); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected wedged pod to finalize and disappear, got err=%v pod=%+v", err, got)
 	}
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -3,6 +3,7 @@ package macos
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
@@ -258,7 +261,7 @@ func TestNodeMissingAfterBootstrap_NodeGone(t *testing.T) {
 	}
 }
 
-func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMachineReconciler {
+func newTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -273,29 +276,40 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMa
 	if err := rbacv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("rbacv1 scheme: %v", err)
 	}
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(objs...).
-		WithStatusSubresource(&infrav1.ScalewayAppleSiliconMachine{}).
-		// Mirror the API server's native spec.nodeName Pod field selector so
-		// reconcileDelete's stranded-Pod sweep resolves against the fake client
-		// (which leaves APIReader unset and falls back to this Client).
-		WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
-			return []string{o.(*corev1.Pod).Spec.NodeName}
-		}).
-		Build()
+	return scheme
+}
+
+// podNodeNameIndexValue mirrors the API server's native spec.nodeName Pod
+// field selector so reconcileDelete's stranded-Pod sweep resolves against the
+// fake client (which leaves APIReader unset and falls back to this Client).
+func podNodeNameIndexValue(o client.Object) []string {
+	return []string{o.(*corev1.Pod).Spec.NodeName}
+}
+
+// reconcilerForClient wires a reconciler around a prebuilt fake client with a
+// real CredentialsManager backed by it. The per-machine Delete methods tolerate
+// IsNotFound, so reconcileDelete flows through Stages 2-3 without any pre-staged
+// Secret / ServiceAccount / ClusterRoleBinding fixtures.
+func reconcilerForClient(c client.Client, recorder record.EventRecorder) *ScalewayAppleSiliconMachineReconciler {
 	return &ScalewayAppleSiliconMachineReconciler{
 		Client:   c,
-		Recorder: fakeRecorder(),
-		// Real CredentialsManager backed by the same fake client. The
-		// per-machine Delete methods tolerate IsNotFound, so reconcileDelete
-		// can flow through Stages 2-3 without any pre-staged Secret /
-		// ServiceAccount / ClusterRoleBinding fixtures.
+		Recorder: recorder,
 		CredentialsManager: &credentials.Manager{
 			Client:    c,
 			Namespace: "ns",
 		},
 	}
+}
+
+func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMachineReconciler {
+	t.Helper()
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithRuntimeObjects(objs...).
+		WithStatusSubresource(&infrav1.ScalewayAppleSiliconMachine{}).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", podNodeNameIndexValue).
+		Build()
+	return reconcilerForClient(c, fakeRecorder())
 }
 
 func backdateBootstrappedCondition(machine *infrav1.ScalewayAppleSiliconMachine, by time.Duration) {
@@ -920,6 +934,119 @@ func TestReconcileDelete_UnwedgesTerminatingPod(t *testing.T) {
 	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pod), &got); !apierrors.IsNotFound(err) {
 		t.Fatalf("expected wedged pod to finalize and disappear, got err=%v pod=%+v", err, got)
 	}
+}
+
+// TestPodVMCleanupFinalizerValue pins this module's copy of the finalizer to
+// the literal tart-kubelet stamps. capt can't import tart-kubelet's internal
+// podagent package, so the string is hand-duplicated; this test (plus its
+// tart-kubelet-side counterpart, TestPodFinalizerValue) fails loudly if either
+// side drifts.
+func TestPodVMCleanupFinalizerValue(t *testing.T) {
+	const want = "tart-kubelet.tuist.dev/vm-cleanup"
+	if PodVMCleanupFinalizer != want {
+		t.Fatalf("PodVMCleanupFinalizer = %q, want %q — must match podagent.PodFinalizer in tart-kubelet", PodVMCleanupFinalizer, want)
+	}
+}
+
+// podPatchDenyingReconciler builds a reconciler whose fake client rejects every
+// Pod patch with the given error, so the Stage 4.5 sweep always fails. Used by
+// the best-effort error-path tests. The recorder is returned so the caller can
+// assert on emitted Events.
+func podPatchDenyingReconciler(t *testing.T, patchErr error, objs ...runtime.Object) (*ScalewayAppleSiliconMachineReconciler, *record.FakeRecorder) {
+	t.Helper()
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithRuntimeObjects(objs...).
+		WithStatusSubresource(&infrav1.ScalewayAppleSiliconMachine{}).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", podNodeNameIndexValue).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*corev1.Pod); ok {
+					return patchErr
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	rec := record.NewFakeRecorder(32)
+	return reconcilerForClient(c, rec), rec
+}
+
+func deletingMachine(name string, deletedAt time.Time) *infrav1.ScalewayAppleSiliconMachine {
+	ts := metav1.NewTime(deletedAt)
+	return &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "ns",
+			Finalizers:        []string{MachineFinalizer},
+			DeletionTimestamp: &ts,
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{Zone: "fr-par-1"},
+	}
+}
+
+func assertEventReason(t *testing.T, rec *record.FakeRecorder, reason string) {
+	t.Helper()
+	for {
+		select {
+		case e := <-rec.Events:
+			if strings.Contains(e, reason) {
+				return
+			}
+		default:
+			t.Fatalf("expected an event with reason %q, none found", reason)
+		}
+	}
+}
+
+// TestReconcileDelete_PodFinalizerStripFailureWithinBudgetRequeues covers the
+// best-effort sweep's retry window: while the machine has been deleting for
+// less than podFinalizerCleanupRetryBudget, a failing strip requeues and keeps
+// the machine finalizer so the next reconcile tries again (e.g. transient error
+// or a lagging pods/patch RBAC grant).
+func TestReconcileDelete_PodFinalizerStripFailureWithinBudgetRequeues(t *testing.T) {
+	const node = "macos-fleet-recent"
+	pod := strandedPod("tuist-runners", "runner-x", node, PodVMCleanupFinalizer)
+	denied := apierrors.NewForbidden(corev1.Resource("pods"), pod.Name, errors.New("pods patch not yet granted"))
+	r, rec := podPatchDenyingReconciler(t, denied, pod)
+
+	machine := deletingMachine(node, time.Now())
+	res, err := r.reconcileDelete(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if res.RequeueAfter != 30*time.Second {
+		t.Fatalf("expected 30s requeue within budget, got %+v", res)
+	}
+	if !controllerutil.ContainsFinalizer(machine, MachineFinalizer) {
+		t.Fatalf("machine finalizer must be retained while retrying")
+	}
+	assertEventReason(t, rec, "PodFinalizerCleanupFailed")
+}
+
+// TestReconcileDelete_PodFinalizerStripFailureBeyondBudgetProceeds covers the
+// give-up path: once the strip has been failing past the retry budget, the
+// machine delete must PROCEED (drop the machine finalizer, no requeue) rather
+// than wedge the owning MachineDeployment forever. Stage 1 already released the
+// host, so proceeding leaks nothing; the failure is surfaced as an Event.
+func TestReconcileDelete_PodFinalizerStripFailureBeyondBudgetProceeds(t *testing.T) {
+	const node = "macos-fleet-stale"
+	pod := strandedPod("tuist-runners", "runner-x", node, PodVMCleanupFinalizer)
+	denied := apierrors.NewForbidden(corev1.Resource("pods"), pod.Name, errors.New("pods patch never granted"))
+	r, rec := podPatchDenyingReconciler(t, denied, pod)
+
+	machine := deletingMachine(node, time.Now().Add(-2*podFinalizerCleanupRetryBudget))
+	res, err := r.reconcileDelete(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if res.RequeueAfter != 0 || res.Requeue {
+		t.Fatalf("expected machine delete to proceed (no requeue) after budget, got %+v", res)
+	}
+	if controllerutil.ContainsFinalizer(machine, MachineFinalizer) {
+		t.Fatalf("machine finalizer must be removed so deletion proceeds past an un-strippable pod")
+	}
+	assertEventReason(t, rec, "PodFinalizerCleanupGaveUp")
 }
 
 func startsWith(s, prefix string) bool {

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -99,9 +99,12 @@ rules:
     verbs: [get, list, watch, delete]
   - apiGroups: [""]
     # The failover-IP controller reads peer-demux pod readiness to drain the IP
-    # off a box whose demux is rolling.
+    # off a box whose demux is rolling. On macOS Machine delete, the reconciler
+    # also patches Pods bound to the departing node to strip tart-kubelet's
+    # vm-cleanup finalizer — the host (and its tart-kubelet) is gone, so nothing
+    # else can remove it and PodGC-force-deleted Pods would wedge in Terminating.
     resources: [pods]
-    verbs: [get, list, watch]
+    verbs: [get, list, watch, patch]
   - apiGroups: [""]
     # The operator owns four Secret families in its own namespace:
     #   - <fleet>-ssh: per-fleet Ed25519 keypair, generated once

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -42,6 +42,13 @@ import (
 // running on the host until GC sweeps it. The standard finalizer
 // pattern lets us guarantee VM teardown completes before the Pod
 // disappears from the API server's perspective.
+//
+// NOTE: cluster-api-provider-tuist duplicates this literal as
+// macos.PodVMCleanupFinalizer (separate Go module, can't import this
+// internal package) to strip it from Pods stranded on a deleted Mac
+// mini. The two must stay equal; both are pinned to the literal by a
+// test (see TestPodFinalizerValue here and the capt-side counterpart).
+// If you rename this, update capt too.
 const (
 	PodFinalizer = "tart-kubelet.tuist.dev/vm-cleanup"
 

--- a/infra/tart-kubelet/internal/podagent/reconciler_test.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler_test.go
@@ -21,6 +21,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// TestPodFinalizerValue pins the finalizer literal. cluster-api-provider-tuist
+// hand-duplicates this exact string as macos.PodVMCleanupFinalizer (it lives in
+// a separate Go module and can't import this internal package) to strip the
+// finalizer from Pods stranded on a deleted Mac mini. A rename here would
+// silently break that match, so this test — and its capt-side counterpart —
+// fail loudly on drift, forcing the rename to touch both places.
+func TestPodFinalizerValue(t *testing.T) {
+	const want = "tart-kubelet.tuist.dev/vm-cleanup"
+	if PodFinalizer != want {
+		t.Fatalf("PodFinalizer = %q, want %q — update macos.PodVMCleanupFinalizer in cluster-api-provider-tuist to match", PodFinalizer, want)
+	}
+}
+
 func TestCompletePodDeletionRemovesFinalizerAndDeletesPod(t *testing.T) {
 	ctx := context.Background()
 	pod := &corev1.Pod{


### PR DESCRIPTION
## What changed

Adds a **Stage 4.5** to `ScalewayAppleSiliconMachineReconciler.reconcileDelete`: after deleting the departing host's Node object, the controller lists Pods bound to that node and strips tart-kubelet's `tart-kubelet.tuist.dev/vm-cleanup` finalizer from them. The strip is **best-effort with a bounded retry budget** — it never wedges the machine's deletion.

Closes #11889.

## Why

When a `ScalewayAppleSiliconMachine` is deleted (fleet churn, scale-down, MHC remediation), its tart pods could be left stuck in `Terminating` **forever**.

### Root cause

1. `tart-kubelet` stamps the `vm-cleanup` finalizer on every Pod it runs and is the **only** actor that removes it — after it tears the backing Tart VM down (`infra/tart-kubelet/internal/podagent/reconciler.go`).
2. `reconcileDelete` releases the Scaleway host (Stage 1) and deletes the Node object (Stage 4, *because the vanished kubelet can't deregister itself*) — but never touched the Pods bound to that node.
3. Once the host is gone, so is its tart-kubelet. PodGC notices the missing Node, marks the Pods `Failed`, and issues a grace-period-0 delete — which then hangs on the finalizer forever. `kubectl delete` on such a pod hangs indefinitely.

The exact same reasoning that already justifies Stage 4 (the vanished kubelet can't deregister its Node) applies to the finalizer: the vanished kubelet can't strip it either. Observed in production on 2026-07-16, where fleet churn wedged 4 pods in `tuist-runners`.

### Why this solution

Stage 1 already released **and reinstalled** the host back into the Scaleway pool, so there is no VM left for the finalizer to protect against — stripping it is safe and lets the Pods finalize. Doing it in capt (rather than a runners-only sweep or a standalone controller) is the natural home: capt already deletes the Node for the same "host is gone" reason and already owns tart-kubelet's lifecycle (bootstrap, config, rolling updates), and it covers every tart pod on the fleet (runners, xcresult processor, …), not just `RunnerPool` pods.

The scoped strip is deliberately narrow — only the `vm-cleanup` finalizer, only on the deleted node, only after Stage 1 released+reimaged the host. Alternatives (drain-before-delete, force-delete, remove-any-finalizer, self-clean in tart-kubelet) were considered and rejected: they either miss the dead/unreachable-host case that caused the bug, are exactly what PodGC already does, or would clobber other finalizers (volume/IP/mesh) that guard resources that are **not** moot.

### Best-effort, not fail-closed

The sweep does **not** block machine deletion indefinitely. On error, while the machine has been deleting for less than `podFinalizerCleanupRetryBudget` (5m), it requeues so a transient API failure — or a lagging `pods … patch` RBAC grant — gets several shots. Past that budget it emits a Warning event, logs, and **proceeds** to drop the machine finalizer.

Rationale: blocking forever would let a single un-patchable Pod wedge the machine's deletion, and with it the owning MachineDeployment's scale-down/rollout — a strictly worse failure than the original bug (one localized stranded pod). Since Stage 1 already released the host, proceeding leaks no capacity; the worst case degrades back to the original symptom, now loudly evented for follow-up. The budget is measured off the machine's `DeletionTimestamp`, so no new status field / CRD regen is required.

> The optional periodic sweep for manual `kubectl delete node` mentioned in the issue is intentionally **not** included here — this PR closes the reported machine-lifecycle path; the belt-and-braces sweep can follow separately if we decide we want it.

## Implementation notes

- **Finalizer constant** is duplicated from `podagent.PodFinalizer` (capt is a separate Go module and `podagent` is an `internal` package, so it can't be imported; importing tart-kubelet just for the string would drag its whole dependency graph into the build). To guard against silent cross-module drift, **both** copies are pinned to the literal by value tests (`TestPodVMCleanupFinalizerValue` in capt, `TestPodFinalizerValue` in tart-kubelet) with reciprocal comments, so a rename on either side fails CI.
- **Listing** goes through the uncached `APIReader` (`mgr.GetAPIReader()`) with a `spec.nodeName` field selector, which the API server serves natively — a single scoped read that returns only the doomed Pods, avoiding a cluster-wide Pods informer just for delete-time cleanup.
- **Patch, not Update**, drops the finalizer via `client.MergeFrom`. That JSON merge patch replaces the whole `metadata.finalizers` array, which is safe **only because there is no concurrent finalizer writer** (tart-kubelet, the sole other actor on this Pod's finalizers, is gone with the host). The sweep attempts every matching Pod and joins per-pod errors so one bad Pod can't hide the rest.
- **RBAC**: adds `pods … patch` to the kubebuilder marker, the capt manager `ClusterRole` in the Helm chart (`get,list,watch` → `+patch`), and the `config/rbac` intent mirror. The ClusterRole and the operator Deployment ship in the **same Helm release** with a values-sourced image, and Helm applies ClusterRoles before Deployments — so the grant lands no later than the operator rollout. With the best-effort behavior above, even a GitOps split that lags RBAC only delays the strip instead of wedging deletion.

`ScalewayElasticMetalMachine` (Linux) nodes run the standard kubelet and don't use this finalizer — no change there.

## Validation

- `go build ./...` (capt + tart-kubelet) — clean
- `go vet ./controllers/macos/ ./cmd/manager/` — clean
- `go test ./controllers/macos/` — passes, including:
  - `TestReconcileDelete_UnwedgesTerminatingPod` — reproduces the bug: a Pod force-deleted (DeletionTimestamp set) but held open by the finalizer is finalized and disappears after Stage 4.5.
  - `TestReconcileDelete_StripsStrandedPodFinalizers` — scoping: only Pods on the deleted node with the finalizer are touched; other nodes and unrelated finalizers are left intact.
  - `TestReconcileDelete_PodFinalizerStripFailureWithinBudgetRequeues` — a failing strip within the budget requeues (30s) and **keeps** the machine finalizer.
  - `TestReconcileDelete_PodFinalizerStripFailureBeyondBudgetProceeds` — a persistently failing strip past the budget **proceeds** (machine finalizer removed, no requeue, `PodFinalizerCleanupGaveUp` event).
  - `TestPodVMCleanupFinalizerValue` — drift guard.
- `go test ./internal/podagent/ -run TestPodFinalizerValue` (tart-kubelet) — drift guard.

## Remediation for currently-stuck pods

Independent of this rollout, any pods still wedged can be cleared manually (safe — the hosts were released and reinstalled, so there is no VM to orphan):

```
kubectl -n tuist-runners patch pod <pod> --type=merge -p '{"metadata":{"finalizers":null}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
