### PR TITLE
fix(cli): keep auth login going when the browser can't be opened

### DIFF
--- a/cli/Sources/TuistAuthCommand/Services/LoginCommandService.swift
+++ b/cli/Sources/TuistAuthCommand/Services/LoginCommandService.swift
@@ -19,6 +19,7 @@ public protocol LoginCommandServicing {
 
 public enum LoginCommandServiceEvent: CustomStringConvertible {
     case openingBrowser(URL)
+    case browserOpenFailed
     case waitForAuthentication
     case oidcAuthenticating
     case completed
@@ -27,6 +28,8 @@ public enum LoginCommandServiceEvent: CustomStringConvertible {
         switch self {
         case let .openingBrowser(url):
             "Opening \(url.absoluteString) to start the authentication flow"
+        case .browserOpenFailed:
+            "Couldn't open the browser automatically. Visit the URL above to continue authenticating."
         case .waitForAuthentication:
             "Press CTRL + C once to cancel the process."
         case .oidcAuthenticating:
@@ -156,6 +159,9 @@ public struct LoginCommandService: LoginCommandServicing {
             deviceCodeType: .cli,
             onOpeningBrowser: { authURL in
                 await onEvent(.openingBrowser(authURL))
+            },
+            onBrowserOpenFailed: {
+                await onEvent(.browserOpenFailed)
             },
             onAuthWaitBegin: {
                 await onEvent(.waitForAuthentication)

--- a/cli/Sources/TuistServer/Client/ServerSessionController.swift
+++ b/cli/Sources/TuistServer/Client/ServerSessionController.swift
@@ -41,11 +41,15 @@ public protocol ServerSessionControlling {
     ///     - serverURL: Server URL.
     ///     - deviceCodeType: Type of device origin used for authentication.
     ///     - onOpeningBrowser: Triggered when we begin opening the browser at the given authentication url.
+    ///     - onBrowserOpenFailed: Triggered when the browser could not be opened automatically (e.g. headless
+    ///       environments without a browser opener). The auth URL was already surfaced via `onOpeningBrowser`,
+    ///       so authentication keeps going and the user can open the URL manually.
     ///     - onAuthWaitBegin: Custom callback when we started waiting for the authentication to finish in the browser.
     func authenticate(
         serverURL: URL,
         deviceCodeType: DeviceCodeType,
         onOpeningBrowser: @escaping (URL) async -> Void,
+        onBrowserOpenFailed: @escaping () async -> Void,
         onAuthWaitBegin: @escaping () async -> Void
     ) async throws
 
@@ -95,6 +99,7 @@ public struct ServerSessionController: ServerSessionControlling {
         serverURL: URL,
         deviceCodeType: DeviceCodeType,
         onOpeningBrowser: @escaping (URL) async -> Void,
+        onBrowserOpenFailed: () async -> Void,
         onAuthWaitBegin: () async -> Void
     ) async throws {
         var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
@@ -110,7 +115,15 @@ public struct ServerSessionController: ServerSessionControlling {
 
         await onOpeningBrowser(authURL)
 
-        try opener.open(url: authURL)
+        do {
+            try opener.open(url: authURL)
+        } catch {
+            // Opening the browser is best-effort. In headless environments (remote servers,
+            // containers, or sandboxes without `xdg-open`) launching a browser fails. The auth
+            // URL has already been surfaced to the user via `onOpeningBrowser`, so we notify the
+            // caller and keep polling for the token instead of aborting the whole login flow.
+            await onBrowserOpenFailed()
+        }
 
         await onAuthWaitBegin()
 

--- a/cli/Tests/TuistAuthCommandTests/Services/LoginCommandServiceTests.swift
+++ b/cli/Tests/TuistAuthCommandTests/Services/LoginCommandServiceTests.swift
@@ -64,6 +64,7 @@ struct LoginCommandServiceTests {
                 serverURL: .any,
                 deviceCodeType: .any,
                 onOpeningBrowser: .any,
+                onBrowserOpenFailed: .any,
                 onAuthWaitBegin: .any
             )
             .willReturn(())
@@ -81,6 +82,7 @@ struct LoginCommandServiceTests {
                 serverURL: .any,
                 deviceCodeType: .any,
                 onOpeningBrowser: .any,
+                onBrowserOpenFailed: .any,
                 onAuthWaitBegin: .any
             )
             .called(1)
@@ -249,6 +251,7 @@ struct LoginCommandServiceTests {
                 serverURL: .any,
                 deviceCodeType: .any,
                 onOpeningBrowser: .any,
+                onBrowserOpenFailed: .any,
                 onAuthWaitBegin: .any
             )
             .willReturn(())
@@ -274,6 +277,7 @@ struct LoginCommandServiceTests {
                 serverURL: .any,
                 deviceCodeType: .any,
                 onOpeningBrowser: .any,
+                onBrowserOpenFailed: .any,
                 onAuthWaitBegin: .any
             )
             .willReturn(())
@@ -339,7 +343,13 @@ struct LoginCommandServiceTests {
                 .called(1)
 
             verify(serverSessionController)
-                .authenticate(serverURL: .any, deviceCodeType: .any, onOpeningBrowser: .any, onAuthWaitBegin: .any)
+                .authenticate(
+                    serverURL: .any,
+                    deviceCodeType: .any,
+                    onOpeningBrowser: .any,
+                    onBrowserOpenFailed: .any,
+                    onAuthWaitBegin: .any
+                )
                 .called(0)
         }
 

--- a/cli/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -74,11 +74,52 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             serverURL: serverURL,
             deviceCodeType: .cli,
             onOpeningBrowser: { authURLOpened = $0 },
+            onBrowserOpenFailed: {},
             onAuthWaitBegin: {}
         )
 
         // Then
         XCTAssertEqual(authURLOpened, authURL())
+    }
+
+    func test_authenticate_completes_when_opening_the_browser_fails() async throws {
+        // Given
+        struct BrowserOpenError: Error {}
+        let throwingOpener = MockOpening()
+        given(throwingOpener)
+            .open(url: .any)
+            .willThrow(BrowserOpenError())
+        subject = ServerSessionController(
+            opener: throwingOpener,
+            getAuthTokenService: getAuthTokenService,
+            uniqueIDGenerator: uniqueIDGenerator,
+            serverAuthenticationController: serverAuthenticationController
+        )
+        given(getAuthTokenService)
+            .getAuthToken(serverURL: .any, deviceCode: .any)
+            .willReturn(
+                ServerAuthenticationTokens(
+                    accessToken: "access-token", refreshToken: "refresh-token"
+                )
+            )
+        given(uniqueIDGenerator).uniqueID().willReturn("id")
+
+        // When
+        var authURLOpened: URL?
+        var didReportBrowserOpenFailure = false
+        var didWaitForAuthentication = false
+        try await subject.authenticate(
+            serverURL: serverURL,
+            deviceCodeType: .cli,
+            onOpeningBrowser: { authURLOpened = $0 },
+            onBrowserOpenFailed: { didReportBrowserOpenFailure = true },
+            onAuthWaitBegin: { didWaitForAuthentication = true }
+        )
+
+        // Then
+        XCTAssertEqual(authURLOpened, authURL())
+        XCTAssertTrue(didReportBrowserOpenFailure)
+        XCTAssertTrue(didWaitForAuthentication)
     }
 
     func test_whoami_when_logged_in() async throws {


### PR DESCRIPTION
## What changed

`tuist auth login` now treats opening the browser as **best-effort** instead of mandatory. In the device-code flow, if launching the browser fails, the CLI tells the user (through the same message stream that prints "Opening …" and "Press CTRL + C") and keeps polling for the token, rather than aborting the whole login.

## Why

Running `tuist auth login` in a headless environment (remote server, container, CI sandbox without `xdg-open`) failed with:

```
✖ Error
  Error Domain=NSCocoaErrorDomain Code=260 "The file doesn't exist."
  ... NSFilePath=/usr/bin/xdg-open
```

## Root cause

`ServerSessionController.authenticate` called `try opener.open(url:)` with no error handling. On Linux, `Opener.open(target:wait:)` shells out to `/usr/bin/xdg-open`; when that binary is absent, `Process.run()` throws `ENOENT`. Because the call wasn't caught, the error propagated up and aborted login **before** the CLI ever started polling for the device-code token — even though the auth URL had already been printed for the user to open manually.

## Fix

Wrap the browser-open in a `do/catch`. On failure, `authenticate` invokes a new `onBrowserOpenFailed` callback, which `LoginCommandService` maps to a new `LoginCommandServiceEvent.browserOpenFailed`:

```
Opening https://tuist.dev/auth/device_codes/<code>?type=cli to start the authentication flow
Couldn't open the browser automatically. Visit the URL above to continue authenticating.
Press CTRL + C once to cancel the process.
```

The URL is already surfaced to the user, so on failure we show the hint and continue waiting for authentication. The user opens the URL on any machine and the login completes. This matches how `gh auth login` and other device-code flows behave.

## Why this approach (vs. the obvious alternatives)

- **Surfacing via the event stream, not `Logger`:** an earlier iteration logged the failure with `Logger.current.warning`, but the CLI's non-verbose console handler filters that out (user-facing warnings go through Noora/`AlertController`, and deferred alerts wouldn't show while the command blocks in the poll loop). Emitting a `LoginCommandServiceEvent` prints the hint immediately, right where the user is looking.
- **Best-effort open, not PATH resolution:** making the Linux opener resolve `xdg-open` from `PATH` is a reasonable robustness improvement but does not help headless environments where no browser opener exists at all. Best-effort open is the actual fix; PATH resolution can be a separate follow-up.

## Impact

`tuist auth login` works in headless/remote/CI environments: it prints the URL, tries to open a browser, and (whether or not that succeeds) waits for the user to authenticate.

## Validation

- Added `test_authenticate_completes_when_opening_the_browser_fails`: injects an opener that throws and asserts `authenticate` invokes the browser-open-failed callback and still reaches the wait-for-authentication step instead of throwing.
- Built the CLI **on Linux**, reproducing CI's `cli-linux-build` job (Swift 6.2, `swift build --replace-scm-with-registry`) — compiles clean, 0 errors.
- Ran `tuist auth login` end-to-end on the built Linux binary with `xdg-open` absent: it prints the URL, the new "Couldn't open the browser…" hint, and the "Press CTRL + C" wait line, then polls for the token without crashing (previously it aborted at the browser-open).
- Note: the new unit test is macOS-only (`TuistUnitTestCase` is `#if os(macOS)`), so it runs on the macOS CI jobs, not the Linux ones.
