### PR TITLE
feat(cli): make network retry policy configurable

### DIFF
--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,5 +17,5 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
-- [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry behavior uses one shared policy with environment-configurable retry count and base delay.
+- [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry behavior uses one shared policy with environment-configurable retry count and base delay, with bounded attempts and per-attempt delay.
 - Default proxy mode comes from runtime HTTP settings, and the shared session is resolved lazily, reused process-wide, and invalidated when those runtime settings change.

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,4 +17,5 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
+- [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry behavior uses one shared policy with environment-configurable retry count and base delay.
 - Default proxy mode comes from runtime HTTP settings, and the shared session is resolved lazily, reused process-wide, and invalidated when those runtime settings change.

--- a/cli/Sources/TuistHTTP/HTTPRetryPolicy.swift
+++ b/cli/Sources/TuistHTTP/HTTPRetryPolicy.swift
@@ -1,0 +1,61 @@
+import Foundation
+import TuistEnvironment
+
+public struct HTTPRetryPolicy: Sendable {
+    public static let defaultMaximumRetryCount = 3
+    public static let defaultBaseDelayMilliseconds: UInt64 = 100
+
+    public let maximumRetryCount: Int
+    public let baseDelayMilliseconds: UInt64
+
+    public init(
+        maximumRetryCount: Int? = nil,
+        baseDelayMilliseconds: UInt64? = nil,
+        environment: [String: String] = Environment.current.variables
+    ) {
+        let resolvedMaximumRetryCount = maximumRetryCount ?? Self.maximumRetryCount(environment: environment)
+        let resolvedBaseDelayMilliseconds = baseDelayMilliseconds ?? Self.baseDelayMilliseconds(environment: environment)
+
+        self.maximumRetryCount = max(0, resolvedMaximumRetryCount)
+        self.baseDelayMilliseconds = Self.validatedBaseDelayMilliseconds(resolvedBaseDelayMilliseconds)
+    }
+
+    public func delay(for retry: Int) -> UInt64 {
+        let baseDelayNanoseconds = baseDelayMilliseconds * 1_000_000
+        guard baseDelayNanoseconds > 0 else { return 0 }
+
+        let exponent = max(0, retry)
+        guard exponent < UInt64.bitWidth else { return .max }
+
+        let exponentialDelay = baseDelayNanoseconds.multipliedReportingOverflow(by: UInt64(1) << exponent)
+        guard !exponentialDelay.overflow else { return .max }
+
+        let jitter = UInt64.random(in: 0 ... baseDelayNanoseconds)
+        let delay = exponentialDelay.partialValue.addingReportingOverflow(jitter)
+        return delay.overflow ? .max : delay.partialValue
+    }
+
+    private static func maximumRetryCount(environment: [String: String]) -> Int {
+        guard let value = environment["TUIST_HTTP_MAXIMUM_RETRY_COUNT"],
+              let maximumRetryCount = Int(value),
+              maximumRetryCount >= 0
+        else {
+            return defaultMaximumRetryCount
+        }
+        return maximumRetryCount
+    }
+
+    private static func baseDelayMilliseconds(environment: [String: String]) -> UInt64 {
+        guard let value = environment["TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS"],
+              let baseDelayMilliseconds = UInt64(value)
+        else {
+            return defaultBaseDelayMilliseconds
+        }
+        return baseDelayMilliseconds
+    }
+
+    private static func validatedBaseDelayMilliseconds(_ baseDelayMilliseconds: UInt64) -> UInt64 {
+        let nanoseconds = baseDelayMilliseconds.multipliedReportingOverflow(by: 1_000_000)
+        return nanoseconds.overflow ? defaultBaseDelayMilliseconds : baseDelayMilliseconds
+    }
+}

--- a/cli/Sources/TuistHTTP/HTTPRetryPolicy.swift
+++ b/cli/Sources/TuistHTTP/HTTPRetryPolicy.swift
@@ -4,6 +4,10 @@ import TuistEnvironment
 public struct HTTPRetryPolicy: Sendable {
     public static let defaultMaximumRetryCount = 3
     public static let defaultBaseDelayMilliseconds: UInt64 = 100
+    static let maximumRetryCountLimit = 10
+    static let maximumDelayMilliseconds: UInt64 = 30000
+
+    private static let nanosecondsPerMillisecond: UInt64 = 1_000_000
 
     public let maximumRetryCount: Int
     public let baseDelayMilliseconds: UInt64
@@ -16,23 +20,31 @@ public struct HTTPRetryPolicy: Sendable {
         let resolvedMaximumRetryCount = maximumRetryCount ?? Self.maximumRetryCount(environment: environment)
         let resolvedBaseDelayMilliseconds = baseDelayMilliseconds ?? Self.baseDelayMilliseconds(environment: environment)
 
-        self.maximumRetryCount = max(0, resolvedMaximumRetryCount)
-        self.baseDelayMilliseconds = Self.validatedBaseDelayMilliseconds(resolvedBaseDelayMilliseconds)
+        self.maximumRetryCount = min(max(0, resolvedMaximumRetryCount), Self.maximumRetryCountLimit)
+        self.baseDelayMilliseconds = min(resolvedBaseDelayMilliseconds, Self.maximumDelayMilliseconds)
     }
 
     public func delay(for retry: Int) -> UInt64 {
-        let baseDelayNanoseconds = baseDelayMilliseconds * 1_000_000
+        let maximumDelayNanoseconds = Self.maximumDelayMilliseconds * Self.nanosecondsPerMillisecond
+        let baseDelayNanoseconds = baseDelayMilliseconds * Self.nanosecondsPerMillisecond
         guard baseDelayNanoseconds > 0 else { return 0 }
 
         let exponent = max(0, retry)
-        guard exponent < UInt64.bitWidth else { return .max }
+        guard exponent < UInt64.bitWidth else { return maximumDelayNanoseconds }
 
         let exponentialDelay = baseDelayNanoseconds.multipliedReportingOverflow(by: UInt64(1) << exponent)
-        guard !exponentialDelay.overflow else { return .max }
+        guard !exponentialDelay.overflow,
+              exponentialDelay.partialValue < maximumDelayNanoseconds
+        else {
+            return maximumDelayNanoseconds
+        }
 
-        let jitter = UInt64.random(in: 0 ... baseDelayNanoseconds)
-        let delay = exponentialDelay.partialValue.addingReportingOverflow(jitter)
-        return delay.overflow ? .max : delay.partialValue
+        let maximumJitter = min(
+            baseDelayNanoseconds,
+            maximumDelayNanoseconds - exponentialDelay.partialValue
+        )
+        let jitter = UInt64.random(in: 0 ... maximumJitter)
+        return exponentialDelay.partialValue + jitter
     }
 
     private static func maximumRetryCount(environment: [String: String]) -> Int {
@@ -52,10 +64,5 @@ public struct HTTPRetryPolicy: Sendable {
             return defaultBaseDelayMilliseconds
         }
         return baseDelayMilliseconds
-    }
-
-    private static func validatedBaseDelayMilliseconds(_ baseDelayMilliseconds: UInt64) -> UInt64 {
-        let nanoseconds = baseDelayMilliseconds.multipliedReportingOverflow(by: 1_000_000)
-        return nanoseconds.overflow ? defaultBaseDelayMilliseconds : baseDelayMilliseconds
     }
 }

--- a/cli/Sources/TuistHTTP/RetryMiddleware.swift
+++ b/cli/Sources/TuistHTTP/RetryMiddleware.swift
@@ -4,10 +4,16 @@ import OpenAPIRuntime
 import TuistLogging
 
 public struct RetryMiddleware: ClientMiddleware {
-    private let maxRetries: Int
+    private let retryPolicy: HTTPRetryPolicy
 
-    public init(maxRetries: Int = 3) {
-        self.maxRetries = maxRetries
+    public init(
+        maxRetries: Int? = nil,
+        baseDelayMilliseconds: UInt64? = nil
+    ) {
+        retryPolicy = HTTPRetryPolicy(
+            maximumRetryCount: maxRetries,
+            baseDelayMilliseconds: baseDelayMilliseconds
+        )
     }
 
     public func intercept(
@@ -24,7 +30,7 @@ public struct RetryMiddleware: ClientMiddleware {
             bodyData = nil
         }
 
-        for retry in 0 ..< maxRetries {
+        for retry in 0 ..< retryPolicy.maximumRetryCount {
             let replayBody = bodyData.map { HTTPBody($0) }
             do {
                 let (response, responseBody) = try await next(request, replayBody, baseURL)
@@ -32,27 +38,21 @@ public struct RetryMiddleware: ClientMiddleware {
                     return (response, responseBody)
                 }
                 Logger.current.debug(
-                    "Received HTTP \(response.status.code) for \(request.method.rawValue) \(request.path ?? ""), retrying (\(retry + 1)/\(maxRetries))..."
+                    "Received HTTP \(response.status.code) for \(request.method.rawValue) \(request.path ?? ""), retrying (\(retry + 1)/\(retryPolicy.maximumRetryCount))..."
                 )
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
                 Logger.current.debug(
-                    "HTTP request failed for \(request.method.rawValue) \(request.path ?? ""): \(error.localizedDescription), retrying (\(retry + 1)/\(maxRetries))..."
+                    "HTTP request failed for \(request.method.rawValue) \(request.path ?? ""): \(error.localizedDescription), retrying (\(retry + 1)/\(retryPolicy.maximumRetryCount))..."
                 )
             }
-            try await Task<Never, Never>.sleep(nanoseconds: delay(for: retry))
+            try await Task<Never, Never>.sleep(nanoseconds: retryPolicy.delay(for: retry))
         }
 
         try Task<Never, Never>.checkCancellation()
         let replayBody = bodyData.map { HTTPBody($0) }
         return try await next(request, replayBody, baseURL)
-    }
-
-    private func delay(for retry: Int) -> UInt64 {
-        let baseInterval = TimeInterval(100_000_000) // 100ms
-        let jitter = Double.random(in: 0 ... 100_000_000) // 0-100ms jitter
-        return UInt64(baseInterval * pow(2, Double(retry)) + jitter)
     }
 
     private static func isRetryableStatusCode(_ statusCode: Int) -> Bool {

--- a/cli/Sources/TuistServer/AGENTS.md
+++ b/cli/Sources/TuistServer/AGENTS.md
@@ -6,6 +6,7 @@ This module handles CLI integration with the Tuist Server APIs.
 - Resolve server environment (base URL, OAuth client ID) with env var overrides.
 - Provide cache storage factories and API clients for server-backed features.
 - Map CLI actions to server operations (projects, previews, analytics, registry).
+- Apply the shared [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry policy to retryable server operations.
 
 ## Related Context
 - Server codebase: `server/AGENTS.md`

--- a/cli/Sources/TuistServer/Utilities/DelayProvider.swift
+++ b/cli/Sources/TuistServer/Utilities/DelayProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Mockable
+import TuistHTTP
 
 @Mockable
 public protocol DelayProviding {
@@ -7,12 +8,13 @@ public protocol DelayProviding {
 }
 
 public struct DelayProvider: DelayProviding {
-    public init() {}
+    private let retryPolicy: HTTPRetryPolicy
+
+    public init(baseDelayMilliseconds: UInt64? = nil) {
+        retryPolicy = HTTPRetryPolicy(baseDelayMilliseconds: baseDelayMilliseconds)
+    }
 
     public func delay(for retry: Int) -> UInt64 {
-        // 0.1 seconds
-        let baseInterval = TimeInterval(1_000_000)
-        let randomInterval = Double.random(in: -1_000_000 ... 1_000_000)
-        return UInt64(baseInterval * pow(2, Double(retry)) + randomInterval)
+        retryPolicy.delay(for: retry)
     }
 }

--- a/cli/Sources/TuistServer/Utilities/RetryProvider.swift
+++ b/cli/Sources/TuistServer/Utilities/RetryProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Logging
+import TuistHTTP
 
 public protocol RetryProviding {
     func runWithRetries<T>(
@@ -9,18 +10,20 @@ public protocol RetryProviding {
 
 public struct RetryProvider: RetryProviding {
     private let delayProvider: DelayProviding
+    private let maximumRetryCount: Int
 
     public init(
+        maximumRetryCount: Int? = nil,
         delayProvider: DelayProviding = DelayProvider()
     ) {
+        self.maximumRetryCount = HTTPRetryPolicy(maximumRetryCount: maximumRetryCount).maximumRetryCount
         self.delayProvider = delayProvider
     }
 
     public func runWithRetries<T>(
         operation: @Sendable @escaping () async throws -> T
     ) async throws -> T {
-        let maxRetryCount = 3
-        for retry in 0 ..< maxRetryCount {
+        for retry in 0 ..< maximumRetryCount {
             try Task<Never, Never>.checkCancellation()
             do {
                 return try await operation()

--- a/cli/Tests/TuistHTTPTests/HTTPRetryPolicyTests.swift
+++ b/cli/Tests/TuistHTTPTests/HTTPRetryPolicyTests.swift
@@ -1,0 +1,52 @@
+import Testing
+
+@testable import TuistHTTP
+
+struct HTTPRetryPolicyTests {
+    @Test func uses_defaults_when_environment_is_empty() {
+        let subject = HTTPRetryPolicy(environment: [:])
+
+        #expect(subject.maximumRetryCount == 3)
+        #expect(subject.baseDelayMilliseconds == 100)
+    }
+
+    @Test func uses_environment_overrides() {
+        let subject = HTTPRetryPolicy(environment: [
+            "TUIST_HTTP_MAXIMUM_RETRY_COUNT": "1",
+            "TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS": "250",
+        ])
+
+        #expect(subject.maximumRetryCount == 1)
+        #expect(subject.baseDelayMilliseconds == 250)
+    }
+
+    @Test func accepts_zero_retries_and_zero_delay() {
+        let subject = HTTPRetryPolicy(environment: [
+            "TUIST_HTTP_MAXIMUM_RETRY_COUNT": "0",
+            "TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS": "0",
+        ])
+
+        #expect(subject.maximumRetryCount == 0)
+        #expect(subject.delay(for: 0) == 0)
+    }
+
+    @Test func falls_back_to_defaults_for_invalid_environment_values() {
+        let subject = HTTPRetryPolicy(environment: [
+            "TUIST_HTTP_MAXIMUM_RETRY_COUNT": "-1",
+            "TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS": "not-a-number",
+        ])
+
+        #expect(subject.maximumRetryCount == 3)
+        #expect(subject.baseDelayMilliseconds == 100)
+    }
+
+    @Test func applies_exponential_backoff_and_jitter() {
+        let subject = HTTPRetryPolicy(baseDelayMilliseconds: 100, environment: [:])
+
+        for _ in 0 ... 20 {
+            #expect((UInt64(100_000_000) ... UInt64(200_000_000)).contains(subject.delay(for: 0)))
+            #expect((UInt64(200_000_000) ... UInt64(300_000_000)).contains(subject.delay(for: 1)))
+            #expect((UInt64(400_000_000) ... UInt64(500_000_000)).contains(subject.delay(for: 2)))
+        }
+    }
+}

--- a/cli/Tests/TuistHTTPTests/HTTPRetryPolicyTests.swift
+++ b/cli/Tests/TuistHTTPTests/HTTPRetryPolicyTests.swift
@@ -40,6 +40,24 @@ struct HTTPRetryPolicyTests {
         #expect(subject.baseDelayMilliseconds == 100)
     }
 
+    @Test func clamps_extreme_environment_values_to_safe_limits() {
+        let subject = HTTPRetryPolicy(environment: [
+            "TUIST_HTTP_MAXIMUM_RETRY_COUNT": String(Int.max),
+            "TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS": String(UInt64.max),
+        ])
+
+        #expect(subject.maximumRetryCount == HTTPRetryPolicy.maximumRetryCountLimit)
+        #expect(subject.baseDelayMilliseconds == HTTPRetryPolicy.maximumDelayMilliseconds)
+    }
+
+    @Test func caps_computed_delays() {
+        let subject = HTTPRetryPolicy(baseDelayMilliseconds: 100, environment: [:])
+        let maximumDelayNanoseconds = HTTPRetryPolicy.maximumDelayMilliseconds * 1_000_000
+
+        #expect(subject.delay(for: 9) == maximumDelayNanoseconds)
+        #expect(subject.delay(for: .max) == maximumDelayNanoseconds)
+    }
+
     @Test func applies_exponential_backoff_and_jitter() {
         let subject = HTTPRetryPolicy(baseDelayMilliseconds: 100, environment: [:])
 

--- a/cli/Tests/TuistServerTests/Utilities/DelayProviderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/DelayProviderTests.swift
@@ -1,44 +1,29 @@
-import Foundation
-import TuistTesting
-import XCTest
+import Testing
 
 @testable import TuistServer
 
-final class DelayProviderTests: TuistUnitTestCase {
-    private var subject: DelayProviding!
+struct DelayProviderTests {
+    @Test func delay_for_first_retry() {
+        let subject = DelayProvider(baseDelayMilliseconds: 100)
 
-    override func setUp() {
-        super.setUp()
-
-        subject = DelayProvider(baseDelayMilliseconds: 100)
-    }
-
-    override func tearDown() {
-        subject = nil
-        super.tearDown()
-    }
-
-    func test_delay_for_first_retry() {
         for _ in 0 ... 20 {
-            XCTAssertTrue(
-                (UInt64(100_000_000) ... UInt64(200_000_000)).contains(subject.delay(for: 0))
-            )
+            #expect((UInt64(100_000_000) ... UInt64(200_000_000)).contains(subject.delay(for: 0)))
         }
     }
 
-    func test_delay_for_second_retry() {
+    @Test func delay_for_second_retry() {
+        let subject = DelayProvider(baseDelayMilliseconds: 100)
+
         for _ in 0 ... 20 {
-            XCTAssertTrue(
-                (UInt64(200_000_000) ... UInt64(300_000_000)).contains(subject.delay(for: 1))
-            )
+            #expect((UInt64(200_000_000) ... UInt64(300_000_000)).contains(subject.delay(for: 1)))
         }
     }
 
-    func test_delay_for_third_retry() {
+    @Test func delay_for_third_retry() {
+        let subject = DelayProvider(baseDelayMilliseconds: 100)
+
         for _ in 0 ... 20 {
-            XCTAssertTrue(
-                (UInt64(400_000_000) ... UInt64(500_000_000)).contains(subject.delay(for: 2))
-            )
+            #expect((UInt64(400_000_000) ... UInt64(500_000_000)).contains(subject.delay(for: 2)))
         }
     }
 }

--- a/cli/Tests/TuistServerTests/Utilities/DelayProviderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/DelayProviderTests.swift
@@ -10,7 +10,7 @@ final class DelayProviderTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
 
-        subject = DelayProvider()
+        subject = DelayProvider(baseDelayMilliseconds: 100)
     }
 
     override func tearDown() {
@@ -21,7 +21,7 @@ final class DelayProviderTests: TuistUnitTestCase {
     func test_delay_for_first_retry() {
         for _ in 0 ... 20 {
             XCTAssertTrue(
-                (UInt64(0) ... UInt64(2_000_000)).contains(subject.delay(for: 0))
+                (UInt64(100_000_000) ... UInt64(200_000_000)).contains(subject.delay(for: 0))
             )
         }
     }
@@ -29,7 +29,7 @@ final class DelayProviderTests: TuistUnitTestCase {
     func test_delay_for_second_retry() {
         for _ in 0 ... 20 {
             XCTAssertTrue(
-                (UInt64(1_000_000) ... UInt64(3_000_000)).contains(subject.delay(for: 1))
+                (UInt64(200_000_000) ... UInt64(300_000_000)).contains(subject.delay(for: 1))
             )
         }
     }
@@ -37,7 +37,7 @@ final class DelayProviderTests: TuistUnitTestCase {
     func test_delay_for_third_retry() {
         for _ in 0 ... 20 {
             XCTAssertTrue(
-                (UInt64(3_000_000) ... UInt64(5_000_000)).contains(subject.delay(for: 2))
+                (UInt64(400_000_000) ... UInt64(500_000_000)).contains(subject.delay(for: 2))
             )
         }
     }

--- a/cli/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
@@ -18,6 +18,7 @@ final class RetryProviderTests: TuistUnitTestCase {
             .willReturn(1)
 
         subject = RetryProvider(
+            maximumRetryCount: 3,
             delayProvider: delayProvider
         )
     }
@@ -66,6 +67,24 @@ final class RetryProviderTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(operationCalls, 4)
+    }
+
+    func test_runWithRetries_whenMaximumRetryCountIsZero_doesNotRetry() async throws {
+        // Given
+        let error = TestError("exists failed")
+        let subject = RetryProvider(maximumRetryCount: 0)
+
+        // When
+        await XCTAssertThrowsSpecific(
+            try await subject.runWithRetries { [self] in
+                operationCalls += 1
+                throw error
+            },
+            error
+        )
+
+        // Then
+        XCTAssertEqual(operationCalls, 1)
     }
 
     func test_runWithRetries_whenOperationIsCancelled_doesNotRetry() async throws {

--- a/server/priv/docs/en/cli/debugging.md
+++ b/server/priv/docs/en/cli/debugging.md
@@ -80,9 +80,9 @@ log stream --predicate 'subsystem == "dev.tuist.cache"' --debug
 
 These logs are also visible in Console.app by filtering for the `dev.tuist.cache` subsystem. This provides detailed information about cache operations, which can help diagnose cache upload, download, and communication issues.
 
-## Tuning network timeouts {#tuning-network-timeouts}
+## Tuning network timeouts and retries {#tuning-network-timeouts}
 
-All of Tuist's HTTP traffic—server API calls, the registry, previews, and cache artifact transfers—goes through a shared `URLSession` with sensible defaults. On slow or congested network paths (for example, a self-hosted setup reaching object storage through a corporate proxy), an individual request can starve and hit the resource timeout before it completes. For cache downloads in particular, hitting the timeout makes Tuist fall back to building the module from source, which is far more expensive than waiting a bit longer for the cached binary. You can tune the underlying HTTP settings through environment variables, with the defaults applied when they're unset or set to an invalid value:
+All of Tuist's [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) traffic, including server calls, the registry, previews, and cache artifact transfers, goes through a shared `URLSession` with sensible defaults. On slow or congested network paths (for example, a self-hosted setup reaching object storage through a corporate proxy), an individual request can starve and hit the resource timeout before it completes. For cache downloads in particular, hitting the timeout makes Tuist fall back to building the module from source, which is far more expensive than waiting a bit longer for the cached binary. You can tune the underlying settings through environment variables, with the defaults applied when they are unset or set to an invalid value:
 
 ```bash
 # Maximum time (in seconds) a single resource transfer can take before it's cancelled (default: 90)
@@ -93,6 +93,12 @@ export TUIST_HTTP_TIMEOUT_INTERVAL_FOR_REQUEST=300
 
 # Maximum number of simultaneous connections per host (default: 20)
 export TUIST_HTTP_MAXIMUM_CONNECTIONS_PER_HOST=40
+
+# Maximum retries after the initial attempt (default: 3, for up to 4 attempts)
+export TUIST_HTTP_MAXIMUM_RETRY_COUNT=1
+
+# Initial exponential backoff delay in milliseconds (default: 100)
+export TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS=250
 ```
 
-Raising `TUIST_HTTP_TIMEOUT_INTERVAL_FOR_RESOURCE` lets a recoverable-but-slow download finish instead of timing out—for cache downloads, that means landing a cache hit rather than falling back to a build from source.
+Raising `TUIST_HTTP_TIMEOUT_INTERVAL_FOR_RESOURCE` lets a recoverable but slow download finish instead of timing out. For cache downloads, that means landing a cache hit rather than falling back to a build from source. Lowering `TUIST_HTTP_MAXIMUM_RETRY_COUNT` can keep a longer timeout from multiplying the worst-case wait across several attempts. Retry delays double after every failure and include up to one base delay of random jitter.

--- a/server/priv/docs/en/cli/debugging.md
+++ b/server/priv/docs/en/cli/debugging.md
@@ -94,11 +94,11 @@ export TUIST_HTTP_TIMEOUT_INTERVAL_FOR_REQUEST=300
 # Maximum number of simultaneous connections per host (default: 20)
 export TUIST_HTTP_MAXIMUM_CONNECTIONS_PER_HOST=40
 
-# Maximum retries after the initial attempt (default: 3, for up to 4 attempts)
+# Maximum retries after the initial attempt (default: 3, maximum: 10)
 export TUIST_HTTP_MAXIMUM_RETRY_COUNT=1
 
-# Initial exponential backoff delay in milliseconds (default: 100)
+# Initial exponential backoff delay in milliseconds (default: 100, maximum: 30000)
 export TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS=250
 ```
 
-Raising `TUIST_HTTP_TIMEOUT_INTERVAL_FOR_RESOURCE` lets a recoverable but slow download finish instead of timing out. For cache downloads, that means landing a cache hit rather than falling back to a build from source. Lowering `TUIST_HTTP_MAXIMUM_RETRY_COUNT` can keep a longer timeout from multiplying the worst-case wait across several attempts. Retry delays double after every failure and include up to one base delay of random jitter.
+Raising `TUIST_HTTP_TIMEOUT_INTERVAL_FOR_RESOURCE` lets a recoverable but slow download finish instead of timing out. For cache downloads, that means landing a cache hit rather than falling back to a build from source. Lowering `TUIST_HTTP_MAXIMUM_RETRY_COUNT` can keep a longer timeout from multiplying the worst-case wait across several attempts. Retry delays double after every failure, include up to one base delay of random jitter, and never exceed 30 seconds.

--- a/server/priv/marketing/changelog/2026.07.21-configurable-network-retries.md
+++ b/server/priv/marketing/changelog/2026.07.21-configurable-network-retries.md
@@ -1,0 +1,17 @@
+---
+title: Tune network retries for slow or congested connections
+description: "Configure retry attempts and backoff so longer cache download timeouts do not multiply the worst-case wait."
+category: "Product"
+pull_request: 11960
+---
+
+A longer resource timeout can keep a slow but progressing cache download from falling back to a source build. Until now, however, every failed request still used three fixed retries. Raising the timeout could therefore turn one stalled transfer into up to four long waits, with no way to adjust that tradeoff.
+
+Tuist now exposes the shared [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry policy through two environment variables:
+
+- `TUIST_HTTP_MAXIMUM_RETRY_COUNT` controls how many retries follow the initial attempt. It defaults to `3`, and setting it to `0` disables retries.
+- `TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS` controls the initial exponential backoff delay. It defaults to `100` milliseconds.
+
+The base delay now correctly starts at 100 milliseconds rather than roughly one millisecond. Each retry doubles the delay and adds up to one base delay of random jitter, helping clients avoid retrying in lockstep after a shared network failure.
+
+Self-hosted operators can now pair a longer resource timeout with fewer attempts, or increase the base delay to spread retries during congestion. Invalid values fall back to the defaults.

--- a/server/priv/marketing/changelog/2026.07.21-configurable-network-retries.md
+++ b/server/priv/marketing/changelog/2026.07.21-configurable-network-retries.md
@@ -9,9 +9,9 @@ A longer resource timeout can keep a slow but progressing cache download from fa
 
 Tuist now exposes the shared [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry policy through two environment variables:
 
-- `TUIST_HTTP_MAXIMUM_RETRY_COUNT` controls how many retries follow the initial attempt. It defaults to `3`, and setting it to `0` disables retries.
-- `TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS` controls the initial exponential backoff delay. It defaults to `100` milliseconds.
+- `TUIST_HTTP_MAXIMUM_RETRY_COUNT` controls how many retries follow the initial attempt. It defaults to `3`, setting it to `0` disables retries, and values above `10` are capped at `10`.
+- `TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS` controls the initial exponential backoff delay. It defaults to `100` milliseconds and values above `30000` are capped at `30000` milliseconds.
 
-The base delay now correctly starts at 100 milliseconds rather than roughly one millisecond. Each retry doubles the delay and adds up to one base delay of random jitter, helping clients avoid retrying in lockstep after a shared network failure.
+The base delay now correctly starts at 100 milliseconds rather than roughly one millisecond. Each retry doubles the delay and adds up to one base delay of random jitter, helping clients avoid retrying in lockstep after a shared network failure. Individual retry delays never exceed 30 seconds.
 
 Self-hosted operators can now pair a longer resource timeout with fewer attempts, or increase the base delay to spread retries during congestion. Invalid values fall back to the defaults.


### PR DESCRIPTION
## What changed

The command-line client now resolves [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) retry behavior from a shared policy. It adds two environment variables:

- `TUIST_HTTP_MAXIMUM_RETRY_COUNT` controls retries after the initial attempt, defaults to `3`, and is capped at `10`.
- `TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS` controls the initial exponential backoff delay, defaults to `100`, and is capped at `30000`.

The request middleware and server retry provider use the same policy. Tests cover defaults, overrides, disabled retries, invalid and extreme values, exponential backoff, jitter, and computed delay limits. The debugging guide, intent documentation, and product changelog describe the new behavior.

## Why

Self-hosted operators may raise network timeouts so slow but progressing cache transfers can complete. A fixed retry count makes that longer timeout multiply the worst-case wait, so operators need to tune retries and backoff together.

## Root cause

`DelayProvider` passed `1_000_000` to `Task.sleep(nanoseconds:)`, producing a one-millisecond base delay despite the intended 100 milliseconds. Its jitter was similarly too small to spread retries after simultaneous failures. The retry provider also hardcoded three retries, resulting in up to four attempts with no override.

## Approach

A shared policy keeps both retry paths aligned. It preserves three retries and a 100-millisecond base delay as defaults, accepts zero retries, and falls back safely for malformed environment values. It caps retry count at 10 and every computed jittered delay at 30 seconds, including exponential or arithmetic overflow, so an extreme configuration remains recoverable.

## Impact

Existing users keep the intended defaults. Operators can reduce retries when using longer resource timeouts or increase the base delay to spread retries under congestion. No migration is required.

## Validation

Twenty-eight focused tests passed across five suites, and the command-line executable built successfully.

### How to test locally

- `mise run cli:lint --fix`
- `tuist generate tuist TuistHTTP TuistHTTPTests TuistServer TuistServerTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHTTPTests/HTTPRetryPolicyTests -only-testing TuistServerTests/DelayProviderTests -only-testing TuistServerTests/RetryProviderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHTTPTests/RetryMiddlewareTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `cd server && mix test test/tuist/marketing/changelog_entry_parser_test.exs`
