### PR TITLE
test(server): raise test Repo statement timeout to tolerate transient CI DB stalls

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -68,7 +68,11 @@ config :tuist, Tuist.Repo,
   pool: Sandbox,
   pool_size: System.schedulers_online() * 2,
   queue_target: 5000,
-  queue_interval: 1000
+  queue_interval: 1000,
+  # Tolerate transient statement stalls on oversubscribed CI runners where a
+  # single round-trip can block on the socket well past the 15s DBConnection
+  # default; a genuinely hung query still fails within this bound.
+  timeout: 60_000
 
 config :tuist, Tuist.Tasks, sync: true
 


### PR DESCRIPTION
> Describe here the purpose of your PR.

Makes the flaky `Tuist.AlertsTest` case *"evaluate/1 for cache_hit_rate filters to CI builds only when environment is ci"* deterministic in CI. It intermittently failed with a DB connection-pool timeout while inserting a fixture (surfaced in CI for an unrelated PR, where it was the only red test at 5907/5908).

### What changed

Raised the **test** `Tuist.Repo` statement timeout from the 15s DBConnection default to 60s in `config/test.exs`. Scoped to `Tuist.Repo` (Postgres); ClickHouse `IngestRepo` is untouched.

### Root cause

This is **not** a slow test or an expensive query. The failing operation was a trivial `INSERT INTO alert_rules`, and the stacktrace pins the block to the network receive, not query logic:

```
:prim_inet.recv0/3
Postgrex.Protocol.msg_recv/4
Postgrex.Protocol.recv_bind/3      # blocked waiting for Postgres to answer the INSERT
```

The client sent the insert and then blocked on the socket waiting for Postgres to respond for 15s, at which point DBConnection's default per-query deadline (`@timeout 15000` in `holder.ex:441`) killed the connection (`tcp recv: closed`). It was waiting on the server, not doing work.

Evidence this is a transient infrastructure stall under CI contention, not the test itself:

- **Fast in isolation.** Runs in 0.9s; looped 20×, all green at 0.5–0.7s. The failing line is a bare fixture insert reached *before* `Alerts.evaluate/1`, so the rolling `cache_hit_rate` query was never even executed in the failing run.
- **No neighbor pool contention.** The test is `async: false`, and ExUnit runs sync modules fully isolated *after* every async module finishes (`runner.ex:122-137`), so nothing else held the shared sandbox connection during it.
- **No pool exhaustion.** Postgres `max_connections=100`, pool_size=8, and only 1 of 5908 tests failed with zero other DB errors anywhere in the job — on an oversubscribed 4-vCPU runner (8 concurrent modules on 4 vCPUs alongside the Postgres and ClickHouse containers).

### Why this solution

The task's usual preference — "make the query/fixtures cheaper" — can't help a network-recv stall on an unrelated trivial insert; there's no expensive query or fixture in the failure path. Since the exact deadline that tripped is the per-query `:timeout` (Ecto's repo-level `:timeout` sets this default), bumping it there is the targeted lever. 60s gives generous headroom for a transient socket stall under CI contention while a genuinely hung query still fails within a minute — well under `ownership_timeout` (120s) and the job timeout.

`max_cases` tuning was considered and rejected for this failure: it only gates the async phase, whereas this `async: false` test runs in the sync phase where `max_cases` has no effect (and lowering it would slow this I/O-bound suite without helping sync-phase tests).

### Developer impact

Test-only configuration change; no product/runtime behavior is affected. Failure detection for a genuinely hung query in tests moves from 15s to 60s.

### How to test locally

```bash
cd server
for i in $(seq 1 20); do mise exec -- mix test test/tuist/alerts/alerts_test.exs:649 || break; done
```

All iterations pass. You can also confirm the config is applied:

```bash
MIX_ENV=test mise exec -- mix run -e 'IO.inspect(Keyword.get(Application.get_env(:tuist, Tuist.Repo), :timeout))'
# => 60000
```
