### PR TITLE
feat(kura): make bootstrap progress observable

### DIFF
--- a/kura/README.md
+++ b/kura/README.md
@@ -183,6 +183,7 @@ Replication is leaderless and eventually consistent:
 
 - 🔁 local writes become durable together with their outbox work
 - 🌍 peers bootstrap by pulling manifests, tombstones, and artifact bodies, reconciling only the diverging ranges via a per-bucket manifest digest exchange
+- 📈 in-flight bootstraps log a progress line every 30 seconds and report per-peer counters (phase, buckets completed, artifacts applied/failed) as `bootstrap_progress` on `/ready` and `/status/rollout`, so a long cold pull is distinguishable from a hang
 - 🔎 DNS discovery can expand the peer set automatically
 - 🧠 the outbox is processed incrementally so queue depth does not blow up heap usage during backlog
 

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -105,6 +105,8 @@ Before walking a peer's manifests, bootstrap runs **range-digest anti-entropy** 
 
 A per-peer bootstrap runs under a **no-progress watchdog** rather than a fixed total-runtime cap. `KURA_BOOTSTRAP_TIMEOUT_MS` is the maximum time the bootstrap may go *without* forward progress (a fetched page or applied artifact); a bootstrap that keeps advancing runs to completion however long that takes, and only a genuinely stalled one is abandoned and retried. A single wall-clock cap could never let a large cold pull finish — it would be killed and restarted from scratch every window — so a node whose backlog exceeds one window's worth of transfer would stay `NotReady` indefinitely.
 
+Bootstrap progress is **externally observable** while a pass runs. Each in-flight pass logs a progress line every 30 seconds (phase, diverged buckets completed with an approximate percentage, artifacts applied and failed, pages fetched, elapsed time), and the same per-peer counters are reported as `bootstrap_progress` in the `/ready` and `/status/rollout` bodies. This exists because a bootstrapping node is `NotReady` — excluded from the Service endpoints Prometheus scrapes — and previously logged nothing between the one-shot divergence-scan line and completion, which made a slow-but-converging multi-hour cold pull indistinguishable from a hang.
+
 See `src/replication/mod.rs` for the membership/outbox/bootstrap loops, and `src/replication/operation.rs` + `outbox_message.rs` for the message types.
 
 ## Discovery And Membership

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -176,6 +176,7 @@ async fn run_with_config(
         bootstrap_fetch_locks: (0..crate::constants::BOOTSTRAP_FETCH_LOCK_STRIPES)
             .map(|_| tokio::sync::Mutex::new(()))
             .collect(),
+        bootstrap_progress: std::sync::Mutex::new(std::collections::HashMap::new()),
         replication_backoff: tokio::sync::Mutex::new(std::collections::HashMap::new()),
     });
     state.sync_runtime_metrics().await;

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -72,6 +72,12 @@ pub const ACTION_CACHE_TRUNK_SCAN_FACTOR: usize = 8;
 // is abandoned and retried. A large cold pull that keeps making progress runs to
 // completion however long that takes; only a genuinely stalled one is dropped.
 pub const DEFAULT_BOOTSTRAP_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+// How often an in-flight bootstrap logs a progress line. Between the one-shot
+// divergence-scan log and completion, a large cold pull is otherwise log-silent
+// for its whole duration (possibly an hour+), which is externally
+// indistinguishable from a hang — the node is NotReady during that window, so
+// it is also absent from scraped metrics.
+pub const BOOTSTRAP_PROGRESS_LOG_INTERVAL_SECS: u64 = 30;
 pub const SEGMENT_FREE_SPACE_MARGIN: u64 = 2;
 pub const DEFAULT_USAGE_WINDOW_SECS: u64 = 60;
 pub const DEFAULT_USAGE_FLUSH_INTERVAL_MS: u64 = 60_000;

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1059,6 +1059,7 @@ async fn ready(State(state): State<SharedState>) -> impl IntoResponse {
             "known_peers": readiness.known_peers,
             "bootstrapped_peers": readiness.bootstrapped_peers,
             "bootstrap_inflight_peers": readiness.bootstrap_inflight_peers,
+            "bootstrap_progress": state.bootstrap_progress_snapshots(),
             "http_inflight_requests": readiness.http_inflight,
             "grpc_inflight_requests": readiness.grpc_inflight,
             "reasons": readiness.reasons,
@@ -1079,6 +1080,7 @@ async fn rollout_status(State(state): State<SharedState>) -> impl IntoResponse {
         "bootstrap_known_peers": status.bootstrap_known_peers,
         "bootstrap_completed_peers": status.bootstrap_completed_peers,
         "bootstrap_inflight_peers": status.bootstrap_inflight_peers,
+        "bootstrap_progress": state.bootstrap_progress_snapshots(),
         "http_inflight_requests": status.http_inflight,
         "grpc_inflight_requests": status.grpc_inflight,
         "outbox_messages": status.outbox_messages,
@@ -2906,6 +2908,60 @@ mod tests {
             .expect("ready response should be json");
         assert_eq!(body["state"], "serving");
         assert_eq!(body["ready"], true);
+    }
+
+    #[tokio::test]
+    async fn ready_reports_inflight_bootstrap_progress() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443";
+
+        let progress = context.state.begin_bootstrap_progress(peer);
+        progress.set_phase(crate::state::BootstrapPhase::ManifestFetch);
+        progress.set_divergent_buckets(200);
+        for _ in 0..50 {
+            progress.record_bucket_completed();
+        }
+        progress.record_manifest_page();
+        progress.record_artifact_applied();
+        progress.record_artifact_failed();
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        let entries = body["bootstrap_progress"]
+            .as_array()
+            .expect("bootstrap_progress should be an array");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["peer"], peer);
+        assert_eq!(entries[0]["phase"], "manifest_fetch");
+        assert_eq!(entries[0]["divergent_buckets"], 200);
+        assert_eq!(entries[0]["completed_buckets"], 50);
+        assert_eq!(entries[0]["percent_buckets_completed"], 25.0);
+        assert_eq!(entries[0]["pages_fetched"], 1);
+        assert_eq!(entries[0]["artifacts_applied"], 1);
+        assert_eq!(entries[0]["artifacts_failed"], 1);
+
+        context.state.end_bootstrap_progress(peer);
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        assert_eq!(body["bootstrap_progress"], serde_json::json!([]));
     }
 
     #[tokio::test]

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     net::{IpAddr, SocketAddr},
     path::Path,
-    sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
 
@@ -23,11 +22,12 @@ use crate::{
     artifact::manifest::ArtifactManifest,
     config::Config,
     constants::{
-        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, MAX_BOOTSTRAP_PAGE_BYTES,
-        MAX_INLINE_REPLICATION_BODY_BYTES, MAX_REPLICATION_BODY_BYTES, REPLICATION_RETRY_SECS,
+        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, BOOTSTRAP_PROGRESS_LOG_INTERVAL_SECS,
+        MAX_BOOTSTRAP_PAGE_BYTES, MAX_INLINE_REPLICATION_BODY_BYTES, MAX_REPLICATION_BODY_BYTES,
+        REPLICATION_RETRY_SECS,
     },
     failpoints::FailpointName,
-    state::SharedState,
+    state::{BootstrapPhase, BootstrapProgress, SharedState},
     store::{
         ArtifactApplyOutcome, ManifestBucketDigest, ManifestDigest, ManifestPage,
         NamespaceTombstonePage,
@@ -300,24 +300,29 @@ async fn bootstrap_from_peer_with_watchdog(
     peer: &str,
     no_progress_timeout: Duration,
 ) -> Result<BootstrapStats, String> {
-    let progress = AtomicU64::new(0);
-    tokio::select! {
+    let progress = state.begin_bootstrap_progress(peer);
+    let result = tokio::select! {
         result = bootstrap_from_peer(state, peer, &progress) => result,
         () = bootstrap_no_progress_watchdog(&progress, no_progress_timeout) => Err(format!(
             "bootstrap from {peer} made no progress for {} ms; abandoning this attempt",
             no_progress_timeout.as_millis()
         )),
-    }
+        () = bootstrap_progress_logger(peer, &progress) => {
+            unreachable!("the bootstrap progress logger never resolves")
+        }
+    };
+    state.end_bootstrap_progress(peer);
+    result
 }
 
-/// Resolve once the `progress` counter has failed to advance across a full
+/// Resolve once the `progress` tick counter has failed to advance across a full
 /// `interval`. Callers select this against the bootstrap future, so it acts as a
 /// stall detector rather than a total-runtime cap.
-async fn bootstrap_no_progress_watchdog(progress: &AtomicU64, interval: Duration) {
-    let mut last = progress.load(Ordering::Relaxed);
+async fn bootstrap_no_progress_watchdog(progress: &BootstrapProgress, interval: Duration) {
+    let mut last = progress.ticks();
     loop {
         sleep(interval).await;
-        let current = progress.load(Ordering::Relaxed);
+        let current = progress.ticks();
         if current == last {
             return;
         }
@@ -325,11 +330,25 @@ async fn bootstrap_no_progress_watchdog(progress: &AtomicU64, interval: Duration
     }
 }
 
+/// Periodically log how far this peer's bootstrap has advanced. A large cold
+/// pull emits nothing between the one-shot divergence-scan log and completion,
+/// so without this heartbeat a slow-but-progressing bootstrap reads exactly
+/// like a hung one. Never resolves; the enclosing select drops it when the
+/// bootstrap finishes or the watchdog fires.
+async fn bootstrap_progress_logger(peer: &str, progress: &BootstrapProgress) {
+    let interval = Duration::from_secs(BOOTSTRAP_PROGRESS_LOG_INTERVAL_SECS);
+    loop {
+        sleep(interval).await;
+        info!("{}", progress.snapshot(peer).describe());
+    }
+}
+
 async fn bootstrap_from_peer(
     state: &SharedState,
     peer: &str,
-    progress: &AtomicU64,
+    progress: &BootstrapProgress,
 ) -> Result<BootstrapStats, String> {
+    progress.set_phase(BootstrapPhase::NamespaceTombstones);
     let tombstones_applied =
         bootstrap_namespace_tombstones_from_peer(state, peer, progress).await?;
     let artifacts_applied = bootstrap_manifests_from_peer(state, peer, progress).await?;
@@ -342,14 +361,14 @@ async fn bootstrap_from_peer(
 async fn bootstrap_namespace_tombstones_from_peer(
     state: &SharedState,
     peer: &str,
-    progress: &AtomicU64,
+    progress: &BootstrapProgress,
 ) -> Result<u64, String> {
     let mut after = None;
     let mut applied = 0_u64;
 
     loop {
         let page = fetch_bootstrap_tombstones_page(state, peer, after.as_deref()).await?;
-        progress.fetch_add(1, Ordering::Relaxed);
+        progress.tick();
         for tombstone in &page.tombstones {
             let outcome = state
                 .store
@@ -369,6 +388,7 @@ async fn bootstrap_namespace_tombstones_from_peer(
             );
             if outcome.applied() {
                 applied += 1;
+                progress.record_tombstone_applied();
             }
         }
 
@@ -382,11 +402,12 @@ async fn bootstrap_namespace_tombstones_from_peer(
 async fn bootstrap_manifests_from_peer(
     state: &SharedState,
     peer: &str,
-    progress: &AtomicU64,
+    progress: &BootstrapProgress,
 ) -> Result<u64, String> {
     let prefix_len = BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN;
     let mut applied = 0_u64;
     let mut failed = 0_u64;
+    progress.set_phase(BootstrapPhase::DigestReconcile);
 
     // Range-based anti-entropy: exchange per-bucket digests and walk only the
     // buckets whose contents differ. For a mostly-in-sync pair this collapses a
@@ -396,7 +417,7 @@ async fn bootstrap_manifests_from_peer(
     // timeout fires.
     match fetch_bootstrap_digest(state, peer, prefix_len).await? {
         Some(peer_digest) => {
-            progress.fetch_add(1, Ordering::Relaxed);
+            progress.tick();
             let local_digest = state.store.manifests_digest(prefix_len)?;
             let divergent = divergent_prefixes(&local_digest, &peer_digest.buckets);
             let walked = divergent.len() as u64;
@@ -408,18 +429,22 @@ async fn bootstrap_manifests_from_peer(
                 "bootstrap from {peer}: {walked}/{} manifest buckets diverged, {matched} matched and skipped",
                 peer_digest.buckets.len()
             );
+            progress.set_divergent_buckets(walked);
+            progress.set_phase(BootstrapPhase::ManifestFetch);
             for prefix in divergent {
                 let (range_applied, range_failed) =
                     bootstrap_manifest_range_from_peer(state, peer, Some(&prefix), progress)
                         .await?;
                 applied += range_applied;
                 failed += range_failed;
+                progress.record_bucket_completed();
             }
         }
         None => {
             // Peer predates the digest endpoint (one-version-skew during a
             // rollout, or a mixed-version mesh): fall back to a full keyspace
             // walk, exactly as before.
+            progress.set_phase(BootstrapPhase::ManifestFetch);
             let (range_applied, range_failed) =
                 bootstrap_manifest_range_from_peer(state, peer, None, progress).await?;
             applied += range_applied;
@@ -471,7 +496,7 @@ async fn bootstrap_manifest_range_from_peer(
     state: &SharedState,
     peer: &str,
     prefix: Option<&str>,
-    progress: &AtomicU64,
+    progress: &BootstrapProgress,
 ) -> Result<(u64, u64), String> {
     let mut after = None;
     let mut applied = 0_u64;
@@ -482,7 +507,7 @@ async fn bootstrap_manifest_range_from_peer(
         // Fetching a page is forward progress even when it applies nothing (a
         // warm re-walk or an already-present range), so the no-progress watchdog
         // never abandons a bootstrap that is still advancing through the walk.
-        progress.fetch_add(1, Ordering::Relaxed);
+        progress.record_manifest_page();
         state
             .store
             .hit_failpoint(FailpointName::AfterBootstrapManifestPageFetchBeforeApply)
@@ -557,7 +582,7 @@ async fn bootstrap_manifest_range_from_peer(
                             // longer than the no-progress window on a slow/cold
                             // link, and batching the bump to page end would let the
                             // watchdog cancel a bootstrap that is in fact applying.
-                            progress.fetch_add(1, Ordering::Relaxed);
+                            progress.record_artifact_applied();
                         }
                         Ok(applied)
                     }
@@ -578,7 +603,10 @@ async fn bootstrap_manifest_range_from_peer(
             match outcome {
                 Ok(true) => applied += 1,
                 Ok(false) => {}
-                Err(_) => failed += 1,
+                Err(_) => {
+                    failed += 1;
+                    progress.record_artifact_failed();
+                }
             }
         }
 
@@ -2321,7 +2349,8 @@ mod tests {
 
         let local = test_context(|_| {}).await;
         let result =
-            bootstrap_manifests_from_peer(&local.state, &remote_url, &AtomicU64::new(0)).await;
+            bootstrap_manifests_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
+                .await;
 
         // The peer bootstrap surfaces failure so it gets retried ...
         assert!(
@@ -2384,7 +2413,8 @@ mod tests {
 
         let local = test_context(|_| {}).await;
         let result =
-            bootstrap_manifests_from_peer(&local.state, &remote_url, &AtomicU64::new(0)).await;
+            bootstrap_manifests_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
+                .await;
 
         // The oversized entry is skipped, not fetched-and-failed, so the peer
         // bootstrap completes rather than surfacing a retryable failure that
@@ -2529,7 +2559,7 @@ mod tests {
         let (remote_url, _server) = spawn_server(app).await;
         let local = test_context(|_| {}).await;
 
-        let stats = bootstrap_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
+        let stats = bootstrap_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
             .await
             .expect("bootstrap should complete");
         assert_eq!(stats.tombstones_applied, 1);
@@ -2599,10 +2629,13 @@ mod tests {
                 .is_some()
         );
 
-        let applied =
-            bootstrap_namespace_tombstones_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
-                .await
-                .expect("tombstone bootstrap should complete");
+        let applied = bootstrap_namespace_tombstones_from_peer(
+            &local.state,
+            &remote_url,
+            &BootstrapProgress::new(),
+        )
+        .await
+        .expect("tombstone bootstrap should complete");
         assert_eq!(applied, 1);
         assert!(
             local
@@ -2694,9 +2727,10 @@ mod tests {
             FailpointAction::Error("no range should be walked for an in-sync pair".into()),
         );
 
-        let applied = bootstrap_manifests_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
-            .await
-            .expect("bootstrap should succeed without walking any range");
+        let applied =
+            bootstrap_manifests_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
+                .await
+                .expect("bootstrap should succeed without walking any range");
         assert_eq!(applied, 0, "an in-sync pair applies nothing");
     }
 
@@ -2734,9 +2768,10 @@ mod tests {
         let (remote_url, _server) = spawn_server(peer_router).await;
 
         let local = test_context(|_| {}).await;
-        let applied = bootstrap_manifests_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
-            .await
-            .expect("bootstrap should fall back to a full walk");
+        let applied =
+            bootstrap_manifests_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
+                .await
+                .expect("bootstrap should fall back to a full walk");
         assert_eq!(
             applied, 1,
             "the peer's artifact should replicate via the fallback walk"
@@ -2837,7 +2872,7 @@ mod tests {
 
         let local_new = build_local_holding_all_but_missing(&keys).await;
         let applied_new =
-            bootstrap_manifests_from_peer(&local_new.state, &digest_url, &AtomicU64::new(0))
+            bootstrap_manifests_from_peer(&local_new.state, &digest_url, &BootstrapProgress::new())
                 .await
                 .expect("digest-path bootstrap converges");
         assert_eq!(applied_new, MISSING as u64, "only the delta is applied");
@@ -2907,10 +2942,13 @@ mod tests {
         let (fallback_url, _fallback_server) = spawn_server(fallback_router).await;
 
         let local_old = build_local_holding_all_but_missing(&keys).await;
-        let applied_old =
-            bootstrap_manifests_from_peer(&local_old.state, &fallback_url, &AtomicU64::new(0))
-                .await
-                .expect("fallback bootstrap converges");
+        let applied_old = bootstrap_manifests_from_peer(
+            &local_old.state,
+            &fallback_url,
+            &BootstrapProgress::new(),
+        )
+        .await
+        .expect("fallback bootstrap converges");
         assert_eq!(
             applied_old, MISSING as u64,
             "fallback applies the same delta"
@@ -2986,6 +3024,10 @@ mod tests {
             stats.artifacts_applied, 800,
             "the whole dataset must be pulled despite the runtime exceeding many windows"
         );
+        assert!(
+            local.state.bootstrap_progress_snapshots().is_empty(),
+            "a completed pass must deregister its progress tracker"
+        );
     }
 
     #[tokio::test]
@@ -3036,6 +3078,10 @@ mod tests {
         assert!(
             error.contains("made no progress"),
             "unexpected error: {error}"
+        );
+        assert!(
+            local.state.bootstrap_progress_snapshots().is_empty(),
+            "an abandoned pass must deregister its progress tracker"
         );
     }
 
@@ -3127,7 +3173,7 @@ mod tests {
             "test should stage far more than the tmp budget allows at once"
         );
 
-        let stats = bootstrap_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
+        let stats = bootstrap_from_peer(&local.state, &remote_url, &BootstrapProgress::new())
             .await
             .expect("bootstrap should converge under a fixed tmp budget");
         assert_eq!(stats.artifacts_applied, artifact_count as u64);
@@ -3373,9 +3419,9 @@ mod tests {
             .map(|peer| {
                 let state = local.state.clone();
                 let peer = peer.clone();
-                tokio::spawn(
-                    async move { bootstrap_from_peer(&state, &peer, &AtomicU64::new(0)).await },
-                )
+                tokio::spawn(async move {
+                    bootstrap_from_peer(&state, &peer, &BootstrapProgress::new()).await
+                })
             })
             .collect();
         for task in tasks {

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -1,11 +1,15 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU8, AtomicU64, Ordering},
+    },
 };
 
 use arc_swap::ArcSwap;
 use axum_server::tls_rustls::RustlsConfig;
 use reqwest::Client;
+use serde::Serialize;
 use tokio::{
     sync::{Mutex, Notify, Semaphore},
     time::{Duration, Instant},
@@ -64,6 +68,12 @@ pub struct AppState {
     // `bootstrap_fetch_lock`). Bootstrap-scoped so it never blocks the
     // live-replication apply path, which the node still serves while joining.
     pub bootstrap_fetch_locks: Vec<Mutex<()>>,
+    // Live per-peer progress of in-flight bootstraps, keyed by peer URL. A cold
+    // pull of a large dataset can run for an hour; this is what lets the
+    // periodic progress log line and the `/ready` / `/status/rollout` bodies
+    // show that it is advancing rather than hung. std mutex: touched briefly
+    // from sync and async contexts alike, never held across an await.
+    pub bootstrap_progress: std::sync::Mutex<HashMap<String, Arc<BootstrapProgress>>>,
     pub replication_backoff: Mutex<HashMap<String, ReplicationBackoff>>,
 }
 
@@ -87,6 +97,199 @@ impl AppState {
         let index =
             (std::hash::Hasher::finish(&hasher) as usize) % self.bootstrap_fetch_locks.len();
         &self.bootstrap_fetch_locks[index]
+    }
+
+    /// Registers a fresh progress tracker for a starting bootstrap pass. Each
+    /// pass gets its own tracker, so a retried pass restarts its counters.
+    pub fn begin_bootstrap_progress(&self, peer: &str) -> Arc<BootstrapProgress> {
+        let progress = Arc::new(BootstrapProgress::new());
+        self.bootstrap_progress
+            .lock()
+            .expect("bootstrap progress lock poisoned")
+            .insert(peer.to_string(), progress.clone());
+        progress
+    }
+
+    pub fn end_bootstrap_progress(&self, peer: &str) {
+        self.bootstrap_progress
+            .lock()
+            .expect("bootstrap progress lock poisoned")
+            .remove(peer);
+    }
+
+    pub fn bootstrap_progress_snapshots(&self) -> Vec<BootstrapProgressSnapshot> {
+        let mut snapshots: Vec<BootstrapProgressSnapshot> = self
+            .bootstrap_progress
+            .lock()
+            .expect("bootstrap progress lock poisoned")
+            .iter()
+            .map(|(peer, progress)| progress.snapshot(peer))
+            .collect();
+        snapshots.sort_by(|a, b| a.peer.cmp(&b.peer));
+        snapshots
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapPhase {
+    NamespaceTombstones = 0,
+    DigestReconcile = 1,
+    ManifestFetch = 2,
+}
+
+impl BootstrapPhase {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => BootstrapPhase::NamespaceTombstones,
+            1 => BootstrapPhase::DigestReconcile,
+            _ => BootstrapPhase::ManifestFetch,
+        }
+    }
+}
+
+/// Live counters for one in-flight peer bootstrap. While a node bootstraps it
+/// is NotReady, which drops it from the Service endpoints Prometheus scrapes —
+/// so these counters, surfaced through the periodic progress log line and the
+/// `/ready` / `/status/rollout` bodies, are the only external evidence that a
+/// long cold pull is advancing. Also carries the no-progress watchdog counter
+/// (`ticks`), bumped on every fetched page and applied artifact.
+#[derive(Debug, Default)]
+pub struct BootstrapProgress {
+    started_at: Option<Instant>,
+    ticks: AtomicU64,
+    phase: AtomicU8,
+    tombstones_applied: AtomicU64,
+    divergent_buckets: AtomicU64,
+    completed_buckets: AtomicU64,
+    pages_fetched: AtomicU64,
+    artifacts_applied: AtomicU64,
+    artifacts_failed: AtomicU64,
+}
+
+impl BootstrapProgress {
+    pub fn new() -> Self {
+        Self {
+            started_at: Some(Instant::now()),
+            ..Self::default()
+        }
+    }
+
+    /// Records raw forward progress for the no-progress watchdog.
+    pub fn tick(&self) {
+        self.ticks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn ticks(&self) -> u64 {
+        self.ticks.load(Ordering::Relaxed)
+    }
+
+    pub fn set_phase(&self, phase: BootstrapPhase) {
+        self.phase.store(phase as u8, Ordering::Relaxed);
+    }
+
+    pub fn record_tombstone_applied(&self) {
+        self.tombstones_applied.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn set_divergent_buckets(&self, total: u64) {
+        self.divergent_buckets.store(total, Ordering::Relaxed);
+    }
+
+    pub fn record_bucket_completed(&self) {
+        self.completed_buckets.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_manifest_page(&self) {
+        self.pages_fetched.fetch_add(1, Ordering::Relaxed);
+        self.tick();
+    }
+
+    pub fn record_artifact_applied(&self) {
+        self.artifacts_applied.fetch_add(1, Ordering::Relaxed);
+        self.tick();
+    }
+
+    pub fn record_artifact_failed(&self) {
+        self.artifacts_failed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self, peer: &str) -> BootstrapProgressSnapshot {
+        let divergent_buckets = self.divergent_buckets.load(Ordering::Relaxed);
+        let completed_buckets = self.completed_buckets.load(Ordering::Relaxed);
+        // Approximate: buckets vary in size, but it is the only completion
+        // denominator known up front (the digest exchange fixes the bucket
+        // count before the walk starts).
+        let percent_buckets_completed = (divergent_buckets > 0).then(|| {
+            ((completed_buckets.min(divergent_buckets) as f64 / divergent_buckets as f64) * 1000.0)
+                .round()
+                / 10.0
+        });
+        BootstrapProgressSnapshot {
+            peer: peer.to_string(),
+            phase: BootstrapPhase::from_u8(self.phase.load(Ordering::Relaxed)),
+            elapsed_seconds: self
+                .started_at
+                .map_or(0, |started_at| started_at.elapsed().as_secs()),
+            tombstones_applied: self.tombstones_applied.load(Ordering::Relaxed),
+            divergent_buckets,
+            completed_buckets,
+            pages_fetched: self.pages_fetched.load(Ordering::Relaxed),
+            artifacts_applied: self.artifacts_applied.load(Ordering::Relaxed),
+            artifacts_failed: self.artifacts_failed.load(Ordering::Relaxed),
+            percent_buckets_completed,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BootstrapProgressSnapshot {
+    pub peer: String,
+    pub phase: BootstrapPhase,
+    pub elapsed_seconds: u64,
+    pub tombstones_applied: u64,
+    pub divergent_buckets: u64,
+    pub completed_buckets: u64,
+    pub pages_fetched: u64,
+    pub artifacts_applied: u64,
+    pub artifacts_failed: u64,
+    pub percent_buckets_completed: Option<f64>,
+}
+
+impl BootstrapProgressSnapshot {
+    /// One-line summary for the periodic bootstrap progress log.
+    pub fn describe(&self) -> String {
+        let elapsed = self.elapsed_seconds;
+        match self.phase {
+            BootstrapPhase::NamespaceTombstones => format!(
+                "bootstrap from {} in progress: applying namespace tombstones, {} applied, {elapsed}s elapsed",
+                self.peer, self.tombstones_applied
+            ),
+            BootstrapPhase::DigestReconcile => format!(
+                "bootstrap from {} in progress: exchanging manifest digests, {elapsed}s elapsed",
+                self.peer
+            ),
+            BootstrapPhase::ManifestFetch => {
+                let rate = if elapsed > 0 {
+                    self.artifacts_applied / elapsed
+                } else {
+                    self.artifacts_applied
+                };
+                let buckets = match self.percent_buckets_completed {
+                    Some(percent) => format!(
+                        "{}/{} diverged buckets (~{percent}%), ",
+                        self.completed_buckets, self.divergent_buckets
+                    ),
+                    // No digest exchange happened (peer predates the digest
+                    // endpoint), so the walk has no known denominator.
+                    None => String::new(),
+                };
+                format!(
+                    "bootstrap from {} in progress: {buckets}{} artifacts applied (~{rate}/s), {} failed, {} pages fetched, {elapsed}s elapsed",
+                    self.peer, self.artifacts_applied, self.artifacts_failed, self.pages_fetched
+                )
+            }
+        }
     }
 }
 
@@ -625,6 +828,104 @@ mod tests {
     use crate::test_support::test_context;
 
     use super::*;
+
+    #[test]
+    fn bootstrap_progress_snapshot_reports_phase_counters_and_percent() {
+        let progress = BootstrapProgress::new();
+        let initial = progress.snapshot("http://peer-a:7443");
+        assert_eq!(initial.phase, BootstrapPhase::NamespaceTombstones);
+        assert_eq!(initial.percent_buckets_completed, None);
+
+        progress.record_tombstone_applied();
+        progress.set_phase(BootstrapPhase::ManifestFetch);
+        progress.set_divergent_buckets(400);
+        for _ in 0..100 {
+            progress.record_bucket_completed();
+        }
+        progress.record_manifest_page();
+        progress.record_manifest_page();
+        progress.record_artifact_applied();
+        progress.record_artifact_failed();
+
+        let snapshot = progress.snapshot("http://peer-a:7443");
+        assert_eq!(snapshot.peer, "http://peer-a:7443");
+        assert_eq!(snapshot.phase, BootstrapPhase::ManifestFetch);
+        assert_eq!(snapshot.tombstones_applied, 1);
+        assert_eq!(snapshot.divergent_buckets, 400);
+        assert_eq!(snapshot.completed_buckets, 100);
+        assert_eq!(snapshot.percent_buckets_completed, Some(25.0));
+        assert_eq!(snapshot.pages_fetched, 2);
+        assert_eq!(snapshot.artifacts_applied, 1);
+        assert_eq!(snapshot.artifacts_failed, 1);
+        // Pages and applied artifacts both feed the no-progress watchdog.
+        assert_eq!(progress.ticks(), 3);
+    }
+
+    #[test]
+    fn bootstrap_progress_describe_covers_each_phase() {
+        let progress = BootstrapProgress::new();
+        progress.record_tombstone_applied();
+        assert_eq!(
+            progress.snapshot("http://peer-a:7443").describe(),
+            "bootstrap from http://peer-a:7443 in progress: applying namespace tombstones, 1 applied, 0s elapsed"
+        );
+
+        progress.set_phase(BootstrapPhase::DigestReconcile);
+        assert_eq!(
+            progress.snapshot("http://peer-a:7443").describe(),
+            "bootstrap from http://peer-a:7443 in progress: exchanging manifest digests, 0s elapsed"
+        );
+
+        progress.set_phase(BootstrapPhase::ManifestFetch);
+        progress.set_divergent_buckets(8);
+        progress.record_bucket_completed();
+        progress.record_manifest_page();
+        progress.record_artifact_applied();
+        progress.record_artifact_applied();
+        assert_eq!(
+            progress.snapshot("http://peer-a:7443").describe(),
+            "bootstrap from http://peer-a:7443 in progress: 1/8 diverged buckets (~12.5%), 2 artifacts applied (~2/s), 0 failed, 1 pages fetched, 0s elapsed"
+        );
+    }
+
+    #[test]
+    fn bootstrap_progress_describe_omits_buckets_when_no_digest_was_exchanged() {
+        let progress = BootstrapProgress::new();
+        progress.set_phase(BootstrapPhase::ManifestFetch);
+        progress.record_manifest_page();
+        progress.record_artifact_applied();
+        assert_eq!(
+            progress.snapshot("http://peer-a:7443").describe(),
+            "bootstrap from http://peer-a:7443 in progress: 1 artifacts applied (~1/s), 0 failed, 1 pages fetched, 0s elapsed"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_progress_registry_tracks_inflight_passes() {
+        let context = test_context(|_| {}).await;
+        let progress = context.state.begin_bootstrap_progress("http://peer-b:7443");
+        context.state.begin_bootstrap_progress("http://peer-a:7443");
+        progress.set_phase(BootstrapPhase::ManifestFetch);
+
+        let snapshots = context.state.bootstrap_progress_snapshots();
+        assert_eq!(
+            snapshots
+                .iter()
+                .map(|snapshot| snapshot.peer.as_str())
+                .collect::<Vec<_>>(),
+            vec!["http://peer-a:7443", "http://peer-b:7443"]
+        );
+        assert_eq!(snapshots[1].phase, BootstrapPhase::ManifestFetch);
+
+        // A retried pass re-registers and restarts its counters.
+        progress.record_artifact_applied();
+        let fresh = context.state.begin_bootstrap_progress("http://peer-b:7443");
+        assert_eq!(fresh.snapshot("http://peer-b:7443").artifacts_applied, 0);
+
+        context.state.end_bootstrap_progress("http://peer-a:7443");
+        context.state.end_bootstrap_progress("http://peer-b:7443");
+        assert!(context.state.bootstrap_progress_snapshots().is_empty());
+    }
 
     #[test]
     fn readiness_state_advances_generation_and_reconciles_peer_sets() {

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -161,6 +161,7 @@ where
         bootstrap_fetch_locks: (0..crate::constants::BOOTSTRAP_FETCH_LOCK_STRIPES)
             .map(|_| tokio::sync::Mutex::new(()))
             .collect(),
+        bootstrap_progress: std::sync::Mutex::new(std::collections::HashMap::new()),
         replication_backoff: tokio::sync::Mutex::new(std::collections::HashMap::new()),
     });
     state.sync_runtime_metrics().await;


### PR DESCRIPTION
Works towards #11955 — implements the improvement that issue ranks highest value: making bootstrap progress observable.

## What changed

- **Per-peer bootstrap progress tracking.** A new `BootstrapProgress` tracker (in `src/state.rs`) records the pass's phase (`namespace_tombstones` → `digest_reconcile` → `manifest_fetch`) plus counters: tombstones applied, diverged buckets total/completed, manifest pages fetched, artifacts applied and failed, and elapsed time. Each bootstrap pass registers its tracker in an `AppState` registry keyed by peer URL, and deregisters when the pass completes or is abandoned.
- **Periodic INFO progress log.** The bootstrap task now emits a progress line every 30 seconds (a new select branch next to the no-progress watchdog), e.g. `bootstrap from <peer> in progress: 120/4096 diverged buckets (~2.9%), 51230 artifacts applied (~48/s), 0 failed, 231 pages fetched, 1071s elapsed`. When the peer predates the digest endpoint (full-walk fallback), the bucket denominator is omitted rather than invented.
- **Progress on `/ready` and `/status/rollout`.** Both bodies now carry a `bootstrap_progress` array with the same per-peer snapshots, so an operator (or the rollout gate's data source) can confirm forward progress with one request even when logs are inconvenient to reach.
- The tracker also carries the existing no-progress watchdog tick counter, replacing the bare `AtomicU64` — watchdog semantics are unchanged (page fetches and applied artifacts tick it, exactly as before).
- Docs: `docs/architecture.md` replication section and the README feature list now describe the progress surface.

## Why

In the 2026-07-21 incident (#11955), both replicas of a 2-pod region cold-bootstrapped a ~160K-manifest dataset at ~50 artifacts/s (~1h+). During that window the pass was completely silent after the one-shot `N/4096 buckets diverged` line, and the pods — being NotReady — were absent from the Service endpoints Prometheus scrapes, so `kura_bootstrap_*` metrics didn't exist either. "Slow but converging" and "hung" were externally indistinguishable; confirming progress required inferring it from the *source peer's* `/_internal/bootstrap/*` request rate, and the ambiguity triggered counterproductive interventions (restarting an in-flight bootstrap).

Logs and status endpoints are exactly the two channels that survive that failure mode: structured logs flow to Loki regardless of readiness (and independent of the dedibox kubelet-hostname issue that breaks `kubectl logs`), and `/ready` / `/status/rollout` are reachable in-cluster (the rollout gate already relies on exactly that assumption).

### Why this shape

- A registry on `AppState` (rather than counters local to the bootstrap task) is what lets the HTTP handlers see the numbers; the periodic logger doubles down on it so both surfaces report identical figures.
- The per-peer tracker is re-created per pass, so a retried pass restarts its counters instead of accumulating misleading totals across attempts.
- Bucket completion percent is an approximation (buckets vary in size) and is labeled as such (`~`); it's the only denominator known up front, fixed by the digest exchange before the walk starts.
- The 30s log interval is a constant, not config: it's an observability heartbeat, not a tuning knob, and avoids a Helm values change.

Rollout safety: additive only — no wire-format, on-disk, or protocol changes; the new JSON fields are additions to existing bodies, so mixed-version meshes and older clients are unaffected.

The issue's other proposals (scraping not-Ready pods via PodMonitor, shrinking the both-unready 503 window, disambiguating drain-time fs aborts) are intentionally not in this PR.

## Validation

- `mise run test-unit` (Bazel): 373 passed, 0 failed — includes new tests:
  - snapshot counters/percent math and watchdog tick aggregation,
  - `describe()` output for each phase, including the no-digest fallback,
  - registry lifecycle (register, sorted snapshots, per-pass reset, deregister),
  - `/ready` reporting an in-flight pass's `bootstrap_progress` and returning `[]` after it ends,
  - existing watchdog tests extended to assert the tracker deregisters on both completion and abandonment.
- `mise run clippy` — clean (warnings as errors).
- `mise run format -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)