### PR TITLE
fix(server,app): fix slow and failing iOS preview installs

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -232,6 +232,8 @@ jobs:
           github.event_name == 'push' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' && needs.check-team-membership.outputs.is-team-member == 'true')
+        env:
+          EXPORT_METHOD: release-testing
         run: mise run app:bundle-ios
       - name: Inspect TuistApp
         if: |

--- a/mise/tasks/app/bundle-ios.sh
+++ b/mise/tasks/app/bundle-ios.sh
@@ -23,6 +23,25 @@ mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
 op read "op://tuist/Tuist App Ad Hoc/Tuist_App_Ad_Hoc.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_ad_hoc.mobileprovision"
 op read "op://tuist/Tuist App Store Connect Provisioning Profile/Tuist_App_Store_Connect.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_app_store.mobileprovision"
 
+# The App Store upload path needs an app-store-connect export, while the
+# shareable device preview needs an ad-hoc (release-testing) export so it can be
+# installed on registered devices over the air. Both provisioning profiles are
+# imported above; select the matching one for the requested method.
+EXPORT_METHOD="${EXPORT_METHOD:-app-store-connect}"
+
+case "$EXPORT_METHOD" in
+    app-store-connect)
+        PROVISIONING_PROFILE_NAME="Tuist App Store Connect"
+        ;;
+    release-testing)
+        PROVISIONING_PROFILE_NAME="Tuist App Ad Hoc"
+        ;;
+    *)
+        echo "Unsupported EXPORT_METHOD '$EXPORT_METHOD' (expected 'app-store-connect' or 'release-testing')" >&2
+        exit 1
+        ;;
+esac
+
 EXPORT_OPTIONS_PLIST_PATH=$TMP_DIR/ExportOptions.plist
 
 cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
@@ -33,11 +52,11 @@ cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
 	<key>destination</key>
 	<string>export</string>
 	<key>method</key>
-	<string>app-store-connect</string>
+	<string>${EXPORT_METHOD}</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>dev.tuist.app</key>
-		<string>Tuist App Store Connect</string>
+		<string>${PROVISIONING_PROFILE_NAME}</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution: Tuist GmbH (U6LC622NKF)</string>

--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -115,10 +115,26 @@ defmodule TuistWeb.PreviewController do
     end)
   end
 
+  # iOS extracts the software-package URL from the manifest and retries that
+  # exact URL on queued/stuck installs without re-fetching the manifest, so the
+  # presigned url baked into the manifest gets a generous window. A browser
+  # hitting /app.ipa directly re-mints the url on every request, so that path
+  # keeps the shorter default.
+  @manifest_ipa_url_expires_in 24 * 60 * 60
+  @archive_ipa_url_expires_in 60 * 60
+
   def download_archive(
         %{assigns: %{current_preview: preview, selected_account: account}} = conn,
         %{"account_handle" => account_handle, "project_handle" => project_handle} = _params
       ) do
+    url = ipa_download_url(preview, account_handle, project_handle, account, @archive_ipa_url_expires_in)
+
+    conn
+    |> redirect(external: url)
+    |> halt()
+  end
+
+  defp ipa_download_url(preview, account_handle, project_handle, account, expires_in) do
     app_build = AppBuilds.latest_ipa_app_build_for_preview(preview)
 
     storage_key =
@@ -133,7 +149,7 @@ defmodule TuistWeb.PreviewController do
       raise NotFoundError, dgettext("dashboard", "The preview ipa doesn't exist or has expired.")
     end
 
-    send_resp(conn, :ok, Storage.get_object_as_string(storage_key, account))
+    Storage.generate_download_url(storage_key, account, expires_in: expires_in)
   end
 
   def download_apk(
@@ -162,9 +178,17 @@ defmodule TuistWeb.PreviewController do
   end
 
   def manifest(
-        %{assigns: %{current_preview: preview}} = conn,
+        %{assigns: %{current_preview: preview, selected_account: account}} = conn,
         %{"account_handle" => account_handle, "project_handle" => project_handle} = _params
       ) do
+    # The manifest points the software-package asset directly at a presigned
+    # storage URL. iOS' install daemon does not follow redirects for this URL,
+    # so it must resolve to the ipa without any indirection through the server.
+    ipa_url =
+      preview
+      |> ipa_download_url(account_handle, project_handle, account, @manifest_ipa_url_expires_in)
+      |> Plug.HTML.html_escape()
+
     plist_content = """
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -179,7 +203,7 @@ defmodule TuistWeb.PreviewController do
                             <key>kind</key>
                             <string>software-package</string>
                             <key>url</key>
-                            <string>#{url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/app.ipa")}</string>
+                            <string>#{ipa_url}</string>
                           </dict>
                     </array>
                     <key>metadata</key>

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -350,7 +350,7 @@ msgstr ""
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/controllers/preview_controller.ex:133
+#: lib/tuist_web/controllers/preview_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "The preview ipa doesn't exist or has expired."
 msgstr ""
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/controllers/preview_controller.ex:154
+#: lib/tuist_web/controllers/preview_controller.ex:170
 #, elixir-autogen, elixir-format
 msgid "The preview APK doesn't exist or has expired."
 msgstr ""

--- a/server/test/tuist_web/controllers/preview_controller_test.exs
+++ b/server/test/tuist_web/controllers/preview_controller_test.exs
@@ -297,6 +297,12 @@ defmodule TuistWeb.PreviewControllerTest do
         type: :ipa
       )
 
+      stub(Storage, :object_exists?, fn _object_key, _actor -> true end)
+
+      stub(Storage, :generate_download_url, fn _object_key, _actor, _opts ->
+        "https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc&X-Amz-Expires=3600"
+      end)
+
       # When
       conn = get(conn, ~p"/#{account_name}/#{project_name}/previews/#{preview.id}/manifest.plist")
 
@@ -305,6 +311,13 @@ defmodule TuistWeb.PreviewControllerTest do
 
       assert plist_response =~ "<string>dev.tuist.app</string>"
       assert plist_response =~ "<string>1.0.0</string>"
+
+      # The presigned url is embedded directly (no redirect through the server)
+      # and XML-escaped so the plist stays valid.
+      assert plist_response =~
+               "<string>https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc&amp;X-Amz-Expires=3600</string>"
+
+      refute plist_response =~ "/app.ipa</string>"
     end
 
     test "raises not found error when the preview does not exist", %{conn: conn} do
@@ -322,7 +335,7 @@ defmodule TuistWeb.PreviewControllerTest do
   end
 
   describe "download_archive/2" do
-    test "returns archive object when it exists", %{conn: conn} do
+    test "redirects to the presigned archive url when it exists", %{conn: conn} do
       # Given
       preview =
         [
@@ -342,14 +355,16 @@ defmodule TuistWeb.PreviewControllerTest do
         type: :ipa
       )
 
+      presigned_url = "https://storage.tuist.dev/lapse/marquis/previews/build.zip?X-Amz-Signature=abc"
+
       stub(Storage, :object_exists?, fn _object_key, _actor -> true end)
-      stub(Storage, :get_object_as_string, fn _object_key, _actor -> "ipa-contents" end)
+      stub(Storage, :generate_download_url, fn _object_key, _actor, _opts -> presigned_url end)
 
       # When
       conn = get(conn, ~p"/#{account_name}/#{project_name}/previews/#{preview.id}/app.ipa")
 
       # Then
-      assert response(conn, 200) =~ "ipa-contents"
+      assert redirected_to(conn) == presigned_url
     end
 
     test "throws an error when it doesn't exist", %{conn: conn} do


### PR DESCRIPTION
Fixes iOS preview installs, which had three independent problems (two code, one Cloudflare dashboard change documented below).

## 1. Server: serve the preview `.ipa` directly from storage

### Root cause

`PreviewController.download_archive/2` served `/app.ipa` with `send_resp(conn, :ok, Storage.get_object_as_string(...))`. `get_object_as_string` does a single `ExAws.S3.get_object` that buffers the whole object into the BEAM process, and `send_resp` emits nothing to the client until the full file is in memory. So the device's time-to-first-byte equals the full server-side fetch of the entire `.ipa`, and the device sits on "Waiting..." the whole time.

Measured in production for a ~68 MB `.ipa`: `HEAD /app.ipa` (which iOS issues before downloading, and retries) took over 3 seconds even though a HEAD returns no body; `GET` time-to-first-byte was ~2.8s uncontended, and one real request took 147 seconds. The Android APK path already redirected to a presigned URL; only the `.ipa` path proxy-buffered.

### Change

- `manifest/2` embeds a presigned storage URL directly in the `software-package` field. iOS' install daemon does not follow redirects on that URL, so it must resolve to the `.ipa` with no server indirection. The URL is XML-escaped because presigned URLs contain `&`.
- `download_archive/2` (`/app.ipa`, used by browsers and direct links, which do follow redirects) redirects to a presigned URL, sharing the URL-generation helper.
- The manifest URL gets a 24h expiry because iOS may retry the extracted URL on a queued install without re-fetching the manifest; the browser `/app.ipa` path keeps the 1h default since it re-mints per request.

A 302 on `/app.ipa` alone is not enough, because iOS' install daemon does not reliably follow redirects on the `software-package` URL, so the presigned URL has to live in the manifest itself.

## 2. App: export the shared device preview ad-hoc

### Root cause

`mise/tasks/app/bundle-ios.sh` produced `build/Tuist.ipa` with export `method: app-store-connect` (Apple Distribution certificate plus the "Tuist App Store Connect" profile). App Store distribution builds can only be vended through the App Store or TestFlight; installing one via the preview's over-the-air flow fails with "This app cannot be installed because its integrity could not be verified." The same script is reused by the App Store Connect submission (`mise/tasks/app/upload-ios.sh`), so it must keep producing an app-store-connect build there. The ad-hoc profile ("Tuist App Ad Hoc") was already being downloaded in the script but never used, and `app/Project.swift` declared the ad-hoc profile for the release configuration, so ad-hoc was the intent for the shared build.

### Change

- `bundle-ios.sh` takes an `EXPORT_METHOD` env var (default `app-store-connect`, so the submission path is unchanged) and selects the matching provisioning profile.
- The `Device Build` job in `.github/workflows/app.yml` sets `EXPORT_METHOD: release-testing` (ad-hoc), using the "Tuist App Ad Hoc" profile. Ad-hoc builds only install on devices registered in that profile.

## 3. Cloudflare (dashboard change, not in this diff)

A Cloudflare custom rule ("Bot protection") applies a Managed Challenge to paths starting with `/tuist/tuist`, `/tuist/gradle-plugin`, and `/tuist/android`. Browsers solve the challenge, but iOS' install daemon (which fetches `manifest.plist` and `app.ipa`) and image fetchers (the QR code) cannot, so for Tuist's own previews the install silently did nothing, the QR code did not render, and the download came back empty. Customer previews were unaffected because they live under different paths.

The rule was updated to keep the challenge on the pages but exclude the public asset endpoints:

```
... and not (
  ends_with(http.request.uri.path, "/manifest.plist") or
  ends_with(http.request.uri.path, "/app.ipa") or
  ends_with(http.request.uri.path, "/app.apk") or
  ends_with(http.request.uri.path, "/qr-code.svg") or
  ends_with(http.request.uri.path, "/qr-code.png") or
  ends_with(http.request.uri.path, "/icon.png") or
  ends_with(http.request.uri.path, "/download")
)
```

This lives in the Cloudflare dashboard, not in this repository.

### How to test locally

Server: share a preview with an `.ipa` build to a server running this branch, fetch `.../previews/<id>/manifest.plist` and confirm the `software-package` value is a presigned storage URL (contains `X-Amz-...`), fetch that URL and confirm an immediate time-to-first-byte, and confirm `.../previews/<id>/app.ipa` returns a 302 to storage.

App: run the `App` workflow (push, dispatch, or a team-member PR) and confirm the Device Build job exports with `EXPORT_METHOD: release-testing`, then install the resulting preview on a device registered in the "Tuist App Ad Hoc" profile.

### Validation

Validated end to end against staging: the manifest serves a presigned storage URL (24h expiry) and the device pulls the `.ipa` directly with ~0.3s time-to-first-byte; the CI-built preview is signed with the "Tuist App Ad Hoc" profile (6 provisioned devices, was 0 before) and installed on a registered device without the "Waiting" stall or the integrity error. Preview controller test suite passes.
