### PR TITLE
feat(infra): enable per-account cache volumes on the production macOS fleet

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -561,17 +561,16 @@ macosFleet:
   # a single host keeps hot once affinity spreads them across the fleet.
   # Kept well under the 512 GB disk, which is dominated by the ~85 GB
   # golden VM image(s) (two during a digest roll) + per-job DerivedData.
-  # DISABLED (2026-07-16): rolling this to the prod fleet broke every
-  # macOS CI job — the guest mounts the virtio-fs cache share and exports
-  # TUIST_XDG_CACHE_HOME at it, but `mkdir -p $CACHE_MOUNT/tuist` in
-  # dispatch-poll.sh fails silently (`2>/dev/null || true`) while the env
-  # var is exported regardless, so the CLI dies with "Couldn't create the
-  # directory at /Volumes/My Shared Files/cache/tuist/... because its
-  # parent directory doesn't exists". Re-enable only once a real CI job
-  # is verified green on a cache-volume host (host-side provisioning
-  # checks are NOT sufficient — that gap is what let this reach prod).
+  # Enabled after the disk-image redesign (#11908): the cache is now a
+  # sparse APFS disk image on the share, not files on it, because virtio-fs
+  # cannot carry a macOS cache faithfully (no xattrs on the symlinks in
+  # versioned framework bundles → the ELOOP that broke every macOS job on
+  # 2026-07-16). Validated end-to-end on a real staging runner (gib: 40):
+  # the framework-with-xattr copy that failed on the old share succeeds
+  # inside the image, and a promoted master clones back warm with symlinks
+  # and xattrs intact.
   runnerCacheVolume:
-    gib: 0
+    gib: 80
   # Production tailnet — alloy-metrics scrapes PromEx (xcresult VM)
   # + node_exporter (host) over the tailnet. The pre-auth key lives
   # in the production 1Password vault under TAILSCALE/auth-key.


### PR DESCRIPTION
## What

Enable per-account cache volumes on the **production** macOS runner fleet — `macosFleet.runnerCacheVolume.gib` 0 → 80. Canary stays 0.

## Why now

The disk-image redesign (#11908) is merged and **live in production**:
- Operator: `capi-provider-scaleway-applesilicon:0.16.3` (new tart-kubelet host code) ✅ verified running in prod
- Guest: runner pods on `tuist-runner:macos-*-0.11.2` (new dispatch-poll.sh) ✅ verified

It was validated end-to-end on a real staging runner (`gib: 40`): the framework-with-xattr-on-symlink copy that ELOOP'd on the old virtio-fs share now succeeds inside the APFS image, and a promoted master clones back warm with symlinks + xattrs intact, including re-signing a read-only artifact in place.

## Safety

- **Order matters and is satisfied:** enabling `gib>0` requires the new disk-image code to be live first, or prod runs the old tree-based path and re-breaks (the 2026-07-16 outage). Confirmed live before this flip.
- **In-place provisioning:** changing `gib` changes `HostConfigHash`, so the drift loop re-pushes host config and provisions the 80 GiB volume on the existing fleet — no host replacement.
- **Sparse:** 80 GiB is a quota ceiling (~30 masters), not an allocation; near-zero initial disk. `masterCapGib` stays at the tart-kubelet default (20).
- **Fail-safe:** any space pressure or unusable share degrades a job to the cold path; it can only cost warmth, never the job.

## After merge

Real prod macOS CI jobs exercise the warm volume. I'll gather the before/after improvement (fleet jobs' local-cache-hit share goes 0 → >0, `cache`/`generate` durations drop) from ClickHouse and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
