### PR TITLE
fix(kura): validate stdout/stderr and tree output blobs on action-cache serve

### DIFF
--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1100,23 +1100,17 @@ impl ActionCache for ReapiService {
         .await?;
         // Presence gate, the per-key counterpart of the snapshot reconcile's:
         // an entry whose output blobs were evicted is unserveable by
-        // construction — the compiler replaying it hard-fails the build on
-        // the first missing object (a production cold build died on its very
-        // first resolve this way), while a not-found here is an ordinary miss
-        // the client recompiles from and republishes with fresh blobs.
-        // Entries older than the snapshot index's scan cap are exactly the
-        // ones its reconcile-time gate and cascade never examine, so without
-        // this they serve dead forever. Mostly existence-cache hits.
-        let evicted = action_result.output_files.iter().find_map(|file| {
-            let digest = file.digest.as_ref()?;
-            let node_key = blob_key(&digest_key(digest).ok()?);
-            let exists = self
-                .state
-                .store
-                .artifact_manifest_exists(ArtifactProducer::Reapi, namespace_id, &node_key)
-                .unwrap_or(true);
-            (!exists).then(|| digest.hash.clone())
-        });
+        // construction — the client replaying it hard-fails the build on the
+        // first missing object (a production cold build died on its very first
+        // resolve this way), while a not-found here is an ordinary miss the
+        // client recompiles from and republishes with fresh blobs. Entries
+        // older than the snapshot index's scan cap are exactly the ones its
+        // reconcile-time gate and cascade never examine, so without this they
+        // serve dead forever. This checks every blob a replay fetches — output
+        // files, stdout/stderr, and each output directory's tree plus the files
+        // it lists — not just output files, so a Bazel client with tree
+        // artifacts is covered as well. Mostly existence-cache hits.
+        let evicted = first_evicted_output(&self.state, namespace_id, &action_result).await;
         if let Some(missing) = evicted {
             // Delete the dead entry past the replication grace window (a
             // freshly replicated entry's blobs may still be in flight), so
@@ -1870,6 +1864,78 @@ async fn maybe_read_cas_bytes(
         .metrics
         .record_artifact_read(ArtifactProducer::Reapi, "ok", bytes.len() as u64);
     Ok(Some(bytes))
+}
+
+/// The hash of the first blob this action result references that is no longer
+/// present in the CAS, or `None` when every referenced blob is present.
+///
+/// The original per-key gate (PR #11793) checked `output_files` only; this
+/// covers the rest of what a client fetches when it replays a hit: `stdout` and
+/// `stderr`, and each output directory's `Tree` blob together with the file
+/// blobs the tree lists. Any one of them missing hard-fails the replay on the
+/// first missing object exactly as an evicted output file does, so all of them
+/// must gate the serve — a Bazel client emitting tree artifacts would otherwise
+/// keep hitting the same "Lost inputs"/missing-object failure this fix targets.
+/// The checks are manifest lookups (mostly existence-cache hits); only an entry
+/// that actually carries directory outputs pays the extra tree read, and only
+/// once its cheap checks pass. Read or decode failures are treated as "present"
+/// so a transient blip never turns a live entry into a spurious miss — the same
+/// bias as the `unwrap_or(true)` manifest checks.
+async fn first_evicted_output(
+    state: &SharedState,
+    namespace_id: &str,
+    action_result: &reapi::ActionResult,
+) -> Option<String> {
+    let missing = |digest: &reapi::Digest| {
+        digest_key(digest).is_ok_and(|key| {
+            !state
+                .store
+                .artifact_manifest_exists(ArtifactProducer::Reapi, namespace_id, &blob_key(&key))
+                .unwrap_or(true)
+        })
+    };
+
+    let stream_evicted = action_result
+        .output_files
+        .iter()
+        .filter_map(|file| file.digest.as_ref())
+        .chain(action_result.stdout_digest.as_ref())
+        .chain(action_result.stderr_digest.as_ref())
+        .find(|&digest| missing(digest));
+    if let Some(digest) = stream_evicted {
+        return Some(digest.hash.clone());
+    }
+
+    for directory in &action_result.output_directories {
+        let Some(tree_digest) = directory.tree_digest.as_ref() else {
+            continue;
+        };
+        if missing(tree_digest) {
+            return Some(tree_digest.hash.clone());
+        }
+        // The tree blob survives; a client next fetches every file it lists, so
+        // an evicted leaf poisons the replay just as a missing tree would. This
+        // read is the one non-manifest cost, paid only by directory-output
+        // entries and only after their tree passed the cheap check above.
+        let Ok(Some(bytes)) = maybe_read_cas_bytes(state, namespace_id, tree_digest, None).await
+        else {
+            continue;
+        };
+        let Ok(tree) = reapi::Tree::decode(bytes.as_slice()) else {
+            continue;
+        };
+        let leaf_evicted = tree
+            .root
+            .iter()
+            .chain(&tree.children)
+            .flat_map(|directory| &directory.files)
+            .filter_map(|file| file.digest.as_ref())
+            .find(|&digest| missing(digest));
+        if let Some(digest) = leaf_evicted {
+            return Some(digest.hash.clone());
+        }
+    }
+    None
 }
 
 // Persists a CAS blob and returns whether it was newly stored (`true`) or was
@@ -2944,6 +3010,193 @@ mod tests {
             exists(&young_dead_key),
             "a young dead entry is kept — its blobs may still be mid-replication"
         );
+    }
+
+    #[tokio::test]
+    async fn per_key_serve_gates_evicted_streams_and_tree_blobs() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        let store = &context.state.store;
+        let uploads = context.state.config.tmp_dir.join("uploads");
+        std::fs::create_dir_all(&uploads).expect("uploads dir should create");
+
+        async fn write_artifact(
+            store: &crate::store::Store,
+            uploads: &std::path::Path,
+            key: &str,
+            bytes: &[u8],
+            version_ms: u64,
+        ) {
+            let path = uploads.join(key.replace('/', "-"));
+            std::fs::write(&path, bytes).expect("source should write");
+            store
+                .apply_replicated_artifact_from_path(
+                    ArtifactProducer::Reapi,
+                    "ios",
+                    key,
+                    "application/octet-stream",
+                    &path,
+                    version_ms,
+                )
+                .await
+                .expect("artifact should persist");
+        }
+        fn digest(hash: [u8; 32], size_bytes: i64) -> reapi::Digest {
+            reapi::Digest {
+                hash: hex::encode(hash),
+                size_bytes,
+            }
+        }
+        fn tree_bytes(leaf: [u8; 32]) -> Vec<u8> {
+            reapi::Tree {
+                root: Some(reapi::Directory {
+                    files: vec![reapi::FileNode {
+                        name: "out".into(),
+                        digest: Some(digest(leaf, 7)),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+            .encode_to_vec()
+        }
+        fn get_request(action_hash: [u8; 32]) -> Request<reapi::GetActionResultRequest> {
+            Request::new(reapi::GetActionResultRequest {
+                instance_name: "ios".into(),
+                action_digest: Some(digest(action_hash, 10)),
+                ..Default::default()
+            })
+        }
+
+        let now = crate::utils::now_ms();
+        let live_blob = [0x11u8; 32];
+        let missing_blob = [0x22u8; 32];
+        write_artifact(
+            store,
+            &uploads,
+            &blob_key(&format!("{}/7", hex::encode(live_blob))),
+            b"payload",
+            now,
+        )
+        .await;
+
+        // A tree whose one file is present, and one whose file is evicted. Both
+        // tree blobs themselves exist; the missing tree hash is never written.
+        let live_tree = tree_bytes(live_blob);
+        let dead_leaf_tree = tree_bytes(missing_blob);
+        let live_tree_hash = [0x33u8; 32];
+        let dead_leaf_tree_hash = [0x34u8; 32];
+        let missing_tree_hash = [0x35u8; 32];
+        write_artifact(
+            store,
+            &uploads,
+            &blob_key(&format!(
+                "{}/{}",
+                hex::encode(live_tree_hash),
+                live_tree.len()
+            )),
+            &live_tree,
+            now,
+        )
+        .await;
+        write_artifact(
+            store,
+            &uploads,
+            &blob_key(&format!(
+                "{}/{}",
+                hex::encode(dead_leaf_tree_hash),
+                dead_leaf_tree.len()
+            )),
+            &dead_leaf_tree,
+            now,
+        )
+        .await;
+
+        let live_file = || reapi::OutputFile {
+            path: hex::encode([0xAB, 0xCD]),
+            digest: Some(digest(live_blob, 7)),
+            ..Default::default()
+        };
+        let with_tree = |tree_hash: [u8; 32], tree_len: usize| reapi::OutputDirectory {
+            path: "outdir".into(),
+            tree_digest: Some(digest(tree_hash, tree_len as i64)),
+            ..Default::default()
+        };
+
+        // The output file is present in every entry, so each rejection is
+        // attributable to the stream/tree blob under test, not the file.
+        let cases = [
+            (
+                [0x41u8; 32],
+                reapi::ActionResult {
+                    output_files: vec![live_file()],
+                    stdout_digest: Some(digest(missing_blob, 7)),
+                    ..Default::default()
+                },
+                "an evicted stdout blob",
+            ),
+            (
+                [0x42u8; 32],
+                reapi::ActionResult {
+                    output_files: vec![live_file()],
+                    output_directories: vec![with_tree(missing_tree_hash, 5)],
+                    ..Default::default()
+                },
+                "an evicted output-directory tree",
+            ),
+            (
+                [0x43u8; 32],
+                reapi::ActionResult {
+                    output_files: vec![live_file()],
+                    output_directories: vec![with_tree(dead_leaf_tree_hash, dead_leaf_tree.len())],
+                    ..Default::default()
+                },
+                "a present tree that lists an evicted file",
+            ),
+        ];
+        for (action, result, label) in &cases {
+            write_artifact(
+                store,
+                &uploads,
+                &format!("action_cache/{}/10", hex::encode(action)),
+                &result.encode_to_vec(),
+                now,
+            )
+            .await;
+            let status = service
+                .get_action_result(get_request(*action))
+                .await
+                .expect_err(label);
+            assert_eq!(
+                status.code(),
+                tonic::Code::NotFound,
+                "{label} must gate the serve"
+            );
+        }
+
+        let all_live_action = [0x44u8; 32];
+        let all_live = reapi::ActionResult {
+            output_files: vec![live_file()],
+            stdout_digest: Some(digest(live_blob, 7)),
+            output_directories: vec![with_tree(live_tree_hash, live_tree.len())],
+            ..Default::default()
+        };
+        write_artifact(
+            store,
+            &uploads,
+            &format!("action_cache/{}/10", hex::encode(all_live_action)),
+            &all_live.encode_to_vec(),
+            now,
+        )
+        .await;
+        service
+            .get_action_result(get_request(all_live_action))
+            .await
+            .expect("an entry whose stream and tree blobs are all present serves");
     }
 
     #[tokio::test]

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1110,14 +1110,14 @@ impl ActionCache for ReapiService {
         // files, stdout/stderr, and each output directory's tree plus the files
         // it lists — not just output files, so a Bazel client with tree
         // artifacts is covered as well. Mostly existence-cache hits.
-        let evicted = first_evicted_output(
+        if let Some(missing) = first_evicted_output(
             &self.state,
             namespace_id,
             &action_result,
             &mut materialization_budget,
         )
-        .await;
-        if let Some(missing) = evicted {
+        .await
+        {
             // Delete the dead entry past the replication grace window (a
             // freshly replicated entry's blobs may still be in flight), so
             // the next publish recreates it instead of every reader paying

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1110,7 +1110,13 @@ impl ActionCache for ReapiService {
         // files, stdout/stderr, and each output directory's tree plus the files
         // it lists — not just output files, so a Bazel client with tree
         // artifacts is covered as well. Mostly existence-cache hits.
-        let evicted = first_evicted_output(&self.state, namespace_id, &action_result).await;
+        let evicted = first_evicted_output(
+            &self.state,
+            namespace_id,
+            &action_result,
+            &mut materialization_budget,
+        )
+        .await;
         if let Some(missing) = evicted {
             // Delete the dead entry past the replication grace window (a
             // freshly replicated entry's blobs may still be in flight), so
@@ -1344,6 +1350,12 @@ impl ContentAddressableStorage for ReapiService {
         let principal = self.authorize_request(&request, extension.clone()).await?;
         let mut missing = Vec::new();
         for digest in &request.get_ref().blob_digests {
+            // The empty blob is present by REAPI convention even when it was
+            // never uploaded; reporting it missing would push clients to upload
+            // a zero-byte blob they otherwise synthesize.
+            if is_empty_blob(digest) {
+                continue;
+            }
             let key = blob_key(&digest_key(digest)?);
             let exists = self
                 .state
@@ -1878,21 +1890,33 @@ async fn maybe_read_cas_bytes(
 /// keep hitting the same "Lost inputs"/missing-object failure this fix targets.
 /// The checks are manifest lookups (mostly existence-cache hits); only an entry
 /// that actually carries directory outputs pays the extra tree read, and only
-/// once its cheap checks pass. Read or decode failures are treated as "present"
-/// so a transient blip never turns a live entry into a spurious miss — the same
-/// bias as the `unwrap_or(true)` manifest checks.
+/// once its cheap checks pass. That read claims the request's
+/// `MaterializationBudget` like every other read on this path, so a large tree
+/// cannot pull unbounded bytes into a pressured node — a failed claim surfaces
+/// as an error the loop treats as "present", degrading the gate to serving
+/// unchecked rather than adding load. Read or decode failures are treated as
+/// "present" throughout, and the canonical empty blob is always present (REAPI
+/// convention), so a transient blip or a zero-byte reference never turns a live
+/// entry into a spurious miss — the same bias as the `unwrap_or(true)` manifest
+/// checks.
 async fn first_evicted_output(
     state: &SharedState,
     namespace_id: &str,
     action_result: &reapi::ActionResult,
+    materialization_budget: &mut MaterializationBudget<'_>,
 ) -> Option<String> {
     let missing = |digest: &reapi::Digest| {
-        digest_key(digest).is_ok_and(|key| {
-            !state
-                .store
-                .artifact_manifest_exists(ArtifactProducer::Reapi, namespace_id, &blob_key(&key))
-                .unwrap_or(true)
-        })
+        !is_empty_blob(digest)
+            && digest_key(digest).is_ok_and(|key| {
+                !state
+                    .store
+                    .artifact_manifest_exists(
+                        ArtifactProducer::Reapi,
+                        namespace_id,
+                        &blob_key(&key),
+                    )
+                    .unwrap_or(true)
+            })
     };
 
     let stream_evicted = action_result
@@ -1916,8 +1940,15 @@ async fn first_evicted_output(
         // The tree blob survives; a client next fetches every file it lists, so
         // an evicted leaf poisons the replay just as a missing tree would. This
         // read is the one non-manifest cost, paid only by directory-output
-        // entries and only after their tree passed the cheap check above.
-        let Ok(Some(bytes)) = maybe_read_cas_bytes(state, namespace_id, tree_digest, None).await
+        // entries and only after their tree passed the cheap check above, and it
+        // claims the shared budget so a large tree can't materialize unbounded.
+        let Ok(Some(bytes)) = maybe_read_cas_bytes(
+            state,
+            namespace_id,
+            tree_digest,
+            Some(&mut *materialization_budget),
+        )
+        .await
         else {
             continue;
         };
@@ -2414,6 +2445,18 @@ fn compress_snapshot(body: &[u8]) -> Vec<u8> {
     out.extend_from_slice(&(body.len() as u64).to_le_bytes());
     out.extend_from_slice(&compressed);
     out
+}
+
+/// The canonical SHA-256 of the empty byte string. REAPI clients assume the
+/// empty blob always exists and never fetch it (Bazel synthesizes it
+/// client-side), so a server must report it present regardless of whether a
+/// zero-byte blob was ever uploaded — otherwise a result referencing an empty
+/// file, empty stdout, or empty stderr would be treated as evicted even though
+/// a replay succeeds.
+const EMPTY_BLOB_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+fn is_empty_blob(digest: &reapi::Digest) -> bool {
+    digest.size_bytes == 0 && digest.hash == EMPTY_BLOB_SHA256
 }
 
 fn digest_key(digest: &reapi::Digest) -> Result<String, Status> {
@@ -3157,6 +3200,15 @@ mod tests {
                 },
                 "a present tree that lists an evicted file",
             ),
+            (
+                [0x46u8; 32],
+                reapi::ActionResult {
+                    output_files: vec![live_file()],
+                    stderr_digest: Some(digest(missing_blob, 7)),
+                    ..Default::default()
+                },
+                "an evicted stderr blob",
+            ),
         ];
         for (action, result, label) in &cases {
             write_artifact(
@@ -3197,6 +3249,90 @@ mod tests {
             .get_action_result(get_request(all_live_action))
             .await
             .expect("an entry whose stream and tree blobs are all present serves");
+
+        // The canonical empty blob is present by REAPI convention even though it
+        // was never uploaded, so an entry referencing it for stdout and as a
+        // tree leaf must still serve rather than gate as evicted.
+        let empty_digest = reapi::Digest {
+            hash: EMPTY_BLOB_SHA256.to_string(),
+            size_bytes: 0,
+        };
+        let empty_leaf_tree = reapi::Tree {
+            root: Some(reapi::Directory {
+                files: vec![reapi::FileNode {
+                    name: "empty".into(),
+                    digest: Some(empty_digest.clone()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let empty_leaf_tree_hash = [0x37u8; 32];
+        write_artifact(
+            store,
+            &uploads,
+            &blob_key(&format!(
+                "{}/{}",
+                hex::encode(empty_leaf_tree_hash),
+                empty_leaf_tree.len()
+            )),
+            &empty_leaf_tree,
+            now,
+        )
+        .await;
+        let empty_ref_action = [0x45u8; 32];
+        let empty_ref = reapi::ActionResult {
+            output_files: vec![live_file()],
+            stdout_digest: Some(empty_digest),
+            output_directories: vec![with_tree(empty_leaf_tree_hash, empty_leaf_tree.len())],
+            ..Default::default()
+        };
+        write_artifact(
+            store,
+            &uploads,
+            &format!("action_cache/{}/10", hex::encode(empty_ref_action)),
+            &empty_ref.encode_to_vec(),
+            now,
+        )
+        .await;
+        service
+            .get_action_result(get_request(empty_ref_action))
+            .await
+            .expect("an entry referencing the empty blob for stdout and a tree leaf still serves");
+    }
+
+    #[tokio::test]
+    async fn find_missing_blobs_treats_the_empty_blob_as_present() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        let empty = reapi::Digest {
+            hash: EMPTY_BLOB_SHA256.to_string(),
+            size_bytes: 0,
+        };
+        let absent = reapi::Digest {
+            hash: hex::encode([0x77u8; 32]),
+            size_bytes: 5,
+        };
+        let missing = service
+            .find_missing_blobs(Request::new(reapi::FindMissingBlobsRequest {
+                instance_name: "ios".into(),
+                blob_digests: vec![empty, absent.clone()],
+                digest_function: 0,
+            }))
+            .await
+            .expect("find_missing_blobs should succeed")
+            .into_inner()
+            .missing_blob_digests;
+        assert_eq!(
+            missing,
+            vec![absent],
+            "the empty blob is always present; only the genuinely absent blob is reported"
+        );
     }
 
     #[tokio::test]

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1108,7 +1108,7 @@ impl ActionCache for ReapiService {
         // reconcile-time gate and cascade never examine, so without this they
         // serve dead forever. This checks every blob a replay fetches — output
         // files, stdout/stderr, and each output directory's tree plus the files
-        // it lists — not just output files, so a Bazel client with tree
+        // it lists — not just output files, so an REAPI client with tree
         // artifacts is covered as well. Mostly existence-cache hits.
         if let Some(missing) = first_evicted_output(
             &self.state,
@@ -1886,7 +1886,7 @@ async fn maybe_read_cas_bytes(
 /// `stderr`, and each output directory's `Tree` blob together with the file
 /// blobs the tree lists. Any one of them missing hard-fails the replay on the
 /// first missing object exactly as an evicted output file does, so all of them
-/// must gate the serve — a Bazel client emitting tree artifacts would otherwise
+/// must gate the serve — an REAPI client emitting tree artifacts would otherwise
 /// keep hitting the same "Lost inputs"/missing-object failure this fix targets.
 /// The checks are manifest lookups (mostly existence-cache hits); only an entry
 /// that actually carries directory outputs pays the extra tree read, and only


### PR DESCRIPTION
### What

Extends the per-key `GetActionResult` presence gate so it validates **every** blob a client fetches when it replays a cached action result, not just `output_files`:

- `output_files[].digest`, `stdout_digest`, `stderr_digest` — manifest-existence checks (mostly existence-cache hits).
- each `output_directories[].tree_digest` — and, reading the surviving `Tree` blob once, the `FileNode` digests it lists (root + children).

Any referenced blob missing makes the serve answer `NotFound` (and, past the replication grace window, deletes the dead entry) — the same behavior #11793 introduced for output files, now covering the rest of the result.

### Why

#11793 fixed the reported failure in #11221 — an action-cache hit whose **output-file** blob was evicted serving unchecked, so the client hard-fails the build on the first missing object ("Lost inputs no longer available remotely"). But it only gated on `output_files`. The other blobs a replay fetches were still served unchecked:

- **Output directories (tree artifacts).** An entry whose only outputs are directories bypassed the gate entirely (the `find_map` over an empty `output_files` returned `None`), and even with output files present, an evicted `Tree` blob — or an evicted file *inside* a present tree — still served. Tree artifacts are first-class Bazel outputs, so this reproduces the exact same missing-object failure class through a different digest.
- **stdout/stderr.** Served with a digest pointing at a possibly-evicted blob.

So the correctness fix in #11793 was incomplete relative to what #11221 called for (`output_files`, `output_directories[].tree_digest` + the Tree's sub-blobs, `stdout_digest`, `stderr_digest`). This closes that residual gap.

### Root cause

CAS blob lifecycle (eviction) is decoupled from action-cache entry lifecycle. The serve path must therefore presence-check the blobs an entry references before handing it out; #11793 did this for output files only. The gate now checks all referenced blobs, degrading a poisoned entry to an ordinary miss the client recompiles from and republishes with fresh blobs — self-healing fleet-wide — instead of failing the build.

### Why this shape (and why the snapshot path is untouched)

- The tree read is the only non-manifest cost. It is paid **only** by entries that actually carry directory outputs, and **only** after the cheap manifest checks pass — the common Xcode/llcas workflow (no output directories) adds a couple of existence-cache lookups and no reads.
- Read/decode failures bias to "present" (`unwrap_or(true)`, `let Ok(Some(..)) = .. else { continue }`), so a transient store blip never turns a live entry into a spurious miss — matching the existing manifest-check bias.
- The **snapshot/reconcile path is deliberately left unchanged.** Its node model (`SnapshotIndexEntry`) represents `output_files` only — the `llcas` Xcode CAS-plugin workflow, which has no REAPI tree/stdout/stderr artifacts. A stock Bazel client with tree artifacts never requests the snapshot; those entries always resolve through the per-key path, which this gate now fully covers. Extending the snapshot representation to carry tree/stdout/stderr would be a larger, unrelated change with no correctness benefit here.

### Validation

- New test `per_key_serve_gates_evicted_streams_and_tree_blobs`: an evicted `stdout` blob, an evicted output-directory tree, and a present tree that lists an evicted file each answer `NotFound`; an entry whose stream and tree blobs are all present serves. The pre-existing `per_key_serve_gates_entries_with_evicted_outputs` (output-file eviction + grace-window delete) still passes.
- Full `reapi` module: 36 passed, 1 ignored.
- `cargo clippy --lib --tests -- -D warnings` clean; `cargo fmt --check` clean.

(Built/tested via the `cargo` fallback — the local `mise` config failed to parse in this environment; CI gates on Bazel.)

Addresses the remaining part of #11221 (follows #11793).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review follow-ups

Addressed feedback from a review pass:

- **Empty-blob convention (correctness).** REAPI clients assume the canonical zero-byte blob (`e3b0c442…`, size 0) always exists and synthesize it client-side, so a plain manifest lookup could gate an entry that references an empty file / empty stdout / empty stderr as evicted and eventually delete it, even though a replay would succeed. The gate now treats the empty digest as always present, and `FindMissingBlobs` no longer reports it missing (it would otherwise push clients to upload a blob they synthesize). More reachable now that stdout/stderr and tree leaves are covered.
- **Materialization budget (resource-safety).** The tree read now claims the request's `MaterializationBudget` like every other read on the serve path, so a large output-directory tree can't materialize unbounded bytes on a pressured node. A failed claim surfaces as an error the gate loop already treats as "present", so under memory pressure it degrades to serving unchecked rather than adding load.
- **Per-serve tree read cost (perf, acknowledged).** Directory-carrying hits pay a tree read + decode + per-leaf manifest check per serve; the client re-fetches the same tree immediately after, so the gate's read warms the page cache. Left as-is — the right trade-off for correctness. If tree-artifact traffic grows, memoizing the verdict per entry (keyed by the manifest's `version_ms`) would return the steady state to the cheap manifest tier.
- **Tests.** Added an evicted-`stderr` case, an entry referencing the empty blob for stdout and as a tree leaf (must still serve), and a `FindMissingBlobs` case asserting the empty blob is never reported missing. Full `reapi` module now 37 passed, 1 ignored; clippy/`fmt` clean.
