### PR TITLE
fix(server): serve preview ipa directly from storage instead of buffering in memory

### DIFF
--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -115,10 +115,26 @@ defmodule TuistWeb.PreviewController do
     end)
   end
 
+  # iOS extracts the software-package URL from the manifest and retries that
+  # exact URL on queued/stuck installs without re-fetching the manifest, so the
+  # presigned url baked into the manifest gets a generous window. A browser
+  # hitting /app.ipa directly re-mints the url on every request, so that path
+  # keeps the shorter default.
+  @manifest_ipa_url_expires_in 24 * 60 * 60
+  @archive_ipa_url_expires_in 60 * 60
+
   def download_archive(
         %{assigns: %{current_preview: preview, selected_account: account}} = conn,
         %{"account_handle" => account_handle, "project_handle" => project_handle} = _params
       ) do
+    url = ipa_download_url(preview, account_handle, project_handle, account, @archive_ipa_url_expires_in)
+
+    conn
+    |> redirect(external: url)
+    |> halt()
+  end
+
+  defp ipa_download_url(preview, account_handle, project_handle, account, expires_in) do
     app_build = AppBuilds.latest_ipa_app_build_for_preview(preview)
 
     storage_key =
@@ -133,7 +149,7 @@ defmodule TuistWeb.PreviewController do
       raise NotFoundError, dgettext("dashboard", "The preview ipa doesn't exist or has expired.")
     end
 
-    send_resp(conn, :ok, Storage.get_object_as_string(storage_key, account))
+    Storage.generate_download_url(storage_key, account, expires_in: expires_in)
   end
 
   def download_apk(
@@ -162,9 +178,17 @@ defmodule TuistWeb.PreviewController do
   end
 
   def manifest(
-        %{assigns: %{current_preview: preview}} = conn,
+        %{assigns: %{current_preview: preview, selected_account: account}} = conn,
         %{"account_handle" => account_handle, "project_handle" => project_handle} = _params
       ) do
+    # The manifest points the software-package asset directly at a presigned
+    # storage URL. iOS' install daemon does not follow redirects for this URL,
+    # so it must resolve to the ipa without any indirection through the server.
+    ipa_url =
+      preview
+      |> ipa_download_url(account_handle, project_handle, account, @manifest_ipa_url_expires_in)
+      |> Plug.HTML.html_escape()
+
     plist_content = """
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -179,7 +203,7 @@ defmodule TuistWeb.PreviewController do
                             <key>kind</key>
                             <string>software-package</string>
                             <key>url</key>
-                            <string>#{url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/app.ipa")}</string>
+                            <string>#{ipa_url}</string>
                           </dict>
                     </array>
                     <key>metadata</key>

--- a/server/test/tuist_web/controllers/preview_controller_test.exs
+++ b/server/test/tuist_web/controllers/preview_controller_test.exs
@@ -297,6 +297,12 @@ defmodule TuistWeb.PreviewControllerTest do
         type: :ipa
       )
 
+      stub(Storage, :object_exists?, fn _object_key, _actor -> true end)
+
+      stub(Storage, :generate_download_url, fn _object_key, _actor, _opts ->
+        "https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc&X-Amz-Expires=3600"
+      end)
+
       # When
       conn = get(conn, ~p"/#{account_name}/#{project_name}/previews/#{preview.id}/manifest.plist")
 
@@ -305,6 +311,13 @@ defmodule TuistWeb.PreviewControllerTest do
 
       assert plist_response =~ "<string>dev.tuist.app</string>"
       assert plist_response =~ "<string>1.0.0</string>"
+
+      # The presigned url is embedded directly (no redirect through the server)
+      # and XML-escaped so the plist stays valid.
+      assert plist_response =~
+               "<string>https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc&amp;X-Amz-Expires=3600</string>"
+
+      refute plist_response =~ "/app.ipa</string>"
     end
 
     test "raises not found error when the preview does not exist", %{conn: conn} do
@@ -322,7 +335,7 @@ defmodule TuistWeb.PreviewControllerTest do
   end
 
   describe "download_archive/2" do
-    test "returns archive object when it exists", %{conn: conn} do
+    test "redirects to the presigned archive url when it exists", %{conn: conn} do
       # Given
       preview =
         [
@@ -342,14 +355,16 @@ defmodule TuistWeb.PreviewControllerTest do
         type: :ipa
       )
 
+      presigned_url = "https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc"
+
       stub(Storage, :object_exists?, fn _object_key, _actor -> true end)
-      stub(Storage, :get_object_as_string, fn _object_key, _actor -> "ipa-contents" end)
+      stub(Storage, :generate_download_url, fn _object_key, _actor, _opts -> presigned_url end)
 
       # When
       conn = get(conn, ~p"/#{account_name}/#{project_name}/previews/#{preview.id}/app.ipa")
 
       # Then
-      assert response(conn, 200) =~ "ipa-contents"
+      assert redirected_to(conn) == presigned_url
     end
 
     test "throws an error when it doesn't exist", %{conn: conn} do


### PR DESCRIPTION
## What

The iOS over-the-air install path for previews served the `.ipa` by buffering the entire file into the server's memory before responding. This makes the install `manifest.plist` hand the device a presigned storage URL directly, and makes the `/app.ipa` endpoint redirect to a presigned URL instead of proxy-buffering the file.

## Root cause

`PreviewController.download_archive/2` served `/app.ipa` with `send_resp(conn, :ok, Storage.get_object_as_string(...))`. `get_object_as_string` does a single `ExAws.S3.get_object` that buffers the whole object into the BEAM process, and `send_resp` emits nothing to the client until the full file is in memory. So the device's time-to-first-byte equals the full server-side fetch of the entire `.ipa`, and the device sits on "Waiting..." the whole time.

Measured in production for a ~68 MB `.ipa`:

- `HEAD /app.ipa` (which iOS issues before downloading, and retries) took over 3 seconds, because even a HEAD ran the same buffering code with no body to return.
- `GET /app.ipa` time-to-first-byte was ~2.8s uncontended, and one real request took 147 seconds end to end.

The Android APK path (`download_apk/2`) already redirected to a presigned URL; only the `.ipa` path proxy-buffered.

## Change

- `manifest/2` embeds a presigned storage URL directly in the `software-package` field. iOS' install daemon does not follow redirects on that URL, so it must resolve to the `.ipa` with no server indirection. The URL is XML-escaped because presigned URLs contain `&`.
- `download_archive/2` (`/app.ipa`, used by browsers and direct links, which do follow redirects) redirects to a presigned URL, sharing the URL-generation helper.
- The manifest URL gets a 24h expiry because iOS may retry the extracted URL on a queued install without re-fetching the manifest. The browser `/app.ipa` path keeps the 1h default since it re-mints per request.

## Why this approach

- A 302 redirect on `/app.ipa` alone is not enough: iOS' install daemon does not reliably follow redirects on the `software-package` URL, so the presigned URL has to live in the manifest itself.
- Streaming through the server (`send_chunked`) would fix the buffering but still route every byte through the pod. A presigned URL lets the device pull directly from storage.

## Impact

Preview installs on iOS begin immediately, and the server no longer holds a full `.ipa` in memory per in-flight install.

### How to test locally

1. Share a preview with an `.ipa` build to a server running this branch.
2. Fetch `.../previews/<id>/manifest.plist` and confirm the `software-package` value is a presigned storage URL (contains `X-Amz-...`), not `.../app.ipa`.
3. Fetch that URL and confirm it returns the `.ipa` with immediate time-to-first-byte.
4. Fetch `.../previews/<id>/app.ipa` and confirm it returns a 302 to storage.

Validated end to end against staging: the manifest serves a presigned storage URL (24h expiry), the device pulls the `.ipa` directly with ~0.3s time-to-first-byte, and installs without the "Waiting" stall. Preview controller test suite passes.
