### PR TITLE
fix(server): make Xcode result processing recoverable

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -1781,6 +1781,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .notFound(.init(body: body))
+                case 503:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.createTest.Output.ServiceUnavailable.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .serviceUnavailable(.init(body: body))
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
@@ -2674,13 +2696,6 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -2690,6 +2705,13 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "page_size",
                     value: input.query.page_size
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -16712,6 +16712,57 @@ public enum Operations {
                     }
                 }
             }
+            public struct ServiceUnavailable: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/POST/responses/503/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/POST/responses/503/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.createTest.Output.ServiceUnavailable.Body
+                /// Creates a new `ServiceUnavailable`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.createTest.Output.ServiceUnavailable.Body) {
+                    self.body = body
+                }
+            }
+            /// The test run could not be scheduled for processing
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/post(createTest)/responses/503`.
+            ///
+            /// HTTP response code: `503 serviceUnavailable`.
+            case serviceUnavailable(Operations.createTest.Output.ServiceUnavailable)
+            /// The associated value of the enum case if `self` is `.serviceUnavailable`.
+            ///
+            /// - Throws: An error if `self` is not `.serviceUnavailable`.
+            /// - SeeAlso: `.serviceUnavailable`.
+            public var serviceUnavailable: Operations.createTest.Output.ServiceUnavailable {
+                get throws {
+                    switch self {
+                    case let .serviceUnavailable(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "serviceUnavailable",
+                            response: self
+                        )
+                    }
+                }
+            }
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
@@ -19035,10 +19086,6 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -19047,20 +19094,24 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
-                ///   - git_branch: Filter bundles by git branch.
                 ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
+                ///   - git_branch: Filter bundles by git branch.
                 public init(
-                    git_branch: Swift.String? = nil,
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil
+                    page_size: Swift.Int? = nil,
+                    git_branch: Swift.String? = nil
                 ) {
-                    self.git_branch = git_branch
                     self.page = page
                     self.page_size = page_size
+                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -8089,6 +8089,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The project doesn't exist
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The test run could not be scheduled for processing
       summary: Create a new test run.
       tags:
         - Tests
@@ -8741,14 +8747,6 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
-            x-struct:
-            x-validate:
         - description: Page number for pagination.
           in: query
           name: page
@@ -8771,6 +8769,14 @@ paths:
           required: false
           schema:
             type: integer
+            x-struct:
+            x-validate:
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
+          schema:
+            type: string
             x-struct:
             x-validate:
         - description: The handle of the project.

--- a/cli/Sources/TuistServer/Services/CreateTestService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestService.swift
@@ -39,6 +39,7 @@ import TuistHTTP
         case notFound(String)
         case unauthorized(String)
         case badRequest(String)
+        case serviceUnavailable(String)
 
         var errorDescription: String? {
             switch self {
@@ -46,7 +47,7 @@ import TuistHTTP
                 return
                     "The test run could not be uploaded due to an unknown server response of \(statusCode)."
             case let .forbidden(message), let .notFound(message), let .unauthorized(message),
-                 let .badRequest(message):
+                 let .badRequest(message), let .serviceUnavailable(message):
                 return message
             }
         }
@@ -279,6 +280,11 @@ import TuistHTTP
                 switch badRequestResponse.body {
                 case let .json(error):
                     throw CreateTestServiceError.badRequest(error.message)
+                }
+            case let .serviceUnavailable(serviceUnavailableResponse):
+                switch serviceUnavailableResponse.body {
+                case let .json(error):
+                    throw CreateTestServiceError.serviceUnavailable(error.message)
                 }
             }
         }

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,9 +63,9 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
-                    git_branch: gitBranch,
                     page: page,
-                    page_size: pageSize
+                    page_size: pageSize,
+                    git_branch: gitBranch
                 )
             )
         )

--- a/infra/grafana-dashboards/xcresult-processor.json
+++ b/infra/grafana-dashboards/xcresult-processor.json
@@ -156,7 +156,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Jobs the ProcessXcresultWorker discarded in the last 30 minutes. A non-zero value means at least one xcresult parse exhausted its retries — investigate the failures panel below.",
+        "description": "Jobs that finalized as failed or exhausted recovery in the last 30 minutes. A cancellation means the customer-visible status was finalized as failed_processing; a discard means Oban exhausted recovery before finalization completed.",
         "fieldConfig": {
           "defaults": {
             "color": {"mode": "thresholds"},
@@ -186,12 +186,12 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(increase(tuist_oban_job_processing_duration_milliseconds_count{worker=\"Tuist.Tests.Workers.ProcessXcresultWorker\", state=\"discarded\"}[30m]))",
+            "expr": "sum(increase(tuist_oban_job_processing_duration_milliseconds_count{worker=\"Tuist.Tests.Workers.ProcessXcresultWorker\", state=~\"cancelled|discarded\"}[30m]))",
             "instant": false,
             "refId": "A"
           }
         ],
-        "title": "Discarded (last 30m)",
+        "title": "Terminal failures (last 30m)",
         "type": "stat"
       },
       {
@@ -377,7 +377,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Distribution of how many attempts a job needed before completing successfully. The Oban max_attempts on this worker is 3; anything in the 2-3 range means the parser eventually succeeded but only after a retry. A floor that's drifting up usually points at flaky upstream behaviour.",
+        "description": "Distribution of how many attempts a job needed before reaching a terminal state. The first five attempts may process the archive; later attempts only finalize failed_processing. Successful jobs above attempt one indicate transient storage, parser, or ClickHouse failures.",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -423,7 +423,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Discards (job exhausted retries → moved to discarded) and cancellations (cancelled mid-flight) over time, per state. Both are terminal: the parse won't be tried again automatically. Sustained discards are usually correlated with a specific bundle pattern; spot-check via the Logs section in Loki.",
+        "description": "Terminal outcomes over time. Cancellations mean the worker persisted failed_processing and intentionally stopped. Discards mean Oban exhausted recovery without completing finalization and require investigation.",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -450,7 +450,7 @@
             "refId": "A"
           }
         ],
-        "title": "Discards & Cancellations Rate",
+        "title": "Terminal Failure Rate",
         "type": "timeseries"
       },
       {
@@ -503,6 +503,50 @@
           }
         ],
         "title": "Guest Disk Usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Utilization of Finch's fallback connection pool on each Xcode result processor. Virtual-hosted buckets and customer-provided storage origins use this pool. Sustained utilization above 75 percent indicates that download concurrency is approaching capacity before excess queuing reaches customers.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {"mode": "thresholds"},
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 1,
+              "showPoints": "never",
+              "thresholdsStyle": {"mode": "line"}
+            },
+            "max": 100,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"color": "green", "value": null},
+                {"color": "yellow", "value": 75},
+                {"color": "red", "value": 90}
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 33},
+        "id": 12,
+        "options": {
+          "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+          "tooltip": {"mode": "multi", "sort": "desc"}
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "100 * sum by (instance) (tuist_http_queue_in_use_connections{url=\"default\"}) / clamp_min(sum by (instance) (tuist_http_queue_in_use_connections{url=\"default\"}) + sum by (instance) (tuist_http_queue_available_connections{url=\"default\"}), 1)",
+            "legendFormat": "{{instance}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Fallback Pool Utilization",
         "type": "timeseries"
       }
     ],

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -86,6 +86,7 @@ defmodule Tuist do
       Tests.TestRunQuery,
       Tests.TestRunDestination,
       Tests.Analytics,
+      Tests.XcresultProcessing,
       Tests.Workers.ProcessXcresultWorker,
       Shards,
       Shards.Analytics,

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -4,6 +4,7 @@ defmodule Tuist.Application do
   use Application
   use Boundary, top_level?: true, deps: [Tuist, TuistWeb]
 
+  alias EMCP.SessionStore.ETS, as: SessionStore
   alias Tuist.Application.RuntimeChildren
   alias Tuist.Builds.Build
   alias Tuist.Builds.BuildFile
@@ -47,7 +48,7 @@ defmodule Tuist.Application do
     start_telemetry()
     start_sentry_logger()
     start_loki_logger()
-    EMCP.SessionStore.ETS.init()
+    SessionStore.init()
 
     application =
       Supervisor.start_link(get_children(), strategy: :one_for_one, name: Tuist.Supervisor)
@@ -437,7 +438,10 @@ defmodule Tuist.Application do
 
       base_pools =
         %{
-          :default => [size: 10, start_pool_metrics?: true],
+          :default => [
+            size: TuistCommon.FinchPools.download_pool_size(active_download_queue_concurrencies()),
+            start_pool_metrics?: true
+          ],
           "https://api.github.com" => [
             conn_opts: [
               log: true,
@@ -494,6 +498,21 @@ defmodule Tuist.Application do
         end)
 
       Map.merge(base_pools, additional_pools)
+    end
+  end
+
+  defp active_download_queue_concurrencies do
+    :tuist
+    |> Application.fetch_env!(Oban)
+    |> Keyword.get(:queues, [])
+    |> case do
+      queues when is_list(queues) ->
+        queues
+        |> Keyword.take([:process_build, :process_xcresult])
+        |> Keyword.values()
+
+      _ ->
+        []
     end
   end
 

--- a/server/lib/tuist/http/prom_ex_plugin.ex
+++ b/server/lib/tuist/http/prom_ex_plugin.ex
@@ -245,25 +245,60 @@ defmodule Tuist.HTTP.PromExPlugin do
   def execute_http_queue_status_telemetry_event do
     url = Tuist.Environment.s3_endpoint()
 
+    emit_configured_pool_status(url)
+    emit_default_pool_status()
+  end
+
+  defp emit_configured_pool_status(url) do
     case Finch.get_pool_status(Tuist.Finch, url) do
       {:ok, pools} ->
         Enum.each(pools, fn pool ->
-          :telemetry.execute(
-            Tuist.Telemetry.event_name_http_queue_status(),
-            %{
-              available_connections: pool.available_connections,
-              in_use_connections: pool.in_use_connections
-            },
-            %{
-              url: url,
-              size: pool.pool_size,
-              index: pool.pool_index
-            }
-          )
+          emit_pool_status(url, pool.pool_size, pool.pool_index, pool)
         end)
 
       {:error, _} ->
         :ok
     end
+  end
+
+  # Virtual-hosted buckets and customer-provided storage origins are created
+  # from Finch's fallback pool. Aggregate them under one bounded label so pool
+  # saturation is visible without exposing customer hostnames or creating an
+  # unbounded metric series per origin.
+  defp emit_default_pool_status do
+    case Finch.get_pool_status(Tuist.Finch, :default) do
+      {:ok, pools_by_origin} ->
+        totals =
+          pools_by_origin
+          |> Map.values()
+          |> List.flatten()
+          |> Enum.reduce(%{available_connections: 0, in_use_connections: 0, pool_size: 0}, fn pool, acc ->
+            %{
+              available_connections: acc.available_connections + pool.available_connections,
+              in_use_connections: acc.in_use_connections + pool.in_use_connections,
+              pool_size: acc.pool_size + pool.pool_size
+            }
+          end)
+
+        emit_pool_status("default", totals.pool_size, 0, totals)
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  defp emit_pool_status(url, size, index, pool) do
+    :telemetry.execute(
+      Tuist.Telemetry.event_name_http_queue_status(),
+      %{
+        available_connections: pool.available_connections,
+        in_use_connections: pool.in_use_connections
+      },
+      %{
+        url: url,
+        size: size,
+        index: index
+      }
+    )
   end
 end

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -549,19 +549,27 @@ defmodule Tuist.Tests do
               create_test_modules(existing_test, test_modules, shard_index, shard_plan)
             end
 
-          # Each shard can have multiple ShardRun rows (the controller
-          # inserts one with status=processing when the CLI is still
-          # uploading, the worker inserts another after parsing). Count
-          # distinct shard indexes that have already produced a non-
-          # processing row, and only count the current shard if its own
-          # status is non-processing too.
-          reported_count =
-            count_completed_shards(existing_test.id, shard_index) +
-              if shard_status == "processing", do: 0, else: 1
+          insert_shard_run(
+            shard_plan_id,
+            project_id,
+            existing_test.id,
+            shard_index,
+            shard_status,
+            shard_duration,
+            attrs
+          )
+
+          # A shard can move through processing, failed_processing, and a
+          # successful client retry. Collapse that append-only history before
+          # deciding whether the merged run is complete. Insert the current
+          # row first so concurrent workers cannot both miss each other's
+          # terminal status and leave the merged run in_progress forever.
+          latest_statuses = latest_shard_statuses(existing_test.id)
+          reported_count = Enum.count(latest_statuses, &(&1 != "processing"))
 
           merged_status =
             if reported_count >= expected_shard_count do
-              compute_final_shard_status(existing_test, shard_status)
+              compute_final_shard_status(latest_statuses)
             else
               "in_progress"
             end
@@ -598,15 +606,17 @@ defmodule Tuist.Tests do
       end
 
     with {:ok, test} <- result do
-      insert_shard_run(
-        shard_plan_id,
-        project_id,
-        test.id,
-        shard_index,
-        shard_status,
-        shard_duration,
-        attrs
-      )
+      if is_nil(existing) do
+        insert_shard_run(
+          shard_plan_id,
+          project_id,
+          test.id,
+          shard_index,
+          shard_status,
+          shard_duration,
+          attrs
+        )
+      end
 
       {:ok, test}
     end
@@ -650,34 +660,20 @@ defmodule Tuist.Tests do
   defp blank?(""), do: true
   defp blank?(_), do: false
 
-  defp count_completed_shards(test_run_id, current_shard_index) do
-    # A shard counts as completed once any ShardRun row for it carries a
-    # non-processing status. The current shard is excluded because the
-    # caller decides whether to add it based on the incoming attrs.
-    ClickHouseRepo.one(
+  defp latest_shard_statuses(test_run_id) do
+    ClickHouseRepo.all(
       from(sr in ShardRun,
         where: sr.test_run_id == ^test_run_id,
-        where: sr.status != "processing",
-        where: sr.shard_index != ^(current_shard_index || -1),
-        select: fragment("uniqExact(?)", sr.shard_index)
+        group_by: sr.shard_index,
+        select: fragment("argMax(?, ?)", sr.status, sr.inserted_at)
       )
-    ) || 0
+    )
   end
 
-  defp compute_final_shard_status(existing_test, current_shard_status) do
-    has_failed_shard =
-      ClickHouseRepo.one(
-        from(sr in ShardRun,
-          where: sr.test_run_id == ^existing_test.id,
-          where: sr.status == "failure",
-          select: count(),
-          limit: 1
-        )
-      ) || 0
-
+  defp compute_final_shard_status(latest_statuses) do
     cond do
-      current_shard_status == "failure" -> "failure"
-      has_failed_shard > 0 -> "failure"
+      "failed_processing" in latest_statuses -> "failed_processing"
+      "failure" in latest_statuses -> "failure"
       true -> "success"
     end
   end

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -12,70 +12,130 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   The xcresult parse path leans on `xcresulttool` from Xcode, which has no
   Linux equivalent — that's why the processor fleet lives outside the
   Hetzner-backed k8s cluster on Scaleway Mac minis.
+
+  The first five attempts download and process the result bundle. Later
+  attempts only persist `failed_processing`; when ClickHouse is unavailable,
+  that finalization phase snoozes the same Oban job and retries without
+  downloading or parsing the bundle again.
   """
 
   use Oban.Worker,
     queue: :process_xcresult,
-    max_attempts: 5,
-    unique: [keys: [:test_run_id, :shard_index]]
+    max_attempts: 20,
+    unique: [
+      keys: [:test_run_id, :shard_index],
+      states: [:scheduled, :available, :executing, :retryable],
+      period: :infinity
+    ]
 
+  alias Tuist.Environment
+  alias Tuist.Processor.XCResultProcessor
   alias Tuist.Projects
   alias Tuist.Storage
   alias Tuist.Tests
   alias Tuist.Tests.Workers.BroadcastTestCreatedWorker
+  alias Tuist.Tests.XcresultProcessing
 
   require Logger
+
+  @processing_attempts 5
+  @finalization_snooze_seconds 300
+  @processing_backoff_seconds {30, 120, 300, 600, 1}
 
   # Failures whose root cause is the uploaded archive itself, not anything
   # transient. Retrying is pointless and surfacing them as Oban errors lights
   # up Sentry every five attempts for what is fundamentally a CLI-side
   # mistake (xcodebuild never populated the bundle, or the upload was a
   # bare `quarantined_tests.json` skeleton). We mark the run as
-  # `failed_processing` once and discard the job.
+  # `failed_processing` once and cancel the job.
   @unprocessable_input_reasons [:bundle_invalid, :xcresult_not_found]
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{"test_run_id" => test_run_id, "storage_key" => storage_key} = args,
-        attempt: attempt,
-        max_attempts: max_attempts
-      }) do
+  def perform(%Oban.Job{args: args, attempt: attempt}) when attempt > @processing_attempts do
+    finalize_failed_processing(args)
+  end
+
+  def perform(%Oban.Job{args: %{"test_run_id" => test_run_id, "storage_key" => storage_key} = args, attempt: attempt}) do
     case process_xcresult(test_run_id, storage_key, args) do
       {:ok, parsed_data} ->
-        replace_test_run(parsed_data, args)
-
-        # The run just finished on this (isolated, non-clustered) processor
-        # node, so the in-process PubSub broadcast from create_test can't
-        # reach the web tier. Enqueue an explicit notify job that a web pod
-        # will pick up and broadcast from inside the cluster.
-        enqueue_test_run_broadcast(args)
-
-        case Map.get(args, "vcs_comment_params", %{}) do
-          params when params != %{} -> Tuist.VCS.enqueue_vcs_pull_request_comment(params)
-          _ -> :ok
+        case replace_test_run(parsed_data, args) do
+          :ok -> complete_processing(args)
+          {:error, reason} -> handle_processing_error(args, attempt, reason)
         end
-
-        :ok
 
       {:error, reason} when reason in @unprocessable_input_reasons ->
         Logger.info(
-          "Discarding xcresult for test run #{test_run_id}: uploaded archive is unprocessable (#{inspect(reason)})"
+          "Cancelling xcresult for test run #{test_run_id}: uploaded archive is unprocessable (#{inspect(reason)})"
         )
 
-        mark_failed_processing(args)
-        {:discard, reason}
-
-      {:error, reason} ->
-        if attempt >= max_attempts do
-          Logger.error(
-            "Failed to process xcresult for test run #{test_run_id} after #{max_attempts} attempts: #{inspect(reason)}"
-          )
-
-          mark_failed_processing(args)
+        case safely_mark_test_run_failed(args) do
+          :ok -> {:cancel, reason}
+          {:error, mark_reason} -> {:error, mark_reason}
         end
 
-        {:error, reason}
+      {:error, reason} ->
+        handle_processing_error(args, attempt, reason)
     end
+  end
+
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}) when attempt > 0 and attempt <= tuple_size(@processing_backoff_seconds) do
+    elem(@processing_backoff_seconds, attempt - 1)
+  end
+
+  def backoff(job), do: Oban.Worker.backoff(job)
+
+  defp complete_processing(args) do
+    # The run just finished on this (isolated, non-clustered) processor
+    # node, so the in-process PubSub broadcast from create_test can't
+    # reach the web tier. Enqueue an explicit notify job that a web pod
+    # will pick up and broadcast from inside the cluster.
+    enqueue_test_run_broadcast(args)
+
+    case Map.get(args, "vcs_comment_params", %{}) do
+      params when params != %{} -> Tuist.VCS.enqueue_vcs_pull_request_comment(params)
+      _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp handle_processing_error(args, @processing_attempts, reason) do
+    Logger.error(
+      "Failed to process xcresult for test run #{args["test_run_id"]} after #{@processing_attempts} attempts: #{inspect(reason)}"
+    )
+
+    {:error, reason}
+  end
+
+  defp handle_processing_error(_args, _attempt, reason), do: {:error, reason}
+
+  defp finalize_failed_processing(args) do
+    with :ok <- safely_mark_test_run_failed(args),
+         {:ok, _job} <- safely_enqueue_test_run_broadcast(args) do
+      {:cancel, :processing_failed}
+    else
+      {:error, reason} ->
+        Logger.error("Failed to finalize Xcode result processing for test run #{args["test_run_id"]}: #{inspect(reason)}")
+
+        {:snooze, @finalization_snooze_seconds}
+    end
+  end
+
+  defp safely_enqueue_test_run_broadcast(args) do
+    enqueue_test_run_broadcast(args)
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp safely_mark_test_run_failed(args) do
+    XcresultProcessing.mark_test_run_failed(args)
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
   end
 
   defp enqueue_test_run_broadcast(args) do
@@ -93,7 +153,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
       # For sharded runs, multiple workers share the same merged
       # test_run_id and can run concurrently. Suffix the temp path with
       # the shard index so they never clobber each other's download
-      # mid-parse. Oban's unique constraint already keeps a given
+      # mid-parse. Oban's unique job configuration already keeps a given
       # (test_run_id, shard_index) pair from running in parallel.
       filename =
         case Map.get(args, "shard_index") do
@@ -110,10 +170,10 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
               test_run_id: test_run_id,
               account_handle: args["account_handle"],
               project_handle: args["project_handle"],
-              s3_bucket: Tuist.Environment.s3_bucket_name()
+              s3_bucket: Environment.s3_bucket_name()
             ]
 
-            Tuist.Processor.XCResultProcessor.process_local(temp_path, opts)
+            XCResultProcessor.process_local(temp_path, opts)
 
           {:error, _} = error ->
             error
@@ -135,7 +195,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
     test_modules = parsed_data["test_modules"] || []
 
     attrs =
-      Map.merge(base_attrs(args), %{
+      Map.merge(XcresultProcessing.base_test_attrs(args), %{
         scheme: parsed_data["test_plan_name"] || Map.get(args, "scheme"),
         status: run_status(parsed_data, test_modules),
         duration: parsed_data["duration"] || 0,
@@ -185,42 +245,4 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   defp normalize_platform("visionOS"), do: "visionos"
   defp normalize_platform("visionOS Simulator"), do: "visionos_simulator"
   defp normalize_platform(_), do: "unknown"
-
-  defp mark_failed_processing(args) do
-    attrs =
-      Map.merge(base_attrs(args), %{
-        status: "failed_processing",
-        duration: 0,
-        test_modules: []
-      })
-
-    case Tests.create_test(attrs) do
-      {:ok, _} -> :ok
-      error -> error
-    end
-  end
-
-  defp base_attrs(args) do
-    %{
-      id: args["test_run_id"],
-      project_id: args["project_id"],
-      account_id: args["account_id"],
-      is_ci: Map.get(args, "is_ci", false),
-      git_branch: Map.get(args, "git_branch"),
-      git_commit_sha: Map.get(args, "git_commit_sha"),
-      git_ref: Map.get(args, "git_ref"),
-      macos_version: Map.get(args, "macos_version"),
-      xcode_version: Map.get(args, "xcode_version"),
-      model_identifier: Map.get(args, "model_identifier"),
-      scheme: Map.get(args, "scheme"),
-      ci_run_id: Map.get(args, "ci_run_id"),
-      ci_project_handle: Map.get(args, "ci_project_handle"),
-      ci_host: Map.get(args, "ci_host"),
-      ci_provider: Map.get(args, "ci_provider"),
-      build_run_id: Map.get(args, "build_run_id"),
-      shard_plan_id: Map.get(args, "shard_plan_id"),
-      shard_index: Map.get(args, "shard_index"),
-      ran_at: NaiveDateTime.utc_now()
-    }
-  end
 end

--- a/server/lib/tuist/tests/xcresult_processing.ex
+++ b/server/lib/tuist/tests/xcresult_processing.ex
@@ -1,0 +1,55 @@
+defmodule Tuist.Tests.XcresultProcessing do
+  @moduledoc """
+  Enqueues Xcode result processing and builds the shared test-run attributes
+  used for successful and failed processing results.
+  """
+
+  alias Tuist.Tests
+  alias Tuist.Tests.Workers.ProcessXcresultWorker
+
+  def enqueue(args) do
+    args
+    |> ProcessXcresultWorker.new()
+    |> Oban.insert()
+  end
+
+  def mark_test_run_failed(args) do
+    attrs =
+      args
+      |> base_test_attrs()
+      |> Map.merge(%{
+        status: "failed_processing",
+        duration: 0,
+        test_modules: []
+      })
+
+    case Tests.create_test(attrs) do
+      {:ok, _} -> :ok
+      error -> error
+    end
+  end
+
+  def base_test_attrs(args) do
+    %{
+      id: args["test_run_id"],
+      project_id: args["project_id"],
+      account_id: args["account_id"],
+      is_ci: Map.get(args, "is_ci", false),
+      git_branch: Map.get(args, "git_branch"),
+      git_commit_sha: Map.get(args, "git_commit_sha"),
+      git_ref: Map.get(args, "git_ref"),
+      macos_version: Map.get(args, "macos_version"),
+      xcode_version: Map.get(args, "xcode_version"),
+      model_identifier: Map.get(args, "model_identifier"),
+      scheme: Map.get(args, "scheme"),
+      ci_run_id: Map.get(args, "ci_run_id"),
+      ci_project_handle: Map.get(args, "ci_project_handle"),
+      ci_host: Map.get(args, "ci_host"),
+      ci_provider: Map.get(args, "ci_provider"),
+      build_run_id: Map.get(args, "build_run_id"),
+      shard_plan_id: Map.get(args, "shard_plan_id"),
+      shard_index: Map.get(args, "shard_index"),
+      ran_at: Map.get(args, "ran_at", NaiveDateTime.utc_now())
+    }
+  end
+end

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -5,11 +5,14 @@ defmodule TuistWeb.API.TestsController do
   alias OpenApiSpex.Schema
   alias Tuist.Tests
   alias Tuist.Tests.TestRunQuery
+  alias Tuist.Tests.XcresultProcessing
   alias TuistWeb.API.Schemas.BuildSystem
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.Tests.Test
   alias TuistWeb.Authentication
+
+  require Logger
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -513,7 +516,8 @@ defmodule TuistWeb.API.TestsController do
       unauthorized: {"You need to be authenticated to create a test run", "application/json", Error},
       forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project doesn't exist", "application/json", Error},
-      bad_request: {"The request parameters are invalid", "application/json", Error}
+      bad_request: {"The request parameters are invalid", "application/json", Error},
+      service_unavailable: {"The test run could not be scheduled for processing", "application/json", Error}
     }
   )
 
@@ -537,81 +541,115 @@ defmodule TuistWeb.API.TestsController do
         # to "in_progress" while it waits for the other shards, so
         # test_run.status is never "processing" even though the CLI is
         # uploading an xcresult that still needs parsing.
-        if Map.get(body_params, :status) == "processing" do
-          # The CLI uploads each shard's xcresult to S3 keyed on the UUID
-          # it generated locally (body_params.id). For sharded runs, the
-          # server merges all shards into a single Test row, so test_run.id
-          # is the merged id — only the first shard's. Falling back to the
-          # merged id would point the worker at a missing object for every
-          # other shard, leaving their data unprocessed and the dashboard
-          # stuck at 0.
-          xcresult_id = Map.get(body_params, :id) || test_run.id
+        processing_result =
+          if Map.get(body_params, :status) == "processing" do
+            # The CLI uploads each shard's xcresult to S3 keyed on the UUID
+            # it generated locally (body_params.id). For sharded runs, the
+            # server merges all shards into a single Test row, so test_run.id
+            # is the merged id — only the first shard's. Falling back to the
+            # merged id would point the worker at a missing object for every
+            # other shard, leaving their data unprocessed and the dashboard
+            # stuck at 0.
+            xcresult_id = Map.get(body_params, :id) || test_run.id
 
-          storage_key =
-            "#{selected_project.account.name}/#{selected_project.name}/runs/#{xcresult_id}/result_bundle.zip"
+            storage_key =
+              "#{selected_project.account.name}/#{selected_project.name}/runs/#{xcresult_id}/result_bundle.zip"
 
-          %{
-            test_run_id: test_run.id,
-            storage_key: storage_key,
-            account_id: test_run.account_id,
-            project_id: selected_project.id,
-            account_handle: selected_project.account.name,
-            project_handle: selected_project.name,
-            is_ci: test_run.is_ci || false,
-            git_branch: test_run.git_branch,
-            git_commit_sha: test_run.git_commit_sha,
-            git_ref: test_run.git_ref,
-            macos_version: test_run.macos_version,
-            xcode_version: test_run.xcode_version,
-            model_identifier: test_run.model_identifier,
-            scheme: test_run.scheme,
-            ci_run_id: test_run.ci_run_id,
-            ci_project_handle: test_run.ci_project_handle,
-            ci_host: test_run.ci_host,
-            ci_provider: test_run.ci_provider,
-            build_run_id: test_run.build_run_id,
-            shard_plan_id: test_run.shard_plan_id,
-            shard_index: Map.get(body_params, :shard_index),
-            vcs_comment_params: vcs_comment_params
-          }
-          |> Tuist.Tests.Workers.ProcessXcresultWorker.new()
-          |> Oban.insert()
-          |> then(fn {:ok, _job} -> :ok end)
-        else
-          Tuist.VCS.enqueue_vcs_pull_request_comment(vcs_comment_params)
-        end
+            enqueue_xcresult_processing(%{
+              test_run_id: test_run.id,
+              storage_key: storage_key,
+              account_id: test_run.account_id,
+              project_id: selected_project.id,
+              account_handle: selected_project.account.name,
+              project_handle: selected_project.name,
+              is_ci: test_run.is_ci || false,
+              git_branch: test_run.git_branch,
+              git_commit_sha: test_run.git_commit_sha,
+              git_ref: test_run.git_ref,
+              macos_version: test_run.macos_version,
+              xcode_version: test_run.xcode_version,
+              model_identifier: test_run.model_identifier,
+              scheme: test_run.scheme,
+              ci_run_id: test_run.ci_run_id,
+              ci_project_handle: test_run.ci_project_handle,
+              ci_host: test_run.ci_host,
+              ci_provider: test_run.ci_provider,
+              build_run_id: test_run.build_run_id,
+              shard_plan_id: test_run.shard_plan_id,
+              shard_index: Map.get(body_params, :shard_index),
+              ran_at: processing_ran_at(test_run.ran_at),
+              vcs_comment_params: vcs_comment_params
+            })
+          else
+            Tuist.VCS.enqueue_vcs_pull_request_comment(vcs_comment_params)
+            :ok
+          end
 
-        conn
-        |> put_status(:ok)
-        |> json(%{
-          type: "test",
-          id: test_run.id,
-          duration: test_run.duration,
-          project_id: test_run.project_id,
-          url: url(~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-runs/#{test_run.id}"),
-          test_case_runs:
-            Enum.map(test_run.test_case_runs, fn run ->
-              result = %{
-                id: run.id,
-                name: run.name,
-                module_name: run.module_name,
-                suite_name: run.suite_name
-              }
-
-              case Map.get(run, :arguments) do
-                nil ->
-                  result
-
-                arguments ->
-                  Map.put(result, :arguments, Enum.map(arguments, &Map.take(&1, [:id, :name])))
-              end
-            end)
-        })
+        respond_to_test_creation(conn, test_run, selected_project, processing_result)
 
       {:error, _changeset} ->
         conn |> put_status(:bad_request) |> json(%{message: "The request parameters are invalid"})
     end
   end
+
+  defp respond_to_test_creation(conn, test_run, selected_project, :ok) do
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      type: "test",
+      id: test_run.id,
+      duration: test_run.duration,
+      project_id: test_run.project_id,
+      url: url(~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-runs/#{test_run.id}"),
+      test_case_runs:
+        Enum.map(test_run.test_case_runs, fn run ->
+          result = %{
+            id: run.id,
+            name: run.name,
+            module_name: run.module_name,
+            suite_name: run.suite_name
+          }
+
+          case Map.get(run, :arguments) do
+            nil ->
+              result
+
+            arguments ->
+              Map.put(result, :arguments, Enum.map(arguments, &Map.take(&1, [:id, :name])))
+          end
+        end)
+    })
+  end
+
+  defp respond_to_test_creation(conn, _test_run, _selected_project, {:error, _reason}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> json(%{message: "The test run could not be scheduled for processing"})
+  end
+
+  defp enqueue_xcresult_processing(args) do
+    case XcresultProcessing.enqueue(args) do
+      {:ok, _result} ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error("Failed to enqueue Xcode result processing: #{inspect(reason)}")
+
+        case XcresultProcessing.mark_test_run_failed(Map.new(args, fn {key, value} -> {to_string(key), value} end)) do
+          :ok ->
+            :ok
+
+          {:error, mark_reason} ->
+            Logger.error("Failed to mark unscheduled Xcode result processing: #{inspect(mark_reason)}")
+        end
+
+        error
+    end
+  end
+
+  defp processing_ran_at(%NaiveDateTime{} = ran_at), do: NaiveDateTime.to_iso8601(ran_at)
+  defp processing_ran_at(%DateTime{} = ran_at), do: DateTime.to_iso8601(ran_at)
+  defp processing_ran_at(_), do: NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
 
   operation(:show,
     summary: "Get a test run by ID.",

--- a/server/test/tuist/http/prom_ex_plugin_test.exs
+++ b/server/test/tuist/http/prom_ex_plugin_test.exs
@@ -1,7 +1,12 @@
 defmodule Tuist.HTTP.PromExPluginTest do
   use ExUnit.Case, async: true
+  use Mimic
 
+  alias Finch.HTTP1.PoolMetrics
   alias Tuist.HTTP.PromExPlugin
+
+  setup :set_mimic_from_context
+  setup :verify_on_exit!
 
   describe "request event tag values" do
     test "extracts the response status from streamed Req responses" do
@@ -57,6 +62,68 @@ defmodule Tuist.HTTP.PromExPluginTest do
                request_query: "sv=2025-11-05",
                request_port: 443
              }
+    end
+  end
+
+  describe "pool status polling" do
+    test "reports configured and fallback pools without exposing fallback origins" do
+      endpoint = "https://objects.example.com"
+      stub(Tuist.Environment, :s3_endpoint, fn -> endpoint end)
+
+      expect(Finch, :get_pool_status, 2, fn
+        Tuist.Finch, ^endpoint ->
+          {:ok,
+           [
+             %PoolMetrics{
+               pool_index: 1,
+               pool_size: 500,
+               available_connections: 490,
+               in_use_connections: 10
+             }
+           ]}
+
+        Tuist.Finch, :default ->
+          {:ok,
+           %{
+             {:https, "customer-one.example.com", 443} => [
+               %PoolMetrics{
+                 pool_index: 1,
+                 pool_size: 64,
+                 available_connections: 40,
+                 in_use_connections: 24
+               }
+             ],
+             {:https, "customer-two.example.com", 443} => [
+               %PoolMetrics{
+                 pool_index: 1,
+                 pool_size: 64,
+                 available_connections: 32,
+                 in_use_connections: 32
+               }
+             ]
+           }}
+      end)
+
+      handler_id = "http-pool-test-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        Tuist.Telemetry.event_name_http_queue_status(),
+        fn _event, measurements, metadata, test_pid ->
+          send(test_pid, {:pool_status, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      PromExPlugin.execute_http_queue_status_telemetry_event()
+
+      assert_received {:pool_status, %{available_connections: 490, in_use_connections: 10},
+                       %{url: ^endpoint, size: 500, index: 1}}
+
+      assert_received {:pool_status, %{available_connections: 72, in_use_connections: 56},
+                       %{url: "default", size: 128, index: 0}}
     end
   end
 

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -3,7 +3,10 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
   use Mimic
 
   alias Tuist.Processor.XCResultProcessor
+  alias Tuist.Tests.Workers.BroadcastTestCreatedWorker
   alias Tuist.Tests.Workers.ProcessXcresultWorker
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   @moduletag capture_log: true
 
@@ -12,10 +15,9 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
   @storage_key "tuist/tests/test-xcresult.zip"
 
   setup do
-    %{account: account} =
-      TuistTestSupport.Fixtures.AccountsFixtures.user_fixture(preload: [:account])
+    %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
 
-    project = TuistTestSupport.Fixtures.ProjectsFixtures.project_fixture()
+    project = ProjectsFixtures.project_fixture()
 
     %{account: account, project: project}
   end
@@ -44,7 +46,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     end)
   end
 
-  defp oban_job(args, attempt \\ 1, max_attempts \\ 3) do
+  defp oban_job(args, attempt \\ 1, max_attempts \\ 20) do
     %Oban.Job{args: args, attempt: attempt, max_attempts: max_attempts}
   end
 
@@ -310,6 +312,16 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
   end
 
   describe "perform/1 failure path" do
+    test "returns an error when the parsed test run cannot be persisted", %{account: account, project: project} do
+      test_run_id = Ecto.UUID.generate()
+      expect_local_parse(parsed_data())
+
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:error, :clickhouse_unavailable} end)
+
+      assert {:error, :clickhouse_unavailable} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 3))
+    end
+
     test "returns error when the parser fails", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 
@@ -334,14 +346,14 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
                ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 3))
     end
 
-    test "marks test run as failed_processing on max attempts", %{account: account, project: project} do
+    test "uses later Oban attempts to mark the test run as failed processing", %{
+      account: account,
+      project: project
+    } do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
-
-      expect(XCResultProcessor, :process_local, fn _path, _opts ->
-        {:error, "parse failed"}
-      end)
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.id == test_run_id
@@ -351,8 +363,10 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         {:ok, %{id: test_run_id}}
       end)
 
-      assert {:error, _} =
-               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 3, 3))
+      assert {:cancel, :processing_failed} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 6, 20))
+
+      assert_enqueued(worker: BroadcastTestCreatedWorker, args: %{"test_run_id" => test_run_id})
     end
 
     test "passes ci_project_handle through for failed_processing", %{account: account, project: project} do
@@ -364,11 +378,8 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         "ci_provider" => "github"
       }
 
-      expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
-
-      expect(XCResultProcessor, :process_local, fn _path, _opts ->
-        {:error, "parse failed"}
-      end)
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.status == "failed_processing"
@@ -377,7 +388,50 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       end)
 
       args = job_args(test_run_id, account.id, project.id, extra: extra)
-      assert {:error, _} = ProcessXcresultWorker.perform(oban_job(args, 3, 3))
+      assert {:cancel, :processing_failed} = ProcessXcresultWorker.perform(oban_job(args, 6, 20))
+    end
+
+    test "snoozes finalization when the failure status cannot be persisted", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:error, :clickhouse_unavailable} end)
+
+      assert {:snooze, 300} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 6, 20))
+    end
+
+    test "snoozes finalization when persisting the failure status raises", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
+      expect(Tuist.Tests, :create_test, fn _attrs -> raise "ClickHouse unavailable" end)
+
+      assert {:snooze, 300} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 6, 20))
+    end
+
+    test "snoozes finalization when the web-tier broadcast cannot be enqueued", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+      expect(Oban, :insert, fn _changeset -> {:error, :database_unavailable} end)
+
+      assert {:snooze, 300} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 6, 20))
     end
 
     test "does not mark as failed_processing on non-final attempt", %{account: account, project: project} do
@@ -411,9 +465,18 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
           {:ok, %{id: test_run_id}}
         end)
 
-        assert {:discard, unquote(reason)} =
-                 ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 5))
+        assert {:cancel, unquote(reason)} =
+                 ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 20))
       end
+    end
+  end
+
+  describe "backoff/1" do
+    test "spaces processing retries and enters finalization immediately after the fifth failure" do
+      assert [30, 120, 300, 600, 1] ==
+               Enum.map(1..5, fn attempt ->
+                 ProcessXcresultWorker.backoff(%Oban.Job{attempt: attempt, max_attempts: 20})
+               end)
     end
   end
 
@@ -470,11 +533,8 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     } do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
-
-      expect(XCResultProcessor, :process_local, fn _path, _opts ->
-        {:error, "parse failed"}
-      end)
+      reject(&Tuist.Storage.download_to_file/3)
+      reject(&XCResultProcessor.process_local/2)
 
       expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
       reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
@@ -490,7 +550,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         |> job_args(account.id, project.id)
         |> Map.put("vcs_comment_params", vcs_params)
 
-      assert {:error, _} = ProcessXcresultWorker.perform(oban_job(args, 3, 3))
+      assert {:cancel, :processing_failed} = ProcessXcresultWorker.perform(oban_job(args, 6, 20))
     end
   end
 

--- a/server/test/tuist/tests/xcresult_processing_test.exs
+++ b/server/test/tuist/tests/xcresult_processing_test.exs
@@ -1,0 +1,62 @@
+defmodule Tuist.Tests.XcresultProcessingTest do
+  use TuistTestSupport.Cases.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Tuist.Repo
+  alias Tuist.Tests.Workers.ProcessXcresultWorker
+  alias Tuist.Tests.XcresultProcessing
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
+
+  setup do
+    %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
+    project = ProjectsFixtures.project_fixture(account_id: account.id)
+
+    %{account: account, project: project}
+  end
+
+  test "enqueues the processing job", %{account: account, project: project} do
+    args = processing_args(account.id, project.id)
+
+    assert {:ok, job} = XcresultProcessing.enqueue(args)
+    assert job.max_attempts == 20
+    assert_enqueued(worker: ProcessXcresultWorker, args: %{"test_run_id" => args.test_run_id})
+  end
+
+  test "enqueues a new job after an earlier matching job completed", %{account: account, project: project} do
+    args = processing_args(account.id, project.id)
+    {:ok, first_job} = XcresultProcessing.enqueue(args)
+
+    Repo.update_all(from(oban_job in Oban.Job, where: oban_job.id == ^first_job.id),
+      set: [state: "completed", completed_at: DateTime.utc_now()]
+    )
+
+    assert {:ok, second_job} = XcresultProcessing.enqueue(args)
+    refute second_job.id == first_job.id
+  end
+
+  test "reuses an older matching job while it is still active", %{account: account, project: project} do
+    args = processing_args(account.id, project.id)
+    {:ok, first_job} = XcresultProcessing.enqueue(args)
+
+    Repo.update_all(from(oban_job in Oban.Job, where: oban_job.id == ^first_job.id),
+      set: [state: "retryable", attempt: 3, inserted_at: DateTime.add(DateTime.utc_now(), -3600)]
+    )
+
+    assert {:ok, second_job} = XcresultProcessing.enqueue(args)
+    assert second_job.id == first_job.id
+  end
+
+  defp processing_args(account_id, project_id) do
+    %{
+      test_run_id: UUIDv7.generate(),
+      storage_key: "account/project/runs/test/result_bundle.zip",
+      account_id: account_id,
+      project_id: project_id,
+      account_handle: "account",
+      project_handle: "project",
+      is_ci: true
+    }
+  end
+end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2132,6 +2132,174 @@ defmodule Tuist.TestsTest do
       assert updated_test.status == "failure"
     end
 
+    test "processing failure in the final shard propagates to final status" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "failed_processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.status == "failed_processing"
+    end
+
+    test "processing failure in an earlier shard propagates to final status" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "failed_processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.status == "failed_processing"
+    end
+
+    test "a successful retry replaces an earlier processing failure for the same shard" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      shard_0_id = UUIDv7.generate()
+
+      {:ok, _failed_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "failed_processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, retried_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      assert retried_test.status == "in_progress"
+
+      {:ok, completed_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 600,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert completed_test.status == "success"
+    end
+
+    test "a retried shard remains incomplete while its latest status is processing" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      shard_0_id = UUIDv7.generate()
+
+      {:ok, _failed_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "failed_processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, _processing_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, merged_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 600,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert merged_test.status == "in_progress"
+    end
+
     test "three shards all success" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -737,6 +737,63 @@ defmodule TuistWeb.API.TestsControllerTest do
       )
     end
 
+    test "returns service unavailable and marks the test run failed when processing cannot be scheduled", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      test_pid = self()
+      test_run_id = UUIDv7.generate()
+
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
+
+      expect(Tests, :create_test, 2, fn attrs ->
+        send(test_pid, {:created_test_status, attrs.status})
+
+        case attrs.status do
+          "processing" ->
+            {:ok,
+             %Test{
+               id: attrs.id,
+               duration: attrs.duration,
+               project_id: project.id,
+               account_id: attrs.account_id,
+               is_ci: false,
+               build_system: "xcode",
+               status: "processing",
+               test_case_runs: []
+             }}
+
+          "failed_processing" ->
+            {:ok, %{id: attrs.id}}
+        end
+      end)
+
+      expect(Oban, :insert, fn %Ecto.Changeset{} -> {:error, :database_unavailable} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/api/projects/#{user.account.name}/#{project.name}/tests",
+          %{
+            id: test_run_id,
+            duration: 0,
+            is_ci: false,
+            status: "processing",
+            test_modules: []
+          }
+        )
+
+      assert json_response(conn, :service_unavailable) == %{
+               "message" => "The test run could not be scheduled for processing"
+             }
+
+      assert_received {:created_test_status, "processing"}
+      assert_received {:created_test_status, "failed_processing"}
+      refute_enqueued(worker: ProcessXcresultWorker, args: %{"test_run_id" => test_run_id})
+    end
+
     test "attributes the run to the authenticated user while keeping storage under the project account", %{conn: conn} do
       user = AccountsFixtures.user_fixture(preload: [:account])
       organization = AccountsFixtures.organization_fixture(creator: user, preload: [:account])

--- a/tuist_common/lib/tuist_common/finch_pools.ex
+++ b/tuist_common/lib/tuist_common/finch_pools.ex
@@ -13,6 +13,29 @@ defmodule TuistCommon.FinchPools do
 
   @default_size 500
   @default_protocols [:http1]
+  @download_request_concurrency 8
+  @download_pool_headroom 2
+  @minimum_download_pool_size 10
+
+  @doc """
+  Sizes a fallback Finch pool for concurrent object-storage downloads.
+
+  `ExAws.S3.download_file/3` opens up to eight concurrent range requests for
+  each download. The pool must cover every concurrent download and leave room
+  for a second batch while timed-out requests release their connections. Pass
+  a list when more than one download queue is active in the same process.
+  """
+  def download_pool_size(queue_concurrency)
+      when is_integer(queue_concurrency) and queue_concurrency > 0 do
+    queue_concurrency * @download_request_concurrency * @download_pool_headroom
+  end
+
+  def download_pool_size(queue_concurrencies) when is_list(queue_concurrencies) do
+    case Enum.sum(queue_concurrencies) do
+      0 -> @minimum_download_pool_size
+      queue_concurrency -> download_pool_size(queue_concurrency)
+    end
+  end
 
   @doc """
   Builds a `{endpoint, pool_opts}` entry for Finch's `:pools` option.

--- a/tuist_common/test/tuist_common/finch_pools_test.exs
+++ b/tuist_common/test/tuist_common/finch_pools_test.exs
@@ -3,6 +3,21 @@ defmodule TuistCommon.FinchPoolsTest do
 
   alias TuistCommon.FinchPools
 
+  describe "download_pool_size/1" do
+    test "covers the queue's range requests with one batch of headroom" do
+      assert FinchPools.download_pool_size(4) == 64
+    end
+
+    test "combines every active download queue" do
+      assert FinchPools.download_pool_size([2, 2]) == 64
+      assert FinchPools.download_pool_size([5]) == 80
+    end
+
+    test "preserves the minimum pool when no download queue is active" do
+      assert FinchPools.download_pool_size([]) == 10
+    end
+  end
+
   describe "s3_pool/1" do
     test "returns {endpoint, opts} with production defaults" do
       {endpoint, opts} = FinchPools.s3_pool(endpoint: "https://s3.example.com")


### PR DESCRIPTION
## What changed

Xcode result processing now has enough object-storage connection capacity, uses Oban's durable attempt state to reach a terminal customer-visible status, and exposes the saturation signal that was previously missing.

- Size Finch's fallback pool from every download queue active in the current server boot mode. The production Xcode result processor gets 64 connections for four concurrent jobs, the build processor gets 80 for five concurrent jobs, and self-hosted web processes include both queues.
- Publish aggregate fallback-pool utilization without exposing customer storage hostnames, and show that utilization in the Xcode result processor Grafana dashboard.
- Give each processing job twenty attempts. The first five may download and process the archive; later attempts only persist `failed_processing` and notify the web tier.
- Space processing retries by 30 seconds, two minutes, five minutes, and ten minutes so timed-out connections can drain instead of creating a retry storm.
- Snooze failure finalization for five minutes when ClickHouse or the web-tier notification is unavailable. Oban persists the snooze and retries without repeating archive work.
- Return a service-unavailable response and mark the test run as failed when processing cannot be scheduled.
- Merge sharded runs from each shard's latest status, allowing a successful client retry to replace an earlier enqueue or processing failure.

## Why

A customer reported test insights remaining in `processing`. Production currently runs two Xcode result processors with four concurrent jobs per processor. The processors recovered, but the existing design made the same failure mode likely to recur and did not expose the affected fallback connection pool in the processor dashboard.

The durable fix needs sufficient connection capacity, retries that let the dependency recover, a reliable transition from processing failure to a terminal status, and an operational signal before customers notice the backlog.

## Root cause

Each archive download can open up to eight parallel range requests. Four concurrent jobs therefore create an immediate demand for 32 connections per processor, while Finch's fallback pool had only 10. Virtual-hosted buckets and customer-provided storage origins use that fallback pool rather than the separately configured object-storage pool. Timed-out downloads could leave requests in flight while rapid retries added another batch, eventually producing excess queuing and exhausting processing attempts.

Separately, the worker ignored failures from the final ClickHouse write. Oban could therefore record success while the test run remained in `processing`. If processing failed on the last permitted attempt, Oban discarded the job outside the worker, leaving no worker attempt available to persist `failed_processing`. A scheduling failure could produce the same visible outcome because the processing row existed before its Oban job was guaranteed to exist.

Sharded aggregation also treated any historical `failed_processing` row as permanent. A client retry that later succeeded could not recover the merged run, and concurrent shard workers could both compute completion before either terminal shard row was visible.

## Approach

Oban remains the single durable owner of execution state. The first five attempts perform archive work. Attempts six and later enter a finalization-only phase that never downloads or parses the archive. A handled finalization failure returns a snooze, which Oban stores in PostgreSQL while extending the attempt allowance. Fifteen reserved attempts provide additional recovery capacity for unexpected processor termination before the snooze path takes over.

This avoids a second lifecycle table and a global scheduled reconciler. Oban telemetry was not used for recovery because telemetry delivery is not durable across process or node failure. Enqueue failures are handled synchronously because no Oban job exists in that case.

For sharded runs, the current shard row is inserted before aggregation and one grouped ClickHouse query selects the latest status for every shard. This both removes historical-failure poisoning and ensures that the last concurrent writer can observe all terminal shard rows and finalize the merged run.

Fallback-pool metrics aggregate all dynamically created origins under a single `default` label. This keeps the metric bounded and prevents customer hostnames from becoming labels.

## Impact

New Xcode result jobs have five processing attempts followed by finalization-only attempts. Download and parser work is never repeated during finalization. Scheduling, persistence, and processor failures now become explicit failures rather than test runs that remain in `processing` indefinitely.

Recovered sharded uploads can reach success after an earlier failure, while an actively retrying shard remains incomplete. Operators can see fallback-pool utilization, finalized failures, and unrecovered discards in the existing processor dashboard. No database migration, new permissions, or periodic database scan is introduced.

## Validation

- `MIX_ENV=test mise exec -- mix compile --warnings-as-errors`
- Focused server tests covering the worker, controller, persistence, shard recovery, and pool telemetry: 290 passed
- `MIX_ENV=test mise exec -- mix test test/tuist_common/finch_pools_test.exs` from `tuist_common/`: 13 passed
- Strict Credo analysis of the changed Elixir files: no issues
- Grafana dashboard JavaScript Object Notation validation with `jq empty`
- `git diff --check origin/main...HEAD`
