### PR TITLE
fix(cli): false-positive diagnostics in tuist edit projects

### DIFF
--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -60,9 +60,9 @@ struct ProjectEditorMapper: ProjectEditorMapping {
         projectDescriptionSearchPath: AbsolutePath
     ) async throws -> Graph {
         Logger.current.notice("Building the editable project graph")
-        // Tuist evaluates manifests and compiles helpers with `xcrun swift`/`swiftc`, whose default language mode
-        // is Swift 5.
-        let swiftVersion = Version(5, 0, 0).description
+        // The Swift compiler version and its default language mode can differ. Match edit targets to the language mode
+        // used by the unversioned `swift` and `swiftc` invocations that evaluate manifests and compile helpers.
+        let swiftVersion = try await SwiftVersionProvider.current.swiftDefaultLanguageModeVersion()
 
         let pluginsProject = try await mapPluginsProject(
             pluginManifests: editablePluginManifests,

--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -60,7 +60,9 @@ struct ProjectEditorMapper: ProjectEditorMapping {
         projectDescriptionSearchPath: AbsolutePath
     ) async throws -> Graph {
         Logger.current.notice("Building the editable project graph")
-        let swiftVersion = try await SwiftVersionProvider.current.swiftVersion()
+        // Tuist evaluates manifests and compiles helpers with `xcrun swift`/`swiftc`, whose default language mode
+        // is Swift 5.
+        let swiftVersion = Version(5, 0, 0).description
 
         let pluginsProject = try await mapPluginsProject(
             pluginManifests: editablePluginManifests,
@@ -179,7 +181,8 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 name: "Config",
                 filesGroup: manifestsFilesGroup,
                 targetSettings: baseTargetSettings,
-                sourcePaths: [configPath]
+                sourcePaths: [configPath],
+                excludeSourcesFromBuild: true
             )
         }()
 
@@ -289,6 +292,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                     defaultSettings: .recommended
                 ),
                 sourcePaths: [packageManifestPath],
+                excludeSourcesFromBuild: true,
                 dependencies: dependencies
             )
         }()
@@ -299,6 +303,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 filesGroup: manifestsFilesGroup,
                 targetSettings: targetWithLinkedPluginsSettings,
                 sourcePaths: [projectManifestSourcePath],
+                excludeSourcesFromBuild: true,
                 dependencies: helperAndPluginDependencies
             )
         }
@@ -502,6 +507,9 @@ struct ProjectEditorMapper: ProjectEditorMapping {
     ///   - filesGroup: File group for target.
     ///   - targetSettings: Target's settings.
     ///   - sourcePaths: Target's sources.
+    ///   - excludeSourcesFromBuild: Whether Xcode should exclude the sources from compilation while retaining
+    ///     their original file references.
+    ///   - additionalFilePaths: Additional files shown in the target.
     ///   - dependencies: Target's dependencies.
     /// - Returns: Target for edit project.
     private func editorHelperTarget(
@@ -509,16 +517,26 @@ struct ProjectEditorMapper: ProjectEditorMapping {
         filesGroup: ProjectGroup,
         targetSettings: Settings,
         sourcePaths: [AbsolutePath],
+        excludeSourcesFromBuild: Bool = false,
         additionalFilePaths: [AbsolutePath] = [],
         dependencies: [TargetDependency] = []
     ) -> Target {
-        Target(
+        let settings = excludeSourcesFromBuild
+            ? targetSettings.with(base: targetSettings.base.merging(
+                [
+                    "DEFINES_MODULE": "NO",
+                    "EXCLUDED_SOURCE_FILE_NAMES": .array(sourcePaths.map(\.basename)),
+                ],
+                uniquingKeysWith: { _, new in new }
+            ))
+            : targetSettings
+        return Target(
             name: name,
             destinations: .macOS,
             product: .staticFramework,
             productName: name,
             bundleId: "dev.tuist.${PRODUCT_NAME:rfc1034identifier}",
-            settings: targetSettings,
+            settings: settings,
             sources: sourcePaths.map { SourceFile(path: $0, compilerFlags: nil) },
             filesGroup: filesGroup,
             dependencies: dependencies,

--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -182,7 +182,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 filesGroup: manifestsFilesGroup,
                 targetSettings: baseTargetSettings,
                 sourcePaths: [configPath],
-                excludeSourcesFromBuild: true
+                excludeFromBuildPaths: [configPath]
             )
         }()
 
@@ -216,6 +216,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 filesGroup: manifestsFilesGroup,
                 targetSettings: baseTargetSettings,
                 sourcePaths: templateSources,
+                excludeFromBuildPaths: templateSources,
                 additionalFilePaths: templateResources,
                 dependencies: helpersTarget.flatMap { [TargetDependency.target(name: $0.name)] } ?? []
             )
@@ -292,7 +293,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                     defaultSettings: .recommended
                 ),
                 sourcePaths: [packageManifestPath],
-                excludeSourcesFromBuild: true,
+                excludeFromBuildPaths: [packageManifestPath],
                 dependencies: dependencies
             )
         }()
@@ -303,7 +304,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 filesGroup: manifestsFilesGroup,
                 targetSettings: targetWithLinkedPluginsSettings,
                 sourcePaths: [projectManifestSourcePath],
-                excludeSourcesFromBuild: true,
+                excludeFromBuildPaths: [projectManifestSourcePath],
                 dependencies: helperAndPluginDependencies
             )
         }
@@ -412,6 +413,7 @@ struct ProjectEditorMapper: ProjectEditorMapping {
                 filesGroup: pluginsFilesGroup,
                 targetSettings: targetSettings,
                 sourcePaths: sourcePaths,
+                excludeFromBuildPaths: [pluginManifest] + pluginTemplates,
                 dependencies: []
             )
         }
@@ -507,8 +509,9 @@ struct ProjectEditorMapper: ProjectEditorMapping {
     ///   - filesGroup: File group for target.
     ///   - targetSettings: Target's settings.
     ///   - sourcePaths: Target's sources.
-    ///   - excludeSourcesFromBuild: Whether Xcode should exclude the sources from compilation while retaining
-    ///     their original file references.
+    ///   - excludeFromBuildPaths: Subset of `sourcePaths` that Xcode should keep as file references but exclude
+    ///     from compilation. Used for script-style manifest and template files that produce false-positive
+    ///     diagnostics when compiled as library sources.
     ///   - additionalFilePaths: Additional files shown in the target.
     ///   - dependencies: Target's dependencies.
     /// - Returns: Target for edit project.
@@ -517,19 +520,22 @@ struct ProjectEditorMapper: ProjectEditorMapping {
         filesGroup: ProjectGroup,
         targetSettings: Settings,
         sourcePaths: [AbsolutePath],
-        excludeSourcesFromBuild: Bool = false,
+        excludeFromBuildPaths: [AbsolutePath] = [],
         additionalFilePaths: [AbsolutePath] = [],
         dependencies: [TargetDependency] = []
     ) -> Target {
-        let settings = excludeSourcesFromBuild
-            ? targetSettings.with(base: targetSettings.base.merging(
+        let settings: Settings
+        if excludeFromBuildPaths.isEmpty {
+            settings = targetSettings
+        } else {
+            settings = targetSettings.with(base: targetSettings.base.merging(
                 [
                     "DEFINES_MODULE": "NO",
-                    "EXCLUDED_SOURCE_FILE_NAMES": .array(sourcePaths.map(\.basename)),
+                    "EXCLUDED_SOURCE_FILE_NAMES": .array(excludeFromBuildPaths.map(\.basename)),
                 ],
                 uniquingKeysWith: { _, new in new }
             ))
-            : targetSettings
+        }
         return Target(
             name: name,
             destinations: .macOS,

--- a/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
+++ b/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
@@ -1,15 +1,19 @@
 import Command
 import Foundation
 import Mockable
+import TuistEnvironment
 import TuistLogging
 
 public enum SwiftVersionProviderError: FatalError, Equatable {
     case parseSwiftVersion(String)
+    case parseSwiftDefaultLanguageModeVersion(String)
 
     public var description: String {
         switch self {
         case let .parseSwiftVersion(output):
             return "Couldn't obtain the Swift version from the output: \(output)."
+        case let .parseSwiftDefaultLanguageModeVersion(output):
+            return "Couldn't obtain the default Swift language mode from the output: \(output)."
         }
     }
 
@@ -31,6 +35,10 @@ public protocol SwiftVersionProviding {
     /// - Returns: Swift version including the build number.
     /// - Throws: An error if Swift is not installed or it exists unsuccessfully.
     func swiftlangVersion() async throws -> String
+
+    /// Returns the language mode selected by `xcrun swift` when no language mode is specified,
+    /// normalized for Xcode's `SWIFT_VERSION` build setting.
+    func swiftDefaultLanguageModeVersion() async throws -> String
 }
 
 public struct SwiftVersionProvider: SwiftVersionProviding {
@@ -51,6 +59,22 @@ public struct SwiftVersionProvider: SwiftVersionProviding {
 
     // swiftlint:enable force_try
 
+    static let swiftDefaultLanguageModeVersionProbe = """
+    #if swift(>=6)
+    print("6")
+    #elseif swift(>=5)
+    print("5")
+    #elseif swift(>=4.2)
+    print("4.2")
+    #elseif swift(>=4)
+    print("4")
+    #else
+    print("unsupported")
+    #endif
+    """
+
+    private static let supportedSwiftDefaultLanguageModeVersions: Set<String> = ["4", "4.2", "5", "6"]
+
     public func swiftVersion() async throws -> String {
         try await cachedSwiftVersion.value()
     }
@@ -59,8 +83,13 @@ public struct SwiftVersionProvider: SwiftVersionProviding {
         try await cachedSwiftlangVersion.value()
     }
 
+    public func swiftDefaultLanguageModeVersion() async throws -> String {
+        try await cachedSwiftDefaultLanguageModeVersion.value()
+    }
+
     private let cachedSwiftVersion: AsyncThrowableCaching<String>
     private let cachedSwiftlangVersion: AsyncThrowableCaching<String>
+    private let cachedSwiftDefaultLanguageModeVersion: AsyncThrowableCaching<String>
 
     init(commandRunner: CommandRunning) {
         cachedSwiftVersion = AsyncThrowableCaching<String> {
@@ -85,6 +114,18 @@ public struct SwiftVersionProvider: SwiftVersionProviding {
                 throw SwiftVersionProviderError.parseSwiftVersion(output)
             }
             return NSString(string: output).substring(with: match.range(at: 1)).spm_chomp()
+        }
+
+        cachedSwiftDefaultLanguageModeVersion = AsyncThrowableCaching<String> {
+            let output = try await commandRunner.capture(
+                arguments: ["/usr/bin/xcrun", "swift", "-e", Self.swiftDefaultLanguageModeVersionProbe],
+                environment: Environment.current.manifestLoadingVariables
+            )
+            let version = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard Self.supportedSwiftDefaultLanguageModeVersions.contains(version) else {
+                throw SwiftVersionProviderError.parseSwiftDefaultLanguageModeVersion(output)
+            }
+            return version
         }
     }
 }

--- a/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -18,10 +18,15 @@ import XcodeGraph
 struct ProjectEditorMapperTests {
     private var subject: ProjectEditorMapper!
     private var swiftPackageManagerController: MockSwiftPackageManagerControlling!
+    private var swiftVersionProvider: MockSwiftVersionProviding!
 
-    init() {
+    init() throws {
         Environment.mocked?.stubbedArchitecture = .arm64
         swiftPackageManagerController = MockSwiftPackageManagerControlling()
+        swiftVersionProvider = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProvider)
+            .swiftDefaultLanguageModeVersion()
+            .willReturn("6")
         subject = ProjectEditorMapper(
             swiftPackageManagerController: swiftPackageManagerController
         )
@@ -30,7 +35,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func edit_when_there_are_helpers_and_setup_and_config_and_dependencies_and_tasks_and_plugins() async throws {
         // Given
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
@@ -83,6 +89,9 @@ struct ProjectEditorMapperTests {
 
         // Then
         #expect(graph.name == "TestManifests")
+        verify(swiftVersionProvider)
+            .swiftDefaultLanguageModeVersion()
+            .called(1)
 
         #expect(targets.count == 9)
 
@@ -274,7 +283,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func edit_when_there_are_no_helpers_and_no_setup_and_no_config_and_no_dependencies() async throws {
         // Given
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
@@ -360,7 +370,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func tuist_edit_with_more_than_one_manifest() async throws {
         // Given
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
@@ -485,7 +496,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func tuist_edit_with_one_plugin_no_projects() async throws {
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
         let pluginManifestPaths = [sourceRootPath].map { $0.appending(component: "Plugin.swift") }
@@ -565,7 +577,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func tuist_edit_with_more_than_one_plugin_no_projects() async throws {
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
         let pluginManifestPaths = [
@@ -673,7 +686,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func tuist_edit_plugin_only_takes_required_sources() async throws {
         // Given
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
@@ -733,7 +747,8 @@ struct ProjectEditorMapperTests {
     @Test(
         .withMockedEnvironment(),
         .inTemporaryDirectory,
-        .withMockedXcodeController
+        .withMockedXcodeController,
+        .withMockedSwiftVersionProvider
     ) func tuist_edit_project_with_plugin() async throws {
         // Given
         let sourceRootPath = try #require(FileSystem.temporaryTestDirectory)
@@ -888,7 +903,7 @@ struct ProjectEditorMapperTests {
                 "FRAMEWORK_SEARCH_PATHS": .array(paths),
                 "LIBRARY_SEARCH_PATHS": .array(paths),
                 "SWIFT_INCLUDE_PATHS": .array(paths),
-                "SWIFT_VERSION": .string("5.0.0"),
+                "SWIFT_VERSION": .string("6"),
             ],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended

--- a/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -19,12 +19,7 @@ struct ProjectEditorMapperTests {
     private var subject: ProjectEditorMapper!
     private var swiftPackageManagerController: MockSwiftPackageManagerControlling!
 
-    init() throws {
-        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
-        given(swiftVersionProviderMock)
-            .swiftVersion()
-            .willReturn("5.2")
-
+    init() {
         Environment.mocked?.stubbedArchitecture = .arm64
         swiftPackageManagerController = MockSwiftPackageManagerControlling()
         subject = ProjectEditorMapper(
@@ -34,7 +29,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func edit_when_there_are_helpers_and_setup_and_config_and_dependencies_and_tasks_and_plugins() async throws {
@@ -104,7 +98,10 @@ struct ProjectEditorMapperTests {
         #expect(manifestsTarget.product == .staticFramework)
         #expect(
             manifestsTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: projectManifestPaths[0]
+                )
         )
         #expect(manifestsTarget.sources.map(\.path) == projectManifestPaths)
         #expect(manifestsTarget.filesGroup == projectsGroup)
@@ -197,7 +194,10 @@ struct ProjectEditorMapperTests {
         #expect(configTarget.product == .staticFramework)
         #expect(
             configTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: configPath
+                )
         )
         #expect(configTarget.sources.map(\.path) == [configPath])
         #expect(configTarget.filesGroup == projectsGroup)
@@ -217,6 +217,8 @@ struct ProjectEditorMapperTests {
         expectedPackagesSettings = expectedPackagesSettings.with(
             base: expectedPackagesSettings.base.merging(
                 [
+                    "DEFINES_MODULE": "NO",
+                    "EXCLUDED_SOURCE_FILE_NAMES": .array([packageManifestPath.basename]),
                     "OTHER_SWIFT_FLAGS": .array([
                         "-package-description-version",
                         "5.5.0",
@@ -271,7 +273,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func edit_when_there_are_no_helpers_and_no_setup_and_no_config_and_no_dependencies() async throws {
@@ -323,7 +324,10 @@ struct ProjectEditorMapperTests {
         #expect(manifestsTarget.product == .staticFramework)
         #expect(
             manifestsTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: projectManifestPaths[0]
+                )
         )
         #expect(manifestsTarget.sources.map(\.path) == projectManifestPaths)
         #expect(manifestsTarget.filesGroup == projectsGroup)
@@ -355,7 +359,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func tuist_edit_with_more_than_one_manifest() async throws {
@@ -365,7 +368,7 @@ struct ProjectEditorMapperTests {
         let otherProjectPath = "Module"
         let projectManifestPaths = [
             sourceRootPath.appending(component: "Project.swift"),
-            sourceRootPath.appending(component: otherProjectPath).appending(component: "Project.swift"),
+            sourceRootPath.appending(component: otherProjectPath).appending(component: "Workspace.swift"),
         ]
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
@@ -410,7 +413,10 @@ struct ProjectEditorMapperTests {
         #expect(manifestOneTarget.product == .staticFramework)
         #expect(
             manifestOneTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: try #require(projectManifestPaths.last)
+                )
         )
         #expect(manifestOneTarget.sources.map(\.path) == [try #require(projectManifestPaths.last)])
         #expect(manifestOneTarget.filesGroup == .group(name: projectName))
@@ -426,7 +432,10 @@ struct ProjectEditorMapperTests {
         #expect(manifestTwoTarget.product == .staticFramework)
         #expect(
             manifestTwoTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: try #require(projectManifestPaths.first)
+                )
         )
         #expect(manifestTwoTarget.sources.map(\.path) == [try #require(projectManifestPaths.first)])
         #expect(manifestTwoTarget.filesGroup == .group(name: projectName))
@@ -440,7 +449,10 @@ struct ProjectEditorMapperTests {
         #expect(configTarget.product == .staticFramework)
         #expect(
             configTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePath: configPath
+                )
         )
         #expect(configTarget.sources.map(\.path) == [configPath])
         #expect(configTarget.filesGroup == .group(name: projectName))
@@ -472,7 +484,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func tuist_edit_with_one_plugin_no_projects() async throws {
@@ -553,7 +564,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func tuist_edit_with_more_than_one_plugin_no_projects() async throws {
@@ -662,7 +672,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func tuist_edit_plugin_only_takes_required_sources() async throws {
@@ -723,7 +732,6 @@ struct ProjectEditorMapperTests {
 
     @Test(
         .withMockedEnvironment(),
-        .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
     ) func tuist_edit_project_with_plugin() async throws {
@@ -819,12 +827,15 @@ struct ProjectEditorMapperTests {
         )
         #expect(
             manifestsTarget.settings ==
-                expectedSettings(includePaths: [
-                    projectDescriptionPath,
-                    projectDescriptionPath.parentDirectory,
-                    // Manifests can include plugins
-                    remotePlugin.path.parentDirectory,
-                ])
+                expectedManifestSettings(
+                    includePaths: [
+                        projectDescriptionPath,
+                        projectDescriptionPath.parentDirectory,
+                        // Manifests can include plugins
+                        remotePlugin.path.parentDirectory,
+                    ],
+                    sourcePath: projectManifestPaths[0]
+                )
         )
 
         // Generated manifests Project
@@ -877,10 +888,21 @@ struct ProjectEditorMapperTests {
                 "FRAMEWORK_SEARCH_PATHS": .array(paths),
                 "LIBRARY_SEARCH_PATHS": .array(paths),
                 "SWIFT_INCLUDE_PATHS": .array(paths),
-                "SWIFT_VERSION": .string("5.2"),
+                "SWIFT_VERSION": .string("5.0.0"),
             ],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         )
+    }
+
+    private func expectedManifestSettings(includePaths: [AbsolutePath], sourcePath: AbsolutePath) -> Settings {
+        let settings = expectedSettings(includePaths: includePaths)
+        return settings.with(base: settings.base.merging(
+            [
+                "DEFINES_MODULE": "NO",
+                "EXCLUDED_SOURCE_FILE_NAMES": .array([sourcePath.basename]),
+            ],
+            uniquingKeysWith: { _, new in new }
+        ))
     }
 }

--- a/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -109,7 +109,7 @@ struct ProjectEditorMapperTests {
             manifestsTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: projectManifestPaths[0]
+                    sourcePaths: [projectManifestPaths[0]]
                 )
         )
         #expect(manifestsTarget.sources.map(\.path) == projectManifestPaths)
@@ -148,7 +148,10 @@ struct ProjectEditorMapperTests {
         #expect(templatesTarget.product == .staticFramework)
         #expect(
             templatesTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePaths: templates
+                )
         )
         #expect(templatesTarget.sources.map(\.path) == templates)
         #expect(templatesTarget.additionalFiles.map(\.path) == templateResource)
@@ -205,7 +208,7 @@ struct ProjectEditorMapperTests {
             configTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: configPath
+                    sourcePaths: [configPath]
                 )
         )
         #expect(configTarget.sources.map(\.path) == [configPath])
@@ -336,7 +339,7 @@ struct ProjectEditorMapperTests {
             manifestsTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: projectManifestPaths[0]
+                    sourcePaths: [projectManifestPaths[0]]
                 )
         )
         #expect(manifestsTarget.sources.map(\.path) == projectManifestPaths)
@@ -426,7 +429,7 @@ struct ProjectEditorMapperTests {
             manifestOneTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: try #require(projectManifestPaths.last)
+                    sourcePaths: [try #require(projectManifestPaths.last)]
                 )
         )
         #expect(manifestOneTarget.sources.map(\.path) == [try #require(projectManifestPaths.last)])
@@ -445,7 +448,7 @@ struct ProjectEditorMapperTests {
             manifestTwoTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: try #require(projectManifestPaths.first)
+                    sourcePaths: [try #require(projectManifestPaths.first)]
                 )
         )
         #expect(manifestTwoTarget.sources.map(\.path) == [try #require(projectManifestPaths.first)])
@@ -462,7 +465,7 @@ struct ProjectEditorMapperTests {
             configTarget.settings ==
                 expectedManifestSettings(
                     includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
-                    sourcePath: configPath
+                    sourcePaths: [configPath]
                 )
         )
         #expect(configTarget.sources.map(\.path) == [configPath])
@@ -546,7 +549,10 @@ struct ProjectEditorMapperTests {
         #expect(pluginTarget.product == .staticFramework)
         #expect(
             pluginTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePaths: pluginManifestPaths
+                )
         )
         #expect(pluginTarget.sources.map(\.path) == pluginManifestPaths)
         #expect(pluginTarget.filesGroup == projectsGroup)
@@ -630,7 +636,10 @@ struct ProjectEditorMapperTests {
         #expect(firstPluginTarget.product == .staticFramework)
         #expect(
             firstPluginTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePaths: [pluginManifestPaths[0]]
+                )
         )
         #expect(firstPluginTarget.sources.map(\.path) == [pluginManifestPaths[0]])
         #expect(firstPluginTarget.filesGroup == projectsGroup)
@@ -643,7 +652,10 @@ struct ProjectEditorMapperTests {
         #expect(secondPluginTarget.product == .staticFramework)
         #expect(
             secondPluginTarget.settings ==
-                expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePaths: [pluginManifestPaths[1]]
+                )
         )
         #expect(secondPluginTarget.sources.map(\.path) == [pluginManifestPaths[1]])
         #expect(secondPluginTarget.filesGroup == projectsGroup)
@@ -742,6 +754,15 @@ struct ProjectEditorMapperTests {
             pluginTarget.sources.sorted(by: { $0.path < $1.path }) ==
                 ([pluginManifestPath] + helperSources + templateSources).map { SourceFile(path: $0) }
         )
+
+        // Plugin manifest and template sources are excluded from compilation; helpers are not.
+        #expect(
+            pluginTarget.settings ==
+                expectedManifestSettings(
+                    includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory],
+                    sourcePaths: [pluginManifestPath] + templateSources
+                )
+        )
     }
 
     @Test(
@@ -803,10 +824,13 @@ struct ProjectEditorMapperTests {
         #expect(localPluginTarget.dependencies.isEmpty)
         #expect(
             localPluginTarget.settings ==
-                expectedSettings(includePaths: [
-                    projectDescriptionPath,
-                    projectDescriptionPath.parentDirectory,
-                ])
+                expectedManifestSettings(
+                    includePaths: [
+                        projectDescriptionPath,
+                        projectDescriptionPath.parentDirectory,
+                    ],
+                    sourcePaths: [localPlugin.path.appending(component: "Plugin.swift")]
+                )
         )
 
         // ProjectDescriptionHelpers target
@@ -849,7 +873,7 @@ struct ProjectEditorMapperTests {
                         // Manifests can include plugins
                         remotePlugin.path.parentDirectory,
                     ],
-                    sourcePath: projectManifestPaths[0]
+                    sourcePaths: [projectManifestPaths[0]]
                 )
         )
 
@@ -910,12 +934,12 @@ struct ProjectEditorMapperTests {
         )
     }
 
-    private func expectedManifestSettings(includePaths: [AbsolutePath], sourcePath: AbsolutePath) -> Settings {
+    private func expectedManifestSettings(includePaths: [AbsolutePath], sourcePaths: [AbsolutePath]) -> Settings {
         let settings = expectedSettings(includePaths: includePaths)
         return settings.with(base: settings.base.merging(
             [
                 "DEFINES_MODULE": "NO",
-                "EXCLUDED_SOURCE_FILE_NAMES": .array([sourcePath.basename]),
+                "EXCLUDED_SOURCE_FILE_NAMES": .array(sourcePaths.map(\.basename)),
             ],
             uniquingKeysWith: { _, new in new }
         ))

--- a/cli/Tests/TuistSupportTests/Swift/SwiftVersionProviderTests.swift
+++ b/cli/Tests/TuistSupportTests/Swift/SwiftVersionProviderTests.swift
@@ -1,0 +1,63 @@
+import Command
+import Mockable
+import Testing
+import TuistEnvironment
+@testable import TuistSupport
+
+struct SwiftVersionProviderTests {
+    private let commandRunner = MockCommandRunning()
+    private let subject: SwiftVersionProvider
+
+    init() {
+        subject = SwiftVersionProvider(commandRunner: commandRunner)
+    }
+
+    @Test func swift_default_language_mode_version_returns_canonical_version_and_caches_it() async throws {
+        given(commandRunner)
+            .run(
+                arguments: .value([
+                    "/usr/bin/xcrun",
+                    "swift",
+                    "-e",
+                    SwiftVersionProvider.swiftDefaultLanguageModeVersionProbe,
+                ]),
+                environment: .value(Environment.current.manifestLoadingVariables),
+                workingDirectory: .any
+            )
+            .willReturn(outputStream("5\n"))
+
+        let first = try await subject.swiftDefaultLanguageModeVersion()
+        let second = try await subject.swiftDefaultLanguageModeVersion()
+
+        #expect(first == "5")
+        #expect(second == "5")
+        verify(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .called(1)
+    }
+
+    @Test func swift_default_language_mode_version_throws_on_unexpected_output() async throws {
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(outputStream("5.10\n"))
+
+        await #expect(throws: SwiftVersionProviderError.parseSwiftDefaultLanguageModeVersion("5.10\n")) {
+            try await subject.swiftDefaultLanguageModeVersion()
+        }
+    }
+
+    private func outputStream(_ output: String) -> AsyncThrowingStream<CommandEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(.standardOutput(Array(output.utf8)))
+            continuation.finish()
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Keep manifest source files visible in the editable project while excluding project, workspace, config, and package manifests from compilation where appropriate.
- Disable module definition for those non-buildable manifest targets.
- Add a cached `SwiftVersionProvider.swiftDefaultLanguageModeVersion()` probe that asks the selected toolchain which Swift language mode it uses when no mode is specified.
- Use that language mode for the edit project's `SWIFT_VERSION` setting.
- Add focused mapper and provider coverage.

The existing generated-project `defaultSwiftVersion` behavior remains unchanged; this adjustment is scoped to projects created by `tuist edit`.

## Why

The edit project modeled manifests as static-framework sources. Xcode consequently tried to compile script-style manifest files as library code, producing false diagnostics such as “expressions are not allowed at the top level.”

The edit project also derived `SWIFT_VERSION` from the compiler's product version. A compiler version and its default Swift language mode are different concepts, so this could make Xcode diagnose manifests with concurrency semantics that differ from the unversioned `swift` and `swiftc` invocations Tuist uses to evaluate manifests and compile helpers.

Excluding non-buildable manifest sources and matching the selected toolchain's default language mode keeps Xcode's editor diagnostics aligned with Tuist's actual manifest-loading behavior.

## Impact

Developers opening a project generated by `tuist edit` should no longer see the false top-level-expression and Swift concurrency diagnostics covered by this change. Manifest files remain navigable and editable in Xcode.

## Validation

Validated with Xcode 26.6 and a locally built Tuist binary:

- `TuistSupportTests/SwiftVersionProviderTests`
- `TuistKitTests/ProjectEditorMapperTests`
- Tuist CLI build
- `tuist edit --permanent` plus Manifests workspace builds for DemoKit and OpenSwiftUI/Example