### PR TITLE
feat(status): show incident status updates

### DIFF
--- a/status/AGENTS.md
+++ b/status/AGENTS.md
@@ -141,7 +141,7 @@ It calls `IncidentsService.QueryIncidents` twice on every page load:
 
 The response shape is `{ error, incidents: [...], cursor: { hasMore, nextValue } }`. The client follows the cursor up to 5 pages defensively.
 
-After filtering resolved incidents to the last 14 days, the client calls `KeyUpdatesService.QueryKeyUpdates` for every active and recent incident. These key updates supply the timestamped status-update timeline shown on the page and republished in the feeds. The incident summary remains a fallback for incidents without key updates. Key-update queries follow the same cursor limit as incident queries.
+After filtering resolved incidents to the last 14 days, the client calls `KeyUpdatesService.QueryKeyUpdates` for every active and recent incident. These key updates supply the timestamped status-update timeline shown on the page and republished in the feeds. The incident summary remains a fallback for incidents without key updates. Key-update queries follow the same cursor limit as incident queries and are hydrated with at most five concurrent requests.
 
 ## Severity Mapping
 

--- a/status/AGENTS.md
+++ b/status/AGENTS.md
@@ -141,6 +141,8 @@ It calls `IncidentsService.QueryIncidents` twice on every page load:
 
 The response shape is `{ error, incidents: [...], cursor: { hasMore, nextValue } }`. The client follows the cursor up to 5 pages defensively.
 
+After filtering resolved incidents to the last 14 days, the client calls `KeyUpdatesService.QueryKeyUpdates` for every active and recent incident. These key updates supply the timestamped status-update timeline shown on the page and republished in the feeds. The incident summary remains a fallback for incidents without key updates. Key-update queries follow the same cursor limit as incident queries.
+
 ## Severity Mapping
 
 Grafana Incident severity → component status (`severityToComponentStatus` in `grafana-irm.ts`):

--- a/status/src/dev/fake-status.ts
+++ b/status/src/dev/fake-status.ts
@@ -57,6 +57,7 @@ export function fakeStatus(): StatusSnapshot {
         {
           at: minutesAgo(8),
           status: "monitoring",
+          title: "Mitigation applied, monitoring impact",
           body: "Latency is back to baseline. We're keeping an eye on it for the next 30 minutes before resolving.",
         },
         {

--- a/status/src/grafana-irm.test.ts
+++ b/status/src/grafana-irm.test.ts
@@ -223,6 +223,125 @@ describe("fetchStatusFromGrafana", () => {
     expect(snapshot.recentIncidents.map((i) => i.id)).toEqual(["fresh"]);
   });
 
+  it("loads every key update for an incident and uses its summary as a fallback", async () => {
+    const keyUpdateBodies: Array<Record<string, unknown>> = [];
+    let keyUpdatePage = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      if (url.endsWith("FieldsService.GetFields")) {
+        return new Response(JSON.stringify({ fields: [] }));
+      }
+      if (url.endsWith("IncidentsService.QueryIncidents")) {
+        const isActive = JSON.stringify(body).includes("status:active");
+        return new Response(
+          JSON.stringify({
+            incidents: isActive
+              ? [
+                  {
+                    incidentID: "with-updates",
+                    title: "Cache unavailable",
+                    status: "active",
+                    summary: "This is replaced by the key updates.",
+                    createdTime: "2026-05-05T10:00:00.000Z",
+                  },
+                  {
+                    incidentID: "with-summary",
+                    title: "Cache slow",
+                    status: "active",
+                    summary: "We are investigating elevated latency.",
+                    createdTime: "2026-05-05T11:00:00.000Z",
+                  },
+                ]
+              : [],
+          }),
+        );
+      }
+      if (url.endsWith("KeyUpdatesService.QueryKeyUpdates")) {
+        const incidentID = body.query.incidentID;
+        if (incidentID === "with-summary") {
+          return new Response(JSON.stringify({ keyUpdates: [] }));
+        }
+        keyUpdateBodies.push(body);
+        keyUpdatePage++;
+        if (keyUpdatePage === 1) {
+          return new Response(
+            JSON.stringify({
+              keyUpdates: [
+                {
+                  id: "update-2",
+                  title: "Monitoring",
+                  content: "Authentication has recovered and we are monitoring cache traffic.",
+                  createdTime: "2026-05-05T11:30:00.000Z",
+                },
+              ],
+              cursor: { hasMore: true, nextValue: "next-update" },
+            }),
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            keyUpdates: [
+              {
+                id: "update-1",
+                title: "Investigating",
+                content: "We are investigating cache authentication failures.",
+                createdTime: "2026-05-05T10:00:00.000Z",
+              },
+            ],
+            cursor: { hasMore: false, nextValue: "" },
+          }),
+        );
+      }
+      throw new Error(`unmocked URL: ${url}`);
+    }) as typeof fetch;
+
+    const snapshot = await fetchStatusFromGrafana(ENV);
+
+    expect(snapshot.activeIncidents[0]?.updates).toEqual([
+      {
+        at: "2026-05-05T11:30:00.000Z",
+        status: "monitoring",
+        title: "Monitoring",
+        body: "Authentication has recovered and we are monitoring cache traffic.",
+      },
+      {
+        at: "2026-05-05T10:00:00.000Z",
+        status: "investigating",
+        title: "Investigating",
+        body: "We are investigating cache authentication failures.",
+      },
+    ]);
+    expect(snapshot.activeIncidents[1]?.updates).toEqual([
+      {
+        at: "2026-05-05T11:00:00.000Z",
+        status: "investigating",
+        body: "We are investigating elevated latency.",
+      },
+    ]);
+    expect(keyUpdateBodies).toEqual([
+      {
+        query: {
+          incidentID: "with-updates",
+          limit: 100,
+          orderDirection: "DESC",
+          orderField: "createdTime",
+          contentType: "text/plain",
+        },
+      },
+      {
+        query: {
+          incidentID: "with-updates",
+          limit: 100,
+          orderDirection: "DESC",
+          orderField: "createdTime",
+          contentType: "text/plain",
+        },
+        cursor: "next-update",
+      },
+    ]);
+  });
+
   it("matches affectedComponents from real Grafana labels of shape {key, label}", async () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/status/src/grafana-irm.test.ts
+++ b/status/src/grafana-irm.test.ts
@@ -342,6 +342,73 @@ describe("fetchStatusFromGrafana", () => {
     ]);
   });
 
+  it("limits concurrent key-update queries across active and recent incidents", async () => {
+    const active = Array.from({ length: 4 }, (_, index) => ({
+      incidentID: `active-${index}`,
+      title: `Active ${index}`,
+      status: "active",
+      createdTime: "2026-05-05T10:00:00.000Z",
+    }));
+    const recent = Array.from({ length: 3 }, (_, index) => ({
+      incidentID: `recent-${index}`,
+      title: `Recent ${index}`,
+      status: "resolved",
+      closedTime: "2026-05-04T10:00:00.000Z",
+    }));
+    const blockedRequests: Array<() => void> = [];
+    let releaseImmediately = false;
+    let startedRequests = 0;
+    let inFlightRequests = 0;
+    let maximumInFlightRequests = 0;
+
+    globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      if (url.endsWith("FieldsService.GetFields")) {
+        return Promise.resolve(new Response(JSON.stringify({ fields: [] })));
+      }
+      if (url.endsWith("IncidentsService.QueryIncidents")) {
+        const incidents = JSON.stringify(body).includes("status:active") ? active : recent;
+        return Promise.resolve(new Response(JSON.stringify({ incidents })));
+      }
+      if (url.endsWith("KeyUpdatesService.QueryKeyUpdates")) {
+        startedRequests++;
+        inFlightRequests++;
+        maximumInFlightRequests = Math.max(maximumInFlightRequests, inFlightRequests);
+        const response = () => new Response(JSON.stringify({ keyUpdates: [] }));
+        if (releaseImmediately) {
+          inFlightRequests--;
+          return Promise.resolve(response());
+        }
+        return new Promise<Response>((resolve) => {
+          blockedRequests.push(() => {
+            inFlightRequests--;
+            resolve(response());
+          });
+        });
+      }
+      return Promise.reject(new Error(`unmocked URL: ${url}`));
+    }) as typeof fetch;
+
+    const snapshotPromise = fetchStatusFromGrafana(ENV);
+    for (let attempt = 0; attempt < 20 && blockedRequests.length < 5; attempt++) {
+      await Promise.resolve();
+    }
+
+    expect(startedRequests).toBe(5);
+    expect(inFlightRequests).toBe(5);
+    expect(maximumInFlightRequests).toBe(5);
+
+    releaseImmediately = true;
+    blockedRequests.splice(0).forEach((release) => release());
+    const snapshot = await snapshotPromise;
+
+    expect(startedRequests).toBe(7);
+    expect(maximumInFlightRequests).toBe(5);
+    expect(snapshot.activeIncidents).toHaveLength(4);
+    expect(snapshot.recentIncidents).toHaveLength(3);
+  });
+
   it("matches affectedComponents from real Grafana labels of shape {key, label}", async () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/status/src/grafana-irm.ts
+++ b/status/src/grafana-irm.ts
@@ -72,6 +72,21 @@ interface QueryIncidentsResponse {
   cursor?: { hasMore: boolean; nextValue: string };
 }
 
+interface RawKeyUpdate {
+  id?: string;
+  title?: string;
+  content?: string;
+  createdTime?: string;
+  modifiedTime?: string;
+  statusID?: string;
+}
+
+interface QueryKeyUpdatesResponse {
+  error?: string;
+  keyUpdates?: RawKeyUpdate[];
+  cursor?: { hasMore: boolean; nextValue: string };
+}
+
 interface GetFieldsResponse {
   error?: string;
   fields?: RawField[];
@@ -92,7 +107,16 @@ function severityFrom(input: string | undefined, labels: RawLabel[] = []): Incid
 
 function statusFrom(input: string | undefined): IncidentStatus {
   if (!input) return "investigating";
-  return input.toLowerCase() === "resolved" ? "resolved" : "investigating";
+  switch (input.trim().toLowerCase()) {
+    case "identified":
+      return "identified";
+    case "monitoring":
+      return "monitoring";
+    case "resolved":
+      return "resolved";
+    default:
+      return "investigating";
+  }
 }
 
 function labelKey(l: RawLabel): string | undefined {
@@ -123,7 +147,7 @@ function affectedComponentsFrom(
   return Array.from(ids);
 }
 
-function toIncident(raw: RawIncident, componentLabelKey: string, knownIds: Set<string>): Incident {
+function summaryUpdate(raw: RawIncident): IncidentUpdate[] {
   const updates: IncidentUpdate[] = [];
   if (raw.summary) {
     updates.push({
@@ -132,6 +156,15 @@ function toIncident(raw: RawIncident, componentLabelKey: string, knownIds: Set<s
       body: raw.summary,
     });
   }
+  return updates;
+}
+
+function toIncident(
+  raw: RawIncident,
+  componentLabelKey: string,
+  knownIds: Set<string>,
+  updates = summaryUpdate(raw),
+): Incident {
   return {
     id: raw.incidentID,
     title: raw.title,
@@ -238,6 +271,54 @@ async function queryIncidents(opts: ClientOpts, queryString: string, limit = 100
   return out;
 }
 
+async function queryKeyUpdates(opts: ClientOpts, incidentID: string, limit = 100): Promise<RawKeyUpdate[]> {
+  const out: RawKeyUpdate[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 5; page++) {
+    const body: Record<string, unknown> = {
+      query: {
+        incidentID,
+        limit,
+        orderDirection: "DESC",
+        orderField: "createdTime",
+        contentType: "text/plain",
+      },
+    };
+    if (cursor) body.cursor = cursor;
+    const res = await rpc<QueryKeyUpdatesResponse>(opts, "KeyUpdatesService.QueryKeyUpdates", body);
+    out.push(...(res.keyUpdates ?? []));
+    if (!res.cursor?.hasMore) break;
+    cursor = res.cursor.nextValue;
+  }
+  return out;
+}
+
+function incidentUpdates(raw: RawIncident, keyUpdates: RawKeyUpdate[]): IncidentUpdate[] {
+  const updates = keyUpdates
+    .filter((update) => update.content?.trim())
+    .map((update) => ({
+      at: update.createdTime ?? update.modifiedTime ?? raw.modifiedTime ?? raw.createdTime ?? new Date().toISOString(),
+      status: statusFrom(update.title ?? raw.status),
+      title: update.title?.trim() || undefined,
+      body: update.content!.trim(),
+    }));
+  return updates.length > 0 ? updates : summaryUpdate(raw);
+}
+
+async function hydrateIncidents(
+  opts: ClientOpts,
+  rawIncidents: RawIncident[],
+  componentLabelKey: string,
+  knownIds: Set<string>,
+): Promise<Incident[]> {
+  return Promise.all(
+    rawIncidents.map(async (raw) => {
+      const keyUpdates = await queryKeyUpdates(opts, raw.incidentID);
+      return toIncident(raw, componentLabelKey, knownIds, incidentUpdates(raw, keyUpdates));
+    }),
+  );
+}
+
 function withinLastDays(iso: string | null | undefined, days: number): boolean {
   if (!iso) return false;
   const t = Date.parse(iso);
@@ -331,10 +412,11 @@ export async function fetchStatusFromGrafana(env: {
     queryIncidents(opts, "isdrill:false status:resolved"),
   ]);
   const knownIds = new Set(defs.map((d) => d.id));
-  const activeIncidents = active.map((r) => toIncident(r, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds));
-  const recentIncidents = recentAll
-    .filter((i) => withinLastDays(i.closedTime ?? i.incidentEnd ?? i.modifiedTime, 14))
-    .map((r) => toIncident(r, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds));
+  const recent = recentAll.filter((i) => withinLastDays(i.closedTime ?? i.incidentEnd ?? i.modifiedTime, 14));
+  const [activeIncidents, recentIncidents] = await Promise.all([
+    hydrateIncidents(opts, active, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds),
+    hydrateIncidents(opts, recent, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds),
+  ]);
   const components = rollUpComponents(defs, activeIncidents);
   return {
     overall: rollUpOverall(components),

--- a/status/src/grafana-irm.ts
+++ b/status/src/grafana-irm.ts
@@ -230,6 +230,8 @@ interface ClientOpts {
   token: string;
 }
 
+const KEY_UPDATE_CONCURRENCY = 5;
+
 async function rpc<T>(opts: ClientOpts, method: string, body: object): Promise<T> {
   const url = `${opts.baseUrl.replace(/\/$/, "")}/api/v1/${method}`;
   const response = await fetch(url, {
@@ -311,12 +313,20 @@ async function hydrateIncidents(
   componentLabelKey: string,
   knownIds: Set<string>,
 ): Promise<Incident[]> {
-  return Promise.all(
-    rawIncidents.map(async (raw) => {
+  const incidents = new Array<Incident>(rawIncidents.length);
+  let nextIndex = 0;
+
+  async function hydrateNext(): Promise<void> {
+    while (nextIndex < rawIncidents.length) {
+      const index = nextIndex++;
+      const raw = rawIncidents[index]!;
       const keyUpdates = await queryKeyUpdates(opts, raw.incidentID);
-      return toIncident(raw, componentLabelKey, knownIds, incidentUpdates(raw, keyUpdates));
-    }),
-  );
+      incidents[index] = toIncident(raw, componentLabelKey, knownIds, incidentUpdates(raw, keyUpdates));
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(KEY_UPDATE_CONCURRENCY, rawIncidents.length) }, () => hydrateNext()));
+  return incidents;
 }
 
 function withinLastDays(iso: string | null | undefined, days: number): boolean {
@@ -413,10 +423,9 @@ export async function fetchStatusFromGrafana(env: {
   ]);
   const knownIds = new Set(defs.map((d) => d.id));
   const recent = recentAll.filter((i) => withinLastDays(i.closedTime ?? i.incidentEnd ?? i.modifiedTime, 14));
-  const [activeIncidents, recentIncidents] = await Promise.all([
-    hydrateIncidents(opts, active, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds),
-    hydrateIncidents(opts, recent, env.GRAFANA_COMPONENT_LABEL_KEY, knownIds),
-  ]);
+  const incidents = await hydrateIncidents(opts, [...active, ...recent], env.GRAFANA_COMPONENT_LABEL_KEY, knownIds);
+  const activeIncidents = incidents.slice(0, active.length);
+  const recentIncidents = incidents.slice(active.length);
   const components = rollUpComponents(defs, activeIncidents);
   return {
     overall: rollUpOverall(components),

--- a/status/src/types.ts
+++ b/status/src/types.ts
@@ -14,6 +14,7 @@ export type OverallStatus = ComponentStatus;
 export interface IncidentUpdate {
   at: string;
   status: IncidentStatus;
+  title?: string;
   body: string;
 }
 

--- a/status/src/views/feed.test.ts
+++ b/status/src/views/feed.test.ts
@@ -61,6 +61,15 @@ describe("rssFeed", () => {
     expect(titles).toEqual(["[Monitoring] Cache slow", "[Investigating] Cache slow", "[Resolved] Dashboard down"]);
   });
 
+  it("uses an update's Grafana title when present", () => {
+    const customTitleSnapshot = snapshot();
+    customTitleSnapshot.activeIncidents[0]!.updates[0]!.title = "Mitigation applied";
+
+    const xml = rssFeed({ ...opts, snapshot: customTitleSnapshot });
+
+    expect(xml).toContain("[Mitigation applied] Cache slow");
+  });
+
   it("links every item to the incident anchor on the page", () => {
     const xml = rssFeed(opts);
     expect(xml).toContain("<link>https://status.example.com/#inc-1</link>");

--- a/status/src/views/feed.ts
+++ b/status/src/views/feed.ts
@@ -8,6 +8,10 @@ const STATUS_PREFIX: Record<IncidentStatus, string> = {
   resolved: "Resolved",
 };
 
+function updateTitle(update: Incident["updates"][number]): string {
+  return update.title?.trim() || STATUS_PREFIX[update.status];
+}
+
 interface Opts {
   title: string;
   baseUrl: string;
@@ -30,7 +34,7 @@ function entriesFor(snapshot: StatusSnapshot, baseUrl: string): Entry[] {
     for (const update of incident.updates) {
       entries.push({
         id: `${incident.id}#${update.at}`,
-        title: `[${STATUS_PREFIX[update.status]}] ${incident.title}`,
+        title: `[${updateTitle(update)}] ${incident.title}`,
         link: incidentLink,
         publishedAt: update.at,
         body: update.body,

--- a/status/src/views/page.test.ts
+++ b/status/src/views/page.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { StatusSnapshot } from "../types.js";
+import { statusPage } from "./page.js";
+
+describe("statusPage", () => {
+  it("renders the status updates for an incident", async () => {
+    const snapshot: StatusSnapshot = {
+      overall: "partial_outage",
+      components: [],
+      activeIncidents: [
+        {
+          id: "incident-1",
+          title: "Authentication issues against the cache",
+          severity: "major",
+          status: "monitoring",
+          affectedComponents: ["cache"],
+          startedAt: "2026-07-17T15:18:00.000Z",
+          resolvedAt: null,
+          updates: [
+            {
+              at: "2026-07-17T15:42:00.000Z",
+              status: "monitoring",
+              title: "Mitigation applied, monitoring impact",
+              body: "Cache authentication is recovering after the configuration change.",
+            },
+            {
+              at: "2026-07-17T15:18:00.000Z",
+              status: "investigating",
+              title: "Investigating",
+              body: "We are investigating authentication failures against the cache.",
+            },
+          ],
+        },
+      ],
+      recentIncidents: [],
+      fetchedAt: "2026-07-17T15:45:00.000Z",
+    };
+
+    const output = String(await statusPage({ title: "Tuist Status", snapshot }));
+
+    expect(output).toContain('ol data-part="updates"');
+    expect(output).toContain("Mitigation applied, monitoring impact.");
+    expect(output).toContain("Cache authentication is recovering after the configuration change.");
+    expect(output).toContain("Investigating.");
+    expect(output).toContain("We are investigating authentication failures against the cache.");
+  });
+});

--- a/status/src/views/page.ts
+++ b/status/src/views/page.ts
@@ -85,6 +85,13 @@ const SEVERITY_TO_BADGE_COLOR: Record<IncidentSeverity, NooraBadgeColor> = {
   maintenance: "information",
 };
 
+const INCIDENT_STATUS_LABEL: Record<Incident["status"], string> = {
+  investigating: "Investigating",
+  identified: "Identified",
+  monitoring: "Monitoring",
+  resolved: "Resolved",
+};
+
 function formatDate(iso: string): string {
   const date = new Date(iso);
   return date.toLocaleString("en-US", {
@@ -157,13 +164,14 @@ function incidentToComponentStatus(i: Incident): ComponentStatus {
 }
 
 function incidentBlock(incident: Incident): Renderable {
-  const updates = incident.updates.map(
-    (u) =>
-      html`<li>
-        <time data-part="time" datetime="${u.at}">${formatDate(u.at)}</time>
-        <div data-part="body"><span data-part="status">${u.status}.</span> ${u.body}</div>
-      </li>`,
-  );
+  const updates = incident.updates.map((u) => {
+    const title = u.title?.trim() || INCIDENT_STATUS_LABEL[u.status];
+    const punctuation = /[.!?]$/.test(title) ? "" : ".";
+    return html`<li>
+      <time data-part="time" datetime="${u.at}">${formatDate(u.at)}</time>
+      <div data-part="body"><span data-part="status">${title}${punctuation}</span> ${u.body}</div>
+    </li>`;
+  });
   return html`<article class="status-incident" id="${incident.id}">
     <header data-part="header">
       <h3 data-part="title">${incident.title}</h3>

--- a/status/src/views/styles.ts
+++ b/status/src/views/styles.ts
@@ -137,7 +137,6 @@ main {
       & > [data-part="body"] > [data-part="status"] {
         font-weight: var(--noora-font-weight-medium);
         color: var(--noora-surface-label-primary);
-        text-transform: capitalize;
       }
     }
   }


### PR DESCRIPTION
## What changed

Incident cards now show the timestamped status updates authored in Grafana Incident. The status page loads paginated key updates for every active incident and every resolved incident retained in the 14-day history, then displays each update's title, content, and creation time.

The same authored titles are reused in the incident feeds. The local fixture and focused rendering coverage were also updated so the behavior remains easy to exercise without Grafana credentials.

## Why

The status page showed the incident headline and severity, but not the sequence of updates that explains how the response is progressing. Visitors could see that the cache had a partial outage, for example, without seeing whether the problem was still under investigation, had been identified, or was being monitored after mitigation.

## Root cause

The page renderer already supported an update list, but the Grafana client only converted the incident summary into an update. It never queried the key updates exposed by the Grafana Incident [application programming interface](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/reference/incident-api/reference/), so incidents without a summary rendered no update timeline.

## Approach

After the active and recent incident queries complete, the client calls `KeyUpdatesService.QueryKeyUpdates` for each incident. It requests plain text in reverse chronological order, follows pagination defensively, and converts every non-empty key update into the existing incident-update model.

When Grafana has no key updates for an incident, the existing summary remains the fallback. This keeps older incidents useful while making key updates the canonical timeline when they are available.

The page and feed render the authored key-update title when present. The old forced capitalization was removed so prose casing remains exactly as written.

## Impact

Status-page visitors can follow an incident's progression directly from the active-incident card and the 14-day incident history. Feed subscribers receive the same update titles and content.

There is one additional Grafana request per displayed incident, with pagination capped at the same five-page limit as incident queries.

## Visual verification

The local fixture below shows a custom update title followed by the earlier Identified and Investigating updates.

![Status page showing timestamped incident updates](https://github.com/user-attachments/assets/48b51489-9965-45ef-b99d-6218d2108d50)

## Validation

- `aube run format:check`
- `aube run typecheck`
- `aube run test`, 19 tests passed
- `aube run build`
- Ran the worker locally with fake Grafana data and captured the page in headless Chrome
