### PR TITLE
fix(server): skip Grafana role grants until CloudNativePG creates the role (hotfix)

### DIFF
--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -328,19 +328,39 @@ defmodule Tuist.Release do
   defp do_grant_grafana_role(repo, role) do
     Environment.validate_postgres_identifier!(role, "TUIST_DATABASE_GRAFANA_ROLE")
 
-    role = Environment.quote_postgres_identifier(role)
-    database = repo.config() |> Keyword.fetch!(:database) |> Environment.quote_postgres_identifier()
-    quoted_schema = Environment.quote_postgres_identifier(Environment.database_schema())
+    # CloudNativePG creates this role from the Cluster CR, which Helm applies
+    # only after this pre-upgrade migration Job. On the deploy that first
+    # introduces the role it therefore does not exist yet: skip the grants
+    # rather than aborting the migration (which, under --rollback-on-failure,
+    # would roll the release back before CNPG ever creates the role). The next
+    # migrate, once the role exists, applies them.
+    if role_exists?(repo, role) do
+      quoted_role = Environment.quote_postgres_identifier(role)
+      database = repo.config() |> Keyword.fetch!(:database) |> Environment.quote_postgres_identifier()
+      quoted_schema = Environment.quote_postgres_identifier(Environment.database_schema())
 
-    {:ok, :ok} =
-      repo.transaction(fn ->
-        Enum.each(
-          grafana_role_grant_statements(role, database, quoted_schema),
-          &SQL.query!(repo, &1, [])
-        )
+      {:ok, :ok} =
+        repo.transaction(fn ->
+          Enum.each(
+            grafana_role_grant_statements(quoted_role, database, quoted_schema),
+            &SQL.query!(repo, &1, [])
+          )
 
-        :ok
-      end)
+          :ok
+        end)
+    else
+      Logger.info(
+        "Skipping Grafana role grants: role #{inspect(role)} does not exist yet " <>
+          "(CloudNativePG creates it after this migration hook)."
+      )
+
+      :ok
+    end
+  end
+
+  defp role_exists?(repo, role) do
+    %{rows: rows} = SQL.query!(repo, "SELECT 1 FROM pg_roles WHERE rolname = $1", [role])
+    rows != []
   end
 
   @doc false


### PR DESCRIPTION
## What changed

Gate `grant_grafana_role/1` in `server/lib/tuist/release.ex` on the `tuist_grafana_ro` role actually existing (`SELECT 1 FROM pg_roles WHERE rolname = $1`) before running its column-level GRANTs. If the role is absent, the migration logs and skips instead of failing.

## Why

The production deployment for [#11893](https://github.com/tuist/tuist/pull/11893) ([run 29587590922](https://github.com/tuist/tuist/actions/runs/29587590922)) failed on the canary migration Job:

```
** (Postgrex.Error) ERROR 42704 (undefined_object) role "tuist_grafana_ro" does not exist
    lib/tuist/release.ex:337: anonymous fn/4 in Tuist.Release.do_grant_grafana_role/2
```

## Root cause

That commit introduced the new CNPG-managed role `tuist_grafana_ro` and, in the same change, made the migration run `GRANT ... TO tuist_grafana_ro`. The ordering is the problem:

- The migration Job is a Helm **pre-upgrade hook** (`helm.sh/hook-weight: "-1"`).
- The CNPG `Cluster` CR that declares the `grafanaRo` managed role is a **normal resource**, applied by Helm only *after* the pre-upgrade hooks pass.

So on the deploy that first introduces the role, the GRANT runs before CNPG has been told to create it. The Job exhausts its backoff limit (`failed: 4/1`), `--rollback-on-failure` rolls the whole release back, the Cluster CR update never lands, and CNPG never creates the role — a chicken-and-egg wedge that blocks every subsequent deploy too.

The existing `processor` and `swift_registry_sync` roles never hit this because they already existed in the live clusters (bootstrapped via the manual `.sql` runbooks) by the time their git-tracked grant code shipped. `grafanaRo` is created for the first time *by* this code path, so there was nothing to grant to.

## Why this fix over the alternatives

- **Manually pre-creating the role via psql** would unblock this one deploy but isn't declarative or reproducible across canary/production, and fights the intent of the original change.
- **Moving the grant to a post-upgrade hook** doesn't help: CNPG reconciles managed roles asynchronously, so the role may still not exist by then.

Gating on existence makes the flow self-healing and matches how these grant helpers are meant to run (idempotently, on every migrate): the first deploy skips the grants and lets CNPG create the role; the next migrate, once the role exists, applies them. The dashboard role is new and not yet in use, so the one-deploy lag before grants land is harmless.

## Follow-up prerequisite (not addressed here)

This unblocks the deploy regardless, but for CNPG to actually create `tuist_grafana_ro`, the `GRAFANA_DATABASE_PASSWORD` item (referenced by the new `pg-tuist-grafana-ro` ExternalSecret) must exist in each env's 1Password vault. If it's missing, the deploy still goes green but the role/grants won't materialize until it's added.

## Validation

- `mix compile --warnings-as-errors` — clean
- `mix test test/tuist/release_test.exs` — 8 passed (existing pure-function coverage of the grant statements is unchanged)