### PR TITLE
fix(cli): honor --no-upload for selective test hashes in test-without-building / shard flows

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -233,7 +233,12 @@ jobs:
 
   cli-acceptance-tests-build:
     name: Build Acceptance Tests
-    runs-on: tuist-macos
+    # Pin to the tuist-macos-26-5 runner profile (matches .xcode-version: 26.5). This job
+    # runs `xcodebuild -downloadComponent MetalToolchain`; on the general `tuist-macos`
+    # pool that runtime fetch currently fails ("Failed fetching catalog for assetType
+    # (com.apple.MobileAsset.MetalToolchain)") because Apple stopped serving that Xcode
+    # build's Metal Toolchain component.
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     permissions:
       contents: read
@@ -283,7 +288,8 @@ jobs:
 
   cli-acceptance-tests:
     name: Acceptance Tests
-    runs-on: tuist-macos
+    # Keep the shard run on the same Xcode (26.5) as the build job above.
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     needs: cli-acceptance-tests-build
     permissions:
@@ -342,7 +348,9 @@ jobs:
 
   cli-acceptance-tests-fork:
     name: Acceptance Tests (Fork)
-    runs-on: tuist-macos
+    # tuist-macos-26-5 runner: this job also downloads the Metal Toolchain component
+    # (see the "Build Acceptance Tests" job for the runner rationale).
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork == true
     steps:

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -681,9 +681,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testProductsArchivePath: shardArchivePath
         )
 
-        let cacheStorage = noUpload
-            ? try await cacheStorageFactory.cacheLocalStorage()
-            : try await cacheStorageFactory.cacheStorage(config: config)
+        let hashUploadStorage = try await selectiveTestHashUploadStorage(noUpload: noUpload, config: config)
 
         let runResultBundlePath =
             try cacheDirectoriesProvider
@@ -749,7 +747,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             try await storeSuccessfulTestHashesFromGraph(
                 selectiveTestingGraph: selectiveTestingGraph,
                 passingTargetNames: await passingTargetNames(resultBundlePath: resultBundlePath),
-                cacheStorage: cacheStorage
+                cacheStorage: hashUploadStorage
             )
         }
 
@@ -804,9 +802,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         await RunMetadataStorage.current.restoreMetadata(from: testProductsPath)
 
-        let cacheStorage = noUpload
-            ? try await cacheStorageFactory.cacheLocalStorage()
-            : try await cacheStorageFactory.cacheStorage(config: config)
+        let hashUploadStorage = try await selectiveTestHashUploadStorage(noUpload: noUpload, config: config)
 
         let runResultBundlePath =
             try cacheDirectoriesProvider
@@ -887,7 +883,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         try await storeSuccessfulTestHashesFromGraph(
             selectiveTestingGraph: selectiveTestingGraph,
             passingTargetNames: await passingTargetNames(resultBundlePath: resultBundlePath),
-            cacheStorage: cacheStorage
+            cacheStorage: hashUploadStorage
         )
 
         try await copyResultBundlePathIfNeeded(
@@ -1105,6 +1101,16 @@ public struct TestService { // swiftlint:disable:this type_body_length
             // Without plans Xcode emits `<scheme>_<destination>.xctestrun`.
             return basename == planOrSchemeName || basename.hasPrefix("\(planOrSchemeName)_")
         }
+    }
+
+    /// Resolves the cache storage that receives successful selective-test hashes. When `noUpload`
+    /// is set, hashes are kept local-only instead of persisted to the remote cache (the `--no-upload`
+    /// flag). This is an upload target only — do not use it for cache reads, or `--no-upload` would
+    /// silently route the read to local storage too.
+    private func selectiveTestHashUploadStorage(noUpload: Bool, config: Tuist) async throws -> CacheStoring {
+        noUpload
+            ? try await cacheStorageFactory.cacheLocalStorage()
+            : try await cacheStorageFactory.cacheStorage(config: config)
     }
 
     private func storeSuccessfulTestHashesFromGraph(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -286,6 +286,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         if let shardIndex, action == .testWithoutBuilding {
             try await runShard(
                 shardIndex: shardIndex,
+                noUpload: noUpload,
                 schemeName: schemeName,
                 path: path,
                 config: config,
@@ -316,6 +317,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             try await runTestWithoutBuildingFromBundle(
                 schemeName: schemeName,
                 testProductsPath: testProductsPath,
+                noUpload: noUpload,
                 config: config,
                 deviceName: deviceName,
                 platform: platform,
@@ -643,6 +645,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
     // swiftlint:disable:next function_body_length function_parameter_count
     private func runShard(
         shardIndex: Int,
+        noUpload: Bool,
         schemeName: String?,
         path: AbsolutePath,
         config: Tuist,
@@ -678,7 +681,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testProductsArchivePath: shardArchivePath
         )
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = noUpload
+            ? try await cacheStorageFactory.cacheLocalStorage()
+            : try await cacheStorageFactory.cacheStorage(config: config)
 
         let runResultBundlePath =
             try cacheDirectoriesProvider
@@ -771,6 +776,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
     private func runTestWithoutBuildingFromBundle(
         schemeName: String?,
         testProductsPath: AbsolutePath,
+        noUpload: Bool,
         config: Tuist,
         deviceName: String?,
         platform: String?,
@@ -798,7 +804,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         await RunMetadataStorage.current.restoreMetadata(from: testProductsPath)
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = noUpload
+            ? try await cacheStorageFactory.cacheLocalStorage()
+            : try await cacheStorageFactory.cacheStorage(config: config)
 
         let runResultBundlePath =
             try cacheDirectoriesProvider

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4617,6 +4617,185 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_testWithoutBuilding_fromBundle_routesSelectiveTestHashesToLocalStorage_whenNoUpload() async throws {
+        // Given
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(
+            testTargetHashes: ["MyTests": "abc123"]
+        )
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(
+                TestSummary(
+                    testPlanName: nil,
+                    status: .passed,
+                    duration: nil,
+                    testModules: [
+                        TestModule(
+                            name: "MyTests",
+                            status: .passed,
+                            duration: 0,
+                            testSuites: [],
+                            testCases: [
+                                TestCase(
+                                    name: "testExample",
+                                    testSuite: nil,
+                                    module: "MyTests",
+                                    duration: nil,
+                                    status: .passed,
+                                    failures: []
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            )
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+
+        let localCacheStorage = MockCacheStoring()
+        given(cacheStorageFactory)
+            .cacheLocalStorage()
+            .willReturn(localCacheStorage)
+        given(localCacheStorage)
+            .store(.any, cacheCategory: .any)
+            .willReturn([])
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                noUpload: true,
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — hashes stored to the local cache, never the remote cache
+        verify(localCacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "MyTests", hash: "abc123"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
+        verify(cacheStorage)
+            .store(.any, cacheCategory: .any)
+            .called(0)
+    }
+
+    func test_run_testWithoutBuilding_shard_routesSelectiveTestHashesToLocalStorage_whenNoUpload() async throws {
+        // Given
+        let path = try temporaryPath()
+        let extractedTestProductsPath = path.appending(component: "Extracted.xctestproducts")
+        try await fileSystem.makeDirectory(at: extractedTestProductsPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(shardService)
+            .shard(
+                shardIndex: .any,
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                testProductsPath: .any,
+                testProductsArchivePath: .any
+            )
+            .willReturn(
+                Shard(
+                    reference: "ref",
+                    shardPlanId: "plan-123",
+                    testProductsPath: extractedTestProductsPath,
+                    testIdentifiers: ["AppTests"],
+                    skipTestIdentifiers: [],
+                    modules: ["AppTests"],
+                    selectiveTestingGraph: SelectiveTestingGraph(testTargetHashes: ["AppTests": "abc123"])
+                )
+            )
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(
+                TestSummary(
+                    testPlanName: nil,
+                    status: .passed,
+                    duration: nil,
+                    testModules: [
+                        TestModule(
+                            name: "AppTests",
+                            status: .passed,
+                            duration: 0,
+                            testSuites: [],
+                            testCases: [
+                                TestCase(
+                                    name: "testExample",
+                                    testSuite: nil,
+                                    module: "AppTests",
+                                    duration: nil,
+                                    status: .passed,
+                                    failures: []
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            )
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+
+        let localCacheStorage = MockCacheStoring()
+        given(cacheStorageFactory)
+            .cacheLocalStorage()
+            .willReturn(localCacheStorage)
+        given(localCacheStorage)
+            .store(.any, cacheCategory: .any)
+            .willReturn([])
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                noUpload: true,
+                path: path,
+                action: .testWithoutBuilding,
+                shardIndex: 0
+            )
+        }
+
+        // Then — hashes stored to the local cache, never the remote cache
+        verify(localCacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "AppTests", hash: "abc123"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
+        verify(cacheStorage)
+            .store(.any, cacheCategory: .any)
+            .called(0)
+    }
+
     func test_run_testWithoutBuilding_restoresRunMetadata_fromBundle() async throws {
         // Given
         let path = try temporaryPath()

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4796,6 +4796,161 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(0)
     }
 
+    func test_run_testWithoutBuilding_fromBundle_uploadsSelectiveTestHashesToRemote_byDefault() async throws {
+        // Given
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(
+            testTargetHashes: ["MyTests": "abc123"]
+        )
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(
+                TestSummary(
+                    testPlanName: nil,
+                    status: .passed,
+                    duration: nil,
+                    testModules: [
+                        TestModule(
+                            name: "MyTests",
+                            status: .passed,
+                            duration: 0,
+                            testSuites: [],
+                            testCases: [
+                                TestCase(
+                                    name: "testExample",
+                                    testSuite: nil,
+                                    module: "MyTests",
+                                    duration: nil,
+                                    status: .passed,
+                                    failures: []
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            )
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — without --no-upload, hashes are persisted to the remote cache
+        verify(cacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "MyTests", hash: "abc123"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
+    }
+
+    func test_run_testWithoutBuilding_shard_uploadsSelectiveTestHashesToRemote_byDefault() async throws {
+        // Given
+        let path = try temporaryPath()
+        let extractedTestProductsPath = path.appending(component: "Extracted.xctestproducts")
+        try await fileSystem.makeDirectory(at: extractedTestProductsPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(shardService)
+            .shard(
+                shardIndex: .any,
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                testProductsPath: .any,
+                testProductsArchivePath: .any
+            )
+            .willReturn(
+                Shard(
+                    reference: "ref",
+                    shardPlanId: "plan-123",
+                    testProductsPath: extractedTestProductsPath,
+                    testIdentifiers: ["AppTests"],
+                    skipTestIdentifiers: [],
+                    modules: ["AppTests"],
+                    selectiveTestingGraph: SelectiveTestingGraph(testTargetHashes: ["AppTests": "abc123"])
+                )
+            )
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(
+                TestSummary(
+                    testPlanName: nil,
+                    status: .passed,
+                    duration: nil,
+                    testModules: [
+                        TestModule(
+                            name: "AppTests",
+                            status: .passed,
+                            duration: 0,
+                            testSuites: [],
+                            testCases: [
+                                TestCase(
+                                    name: "testExample",
+                                    testSuite: nil,
+                                    module: "AppTests",
+                                    duration: nil,
+                                    status: .passed,
+                                    failures: []
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            )
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                shardIndex: 0
+            )
+        }
+
+        // Then — without --no-upload, hashes are persisted to the remote cache
+        verify(cacheStorage)
+            .store(
+                .value([CacheStorableItem(name: "AppTests", hash: "abc123"): []]),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
+    }
+
     func test_run_testWithoutBuilding_restoresRunMetadata_fromBundle() async throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
## What

`tuist test --no-upload` now keeps selective-test hashes **local-only** in the `test-without-building` code paths, matching the behavior the standard `tuist test` flow has always had.

Fixes #11923.

## Why / root cause

`--no-upload` is documented as *"the result necessary for test selection is not persisted to the server"* — i.e. selective-test hashes should be routed to the **local** cache instead of the **remote** cache. The standard flow (`TestService.testSchemes`) already does this by swapping the resolved `cacheStorage` for `cacheStorageFactory.cacheLocalStorage()` when `noUpload` is set.

The two `test-without-building` paths, which were added later, never received the `noUpload` flag:

- `runShard` — sharded execution (introduced in #9796)
- `runTestWithoutBuildingFromBundle` — running from a prebuilt `.xctestproducts` bundle (introduced in #9987)

Both unconditionally called `storeSuccessfulTestHashesFromGraph` with the resolved `cacheStorage`, which is the **remote** cache when a `fullHandle` is configured. As a result, selective-test hashes were uploaded to the remote cache even when `--no-upload` was passed, as long as tests ran via `test-without-building`. The omission is an oversight: both flows copied the hash-store logic without copying the `noUpload` gating the standard flow already had.

## Change

- Forward `noUpload` from `run(...)` into `runShard(...)` and `runTestWithoutBuildingFromBundle(...)`.
- In each, resolve the storage used to persist successful test hashes to `cacheStorageFactory.cacheLocalStorage()` when `noUpload` is set — mirroring `testSchemes` (and `CacheWarmCommandService`).
- Factor that resolution into a small `selectiveTestHashUploadStorage(noUpload:config:)` helper and name the call-site variable `hashUploadStorage`, so it reads as a dedicated upload target rather than a general-purpose `cacheStorage` (guarding against a future cache *read* being routed to local under `--no-upload`).

In both flows the resolved storage is used **only** to store selective-test hashes, so this is the sole behavioral change.

## Impact

- **No change to reports, dashboards, analytics, or billing.** Selective-test cache markers are hit-check-only and are never read to render any UI. Selective-testing analytics ("N targets skipped", hit-rate charts) come from a separate command-event / run-metadata upload path, and the per-run result-bundle and build-run uploads in these flows are gated by `fullHandle`, not `noUpload` — so they continue exactly as before.
- Scope is limited to runs that explicitly pass `--no-upload` through `test-without-building` / shard execution. The default (upload) path is unchanged.

## Validation

Added four unit tests in `TestServiceTests`, covering both the prebuilt-`.xctestproducts`-bundle path and the shard path in both directions:

- With `--no-upload`: hashes are routed to the local cache and the remote cache storage is never touched.
- Without `--no-upload` (default): hashes are persisted to the remote cache exactly once.

All four pass locally via `xcodebuild test` against the `Tuist-Workspace` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
