### PR TITLE
fix(cli): import Musl so the static Linux release build compiles

### DIFF
--- a/cli/Sources/TuistRunnerCommand/Services/RunnerShellTerminalClient.swift
+++ b/cli/Sources/TuistRunnerCommand/Services/RunnerShellTerminalClient.swift
@@ -4,9 +4,11 @@ import Foundation
     import FoundationNetworking
 #endif
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 


### PR DESCRIPTION
## What changed

`RunnerShellTerminalClient.swift` now imports the libc module via the three-way `#if canImport(Glibc) / Musl / Darwin` cascade instead of the older `#if os(Linux) → import Glibc` form.

## Why

The canary and stable **Linux** CLI release ([`release-cli-linux`](.github/workflows/cli-build-publish.yml)) builds the binary against the Swift **static musl SDK** (`aarch64-swift-linux-musl` / `x86_64-swift-linux-musl`) to produce fully static, cross-distro binaries. On that SDK the C library module is `Musl`, **not** `Glibc`.

`RunnerShellTerminalClient.swift`, added in #11748 (interactive runner shell), imported the libc module unconditionally on Linux:

```swift
#if os(Linux)
    import Glibc
#else
    import Darwin
#endif
```

Under the musl SDK this fails hard:

```
cli/Sources/TuistRunnerCommand/Services/RunnerShellTerminalClient.swift:8:12: error: no such module 'Glibc'
```

The file depends on the libc module for `termios` / `ioctl` / `isatty` / `tcsetattr` / `cfmakeraw` / `signal` symbols, so the import can't simply be dropped — it must resolve to `Musl` under the static SDK.

### User/developer impact

Every canary run since #11748 landed has failed. Both Linux jobs retried the bundle three times (the retry loop assumes a flaky SwiftPM download, but this is a deterministic compile error), then hit the 30-minute timeout, which cancelled the run and blocked `publish-cli`. See the failing run: https://github.com/tuist/tuist/actions/runs/29587101633

The macOS job was unaffected (it takes the `canImport(Darwin)` branch, which the new cascade preserves).

### Why this solution

The `canImport` cascade is already the established idiom for libc imports across the CLI (`ThreadDumpSignalHandler`, `TemporaryDirectory`, `Environment`, `AbsolutePath+Extras`, `SideEffectDescriptorExecutor`), all of which compile cleanly under musl. `RunnerShellTerminalClient` was the one file that diverged. Auditing the remaining `import Glibc` sites confirms every other one is already guarded with `canImport`, so this was the sole offender.

## How to test locally

Cross-compile against the same static SDK the release uses (from a `swift:6.2` Linux container):

```bash
swift sdk install https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
  --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c
./mise/tasks/cli/bundle-linux.sh
```

Before this change the build fails with `no such module 'Glibc'`; after it, it compiles. I verified the fix by cross-compiling the file's exact C-API surface (termios/ioctl/winsize/signal) against `aarch64-swift-linux-musl`, which now links successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)