### PR TITLE
perf(server): prune ClickHouse test case run hydration

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1200,21 +1200,65 @@ defmodule Tuist.Tests do
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
 
-    # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
-    # updates) leave multiple versions per id until background merges
-    # collapse them. Dedupe in Elixir by `desc: inserted_at` rather than
-    # paying FINAL's full-part scan and in-memory merge for the page-sized
-    # set of ids that the slim MV already narrowed us to.
-    from(tcr in TestCaseRun,
-      where: tcr.project_id in ^project_ids,
-      where: tcr.test_case_id in ^test_case_ids,
-      where: tcr.ran_at >= ^min_ran_at,
-      where: tcr.ran_at <= ^max_ran_at,
-      where: tcr.id in ^ids,
-      order_by: [desc: tcr.inserted_at]
-    )
-    |> ClickHouseRepo.all()
-    |> Enum.uniq_by(& &1.id)
+    base_query =
+      from(tcr in TestCaseRun,
+        where: tcr.project_id in ^project_ids,
+        where: tcr.test_case_id in ^test_case_ids,
+        where: tcr.ran_at >= ^min_ran_at,
+        where: tcr.ran_at <= ^max_ran_at,
+        where: tcr.id in ^ids,
+        order_by: [desc: tcr.inserted_at]
+      )
+
+    results =
+      case inserted_at_by_id(slim_results) do
+        nil ->
+          ClickHouseRepo.all(base_query)
+
+        inserted_at_by_id ->
+          inserted_ats = inserted_at_by_id |> Map.values() |> Enum.uniq()
+
+          versioned_results =
+            base_query
+            |> where([tcr], tcr.inserted_at in ^inserted_ats)
+            |> ClickHouseRepo.all()
+
+          versioned_results =
+            Enum.filter(versioned_results, fn result ->
+              Map.fetch!(inserted_at_by_id, result.id) == result.inserted_at
+            end)
+
+          found_ids = MapSet.new(versioned_results, & &1.id)
+          missing_ids = Enum.reject(ids, &MapSet.member?(found_ids, &1))
+
+          missing_results =
+            case missing_ids do
+              [] ->
+                []
+
+              missing_ids ->
+                base_query
+                |> where([tcr], tcr.id in ^missing_ids)
+                |> ClickHouseRepo.all()
+            end
+
+          versioned_results ++ missing_results
+      end
+
+    # `test_case_runs` is ReplacingMergeTree; re-inserts leave multiple
+    # versions per id until background merges collapse them. The timestamp
+    # filter normally selects the versions returned by the slim view and
+    # prunes unrelated parts. Missing ids are retried without it so reads
+    # remain correct if two replicas have temporarily different visibility.
+    Enum.uniq_by(results, & &1.id)
+  end
+
+  defp inserted_at_by_id(slim_results) do
+    versions = Enum.map(slim_results, &{&1.id, Map.get(&1, :inserted_at)})
+
+    if Enum.all?(versions, fn {_id, inserted_at} -> not is_nil(inserted_at) end) do
+      Map.new(versions)
+    end
   end
 
   defp ran_at_bounds([first | rest]) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -13,6 +13,7 @@ defmodule Tuist.TestsTest do
   alias Tuist.Tests.TestCase
   alias Tuist.Tests.TestCaseEvent
   alias Tuist.Tests.TestCaseRun
+  alias Tuist.Tests.TestCaseRunByTestRun
   alias Tuist.Tests.TestRunDestination
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.AutomationsFixtures
@@ -843,6 +844,93 @@ defmodule Tuist.TestsTest do
       assert meta.total_count == 3
       names = runs |> Enum.map(& &1.name) |> Enum.sort()
       assert names == ["testAlpha", "testBeta", "testGamma"]
+    end
+
+    test "hydrates the replacement version selected by the test-run materialized view" do
+      project = ProjectsFixtures.project_fixture()
+      inserted_at = ~N[2026-07-21 10:00:00.000000]
+
+      attrs = [
+        id: UUIDv7.generate(),
+        test_run_id: UUIDv7.generate(),
+        test_module_run_id: UUIDv7.generate(),
+        test_case_id: UUIDv7.generate(),
+        project_id: project.id,
+        ran_at: ~N[2026-07-21 09:00:00.000000]
+      ]
+
+      RunsFixtures.test_case_run_fixture(
+        Keyword.merge(attrs, status: 0, inserted_at: NaiveDateTime.add(inserted_at, -60))
+      )
+
+      latest =
+        RunsFixtures.test_case_run_fixture(Keyword.merge(attrs, status: 1, inserted_at: inserted_at))
+
+      {[run], _meta} =
+        Tests.list_test_case_runs(%{
+          filters: [%{field: :test_run_id, op: :==, value: latest.test_run_id}]
+        })
+
+      assert run.status == "failure"
+      assert run.inserted_at == inserted_at
+    end
+
+    test "retries without the version filter when a materialized-view version is not visible in the main table" do
+      inserted_at = ~N[2026-07-21 10:00:00.000000]
+
+      main_row =
+        RunsFixtures.test_case_run_fixture(
+          status: 0,
+          ran_at: ~N[2026-07-21 09:00:00.000000],
+          inserted_at: inserted_at
+        )
+
+      latest_main_row =
+        RunsFixtures.test_case_run_fixture(
+          id: main_row.id,
+          test_run_id: main_row.test_run_id,
+          test_module_run_id: main_row.test_module_run_id,
+          test_case_id: main_row.test_case_id,
+          project_id: main_row.project_id,
+          status: 0,
+          ran_at: main_row.ran_at,
+          inserted_at: NaiveDateTime.add(inserted_at, 30)
+        )
+
+      other_row =
+        RunsFixtures.test_case_run_fixture(
+          test_run_id: main_row.test_run_id,
+          ran_at: main_row.ran_at,
+          inserted_at: inserted_at
+        )
+
+      IngestRepo.insert_all(TestCaseRunByTestRun, [
+        %{
+          id: main_row.id,
+          test_run_id: main_row.test_run_id,
+          status: 1,
+          is_flaky: false,
+          is_new: false,
+          duration: main_row.duration,
+          inserted_at: NaiveDateTime.add(inserted_at, 60),
+          ran_at: main_row.ran_at,
+          name: main_row.name,
+          project_id: main_row.project_id,
+          test_case_id: main_row.test_case_id
+        }
+      ])
+
+      {runs, _meta} =
+        Tests.list_test_case_runs(%{
+          filters: [%{field: :test_run_id, op: :==, value: main_row.test_run_id}]
+        })
+
+      run = Enum.find(runs, &(&1.id == main_row.id))
+      other_run = Enum.find(runs, &(&1.id == other_row.id))
+
+      assert run.status == "success"
+      assert run.inserted_at == latest_main_row.inserted_at
+      assert other_run.inserted_at == inserted_at
     end
   end
 


### PR DESCRIPTION
Related Grafana slow-query alert: <https://tuist.grafana.net/alerting/grafana/ffeb6l2ax5qtcf/view?orgId=1>

## What changed

Test case run hydration now reuses the exact insertion timestamps returned by the slim materialized views. This gives ClickHouse a selective condition on the main table's insertion-time partitioning while preserving the existing project, test case, run time, and identifier conditions.

The hydration step validates each identifier and timestamp pair before accepting a row. If a materialized-view version is not visible in the main-table query, only the missing identifiers are retried through the previous unbounded lookup. Callers whose slim results do not contain insertion timestamps keep the previous query unchanged.

Regression coverage exercises replacement-version hydration, replica visibility differences, and timestamp collisions between unrelated rows.

## Why

The alert was triggered while hydrating a page-sized set of test case runs from the main ClickHouse table. Although the page was already narrowed to a few identifiers, the query still inspected historical parts and their secondary indexes because it did not constrain insertion time.

Read-only production comparisons showed the alert-shaped lookup dropping from about 2.1 seconds and 384 megabytes read to 711 milliseconds and 39 megabytes read. A broader sample dropped from about 7.1 seconds and 1.5 gigabytes read to 289 milliseconds and 8 megabytes read.

## Root cause

The main table is partitioned by insertion month, but hydration constrained only project, test case, run time, and identifiers. The preceding materialized-view query already returned the insertion timestamp for each selected version, but hydration discarded that information, forcing ClickHouse to evaluate indexes across unrelated historical parts.

## Approach

The fast path applies the exact insertion timestamps only when every slim result provides one. Pair validation prevents a timestamp belonging to one row from accidentally selecting a stale version of another row. A targeted fallback retains the previous behavior when replicas temporarily expose different versions.

Selecting fewer columns did not avoid the historical index work, adding a primary-key tuple condition did not materially reduce reads, and a one-sided insertion-time bound would scan progressively more parts as data accumulates. Adding another projection or widening the materialized views would carry a larger storage and deployment cost for a lookup that already has the needed timestamp available.

## Impact

The common test-run and project-scoped paths read substantially less data. The fallback can issue a second query only for identifiers whose selected version is not visible. Response ordering, replacement-row deduplication, and paths without insertion timestamps remain unchanged. There is no schema change or migration.

## Validation

- `mise exec -- mix test test/tuist/tests_test.exs`: 236 tests passed.
- Focused replacement-version and replica-fallback tests passed.
- `mise exec -- mix format --check-formatted lib/tuist/tests.ex test/tuist/tests_test.exs` passed.
- `mise exec -- mix credo --strict lib/tuist/tests.ex` found no issues.
- `git diff --check` passed.
