### PR TITLE
fix(infra): point Product Usage Postgres panels at the live CNPG datasource

### DIFF
--- a/infra/grafana-dashboards/product-usage.json
+++ b/infra/grafana-dashboards/product-usage.json
@@ -48,7 +48,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "format": "table",
@@ -248,7 +248,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "dataset": "postgres",
@@ -360,7 +360,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -504,7 +504,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -661,7 +661,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -830,7 +830,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -1090,7 +1090,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "dataset": "postgres",
@@ -1242,7 +1242,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "format": "table",
@@ -1425,7 +1425,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
@@ -1507,7 +1507,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
@@ -1618,7 +1618,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
@@ -1730,7 +1730,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "format": "table",
@@ -1882,7 +1882,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "dataset": "postgres",
@@ -2044,7 +2044,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "format": "table",
@@ -2400,7 +2400,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "dataset": "postgres",
@@ -2770,7 +2770,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -3612,7 +3612,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -3816,7 +3816,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -3927,7 +3927,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -4038,7 +4038,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",
@@ -4913,7 +4913,7 @@
                       "group": "grafana-postgresql-datasource",
                       "version": "v0",
                       "datasource": {
-                        "name": "denpzjx6h7280b"
+                        "name": "afscyehfnzg8wf"
                       },
                       "spec": {
                         "editorMode": "code",


### PR DESCRIPTION
> Follow-up to #11893.

## What

Repoints the Product Usage dashboard's 21 Postgres panels from datasource `denpzjx6h7280b` to `afscyehfnzg8wf` (**Tuist Production DB**).

## Why

#11893 stood up the PDC tunnel, the `tuist_grafana_ro` role, and its grants, and repointed nothing — the panels still referenced `denpzjx6h7280b`, the legacy Supabase "Production Database". That datasource has since been deleted and replaced by `Tuist Production DB` (CNPG `-ro` replica, `tuist_grafana_ro`, over PDC), so the panels errored with a dangling reference instead of rendering. The repoint was meant to be the final step of #11893 but was left out before merge.

ClickHouse panels are untouched (separate datasource) and were always fine.

## Validation

The target datasource is live in production now: `SELECT count(*) FROM projects` through it returns 3936, no error — so the PDC agent, the role, and the column grants are all working. This change only redirects the panels at the datasource that already works.

Once this merges and Git Sync pulls (~5 min), the dashboard's Postgres panels render production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)