### PR TITLE
perf(server): avoid re-sorting recent test runs

### DIFF
--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -290,27 +290,27 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # for reliability monitors. The full `test_case_runs_recent_per_case`
   # aggregate keeps 1000 entries of both for windows above the largest bucket.
   #
-  # The MV scan is bounded by `active_test_cases_in_project` rather than
-  # total run volume — usually a few thousand rows. The bucket aggregate is
-  # `groupArraySorted` by `-ran_at_microseconds`, so the merged array is
-  # already latest-first before the final user-configured slice (no re-sort);
-  # only the 1000-entry fallback keeps `groupArrayLast` order and has to
-  # `arrayReverseSort` before slicing.
+  # The materialized-view scan is bounded by `active_test_cases_in_project`
+  # rather than total run volume — usually a few thousand rows. The bucket
+  # aggregate is `groupArraySorted` by `-ran_at_microseconds`, so the merged
+  # array is already latest-first before the final user-configured slice (no
+  # re-sort); only the 1000-entry fallback keeps `groupArrayLast` order and has
+  # to `arrayReverseSort` before slicing.
   #
   # `test_case_runs` is a ReplacingMergeTree and flaky detection re-inserts a
-  # run to set `is_flaky` after ingestion, so the MV can absorb the same
-  # logical run several times. Those duplicates concentrate on flaky/failed
-  # runs — a passing run is never re-marked — so counting raw array entries
-  # inflates flakiness and deflates reliability for exactly the runs a
-  # threshold reacts to. `rolling_triggered_test_case_ids_from_recent_runs`
-  # collapses the array to one row per run (keyed on `ran_at`) before
-  # computing a rate.
+  # run to set `is_flaky` after ingestion, so the materialized view can absorb
+  # the same logical run several times. Those duplicates concentrate on
+  # flaky/failed runs — a passing run is never re-marked — so counting raw
+  # array entries inflates flakiness and deflates reliability for exactly the
+  # runs a threshold reacts to.
+  # `rolling_triggered_test_case_ids_from_recent_runs` collapses the array to
+  # one row per run (keyed on `ran_at`) before computing a rate.
   #
-  # `monitor_type`, `comparison`, `table`, `recent_runs_expr`, and
-  # `run_key_expr` are interpolated because they are chosen from fixed
-  # in-module allowlists (or are validated integers via `size`), so there is
-  # no SQL-injection vector. `project_id` and `threshold` flow through bound
-  # parameters.
+  # `monitor_type`, `comparison`, `table`, `ordered_runs_expr`, and
+  # `deduplicated_runs_expr` are interpolated because they are chosen from
+  # fixed in-module allowlists (or are validated integers via `size`), so there
+  # is no query-injection vector. `project_id` and `threshold` flow through
+  # bound parameters.
   defp rolling_triggered_test_case_ids(project_id, monitor_type, size, threshold, comparison, test_case_ids) do
     source = recent_runs_source(recent_runs_column(monitor_type), size)
 
@@ -332,11 +332,13 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   defp recent_runs_column("reliability_rate"), do: "recent_successful_runs"
   defp recent_runs_column(_monitor_type), do: "recent_runs"
 
-  # Returns `{table, recent_runs_expr}`. `recent_runs_expr` merges the full
-  # per-test-case aggregate and normalizes both aggregate encodings to
-  # `(run_key_microseconds, flag)` tuples. The dedup and latest-`size` slice
-  # happen downstream. The 1000-entry fallback stores `ran_at` directly, while
-  # the buckets store `-ran_at_microseconds`.
+  # Returns `{table, ordered_runs_expr, duplicate_position}`.
+  # `ordered_runs_expr` merges the full per-test-case aggregate and orders it
+  # latest-first. `duplicate_position` says whether the correct flag for a
+  # duplicate timestamp is the first or last adjacent tuple. The 1000-entry
+  # fallback stores `ran_at` directly and must be sorted at read time. The
+  # buckets store `-ran_at_microseconds` in sorted states, so they are already
+  # latest-first and only need a linear pass to collapse duplicates.
   #
   # The bucket is chosen strictly larger than the window (`size < bucket`) so
   # de-dup has headroom: a bucket only holds `bucket` physical rows, and
@@ -349,19 +351,21 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       nil ->
         {
           "test_case_runs_recent_per_case",
-          "arrayMap(entry -> (toUnixTimestamp64Micro(tupleElement(entry, 1)), tupleElement(entry, 2)), groupArrayLastMerge(#{@max_rolling_window_size})(#{column}))"
+          "arrayReverseSort(entry -> (tupleElement(entry, 1), tupleElement(entry, 2)), arrayMap(entry -> (toUnixTimestamp64Micro(tupleElement(entry, 1)), tupleElement(entry, 2)), groupArrayLastMerge(#{@max_rolling_window_size})(#{column})))",
+          :first
         }
 
       bucket_size ->
         {
           "test_case_runs_recent_#{bucket_size}_per_case",
-          "arrayMap(entry -> (-tupleElement(entry, 1), tupleElement(entry, 2)), groupArraySortedMerge(#{bucket_size})(#{column}))"
+          "groupArraySortedMerge(#{bucket_size})(#{column})",
+          :last
         }
     end
   end
 
   defp rolling_triggered_test_case_ids_from_recent_runs(
-         {table, recent_runs_expr},
+         {table, ordered_runs_expr, duplicate_position},
          project_id,
          monitor_type,
          size,
@@ -374,6 +378,8 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
         nil -> ""
         _test_case_ids -> "AND test_case_id IN {test_case_ids:Array(UUID)}"
       end
+
+    deduplicated_runs_expr = deduplicated_runs_expr(duplicate_position)
 
     # Collapse the bounded per-test-case array to one tuple per run
     # (`run_key` is the run's `ran_at` in microseconds), keeping `max(flag)` so
@@ -389,25 +395,18 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       SELECT
         test_case_id,
         arraySlice(
-          arrayFilter(
-            (entry, position) -> position = 1,
-            sorted_runs,
-            arrayEnumerateUniq(arrayMap(entry -> tupleElement(entry, 1), sorted_runs))
-          ),
+          #{deduplicated_runs_expr},
           1,
           #{size}
         ) AS recent_runs
       FROM (
         SELECT
           test_case_id,
-          arrayReverseSort(entry -> (tupleElement(entry, 1), tupleElement(entry, 2)), merged_runs) AS sorted_runs
-        FROM (
-          SELECT test_case_id, #{recent_runs_expr} AS merged_runs
-          FROM #{table}
-          WHERE project_id = {project_id:Int64}
-            #{test_case_filter}
-          GROUP BY test_case_id
-        )
+          #{ordered_runs_expr} AS ordered_runs
+        FROM #{table}
+        WHERE project_id = {project_id:Int64}
+          #{test_case_filter}
+        GROUP BY test_case_id
       )
     )
     WHERE length(recent_runs) > 0
@@ -416,17 +415,52 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
 
     params = maybe_put_test_case_ids(%{project_id: project_id, threshold: threshold * 1.0}, test_case_ids)
 
-    # Raise on ClickHouse errors instead of swallowing them. If the MV is
-    # missing or the query fails transiently, returning `[]` would tell the
-    # worker "no test cases match" and trip recovery actions on every active
-    # event. Letting the error propagate matches the `ClickHouseRepo.all`
-    # path in the `last_days` branch and gives Oban a chance to retry.
+    # Raise on ClickHouse errors instead of swallowing them. If the materialized
+    # view is missing or the query fails transiently, returning `[]` would tell
+    # the worker "no test cases match" and trip recovery actions on every
+    # active event. Letting the error propagate matches the
+    # `ClickHouseRepo.all` path in the `last_days` branch and gives Oban a
+    # chance to retry.
     %{rows: rows} = ClickHouseRepo.query!(sql, params)
 
-    # ClickHouse returns UUID columns as 16-byte binaries here; the rest of
-    # the worker compares against string-encoded UUIDs from the Ecto path,
-    # so normalise.
+    # ClickHouse returns identifier columns as 16-byte binaries here; the rest
+    # of the worker compares against string-encoded identifiers from the Ecto
+    # path, so normalise.
     Enum.map(rows, fn [binary] -> Ecto.UUID.load!(binary) end)
+  end
+
+  # The fallback aggregate is unsorted, so `ordered_runs` was sorted by
+  # `(timestamp, flag)` descending. The largest flag is therefore the first
+  # tuple for a duplicate timestamp. Keep the existing de-duplication path for
+  # this less common fallback; the optimized adjacent comparison only applies
+  # to the pre-sorted buckets.
+  defp deduplicated_runs_expr(:first) do
+    """
+    arrayFilter(
+      (entry, position) -> position = 1,
+      ordered_runs,
+      arrayEnumerateUniq(arrayMap(entry -> tupleElement(entry, 1), ordered_runs))
+    )
+    """
+  end
+
+  # Bucket states are already sorted by `(-timestamp, flag)` ascending. Runs
+  # are newest-first, duplicate timestamps are adjacent, and the largest flag
+  # is last. Comparing every tuple's key with the next tuple's key keeps that
+  # last tuple in a linear pass. The positive sentinel cannot collide with the
+  # negative timestamp keys stored in the buckets.
+  defp deduplicated_runs_expr(:last) do
+    """
+    arrayFilter(
+      (entry, next_entry) -> tupleElement(entry, 1) != tupleElement(next_entry, 1),
+      ordered_runs,
+      arrayShiftLeft(
+        ordered_runs,
+        1,
+        (toInt64(9223372036854775807), toUInt8(0))
+      )
+    )
+    """
   end
 
   defp rolling_having_expr("flakiness_rate"),


### PR DESCRIPTION
## What changed

Rolling flaky-test and reliability monitor evaluations now consume bucketed `groupArraySorted` results in their stored order. Duplicate timestamps are collapsed by comparing adjacent tuples with `arrayShiftLeft`, after which the configured rolling window is sliced and evaluated.

The less common 1,000-run fallback retains its existing sorting and uniqueness-enumeration behavior. This keeps the optimization focused on the bucketed query reported by the slow-query alert.

## Why

The [Slow ClickHouse query alert](https://tuist.grafana.net/alerting/grafana/ffeb6l2ax5qtcf/view?orgId=1) reported a 90th-percentile duration of approximately 5.05 seconds for rolling monitor evaluations using the 100-run bucket. The closest retained execution in that query family took 5,353 milliseconds, read 131,611 rows and 6,383,776 bytes, and reported 307,025,013 bytes of memory.

ClickHouse documents that [`groupArraySorted`](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/grouparraysorted) returns entries in ascending order. The bucket stores `(-run_timestamp, flag)` tuples, so its merged result is already newest-first, with duplicates adjacent. Reversing timestamps and sorting that bounded array again was redundant work on every evaluated test case.

This follows ClickHouse's [query optimization guidance](https://clickhouse.com/resources/engineering/clickhouse-query-optimisation-definitive-guide): avoid unnecessary query-time work, identify slow queries through the query log, inspect plans with `EXPLAIN`, change one variable, and measure both cold-cache and typical production behavior.

## Root cause

The query normalized the bucket's negative timestamp keys into positive timestamps and then ran `arrayReverseSort` before deduplicating. That discarded an ordering guarantee already provided by the aggregate state and turned a linear scan into an additional sort.

Query-time duplicate handling is still required. The source uses `ReplacingMergeTree`, where [queries must tolerate duplicates until parts merge](https://clickhouse.com/docs/guides/developer/deduplication), and ClickHouse incremental materialized views [process each newly inserted block](https://clickhouse.com/docs/materialized-view/incremental-materialized-view#using-source-table-in-filters-and-joins), including reinserted flaky-test updates.

## Approach

For bucketed aggregates, tuples with the same timestamp are adjacent and sort by flag in ascending order. Comparing each tuple's timestamp with the next tuple's timestamp retains the final tuple in each duplicate group, which is also the tuple with the maximum flag. A positive sentinel safely terminates the scan because stored bucket timestamps are negative.

I also evaluated broader alternatives:

- Querying the raw replacing table with `FINAL` would move more work into the read path.
- A mapped-maximum aggregation was substantially slower in the isolated benchmark.
- Ordered aggregation activated the in-order pipeline, but did not improve elapsed time in the representative aggregate-table benchmark, so this change does not add a speculative query setting.
- Rebuilding the materialized views or changing the stored tuple shape would require a migration and backfill without removing the need to tolerate reinserted rows.

## Benchmarks

### Production replay through Atlas

Atlas retrieved the retained production execution closest to the alert's approximately 5.05-second data point. It used the 100-entry bucket, a 75-run rolling window, a 5% flakiness threshold, one redacted project, and 1,000 redacted test cases.

The old and new queries were replayed against those same parameters in alternating order. Server-side metrics came from the ClickHouse query log.

| Order | Variant | Duration | Rows read | Bytes read | Reported memory | Results |
| ---: | --- | ---: | ---: | ---: | ---: | ---: |
| 1 | Existing | 220 milliseconds | 72,009 | 3,592,144 | 418,071,189 bytes | 0 |
| 2 | Optimized | 227 milliseconds | 72,009 | 3,592,144 | 426,161,960 bytes | 0 |
| 3 | Optimized | 224 milliseconds | 72,057 | 3,592,912 | 383,965,360 bytes | 0 |
| 4 | Existing | 237 milliseconds | 72,068 | 3,593,088 | 388,038,273 bytes | 0 |
| 5 | Existing | 243 milliseconds | 72,068 | 3,593,088 | 393,664,061 bytes | 0 |
| 6 | Optimized | 242 milliseconds | 72,087 | 3,593,392 | 446,871,246 bytes | 0 |

Median duration improved from 237 to 227 milliseconds, or 4.2%. The ranges overlap, so this is evidence of a modest improvement and no observed duration regression, not a claim that the full query is twice as fast. Rows and bytes read were effectively unchanged. Reported median memory was 8.3% higher for the optimized shape, with overlapping ranges, so memory remains a rollout signal to watch.

All six top-level result sets were identical. Because they returned no triggered test cases and the production tables changed slightly during the sequence, Atlas also compared both de-duplication expressions from one production snapshot:

- 1,000 test cases compared
- 74,920 post-de-duplication window tuples per variant
- 180 real duplicate aggregate entries exercised
- zero mismatched test cases, tuple counts, or tuple values
- zero nonnegative timestamp keys and zero sentinel collisions

The production plan retained the same table read, filters, aggregation, and execution pipeline. The old expression graph contained the timestamp conversion, `arrayReverseSort`, key `arrayMap`, and `arrayEnumerateUniq`; the new graph replaced those steps with `arrayShiftLeft` and an adjacent-key filter. ClickHouse did not optimize the old reverse sort away.

### Isolated array stage

The isolated ClickHouse 26.1 benchmark used 100,000 pre-sorted arrays with 250 tuples each and repeated each variant several times. It measures the array stage changed here, not the full production query.

| Variant | Wall time | Processor time |
| --- | ---: | ---: |
| Existing reverse sort and uniqueness enumeration | 1.03 to 1.09 seconds | 0.73 to 0.76 seconds |
| Adjacent comparison over the stored order | 0.49 to 0.53 seconds | approximately 0.25 seconds |
| Mapped-maximum alternative | 2.16 to 2.26 seconds | 1.63 to 1.65 seconds |

The selected approach roughly halves wall time for the isolated array stage and reduces its processor time by about two thirds. The production replay above captures the end-to-end effect, where table reads and aggregation dominate more of the total duration.

## Impact

Rolling monitor results and duplicate semantics remain unchanged while bucketed evaluations avoid the redundant per-test-case sort and key-array construction.

This is a read-only query change. It has no database migration, backfill, dependency update, or stored-data change. [`arrayShiftLeft`](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayshiftleft) has been available since ClickHouse 23.8. The query was exercised successfully on production ClickHouse 26.2.1.507 and locally on the repository's pinned ClickHouse 26.1 version.

Deployment can proceed through the normal canary. The existing slow-query alert, comparable query-log memory, and triggered test-case identifiers are the rollout signals. A normal server rollback restores the old expression without any stored-data or schema rollback.

## Validation

- `mise exec -- mix format --check-formatted lib/tuist/automations/monitors/flaky_tests_monitor.ex`
- `mise exec -- mix test test/tuist/automations/monitors/flaky_tests_monitor_test.exs` with 24 tests passing
- ClickHouse 26.1 local query checks for duplicate groups at the beginning, middle, and end of the sorted array
- Six alternating read-only production replays through Atlas against the same retained query parameters
- Single-snapshot production equivalence check across 1,000 test cases and 74,920 tuples
- Production `EXPLAIN` plan and pipeline comparison
- `git diff --check`

Production limitations: the alert exposes a normalized query family rather than one unique query identifier, so the 5,353-millisecond execution is the closest retained match to the reported point. The alert-rule configuration endpoint was unavailable, and the live table changed slightly during the replay. The single-snapshot semantic comparison removes that data drift from the correctness check.
