### PR TITLE
fix(server): update vulnerable frontend dependencies

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
       "vue-demi"
     ],
     "overrides": {
-      "axios": "1.16.0",
+      "axios": "1.18.0",
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
       "dompurify": "3.4.11",
@@ -23,9 +23,9 @@
       "yaml": "2.8.3",
       "defu": "6.1.5",
       "follow-redirects": "1.16.0",
-      "protobufjs": "7.6.4",
+      "protobufjs": "7.6.5",
       "postcss": "8.5.10",
-      "shell-quote": "1.8.4",
+      "shell-quote": "1.9.0",
       "form-data": "4.0.6",
       "@opentelemetry/core": "2.8.0",
       "ts-deepmerge": "8.0.0"

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@opentelemetry/core': 2.8.0
   ajv: 8.18.0
-  axios: 1.16.0
+  axios: 1.18.0
   defu: 6.1.5
   dompurify: 3.4.11
   fast-uri: 3.1.2
@@ -16,8 +16,8 @@ overrides:
   form-data: 4.0.6
   mdast-util-to-hast: 13.2.1
   postcss: 8.5.10
-  protobufjs: 7.6.4
-  shell-quote: 1.8.4
+  protobufjs: 7.6.5
+  shell-quote: 1.9.0
   ts-deepmerge: 8.0.0
   yaml: 2.8.3
 
@@ -28,14 +28,16 @@ time:
   '@protobufjs/eventemitter@1.1.1': 2026-05-22T02:33:03.279Z
   '@protobufjs/fetch@1.1.1': 2026-05-17T12:41:02.731Z
   '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
-  axios@1.16.0: 2026-05-02T15:04:00.274Z
+  agent-base@6.0.2: 2020-10-23T19:33:15.354Z
+  axios@1.18.0: 2026-06-14T18:07:37.143Z
   dompurify@3.4.11: 2026-06-17T10:33:28.065Z
   echarts@6.1.0: 2026-05-19T17:52:11.076Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
-  protobufjs@7.6.4: 2026-06-12T12:10:59.442Z
-  shell-quote@1.8.4: 2026-05-22T13:13:48.633Z
+  https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
+  protobufjs@7.6.5: 2026-07-04T01:13:19.092Z
+  shell-quote@1.9.0: 2026-06-25T04:47:19.588Z
   ts-deepmerge@8.0.0: 2026-05-22T00:15:00.073Z
   zrender@6.1.0: 2026-05-04T09:43:16.692Z
 
@@ -579,6 +581,10 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ai@6.0.33:
     resolution: {integrity: sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==}
     engines: {node: '>=18'}
@@ -611,8 +617,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -905,6 +911,10 @@ packages:
 
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   identifier-regex@1.0.1:
     resolution: {integrity: sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==}
@@ -1235,8 +1245,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -1297,8 +1307,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   source-map-js@1.2.1:
@@ -1778,7 +1788,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -1910,7 +1920,7 @@ snapshots:
       '@scalar/workspace-store': 0.44.0
       '@types/har-format': 1.2.16
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/integrations': 13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
+      '@vueuse/integrations': 13.9.0(axios@1.18.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
       focus-trap: 7.8.0
       fuse.js: 7.1.0
       js-base64: 3.7.8
@@ -1921,7 +1931,7 @@ snapshots:
       posthog-js: 1.363.2
       pretty-ms: 9.3.0
       radix-vue: 1.9.17(vue@3.5.30(typescript@5.9.3))
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       type-fest: 5.4.4
       vite-plugin-monaco-editor: 1.1.0(monaco-editor@0.54.0)
       vue: 3.5.30(typescript@5.9.3)
@@ -2321,13 +2331,13 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vueuse/integrations@13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
+  '@vueuse/integrations@13.9.0(axios@1.18.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
-      axios: 1.16.0
+      axios: 1.18.0
       focus-trap: 7.8.0
       fuse.js: 7.1.0
 
@@ -2345,6 +2355,10 @@ snapshots:
   '@vueuse/shared@13.9.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       vue: 3.5.30(typescript@5.9.3)
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
 
   ai@6.0.33(zod@4.3.6):
     dependencies:
@@ -2375,10 +2389,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.16.0:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
 
   bail@2.0.2: {}
@@ -2707,6 +2722,11 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.1
 
   identifier-regex@1.0.1:
     dependencies:
@@ -3201,7 +3221,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -3317,7 +3337,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -3390,7 +3410,7 @@ snapshots:
   typesense@3.0.5(@babel/runtime@7.29.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      axios: 1.16.0
+      axios: 1.18.0
       loglevel: 1.9.2
       tslib: 2.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
## What changed

The server now pins Axios 1.18.0, protobufjs 7.6.5, and shell-quote 1.9.0. The dependency lockfile was regenerated with aube so the complete resolved graph uses those patched releases.

## Why

The server security job began rejecting the dependency graph after the vulnerability database identified twelve findings, including two high-severity findings in Axios and shell-quote. Keeping the patched versions explicitly pinned restores a clean dependency scan and prevents vulnerable transitive versions from being selected.

## Root cause

The server package overrides still pinned Axios 1.16.0, protobufjs 7.6.4, and shell-quote 1.8.4 after security fixes became available. Trivy therefore found the vulnerable versions directly in `pnpm-lock.yaml`.

## Approach

The existing override mechanism remains in place, with only the three affected packages advanced to their first patched releases. Regenerating the lockfile through the repository's package manager also records Axios's new proxy-agent dependencies without changing application code.

## Impact

The server's frontend dependency graph no longer contains the reported vulnerabilities. There are no application behavior changes or migration steps.

## Validation

The same Trivy 0.69.3 filesystem scan used by the GitHub Actions security job reports zero vulnerabilities. The installed package graph is consistent, the package audit reports no known vulnerabilities, and the committed diff passes whitespace validation.

### How to test locally

- `mise x aube@1.6.2 -- aube install --frozen-lockfile`
- `mise x aube@1.6.2 -- aube check`
- `mise x aube@1.6.2 -- aube audit`
- `mise x trivy@0.69.3 -- trivy fs --exit-code 1 --skip-files 'mix.exs,mix.lock' --skip-dirs 'priv/static,node_modules,deps,_build' ./`
- `git diff --check`
