### PR TITLE
fix(status): render Markdown in incident updates

### DIFF
--- a/status/AGENTS.md
+++ b/status/AGENTS.md
@@ -13,7 +13,7 @@ status/
 │   │   └── fake-status.ts  # Runtime dev/demo fixture used when USE_FAKE_DATA=true
 │   ├── types.ts
 │   └── views/
-│       ├── page.ts        # HTML rendering with hono/html (uses real Noora class names + data-* parts)
+│       ├── page.ts        # HTML rendering with hono/html; incident update bodies are rendered as safe Markdown
 │       ├── feed.ts        # RSS 2.0 + Atom 1.0 renderers
 │       ├── logo.ts        # Inlined Tuist mark (verbatim copy of noora/lib/noora/icons/brand-tuist.svg)
 │       ├── icons.ts       # Inlined Tabler/Noora status icons used by noora-banner and noora-status-badge

--- a/status/aube-lock.yaml
+++ b/status/aube-lock.yaml
@@ -50,8 +50,10 @@ time:
   '@speed-highlight/core@1.2.15': 2026-03-18T12:49:31.000Z
   '@standard-schema/spec@1.1.0': 2025-12-15T20:49:46.431Z
   '@types/chai@5.2.3': 2025-10-20T23:32:43.277Z
+  '@types/debug@4.1.13': 2026-03-19T06:47:23.938Z
   '@types/deep-eql@4.0.2': 2023-11-07T01:34:12.026Z
   '@types/estree@1.0.8': 2025-06-06T00:04:34.692Z
+  '@types/ms@2.1.0': 2025-01-16T21:02:46.181Z
   '@vitest/expect@4.1.5': 2026-04-21T11:03:51.080Z
   '@vitest/mocker@4.1.5': 2026-04-21T11:03:36.716Z
   '@vitest/pretty-format@4.1.5': 2026-04-21T11:03:24.603Z
@@ -62,9 +64,14 @@ time:
   assertion-error@2.0.1: 2023-10-18T18:04:13.507Z
   blake3-wasm@2.1.5: 2020-11-29T08:20:10.136Z
   chai@6.2.2: 2025-12-22T21:26:03.989Z
+  character-entities@2.0.2: 2022-06-22T14:01:06.906Z
   convert-source-map@2.0.0: 2022-10-17T22:06:48.628Z
   cookie@1.1.1: 2025-11-26T17:50:20.759Z
+  debug@4.4.3: 2025-09-13T17:25:19.732Z
+  decode-named-character-reference@1.3.0: 2026-01-19T19:53:01.619Z
+  dequal@2.0.3: 2022-07-11T23:29:04.965Z
   detect-libc@2.1.2: 2025-10-05T12:46:33.077Z
+  devlop@1.1.0: 2023-06-29T15:17:11.346Z
   error-stack-parser-es@1.0.5: 2025-01-09T08:51:58.305Z
   es-module-lexer@2.1.0: 2026-04-25T22:50:31.041Z
   esbuild@0.27.3: 2026-02-05T22:03:47.060Z
@@ -84,7 +91,28 @@ time:
   lightningcss-win32-x64-msvc@1.32.0: 2026-03-09T04:23:33.073Z
   lightningcss@1.32.0: 2026-03-09T04:23:43.754Z
   magic-string@0.30.21: 2025-10-24T00:59:47.122Z
+  micromark-core-commonmark@2.0.3: 2025-02-27T13:49:35.477Z
+  micromark-factory-destination@2.0.1: 2024-11-12T11:16:55.545Z
+  micromark-factory-label@2.0.1: 2024-11-12T11:16:59.169Z
+  micromark-factory-space@2.0.1: 2024-11-12T11:17:03.021Z
+  micromark-factory-title@2.0.1: 2024-11-12T11:17:06.622Z
+  micromark-factory-whitespace@2.0.1: 2024-11-12T11:17:10.261Z
+  micromark-util-character@2.1.1: 2024-11-12T11:17:13.750Z
+  micromark-util-chunked@2.0.1: 2024-11-12T11:17:17.117Z
+  micromark-util-classify-character@2.0.1: 2024-11-12T11:17:20.461Z
+  micromark-util-combine-extensions@2.0.1: 2024-11-12T11:17:23.680Z
+  micromark-util-decode-numeric-character-reference@2.0.2: 2024-11-12T11:17:27.210Z
+  micromark-util-encode@2.0.1: 2024-11-12T11:17:34.206Z
+  micromark-util-html-tag-name@2.0.1: 2024-11-12T11:17:37.806Z
+  micromark-util-normalize-identifier@2.0.1: 2024-11-12T11:17:41.347Z
+  micromark-util-resolve-all@2.0.1: 2024-11-12T11:17:45.019Z
+  micromark-util-sanitize-uri@2.0.1: 2024-11-12T11:17:48.745Z
+  micromark-util-subtokenize@2.1.0: 2025-02-27T13:48:52.891Z
+  micromark-util-symbol@2.0.1: 2024-11-12T11:17:55.709Z
+  micromark-util-types@2.0.2: 2025-02-27T13:55:27.982Z
+  micromark@4.0.2: 2025-02-27T14:04:03.516Z
   miniflare@4.20260430.0: 2026-04-30T16:58:59.116Z
+  ms@2.1.3: 2020-12-08T13:54:35.223Z
   nanoid@3.3.12: 2026-04-30T22:04:14.515Z
   obug@2.1.1: 2025-11-22T09:31:55.146Z
   path-to-regexp@6.3.0: 2024-09-12T01:09:36.065Z
@@ -129,6 +157,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.12.16
+      micromark:
+        specifier: ^4.0.2
+        version: 4.0.2
       vite:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.0.10(esbuild@0.27.3)
@@ -456,11 +487,17 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -502,6 +539,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -509,9 +549,26 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -629,10 +686,73 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
   miniflare@4.20260430.0:
     resolution: {integrity: sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -972,9 +1092,15 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/ms@2.1.0': {}
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1022,11 +1148,27 @@ snapshots:
 
   chai@6.2.2: {}
 
+  character-entities@2.0.2: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   error-stack-parser-es@1.0.5: {}
 
@@ -1090,6 +1232,130 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   miniflare@4.20260430.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -1098,6 +1364,8 @@ snapshots:
       workerd: 1.20260430.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
+
+  ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 

--- a/status/package.json
+++ b/status/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "feed": "^4.2.2",
-    "hono": "^4.7.10"
+    "hono": "^4.7.10",
+    "micromark": "^4.0.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251101.0",

--- a/status/src/dev/fake-status.ts
+++ b/status/src/dev/fake-status.ts
@@ -87,7 +87,7 @@ export function fakeStatus(): StatusSnapshot {
         {
           at: hoursAgo(47),
           status: "resolved",
-          body: "Sign-in is fully restored. Postmortem to follow.",
+          body: "Sign-in is fully restored. Follow the [incident review](https://github.com/tuist/tuist/pulls) for more details.",
         },
         {
           at: hoursAgo(48),

--- a/status/src/views/page.test.ts
+++ b/status/src/views/page.test.ts
@@ -21,13 +21,13 @@ describe("statusPage", () => {
               at: "2026-07-17T15:42:00.000Z",
               status: "monitoring",
               title: "Mitigation applied, monitoring impact",
-              body: "Cache authentication is recovering after the configuration change.",
+              body: "Cache authentication is **recovering** after the [configuration change](https://example.com/change).",
             },
             {
               at: "2026-07-17T15:18:00.000Z",
               status: "investigating",
               title: "Investigating",
-              body: "We are investigating authentication failures against the cache.",
+              body: "We are investigating authentication failures against the cache. <script>alert('unsafe')</script> [unsafe](javascript:alert(1))",
             },
           ],
         },
@@ -40,8 +40,13 @@ describe("statusPage", () => {
 
     expect(output).toContain('ol data-part="updates"');
     expect(output).toContain("Mitigation applied, monitoring impact.");
-    expect(output).toContain("Cache authentication is recovering after the configuration change.");
+    expect(output).toContain(
+      'Cache authentication is <strong>recovering</strong> after the <a href="https://example.com/change">configuration change</a>.',
+    );
     expect(output).toContain("Investigating.");
-    expect(output).toContain("We are investigating authentication failures against the cache.");
+    expect(output).toContain(
+      "We are investigating authentication failures against the cache. &lt;script&gt;alert('unsafe')&lt;/script&gt; <a href=\"\">unsafe</a>",
+    );
+    expect(output).not.toContain("<script>alert('unsafe')</script>");
   });
 });

--- a/status/src/views/page.ts
+++ b/status/src/views/page.ts
@@ -1,5 +1,6 @@
 import { html, raw } from "hono/html";
 import type { HtmlEscapedString } from "hono/utils/html";
+import { micromark } from "micromark";
 import type { Component, ComponentStatus, Incident, IncidentSeverity, StatusSnapshot } from "../types.js";
 import {
   ICON_ALERT_CIRCLE,
@@ -167,9 +168,13 @@ function incidentBlock(incident: Incident): Renderable {
   const updates = incident.updates.map((u) => {
     const title = u.title?.trim() || INCIDENT_STATUS_LABEL[u.status];
     const punctuation = /[.!?]$/.test(title) ? "" : ".";
+    const body = micromark(u.body, { allowDangerousHtml: false, allowDangerousProtocol: false });
     return html`<li>
       <time data-part="time" datetime="${u.at}">${formatDate(u.at)}</time>
-      <div data-part="body"><span data-part="status">${title}${punctuation}</span> ${u.body}</div>
+      <div data-part="body">
+        <span data-part="status">${title}${punctuation}</span>
+        <div data-part="markdown">${raw(body)}</div>
+      </div>
     </li>`;
   });
   return html`<article class="status-incident" id="${incident.id}">

--- a/status/src/views/styles.ts
+++ b/status/src/views/styles.ts
@@ -134,9 +134,43 @@ main {
         padding-top: 0.0625rem;
       }
 
-      & > [data-part="body"] > [data-part="status"] {
-        font-weight: var(--noora-font-weight-medium);
-        color: var(--noora-surface-label-primary);
+      & > [data-part="body"] {
+        min-width: 0;
+
+        & > [data-part="status"] {
+          font-weight: var(--noora-font-weight-medium);
+          color: var(--noora-surface-label-primary);
+        }
+
+        & > [data-part="markdown"] {
+          display: contents;
+
+          & > p {
+            margin: var(--noora-spacing-3) 0 0;
+          }
+
+          & > p:first-child {
+            display: inline;
+            margin: 0;
+          }
+
+          & > ul,
+          & > ol {
+            margin: var(--noora-spacing-3) 0 0;
+            padding-left: var(--noora-spacing-7);
+          }
+
+          & a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+            overflow-wrap: anywhere;
+          }
+
+          & code {
+            font-family: var(--noora-font-code);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## What changed

Incident update bodies on the public status page now render Markdown links, emphasis, lists, and inline code. The timeline styles keep the first paragraph alongside the update status while giving longer Markdown content appropriate spacing.

The fake status fixture now contains a Markdown link so the behavior is visible during local development. Regression coverage verifies both successful rendering and safe handling of embedded markup and unsafe link protocols.

## Why

Grafana incident updates can contain Markdown. Rendering those bodies as plain text exposed the Markdown delimiters to visitors and made links such as deployment and pull request references unusable.

## Root cause

The status page interpolated each incident update body directly into the escaped page template. This correctly prevented arbitrary markup from executing, but it also meant Markdown was never parsed.

## Approach

The page now passes only the incident update body through Micromark before inserting the result. Raw markup and unsafe link protocols remain disabled, while the separately rendered update status keeps its existing typography and punctuation.

## Impact

Status page visitors can follow links and read formatted incident updates without seeing raw Markdown syntax. There are no configuration or migration changes.

## Before

![Status page showing raw Markdown link syntax](https://github.com/user-attachments/assets/dac18cef-b280-4b41-a480-085da7ca27e1)

## After

![Status page showing the rendered incident review link](https://github.com/user-attachments/assets/792b0365-ea11-4072-a86c-bedee52db020)

### How to test locally

From `status/`, start the development server with fake data and open the local status page:

```sh
aube run dev -- --var USE_FAKE_DATA:true
```

The resolved dashboard incident under “Past 14 days” should display “incident review” as an underlined, clickable link without Markdown delimiters.

## Validation

- `aube run format:check`
- `aube run typecheck`
- `aube run test` (20 tests passed)
- `mise run build`
- Before-and-after verification in headless Chrome at a 1440 by 1400 pixel viewport
