### PR TITLE
feat(server): clarify billing details management

### DIFF
--- a/server/assets/app/css/pages/billing.css
+++ b/server/assets/app/css/pages/billing.css
@@ -153,7 +153,7 @@
     }
   }
 
-  & > [data-part="billing-email-card-section"],
+  & > [data-part="billing-details-card-section"],
   & > [data-part="billing-payment-method-card-section"] {
     display: flex;
     flex-direction: row;
@@ -265,7 +265,7 @@
     }
   }
 
-  & > [data-part="billing-email-card-section"] {
+  & > [data-part="billing-details-card-section"] {
     & > [data-part="content"] {
       & > [data-part="update-button"] {
         align-self: flex-end;

--- a/server/lib/tuist_web/live/billing_live.html.heex
+++ b/server/lib/tuist_web/live/billing_live.html.heex
@@ -305,13 +305,16 @@
       </div>
     </div>
   </.card_section>
-  <.card_section data-part="billing-email-card-section">
+  <.card_section data-part="billing-details-card-section">
     <div data-part="header">
       <span data-part="title">
-        {dgettext("dashboard_account", "Billing email")}
+        {dgettext("dashboard_account", "Billing details")}
       </span>
       <span data-part="subtitle">
-        {dgettext("dashboard_account", "All billing correspondence will go to this email")}
+        {dgettext(
+          "dashboard_account",
+          "Update the company name, billing address, tax number, and email shown on your invoices."
+        )}
       </span>
     </div>
     <div data-part="content">
@@ -319,7 +322,7 @@
         href={~p"/#{@selected_account.name}/billing/manage"}
         target="_blank"
         variant="secondary"
-        label={dgettext("dashboard_account", "Update billing email")}
+        label={dgettext("dashboard_account", "Update billing details")}
         size="medium"
         data-part="update-button"
       >
@@ -328,7 +331,7 @@
         </:icon_right>
       </.button>
       <div data-part="email">
-        <.label label={dgettext("dashboard_account", "Email")} />
+        <.label label={dgettext("dashboard_account", "Billing email")} />
         <span data-part="billing-email">
           {@selected_account.billing_email}
         </span>

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -56,11 +56,6 @@ msgstr ""
 msgid "Air"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.html.heex:314
-#, elixir-autogen, elixir-format
-msgid "All billing correspondence will go to this email"
-msgstr ""
-
 #: lib/tuist/billing.ex:46
 #: lib/tuist_web/live/billing_live.ex:193
 #, elixir-autogen, elixir-format
@@ -94,7 +89,7 @@ msgstr ""
 msgid "Billing"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.html.heex:311
+#: lib/tuist_web/live/billing_live.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Billing email"
 msgstr ""
@@ -337,7 +332,6 @@ msgstr ""
 msgid "E-mail"
 msgstr ""
 
-#: lib/tuist_web/live/billing_live.html.heex:331
 #: lib/tuist_web/live/members_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Email"
@@ -825,11 +819,6 @@ msgstr ""
 #: lib/tuist/billing.ex:70
 #, elixir-autogen, elixir-format
 msgid "Unlimited projects"
-msgstr ""
-
-#: lib/tuist_web/live/billing_live.html.heex:322
-#, elixir-autogen, elixir-format
-msgid "Update billing email"
 msgstr ""
 
 #: lib/tuist_web/live/billing_live.html.heex:254
@@ -2632,4 +2621,19 @@ msgstr ""
 #: lib/tuist_web/live/account_token_live.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Revoke account token?"
+msgstr ""
+
+#: lib/tuist_web/live/billing_live.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "Billing details"
+msgstr ""
+
+#: lib/tuist_web/live/billing_live.html.heex:325
+#, elixir-autogen, elixir-format
+msgid "Update billing details"
+msgstr ""
+
+#: lib/tuist_web/live/billing_live.html.heex:314
+#, elixir-autogen, elixir-format
+msgid "Update the company name, billing address, tax number, and email shown on your invoices."
 msgstr ""

--- a/server/test/tuist_web/live/billing_live_test.exs
+++ b/server/test/tuist_web/live/billing_live_test.exs
@@ -61,6 +61,22 @@ defmodule TuistWeb.BillingLiveTest do
     assert html =~ "Billing · #{account.name} · Tuist"
   end
 
+  test "links to the Stripe customer portal to update billing details", %{conn: conn, account: account} do
+    {:ok, live_view, _html} = live(conn, ~p"/#{account.name}/billing")
+
+    assert has_element?(
+             live_view,
+             "[data-part='billing-details-card-section'] a[href='/#{account.name}/billing/manage']",
+             "Update billing details"
+           )
+
+    assert has_element?(
+             live_view,
+             "[data-part='billing-details-card-section']",
+             "Update the company name, billing address, tax number, and email shown on your invoices."
+           )
+  end
+
   describe "no active plan" do
     test "renders the correct information", %{conn: conn, account: account} do
       # When


### PR DESCRIPTION
The billing page presented the Stripe customer portal as an email-only action, which made company details, billing addresses, and tax numbers difficult to discover. This change broadens the section and action copy while keeping the existing authenticated billing management route that creates a Stripe customer portal session.

The customer portal configuration in Stripe must expose the tax identifier field in both sandbox and live modes for that field to appear after the redirect.

### Screenshots

#### Before

![Billing email section before the change](https://github.com/user-attachments/assets/4a4c8947-3f9d-44f8-aa89-b85a865293ed)

#### After

![Billing details section after the change](https://github.com/user-attachments/assets/3070ddcd-ab4b-4b11-9000-62d0b30e6458)

### How to test locally

1. Run `mise run dev` from `server/`.
2. Sign in with the local test account.
3. Open the billing page for an account.
4. Confirm the Billing details section describes the supported invoice information and that Update billing details links to the account billing management route in a new tab.

Automated validation:

- `mix test test/tuist_web/live/billing_live_test.exs` completed with 8 passing tests.
- `git diff --check` completed successfully.
