### PR TITLE
feat(infra): detection + NIC-flap observability for DB connection stalls

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -280,11 +280,27 @@ k8s-monitoring:
           # throughput against the Hetzner kura nodes.
           - node_network_receive_bytes_total
           - node_network_transmit_bytes_total
+          # NIC link-state + error signals so a host NIC/datapath flap is
+          # directly visible per-node. 2026-07-20 incident: the Postgres
+          # primary's node eth0 flapped for ~7s (isolating it from its
+          # replicas → a fleet-wide sync-commit stall), but with no NIC
+          # metric the flap was only *inferable* from Cilium's qdisc-reset
+          # burst, and the node's own journal was lost because its log
+          # shipper sat on the same isolated node. carrier_changes is the
+          # direct flap counter; `up` is the operstate; errs catch a virtio
+          # NIC dropping packets without toggling carrier.
+          - node_network_up
+          - node_network_carrier_changes_total
+          - node_network_receive_errs_total
+          - node_network_transmit_errs_total
       # The allow-list above keeps node_cpu_seconds_total for all CPU modes
-      # and node_network_*_bytes_total for every interface, but the dashboards
-      # only read mode="idle" and physical devices (device=~"e(n|th).*").
-      # Drop the unqueried CPU modes and the virtual interfaces — the largest
-      # node-exporter series source left after the curated allow-list.
+      # and every node_network_* series for every interface, but the
+      # dashboards/alerts only read mode="idle" and physical devices
+      # (device=~"e(n|th).*"). Drop the unqueried CPU modes and the virtual
+      # interfaces (the per-pod lxc* veths are the largest node-exporter
+      # series source left after the curated allow-list). The network rule
+      # matches all kept node_network_* metrics generically so the NIC
+      # link-state signals added above are trimmed to physical NICs too.
       # extraMetricProcessingRules runs after the allow-list keep, so it trims
       # within the kept set.
       extraMetricProcessingRules: |
@@ -297,7 +313,7 @@ k8s-monitoring:
         rule {
           source_labels = ["__name__", "device"]
           separator = ";"
-          regex = "node_network_(receive|transmit)_bytes_total;(en|eth).*"
+          regex = "node_network_.*;(en|eth).*"
           target_label = "__tmp_keep_net_iface"
           replacement = "true"
           action = "replace"
@@ -305,7 +321,7 @@ k8s-monitoring:
         rule {
           source_labels = ["__name__", "__tmp_keep_net_iface"]
           separator = ";"
-          regex = "node_network_(receive|transmit)_bytes_total;"
+          regex = "node_network_.*;"
           action = "drop"
         }
         rule {

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -54,6 +54,48 @@ spec:
   # async. With 2 standbys (canary/production) one being down still
   # satisfies the quorum; a 1-standby cluster (staging) can stall.
   #
+  # Known failure mode (2026-07-20 09:53Z incident): if the primary is
+  # briefly isolated from BOTH standbys at once — a ~7s eth0 NIC/datapath
+  # blip on the primary's node dropped its links to both replicas AND the
+  # API server — `required` blocks every COMMIT for the duration, which
+  # surfaces fleet-wide as a burst of `DBConnection ... :queue_timeout`
+  # (all writes funnel through this one primary).
+  #
+  # We deliberately keep `required` (not `preferred`). `preferred` would
+  # de-escalate to async when all standbys are gone (avoiding the stall)
+  # but widens the data-loss surface, and — because in this incident the
+  # primary also lost the operator/API-server path and the blip self-healed
+  # in ~7s — it would not reliably have prevented THIS event anyway (the
+  # de-escalation can't be applied to an unreachable primary in time). The
+  # real lever here is the trigger (host NIC stability), so we invest in
+  # detection instead of trading durability. Revisit `preferred` only as a
+  # deliberate durability-vs-availability decision, not as an incident fix.
+  #
+  # Detection (alerts created in the Grafana Cloud UI — this repo ships no
+  # PrometheusRule CRDs; the metrics and CNPG pod logs already reach Grafana
+  # Cloud, and the NIC-flap metrics are added in infra/helm/k8s-monitoring):
+  #
+  #   1. Sync replication degraded — the primary is streaming to fewer
+  #      standbys than the quorum needs. Under `required` this is when
+  #      writes START blocking, so it must page immediately.
+  #      PromQL:  max by (k8s_cluster_name) (
+  #                 cnpg_pg_replication_streaming_replicas{namespace=~"tuist.*"}
+  #               ) < 1
+  #      - For: 30s   - Severity: critical   (0 standbys streaming)
+  #      Optionally add a `< 2` warning (one standby lost, quorum still met).
+  #
+  #   2. Replication link break / primary self-isolation — the 2026-07-20
+  #      fingerprint, straight from the shipped CNPG logs.
+  #      LogQL:   sum(count_over_time({namespace=~"tuist.*", container="postgres"}
+  #                 |~ "terminating walsender process due to replication timeout|terminating walreceiver due to timeout|Instance connectivity error - liveness probe failing" [5m])) > 0
+  #      - For: 0m (event-driven)   - Severity: warning
+  #
+  #   3. Host NIC flap (the root trigger) — needs the node NIC metrics added
+  #      to infra/helm/k8s-monitoring (node_network_up / _carrier_changes).
+  #      PromQL:  increase(node_network_carrier_changes_total{device=~"e(n|th).*"}[5m]) > 1
+  #      - For: 0m   - Severity: warning   Correlate with the node's Cilium
+  #      bandwidth-manager `Setting qdisc ... device=eth0` burst to confirm.
+  #
   # `parameters` sets server-level Postgres settings (notably
   # max_connections, which must clear the aggregate connection budget).
   # `sharedPreloadLibraries` is a separate list on the CR rather than

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -54,48 +54,6 @@ spec:
   # async. With 2 standbys (canary/production) one being down still
   # satisfies the quorum; a 1-standby cluster (staging) can stall.
   #
-  # Known failure mode (2026-07-20 09:53Z incident): if the primary is
-  # briefly isolated from BOTH standbys at once — a ~7s eth0 NIC/datapath
-  # blip on the primary's node dropped its links to both replicas AND the
-  # API server — `required` blocks every COMMIT for the duration, which
-  # surfaces fleet-wide as a burst of `DBConnection ... :queue_timeout`
-  # (all writes funnel through this one primary).
-  #
-  # We deliberately keep `required` (not `preferred`). `preferred` would
-  # de-escalate to async when all standbys are gone (avoiding the stall)
-  # but widens the data-loss surface, and — because in this incident the
-  # primary also lost the operator/API-server path and the blip self-healed
-  # in ~7s — it would not reliably have prevented THIS event anyway (the
-  # de-escalation can't be applied to an unreachable primary in time). The
-  # real lever here is the trigger (host NIC stability), so we invest in
-  # detection instead of trading durability. Revisit `preferred` only as a
-  # deliberate durability-vs-availability decision, not as an incident fix.
-  #
-  # Detection (alerts created in the Grafana Cloud UI — this repo ships no
-  # PrometheusRule CRDs; the metrics and CNPG pod logs already reach Grafana
-  # Cloud, and the NIC-flap metrics are added in infra/helm/k8s-monitoring):
-  #
-  #   1. Sync replication degraded — the primary is streaming to fewer
-  #      standbys than the quorum needs. Under `required` this is when
-  #      writes START blocking, so it must page immediately.
-  #      PromQL:  max by (k8s_cluster_name) (
-  #                 cnpg_pg_replication_streaming_replicas{namespace=~"tuist.*"}
-  #               ) < 1
-  #      - For: 30s   - Severity: critical   (0 standbys streaming)
-  #      Optionally add a `< 2` warning (one standby lost, quorum still met).
-  #
-  #   2. Replication link break / primary self-isolation — the 2026-07-20
-  #      fingerprint, straight from the shipped CNPG logs.
-  #      LogQL:   sum(count_over_time({namespace=~"tuist.*", container="postgres"}
-  #                 |~ "terminating walsender process due to replication timeout|terminating walreceiver due to timeout|Instance connectivity error - liveness probe failing" [5m])) > 0
-  #      - For: 0m (event-driven)   - Severity: warning
-  #
-  #   3. Host NIC flap (the root trigger) — needs the node NIC metrics added
-  #      to infra/helm/k8s-monitoring (node_network_up / _carrier_changes).
-  #      PromQL:  increase(node_network_carrier_changes_total{device=~"e(n|th).*"}[5m]) > 1
-  #      - For: 0m   - Severity: warning   Correlate with the node's Cilium
-  #      bandwidth-manager `Setting qdisc ... device=eth0` burst to confirm.
-  #
   # `parameters` sets server-level Postgres settings (notably
   # max_connections, which must clear the aggregate connection budget).
   # `sharedPreloadLibraries` is a separate list on the CR rather than


### PR DESCRIPTION
No linked issue: this is a follow-up to the 2026-07-20 production incident (Sentry alert rule 389667 / issues TUIST-3JM, TUIST-3JN, TUIST-10Z).

## Summary

On 2026-07-20 ~09:53Z production fired a ~178-error burst of `DBConnection.ConnectionError ... connection not available and request was dropped from queue` (`reason: :queue_timeout`) across the login page, the `ProcessBuildWorker` Oban job, and authenticated web requests. This PR adds **detection and observability** for that failure mode. It makes **no functional change** to the database cluster spec.

## What happened (root cause)

The DB error was two hops removed from the actual fault:

1. **Trigger (host):** a ~7s NIC/datapath flap on `eth0` of the Postgres primary's node (`tuist-md-0-vq65h-zm8qt-c42wh`). The node-local Cilium agent re-applied the `fq` qdisc on `eth0` **5 times in under 1 second** (normal cadence is once per ~30 min), and each qdisc replacement flushes the interface queue. Node-local: no other node's Cilium agent showed it.
2. **Amplifier (Postgres):** the cluster runs quorum synchronous replication (`ANY 1` of two standbys, `dataDurability: required`). The flap isolated the primary from **both** standbys and the API server at once (primary logs: `terminating walsender ... replication timeout` for both replicas, `Instance connectivity error - liveness probe failing`; replica pg-1 mirror: `terminating walreceiver due to timeout`, then `started streaming WAL from primary` ~7s later). With no reachable sync standby, every COMMIT blocked.
3. **Impact (app):** every app pod writes through the single primary, so their checked-out connections stalled in COMMIT, the Ecto pools drained, and new checkouts timed out fleet-wide across all three worker nodes. Self-healed in ~7s when the standbys rejoined; no failover, no restart.

### Why it looked like a healthy DB

The coarse CNPG metrics were misleading: `backends_total` ~80-100/200, `max_tx_duration` ~0.1s, `backends_waiting` = 0. The last is the trap: `backends_waiting` counts only **lock** waits, and these commits were parked in **`SyncRep`** wait. The stall was also only ~7s, straddled by the 15-30s scrapes. The kubelet liveness probe (its own cadence) is what actually caught it.

## What this PR changes

Rather than trade durability to paper over a network fault, it invests in catching the fault. The only code change is observability:

- **`infra/helm/k8s-monitoring/values.yaml`** — surfaces per-node NIC link-state metrics (`node_network_up`, `node_network_carrier_changes_total`, `node_network_receive|transmit_errs_total`), trimmed to physical interfaces. This is the signal that was missing: the flap could only be **inferred** from Cilium's qdisc-reset burst, and the node's own journal was lost because its log shipper sat on the same isolated node.

The database durability policy is **deliberately left unchanged** (`dataDurability: required`); see "Why we kept `required`" below. The three alerts are created directly in Grafana Cloud (repo convention: no PrometheusRule CRDs) and listed below.

### Alerts (created in Grafana Cloud, folder `Alerts` / rule group `Server`)

Created via the Grafana API, matching the existing CNPG alert set (same folder/group, routed to `Slack #notifications 2`):

- **CNPG Sync Replication Degraded** (critical, for 1m): `max by (k8s_cluster_name)(cnpg_pg_replication_streaming_replicas{namespace=~"tuist.*"}) < 1`. Under `required` this is when writes start blocking. Live and evaluating (production sits at 2, normal).
- **CNPG Replication Link Break** (warning): LogQL on the CNPG pod logs for walsender/walreceiver/liveness failures. Live.
- **Host NIC Carrier Flap** (warning): `max by (instance, device)(increase(node_network_carrier_changes_total{device=~"e(n|th).*"}[5m])) > 1`. Armed but dormant (no-data resolves to OK) until the NIC metrics this PR adds are deployed; it activates automatically once they flow.

## Why we kept `dataDurability: required` (data-loss analysis)

`preferred` would de-escalate to async when all standbys are unreachable (avoiding the stall), but:

- It widens the data-loss surface: loss is possible only under a compound event (all standbys down AND the primary permanently lost in that same window AND the async-committed WAL not yet replicated or archived), but it moves that window from impossible to possible.
- It would not reliably have prevented **this** incident anyway: the primary also lost the operator/API-server path, so the de-escalation could not be applied in time, and the blip self-healed in ~7s (which unblocks `required` too).

So `preferred` is a general-resilience option with a genuine durability tradeoff, not this incident's fix. The real lever is the trigger (host NIC stability). We keep `required` and revisit `preferred` only as a deliberate availability-vs-durability decision.

## How to test locally

- `helm template` renders both charts cleanly. The CNPG cluster spec is unchanged (`dataDurability: required`); only comments differ.
- The k8s-monitoring change keeps the new `node_network_*` series for physical interfaces (`device=~"e(n|th).*"`) after deploy; verify with `node_network_carrier_changes_total` appearing per-node in Grafana Cloud.

## Follow-ups (not in this PR)

- The NIC flap is now directly **detectable** going forward (guest-side): `node_network_carrier_changes_total` is scraped centrally, so it survives even when the flapping node's own log shipper is isolated (as c42wh's was during the incident), and the "Host NIC Carrier Flap" alert fires on it. But the **host-side root cause** (why the virtio link flapped: Hetzner live-migration, a host NIC issue, an SDN/vSwitch event) is not observable from inside the VM and is generally unobtainable as a cloud customer — `dmesg` on the VM would only show the same guest-side symptom, not the hypervisor reason. The only avenues are a hcloud API server-action check or a Hetzner support ticket for the VM + timestamp, both low-yield. If a specific VM flaps repeatedly, treat it as a flaky host and cordon/replace it rather than root-causing Hetzner's infrastructure.
- App-layer question: whether requests should retry / degrade gracefully during a brief DB stall instead of surfacing a 500.

### Potential larger fix, NOT proposed as-of-now: move the CNPG tier to bare metal

Recorded as an option for a future deliberate decision, explicitly **not** something to act on off the back of this incident.

The CNPG pods currently run on Hetzner Cloud VMs with virtio NICs and network-attached `hcloud-volumes`. Moving them to dedicated hardware would address the trigger class directly:

- Removes the virtual-NIC-churn class that caused this incident (physical NIC, no hypervisor / SDN / live-migration).
- Removes a second cloud failure class, network-attached storage stalls, which present the same "healthy DB but stalled" symptom. Local NVMe is also much lower-latency for fsync/WAL.
- Gives host-level visibility (dmesg / ethtool) to root-cause the next flap.

But it is not a free win, which is why it stays a deliberate future decision rather than an incident fix:

- **Local storage flips the durability model.** A dead bare-metal node strands or loses that replica's data (versus a network volume that can reattach), so failover becomes more consequential and replication/backup health matter *more*, not less. This strengthens the case for keeping `dataDurability: required`, 3 instances, and cross-failure-domain placement.
- It does not eliminate network isolation (switch / ToR / rack), and can *reduce* path diversity if the machines are co-located, so placement across failure domains is required.
- Operational cost (provisioning, hardware-failure handling) is real.

The incident self-healed in ~7s with zero data loss, so it is a weak justification on its own. Treat CNPG-on-bare-metal as a platform decision justified on the aggregate (IO performance, cost for an always-on workload, removing two cloud failure classes), with a proper migration / failover / backup design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
