### PR TITLE
fix(server): chart only succeeded and failed runs on the runners dashboard

### DIFF
--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -223,6 +223,7 @@ defmodule TuistWeb.RunnersLive do
         url: workflow_run_detail_url(account_name, run)
       }
     end)
+    |> pad_chart_data()
   end
 
   defp run_duration_seconds(%{duration_ms: ms}) when is_integer(ms) and ms > 0, do: div(ms, 1000)
@@ -262,6 +263,17 @@ defmodule TuistWeb.RunnersLive do
         url: TuistWeb.RunnerJobLive.path(account_name, job)
       }
     end)
+    |> pad_chart_data()
+  end
+
+  # A handful of recent runs on a category axis stretch evenly across the
+  # full card width, which reads as time-spaced gaps rather than a run
+  # trail. Pad the list up to `@chart_limit` slots so the real bars always
+  # render at a fixed density packed on the right (newest last), matching
+  # the Recent Builds chart. Empty leading slots carry a nil value (no bar)
+  # and a blank label so they neither draw nor trigger tooltips.
+  defp pad_chart_data(chart_data) do
+    List.duplicate(%{value: nil, date: ""}, max(@chart_limit - length(chart_data), 0)) ++ chart_data
   end
 
   defp duration_seconds(%{status: "completed", started_at: started, completed_at: completed}) do

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -19,6 +19,11 @@ defmodule TuistWeb.RunnersLive do
 
   @table_limit 5
   @chart_limit 30
+  # Only runs that reached a success/failure conclusion carry a real
+  # duration. Running, cancelled and skipped runs would draw as
+  # zero-height bars that scatter the real ones, so they are kept out of
+  # the chart trail (and are not counted by the success/failure legends).
+  @chart_conclusions ["success", "failure"]
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
@@ -207,13 +212,14 @@ defmodule TuistWeb.RunnersLive do
     )
   end
 
-  # Workflow-run bars mirror the recent-jobs chart: one bar per run,
-  # height in seconds, colour from the run-level conclusion. We URL
-  # the bar to the workflow detail page when the slug fully resolves
-  # so clicking drills down naturally; partial-info rows just don't
-  # carry a navigate target.
+  # Workflow-run bars mirror the recent-jobs chart: one bar per
+  # succeeded/failed run, height in seconds, colour from the run-level
+  # conclusion. We URL the bar to the workflow detail page when the slug
+  # fully resolves so clicking drills down naturally; partial-info rows
+  # just don't carry a navigate target.
   defp recent_workflow_runs_chart_data(recent_workflow_runs, account_name) do
     recent_workflow_runs
+    |> Enum.filter(&(&1.conclusion in @chart_conclusions))
     |> Enum.reverse()
     |> Enum.map(fn run ->
       %{
@@ -247,11 +253,12 @@ defmodule TuistWeb.RunnersLive do
 
   defp workflow_run_detail_url(_account_name, _row), do: nil
 
-  # Bars represent each recent job. Y is the duration in seconds (or
-  # zero for not-yet-started states), the bar colour mirrors the row's
-  # status badge so the chart reads at the same glance as the table.
+  # Bars represent each succeeded/failed job. Y is the duration in
+  # seconds, the bar colour mirrors the row's status badge so the chart
+  # reads at the same glance as the table.
   defp recent_jobs_chart_data(recent_jobs, account_name) do
     recent_jobs
+    |> Enum.filter(&(&1.conclusion in @chart_conclusions))
     |> Enum.reverse()
     |> Enum.map(fn job ->
       seconds = duration_seconds(job)

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -229,7 +229,6 @@ defmodule TuistWeb.RunnersLive do
         url: workflow_run_detail_url(account_name, run)
       }
     end)
-    |> pad_chart_data()
   end
 
   defp run_duration_seconds(%{duration_ms: ms}) when is_integer(ms) and ms > 0, do: div(ms, 1000)
@@ -270,17 +269,6 @@ defmodule TuistWeb.RunnersLive do
         url: TuistWeb.RunnerJobLive.path(account_name, job)
       }
     end)
-    |> pad_chart_data()
-  end
-
-  # A handful of recent runs on a category axis stretch evenly across the
-  # full card width, which reads as time-spaced gaps rather than a run
-  # trail. Pad the list up to `@chart_limit` slots so the real bars always
-  # render at a fixed density packed on the right (newest last), matching
-  # the Recent Builds chart. Empty leading slots carry a nil value (no bar)
-  # and a blank label so they neither draw nor trigger tooltips.
-  defp pad_chart_data(chart_data) do
-    List.duplicate(%{value: nil, date: ""}, max(@chart_limit - length(chart_data), 0)) ++ chart_data
   end
 
   defp duration_seconds(%{status: "completed", started_at: started, completed_at: completed}) do

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -70,7 +70,7 @@ defmodule TuistWeb.RunnersLiveTest do
     assert html =~ "Docker build"
   end
 
-  test "charts only succeeded/failed runs, packed into a fixed-width trail", %{conn: conn, account: account} do
+  test "charts only succeeded and failed runs", %{conn: conn, account: account} do
     complete_run(account, 70_002, 700_020, "success")
     complete_run(account, 70_003, 700_021, "cancelled")
 
@@ -78,12 +78,11 @@ defmodule TuistWeb.RunnersLiveTest do
     html = render_async(lv)
 
     # The cancelled run carries no real duration, so it must not draw a
-    # bar. Only the succeeded run remains, packed into the fixed 30-slot
-    # trail: one real bar plus 29 padded slots.
+    # bar. Only the succeeded run remains on each chart.
     for chart_id <- ["runners-recent-workflows-chart", "runners-recent-jobs-chart"] do
       data = chart_series_data(html, chart_id)
-      assert length(data) == 30
-      assert Enum.count(data, &(&1["value"] != nil)) == 1
+      assert length(data) == 1
+      assert Enum.all?(data, &(&1["value"] != nil))
     end
   end
 

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -70,6 +70,39 @@ defmodule TuistWeb.RunnersLiveTest do
     assert html =~ "Docker build"
   end
 
+  test "pads the recent workflow and job charts to a fixed width", %{conn: conn, account: account} do
+    :ok =
+      Jobs.enqueue(%{
+        workflow_job_id: 70_002,
+        account_id: account.id,
+        fleet_name: "fleet-x",
+        repository: "tuist/tuist",
+        workflow_run_id: 700_020,
+        workflow_name: "Server",
+        run_attempt: 1,
+        job_name: "Docker build",
+        head_branch: "main",
+        head_sha: "abcdef1"
+      })
+
+    {:ok, candidate} = Jobs.pick_queued("fleet-x", [])
+    :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
+    :ok = Jobs.record_running(70_002, "runner-x")
+    {:ok, _} = Jobs.complete(70_002, "success")
+
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
+    html = render_async(lv)
+
+    # A single run must still fill the fixed 30-slot trail: one real bar plus
+    # 29 padded slots, so the bars pack together instead of stretching across
+    # the full card width.
+    for chart_id <- ["runners-recent-workflows-chart", "runners-recent-jobs-chart"] do
+      data = chart_series_data(html, chart_id)
+      assert length(data) == 30
+      assert Enum.count(data, &(&1["value"] == nil)) == 29
+    end
+  end
+
   test "shows empty state when the account has no jobs", %{conn: conn, account: account} do
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
     html = render_async(lv)
@@ -125,6 +158,20 @@ defmodule TuistWeb.RunnersLiveTest do
     assert TuistWeb.RunnersLive.concurrency_chart_options("last-30-days").xAxis.axisLabel.interval == 47
 
     assert TuistWeb.RunnersLive.concurrency_chart_options("last-7-days").tooltip.dateFormat == "hour"
+  end
+
+  defp chart_series_data(html, chart_id) do
+    json =
+      html
+      |> Floki.parse_document!()
+      |> Floki.find("##{chart_id} [data-part='data']")
+      |> Floki.text()
+
+    json
+    |> Jason.decode!()
+    |> Map.fetch!("series")
+    |> List.first()
+    |> Map.fetch!("data")
   end
 
   defp concurrency_after_analytics?(html) do

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -70,36 +70,20 @@ defmodule TuistWeb.RunnersLiveTest do
     assert html =~ "Docker build"
   end
 
-  test "pads the recent workflow and job charts to a fixed width", %{conn: conn, account: account} do
-    :ok =
-      Jobs.enqueue(%{
-        workflow_job_id: 70_002,
-        account_id: account.id,
-        fleet_name: "fleet-x",
-        repository: "tuist/tuist",
-        workflow_run_id: 700_020,
-        workflow_name: "Server",
-        run_attempt: 1,
-        job_name: "Docker build",
-        head_branch: "main",
-        head_sha: "abcdef1"
-      })
-
-    {:ok, candidate} = Jobs.pick_queued("fleet-x", [])
-    :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
-    :ok = Jobs.record_running(70_002, "runner-x")
-    {:ok, _} = Jobs.complete(70_002, "success")
+  test "charts only succeeded/failed runs, packed into a fixed-width trail", %{conn: conn, account: account} do
+    complete_run(account, 70_002, 700_020, "success")
+    complete_run(account, 70_003, 700_021, "cancelled")
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
     html = render_async(lv)
 
-    # A single run must still fill the fixed 30-slot trail: one real bar plus
-    # 29 padded slots, so the bars pack together instead of stretching across
-    # the full card width.
+    # The cancelled run carries no real duration, so it must not draw a
+    # bar. Only the succeeded run remains, packed into the fixed 30-slot
+    # trail: one real bar plus 29 padded slots.
     for chart_id <- ["runners-recent-workflows-chart", "runners-recent-jobs-chart"] do
       data = chart_series_data(html, chart_id)
       assert length(data) == 30
-      assert Enum.count(data, &(&1["value"] == nil)) == 29
+      assert Enum.count(data, &(&1["value"] != nil)) == 1
     end
   end
 
@@ -158,6 +142,27 @@ defmodule TuistWeb.RunnersLiveTest do
     assert TuistWeb.RunnersLive.concurrency_chart_options("last-30-days").xAxis.axisLabel.interval == 47
 
     assert TuistWeb.RunnersLive.concurrency_chart_options("last-7-days").tooltip.dateFormat == "hour"
+  end
+
+  defp complete_run(account, workflow_job_id, workflow_run_id, conclusion) do
+    :ok =
+      Jobs.enqueue(%{
+        workflow_job_id: workflow_job_id,
+        account_id: account.id,
+        fleet_name: "fleet-x",
+        repository: "tuist/tuist",
+        workflow_run_id: workflow_run_id,
+        workflow_name: "Server",
+        run_attempt: 1,
+        job_name: "Docker build",
+        head_branch: "main",
+        head_sha: "abcdef#{workflow_job_id}"
+      })
+
+    {:ok, candidate} = Jobs.pick_queued("fleet-x", [])
+    :ok = Jobs.record_claimed(candidate, "pod-#{workflow_job_id}", DateTime.utc_now())
+    :ok = Jobs.record_running(workflow_job_id, "runner-#{workflow_job_id}")
+    {:ok, _} = Jobs.complete(workflow_job_id, conclusion)
   end
 
   defp chart_series_data(html, chart_id) do

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -172,7 +172,7 @@ defmodule TuistWeb.RunnersLiveTest do
       |> Floki.text()
 
     json
-    |> Jason.decode!()
+    |> JSON.decode!()
     |> Map.fetch!("series")
     |> List.first()
     |> Map.fetch!("data")


### PR DESCRIPTION
## What changed

The **Recent workflows** and **Recent jobs** charts on the runners dashboard now draw a bar only for runs that succeeded or failed.

## Why / root cause

The charts drew a bar for every recent run. Running workflows are already excluded upstream, but **cancelled and skipped** runs are not: they are "completed" yet carry no real duration, so they rendered as zero-height bars. Those invisible bars sat between the real ones and were not counted by the success/failure legends, which is what made the completed bars look spread out across the card (as if the x axis were spacing them by date).

## Solution

Filter both charts to runs with a `success` or `failure` conclusion, so every bar carries a real duration. Cancelled and skipped runs no longer draw a bar; they remain in the tables below the charts. Filtering is done in the chart-data builders rather than the queries, so the tables (and the legend counts) are untouched.

## Impact

Recent workflows/jobs charts read as a clean duration trail of completed runs, with no scattered zero-height bars.

## Validation

- Verified live on the local dashboard: the workflows chart went from 30 bars (with cancelled/skipped zero bars mixed in) to 25 real success/failure bars, matching the "Successful 19 / Failed 6" legend.
- Regression test seeds a cancelled run alongside a succeeded one and asserts only the succeeded run draws a bar on each chart.
- `mix test test/tuist_web/live/runners_live_test.exs` passes (5 tests); `mix format` and `mix credo` clean.