### PR TITLE
perf(server): bound rolling alert queries by key range

### DIFF
--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -21,10 +21,12 @@ defmodule Tuist.Automations do
   @max_dispatch_depth 10
   @dispatch_depth_key :tuist_automation_dispatch_depth
   @flaky_monitor_types ~w(flakiness_rate flaky_run_count reliability_rate)
-  # A random lookup of 1000 test cases already touches nearly every primary-key
-  # granule for a large project. Larger batches amortize that scan while the
-  # serialized identifier array remains below ClickHouse's query-size limit.
-  @scoped_evaluation_chunk_size 4000
+  # Changed test cases are returned in the rolling aggregate table's primary-key
+  # order. Splitting that ordered list into several bounded ranges lets
+  # ClickHouse prune the granules between ranges instead of treating a sparse
+  # project-wide identifier set as one scan.
+  @max_scoped_evaluation_range_size 2000
+  @minimum_scoped_evaluation_ranges 4
 
   def list_alerts(project_id) do
     Alert
@@ -243,12 +245,50 @@ defmodule Tuist.Automations do
   end
 
   def update_alert_scoped_evaluation_cursor(%Alert{} = alert, cursor) do
+    cursor = later_cursor(alert.last_scoped_evaluation_inserted_at, cursor)
+
     alert
     |> Ecto.Changeset.change(last_scoped_evaluation_inserted_at: cursor)
     |> Repo.update()
   end
 
-  def scoped_evaluation_chunk_size, do: @scoped_evaluation_chunk_size
+  def advance_alert_scoped_evaluation_cursors(alerts, cursor) do
+    alert_ids = Enum.map(alerts, & &1.id)
+    now = DateTime.utc_now(:second)
+
+    {updated_count, nil} =
+      Alert
+      |> where([alert], alert.id in ^alert_ids)
+      |> update(
+        [alert],
+        set: [
+          last_scoped_evaluation_inserted_at:
+            fragment(
+              "GREATEST(COALESCE(?, ?), ?)",
+              alert.last_scoped_evaluation_inserted_at,
+              ^cursor,
+              ^cursor
+            ),
+          updated_at: ^now
+        ]
+      )
+      |> Repo.update_all([])
+
+    {:ok, updated_count}
+  end
+
+  def scoped_evaluation_ranges([]), do: []
+
+  def scoped_evaluation_ranges(test_case_ids) do
+    range_size =
+      test_case_ids
+      |> length()
+      |> div(@minimum_scoped_evaluation_ranges)
+      |> max(1)
+      |> min(@max_scoped_evaluation_range_size)
+
+    Enum.chunk_every(test_case_ids, range_size)
+  end
 
   defp alert_evaluation_schedule_in do
     div(Environment.clickhouse_flush_interval_ms(), 1000) + 1
@@ -264,6 +304,12 @@ defmodule Tuist.Automations do
 
   defp scoped_evaluation_cursor_lookback_seconds do
     max(alert_evaluation_schedule_in(), 10)
+  end
+
+  defp later_cursor(nil, cursor), do: cursor
+
+  defp later_cursor(current_cursor, cursor) do
+    Enum.max([current_cursor, cursor], DateTime)
   end
 
   defp latest_inserted_at_cursor([]), do: nil

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -162,6 +162,7 @@ defmodule Tuist.Automations do
         )
 
       alerts
+      |> Enum.filter(&Alert.scoped_evaluation?/1)
       |> Enum.group_by(&Alert.cadence_seconds(&1.cadence))
       |> Enum.each(fn {_cadence_seconds, [alert | _alerts]} ->
         enqueue_scoped_alert_evaluation(alert)

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -21,7 +21,10 @@ defmodule Tuist.Automations do
   @max_dispatch_depth 10
   @dispatch_depth_key :tuist_automation_dispatch_depth
   @flaky_monitor_types ~w(flakiness_rate flaky_run_count reliability_rate)
-  @scoped_evaluation_chunk_size 1000
+  # A random lookup of 1000 test cases already touches nearly every primary-key
+  # granule for a large project. Larger batches amortize that scan while the
+  # serialized identifier array remains below ClickHouse's query-size limit.
+  @scoped_evaluation_chunk_size 4000
 
   def list_alerts(project_id) do
     Alert
@@ -156,21 +159,34 @@ defmodule Tuist.Automations do
           )
         )
 
-      Enum.each(alerts, &enqueue_scoped_alert_evaluation/1)
+      alerts
+      |> Enum.group_by(&Alert.cadence_seconds(&1.cadence))
+      |> Enum.each(fn {_cadence_seconds, [alert | _alerts]} ->
+        enqueue_scoped_alert_evaluation(alert)
+      end)
 
       :ok
     end
   end
 
   def enqueue_scoped_alert_evaluation(%Alert{} = alert, opts \\ []) do
-    schedule_in = Keyword.get(opts, :schedule_in, alert_evaluation_schedule_in())
+    schedule_in =
+      Keyword.get(
+        opts,
+        :schedule_in,
+        max(alert_evaluation_schedule_in(), Alert.cadence_seconds(alert.cadence))
+      )
 
     {:ok, _job} =
-      %{alert_id: alert.id, evaluate_recent_test_case_runs: true}
+      %{
+        project_id: alert.project_id,
+        cadence_seconds: Alert.cadence_seconds(alert.cadence),
+        evaluate_recent_test_case_runs: true
+      }
       |> AlertEvaluationWorker.new(
         schedule_in: schedule_in,
         unique: [
-          keys: [:alert_id, :evaluate_recent_test_case_runs],
+          keys: [:project_id, :cadence_seconds, :evaluate_recent_test_case_runs],
           period: :infinity,
           states: [:available, :scheduled]
         ]
@@ -181,12 +197,23 @@ defmodule Tuist.Automations do
   end
 
   def recent_test_case_run_changes_for_alert(%Alert{} = alert) do
-    since = scoped_evaluation_query_since(alert)
+    recent_test_case_run_changes(alert.project_id, scoped_evaluation_query_since(alert))
+  end
 
+  def recent_test_case_run_changes_for_alerts([%Alert{} = alert | _alerts] = alerts) do
+    since =
+      alerts
+      |> Enum.map(&scoped_evaluation_query_since/1)
+      |> Enum.min(DateTime)
+
+    recent_test_case_run_changes(alert.project_id, since)
+  end
+
+  defp recent_test_case_run_changes(project_id, since) do
     rows =
       ClickHouseRepo.all(
         from(r in {"test_case_runs_by_inserted_at", TestCaseRun},
-          where: r.project_id == ^alert.project_id,
+          where: r.project_id == ^project_id,
           where: not is_nil(r.test_case_id),
           where: r.inserted_at >= ^DateTime.to_naive(since),
           group_by: r.test_case_id,

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -59,6 +59,20 @@ defmodule Tuist.Automations.Alerts.Alert do
   def recovery_ledger?(%{monitor_type: monitor_type}), do: recovery_ledger?(monitor_type)
   def recovery_ledger?(monitor_type), do: monitor_type in @recovery_ledger_monitor_types
 
+  @doc """
+  Established rolling metric alerts are evaluated from recently changed test
+  cases. Calendar-window alerts and rolling alerts without a baseline stay on
+  the periodic full-evaluation path.
+  """
+  def scoped_evaluation?(%{
+        monitor_type: monitor_type,
+        trigger_config: %{"window_type" => "rolling"},
+        baseline_established_at: %DateTime{}
+      })
+      when monitor_type in @recovery_ledger_monitor_types, do: true
+
+  def scoped_evaluation?(_alert), do: false
+
   @primary_key {:id, UUIDv7, autogenerate: true}
   @foreign_key_type UUIDv7
 

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -84,7 +84,15 @@ defmodule Tuist.Automations.Alerts.Alert do
   # Oban job within `cadence`, and completed jobs are pruned at 2h, so the
   # cadence must stay well under that window. Lifting this cap means
   # decoupling that dedup from Oban retention first.
+  @default_cadence_seconds 300
   @max_cadence_seconds 3600
+
+  def cadence_seconds(cadence) do
+    case parse_cadence_seconds(cadence) do
+      {:ok, seconds} -> seconds
+      :error -> @default_cadence_seconds
+    end
+  end
 
   def changeset(alert \\ %__MODULE__{}, attrs) do
     alert

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -39,6 +39,12 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   success column. A project's whole rolling-window scan becomes one row per
   active test case, regardless of run volume — reading raw `test_case_runs`
   for that pattern is unrunnable on busy projects.
+
+  When several alerts use the same rolling window and aggregate column, the
+  ingestion-driven worker calls `evaluate_rolling_alerts/2`. That query returns
+  the numerator and run count once per affected test case, then applies each
+  alert's threshold in Elixir. This avoids repeating the same aggregate-state
+  merge for alerts that only differ by threshold or by rate-versus-count.
   """
   import Ecto.Query
 
@@ -114,6 +120,32 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       end
 
     %{triggered: triggered_test_case_ids}
+  end
+
+  def rolling_group_key(%{monitor_type: monitor_type, trigger_config: trigger_config})
+      when monitor_type in ["flakiness_rate", "flaky_run_count", "reliability_rate"] do
+    case window_mode(trigger_config) do
+      {:rolling, size} -> {:rolling, recent_runs_column(monitor_type), size}
+      {:last_days, _seconds} -> nil
+    end
+  end
+
+  def rolling_group_key(_alert), do: nil
+
+  def evaluate_rolling_alerts([], _test_case_ids), do: %{}
+
+  def evaluate_rolling_alerts([alert | _alerts] = alerts, test_case_ids) do
+    {:rolling, column, size} = rolling_group_key(alert)
+    measurements = rolling_measurements(alert.project_id, column, size, test_case_ids)
+
+    Map.new(alerts, fn alert ->
+      triggered_test_case_ids =
+        measurements
+        |> Enum.filter(&measurement_triggers_alert?(&1, alert))
+        |> Enum.map(&elem(&1, 0))
+
+      {alert.id, triggered_test_case_ids}
+    end)
   end
 
   # The MV is keyed on `(project_id, date, test_case_id)`, so we round the
@@ -324,6 +356,88 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       test_case_ids
     )
   end
+
+  defp rolling_measurements(_project_id, _column, _size, []), do: []
+
+  defp rolling_measurements(project_id, column, size, test_case_ids) do
+    source = recent_runs_source(column, size)
+    rolling_measurements_from_recent_runs(source, project_id, size, test_case_ids)
+  end
+
+  defp rolling_measurements_from_recent_runs(
+         {table, ordered_runs_expr, duplicate_position},
+         project_id,
+         size,
+         test_case_ids
+       ) do
+    deduplicated_runs_expr = deduplicated_runs_expr(duplicate_position)
+
+    sql = """
+    SELECT
+      test_case_id,
+      arraySum(entry -> tupleElement(entry, 2), recent_runs) AS matching_run_count,
+      length(recent_runs) AS run_count
+    FROM (
+      SELECT
+        test_case_id,
+        arraySlice(
+          #{deduplicated_runs_expr},
+          1,
+          #{size}
+        ) AS recent_runs
+      FROM (
+        SELECT
+          test_case_id,
+          #{ordered_runs_expr} AS ordered_runs
+        FROM #{table}
+        WHERE project_id = {project_id:Int64}
+          AND test_case_id IN {test_case_ids:Array(UUID)}
+        GROUP BY test_case_id
+      )
+    )
+    WHERE length(recent_runs) > 0
+    """
+
+    %{rows: rows} =
+      ClickHouseRepo.query!(sql, %{
+        project_id: project_id,
+        test_case_ids: test_case_ids
+      })
+
+    Enum.map(rows, fn [binary, matching_run_count, run_count] ->
+      {Ecto.UUID.load!(binary), matching_run_count, run_count}
+    end)
+  end
+
+  defp measurement_triggers_alert?({_test_case_id, matching_run_count, run_count}, alert) do
+    threshold = alert_threshold(alert)
+
+    value =
+      case alert.monitor_type do
+        "flaky_run_count" -> matching_run_count
+        _rate -> matching_run_count * 100.0 / run_count
+      end
+
+    comparison_matches?(value, threshold, alert_comparison(alert))
+  end
+
+  defp alert_threshold(%{monitor_type: "flaky_run_count", trigger_config: trigger_config}),
+    do: trigger_config["threshold"] || 1
+
+  defp alert_threshold(%{monitor_type: "reliability_rate", trigger_config: trigger_config}),
+    do: trigger_config["threshold"] || 90
+
+  defp alert_threshold(%{trigger_config: trigger_config}), do: trigger_config["threshold"] || 10
+
+  defp alert_comparison(%{monitor_type: "reliability_rate", trigger_config: trigger_config}),
+    do: parse_comparison(trigger_config["comparison"], "lt")
+
+  defp alert_comparison(%{trigger_config: trigger_config}), do: parse_comparison(trigger_config["comparison"])
+
+  defp comparison_matches?(value, threshold, "gte"), do: value >= threshold
+  defp comparison_matches?(value, threshold, "gt"), do: value > threshold
+  defp comparison_matches?(value, threshold, "lt"), do: value < threshold
+  defp comparison_matches?(value, threshold, "lte"), do: value <= threshold
 
   # Reliability measures successful runs; flakiness and count measure flaky
   # runs. Both live as parallel `(sort_key, flag)` aggregates on the same

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -64,7 +64,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       %{test_case_ids: test_case_ids, cursor: cursor} = Automations.recent_test_case_run_changes_for_alert(alert)
 
       test_case_ids
-      |> Enum.chunk_every(Automations.scoped_evaluation_chunk_size())
+      |> Automations.scoped_evaluation_ranges()
       |> Enum.each(&evaluate_and_execute(alert, &1))
 
       {:ok, _alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
@@ -86,12 +86,10 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
         Automations.recent_test_case_run_changes_for_alerts(established_alerts)
 
       test_case_ids
-      |> Enum.chunk_every(Automations.scoped_evaluation_chunk_size())
+      |> Automations.scoped_evaluation_ranges()
       |> Enum.each(&evaluate_alert_group(established_alerts, &1))
 
-      Enum.each(established_alerts, fn alert ->
-        {:ok, _alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
-      end)
+      {:ok, _updated_count} = Automations.advance_alert_scoped_evaluation_cursors(established_alerts, cursor)
     end
 
     :ok

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -21,6 +21,24 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   @recovery_candidate_batch_size 500
 
   @impl Oban.Worker
+  def perform(%Oban.Job{
+        args: %{
+          "project_id" => project_id,
+          "cadence_seconds" => cadence_seconds,
+          "evaluate_recent_test_case_runs" => true
+        }
+      }) do
+    alerts =
+      project_id
+      |> Automations.list_alerts()
+      |> Enum.filter(fn alert ->
+        alert.enabled and Alert.recovery_ledger?(alert) and
+          Alert.cadence_seconds(alert.cadence) == cadence_seconds
+      end)
+
+    evaluate_recent_test_case_runs_and_execute(alerts)
+  end
+
   def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args}) do
     case Automations.get_alert(alert_id) do
       {:ok, alert} ->
@@ -39,7 +57,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     end
   end
 
-  defp evaluate_recent_test_case_runs_and_execute(alert) do
+  defp evaluate_recent_test_case_runs_and_execute(%Alert{} = alert) do
     if alert.baseline_established_at == nil do
       evaluate_and_execute(alert, nil)
     else
@@ -55,21 +73,67 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     :ok
   end
 
+  defp evaluate_recent_test_case_runs_and_execute([]), do: :ok
+
+  defp evaluate_recent_test_case_runs_and_execute(alerts) when is_list(alerts) do
+    {established_alerts, pending_baseline_alerts} =
+      Enum.split_with(alerts, &(&1.baseline_established_at != nil))
+
+    Enum.each(pending_baseline_alerts, &evaluate_and_execute(&1, nil))
+
+    if established_alerts != [] do
+      %{test_case_ids: test_case_ids, cursor: cursor} =
+        Automations.recent_test_case_run_changes_for_alerts(established_alerts)
+
+      test_case_ids
+      |> Enum.chunk_every(Automations.scoped_evaluation_chunk_size())
+      |> Enum.each(&evaluate_alert_group(established_alerts, &1))
+
+      Enum.each(established_alerts, fn alert ->
+        {:ok, _alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
+      end)
+    end
+
+    :ok
+  end
+
   defp evaluate_recent_test_case_runs?(%{"evaluate_recent_test_case_runs" => true}), do: true
   defp evaluate_recent_test_case_runs?(_args), do: false
 
   defp evaluate_and_execute(alert, test_case_ids) do
-    if alert.baseline_established_at == nil do
-      %{triggered: triggered_ids} = evaluate_monitor(alert, nil)
-      triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
-      establish_baseline(alert, triggered_ids)
-    else
-      %{triggered: triggered_ids} = evaluate_monitor(alert, test_case_ids)
-      triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
-      run_transitions(alert, triggered_ids, test_case_ids)
-    end
+    %{triggered: triggered_ids} = evaluate_monitor(alert, test_case_ids)
+    execute_evaluation(alert, triggered_ids, test_case_ids)
 
     :ok
+  end
+
+  defp evaluate_alert_group(alerts, test_case_ids) do
+    alerts
+    |> Enum.group_by(&FlakyTestsMonitor.rolling_group_key/1)
+    |> Enum.each(fn
+      {nil, alerts} ->
+        Enum.each(alerts, &evaluate_and_execute(&1, test_case_ids))
+
+      {_rolling_group_key, [alert]} ->
+        evaluate_and_execute(alert, test_case_ids)
+
+      {_rolling_group_key, alerts} ->
+        triggered_by_alert_id = FlakyTestsMonitor.evaluate_rolling_alerts(alerts, test_case_ids)
+
+        Enum.each(alerts, fn alert ->
+          execute_evaluation(alert, Map.fetch!(triggered_by_alert_id, alert.id), test_case_ids)
+        end)
+    end)
+  end
+
+  defp execute_evaluation(alert, triggered_ids, test_case_ids) do
+    triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
+
+    if alert.baseline_established_at == nil do
+      establish_baseline(alert, triggered_ids)
+    else
+      run_transitions(alert, triggered_ids, test_case_ids)
+    end
   end
 
   # A test case that has never had a successful, non-flaky run on the project's

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -32,7 +32,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       project_id
       |> Automations.list_alerts()
       |> Enum.filter(fn alert ->
-        alert.enabled and Alert.recovery_ledger?(alert) and
+        alert.enabled and Alert.scoped_evaluation?(alert) and
           Alert.cadence_seconds(alert.cadence) == cadence_seconds
       end)
 

--- a/server/lib/tuist/automations/workers/automation_scheduler.ex
+++ b/server/lib/tuist/automations/workers/automation_scheduler.ex
@@ -30,7 +30,7 @@ defmodule Tuist.Automations.Workers.AutomationScheduler do
           |> AlertEvaluationWorker.new(
             unique: [
               keys: [:alert_id],
-              period: cadence_seconds(alert.cadence),
+              period: Alert.cadence_seconds(alert.cadence),
               states: [:available, :scheduled, :executing, :completed]
             ]
           )
@@ -57,15 +57,4 @@ defmodule Tuist.Automations.Workers.AutomationScheduler do
        when monitor_type in ["flakiness_rate", "flaky_run_count", "reliability_rate"], do: true
 
   defp rolling_with_baseline?(_alert), do: false
-
-  defp cadence_seconds(cadence) when is_binary(cadence) do
-    case Integer.parse(cadence) do
-      {value, "m"} -> value * 60
-      {value, "h"} -> value * 3600
-      {value, "s"} -> value
-      _ -> 300
-    end
-  end
-
-  defp cadence_seconds(_), do: 300
 end

--- a/server/lib/tuist/automations/workers/automation_scheduler.ex
+++ b/server/lib/tuist/automations/workers/automation_scheduler.ex
@@ -44,17 +44,8 @@ defmodule Tuist.Automations.Workers.AutomationScheduler do
   defp scheduled_alert?(alert) do
     cond do
       Alert.event_driven?(alert) -> false
-      rolling_with_baseline?(alert) -> false
+      Alert.scoped_evaluation?(alert) -> false
       true -> true
     end
   end
-
-  defp rolling_with_baseline?(%{
-         monitor_type: monitor_type,
-         trigger_config: %{"window_type" => "rolling"},
-         baseline_established_at: %DateTime{}
-       })
-       when monitor_type in ["flakiness_rate", "flaky_run_count", "reliability_rate"], do: true
-
-  defp rolling_with_baseline?(_alert), do: false
 end

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -473,6 +473,30 @@ defmodule Tuist.Automations.Alerts.AlertTest do
     end
   end
 
+  describe "scoped_evaluation?/1" do
+    test "returns true only for established rolling metric alerts" do
+      established_at = DateTime.utc_now()
+
+      assert Alert.scoped_evaluation?(%{
+               monitor_type: "flakiness_rate",
+               trigger_config: %{"window_type" => "rolling"},
+               baseline_established_at: established_at
+             })
+
+      refute Alert.scoped_evaluation?(%{
+               monitor_type: "flakiness_rate",
+               trigger_config: %{"window_type" => "last_days"},
+               baseline_established_at: established_at
+             })
+
+      refute Alert.scoped_evaluation?(%{
+               monitor_type: "flakiness_rate",
+               trigger_config: %{"window_type" => "rolling"},
+               baseline_established_at: nil
+             })
+    end
+  end
+
   describe "trigger_actions validation" do
     test "accepts a change_state action with valid state" do
       project = ProjectsFixtures.project_fixture()

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -436,6 +436,13 @@ defmodule Tuist.Automations.Alerts.AlertTest do
   end
 
   describe "cadence validation" do
+    test "converts cadence values to seconds" do
+      assert Alert.cadence_seconds("30s") == 30
+      assert Alert.cadence_seconds("5m") == 300
+      assert Alert.cadence_seconds("1h") == 3600
+      assert Alert.cadence_seconds("invalid") == 300
+    end
+
     test "accepts cadences at or under one hour" do
       project = ProjectsFixtures.project_fixture()
 

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -477,6 +477,63 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
     end
   end
 
+  describe "evaluate_rolling_alerts/2" do
+    test "shares measurements between flakiness rate and flaky run count alerts" do
+      project = ProjectsFixtures.project_fixture()
+      one_flaky_run_id = Ecto.UUID.generate()
+      two_flaky_runs_id = Ecto.UUID.generate()
+      base = NaiveDateTime.utc_now()
+
+      for {test_case_id, flaky_run_count} <- [{one_flaky_run_id, 1}, {two_flaky_runs_id, 2}],
+          run_number <- 1..5 do
+        ran_at = NaiveDateTime.add(base, -run_number, :minute)
+
+        RunsFixtures.test_case_run_fixture(
+          project_id: project.id,
+          test_case_id: test_case_id,
+          is_flaky: run_number <= flaky_run_count,
+          ran_at: ran_at,
+          inserted_at: ran_at
+        )
+      end
+
+      rate_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{
+            "threshold" => 20,
+            "comparison" => "gte",
+            "window_type" => "rolling",
+            "rolling_window_size" => 5
+          }
+        )
+
+      count_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flaky_run_count",
+          trigger_config: %{
+            "threshold" => 2,
+            "comparison" => "gte",
+            "window_type" => "rolling",
+            "rolling_window_size" => 5
+          }
+        )
+
+      triggered_by_alert_id =
+        FlakyTestsMonitor.evaluate_rolling_alerts(
+          [rate_alert, count_alert],
+          [one_flaky_run_id, two_flaky_runs_id]
+        )
+
+      assert MapSet.new(triggered_by_alert_id[rate_alert.id]) ==
+               MapSet.new([one_flaky_run_id, two_flaky_runs_id])
+
+      assert triggered_by_alert_id[count_alert.id] == [two_flaky_runs_id]
+    end
+  end
+
   describe "evaluate_by_run_count/1 with rolling window" do
     test "fires when flaky run count in last N runs meets the threshold" do
       project = ProjectsFixtures.project_fixture()

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -120,6 +120,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       AutomationsFixtures.automation_alert_fixture(trigger_actions: [%{"type" => "change_state", "state" => "muted"}])
 
     [first_id, second_id] = Enum.map(1..2, fn _ -> Ecto.UUID.generate() end)
+    test_pid = self()
 
     expect(ClickHouseRepo, :all, fn _query ->
       [
@@ -130,14 +131,14 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     reject(&FlakyTestsMonitor.evaluate/1)
 
-    expect(FlakyTestsMonitor, :evaluate, fn ^automation, test_case_ids ->
-      assert MapSet.new(test_case_ids) == MapSet.new([first_id, second_id])
+    expect(FlakyTestsMonitor, :evaluate, 2, fn ^automation, [test_case_id] = test_case_ids ->
+      send(test_pid, {:evaluated_test_case_id, test_case_id})
       %{triggered: [], all: test_case_ids}
     end)
 
-    expect(Automations, :list_active_alert_events, fn id, test_case_ids ->
+    expect(Automations, :list_active_alert_events, 2, fn id, [test_case_id] ->
       assert id == automation.id
-      assert MapSet.new(test_case_ids) == MapSet.new([first_id, second_id])
+      send(test_pid, {:checked_active_test_case_id, test_case_id})
       []
     end)
 
@@ -145,6 +146,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     reject(&Automations.create_alert_event/1)
 
     assert :ok = run_recent_test_case_runs(automation.id)
+
+    assert_receive {:evaluated_test_case_id, ^first_id}
+    assert_receive {:evaluated_test_case_id, ^second_id}
+    assert_receive {:checked_active_test_case_id, ^first_id}
+    assert_receive {:checked_active_test_case_id, ^second_id}
 
     assert {:ok, updated} = Automations.get_alert(automation.id)
     assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
@@ -177,6 +183,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
         }
       )
 
+    {:ok, first_alert} =
+      Automations.update_alert_scoped_evaluation_cursor(first_alert, ~U[2026-06-09 10:00:10Z])
+
+    {:ok, second_alert} =
+      Automations.update_alert_scoped_evaluation_cursor(second_alert, ~U[2026-06-09 10:00:00Z])
+
     test_case_id = Ecto.UUID.generate()
 
     expect(ClickHouseRepo, :all, fn _query ->
@@ -199,7 +211,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     assert {:ok, updated_first_alert} = Automations.get_alert(first_alert.id)
     assert {:ok, updated_second_alert} = Automations.get_alert(second_alert.id)
-    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:10Z]
     assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
   end
 
@@ -214,12 +226,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       end)
     end)
 
-    expect(FlakyTestsMonitor, :evaluate, 2, fn ^automation, chunk ->
+    expect(FlakyTestsMonitor, :evaluate, 5, fn ^automation, chunk ->
       send(test_pid, {:monitor_chunk_size, length(chunk)})
       %{triggered: [], all: chunk}
     end)
 
-    expect(Automations, :list_active_alert_events, 2, fn id, chunk ->
+    expect(Automations, :list_active_alert_events, 5, fn id, chunk ->
       assert id == automation.id
       send(test_pid, {:active_events_chunk_size, length(chunk)})
       []
@@ -230,9 +242,15 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     assert :ok = run_recent_test_case_runs(automation.id)
 
-    assert_receive {:monitor_chunk_size, 4000}
+    assert_receive {:monitor_chunk_size, 1000}
+    assert_receive {:monitor_chunk_size, 1000}
+    assert_receive {:monitor_chunk_size, 1000}
+    assert_receive {:monitor_chunk_size, 1000}
     assert_receive {:monitor_chunk_size, 1}
-    assert_receive {:active_events_chunk_size, 4000}
+    assert_receive {:active_events_chunk_size, 1000}
+    assert_receive {:active_events_chunk_size, 1000}
+    assert_receive {:active_events_chunk_size, 1000}
+    assert_receive {:active_events_chunk_size, 1000}
     assert_receive {:active_events_chunk_size, 1}
 
     assert {:ok, updated} = Automations.get_alert(automation.id)

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -33,6 +33,16 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     AlertEvaluationWorker.perform(%Oban.Job{args: %{"alert_id" => alert_id, "evaluate_recent_test_case_runs" => true}})
   end
 
+  defp run_recent_test_case_runs_for_project(project_id, cadence_seconds \\ 300) do
+    AlertEvaluationWorker.perform(%Oban.Job{
+      args: %{
+        "project_id" => project_id,
+        "cadence_seconds" => cadence_seconds,
+        "evaluate_recent_test_case_runs" => true
+      }
+    })
+  end
+
   test "no-op when automation is missing" do
     reject(&FlakyTestsMonitor.evaluate/1)
     assert :ok = run(UUIDv7.generate())
@@ -140,9 +150,62 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
   end
 
+  test "project-scoped job shares rolling measurements across compatible alerts" do
+    project = ProjectsFixtures.project_fixture()
+
+    first_alert =
+      AutomationsFixtures.automation_alert_fixture(
+        project: project,
+        monitor_type: "flakiness_rate",
+        trigger_config: %{
+          "threshold" => 5,
+          "comparison" => "gte",
+          "window_type" => "rolling",
+          "rolling_window_size" => 75
+        }
+      )
+
+    second_alert =
+      AutomationsFixtures.automation_alert_fixture(
+        project: project,
+        monitor_type: "flakiness_rate",
+        trigger_config: %{
+          "threshold" => 20,
+          "comparison" => "gte",
+          "window_type" => "rolling",
+          "rolling_window_size" => 75
+        }
+      )
+
+    test_case_id = Ecto.UUID.generate()
+
+    expect(ClickHouseRepo, :all, fn _query ->
+      [%{test_case_id: test_case_id, last_inserted_at: ~N[2026-06-09 10:00:02]}]
+    end)
+
+    reject(&FlakyTestsMonitor.evaluate/1)
+    reject(&FlakyTestsMonitor.evaluate/2)
+
+    expect(FlakyTestsMonitor, :evaluate_rolling_alerts, fn alerts, [^test_case_id] ->
+      assert MapSet.new(alerts, & &1.id) == MapSet.new([first_alert.id, second_alert.id])
+      %{first_alert.id => [], second_alert.id => []}
+    end)
+
+    expect(Automations, :list_active_alert_events, 2, fn _alert_id, [^test_case_id] -> [] end)
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert :ok = run_recent_test_case_runs_for_project(project.id)
+
+    assert {:ok, updated_first_alert} = Automations.get_alert(first_alert.id)
+    assert {:ok, updated_second_alert} = Automations.get_alert(second_alert.id)
+    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+    assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+  end
+
   test "ingestion-driven job chunks large affected sets" do
     automation = AutomationsFixtures.automation_alert_fixture()
-    test_case_ids = Enum.map(1..1001, fn _ -> Ecto.UUID.generate() end)
+    test_case_ids = Enum.map(1..4001, fn _ -> Ecto.UUID.generate() end)
     test_pid = self()
 
     expect(ClickHouseRepo, :all, fn _query ->
@@ -167,9 +230,9 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     assert :ok = run_recent_test_case_runs(automation.id)
 
-    assert_receive {:monitor_chunk_size, 1000}
+    assert_receive {:monitor_chunk_size, 4000}
     assert_receive {:monitor_chunk_size, 1}
-    assert_receive {:active_events_chunk_size, 1000}
+    assert_receive {:active_events_chunk_size, 4000}
     assert_receive {:active_events_chunk_size, 1}
 
     assert {:ok, updated} = Automations.get_alert(automation.id)

--- a/server/test/tuist/automations/workers/automation_scheduler_test.exs
+++ b/server/test/tuist/automations/workers/automation_scheduler_test.exs
@@ -1,9 +1,11 @@
 defmodule Tuist.Automations.Workers.AutomationSchedulerTest do
   use TuistTestSupport.Cases.DataCase, async: false
 
+  alias Tuist.Automations
   alias Tuist.Automations.Workers.AlertEvaluationWorker
   alias Tuist.Automations.Workers.AutomationScheduler
   alias TuistTestSupport.Fixtures.AutomationsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   test "enqueues evaluation jobs for enabled alerts" do
     alert = AutomationsFixtures.automation_alert_fixture()
@@ -37,6 +39,17 @@ defmodule Tuist.Automations.Workers.AutomationSchedulerTest do
     assert :ok = AutomationScheduler.perform(%Oban.Job{args: %{}})
 
     assert_enqueued(worker: AlertEvaluationWorker, args: %{alert_id: alert.id})
+  end
+
+  test "calendar-window alerts are owned only by the scheduler" do
+    project = ProjectsFixtures.project_fixture()
+    alert = AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
+
+    assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [Ecto.UUID.generate()])
+    assert :ok = AutomationScheduler.perform(%Oban.Job{args: %{}})
+
+    assert [%{args: %{"alert_id" => alert_id}}] = all_enqueued(worker: AlertEvaluationWorker)
+    assert alert_id == alert.id
   end
 
   test "does not schedule event-driven test_updated alerts" do

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -147,21 +147,21 @@ defmodule Tuist.AutomationsTest do
   end
 
   describe "enqueue_flaky_alert_evaluations/2" do
-    test "enqueues debounced scoped evaluations for enabled scoped monitors only" do
+    test "enqueues one debounced scoped evaluation per project and cadence" do
       project = ProjectsFixtures.project_fixture()
       other_project = ProjectsFixtures.project_fixture()
 
-      flakiness_alert =
+      _flakiness_alert =
         AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
 
-      count_alert =
+      _count_alert =
         AutomationsFixtures.automation_alert_fixture(
           project: project,
           monitor_type: "flaky_run_count",
           trigger_config: %{"threshold" => 1, "window_type" => "last_days", "window" => "30d"}
         )
 
-      reliability_alert =
+      _reliability_alert =
         AutomationsFixtures.automation_alert_fixture(
           project: project,
           monitor_type: "reliability_rate",
@@ -185,33 +185,84 @@ defmodule Tuist.AutomationsTest do
 
       assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, test_case_ids ++ [hd(test_case_ids), nil])
 
-      jobs = all_enqueued(worker: AlertEvaluationWorker)
+      assert [
+               %{
+                 args: %{
+                   "project_id" => project_id,
+                   "cadence_seconds" => 300,
+                   "evaluate_recent_test_case_runs" => true
+                 }
+               }
+             ] = all_enqueued(worker: AlertEvaluationWorker)
 
-      assert length(jobs) == 3
-
-      args_by_alert_id = Map.new(jobs, fn job -> {job.args["alert_id"], job.args} end)
-
-      assert args_by_alert_id[flakiness_alert.id]["evaluate_recent_test_case_runs"]
-      refute Map.has_key?(args_by_alert_id[flakiness_alert.id], "test_case_ids")
-      assert args_by_alert_id[count_alert.id]["evaluate_recent_test_case_runs"]
-      refute Map.has_key?(args_by_alert_id[count_alert.id], "test_case_ids")
-      assert args_by_alert_id[reliability_alert.id]["evaluate_recent_test_case_runs"]
-      refute Map.has_key?(args_by_alert_id[reliability_alert.id], "test_case_ids")
+      assert project_id == project.id
     end
 
-    test "merges repeated enqueue calls into one scoped evaluation job per alert" do
+    test "merges repeated enqueue calls into one scoped evaluation job per project and cadence" do
       project = ProjectsFixtures.project_fixture()
-      alert = AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
+      _alert = AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
 
       [first_id, second_id, third_id] = Enum.map(1..3, fn _ -> Ecto.UUID.generate() end)
 
       assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [first_id, second_id])
       assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [second_id, third_id])
 
-      assert [%{args: %{"alert_id" => alert_id, "evaluate_recent_test_case_runs" => true}}] =
+      assert [
+               %{
+                 args: %{
+                   "project_id" => project_id,
+                   "cadence_seconds" => 300,
+                   "evaluate_recent_test_case_runs" => true
+                 }
+               }
+             ] =
                all_enqueued(worker: AlertEvaluationWorker)
 
-      assert alert_id == alert.id
+      assert project_id == project.id
+    end
+
+    test "keeps different alert cadences in separate evaluation jobs" do
+      project = ProjectsFixtures.project_fixture()
+
+      _five_minute_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          cadence: "5m"
+        )
+
+      _one_minute_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "reliability_rate",
+          cadence: "1m"
+        )
+
+      assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [Ecto.UUID.generate()])
+
+      assert [60, 300] ==
+               [worker: AlertEvaluationWorker]
+               |> all_enqueued()
+               |> Enum.map(& &1.args["cadence_seconds"])
+               |> Enum.sort()
+    end
+
+    test "schedules scoped evaluations at the alert cadence" do
+      project = ProjectsFixtures.project_fixture()
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          cadence: "30s"
+        )
+
+      enqueued_at = DateTime.utc_now(:second)
+
+      assert :ok = Automations.enqueue_scoped_alert_evaluation(alert)
+
+      assert [%{scheduled_at: scheduled_at}] = all_enqueued(worker: AlertEvaluationWorker)
+      assert DateTime.diff(scheduled_at, enqueued_at, :second) in 30..31
     end
   end
 

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -320,6 +320,26 @@ defmodule Tuist.AutomationsTest do
     end
   end
 
+  describe "scoped_evaluation_ranges/1" do
+    test "keeps ordered identifiers in several bounded ranges" do
+      identifiers = Enum.to_list(1..8001)
+
+      ranges = Automations.scoped_evaluation_ranges(identifiers)
+
+      assert Enum.map(ranges, &length/1) == [2000, 2000, 2000, 2000, 1]
+      assert List.flatten(ranges) == identifiers
+    end
+
+    test "splits smaller sets into at least four ranges" do
+      identifiers = Enum.to_list(1..4000)
+
+      assert [1000, 1000, 1000, 1000] ==
+               identifiers
+               |> Automations.scoped_evaluation_ranges()
+               |> Enum.map(&length/1)
+    end
+  end
+
   describe "dispatch_test_case_event/2" do
     defp test_updated_alert(project, opts \\ []) do
       AutomationsFixtures.automation_alert_fixture(

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -152,7 +152,11 @@ defmodule Tuist.AutomationsTest do
       other_project = ProjectsFixtures.project_fixture()
 
       _flakiness_alert =
-        AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{"threshold" => 10, "window_type" => "rolling", "rolling_window_size" => 75}
+        )
 
       _count_alert =
         AutomationsFixtures.automation_alert_fixture(
@@ -198,9 +202,37 @@ defmodule Tuist.AutomationsTest do
       assert project_id == project.id
     end
 
+    test "leaves calendar-window alerts and rolling baselines to the scheduler" do
+      project = ProjectsFixtures.project_fixture()
+
+      _calendar_window_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate"
+        )
+
+      _rolling_baseline_alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          baseline_established_at: nil,
+          monitor_type: "flaky_run_count",
+          trigger_config: %{"threshold" => 1, "window_type" => "rolling", "rolling_window_size" => 75}
+        )
+
+      assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [Ecto.UUID.generate()])
+
+      assert [] = all_enqueued(worker: AlertEvaluationWorker)
+    end
+
     test "merges repeated enqueue calls into one scoped evaluation job per project and cadence" do
       project = ProjectsFixtures.project_fixture()
-      _alert = AutomationsFixtures.automation_alert_fixture(project: project, monitor_type: "flakiness_rate")
+
+      _alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{"threshold" => 10, "window_type" => "rolling", "rolling_window_size" => 75}
+        )
 
       [first_id, second_id, third_id] = Enum.map(1..3, fn _ -> Ecto.UUID.generate() end)
 
@@ -228,14 +260,21 @@ defmodule Tuist.AutomationsTest do
         AutomationsFixtures.automation_alert_fixture(
           project: project,
           monitor_type: "flakiness_rate",
-          cadence: "5m"
+          cadence: "5m",
+          trigger_config: %{"threshold" => 10, "window_type" => "rolling", "rolling_window_size" => 75}
         )
 
       _one_minute_alert =
         AutomationsFixtures.automation_alert_fixture(
           project: project,
           monitor_type: "reliability_rate",
-          cadence: "1m"
+          cadence: "1m",
+          trigger_config: %{
+            "threshold" => 90,
+            "comparison" => "lt",
+            "window_type" => "rolling",
+            "rolling_window_size" => 75
+          }
         )
 
       assert :ok = Automations.enqueue_flaky_alert_evaluations(project.id, [Ecto.UUID.generate()])


### PR DESCRIPTION
## What changed

Rolling test alert evaluations now respect their configured cadence, coalesce work into one job per project and cadence, and split changed test identifiers into bounded contiguous primary-key ranges before querying ClickHouse.

Only established rolling metric alerts use the ingestion-scoped path. Calendar-window alerts and rolling alerts without a baseline remain on the periodic full-evaluation path, preventing both job shapes from evaluating the same alert concurrently.

Compatible alerts that use the same rolling window and aggregate column share a measurement query. Their evaluation cursors are advanced with one monotonic bulk update, so an alert that is already further ahead cannot be moved backwards by a shared evaluation.

## Why

The [slow ClickHouse query alert](https://tuist.grafana.net/alerting/grafana/ffeb6l2ax5qtcf/view?orgId=1) recorded the rolling test query 37,515 times over 24 hours. The rule measures the 99th percentile latency of each query and fires above 1.5 seconds. Atlas showed the targeted query reaching approximately 3.4 seconds.

Reducing execution frequency was useful, but it did not address the individual query latency measured by the alert. The query also needed to read less data on every execution.

## Root cause

Ingestion-driven evaluations were delayed only by the ClickHouse flush interval and ignored each alert's configured cadence. Their uniqueness key was scoped to an individual alert, so alerts for the same project independently repeated compatible work.

The rolling aggregate tables are ordered by project and test identifier, with a sparse primary index. A single identifier set sampled across a large project spans most of that key space, forcing ClickHouse to read nearly every relevant granule even when the set contains relatively few tests. Increasing the identifier batch size amortized executions but retained this project-wide access pattern.

## Approach

The changed-test query already returns identifiers in the rolling table's primary-key order. The worker now preserves that order and selects a range size that produces at least four nonempty ranges whenever four or more identifiers change, capped at 2,000 identifiers per range. Sets with fewer than four identifiers use point lookups. Each resulting set covers a contiguous section of the observed identifier order, allowing the primary index to prune granules between ranges.

Cadence enforcement and project-level coalescing remain because they remove redundant evaluations. Alerts with compatible rolling measurements share the aggregate merge, while reliability stays separate because it reads a different aggregate column.

A shared alert predicate now defines path ownership. The enqueue path and project-scoped worker accept only established rolling metric alerts, while the periodic scheduler handles calendar-window alerts and rolling baselines.

Shared cursor advancement uses the later of the stored cursor and the evaluated cursor for every alert. The bulk update also avoids one database update per alert.

## Impact

The production-shaped Atlas plan for a 256-identifier range selected 10 of 514 granules. Across a fixed five-minute window containing 14,895 changed tests, all eight contiguous ranges completed between 0.27 and 0.60 seconds. Every sampled execution was below the 1.5-second alert threshold. Production monitoring after deployment will confirm the resulting 99th percentile latency.

Alert thresholds, transitions, recovery behavior, and the configured cursor lookback duration remain unchanged. No data migration is required.

## Validation

- `mix test test/tuist/automations_test.exs test/tuist/automations/alerts/alert_test.exs test/tuist/automations/monitors/flaky_tests_monitor_test.exs test/tuist/automations/workers/alert_evaluation_worker_test.exs test/tuist/automations/workers/automation_scheduler_test.exs`
  - 136 tests passed.
- `mix compile --warnings-as-errors`
- Targeted `mix credo --strict`
  - No issues found across the relevant automation source and test files.
- Formatting and `git diff --check` passed.
- Atlas returned identical result counts and digests when the same identifier set was evaluated as one set and as four disjoint subsets.
- Atlas reproduced both production flakiness thresholds from the shared measurement result.
