### PR TITLE
fix(server): stop server ServiceAccount UID churn causing intermittent K8s 401s

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -819,6 +819,37 @@ jobs:
           # so dependent pods (Pending or otherwise) go with the Job.
           echo "$stale_jobs" | xargs -r kubectl -n "$NAMESPACE" delete job \
             --ignore-not-found --cascade=foreground --timeout=2m
+      - name: Adopt server ServiceAccount into the Helm release
+        # The server ServiceAccount used to render as a Helm *hook*
+        # (before-hook-creation), which churned its UID every deploy and
+        # broke bound-token auth. It is now a normal release resource, but a
+        # hook-created object carries no `meta.helm.sh/release-*` ownership
+        # annotations, so the first `helm upgrade` after the switch would
+        # fail its import check with "invalid ownership metadata". Stamp the
+        # ownership annotations + managed-by label (and strip the now-stale
+        # hook annotations) so helm adopts the live SA in place, preserving
+        # its UID. Idempotent: once the SA is a tracked resource this is a
+        # no-op, and it tolerates first installs where the SA does not exist
+        # yet. Applies to every environment because the production cascade
+        # deploys canary first — a production-only manual step would not gate
+        # it. SA name is `server.serviceAccount.name` in
+        # values-managed-common.yaml.
+        run: |
+          set -euo pipefail
+          SA_NAME=tuist-server
+
+          if ! kubectl -n "$NAMESPACE" get serviceaccount "$SA_NAME" >/dev/null 2>&1; then
+            echo "ServiceAccount $SA_NAME not present yet (first install); nothing to adopt."
+            exit 0
+          fi
+
+          kubectl -n "$NAMESPACE" annotate serviceaccount "$SA_NAME" \
+            "meta.helm.sh/release-name=$HELM_RELEASE_NAME" \
+            "meta.helm.sh/release-namespace=$NAMESPACE" --overwrite
+          kubectl -n "$NAMESPACE" label serviceaccount "$SA_NAME" \
+            app.kubernetes.io/managed-by=Helm --overwrite
+          kubectl -n "$NAMESPACE" annotate serviceaccount "$SA_NAME" \
+            helm.sh/hook- helm.sh/hook-weight- helm.sh/hook-delete-policy-
       - name: helm upgrade --install
         # App secrets never pass through --set: the chart runs in
         # `server.managedSecrets: true` mode, which reads DATABASE_URL /

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -820,20 +820,23 @@ jobs:
           echo "$stale_jobs" | xargs -r kubectl -n "$NAMESPACE" delete job \
             --ignore-not-found --cascade=foreground --timeout=2m
       - name: Adopt server ServiceAccount into the Helm release
-        # The server ServiceAccount used to render as a Helm *hook*
-        # (before-hook-creation), which churned its UID every deploy and
-        # broke bound-token auth. It is now a normal release resource, but a
-        # hook-created object carries no `meta.helm.sh/release-*` ownership
-        # annotations, so the first `helm upgrade` after the switch would
-        # fail its import check with "invalid ownership metadata". Stamp the
-        # ownership annotations + managed-by label (and strip the now-stale
-        # hook annotations) so helm adopts the live SA in place, preserving
-        # its UID. Idempotent: once the SA is a tracked resource this is a
-        # no-op, and it tolerates first installs where the SA does not exist
-        # yet. Applies to every environment because the production cascade
-        # deploys canary first — a production-only manual step would not gate
-        # it. SA name is `server.serviceAccount.name` in
-        # values-managed-common.yaml.
+        # One-time migration guard. The server ServiceAccount used to render
+        # as a Helm *hook* (before-hook-creation), which churned its UID every
+        # deploy and broke bound-token auth. It is now a normal release
+        # resource, but a hook-created object carries no `meta.helm.sh/release-*`
+        # ownership annotations, so the first `helm upgrade` after the switch
+        # would fail its import check with "invalid ownership metadata". Stamp
+        # the ownership annotations + managed-by label (and strip the now-stale
+        # hook annotations) so helm adopts the live SA in place, preserving its
+        # UID. Runs in every environment because the production cascade deploys
+        # canary first — a production-only manual step would not gate it.
+        #
+        # Self-skipping: once helm owns the SA it re-stamps these annotations
+        # itself, so the step short-circuits with no API write on every deploy
+        # after the one that adopts a given cluster (and tolerates first
+        # installs where the SA does not exist). Safe to delete once every
+        # managed cluster has adopted. SA name is `server.serviceAccount.name`
+        # in values-managed-common.yaml.
         run: |
           set -euo pipefail
           SA_NAME=tuist-server
@@ -843,6 +846,14 @@ jobs:
             exit 0
           fi
 
+          owner="$(kubectl -n "$NAMESPACE" get serviceaccount "$SA_NAME" \
+            -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)"
+          if [ "$owner" = "$HELM_RELEASE_NAME" ]; then
+            echo "ServiceAccount $SA_NAME already adopted by release $HELM_RELEASE_NAME; nothing to do."
+            exit 0
+          fi
+
+          echo "Adopting ServiceAccount $SA_NAME into Helm release $HELM_RELEASE_NAME."
           kubectl -n "$NAMESPACE" annotate serviceaccount "$SA_NAME" \
             "meta.helm.sh/release-name=$HELM_RELEASE_NAME" \
             "meta.helm.sh/release-namespace=$NAMESPACE" --overwrite

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -38,9 +38,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9091"
         prometheus.io/port-name: metrics
-        {{- if and .Values.server.serviceAccount.create .Values.server.migrationJob.asHook }}
-        tuist.dev/server-service-account-revision: {{ .Release.Revision | quote }}
-        {{- end }}
         {{- with .Values.processor.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -38,9 +38,6 @@ spec:
         # per pod. See helm/k8s-monitoring/values.yaml for the
         # annotation→config mapping.
         prometheus.io/port-name: metrics
-        {{- if and .Values.server.serviceAccount.create .Values.server.migrationJob.asHook }}
-        tuist.dev/server-service-account-revision: {{ .Release.Revision | quote }}
-        {{- end }}
         {{- with .Values.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/infra/helm/tuist/templates/serviceaccount.yaml
+++ b/infra/helm/tuist/templates/serviceaccount.yaml
@@ -7,30 +7,26 @@ metadata:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
   annotations:
-    # Helm checks this annotation on the live object before pruning a
-    # resource that disappeared from the release manifest. Without it, a
-    # release that ever recorded this SA as a regular resource (e.g. a
-    # manual deploy rendered with asHook=false) gets it pruned mid-upgrade
-    # by the next hook-shaped deploy, stranding the server/processor pods
-    # on token mounts. Hook delete/recreate (before-hook-creation) is
-    # unaffected — helm's hook deletion does not honor resource-policy.
+    # The server SA MUST stay a stable, normal release resource — never a Helm
+    # hook. Server and processor pods hold projected (bound) ServiceAccount
+    # tokens whose `uid` claim the apiserver validates against the *current* SA
+    # object. Rendered as a hook with `before-hook-creation`, the SA is
+    # deleted+recreated on every upgrade and gets a new UID, so every token
+    # already minted for a running pod is rejected with "service account UID
+    # does not match claim" (HTTP 401) until kubelet re-mints it on its
+    # token-refresh cycle. That intermittently breaks every server→apiserver
+    # call (Kura reconcile, runner-dispatch TokenReview, pod reads) for the
+    # window after each deploy. As a normal resource Helm patches it in place,
+    # keeping the UID stable across releases.
+    #
+    # The migration Job needs an SA before the main manifests exist on a first
+    # install, so it renders its own throwaway hook SA (`server-migrate`, see
+    # server-migration-job.yaml) — that one may churn freely because a one-shot
+    # Job mints a fresh token per run and holds no long-lived bound token.
+    #
+    # resource-policy: keep guards the SA from being pruned mid-upgrade if a
+    # release ever rendered it differently (e.g. a past asHook toggle).
     helm.sh/resource-policy: keep
-    {{- if .Values.server.migrationJob.asHook }}
-    # Pre-install/upgrade hook ordering (Helm applies in ASCENDING weight,
-    # waiting for each to become ready before the next):
-    #
-    #   -12  this ServiceAccount (applied first, no dependencies)
-    #   -10  ExternalSecrets → ESO fetches the config Secret + license/Kura
-    #    -5  Secret (app-secrets), when managedSecrets=false
-    #    -1  migrate Job — needs the SA bound and the synced Secrets present
-    #
-    # before-hook-creation deletes only the previous hook's copy on the next
-    # install/upgrade, so the SA persists across releases for the main
-    # Deployment (which is a normal release resource) to keep referencing.
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "-12"
-    helm.sh/hook-delete-policy: before-hook-creation
-    {{- end }}
     {{- with .Values.server.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -380,11 +380,18 @@ defmodule Tuist.Kura.Reconciler do
       {:ok, observed} ->
         record(server, derived_status(server, latest_status), observed, now())
 
-      {:error, :not_found} when latest_status == :succeeded ->
-        apply_current_manifest(server, desired)
-
       {:error, :not_found} ->
-        record(server, derived_status(server, latest_status), nil, now())
+        # A present-intent server (provisioning/active/failed) whose backing
+        # KuraInstance has vanished is drift to correct on its own, regardless
+        # of the latest deployment's status. Gating recreation on a `:succeeded`
+        # latest deployment let a transient control-plane error — e.g. an
+        # apiserver 401 during a rollout that marked the deployment `:failed` —
+        # silently and permanently disable self-heal: a failed latest deployment
+        # never flips back to `:succeeded` on its own, so a CR later deleted
+        # out-of-band was never recreated and the instance stranded. Re-applying
+        # is idempotent; a genuinely broken rollout surfaces its own error each
+        # tick instead of the instance disappearing.
+        apply_current_manifest(server, desired)
 
       {:error, reason} ->
         Logger.warning("[Kura.Reconciler] could not observe server #{server.id}: #{inspect(reason)}")

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -360,7 +360,11 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert %Server{status: :active, current_image_tag: "0.5.2"} = Repo.get!(Server, server.id)
   end
 
-  test "leaves a failed server failed while the controller has not converged on the target image" do
+  test "re-applies a vanished KuraInstance for a failed server, healing it forward" do
+    # Regression: a transient apiserver 401 during a rollout marks the
+    # deployment :failed; if the CR is later deleted out-of-band, self-heal must
+    # still recreate it. Gating recreation on a :succeeded latest deployment used
+    # to strand the instance with no CR and no path back.
     {_account, server, deployment} = create_server()
     {:ok, _deployment} = Kura.mark_failed(deployment, "apply failed")
     {:ok, server} = Kura.fail_server(server)
@@ -370,9 +374,15 @@ defmodule Tuist.Kura.ReconcilerTest do
       {:error, :not_found}
     end)
 
+    expect(Provisioner, :rollout, fn %Server{id: id}, inputs ->
+      assert id == server.id
+      assert inputs.image_tag == deployment.image_tag
+      :ok
+    end)
+
     assert :ok = Reconciler.reconcile()
 
-    assert %Server{status: :failed, current_image_tag: nil, url: nil} = Repo.get!(Server, server.id)
+    assert %Server{status: :active, current_image_tag: "0.5.2"} = Repo.get!(Server, server.id)
   end
 
   test "leaves a failed server failed while its public endpoint is not yet serving" do


### PR DESCRIPTION
## What changed

The server's Kubernetes ServiceAccount (`tuist-server`) is no longer rendered as a Helm hook. It is now a stable, normal release resource, so its UID stays constant across deploys. Supporting changes remove a now-obsolete force-rollout workaround, harden the Kura reconciler's self-heal, and automate the one-time SA adoption the switch requires.

- **`serviceaccount.yaml`** — the server SA drops the `helm.sh/hook: pre-install,pre-upgrade` + `hook-delete-policy: before-hook-creation` annotations (previously added when `server.migrationJob.asHook=true`). As a normal resource with `resource-policy: keep`, Helm patches it in place instead of delete+recreate.
- **`server-deployment.yaml` / `processor-deployment.yaml`** — removed the `tuist.dev/server-service-account-revision: {{ .Release.Revision }}` pod annotation.
- **`server/lib/tuist/kura/reconciler.ex`** — `project_server` now re-applies a `not_found` KuraInstance for a present-intent server regardless of the latest deployment's status (was gated on `:succeeded`).
- **`.github/workflows/server-deployment.yml`** — idempotent, self-skipping pre-`helm upgrade` step that adopts the existing SA into the release (see below).
- **`server/test/tuist/kura/reconciler_test.exs`** — rewrote the test that encoded the old stranding behavior to assert self-heal.

## Why

Production saw intermittent HTTP 401s from the apiserver on **every** server→Kubernetes call: the Kura reconciler's GET/apply of `KuraInstance` CRs (which failed Kura deployments into `status=failed`) and, far more loudly, runner-dispatch `POST /tokenreviews` (thousands/min across all replicas). Both paths authenticate with the same in-cluster server SA token.

### Root cause

`before-hook-creation` **deletes and recreates the SA on every `helm upgrade`, minting a new UID each deploy**. Running server and processor pods (both use the server SA) still present projected (bound) tokens whose `uid` claim is the *previous* SA UID. Kubernetes validates a bound token's `uid` claim against the current SA object, so the apiserver rejects them until kubelet re-mints the token on its refresh cycle (`expirationSeconds: 3607`, ~48 min). Reading the token fresh from disk each request doesn't help — the on-disk token itself carries the stale UID.

The apiserver's own logs name it exactly:

```
authentication.go:75 "Unable to authenticate the request"
  err="[invalid bearer token, service account UID (1c7ae…) does not match claim (26d8a…)]"
```

This explains every symptom: intermittent, all accounts/regions/instances, all replicas, self-heals via kubelet refresh, recurs each deploy. Verified live — the SA was recreated mid-investigation (`16:13:47Z`, new UID) and pods started before that recreation presented the stale UID while a pod started after it did not. The bare 401 body is just `"Unauthorized"`; the reason exists only in the apiserver logs.

### Why this fix over the alternatives

- The migration Job **already** has a dedicated throwaway hook SA (`server-migrate`) created specifically to keep this churn away from long-running pods — its comment says the churn "must never happen to an SA that long-running pods hold projected tokens for." The decoupling was half-done; un-hooking the server SA completes it. First-install ordering is unaffected.
- The `server-service-account-revision` annotation was a workaround that force-rolled the whole server every deploy so pods would re-mint tokens after the SA churned. With a stable UID it is dead weight and pointless rollout churn.
- A **client-level retry-on-401 was deliberately not added**: an immediate retry reads the same stale on-disk token, so it cannot help this failure mode.

### Reconciler hardening

A failed deployment never flips back to `:succeeded` on its own, so a transient 401 that marked a deployment `:failed` could **permanently** disable CR self-heal: if the CR was later deleted out-of-band it was never recreated and the instance stranded (this is what happened to `kura-tuist-scw-fr-par`, account_id=3). Re-applying a missing CR for a present-intent server is idempotent drift correction; a genuinely broken rollout surfaces its own error each tick instead of the instance silently disappearing.

## SA adoption (automated, one-time)

The live SA was created by a Helm hook and lacks the `meta.helm.sh/release-*` ownership annotations, so Helm's import check would reject adopting it as a normal resource on the first upgrade after this switch. This is handled by a pre-`helm upgrade` step in `server-deployment.yml` (the `workflow_call` target the production cascade reuses for **every** environment — important because the cascade deploys canary first, whose SA is equally unannotated, so a production-only manual step would not gate it). The step stamps the ownership annotations + `managed-by=Helm` label on the live `tuist-server` SA and strips the stale hook annotations, preserving the UID.

It is a one-time migration guard: it **self-skips with no API write** once a cluster has been adopted (Helm re-stamps the annotations itself thereafter), tolerates first installs where the SA does not exist, and is safe to delete once every managed cluster has adopted (tracked as a follow-up). Purely-manual adoption was considered but is ordering-sensitive: the current chart still hook-deletes the SA, so any old-chart deploy after a manual annotate would wipe it; running the step inside the fix deploy applies it at exactly the right instant.

## User / operator impact

Kura deployments stop failing on transient apiserver auth; runner dispatch stops its 401 flood; deploys no longer force a full server rollout every time. Stranded Kura instances self-heal on the next reconciler tick once this ships.

## How to test locally

- `cd server && mix test test/tuist/kura/reconciler_test.exs` — 24 pass, including the rewritten vanished-CR self-heal test.
- `cd infra/helm/tuist && helm template tuist . --set server.enabled=true --set server.serviceAccount.create=true --set server.migrationJob.asHook=true --show-only templates/serviceaccount.yaml` — SA renders with `resource-policy: keep` and **no** `helm.sh/hook` annotations; `server-migrate` hook SA is preserved. Repeat with `asHook=false` for parity.
- `actionlint .github/workflows/server-deployment.yml` — no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
