### PR TITLE
fix(infra): proxy kubectl exec/port-forward through the Pomerium gateway and add live-debug capabilities to /elevate

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -127,3 +127,44 @@ rules:
   - apiGroups: ["kura.tuist.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+---
+# Live-debug extension to the `edit` tier — the capabilities an operator reaches
+# for when a pod or node is misbehaving and reads alone can't narrow the cause.
+# The upstream `edit` role already covers `pods/exec` (a shell in the container),
+# but two gaps bite during the incidents this elevation exists for:
+#
+#   * `pods/ephemeralcontainers` → `kubectl debug`. The Kura pods (and most of
+#     our images) are distroless, so `exec` lands in a container with no shell
+#     and no `curl` — useless for "curl the instance's own metrics/health
+#     endpoint from inside." An ephemeral debug container shares the target
+#     pod's network namespace, so it can `curl localhost:<port>` against the
+#     process even when the pod is not Ready and even though the per-tenant
+#     NetworkPolicy blocks the apiserver from pod-proxying it directly.
+#
+#   * `nodes/proxy` (get) → the kubelet's read endpoints (`/stats/summary`,
+#     `/metrics`) on the node hosting the pod. This is the "is it disk, or the
+#     algorithm?" question answered without SSH: kubelet stats report the node's
+#     filesystem + resource pressure. Host-level, so unaffected by pod
+#     NetworkPolicies. Scoped to `get` only — POST/`create` through the kubelet
+#     proxy would be a second exec path, and it's not needed to read stats.
+#
+# Aggregates into `edit`, which only the JIT-elevated `tuist-<env>-write` group
+# binds to, so both are gated behind an active `/elevate` (TTL-bounded, audited)
+# and never available to the always-on view tier. Both are genuine privilege
+# boundaries — `kubectl debug` mutates a running pod, and `nodes/proxy` reaches
+# arbitrary kubelet read endpoints — so elevation, not the base tier, is the
+# right home for them.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-edit-live-debug
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]

--- a/infra/helm/pomerium/templates/configmap.yaml
+++ b/infra/helm/pomerium/templates/configmap.yaml
@@ -66,7 +66,25 @@ data:
         to: "http://127.0.0.1:{{ .Values.kubeImpersonator.port }}"
         pass_identity_headers: true
         preserve_host_header: true
-        timeout: 90s
+        # exec / attach / port-forward negotiate an HTTP connection
+        # upgrade (SPDY on older clients, WebSocket on newer ones).
+        # Pomerium only auto-enables upgrades for routes it recognises
+        # as Kubernetes (native SA-token routes); this route forwards
+        # to the kube-impersonator sidecar as a plain HTTP upstream, so
+        # both upgrade types must be enabled explicitly or the upgrade
+        # is dropped and kubectl reports "unable to upgrade connection:
+        # empty server response".
+        allow_spdy: true
+        allow_websockets: true
+        # Unbounded route timeout. A finite `timeout` is applied even to
+        # upgraded connections (Envoy's route timeout takes the explicit
+        # value before the websocket auto-unlimited path), so any value
+        # here would sever a long-lived exec/port-forward session and cut
+        # off `logs -f` / `watch` streams at that bound. `0s` disables it,
+        # matching what Pomerium's native Kubernetes support configures.
+        # The idle timeout is disabled automatically once allow_websockets
+        # is set, so an idle interactive shell isn't reaped.
+        timeout: 0s
         # Coarse domain gate. Per-request fine-grained decision
         # (which Impersonate-Group(s) the user gets) lives in
         # tuist-ops's PolicyController, which the sidecar dials.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/11373

## What

Two changes to the Pomerium kubectl gateway chart, both aimed at making live debugging under a JIT `/elevate` actually possible:

1. **Gateway now proxies connection upgrades.** The kubectl gateway route (`templates/configmap.yaml`) gains `allow_spdy: true` + `allow_websockets: true`, and its `timeout: 90s` becomes `timeout: 0s`.
2. **`/elevate` gains two live-debug capabilities.** A new `tuist-edit-live-debug` ClusterRole (`templates/access-tiers.yaml`) aggregates `pods/ephemeralcontainers` and `nodes/proxy` (get) into the `edit` tier.

## Why

The trigger was an operator hitting permission walls while debugging Kura mesh incidents (e.g. eu-central syncing with the macOS node) and being unable to `exec` into pods to check metrics on not-Ready instances.

**exec/port-forward were dropped at the gateway, not blocked by RBAC (#11373).** `kubectl exec`/`attach`/`port-forward` negotiate an HTTP connection upgrade (SPDY on older clients, WebSocket on newer). Two things on the route killed it:

- Pomerium only auto-enables SPDY/WebSocket upgrades for routes it recognises as native Kubernetes (`IsForKubernetes()`). This route forwards to the `kube-impersonator` sidecar as a **plain HTTP upstream** (`to: http://127.0.0.1:8081`), so Pomerium doesn't treat it as Kubernetes and both `allow_spdy`/`allow_websockets` default to **false** — the upgrade dies and kubectl reports `unable to upgrade connection: empty server response`. This is why forcing `KUBECTL_REMOTE_COMMAND_WEBSOCKETS=true` failed identically in #11373: both protocols were gated.
- The explicit `timeout: 90s` is applied even to upgraded connections. Envoy's `getRouteTimeout` takes the explicit `UpstreamTimeout` value **before** the websocket auto-unlimited path, so any finite value severs a long-lived exec/port-forward session and cuts off `logs -f`/`watch` streams at that bound. `0s` disables it, matching what Pomerium's native Kubernetes support configures; the idle timeout auto-disables once `allow_websockets` is set. The nginx ingress in front was already staged for this (`proxy-read/send-timeout: 3600`, websocket-transparent).

The `kube-impersonator` sidecar itself needs no change: Go's `httputil.ReverseProxy` has hijacked upgrades since 1.12, and its custom `Transport` keeps the upstream hop on HTTP/1.1, which is what SPDY needs.

**Widening RBAC for exec would have been a no-op.** The built-in `edit` role that `/elevate` binds `tuist-<env>-write` to already grants `pods/exec` with `create` (verified live on prod). #11373 reproduced exec failing *under an active canary elevation* — an upgrade failure, not a 403. What the elevation genuinely lacks are two capabilities that are the actual fit for the debugging scenario:

- **`pods/ephemeralcontainers` → `kubectl debug`.** Our images (Kura included) are distroless, so `exec` lands in a container with no shell and no `curl` — useless for "curl the instance's own metrics/health endpoint from inside." An ephemeral debug container shares the target pod's network namespace, so it can `curl localhost:<port>` against the process even when the pod is not Ready and even though the per-tenant NetworkPolicy blocks the apiserver from pod-proxying it directly.
- **`nodes/proxy` (get only) → kubelet read endpoints** (`/stats/summary`, `/metrics`). Answers "is it disk, or the algorithm?" without SSH. Scoped to `get` so it can't become a second exec-via-kubelet path.

Both aggregate into `edit`, which only the JIT-elevated `tuist-<env>-write` group binds to, so they stay behind an active, TTL-bounded, audited elevation and never reach the always-on `view` tier. Both are genuine privilege boundaries (`kubectl debug` mutates a running pod; `nodes/proxy` reaches arbitrary kubelet read endpoints), so elevation — not the base tier — is the right home for them.

## Reviewer notes

- **This is necessary but not sufficient for the bare-metal-fleet case.** exec to a pod on a bare-metal fleet node (Kura eu-central, Dedibox, OVH, Elastic Metal) *also* needs the apiserver→kubelet path, which is separately broken on prod: the running apiserver's `--kubelet-preferred-address-types` still omits `InternalIP` (the #11375 fix is in git but the prod control plane hasn't rolled since — its KCP is wedged), so 18/27 prod nodes are unreachable for logs/exec regardless of this change. That's a separate control-plane issue, not addressed here. macOS/runner tailnet (100.x) nodes stay unreachable too (Hetzner CP not on the tailnet).
- Scope of the RBAC widening is deliberately narrow: no CAPI machine/machinedeployment writes (scaling fleets stays break-glass), `nodes/proxy` is read-only.

## How to test locally

Chart renders and lints across all three envs:

```
helm template pomerium infra/helm/pomerium -f infra/helm/pomerium/values.yaml -f infra/helm/pomerium/values-production.yaml
helm lint infra/helm/pomerium -f infra/helm/pomerium/values.yaml -f infra/helm/pomerium/values-production.yaml
```

End-to-end (post-deploy, under an active `/elevate <env>`):

- `kubectl --context tuist-k8s-<env> exec <pod> -- true` succeeds instead of `unable to upgrade connection`.
- `kubectl --context tuist-k8s-<env> debug <pod> --image=curlimages/curl -it -- sh` attaches an ephemeral container and can `curl localhost:<metrics-port>`.
- `kubectl --context tuist-k8s-<env> get --raw "/api/v1/nodes/<node>/proxy/stats/summary"` returns kubelet stats (on a node whose kubelet the apiserver can reach).
