### PR TITLE
fix(server): preserve global cache endpoint fallback (hotfix)

### DIFF
--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -73,31 +73,23 @@ defmodule TuistWeb.API.CacheController do
   )
 
   def endpoints(conn, params) do
-    case params[:account_handle] do
-      nil ->
-        endpoints =
-          nil
-          |> Accounts.get_cache_endpoints_for_handle(technology(conn))
-          |> Enum.reject(&is_nil/1)
+    endpoints =
+      params[:account_handle]
+      |> authorized_account_handle(conn)
+      |> Accounts.get_cache_endpoints_for_handle(technology(conn))
+      |> Enum.reject(&is_nil/1)
 
-        json(conn, %{endpoints: endpoints})
+    json(conn, %{endpoints: endpoints})
+  end
 
-      account_handle ->
-        account = Accounts.get_account_by_handle(account_handle)
-        subject = Authentication.authenticated_subject(conn)
+  defp authorized_account_handle(nil, _conn), do: nil
 
-        if is_nil(account) or Authorization.authorize(:account_cache_read, subject, account) == :ok do
-          endpoints =
-            account_handle
-            |> Accounts.get_cache_endpoints_for_handle(technology(conn))
-            |> Enum.reject(&is_nil/1)
+  defp authorized_account_handle(account_handle, conn) do
+    account = Accounts.get_account_by_handle(account_handle)
+    subject = Authentication.authenticated_subject(conn)
 
-          json(conn, %{endpoints: endpoints})
-        else
-          conn
-          |> put_status(:forbidden)
-          |> json(%{message: "The authenticated subject is not authorized to perform this action"})
-        end
+    if not is_nil(account) and Authorization.authorize(:account_cache_read, subject, account) == :ok do
+      account_handle
     end
   end
 

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -138,7 +138,7 @@ defmodule TuistWeb.API.CacheControllerTest do
                ])
     end
 
-    test "does not return another account's custom endpoints", %{conn: conn} do
+    test "returns default endpoints instead of another account's custom endpoints", %{conn: conn} do
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
 
       attacker = AccountsFixtures.user_fixture()
@@ -152,14 +152,19 @@ defmodule TuistWeb.API.CacheControllerTest do
           url: "https://victim-private-cache.example.com"
         })
 
+      default_endpoints = [
+        "https://cache-eu-central-test.tuist.dev",
+        "https://cache-us-east-test.tuist.dev"
+      ]
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> default_endpoints end)
+
       conn =
         conn
         |> Authentication.put_current_user(attacker)
         |> get(~p"/api/cache/endpoints?account_handle=#{victim_account.name}")
 
-      assert json_response(conn, :forbidden) == %{
-               "message" => "The authenticated subject is not authorized to perform this action"
-             }
+      assert json_response(conn, :ok) == %{"endpoints" => default_endpoints}
     end
 
     test "returns ready account Kura endpoints when the client requests Kura and the account is opted in", %{


### PR DESCRIPTION
## What changed

Requests for an account's cache endpoints now fall back to the global endpoint list when the authenticated subject cannot read that account. Authorized subjects still receive account-specific endpoints.

Regression coverage verifies that a caller from another account receives global endpoints and never receives the private custom endpoint.

## Why

The recent security hardening correctly protected custom endpoint addresses, but it made cache discovery fail entirely for callers whose credentials do not resolve to the configured account. Production request logs showed the same account receiving successful and forbidden responses depending on the caller's credential.

## Root cause

The controller performed account authorization before endpoint selection and returned a forbidden response on failure. It did not distinguish private custom endpoints from the safe global fallback.

## Approach

Normalize an unauthorized or unknown account handle to no account handle, then reuse the existing global endpoint selection path. This preserves the tenant boundary without duplicating endpoint-selection logic.

## Impact

Affected command-line interface users can discover global endpoints again. Account members and matching project or account tokens continue receiving account-specific endpoints. Private custom endpoints remain hidden from unrelated subjects.

## Validation

- `mix format --check-formatted lib/tuist_web/controllers/api/cache_controller.ex test/tuist_web/controllers/api/cache_controller_test.exs`
- `mix test test/tuist_web/controllers/api/cache_controller_test.exs`, 38 tests passed
- `git diff --check`
- Focused code analysis completed with one pre-existing suggestion outside this change
- Browser screenshots are not applicable because this changes a machine-consumed endpoint with no visual interface