### PR TITLE
fix(cli): link shared package products once

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -633,13 +633,16 @@ public class GraphTraverser: GraphTraversing {
 
             // Exclude any static products linked in a host application
             // however, for search paths it's fine to keep them included
+            let hostApplication: GraphTarget? = if target.target.product == .unitTests, shouldExcludeHostAppDependencies {
+                unitTestHost(path: path, name: name)
+            } else {
+                nil
+            }
             let hostApplicationStaticTargets: Set<GraphDependency>
-            if target.target.product == .unitTests, shouldExcludeHostAppDependencies,
-               let hostApp = unitTestHost(path: path, name: name)
-            {
+            if let hostApplication {
                 hostApplicationStaticTargets =
                     transitiveStaticDependencies(
-                        from: .target(name: hostApp.target.name, path: hostApp.project.path)
+                        from: .target(name: hostApplication.target.name, path: hostApplication.project.path)
                     )
             } else {
                 hostApplicationStaticTargets = Set()
@@ -676,9 +679,18 @@ public class GraphTraverser: GraphTraversing {
                     .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
             )
 
-            references.formUnion(
-                packageProductsLinkedThroughStaticTargets(from: targetGraphDependency)
-            )
+            var packageProducts = packageProductsLinkedThroughStaticTargets(from: targetGraphDependency)
+            if let hostApplication {
+                packageProducts = packageProductsExcludingProductsLinkedByHost(
+                    packageProducts,
+                    hostPackageProducts: packageProductsLinkedThroughStaticTargets(
+                        from: .target(name: hostApplication.target.name, path: hostApplication.project.path)
+                    ),
+                    targetPlatformFilters: target.target.dependencyPlatformFilters,
+                    hostPlatformFilters: hostApplication.target.dependencyPlatformFilters
+                )
+            }
+            references.formUnion(packageProducts)
         }
 
         // Link dynamic libraries and frameworks
@@ -753,6 +765,55 @@ public class GraphTraverser: GraphTraversing {
     private func isPackageProductLinkingBoundary(_ dependency: GraphDependency) -> Bool {
         canDependencyLinkStaticProducts(dependency: dependency)
             || testTarget(dependency: dependency) { $0.product.isDynamic }
+    }
+
+    private func packageProductsExcludingProductsLinkedByHost(
+        _ packageProducts: Set<GraphDependencyReference>,
+        hostPackageProducts: Set<GraphDependencyReference>,
+        targetPlatformFilters: PlatformFilters,
+        hostPlatformFilters: PlatformFilters
+    ) -> Set<GraphDependencyReference> {
+        var hostProductConditions: [String: PlatformCondition.CombinationResult] = [:]
+        for case let .packageProduct(product, condition) in hostPackageProducts {
+            hostProductConditions[product] = hostProductConditions[
+                product,
+                default: .incompatible
+            ].combineWith(.condition(condition))
+        }
+
+        return Set(packageProducts.compactMap { packageProduct in
+            guard case let .packageProduct(product, condition) = packageProduct,
+                  case let .condition(hostCondition) = hostProductConditions[product]
+            else {
+                return packageProduct
+            }
+
+            let requiredPlatformFilters = resolvedPlatformFilters(
+                condition,
+                default: targetPlatformFilters
+            )
+            let providedPlatformFilters = resolvedPlatformFilters(
+                hostCondition,
+                default: hostPlatformFilters
+            )
+            let remainingPlatformFilters = requiredPlatformFilters.subtracting(providedPlatformFilters)
+            guard !remainingPlatformFilters.isEmpty else { return nil }
+
+            return .packageProduct(
+                product: product,
+                condition: remainingPlatformFilters == requiredPlatformFilters
+                    ? condition
+                    : .when(remainingPlatformFilters)
+            )
+        })
+    }
+
+    private func resolvedPlatformFilters(
+        _ condition: PlatformCondition?,
+        default platformFilters: PlatformFilters
+    ) -> PlatformFilters {
+        condition?.platformFilters
+            ?? (platformFilters.isEmpty ? Set(PlatformFilter.allCases) : platformFilters)
     }
 
     private func intersection(

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -675,6 +675,10 @@ public class GraphTraverser: GraphTraversing {
                 hostApplicationStaticTargets
                     .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
             )
+
+            references.formUnion(
+                packageProductsLinkedThroughStaticTargets(from: targetGraphDependency)
+            )
         }
 
         // Link dynamic libraries and frameworks
@@ -687,6 +691,82 @@ public class GraphTraverser: GraphTraversing {
         references.formUnion(dynamicLibrariesAndFrameworks)
 
         return references
+    }
+
+    private func packageProductsLinkedThroughStaticTargets(
+        from rootDependency: GraphDependency
+    ) -> Set<GraphDependencyReference> {
+        var dependenciesToVisit = [rootDependency]
+        var dependencyConditions: [GraphDependency: PlatformCondition.CombinationResult] = [
+            rootDependency: .condition(nil),
+        ]
+        var packageProductConditions: [GraphDependency: PlatformCondition.CombinationResult] = [:]
+
+        while let dependency = dependenciesToVisit.popLast() {
+            guard let accumulatedCondition = dependencyConditions[dependency] else { continue }
+
+            for childDependency in graph.dependencies[dependency, default: []] {
+                let condition = intersection(
+                    accumulatedCondition,
+                    with: graph.dependencyConditions[(dependency, childDependency)]
+                )
+                guard condition != .incompatible else { continue }
+
+                switch childDependency {
+                case .packageProduct(_, _, .runtime), .packageProduct(_, _, .runtimeEmbedded):
+                    packageProductConditions[childDependency] = packageProductConditions[
+                        childDependency,
+                        default: .incompatible
+                    ].combineWith(condition)
+                case .target:
+                    guard !isPackageProductLinkingBoundary(childDependency) else {
+                        continue
+                    }
+                    let combinedCondition = dependencyConditions[
+                        childDependency,
+                        default: .incompatible
+                    ].combineWith(condition)
+                    guard dependencyConditions[childDependency] != combinedCondition else {
+                        continue
+                    }
+                    dependencyConditions[childDependency] = combinedCondition
+                    dependenciesToVisit.append(childDependency)
+                case .bundle, .framework, .foreignBuildOutput, .library, .macro, .packageProduct, .sdk, .xcframework:
+                    continue
+                }
+            }
+        }
+
+        return Set(packageProductConditions.compactMap { dependency, condition in
+            guard case let .packageProduct(_, product, _) = dependency,
+                  case let .condition(platformCondition) = condition
+            else {
+                return nil
+            }
+            return GraphDependencyReference.packageProduct(
+                product: product,
+                condition: platformCondition
+            )
+        })
+    }
+
+    private func isPackageProductLinkingBoundary(_ dependency: GraphDependency) -> Bool {
+        canDependencyLinkStaticProducts(dependency: dependency)
+            || testTarget(dependency: dependency) { $0.product.isDynamic }
+    }
+
+    private func intersection(
+        _ accumulatedCondition: PlatformCondition.CombinationResult,
+        with edgeCondition: PlatformCondition?
+    ) -> PlatformCondition.CombinationResult {
+        switch accumulatedCondition {
+        case .incompatible:
+            return .incompatible
+        case let .condition(.some(condition)):
+            return condition.intersection(edgeCondition)
+        case .condition(nil):
+            return .condition(edgeCondition)
+        }
     }
 
     private func precompiledDynamicLibrariesAndFrameworks(

--- a/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -177,9 +177,21 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
         for dependency in target.dependencies {
             switch dependency {
             case let .package(product: product, type: type, condition: condition):
+                guard !target.canLinkStaticProducts() || type == .plugin || type == .macro else {
+                    continue
+                }
+                let role: PBXTarget.SwiftPackageProductRole
+                switch type {
+                case .plugin:
+                    role = .plugin
+                case .macro:
+                    role = .link
+                case .runtime, .runtimeEmbedded:
+                    role = target.product.isStatic ? .buildOnly : .link
+                }
                 try pbxTarget.addSwiftPackageProduct(
                     productName: product,
-                    isPlugin: type == .plugin,
+                    role: role,
                     pbxproj: pbxproj,
                     target: target,
                     condition: condition
@@ -462,8 +474,16 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
                 try addBuildFile(path, condition: condition, status: status)
             case let .foreignBuildOutput(path, _, condition):
                 try addBuildFile(path, condition: condition)
-            case .bundle, .macro, .packageProduct:
+            case .bundle, .macro:
                 break
+            case let .packageProduct(product, condition):
+                try pbxTarget.addSwiftPackageProduct(
+                    productName: product,
+                    role: .link,
+                    pbxproj: pbxproj,
+                    target: target,
+                    condition: condition
+                )
             case let .product(dependencyTarget, _, status, condition):
                 guard status != .none else { continue }
                 guard let fileRef = fileElements.product(target: dependencyTarget) else {
@@ -654,22 +674,32 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
 }
 
 extension PBXTarget {
+    enum SwiftPackageProductRole {
+        case buildOnly
+        case link
+        case plugin
+    }
+
     func addSwiftPackageProduct(
         productName: String,
-        isPlugin: Bool,
+        role: SwiftPackageProductRole,
         pbxproj: PBXProj,
         target: Target,
         condition: PlatformCondition?
     ) throws {
-        let productDependency = XCSwiftPackageProductDependency(productName: productName, isPlugin: isPlugin)
+        let productDependency = XCSwiftPackageProductDependency(productName: productName, isPlugin: role == .plugin)
         pbxproj.add(object: productDependency)
 
-        if isPlugin {
-            let pluginDependency = PBXTargetDependency(product: productDependency)
-            pbxproj.add(object: pluginDependency)
+        switch role {
+        case .buildOnly, .plugin:
+            let targetDependency = PBXTargetDependency(product: productDependency)
+            if role == .buildOnly {
+                targetDependency.applyCondition(condition, applicableTo: target)
+            }
+            pbxproj.add(object: targetDependency)
 
-            dependencies.append(pluginDependency)
-        } else {
+            dependencies.append(targetDependency)
+        case .link:
             // Build file
             let buildFile = PBXBuildFile(product: productDependency)
             buildFile.applyCondition(condition, applicableTo: target)

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3027,6 +3027,159 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
     }
 
+    func test_linkableDependencies_linksSharedPackageProductOnceAtStaticProductsBoundary() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let featureA = Target.test(name: "FeatureA", product: .staticFramework)
+        let featureB = Target.test(name: "FeatureB", product: .staticFramework)
+        let project = Project.test(path: "/path/project", targets: [app, featureA, featureB])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let featureADependency = GraphDependency.target(name: featureA.name, path: project.path)
+        let featureBDependency = GraphDependency.target(name: featureB.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [featureADependency, featureBDependency],
+                featureADependency: [packageProduct],
+                featureBDependency: [packageProduct],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let appDependencies = try subject.linkableDependencies(path: project.path, name: app.name)
+        let featureADependencies = try subject.linkableDependencies(path: project.path, name: featureA.name)
+        let featureBDependencies = try subject.linkableDependencies(path: project.path, name: featureB.name)
+
+        // Then
+        XCTAssertEqual(
+            appDependencies.filter { if case .packageProduct = $0 { true } else { false } },
+            [.packageProduct(product: "SwiftProtobuf")]
+        )
+        XCTAssertFalse(featureADependencies.contains(.packageProduct(product: "SwiftProtobuf")))
+        XCTAssertFalse(featureBDependencies.contains(.packageProduct(product: "SwiftProtobuf")))
+    }
+
+    func test_linkableDependencies_stopsPackageProductPropagationAtDynamicBoundary() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let dynamicFeature = Target.test(name: "DynamicFeature", product: .framework)
+        let staticFeature = Target.test(name: "StaticFeature", product: .staticFramework)
+        let project = Project.test(path: "/path/project", targets: [app, dynamicFeature, staticFeature])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let dynamicFeatureDependency = GraphDependency.target(name: dynamicFeature.name, path: project.path)
+        let staticFeatureDependency = GraphDependency.target(name: staticFeature.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [dynamicFeatureDependency],
+                dynamicFeatureDependency: [staticFeatureDependency],
+                staticFeatureDependency: [packageProduct],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let appDependencies = try subject.linkableDependencies(path: project.path, name: app.name)
+        let dynamicFeatureDependencies = try subject.linkableDependencies(path: project.path, name: dynamicFeature.name)
+
+        // Then
+        XCTAssertFalse(appDependencies.contains(.packageProduct(product: "SwiftProtobuf")))
+        XCTAssertTrue(dynamicFeatureDependencies.contains(.packageProduct(product: "SwiftProtobuf")))
+    }
+
+    func test_linkableDependencies_stopsPackageProductPropagationAtDynamicLibraryBoundary() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let dynamicLibrary = Target.test(name: "DynamicLibrary", product: .dynamicLibrary)
+        let project = Project.test(path: "/path/project", targets: [app, dynamicLibrary])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let dynamicLibraryDependency = GraphDependency.target(name: dynamicLibrary.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [dynamicLibraryDependency],
+                dynamicLibraryDependency: [packageProduct],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let appDependencies = try subject.linkableDependencies(path: project.path, name: app.name)
+
+        // Then
+        XCTAssertFalse(appDependencies.contains(.packageProduct(product: "SwiftProtobuf")))
+    }
+
+    func test_linkableDependencies_combinesPackageProductConditionsOnlyAcrossStaticPaths() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let iosFeature = Target.test(name: "iOSFeature", product: .staticFramework)
+        let macOSFeature = Target.test(name: "macOSFeature", product: .staticFramework)
+        let dynamicFeature = Target.test(name: "DynamicFeature", product: .framework)
+        let project = Project.test(path: "/path/project", targets: [app, iosFeature, macOSFeature, dynamicFeature])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let iosFeatureDependency = GraphDependency.target(name: iosFeature.name, path: project.path)
+        let macOSFeatureDependency = GraphDependency.target(name: macOSFeature.name, path: project.path)
+        let dynamicFeatureDependency = GraphDependency.target(name: dynamicFeature.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SharedPackage",
+            type: .runtimeEmbedded
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [iosFeatureDependency, macOSFeatureDependency, dynamicFeatureDependency],
+                iosFeatureDependency: [packageProduct],
+                macOSFeatureDependency: [packageProduct],
+                dynamicFeatureDependency: [packageProduct],
+            ],
+            dependencyConditions: [
+                GraphEdge(from: appDependency, to: iosFeatureDependency): try XCTUnwrap(.when([.ios])),
+                GraphEdge(from: appDependency, to: macOSFeatureDependency): try XCTUnwrap(.when([.macos])),
+                GraphEdge(from: appDependency, to: dynamicFeatureDependency): try XCTUnwrap(.when([.visionos])),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let dependencies = try subject.linkableDependencies(path: project.path, name: app.name)
+
+        // Then
+        XCTAssertTrue(
+            dependencies.contains(
+                .packageProduct(
+                    product: "SharedPackage",
+                    condition: .when([.ios, .macos])
+                )
+            )
+        )
+        XCTAssertFalse(
+            dependencies.contains(
+                .packageProduct(
+                    product: "SharedPackage",
+                    condition: .when([.visionos])
+                )
+            )
+        )
+    }
+
     func test_linkableDependencies_includeTransitivePrecompiledDependenciesOfStaticFrameworks() throws {
         // Given
         // App > StaticFramework > PrecompiledDynamicFramework

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3065,6 +3065,129 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertFalse(featureBDependencies.contains(.packageProduct(product: "SwiftProtobuf")))
     }
 
+    func test_linkableDependencies_excludesPackageProductsLinkedByHostedTestApplication() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .staticFramework)
+        let project = Project.test(path: "/path/project", targets: [app, tests, feature])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let testsDependency = GraphDependency.target(name: tests.name, path: project.path)
+        let featureDependency = GraphDependency.target(name: feature.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [featureDependency],
+                testsDependency: [appDependency, featureDependency],
+                featureDependency: [packageProduct],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let dependencies = try subject.linkableDependencies(path: project.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(dependencies.isEmpty)
+    }
+
+    func test_linkableDependencies_preservesPackageProductsUsedOnlyByHostedTests() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .staticFramework)
+        let testSupport = Target.test(name: "TestSupport", product: .staticFramework)
+        let project = Project.test(path: "/path/project", targets: [app, tests, feature, testSupport])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let testsDependency = GraphDependency.target(name: tests.name, path: project.path)
+        let featureDependency = GraphDependency.target(name: feature.name, path: project.path)
+        let testSupportDependency = GraphDependency.target(name: testSupport.name, path: project.path)
+        let sharedPackageProduct = GraphDependency.packageProduct(
+            path: "/path/shared-package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let testPackageProduct = GraphDependency.packageProduct(
+            path: "/path/test-package",
+            product: "SnapshotTesting",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [featureDependency],
+                testsDependency: [appDependency, featureDependency, testSupportDependency],
+                featureDependency: [sharedPackageProduct],
+                testSupportDependency: [testPackageProduct],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let dependencies = try subject.linkableDependencies(path: project.path, name: tests.name)
+
+        // Then
+        XCTAssertEqual(
+            dependencies,
+            [
+                .packageProduct(product: "SnapshotTesting"),
+                .product(target: testSupport.name, productName: testSupport.productNameWithExtension),
+            ]
+        )
+    }
+
+    func test_linkableDependencies_preservesPackageProductPlatformsNotCoveredByHostedTestApplication() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPhone, .mac], product: .app)
+        let tests = Target.test(name: "AppTests", destinations: [.iPhone, .mac], product: .unitTests)
+        let appFeature = Target.test(name: "AppFeature", product: .staticFramework)
+        let testFeature = Target.test(name: "TestFeature", product: .staticFramework)
+        let project = Project.test(path: "/path/project", targets: [app, tests, appFeature, testFeature])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let testsDependency = GraphDependency.target(name: tests.name, path: project.path)
+        let appFeatureDependency = GraphDependency.target(name: appFeature.name, path: project.path)
+        let testFeatureDependency = GraphDependency.target(name: testFeature.name, path: project.path)
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SharedPackage",
+            type: .runtime
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                appDependency: [appFeatureDependency],
+                testsDependency: [appDependency, testFeatureDependency],
+                appFeatureDependency: [packageProduct],
+                testFeatureDependency: [packageProduct],
+            ],
+            dependencyConditions: [
+                GraphEdge(from: appDependency, to: appFeatureDependency): try XCTUnwrap(.when([.ios])),
+                GraphEdge(from: testsDependency, to: testFeatureDependency): try XCTUnwrap(.when([.ios, .macos])),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let dependencies = try subject.linkableDependencies(path: project.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(
+            dependencies.contains(
+                .packageProduct(product: "SharedPackage", condition: .when([.macos]))
+            )
+        )
+        XCTAssertFalse(
+            dependencies.contains(
+                .packageProduct(product: "SharedPackage", condition: .when([.ios]))
+            )
+        )
+    }
+
     func test_linkableDependencies_stopsPackageProductPropagationAtDynamicBoundary() throws {
         // Given
         let app = Target.test(name: "App", product: .app)

--- a/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -416,13 +416,43 @@ final class LinkGeneratorTests: XCTestCase {
         ])
     }
 
-    func test_generatePackages_initializesPackageProductDependencies() throws {
+    func test_generateLinkingPhase_initializesPackageProductDependencies() throws {
         // Given
         let target = Target.test(
             name: "Test",
-            product: .framework,
+            product: .framework
+        )
+        let pbxproj = PBXProj()
+        let pbxTarget = PBXNativeTarget(name: target.name)
+        pbxproj.add(object: pbxTarget)
+        let graphTraverser = MockGraphTraversing()
+        given(graphTraverser)
+            .linkableDependencies(path: .any, name: .any)
+            .willReturn([.packageProduct(product: "OrderedCollections")])
+
+        // When
+        try subject.generateLinkingPhase(
+            target: target,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            fileElements: ProjectFileElements(),
+            path: "/path",
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        XCTAssertEqual(pbxTarget.packageProductDependencies?.map(\.productName), ["OrderedCollections"])
+        XCTAssertEqual(try pbxTarget.frameworksBuildPhase()?.files?.map(\.product?.productName), ["OrderedCollections"])
+    }
+
+    func test_generatePackages_addsRuntimePackageAsBuildOnlyDependencyForStaticTarget() throws {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            destinations: [.iPhone, .mac],
+            product: .staticFramework,
             dependencies: [
-                .package(product: "OrderedCollections", type: .runtime),
+                .package(product: "OrderedCollections", type: .runtime, condition: .when([.ios])),
             ]
         )
         let pbxproj = PBXProj()
@@ -441,8 +471,41 @@ final class LinkGeneratorTests: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(pbxTarget.packageProductDependencies?.map(\.productName), ["OrderedCollections"])
-        XCTAssertEqual(try pbxTarget.frameworksBuildPhase()?.files?.map(\.product?.productName), ["OrderedCollections"])
+        XCTAssertTrue(try XCTUnwrap(pbxTarget.packageProductDependencies).isEmpty)
+        XCTAssertTrue(try XCTUnwrap(pbxTarget.frameworksBuildPhase()?.files).isEmpty)
+        XCTAssertEqual(pbxTarget.dependencies.map(\.product?.productName), ["OrderedCollections"])
+        XCTAssertEqual(pbxTarget.dependencies.map(\.platformFilter), ["ios"])
+    }
+
+    func test_generatePackages_preservesPluginAndMacroRolesForStaticTarget() throws {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            product: .staticFramework,
+            dependencies: [
+                .package(product: "Plugin", type: .plugin),
+                .package(product: "Macro", type: .macro),
+            ]
+        )
+        let pbxproj = PBXProj()
+        let pbxTarget = PBXNativeTarget(name: target.name)
+        pbxproj.add(object: pbxTarget)
+
+        let frameworksBuildPhase = PBXFrameworksBuildPhase()
+        pbxproj.add(object: frameworksBuildPhase)
+        pbxTarget.buildPhases.append(frameworksBuildPhase)
+
+        // When
+        try subject.generatePackages(
+            target: target,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertEqual(pbxTarget.dependencies.map(\.product?.productName), ["Plugin"])
+        XCTAssertEqual(pbxTarget.packageProductDependencies?.map(\.productName), ["Macro"])
+        XCTAssertEqual(try pbxTarget.frameworksBuildPhase()?.files?.map(\.product?.productName), ["Macro"])
     }
 
     func test_generateEmbedPhase_setupEmbedFrameworksBuildPhase_whenPackageProductIsPresent() throws {


### PR DESCRIPTION
This pull request fixes duplicate symbol linker failures when multiple static frameworks depend on the same Swift package product. The issue became visible when another dependency supplied the Objective-C `-ObjC` linker flag, as UIKitNavigation 2.9.0 does.

## What changed

- Runtime package products referenced by static targets are represented as build-only dependencies, preserving build order and module visibility without copying their object code into every static archive.
- Runtime and embedded package products propagate through static target chains and are linked once by the nearest executable or dynamic binary.
- Package propagation preserves platform conditions and stops at dynamic framework and dynamic library boundaries.
- Hosted unit test bundles omit package products already supplied by their host application while retaining test-only products and platform conditions not covered by the host.
- Plugin and macro package behavior remains unchanged.
- Regression coverage exercises shared static dependencies, hosted tests, dynamic boundaries, platform conditions, embedded products, plugins, and macros.

## Why

Static targets need their package products to be built before compilation, but they should not each absorb the package's object code. Linking the product once at the final binary matches Swift Package Manager behavior and avoids duplicate definitions without weakening linker behavior.

## Root cause

Tuist added each package product to the Frameworks build phase of every static framework that declared it. Xcode then folded the package's object files into each static framework archive. When `-ObjC` forced the linker to load those archives, the final application received the same symbols from multiple frameworks and failed with duplicate symbol errors.

## Approach

The generated project now separates building a package product from linking it. Static targets receive build-only product dependencies, while graph traversal finds runtime products through static paths and assigns the actual link to the nearest binary that can own it. Dynamic binaries remain boundaries because they already link their own dependencies.

For hosted unit tests, the same traversal computes which package products the host application supplies. The test bundle subtracts only the host-covered platform conditions, leaving test-only products and uncovered platform conditions linked by the test bundle.

This keeps `-ObjC` intact because Objective-C categories and load hooks can depend on it.

## Impact

Projects with shared package products behind multiple static frameworks no longer need dependency-specific linker workarounds. Existing project manifests do not need to change, and dynamic frameworks, dynamic libraries, plugins, macros, embedded products, and conditional dependencies retain their intended behavior.

### How to test locally

Generate the focused workspace and run the affected test suites:

```sh
tuist generate tuist TuistCore TuistCoreTests TuistGenerator TuistGeneratorTests ProjectDescription --no-open
xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistCoreTests -only-testing:TuistGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
mise run cli:lint --fix
```

For the reported reproduction, generate the project with this branch and build the `App` scheme that depends on UIKitNavigation 2.9.0. The build should succeed with `-ObjC` still present. Add a hosted unit test target that also depends on the shared feature and run `build-for-testing`; the test bundle should not link SwiftProtobuf again.

## Validation

- The full TuistCore and TuistGenerator test suites passed.
- Formatting and linting passed without changes.
- The reported reproduction generated and built successfully with UIKitNavigation 2.9.0.
- The generated FeatureA and FeatureB archives contain only their own object files, while the application link file list contains SwiftProtobuf exactly once.
- A hosted unit test variant completed an Xcode test build successfully. Its application link file list contains SwiftProtobuf once, while the test bundle link file list contains neither SwiftProtobuf nor the host-provided feature archives.
- The implementation was checked against current Swift Build and Swift Package Manager package-product planning behavior.
