### PR TITLE
fix(server): retry the registry package-metadata lock in-job instead of failing

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -766,9 +766,12 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
   # Sibling ReleaseWorker jobs from the same sync batch contend for this
   # per-package S3 lock, which is only held for a metadata read + write
-  # (sub-second). Retrying briefly in-job clears that contention so the job
-  # finishes instead of failing and paging Sentry; callers snooze when the
-  # budget is exhausted (e.g. a crashed holder's lock lingering until its TTL).
+  # (sub-second). The release write happens after the source archive and
+  # manifests are already uploaded, so a short in-job retry finishes the job
+  # rather than snoozing and redoing that GitHub + S3 work. Callers snooze when
+  # the retry budget is exhausted (e.g. a crashed holder's lock lingering until
+  # its TTL). The skipped-release write has nothing expensive to redo, so it
+  # deliberately does not use this and snoozes immediately instead.
   defp acquire_metadata_lock(lock_key) do
     acquire_metadata_lock(lock_key, @metadata_lock_max_attempts)
   end
@@ -813,7 +816,10 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp update_metadata_with_skipped_release(scope, name, full_handle, version, reason) do
     lock_key = {:package, scope, name}
 
-    case acquire_metadata_lock(lock_key) do
+    # No in-job retry: the skip write only fetched the repo contents, so there is
+    # nothing expensive to redo. Snooze immediately on contention rather than
+    # holding an Oban concurrency slot asleep on a backoff.
+    case Lock.try_acquire(lock_key, @metadata_lock_ttl_seconds) do
       {:ok, :acquired} ->
         try do
           with {:ok, metadata} <- get_or_create_metadata(scope, name, full_handle) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -23,6 +23,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
   @lock_ttl_seconds 1_800
   @metadata_lock_ttl_seconds 300
+  @metadata_lock_max_attempts 5
+  @metadata_lock_backoff_ms 200
+  @metadata_lock_snooze_seconds 30
   @skippable_submodule_failure_markers [
     "no url found for submodule path",
     "transport 'file' not allowed",
@@ -98,6 +101,10 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
         case maybe_skip_release(scope, name, full_handle, version, reason) do
           :ok ->
             :ok
+
+          {:snooze, seconds} ->
+            Logger.info("Deferring release #{scope}/#{name}@#{tag}: package metadata lock is contended")
+            {:snooze, seconds}
 
           :not_skipped ->
             Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
@@ -729,7 +736,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp update_metadata_with_release(scope, name, full_handle, version, checksum, manifests) do
     lock_key = {:package, scope, name}
 
-    case Lock.try_acquire(lock_key, @metadata_lock_ttl_seconds) do
+    case acquire_metadata_lock(lock_key) do
       {:ok, :acquired} ->
         try do
           with {:ok, metadata} <- get_or_create_metadata(scope, name, full_handle) do
@@ -751,10 +758,38 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
         end
 
       {:error, :already_locked} ->
-        Logger.info("Metadata update deferred for #{scope}/#{name}@#{version}: lock held by another node")
+        Logger.info("Metadata update deferred for #{scope}/#{name}@#{version}: package lock contended, snoozing")
 
-        {:error, {:release_metadata_locked, scope, name, version}}
+        {:snooze, @metadata_lock_snooze_seconds}
     end
+  end
+
+  # Sibling ReleaseWorker jobs from the same sync batch contend for this
+  # per-package S3 lock, which is only held for a metadata read + write
+  # (sub-second). Retrying briefly in-job clears that contention so the job
+  # finishes instead of failing and paging Sentry; callers snooze when the
+  # budget is exhausted (e.g. a crashed holder's lock lingering until its TTL).
+  defp acquire_metadata_lock(lock_key) do
+    acquire_metadata_lock(lock_key, @metadata_lock_max_attempts)
+  end
+
+  defp acquire_metadata_lock(lock_key, attempts_remaining) do
+    case Lock.try_acquire(lock_key, @metadata_lock_ttl_seconds) do
+      {:ok, :acquired} ->
+        {:ok, :acquired}
+
+      {:error, :already_locked} when attempts_remaining > 1 ->
+        Process.sleep(metadata_lock_backoff_ms(attempts_remaining))
+        acquire_metadata_lock(lock_key, attempts_remaining - 1)
+
+      {:error, :already_locked} ->
+        {:error, :already_locked}
+    end
+  end
+
+  defp metadata_lock_backoff_ms(attempts_remaining) do
+    step = @metadata_lock_max_attempts - attempts_remaining + 1
+    @metadata_lock_backoff_ms * step + :rand.uniform(@metadata_lock_backoff_ms)
   end
 
   defp maybe_skip_release(scope, name, full_handle, version, {:missing_manifests, failed_full_handle, tag}) do
@@ -778,7 +813,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp update_metadata_with_skipped_release(scope, name, full_handle, version, reason) do
     lock_key = {:package, scope, name}
 
-    case Lock.try_acquire(lock_key, @metadata_lock_ttl_seconds) do
+    case acquire_metadata_lock(lock_key) do
       {:ok, :acquired} ->
         try do
           with {:ok, metadata} <- get_or_create_metadata(scope, name, full_handle) do
@@ -799,11 +834,11 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
         end
 
       {:error, :already_locked} ->
-        Logger.warning(
-          "Skipped release metadata update deferred for #{scope}/#{name}@#{version}: lock held by another node"
+        Logger.info(
+          "Skipped release metadata update deferred for #{scope}/#{name}@#{version}: package lock contended, snoozing"
         )
 
-        {:error, {:skipped_release_metadata_locked, scope, name, version}}
+        {:snooze, @metadata_lock_snooze_seconds}
     end
   end
 

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -203,6 +203,41 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
+  test "snoozes immediately without retrying when the skip-write lock is contended" do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    stub(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "README.md", "type" => "file"}]}
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ -> flunk("unexpected file request") end)
+
+    # A single package-lock acquisition attempt (no in-job retry): a second call
+    # would raise, since only this one is expected.
+    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
+      {:error, :already_locked}
+    end)
+
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected metadata write while the lock is contended") end)
+
+    assert {:snooze, 30} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
   test "retries the contended package lock in-job and records the release without erroring" do
     {:ok, package_lock_attempts} = Agent.start_link(fn -> 0 end)
 
@@ -220,11 +255,34 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     end)
 
     expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
-      {:ok, [%{"path" => "README.md", "type" => "file"}]}
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser", "token", "v1.0.0", archive_path, _ ->
+      write_basic_zipball(archive_path)
+      :ok
+    end)
+
+    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    expect(ExAws, :request, 2, fn _operation ->
+      {:ok, %{status_code: 200, body: ""}}
     end)
 
     expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
-      assert metadata["skipped_releases"]["1.0.0"] == %{"reason" => "missing_manifests"}
+      assert is_binary(metadata["releases"]["1.0.0"]["checksum"])
       :ok
     end)
 

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -117,9 +117,13 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
-  test "returns an error so Oban retries when release metadata is locked" do
-    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
-      {:ok, :acquired}
+  test "snoozes instead of erroring when the package lock stays contended past the retry budget" do
+    stub(Lock, :try_acquire, fn
+      {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+        {:ok, :acquired}
+
+      {:package, "apple", "swift-argument-parser"}, _ ->
+        {:error, :already_locked}
     end)
 
     expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
@@ -153,11 +157,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       {:ok, %{status_code: 200, body: ""}}
     end)
 
-    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
-      {:error, :already_locked}
-    end)
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected metadata write while the lock is contended") end)
 
-    assert {:error, {:release_metadata_locked, "apple", "swift-argument-parser", "1.0.0"}} =
+    assert {:snooze, 30} =
              ReleaseWorker.perform(%Oban.Job{
                args: %{
                  "scope" => "apple",
@@ -166,6 +168,77 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
                  "tag" => "v1.0.0"
                }
              })
+  end
+
+  test "records a skipped release when the tag has no root manifest" do
+    stub(Lock, :try_acquire, fn
+      {:release, "apple", "swift-argument-parser", "1.0.0"}, _ -> {:ok, :acquired}
+      {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired}
+    end)
+
+    stub(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "README.md", "type" => "file"}]}
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ -> flunk("unexpected file request") end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      assert metadata["skipped_releases"]["1.0.0"] == %{"reason" => "missing_manifests"}
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "retries the contended package lock in-job and records the release without erroring" do
+    {:ok, package_lock_attempts} = Agent.start_link(fn -> 0 end)
+
+    stub(Lock, :try_acquire, fn
+      {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+        {:ok, :acquired}
+
+      {:package, "apple", "swift-argument-parser"}, _ ->
+        attempt = Agent.get_and_update(package_lock_attempts, &{&1, &1 + 1})
+        if attempt < 2, do: {:error, :already_locked}, else: {:ok, :acquired}
+    end)
+
+    stub(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "README.md", "type" => "file"}]}
+    end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      assert metadata["skipped_releases"]["1.0.0"] == %{"reason" => "missing_manifests"}
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+
+    assert Agent.get(package_lock_attempts, & &1) == 3
   end
 
   test "deduplicates manifest metadata by Swift tools version" do


### PR DESCRIPTION
## What changed

Swift registry `ReleaseWorker` writes to a package's metadata object in S3 under a per-package distributed lock (`{:package, scope, name}`). When acquisition lost a race it returned `{:error, …}`, which Oban records as a job exception, reports to Sentry, and retries. This PR stops that lock contention from surfacing as an error, using an approach tuned to the queue's concurrency and to how expensive each job's work is to redo.

- `server/lib/tuist/registry/swift/release_worker.ex`
  - New `acquire_metadata_lock/1`: retries acquisition in-job (5 attempts, linear backoff `~200ms → 800ms` + jitter, ~2.8s budget). Used **only** by the real-release write.
  - `update_metadata_with_release/6` acquires through the retry helper; on exhaustion returns `{:snooze, 30}` instead of `{:error, {:release_metadata_locked, …}}`.
  - `update_metadata_with_skipped_release/5` does a **single** `try_acquire` and snoozes immediately (`{:snooze, 30}`) on contention — no in-job sleep.
  - `sync_release/6` propagates the snooze.
- `server/test/tuist/registry/swift/release_worker_test.exs`
  - Former "errors when locked" test now asserts `{:snooze, 30}` after the retry budget is exhausted (release path).
  - Added: records a skipped release when the tag has no root manifest; retries the contended lock in-job and still records the release (asserts 3 acquisition attempts, release path); snoozes after a single acquisition attempt on the skip path (no retry).

## Why it changed / root cause

These jobs showed up in Sentry as `Oban.PerformError` with `{:missing_manifests, …}`. That message is misleading:

1. **`:missing_manifests` is expected and already handled.** For pre-release/variant tags (snapshots, betas, rcs, `-dev`, `-Xcode-*`) there is legitimately no root `Package.swift`, and the worker records a *skipped release* so it never retries.
2. **The job only failed because the skip-write lost a lock race.** `SyncWorker` fans out many release jobs for the *same* package at once (e.g. `usabilla` has dozens of `-Xcode-*` tags in one batch), so they contend for the per-package lock. The loser got `{:error, :already_locked}` and the worker returned the original `{:missing_manifests, …}` → Oban exception → Sentry, then retried (up to 20×).

Every `:missing_manifests` exception in the logs is paired at the same millisecond with `Failed to record skipped release … {:skipped_release_metadata_locked, …}`, confirming lock contention — not missing manifests — is what fails the job.

## Why this approach

**Sizing.** The `:swift_registry_release` queue runs **5 jobs in parallel** (single `swift-registry-sync` pod, `replicaCount: 1`). The lock is S3-backed but held only for a metadata GET+PUT (sub-second, released via `after`; the 300s TTL is just a crashed-holder ceiling). `SyncWorker` is cron-every-10-min but rotates the catalog in batches via an S3 cursor, so a package isn't revisited quickly — the retry churn is Oban re-running the *same* job, not the next cron tick. So worst-case same-package contention is ~1–1.5s and clears fast.

**Retry vs. snooze, per path.** A retrying job holds one of the 5 Oban slots while it sleeps (it yields the BEAM scheduler — no CPU burned — but the logical slot is occupied). So the retry is applied asymmetrically, based on how expensive the job's already-done work is to redo:

- **Real-release write** reaches the lock *after* the source archive and manifests are uploaded to S3. Snoozing there throws all that GitHub + S3 I/O away and redoes it on the re-run, so a short in-job retry (holding a slot ~sub-second) is the cheaper choice. `{:snooze, 30}` remains as the fallback for the rare stuck-lock case, matching the existing precedent in `SyncWorker.purge_package_version/3`.
- **Skipped-release write** (the high-frequency `:missing_manifests` case) reaches the lock right after a single `list_repository_contents` call — nothing expensive to redo — so it **snoozes immediately** and never holds a slot asleep.

This keeps the dominant, reported case off the concurrency slots entirely, and reserves the in-job sleep for the lower-frequency path where a snooze would waste an already-uploaded archive.

## Scope

Applied to **both** write paths, because the happy-path release write has the identical contention and is the larger noise source. Production, last 7 days:

| Sentry `Oban.PerformError` | events / 7d | after |
|---|---|---|
| `{:missing_manifests, …}` (skip-write contention) | 333 | job `:ok` (skip recorded) or immediate `:snooze` |
| `{:release_metadata_locked, …}` (release-write contention) | 2,311 | in-job retry, then `:snooze` if still contended |

## Impact

No change to what gets stored — releases and skipped releases are recorded exactly as before. Lock contention that previously failed the job and paged Sentry now resolves in-job (release path) or snoozes, so both exception classes drop to ~zero, replaced by info-level "deferred … snoozing" logs. No availability impact (these jobs already eventually resolved; this removes the wasted retries and Sentry noise).

## Validation

- `mix test test/tuist/registry/swift/release_worker_test.exs` → **8 passed** (incl. the retry-success, immediate-snooze, and retry-then-snooze cases).
- `mix format --check-formatted` on both files → clean.
- `mix credo` on the worker → no issues.
- Root cause, concurrency (`swift_registry_release: 5`, `replicaCount: 1`), and event counts confirmed from config and production Loki logs (Oban `job:exception` payloads shipped to Sentry).
