### PR TITLE
fix(server): serve the Kura peer view to managed instances on any plan

### DIFF
--- a/server/lib/tuist_web/controllers/internal/kura_mesh_controller.ex
+++ b/server/lib/tuist_web/controllers/internal/kura_mesh_controller.ex
@@ -4,7 +4,6 @@ defmodule TuistWeb.Internal.KuraMeshController do
   alias Boruta.BasicAuth
   alias Boruta.Oauth.Authorization.Client
   alias Tuist.Accounts
-  alias Tuist.Billing.Entitlements
   alias Tuist.Environment
   alias Tuist.Kura.Mesh
   alias Tuist.Kura.Registrations
@@ -194,6 +193,13 @@ defmodule TuistWeb.Internal.KuraMeshController do
     end
   end
 
+  # The credential is Tuist's own control-plane client rather than a customer's,
+  # and it speaks for every instance the provisioner manages, including
+  # runner-cache nodes, which are provisioned on any plan. The self-hosted-cache
+  # entitlement gates customer-held credentials instead, in
+  # `SelfHostedClients.verify/2`. Gating here too would deny the peer view to
+  # managed instances whose account never claimed to self-host, and every
+  # instance in a mesh region blocks readiness on that view until it answers.
   defp authorize_control_plane_registration(client_id, client_secret, %{"tenant_id" => tenant_id})
        when is_binary(tenant_id) and tenant_id != "" do
     with {:ok, _client} <-
@@ -202,8 +208,7 @@ defmodule TuistWeb.Internal.KuraMeshController do
              source: %{type: "basic", value: client_secret},
              grant_type: "kura_registration"
            ),
-         %{} = account <- Accounts.get_account_by_handle(tenant_id),
-         true <- Entitlements.allows?(account, :self_hosted_cache) do
+         %{} = account <- Accounts.get_account_by_handle(tenant_id) do
       {:ok, account}
     else
       _ -> {:error, :unauthorized}

--- a/server/test/tuist_web/controllers/internal/kura_mesh_controller_test.exs
+++ b/server/test/tuist_web/controllers/internal/kura_mesh_controller_test.exs
@@ -333,4 +333,34 @@ defmodule TuistWeb.Internal.KuraMeshControllerTest do
 
     assert json_response(conn, 401)
   end
+
+  # The rest of this file runs non-hosted, where every entitlement is granted and
+  # the self-hosted-cache gate is invisible. These two pin the hosted behaviour of
+  # each credential kind against an account whose plan does not grant it.
+  test "serves the peer view to the deployment-level credential for a hosted account without the self-hosted-cache entitlement",
+       %{conn: conn, account: account} do
+    stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+    stub(Tuist.Environment, :kura_control_plane_configured?, fn -> true end)
+    stub(Tuist.Environment, :kura_control_plane_client_id, fn -> "static-kura-client" end)
+    stub(Tuist.Environment, :kura_control_plane_client_secret, fn -> "static-kura-secret" end)
+
+    conn =
+      conn
+      |> basic_auth("static-kura-client", "static-kura-secret")
+      |> get(~p"/_internal/kura/mesh/peers?tenant_id=#{account.name}")
+
+    assert %{"peers" => []} = json_response(conn, 200)
+  end
+
+  test "rejects the peer view for a customer credential on a hosted account without the self-hosted-cache entitlement",
+       %{conn: conn, client: client, secret: secret} do
+    stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+    conn =
+      conn
+      |> basic_auth(client.client_id, secret)
+      |> get(~p"/_internal/kura/mesh/peers")
+
+    assert json_response(conn, 401)
+  end
 end


### PR DESCRIPTION
## What changed

`authorize_control_plane_registration/3` in the internal Kura mesh controller no longer requires the `self_hosted_cache` entitlement. Two tests pin the hosted behaviour of each credential kind.

## Why

Three runner-cache instances in a private region have been stuck `READY=false` with `/ready` returning 503, the oldest for over two days. A fourth instance in the same region, byte-identical in spec and scheduled on the same node, is healthy.

### Root cause

`KURA_MESH_PEERS_SYNC=true` is set for every instance in a mesh-enabled region, and both managed region builders set `mesh: true`. On boot that arms `require_peer_view()`, a gate lifted only by the first successful `GET /_internal/kura/mesh/peers`. Until it lifts, `maybe_mark_serving/0` returns early, `is_serving()` stays false, and `/ready` answers 503 indefinitely.

That request authorized through `authorize_control_plane_registration/3`, which required the `self_hosted_cache` entitlement. That entitlement is Enterprise-only: `plan_allows?(:enterprise, _feature)` is the only clause that grants it, and every other plan falls through to `false`. Runner-cache nodes are provisioned for any account with runners enabled, regardless of plan, so every managed instance belonging to a non-Enterprise account was answered 401 and could never become ready. The healthy instance in the same region differs in exactly one respect: its account is on an Enterprise plan, so it receives a 200.

The gate therefore denied the peer view to precisely the instances that block their own readiness on it.

### Why this fix rather than the alternatives

The check was misplaced rather than merely too strict. The credential on this path is Tuist's own control-plane client, not a customer's, and the endpoint exists specifically so managed pods can read the peer view without enrolling (see the comment on `peers/2`). Customer-held credentials keep their entitlement gate in `SelfHostedClients.verify/2`, which is untouched, so the self-hosted path is unchanged.

Two alternatives were considered and rejected:

- Scope `KURA_MESH_PEERS_SYNC` per account instead of per region. This requires threading the account through `extension_env/1` and changes the manifest revision, forcing a roll of every instance in the fleet, all to work around an authorization bug rather than fix it.
- Relax the boot gate in Kura. A hard boot gate on an optional feature is worth revisiting separately, since any peers outage now makes every mesh-region instance unready, but it is not what made these instances unready and it is a much larger change to the runtime.

### Why it escaped

`Entitlements.allows?/2` short-circuits to `true` whenever `tuist_hosted?` is false, and the controller test file stubs it false for every test. The gate was live only on the hosted deployment, where no test reached it.

## Impact

No pod restart is required. Each stuck instance retries the peer view every 60s (`DEFAULT_INTERVAL_MS`, with no backoff on the failure path), so once this deploys they lift the gate and go ready on their next poll.

It also unblocks a secondary problem. One stuck instance never picked up `KURA_CAS_CAPACITY_BYTES` from #11879. While its pod is unready its StatefulSet `currentRevision` cannot advance, which pins `status.observedImage` at the older tag; the reconciler's `project_server/2` then takes the `record/4` branch, which never re-applies the manifest. Its CR and StatefulSet template both still lack the variable, so deleting the pod would recreate it identically. Once it goes ready, `observedImage` advances to the desired tag, the manifest revision mismatch is noticed, and `apply_current_manifest/2` re-applies the CAS budget within a tick.

## Validation

- The new managed-path test reproduces the production failure exactly (401 with body `{"error":"unauthorized"}`) against the unfixed controller, and passes with the fix.
- The customer-credential guard test passes both with and without the fix, confirming the self-hosted entitlement gate is still enforced.
- `mix test test/tuist/kura test/tuist_web/controllers/internal` passes, 236 tests.
- `mix format --check-formatted` and `mix credo` are clean on the changed files.
- Confirmed against production that the peers endpoint answers 401 on three 60-second-periodic series, one per unready pod, alongside 200s for the Enterprise tenants.
- Confirmed against production Postgres that plan correlates exactly with readiness in the affected region: the only Enterprise account is the healthy instance, and every non-Enterprise account (one Pro, two on no active subscription) is unready.

## Related findings (not addressed here)

These came out of the same investigation and are logged separately; this PR does not change them.

- A fourth instance in the region has disappeared entirely (no CR, StatefulSet, PVC, or pod) yet its `kura_servers` row survives as `failed` rather than `destroyed`. It was the region's busiest instance and served until it went unready, then its workload was removed out-of-band, coinciding with a large disk reclaim on its node. The product's own teardown path sets `destroyed`, so this was not a product-driven deprovision. It does not self-heal because of the item below.
- Every failed Kura deployment fleet-wide for the last nine-plus days is the same intermittent `401` from the apiserver when the server's Kubernetes client reads or applies a `KuraInstance` CR (`server/lib/tuist/kubernetes/client.ex`). The client reads a fresh SA token from disk per request, so this is not a boot-cache bug. Because `project_server/2` only recreates a missing CR when the latest deployment succeeded, this 401 silently disables self-heal for any instance whose last deployment it failed, which is why the disappeared instance stays stranded. Tracked as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
