### PR TITLE
fix(server): deserialize test run timestamps

### DIFF
--- a/server/lib/tuist/tests/xcresult_processing.ex
+++ b/server/lib/tuist/tests/xcresult_processing.ex
@@ -7,6 +7,8 @@ defmodule Tuist.Tests.XcresultProcessing do
   alias Tuist.Tests
   alias Tuist.Tests.Workers.ProcessXcresultWorker
 
+  require Logger
+
   def enqueue(args) do
     args
     |> ProcessXcresultWorker.new()
@@ -28,6 +30,10 @@ defmodule Tuist.Tests.XcresultProcessing do
       error -> error
     end
   end
+
+  def serialize_ran_at(%NaiveDateTime{} = ran_at), do: NaiveDateTime.to_iso8601(ran_at)
+  def serialize_ran_at(%DateTime{} = ran_at), do: DateTime.to_iso8601(ran_at)
+  def serialize_ran_at(_ran_at), do: NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
 
   def base_test_attrs(args) do
     %{
@@ -55,21 +61,36 @@ defmodule Tuist.Tests.XcresultProcessing do
 
   defp deserialize_ran_at(nil), do: NaiveDateTime.utc_now()
   defp deserialize_ran_at(%NaiveDateTime{} = ran_at), do: ran_at
-  defp deserialize_ran_at(%DateTime{} = ran_at), do: DateTime.to_naive(ran_at)
+
+  defp deserialize_ran_at(%DateTime{} = ran_at) do
+    ran_at |> DateTime.shift_zone!("Etc/UTC") |> DateTime.to_naive()
+  end
 
   defp deserialize_ran_at(ran_at) when is_binary(ran_at) do
-    case NaiveDateTime.from_iso8601(ran_at) do
-      {:ok, naive_datetime} ->
-        naive_datetime
+    case DateTime.from_iso8601(ran_at) do
+      {:ok, datetime, _offset} ->
+        DateTime.to_naive(datetime)
 
-      {:error, _reason} ->
-        ran_at |> DateTime.from_iso8601() |> deserialize_datetime_result(ran_at)
+      {:error, :missing_offset} ->
+        deserialize_naive_ran_at(ran_at)
+
+      {:error, reason} ->
+        fallback_ran_at(ran_at, reason)
     end
   end
 
-  defp deserialize_datetime_result({:ok, datetime, _offset}, _ran_at), do: DateTime.to_naive(datetime)
+  defp deserialize_naive_ran_at(ran_at) do
+    case NaiveDateTime.from_iso8601(ran_at) do
+      {:ok, naive_datetime} -> naive_datetime
+      {:error, reason} -> fallback_ran_at(ran_at, reason)
+    end
+  end
 
-  defp deserialize_datetime_result({:error, reason}, ran_at) do
-    raise ArgumentError, "invalid Xcode result processing ran_at #{inspect(ran_at)}: #{inspect(reason)}"
+  defp fallback_ran_at(ran_at, reason) do
+    Logger.warning(
+      "Invalid Xcode result processing ran_at #{inspect(ran_at)}; using the current time: #{inspect(reason)}"
+    )
+
+    NaiveDateTime.utc_now()
   end
 end

--- a/server/lib/tuist/tests/xcresult_processing.ex
+++ b/server/lib/tuist/tests/xcresult_processing.ex
@@ -49,7 +49,27 @@ defmodule Tuist.Tests.XcresultProcessing do
       build_run_id: Map.get(args, "build_run_id"),
       shard_plan_id: Map.get(args, "shard_plan_id"),
       shard_index: Map.get(args, "shard_index"),
-      ran_at: Map.get(args, "ran_at", NaiveDateTime.utc_now())
+      ran_at: args |> Map.get("ran_at") |> deserialize_ran_at()
     }
+  end
+
+  defp deserialize_ran_at(nil), do: NaiveDateTime.utc_now()
+  defp deserialize_ran_at(%NaiveDateTime{} = ran_at), do: ran_at
+  defp deserialize_ran_at(%DateTime{} = ran_at), do: DateTime.to_naive(ran_at)
+
+  defp deserialize_ran_at(ran_at) when is_binary(ran_at) do
+    case NaiveDateTime.from_iso8601(ran_at) do
+      {:ok, naive_datetime} ->
+        naive_datetime
+
+      {:error, _reason} ->
+        ran_at |> DateTime.from_iso8601() |> deserialize_datetime_result(ran_at)
+    end
+  end
+
+  defp deserialize_datetime_result({:ok, datetime, _offset}, _ran_at), do: DateTime.to_naive(datetime)
+
+  defp deserialize_datetime_result({:error, reason}, ran_at) do
+    raise ArgumentError, "invalid Xcode result processing ran_at #{inspect(ran_at)}: #{inspect(reason)}"
   end
 end

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -577,7 +577,7 @@ defmodule TuistWeb.API.TestsController do
               build_run_id: test_run.build_run_id,
               shard_plan_id: test_run.shard_plan_id,
               shard_index: Map.get(body_params, :shard_index),
-              ran_at: processing_ran_at(test_run.ran_at),
+              ran_at: XcresultProcessing.serialize_ran_at(test_run.ran_at),
               vcs_comment_params: vcs_comment_params
             })
           else
@@ -646,10 +646,6 @@ defmodule TuistWeb.API.TestsController do
         error
     end
   end
-
-  defp processing_ran_at(%NaiveDateTime{} = ran_at), do: NaiveDateTime.to_iso8601(ran_at)
-  defp processing_ran_at(%DateTime{} = ran_at), do: DateTime.to_iso8601(ran_at)
-  defp processing_ran_at(_), do: NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
 
   operation(:show,
     summary: "Get a test run by ID.",

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -167,6 +167,21 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
                ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id)))
     end
 
+    test "deserializes ran_at from the persisted job arguments", %{account: account, project: project} do
+      test_run_id = Ecto.UUID.generate()
+      expect_local_parse(parsed_data())
+
+      expect(Tuist.Tests, :create_test, fn attrs ->
+        assert attrs.ran_at == ~N[2026-07-21 02:59:14.935065]
+        {:ok, %{id: test_run_id}}
+      end)
+
+      args =
+        job_args(test_run_id, account.id, project.id, extra: %{"ran_at" => "2026-07-21T02:59:14.935065"})
+
+      assert :ok == ProcessXcresultWorker.perform(oban_job(args))
+    end
+
     test "passes failure status through unchanged", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
       expect_local_parse(parsed_data_with_failure())

--- a/server/test/tuist/tests/xcresult_processing_test.exs
+++ b/server/test/tuist/tests/xcresult_processing_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.Tests.XcresultProcessingTest do
   use TuistTestSupport.Cases.DataCase, async: false
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Tuist.ClickHouseRepo
   alias Tuist.Repo
@@ -91,6 +92,38 @@ defmodule Tuist.Tests.XcresultProcessingTest do
       )
 
     assert failed_shard_run.ran_at == ran_at
+  end
+
+  test "normalizes offset-bearing ran_at values to Coordinated Universal Time" do
+    attrs =
+      XcresultProcessing.base_test_attrs(%{
+        "ran_at" => "2026-07-21T02:59:14.935065+02:00"
+      })
+
+    assert attrs.ran_at == ~N[2026-07-21 00:59:14.935065]
+  end
+
+  test "falls back to the current time when ran_at is invalid" do
+    before_fallback = NaiveDateTime.utc_now()
+
+    {attrs, log} =
+      with_log(fn ->
+        XcresultProcessing.base_test_attrs(%{"ran_at" => "not-a-date"})
+      end)
+
+    after_fallback = NaiveDateTime.utc_now()
+
+    assert NaiveDateTime.compare(attrs.ran_at, before_fallback) in [:eq, :gt]
+    assert NaiveDateTime.compare(attrs.ran_at, after_fallback) in [:eq, :lt]
+    assert log =~ "Invalid Xcode result processing ran_at"
+  end
+
+  test "serializes ran_at values for Oban arguments" do
+    assert XcresultProcessing.serialize_ran_at(~N[2026-07-21 02:59:14.935065]) ==
+             "2026-07-21T02:59:14.935065"
+
+    assert XcresultProcessing.serialize_ran_at(~U[2026-07-21 02:59:14.935065Z]) ==
+             "2026-07-21T02:59:14.935065Z"
   end
 
   defp processing_args(account_id, project_id) do

--- a/server/test/tuist/tests/xcresult_processing_test.exs
+++ b/server/test/tuist/tests/xcresult_processing_test.exs
@@ -3,11 +3,15 @@ defmodule Tuist.Tests.XcresultProcessingTest do
 
   import Ecto.Query
 
+  alias Tuist.ClickHouseRepo
   alias Tuist.Repo
+  alias Tuist.Shards.ShardRun
+  alias Tuist.Tests
   alias Tuist.Tests.Workers.ProcessXcresultWorker
   alias Tuist.Tests.XcresultProcessing
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.ShardsFixtures
 
   setup do
     %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
@@ -46,6 +50,47 @@ defmodule Tuist.Tests.XcresultProcessingTest do
 
     assert {:ok, second_job} = XcresultProcessing.enqueue(args)
     assert second_job.id == first_job.id
+  end
+
+  test "deserializes ran_at before persisting a failed sharded run", %{account: account, project: project} do
+    test_run_id = UUIDv7.generate()
+    ran_at = ~N[2026-07-21 02:59:14.935065]
+    plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+    assert {:ok, _test} =
+             Tests.create_test(%{
+               id: test_run_id,
+               project_id: project.id,
+               account_id: account.id,
+               duration: 0,
+               status: "processing",
+               ran_at: ran_at,
+               is_ci: true,
+               shard_plan_id: plan.id,
+               shard_index: 0
+             })
+
+    assert :ok =
+             XcresultProcessing.mark_test_run_failed(%{
+               "test_run_id" => test_run_id,
+               "project_id" => project.id,
+               "account_id" => account.id,
+               "is_ci" => true,
+               "shard_plan_id" => plan.id,
+               "shard_index" => 0,
+               "ran_at" => "2026-07-21T02:59:14.935065"
+             })
+
+    failed_shard_run =
+      ClickHouseRepo.one(
+        from(shard_run in ShardRun,
+          where: shard_run.test_run_id == ^test_run_id,
+          where: shard_run.status == "failed_processing",
+          limit: 1
+        )
+      )
+
+    assert failed_shard_run.ran_at == ran_at
   end
 
   defp processing_args(account_id, project_id) do


### PR DESCRIPTION
## What changed

Xcode result processing now converts persisted `ran_at` values back into date-time values before building test-run attributes. Serialization and deserialization live together in the processing module, offset-bearing values are normalized to Coordinated Universal Time, and malformed values log a warning before falling back to the current time.

The regression coverage exercises successful worker processing, controller enqueueing, failed sharded-run persistence through ClickHouse, offset normalization, and malformed-value fallback.

## Why

Failed sharded test runs were repeatedly raising while the processing worker tried to record their terminal status. This prevented the worker from completing its recovery path and generated repeated Sentry events.

## Root cause

The controller serializes `ran_at` before storing the processing job. The worker reused that string when inserting a sharded run directly through `insert_all`, which bypasses changeset casting and requires an already-converted date-time value.

## Approach

The shared attribute builder now restores serialized timestamps at the job boundary before either successful or failed processing reaches persistence. Offset-aware values are parsed before naive values so their offsets are preserved during conversion. Invalid serialized values use the same current-time fallback as missing timestamps, avoiding a permanent retry path for a malformed job argument.

## Impact

New and retried Xcode result-processing jobs can persist sharded test-run timestamps without the type conversion error. Jobs that already exhausted their retries still require an operational replay if recovery is needed.

## Validation

- `mix test test/tuist/tests/xcresult_processing_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist_web/controllers/api/tests_controller_test.exs` with 58 tests passing
- `mix format --check-formatted lib/tuist/tests/xcresult_processing.ex lib/tuist_web/controllers/api/tests_controller.ex test/tuist/tests/xcresult_processing_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist_web/controllers/api/tests_controller_test.exs`
- `mix credo --strict lib/tuist/tests/xcresult_processing.ex lib/tuist_web/controllers/api/tests_controller.ex test/tuist/tests/xcresult_processing_test.exs` with no issues
