### PR TITLE
fix(server): handle Oban fetch rollbacks gracefully

### DIFF
--- a/server/lib/tuist/oban/engine.ex
+++ b/server/lib/tuist/oban/engine.ex
@@ -1,9 +1,10 @@
 defmodule Tuist.Oban.Engine do
   @moduledoc """
-  Extends Oban's standard engine with bounded retries for transaction rollbacks.
+  Extends Oban's standard engine with recovery for transaction rollbacks.
 
-  An explicit rollback guarantees that the transaction did not insert a job, so
-  retrying cannot duplicate it. Other errors retain the standard engine behavior.
+  Insertion rollbacks are retried because they guarantee that no job was
+  committed. Fetch rollbacks keep the queue alive and schedule another dispatch.
+  Other errors retain the standard engine behavior.
   """
 
   @behaviour Oban.Engine
@@ -14,6 +15,7 @@ defmodule Tuist.Oban.Engine do
 
   @max_retries 3
   @retry_delay 100
+  @fetch_retry_delay 1_000
 
   @impl Oban.Engine
   defdelegate init(conf, opts), to: Basic
@@ -29,8 +31,6 @@ defmodule Tuist.Oban.Engine do
   defdelegate insert_all_jobs(conf, changesets, opts), to: Basic
   @impl Oban.Engine
   defdelegate stage_jobs(conf, queryable, opts), to: Basic
-  @impl Oban.Engine
-  defdelegate fetch_jobs(conf, meta, running), to: Basic
   @impl Oban.Engine
   defdelegate prune_jobs(conf, queryable, opts), to: Basic
   @impl Oban.Engine
@@ -63,6 +63,19 @@ defmodule Tuist.Oban.Engine do
   @impl Oban.Engine
   def insert_job(conf, changeset, opts) do
     insert_job(conf, changeset, opts, @max_retries)
+  end
+
+  @impl Oban.Engine
+  def fetch_jobs(conf, meta, running) do
+    case Basic.fetch_jobs(conf, meta, running) do
+      {:error, :rollback} ->
+        Logger.warning("Oban job fetch transaction rolled back; retrying in one second")
+        Process.send_after(self(), :dispatch, @fetch_retry_delay)
+        {:ok, {meta, []}}
+
+      result ->
+        result
+    end
   end
 
   defp insert_job(conf, changeset, opts, retries_left) do

--- a/server/test/tuist/oban/engine_test.exs
+++ b/server/test/tuist/oban/engine_test.exs
@@ -1,17 +1,55 @@
 defmodule Tuist.Oban.EngineTest do
-  use ExUnit.Case, async: false
+  use TuistTestSupport.Cases.DataCase, async: false
   use Mimic
 
+  import ExUnit.CaptureLog
+
   alias Oban.Engines.Basic
+  alias Oban.Job
   alias Tuist.Oban.Engine
+
+  @oban_name Module.concat(__MODULE__, "Oban")
+
+  defmodule Worker do
+    @moduledoc false
+    use Oban.Worker, queue: :engine_integration
+
+    @impl Oban.Worker
+    def perform(_job), do: :ok
+  end
+
+  defmodule RollbackOnceRepo do
+    @moduledoc false
+
+    defdelegate config(), to: Tuist.Repo
+    defdelegate get_dynamic_repo(), to: Tuist.Repo
+    defdelegate in_transaction?(), to: Tuist.Repo
+    defdelegate insert(changeset, opts), to: Tuist.Repo
+    defdelegate put_dynamic_repo(repo), to: Tuist.Repo
+    defdelegate update_all(queryable, updates, opts), to: Tuist.Repo
+
+    def rollback_next_transaction do
+      Agent.update(__MODULE__, fn _rollback? -> true end)
+    end
+
+    def transaction(function, opts) do
+      rollback? = Agent.get_and_update(__MODULE__, fn rollback? -> {rollback?, false} end)
+
+      if rollback? do
+        {:error, :rollback}
+      else
+        Tuist.Repo.transaction(function, opts)
+      end
+    end
+  end
 
   test "is configured as the Oban engine" do
     assert Oban.config().engine == Engine
   end
 
   test "retries a rolled-back Oban insertion" do
-    changeset = Ecto.Changeset.change(%Oban.Job{})
-    job = %Oban.Job{}
+    changeset = Ecto.Changeset.change(%Job{})
+    job = %Job{}
     {:ok, counter} = Agent.start_link(fn -> 0 end)
 
     Mimic.expect(Basic, :insert_job, 2, fn _conf, ^changeset, [] ->
@@ -27,7 +65,7 @@ defmodule Tuist.Oban.EngineTest do
   end
 
   test "returns other insertion errors without retrying" do
-    changeset = Ecto.Changeset.change(%Oban.Job{})
+    changeset = Ecto.Changeset.change(%Job{})
 
     Mimic.expect(Basic, :insert_job, 1, fn _conf, ^changeset, [] -> {:error, :invalid} end)
 
@@ -35,10 +73,81 @@ defmodule Tuist.Oban.EngineTest do
   end
 
   test "returns a rollback after exhausting retries" do
-    changeset = Ecto.Changeset.change(%Oban.Job{})
+    changeset = Ecto.Changeset.change(%Job{})
 
     Mimic.expect(Basic, :insert_job, 4, fn _conf, ^changeset, [] -> {:error, :rollback} end)
 
     assert {:error, :rollback} = Engine.insert_job(%Oban.Config{}, changeset, [])
+  end
+
+  test "implements every callback provided by the basic engine" do
+    for {function, arity} <- Oban.Engine.behaviour_info(:callbacks) do
+      assert function_exported?(Engine, function, arity) ==
+               function_exported?(Basic, function, arity)
+    end
+  end
+
+  test "executes a job through a supervised queue" do
+    start_oban(Tuist.Repo, engine_integration: 1)
+
+    assert Oban.config(@oban_name).engine == Engine
+    assert {:ok, job} = Oban.insert(@oban_name, Worker.new(%{}))
+    assert_job_completed(job.id)
+  end
+
+  test "retries a rolled-back fetch without restarting the queue" do
+    start_supervised!(%{
+      id: RollbackOnceRepo,
+      start: {Agent, :start_link, [fn -> false end, [name: RollbackOnceRepo]]}
+    })
+
+    start_oban(RollbackOnceRepo, engine_integration: [limit: 1, paused: true])
+
+    assert {:ok, job} = Oban.insert(@oban_name, Worker.new(%{}))
+    RollbackOnceRepo.rollback_next_transaction()
+
+    producer = Oban.Registry.whereis(@oban_name, {:producer, "engine_integration"})
+
+    {_result, log} =
+      with_log(fn ->
+        assert :ok = Oban.resume_queue(@oban_name, queue: :engine_integration)
+        assert_job_completed(job.id)
+      end)
+
+    assert log =~ "Oban job fetch transaction rolled back; retrying in one second"
+    assert Process.alive?(producer)
+    assert producer == Oban.Registry.whereis(@oban_name, {:producer, "engine_integration"})
+  end
+
+  defp start_oban(repo, queues) do
+    start_supervised!(
+      {Oban,
+       name: @oban_name,
+       engine: Engine,
+       repo: repo,
+       notifier: Oban.Notifiers.Isolated,
+       peer: false,
+       plugins: false,
+       queues: queues,
+       dispatch_cooldown: 1}
+    )
+  end
+
+  defp assert_job_completed(job_id, attempts \\ 500)
+
+  defp assert_job_completed(job_id, 0) do
+    job = Repo.get!(Job, job_id)
+    assert job.state == "completed"
+  end
+
+  defp assert_job_completed(job_id, attempts) do
+    case Repo.get!(Job, job_id) do
+      %Job{state: "completed"} ->
+        :ok
+
+      %Job{} ->
+        Process.sleep(10)
+        assert_job_completed(job_id, attempts - 1)
+    end
   end
 end


### PR DESCRIPTION
## What changed

Extended the existing `Tuist.Oban.Engine` from pull request #11963 to handle transaction rollbacks while fetching jobs. A fetch rollback now keeps the producer alive and schedules another dispatch after one second.

The engine test suite now also verifies callback parity with Oban's basic engine, a normal supervised queue lifecycle, and a forced fetch rollback followed by successful execution without restarting the producer.

## Why

The fix already on `main` retries rollbacks from single-job insertion. The September incident occurred on the separate job-fetch path, which remained delegated directly to Oban's basic engine.

A transient fetch rollback should delay job fetching rather than restart the queue and interrupt jobs that are already running.

## Root cause

Oban's basic engine can return `{:error, :rollback}` from the transaction that fetches jobs. Oban 2.20.1's dispatcher assumes the engine always returns `{:ok, {meta, jobs}}`, so the rollback result raises a match error. Because the queue supervisor uses a one-for-all restart strategy, that producer failure also restarts active job processes.

## Approach

The existing custom engine continues to delegate standard behavior to Oban's basic engine. It now overrides `fetch_jobs` as well as `insert_job`.

On a fetch rollback, it logs a warning, schedules a retry after one second, and returns the current metadata with no jobs. Other fetch results retain the standard behavior.

## Impact

Both insertion and fetch rollbacks are now handled at the Oban engine boundary. Transient fetch rollbacks no longer restart queues or interrupt active jobs, and available work is retried automatically. No database or configuration migration is required.

## Validation

- `MIX_ENV=test mise exec -- mix format lib/tuist/oban/engine.ex test/tuist/oban/engine_test.exs`
- `MIX_ENV=test mise exec -- mix test test/tuist/oban/engine_test.exs`
- Result: 7 tests passed.
