### PR TITLE
fix(app): export the shared device preview ad-hoc so it can be installed on devices

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -232,6 +232,8 @@ jobs:
           github.event_name == 'push' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' && needs.check-team-membership.outputs.is-team-member == 'true')
+        env:
+          EXPORT_METHOD: release-testing
         run: mise run app:bundle-ios
       - name: Inspect TuistApp
         if: |

--- a/mise/tasks/app/bundle-ios.sh
+++ b/mise/tasks/app/bundle-ios.sh
@@ -23,6 +23,25 @@ mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
 op read "op://tuist/Tuist App Ad Hoc/Tuist_App_Ad_Hoc.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_ad_hoc.mobileprovision"
 op read "op://tuist/Tuist App Store Connect Provisioning Profile/Tuist_App_Store_Connect.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_app_store.mobileprovision"
 
+# The App Store upload path needs an app-store-connect export, while the
+# shareable device preview needs an ad-hoc (release-testing) export so it can be
+# installed on registered devices over the air. Both provisioning profiles are
+# imported above; select the matching one for the requested method.
+EXPORT_METHOD="${EXPORT_METHOD:-app-store-connect}"
+
+case "$EXPORT_METHOD" in
+    app-store-connect)
+        PROVISIONING_PROFILE_NAME="Tuist App Store Connect"
+        ;;
+    release-testing)
+        PROVISIONING_PROFILE_NAME="Tuist App Ad Hoc"
+        ;;
+    *)
+        echo "Unsupported EXPORT_METHOD '$EXPORT_METHOD' (expected 'app-store-connect' or 'release-testing')" >&2
+        exit 1
+        ;;
+esac
+
 EXPORT_OPTIONS_PLIST_PATH=$TMP_DIR/ExportOptions.plist
 
 cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
@@ -33,11 +52,11 @@ cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
 	<key>destination</key>
 	<string>export</string>
 	<key>method</key>
-	<string>app-store-connect</string>
+	<string>${EXPORT_METHOD}</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>dev.tuist.app</key>
-		<string>Tuist App Store Connect</string>
+		<string>${PROVISIONING_PROFILE_NAME}</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution: Tuist GmbH (U6LC622NKF)</string>


### PR DESCRIPTION
## What

The Tuist iOS app preview shared to tuist.dev was signed for App Store distribution, which cannot be installed on a device over the air. This exports the shared device preview with an ad-hoc (`release-testing`) method instead, while keeping the App Store Connect submission path unchanged.

## Root cause

`mise/tasks/app/bundle-ios.sh` produced `build/Tuist.ipa` with export `method: app-store-connect` (Apple Distribution certificate plus the "Tuist App Store Connect" profile, `get-task-allow: false`, no provisioned devices). App Store distribution builds can only be vended through the App Store or TestFlight; installing one via the preview's over-the-air flow fails with "This app cannot be installed because its integrity could not be verified."

The same script is reused by the App Store Connect submission (`mise/tasks/app/upload-ios.sh`), so it must keep producing an app-store-connect build for that path. The ad-hoc profile ("Tuist App Ad Hoc") was already being downloaded in the script but never used, and `app/Project.swift` declared the ad-hoc profile specifier for the release configuration, so ad-hoc was the intent for the shared build.

## Change

- `bundle-ios.sh` takes an `EXPORT_METHOD` env var (default `app-store-connect`, so the submission path is unchanged) and selects the matching provisioning profile.
- The `Device Build` job in `.github/workflows/app.yml` sets `EXPORT_METHOD: release-testing` (ad-hoc), using the "Tuist App Ad Hoc" profile.

## Impact

The shared device preview of the Tuist app becomes installable over the air on devices registered in the ad-hoc profile. Ad-hoc builds only install on registered devices, which is inherent to ad-hoc distribution.

### How to test locally

This needs the release signing assets, so it is exercised in CI rather than locally: run the `App` workflow (push, dispatch, or a team-member PR) and confirm the Device Build job exports with `EXPORT_METHOD: release-testing`, then install the resulting preview on a device registered in the "Tuist App Ad Hoc" profile.

Validated: triggered the workflow on this branch, the Device Build job exported ad-hoc and shared successfully, the resulting `.ipa` is signed with the "Tuist App Ad Hoc" profile (6 provisioned devices, was 0 before), and it installed end to end on a registered device from a staging preview.
