### PR TITLE
fix(server): scope Kura mesh peer sync to self-hosting-capable accounts

### DIFF
--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -182,7 +182,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   @impl true
   def manifest_revision(account, %Regions{} = region) do
-    @manifest_revision <> peers_revision_suffix(self_hosted_peers(account, region))
+    manifest_revision_string(account, region, self_hosted_peers(account, region))
   end
 
   @doc "The base manifest revision, independent of dynamic per-account inputs."
@@ -220,7 +220,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   @doc false
   def manifest(name, image_tag, account, %Regions{} = region, %Server{} = server, hook_script, external_peers \\ []) do
     account_handle = dns_handle(account.name)
-    revision = @manifest_revision <> peers_revision_suffix(external_peers)
+    revision = manifest_revision_string(account, region, external_peers)
     annotations = %{@manifest_revision_annotation => revision}
 
     %{
@@ -272,7 +272,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
           "nodeSelector" => instance_node_selector(region, server),
           "tolerations" => tolerations(region),
           "extensionScript" => hook_script,
-          "extraEnv" => extension_env(region)
+          "extraEnv" => extension_env(account, region)
         }
         |> Enum.reject(fn {_key, value} -> value in [nil, "", false] end)
         |> Map.new()
@@ -315,8 +315,29 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   defp mesh_enabled?(%Regions{provisioner_config: %{mesh: mesh}}) when is_boolean(mesh), do: mesh
   defp mesh_enabled?(_region), do: false
 
+  # The dynamic peer view (KURA_MESH_PEERS_SYNC, see mesh_peers_sync_env/2)
+  # only ever carries self-hosted peers, so it is meaningful exactly for the
+  # accounts that can enroll one. That capability is the `self_hosted_cache`
+  # entitlement — the same predicate `SelfHostedClients.verify/2` authorizes
+  # enrollment with — so gating the sync on it can never diverge from who may
+  # actually join a peer. An account that cannot self-host has a fully static
+  # roster (its managed peers, baked into the manifest), so it has nothing
+  # dynamic to under-replicate to and must not arm Kura's peer-view boot gate.
+  defp mesh_peers_sync_enabled?(account, %Regions{} = region) do
+    mesh_enabled?(region) and Entitlements.allows?(account, :self_hosted_cache)
+  end
+
   defp self_hosted_peers(account, %Regions{} = region) do
     (mesh_enabled?(region) && Mesh.self_hosted_peer_urls(account)) || []
+  end
+
+  # The desired revision the reconciler compares against the live CR's
+  # annotation. Both the reconcile check (manifest_revision/2) and the applied
+  # manifest (manifest/7) build it here so they can never disagree and loop.
+  defp manifest_revision_string(account, %Regions{} = region, peer_urls) do
+    @manifest_revision <>
+      peers_revision_suffix(peer_urls) <>
+      mesh_peers_sync_revision_suffix(account, region)
   end
 
   # Folded into the manifest revision so enrolling or dropping a self-hosted
@@ -333,6 +354,24 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
       |> binary_part(0, 12)
 
     "+peers-" <> digest
+  end
+
+  # Whether KURA_MESH_PEERS_SYNC is set has to be part of the revision, or a
+  # plan change that flips mesh_peers_sync_enabled?/2 would alter the desired
+  # env without altering the revision, and the reconciler (which converges on
+  # the revision alone) would never re-apply — an account upgraded to a
+  # self-hosting plan would keep serving without the peer-view gate armed, the
+  # exact silent under-replication the gate exists to prevent. The marker fires
+  # only for a mesh region whose account is not entitled: that keeps both the
+  # enabled state and every non-mesh region byte-identical to today's revision,
+  # so nothing that already runs with the right env is rolled — only the
+  # mesh-region instances that should shed the variable change revision.
+  defp mesh_peers_sync_revision_suffix(account, region) do
+    if mesh_enabled?(region) and not mesh_peers_sync_enabled?(account, region) do
+      "+nosync"
+    else
+      ""
+    end
   end
 
   defp mesh_public_peer_host(handle, region) do
@@ -397,7 +436,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # that ever runs Kura. The controller's envFrom on the StatefulSet
   # picks up that Secret automatically. Non-secret knobs such as the
   # introspection client ID are safe to keep in the spec.
-  defp extension_env(%Regions{} = region) do
+  defp extension_env(account, %Regions{} = region) do
     [
       env_var("KURA_EXTENSION_FAIL_CLOSED_AUTHENTICATE", "true"),
       env_var("KURA_EXTENSION_FAIL_CLOSED_AUTHORIZE", "true"),
@@ -412,7 +451,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
         Environment.kura_control_plane_client_id()
       ) ++
       cas_capacity_env(region) ++
-      mesh_peers_sync_env(region) ++
+      mesh_peers_sync_env(account, region) ++
       telemetry_env(region)
   end
 
@@ -521,12 +560,17 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   defp storage_multiplier("Ti"), do: 1024 * 1024 * 1024 * 1024
   defp storage_multiplier(_), do: nil
 
-  # Managed pods fetch the account's self-hosted peer list from the control
-  # plane at boot and on cadence, so a self-hosted peer joining or leaving
-  # propagates without rolling the fleet. Once the whole fleet runs an image
-  # that fetches, the peers digest can be dropped from the manifest revision.
-  defp mesh_peers_sync_env(region) do
-    if mesh_enabled?(region) do
+  # Managed pods of self-hosting-capable accounts fetch the account's
+  # self-hosted peer list from the control plane at boot and on cadence, so a
+  # self-hosted peer joining or leaving propagates without rolling the fleet.
+  # The variable also arms Kura's peer-view boot gate, so it is set only for
+  # accounts that can have such peers (see mesh_peers_sync_enabled?/2); folding
+  # the flag into the manifest revision (mesh_peers_sync_revision_suffix/2)
+  # keeps a plan change from silently leaving a running instance ungated. Once
+  # the whole fleet runs an image that fetches, the peers digest can be dropped
+  # from the manifest revision.
+  defp mesh_peers_sync_env(account, region) do
+    if mesh_peers_sync_enabled?(account, region) do
       [env_var("KURA_MESH_PEERS_SYNC", "true")]
     else
       []

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -131,6 +131,75 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert spec["podAnnotations"] == %{"kubernetes.io/egress-bandwidth" => "1500M"}
     end
 
+    test "arms the peer-view sync only for a self-hosting-capable account in a mesh region" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+      # The self-hosting-capable account can enroll a self-hosted peer, so its
+      # pods sync the dynamic peer view and arm Kura's peer-view boot gate.
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+
+      entitled =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %Account{id: 1, name: "tuist"},
+          eu_region(%{mesh: true}),
+          %Server{},
+          "return true"
+        )
+
+      entitled_env = Map.new(entitled["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      assert entitled_env["KURA_MESH_PEERS_SYNC"] == "true"
+
+      # An account that cannot self-host has a fully static roster, so it must
+      # not sync or arm the gate — it would otherwise block its own readiness on
+      # a peer view it can never populate.
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+
+      non_entitled =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %Account{id: 1, name: "tuist"},
+          eu_region(%{mesh: true}),
+          %Server{},
+          "return true"
+        )
+
+      non_entitled_env = Map.new(non_entitled["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      refute Map.has_key?(non_entitled_env, "KURA_MESH_PEERS_SYNC")
+    end
+
+    test "withholds the peer-view sync outside a mesh region even for a self-hosting account" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %Account{id: 1, name: "tuist"},
+          eu_region(),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      refute Map.has_key?(env, "KURA_MESH_PEERS_SYNC")
+    end
+
     test "emits the mesh flag only when the region enables the per-account peer mesh" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 
@@ -700,6 +769,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
   describe "manifest_revision/2" do
     test "matches the base revision when no self-hosted peers are enrolled" do
+      # A non-hosted (self-hosted Tuist) deployment grants every feature, so the
+      # account is sync-enabled and no marker is added — the base-revision case.
+      stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
       stub(Mesh, :self_hosted_peer_urls, fn _ -> [] end)
 
       assert KubernetesController.manifest_revision(%{name: "tuist"}, eu_region(%{mesh: true})) ==
@@ -751,6 +823,51 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       assert KubernetesController.manifest_revision(%{name: "tuist"}, eu_region()) ==
                KubernetesController.manifest_revision()
+    end
+
+    test "crosses a revision boundary on the entitlement so a plan upgrade re-applies" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      # A non-self-hosting account can never enroll a self-hosted peer, so the
+      # only thing separating the two revisions is the sync marker.
+      stub(Mesh, :self_hosted_peer_urls, fn _ -> [] end)
+
+      region = eu_region(%{mesh: true})
+      account = %Account{id: 1, name: "tuist"}
+
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      non_entitled = KubernetesController.manifest_revision(account, region)
+
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      entitled = KubernetesController.manifest_revision(account, region)
+
+      # The upgrade crosses a revision boundary, so the reconciler re-applies
+      # and arms the peer-view gate instead of leaving the instance ungated.
+      refute non_entitled == entitled
+      # The entitled revision stays byte-identical to the base, so instances
+      # already running with sync on are not rolled by this change.
+      assert entitled == KubernetesController.manifest_revision()
+
+      # The rendered manifest stamps the same revision the reconciler computes,
+      # so the two never disagree and loop.
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          account,
+          region,
+          %Server{},
+          "return true"
+        )
+
+      assert manifest["metadata"]["annotations"]["tuist.dev/kura-manifest-revision"] == non_entitled
     end
   end
 


### PR DESCRIPTION
## What changed

`KURA_MESH_PEERS_SYNC` is now set only for accounts entitled to `self_hosted_cache`, instead of for every instance in a mesh-enabled region. The decision is threaded through `extension_env/2` → `mesh_peers_sync_env/2` via a single `mesh_peers_sync_enabled?/2` predicate, and folded into the manifest revision so a plan change re-applies the manifest.

Two files: `server/lib/tuist/kura/provisioner/kubernetes_controller.ex` and its test.

## Why

Follow-up to #11907. That PR fixed the immediate outage (managed pods were 401'd off the peer view by a misplaced entitlement check on Tuist's own control-plane credential) by removing the check at the auth layer — the correct fix, with no pod roll. This PR addresses the residual design issue it left open.

`KURA_MESH_PEERS_SYNC` arms Kura's peer-view boot gate (introduced in #11725). That gate is a **durability invariant**, not an optional-feature toggle: a pod that serves before confirming its authoritative peer roster would accept writes without enqueuing replication for peers it can't see — silent, unrecoverable under-replication. So relaxing the gate is not an option.

But the peer view (`GET /_internal/kura/mesh/peers`) only ever carries **self-hosted** peers — managed-to-managed peers are baked into the manifest statically. An account that cannot self-host therefore has a fully static roster; there is nothing dynamic for it to confirm, so the gate is pure overhead **and** an unnecessary dependency of its readiness path on the control plane being reachable. That dependency is exactly what wedged the instances in #11907.

The capability to have a self-hosted peer is the `self_hosted_cache` entitlement — the same predicate `SelfHostedClients.verify/2` authorizes enrollment with. Gating the sync on it means "we sync peers" can never diverge from "this account may have a peer."

## Why the revision fold is required (not just the env change)

The reconciler converges on `(image_tag, manifest_revision)` alone. If `mesh_peers_sync_enabled?/2` only changed the desired env, a Pro→Enterprise upgrade would change the desired manifest without changing the revision, so the reconciler would never re-apply — the account would gain the ability to enroll a self-hosted peer while its running pods stayed **ungated**, reintroducing the exact under-replication #11725 exists to prevent.

Folding the flag into the revision makes the entitlement flip itself force a re-apply. As a bonus, it removes a hidden dependency: today the peers digest happens to re-apply on first peer enrollment, but that digest is explicitly slated for removal (`kubernetes_controller.ex` comment: "the peers digest can be dropped from the manifest revision"). With this change, correctness no longer rides on the digest, so that removal is safe.

## No unnecessary rolls

`mesh_peers_sync_revision_suffix/2` emits its `+nosync` marker **only** for a mesh region whose account is not entitled. That keeps the revision byte-identical to today's for:

- entitled/enterprise mesh instances (already running with sync on) → not rolled;
- every non-mesh instance → not rolled.

Only the mesh-region instances that should shed the variable change revision and roll once. The #11907 auth fix already returned those instances to health, so that roll is non-urgent.

## Root cause of the original design smell

The peer-view sync was built to let managed instances learn when a self-hosted peer joins/leaves without rolling the fleet, but it was enabled for *every* mesh-region account rather than for the accounts that can actually have such a peer. Because self-hosting is `self_hosted_cache`-gated (Enterprise-only) and adding managed nodes already re-provisions, the correct scope is known at provision time — this change encodes that scope and pins it to the enrollment predicate so the two can't drift.

## Validation

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix credo` (both files) — no issues
- `mix test test/tuist/kura/provisioner/kubernetes_controller_test.exs` — 54 passed
- `mix test test/tuist/kura` — 198 passed

New tests cover: the env is present for an entitled account in a mesh region and absent for a non-entitled one; the env is absent outside a mesh region even when entitled; and the revision crosses a boundary on the entitlement (so an upgrade re-applies) while the entitled revision stays equal to the base (so entitled instances are not rolled), with the rendered annotation matching the reconciler's computed revision.

One existing revision test became ambient-dependent under the change (it used a bare account map, which resolves to a non-entitled plan when `tuist_hosted?` is true in the test env); it is now pinned non-hosted, matching its "no peers → base revision" intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
