### PR TITLE
fix(server): restore horizontal padding on preview detail page

### DIFF
--- a/server/assets/app/css/pages/preview.css
+++ b/server/assets/app/css/pages/preview.css
@@ -3,7 +3,7 @@
   position: relative;
   flex-direction: column;
   gap: var(--noora-spacing-6);
-  margin: var(--noora-spacing-7) var(--noora-spacing-0);
+  margin: var(--noora-spacing-7) var(--noora-spacing-5);
 
   &:not(.layout__main &) {
     margin: var(--noora-spacing-7);


### PR DESCRIPTION
> Describe here the purpose of your PR.

The preview detail page rendered with no horizontal padding: its content sat flush against the sidebar on the left and against the right edge of the viewport.

**Root cause:** `#preview` set its margin to `var(--noora-spacing-7) var(--noora-spacing-0)`, i.e. `spacing-0` horizontally. Every sibling dashboard page insets its content horizontally by `spacing-5` (`#previews` and `.overview` both use `padding: var(--noora-spacing-7) var(--noora-spacing-5)`), so the preview detail page was the odd one out and looked cramped/edge-to-edge inside the `.layout__main` shell.

**Fix:** change the horizontal margin from `spacing-0` to `spacing-5` so it matches the surrounding pages.

The standalone/shared-preview case (`&:not(.layout__main &)`, which overrides to `margin: var(--noora-spacing-7)` on all four sides) is untouched. The absolutely-positioned `#download-tuist-app-alert` stays anchored to `#preview`'s box, so it now sits `spacing-5` from the right, consistent with the rest of the content.

**Impact:** visual only, CSS one-liner. No behavior or markup changes.

### How to test locally

1. Run the server dashboard and open a preview detail page (Project → Previews → any preview).
2. Confirm the content (header, Details card, Install App card) now has horizontal breathing room on both sides instead of being flush against the sidebar and the right edge, matching the Previews/Overview pages.