### PR TITLE
perf(server): optimize test case analytics lookups

### DIFF
--- a/server/lib/tuist/mcp/components/tools/get_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/get_test_case.ex
@@ -139,8 +139,8 @@ defmodule Tuist.MCP.Components.Tools.GetTestCase do
   end
 
   defp reply_with_test_case(test_case) do
-    analytics = Analytics.test_case_analytics_by_id(test_case.id)
-    reliability_rate = Analytics.test_case_reliability_by_id(test_case.id, "main")
+    analytics = Analytics.test_case_analytics_by_id(test_case.project_id, test_case.id)
+    reliability_rate = Analytics.test_case_reliability_by_id(test_case.project_id, test_case.id, "main")
     flakiness_rate = Analytics.get_test_case_flakiness_rate(test_case)
 
     data = %{

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -1218,19 +1218,20 @@ defmodule Tuist.Tests.Analytics do
   end
 
   @doc """
-  Calculates the test reliability (success rate) for a specific test case by its UUID.
+  Calculates the test reliability (success rate) for a specific test case by its identifier.
   First attempts to calculate based on the project's default branch. If no runs exist on the
   default branch, falls back to calculating reliability across all branches.
   Returns the percentage of successful runs (0-100) or nil if no runs exist at all.
   """
-  def test_case_reliability_by_id(test_case_id, default_branch) do
+  def test_case_reliability_by_id(project_id, test_case_id, default_branch) do
     default_branch_query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.git_branch == ^default_branch,
         select: %{
           success_count: fragment("countIf(? = 'success')", tcr.status),
-          total_count: count(tcr.id)
+          total_count: count()
         }
       )
 
@@ -1243,10 +1244,11 @@ defmodule Tuist.Tests.Analytics do
       _ ->
         all_branches_query =
           from(tcr in TestCaseRun,
+            where: tcr.project_id == ^project_id,
             where: tcr.test_case_id == ^test_case_id,
             select: %{
               success_count: fragment("countIf(? = 'success')", tcr.status),
-              total_count: count(tcr.id)
+              total_count: count()
             }
           )
 
@@ -1263,14 +1265,15 @@ defmodule Tuist.Tests.Analytics do
   end
 
   @doc """
-  Gets analytics for a specific test case by its UUID including total runs, failed runs, and average duration.
+  Gets analytics for a specific test case by its identifier including total runs, failed runs, and average duration.
   """
-  def test_case_analytics_by_id(test_case_id, _opts \\ []) do
+  def test_case_analytics_by_id(project_id, test_case_id) do
     query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         select: %{
-          total_count: count(tcr.id),
+          total_count: count(),
           failed_count: fragment("countIf(? = 'failure')", tcr.status),
           avg_duration: avg(tcr.duration)
         }

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -261,8 +261,8 @@ defmodule TuistWeb.API.TestCasesController do
       {:ok, test_case} ->
         if test_case.project_id == selected_project.id do
           default_branch = selected_project.default_branch || "main"
-          analytics = Analytics.test_case_analytics_by_id(test_case_id)
-          reliability_rate = Analytics.test_case_reliability_by_id(test_case_id, default_branch)
+          analytics = Analytics.test_case_analytics_by_id(selected_project.id, test_case_id)
+          reliability_rate = Analytics.test_case_reliability_by_id(selected_project.id, test_case_id, default_branch)
           flakiness_rate = Analytics.get_test_case_flakiness_rate(test_case)
 
           json(conn, %{

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -361,10 +361,10 @@ defmodule TuistWeb.TestCaseLive do
        ) do
     socket
     |> assign_async(:reliability, fn ->
-      {:ok, %{reliability: Analytics.test_case_reliability_by_id(test_case_id, project.default_branch)}}
+      {:ok, %{reliability: Analytics.test_case_reliability_by_id(project.id, test_case_id, project.default_branch)}}
     end)
     |> assign_async(:analytics, fn ->
-      {:ok, %{analytics: Analytics.test_case_analytics_by_id(test_case_id)}}
+      {:ok, %{analytics: Analytics.test_case_analytics_by_id(project.id, test_case_id)}}
     end)
     |> assign_async([:flakiness_rate, :flaky_runs_grouped, :flaky_runs_meta], fn ->
       {flaky_runs_grouped, flaky_runs_meta} = Tests.list_flaky_runs_for_test_case(project.id, test_case_id)

--- a/server/test/tuist/tests/analytics_test.exs
+++ b/server/test/tuist/tests/analytics_test.exs
@@ -1074,7 +1074,7 @@ defmodule Tuist.Tests.AnalyticsTest do
     end
   end
 
-  describe "test_case_reliability_by_id/2" do
+  describe "test_case_reliability_by_id/3" do
     test "returns reliability percentage for test case runs on default branch" do
       # Given
       project = ProjectsFixtures.project_fixture(default_branch: "main")
@@ -1131,10 +1131,37 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then - 2 successes out of 3 runs = 66.7%
       assert got == 66.7
+    end
+
+    test "ignores runs belonging to another project" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      other_project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        git_branch: "main",
+        status: 0
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: other_project.id,
+        test_case_id: test_case_id,
+        git_branch: "main",
+        status: 1
+      )
+
+      # When
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
+
+      # Then
+      assert got == 100.0
     end
 
     test "returns 100% when all runs on default branch are successful" do
@@ -1178,7 +1205,7 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then
       assert got == 100.0
@@ -1225,7 +1252,7 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When - no runs on "main" branch, should fall back to all branches
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then - 2 successes out of 2 runs = 100%
       assert got == 100.0
@@ -1272,7 +1299,7 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When - no runs on "main" branch, should fall back to all branches
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then - 1 success out of 2 runs = 50%
       assert got == 50.0
@@ -1280,10 +1307,11 @@ defmodule Tuist.Tests.AnalyticsTest do
 
     test "returns nil when no runs exist at all" do
       # Given
+      project = ProjectsFixtures.project_fixture()
       test_case_id = UUIDv7.generate()
 
       # When
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then
       assert got == nil
@@ -1345,10 +1373,46 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When - should use only "main" branch runs
-      got = Analytics.test_case_reliability_by_id(test_case_id, "main")
+      got = Analytics.test_case_reliability_by_id(project.id, test_case_id, "main")
 
       # Then - 0 successes out of 1 run on main = 0%
       assert got == 0.0
+    end
+  end
+
+  describe "test_case_analytics_by_id/2" do
+    test "aggregates only runs belonging to the project" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      other_project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        status: 0,
+        duration: 100
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        status: 1,
+        duration: 300
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: other_project.id,
+        test_case_id: test_case_id,
+        status: 1,
+        duration: 1000
+      )
+
+      # When
+      got = Analytics.test_case_analytics_by_id(project.id, test_case_id)
+
+      # Then
+      assert got == %{total_count: 2, failed_count: 1, avg_duration: 200}
     end
   end
 

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -519,8 +519,8 @@ defmodule TuistWeb.API.TestCasesControllerTest do
         )
 
       stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
-      stub(Analytics, :test_case_analytics_by_id, fn _id -> %{total_count: 50, failed_count: 2} end)
-      stub(Analytics, :test_case_reliability_by_id, fn _id, _branch -> 96.0 end)
+      stub(Analytics, :test_case_analytics_by_id, fn _project_id, _id -> %{total_count: 50, failed_count: 2} end)
+      stub(Analytics, :test_case_reliability_by_id, fn _project_id, _id, _branch -> 96.0 end)
       stub(Analytics, :get_test_case_flakiness_rate, fn _tc -> 4.0 end)
 
       # When
@@ -551,8 +551,8 @@ defmodule TuistWeb.API.TestCasesControllerTest do
         )
 
       stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
-      stub(Analytics, :test_case_analytics_by_id, fn _id -> %{total_count: 10, failed_count: 0} end)
-      stub(Analytics, :test_case_reliability_by_id, fn _id, _branch -> 100.0 end)
+      stub(Analytics, :test_case_analytics_by_id, fn _project_id, _id -> %{total_count: 10, failed_count: 0} end)
+      stub(Analytics, :test_case_reliability_by_id, fn _project_id, _id, _branch -> 100.0 end)
       stub(Analytics, :get_test_case_flakiness_rate, fn _tc -> 0.0 end)
 
       # When


### PR DESCRIPTION
The [Grafana slow-query alert](https://tuist.grafana.net/alerting/grafana/ffeb6l2ax5qtcf/view?orgId=1) exposed test case analytics lookups that filtered only by `test_case_id`, even though the ClickHouse table is ordered by `project_id` first. That forced ClickHouse to scan broadly across the table and also left open the possibility of combining records when two projects share a test case identifier.

This change threads `project_id` through the reliability and analytics lookups, adds it to both the default-branch and fallback filters, and replaces `count(id)` with `count()`. The controller, live view, agent tool, mocks, and focused tests now use the project-scoped functions. Regression coverage confirms that records from another project are ignored. The public response shape and stored data are unchanged, so there is no migration or caller-visible compatibility change.

### How to test locally

- `mix test test/tuist/tests/analytics_test.exs:1077 test/tuist/tests/analytics_test.exs:1383 test/tuist_web/controllers/api/test_cases_controller_test.exs:503` completed with 9 tests passing and 76 excluded.
- `mix test test/tuist_web/live/test_case_live_test.exs test/tuist/mcp/components/tools/test_tools_test.exs` completed with 33 tests passing.
- `mix format --check-formatted` passed for all six changed files, and `git diff --check` passed.
- A read-only production comparison reduced the alerted lookup from 219 milliseconds, 26,711,706 rows, and 457,977,429 bytes read to 17.7 milliseconds, 337,413 rows, and 8,282,660 bytes read. The optimized query returned the same aggregates for the alerted test case.
