### PR TITLE
fix(server): improve hosted runner dispatch resilience

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -573,7 +573,9 @@ otel_endpoint = Tuist.Environment.get([:otel, :exporter, :otlp, :endpoint])
 # can't starve unrelated work — each job can block for up to 10s and
 # retries six times, and a single `test_case.created` event fans out
 # to one job per subscribed endpoint.
-base_queues = [default: 10, vcs_comments: 20, webhooks: 20, storage_retention: 1]
+# Alert evaluations are isolated at one worker per server Pod because their
+# rolling ClickHouse aggregates are memory-heavy even after query-level limits.
+base_queues = [default: 10, alert_evaluations: 1, vcs_comments: 20, webhooks: 20, storage_retention: 1]
 process_build_queue = {:process_build, Tuist.Environment.process_build_queue_concurrency()}
 process_xcresult_queue = {:process_xcresult, Tuist.Environment.process_xcresult_queue_concurrency()}
 # Swift registry sync queues. Consumed only by

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -59,6 +59,12 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   @default_rolling_window_size 100
   @recent_runs_bucket_sizes [100, 250, 500, 750]
 
+  # Merging the rolling aggregate states is memory-heavy and memory grows with
+  # parallelism. Keep this limit local to these queries so concurrent alert
+  # evaluations leave headroom for runner lifecycle writes and other reads.
+  @rolling_query_max_threads 2
+  @rolling_query_max_memory_bytes 1024 * 1024 * 1024
+
   def evaluate(alert, test_case_ids \\ nil) do
     trigger_config = alert.trigger_config
     threshold = trigger_config["threshold"] || 10
@@ -396,6 +402,8 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       )
     )
     WHERE length(recent_runs) > 0
+    SETTINGS max_threads = #{@rolling_query_max_threads},
+             max_memory_usage = #{@rolling_query_max_memory_bytes}
     """
 
     %{rows: rows} =
@@ -525,6 +533,8 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
     )
     WHERE length(recent_runs) > 0
       AND #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
+    SETTINGS max_threads = #{@rolling_query_max_threads},
+             max_memory_usage = #{@rolling_query_max_memory_bytes}
     """
 
     params = maybe_put_test_case_ids(%{project_id: project_id, threshold: threshold * 1.0}, test_case_ids)

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   @moduledoc false
-  use Oban.Worker, max_attempts: 3, queue: :default
+  use Oban.Worker, max_attempts: 3, queue: :alert_evaluations
 
   import Ecto.Query
 

--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -16,6 +16,8 @@ defmodule Tuist.GitHub.Client do
   alias Tuist.VCS.Repositories.Content
   alias Tuist.VCS.Repositories.Tag
 
+  require Logger
+
   @doc """
   Lists repositories for a GitHub app installation with pagination support.
   Returns {:ok, %{meta: %{next_url: ...}, repositories: [...]}} format similar to Flop.
@@ -352,18 +354,17 @@ defmodule Tuist.GitHub.Client do
 
   @doc """
   Generates a just-in-time runner configuration for an ephemeral
-  GitHub Actions self-hosted runner registered at the org level.
+  GitHub Actions self-hosted runner.
   The returned `encoded_jit_config` is what the in-VM
   `./run.sh --jitconfig` consumes; runners registered this way
   are single-shot and auto-cleaned by GitHub after they exit.
 
-  Org-scoped (vs. repo-scoped) intentionally — the repo-scoped
-  endpoint requires the GH App to hold `administration: write`
-  on the repo, which grants access to settings, secrets,
-  collaborators, and many other unrelated capabilities. The
-  org-scoped endpoint requires only
-  `organization_self_hosted_runners: write`, a targeted scope
-  that does only what the name implies.
+  The organization-scoped endpoint remains the preferred path because it
+  only requires the targeted `organization_self_hosted_runners: write`
+  permission. Personal GitHub accounts cannot use that endpoint, so a 404
+  falls back to the repository-scoped endpoint when
+  `:repository_full_handle` is present. That endpoint requires the GitHub
+  App installation to have accepted `administration: write`.
 
   Runners registered at the org level are usable by any repo in
   the org subject to the runner-group's repo allowlist. The
@@ -371,10 +372,11 @@ defmodule Tuist.GitHub.Client do
   `attrs` to register the runner into a restricted group.
 
   See: https://docs.github.com/en/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization
+  See: https://docs.github.com/en/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository
   """
   def generate_jit_config(installation, org, attrs) do
     api_url = installation_api_url(installation)
-    url = "#{api_url}/orgs/#{org}/actions/runners/generate-jitconfig"
+    org_url = "#{api_url}/orgs/#{org}/actions/runners/generate-jitconfig"
 
     body = %{
       "name" => Map.fetch!(attrs, :name),
@@ -383,8 +385,51 @@ defmodule Tuist.GitHub.Client do
       "work_folder" => Map.get(attrs, :work_folder, "_work")
     }
 
-    with {:ok, %{token: token}} <- App.get_installation_token(installation, api_url: api_url),
-         {:ok, request_url, ssrf_opts} <- pin_ghes_url(url, api_url) do
+    with {:ok, %{token: token}} <- App.get_installation_token(installation, api_url: api_url) do
+      case post_jit_config(org_url, body, token, api_url) do
+        {:error, {:http, 404, _body}} = org_error ->
+          case Map.get(attrs, :repository_full_handle) do
+            repository_full_handle when is_binary(repository_full_handle) ->
+              Logger.info("github: organization runner endpoint unavailable; trying repository endpoint",
+                organization: org,
+                repository: repository_full_handle
+              )
+
+              generate_repository_jit_config(repository_full_handle, body, token, api_url)
+
+            _ ->
+              org_error
+          end
+
+        response ->
+          response
+      end
+    end
+  end
+
+  defp generate_repository_jit_config(repository_full_handle, body, token, api_url) do
+    case String.split(repository_full_handle, "/", parts: 2) do
+      [owner, repository] when owner != "" and repository != "" ->
+        repository_url = "#{api_url}/repos/#{owner}/#{repository}/actions/runners/generate-jitconfig"
+
+        case post_jit_config(repository_url, body, token, api_url) do
+          {:error, {:http, 403, response_body}} ->
+            {:error, {:repository_administration_permission_required, 403, response_body}}
+
+          {:error, {:http, 404, response_body}} ->
+            {:error, {:repository_jit_config_not_found, 404, response_body}}
+
+          response ->
+            response
+        end
+
+      _ ->
+        {:error, {:invalid_repository_full_handle, repository_full_handle}}
+    end
+  end
+
+  defp post_jit_config(url, body, token, api_url) do
+    with {:ok, request_url, ssrf_opts} <- pin_ghes_url(url, api_url) do
       req_opts =
         [
           url: request_url,
@@ -396,8 +441,8 @@ defmodule Tuist.GitHub.Client do
         {:ok, %{status: 201, body: %{"encoded_jit_config" => jit, "runner" => runner}}} ->
           {:ok, %{encoded_jit_config: jit, runner_id: runner["id"], runner_name: runner["name"]}}
 
-        {:ok, %{status: status, body: body}} ->
-          {:error, {:http, status, body}}
+        {:ok, %{status: status, body: response_body}} ->
+          {:error, {:http, status, response_body}}
 
         {:error, reason} ->
           {:error, {:transport, reason}}

--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -391,8 +391,8 @@ defmodule Tuist.GitHub.Client do
           case Map.get(attrs, :repository_full_handle) do
             repository_full_handle when is_binary(repository_full_handle) ->
               Logger.info("github: organization runner endpoint unavailable; trying repository endpoint",
-                organization: org,
-                repository: repository_full_handle
+                org: org,
+                repo: repository_full_handle
               )
 
               generate_repository_jit_config(repository_full_handle, body, token, api_url)

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -468,10 +468,12 @@ defmodule Tuist.Runners do
           fleet_name,
           node_name,
           candidate,
-          excluded_account_ids,
-          excluded_repositories,
-          excluded_workflow_job_ids,
-          attempts_left
+          %{
+            excluded_account_ids: excluded_account_ids,
+            excluded_repositories: excluded_repositories,
+            excluded_workflow_job_ids: excluded_workflow_job_ids,
+            attempts_left: attempts_left
+          }
         )
 
       {:error, :empty} ->
@@ -479,17 +481,7 @@ defmodule Tuist.Runners do
     end
   end
 
-  defp claim_candidate(
-         namespace,
-         sa_name,
-         fleet_name,
-         node_name,
-         candidate,
-         excluded_account_ids,
-         excluded_repositories,
-         excluded_workflow_job_ids,
-         attempts_left
-       ) do
+  defp claim_candidate(namespace, sa_name, fleet_name, node_name, candidate, retry_context) do
     case candidate_resources(candidate, fleet_name) do
       {:ok, resources} ->
         attempt_candidate(
@@ -499,12 +491,7 @@ defmodule Tuist.Runners do
           node_name,
           candidate,
           resources,
-          %{
-            excluded_account_ids: excluded_account_ids,
-            excluded_repositories: excluded_repositories,
-            excluded_workflow_job_ids: excluded_workflow_job_ids,
-            attempts_left: attempts_left
-          }
+          retry_context
         )
 
       {:error, reason} ->
@@ -513,112 +500,121 @@ defmodule Tuist.Runners do
   end
 
   defp attempt_candidate(namespace, sa_name, fleet_name, node_name, candidate, resources, retry_context) do
-    case Claims.attempt(candidate.workflow_job_id, candidate.account_id, fleet_name, sa_name, resources) do
-      {:ok, claim} ->
-        record_volume_affinity(fleet_name, node_name, candidate.account_id)
+    context = %{
+      namespace: namespace,
+      sa_name: sa_name,
+      fleet_name: fleet_name,
+      node_name: node_name,
+      candidate: candidate,
+      retry_context: retry_context
+    }
 
-        case Jobs.record_claimed(candidate, sa_name, claim.claimed_at) do
-          :ok ->
-            case serve_claim(namespace, sa_name, fleet_name, candidate, claim) do
-              {:error, {:github_mint_failed, exclusion_scope}}
-              when exclusion_scope in [:account, :repository, :workflow_job] ->
-                retry_claim_and_serve(
-                  namespace,
-                  sa_name,
-                  fleet_name,
-                  node_name,
-                  retry_context,
-                  candidate,
-                  exclusion_scope
-                )
+    candidate.workflow_job_id
+    |> Claims.attempt(candidate.account_id, fleet_name, sa_name, resources)
+    |> handle_claim_attempt(context)
+  end
 
-              result ->
-                result
-            end
+  defp handle_claim_attempt({:ok, claim}, context) do
+    %{namespace: namespace, sa_name: sa_name, fleet_name: fleet_name, node_name: node_name, candidate: candidate} =
+      context
 
-          {:error, :completed} ->
-            _ = Claims.release(candidate.workflow_job_id, claim.claimed_at)
+    record_volume_affinity(fleet_name, node_name, candidate.account_id)
 
-            retry_claim_and_serve(
-              namespace,
-              sa_name,
-              fleet_name,
-              node_name,
-              retry_context,
-              candidate,
-              :workflow_job
-            )
-        end
+    case Jobs.record_claimed(candidate, sa_name, claim.claimed_at) do
+      :ok ->
+        namespace
+        |> serve_claim(sa_name, fleet_name, candidate, claim)
+        |> handle_serve_claim(context)
 
-      {:error, :lost_race} ->
-        Logger.debug("runners: claim attempt lost race; trying next queued job",
-          fleet: fleet_name,
-          sa: sa_name,
-          workflow_job_id: candidate.workflow_job_id
-        )
-
-        retry_claim_and_serve(
-          namespace,
-          sa_name,
-          fleet_name,
-          node_name,
-          retry_context,
-          candidate,
-          :workflow_job
-        )
-
-      {:error, :account_busy} ->
-        Logger.debug("runners: account admission is busy; trying next account",
-          fleet: fleet_name,
-          sa: sa_name,
-          account_id: candidate.account_id
-        )
-
-        retry_claim_and_serve(
-          namespace,
-          sa_name,
-          fleet_name,
-          node_name,
-          retry_context,
-          candidate,
-          :account
-        )
-
-      {:error, {:concurrency_limit_reached, details}} ->
-        Logger.debug("runners: account reached platform concurrency limit; trying next account",
-          fleet: fleet_name,
-          sa: sa_name,
-          account_id: candidate.account_id,
-          reason: inspect({:concurrency_limit_reached, details})
-        )
-
-        retry_claim_and_serve(
-          namespace,
-          sa_name,
-          fleet_name,
-          node_name,
-          retry_context,
-          candidate,
-          :account
-        )
-
-      {:error, :pod_in_use} ->
-        Logger.debug("runners: claim attempt declined",
-          reason: :pod_in_use,
-          fleet: fleet_name,
-          sa: sa_name
-        )
-
-        {:error, :pod_in_use}
-
-      {:error, reason} ->
-        Logger.warning("runners: dispatch_for_sa failed",
-          reason: inspect(reason),
-          fleet: fleet_name
-        )
-
-        {:error, reason}
+      {:error, :completed} ->
+        _ = Claims.release(candidate.workflow_job_id, claim.claimed_at)
+        retry_claim_and_serve(context, :workflow_job)
     end
+  end
+
+  defp handle_claim_attempt({:error, :lost_race}, context) do
+    %{fleet_name: fleet_name, sa_name: sa_name, candidate: candidate} = context
+
+    Logger.debug("runners: claim attempt lost race; trying next queued job",
+      fleet: fleet_name,
+      sa: sa_name,
+      workflow_job_id: candidate.workflow_job_id
+    )
+
+    retry_claim_and_serve(context, :workflow_job)
+  end
+
+  defp handle_claim_attempt({:error, :account_busy}, context) do
+    %{fleet_name: fleet_name, sa_name: sa_name, candidate: candidate} = context
+
+    Logger.debug("runners: account admission is busy; trying next account",
+      fleet: fleet_name,
+      sa: sa_name,
+      account_id: candidate.account_id
+    )
+
+    retry_claim_and_serve(context, :account)
+  end
+
+  defp handle_claim_attempt({:error, {:concurrency_limit_reached, details}}, context) do
+    %{fleet_name: fleet_name, sa_name: sa_name, candidate: candidate} = context
+
+    Logger.debug("runners: account reached platform concurrency limit; trying next account",
+      fleet: fleet_name,
+      sa: sa_name,
+      account_id: candidate.account_id,
+      reason: inspect({:concurrency_limit_reached, details})
+    )
+
+    retry_claim_and_serve(context, :account)
+  end
+
+  defp handle_claim_attempt({:error, :pod_in_use}, %{fleet_name: fleet_name, sa_name: sa_name}) do
+    Logger.debug("runners: claim attempt declined",
+      reason: :pod_in_use,
+      fleet: fleet_name,
+      sa: sa_name
+    )
+
+    {:error, :pod_in_use}
+  end
+
+  defp handle_claim_attempt({:error, reason}, %{fleet_name: fleet_name}) do
+    Logger.warning("runners: dispatch_for_sa failed",
+      reason: inspect(reason),
+      fleet: fleet_name
+    )
+
+    {:error, reason}
+  end
+
+  defp handle_serve_claim({:error, {:github_mint_failed, exclusion_scope}}, context)
+       when exclusion_scope in [:account, :repository, :workflow_job] do
+    retry_claim_and_serve(context, exclusion_scope)
+  end
+
+  defp handle_serve_claim(result, _context), do: result
+
+  defp retry_claim_and_serve(
+         %{
+           namespace: namespace,
+           sa_name: sa_name,
+           fleet_name: fleet_name,
+           node_name: node_name,
+           retry_context: retry_context,
+           candidate: candidate
+         },
+         exclusion_scope
+       ) do
+    retry_claim_and_serve(
+      namespace,
+      sa_name,
+      fleet_name,
+      node_name,
+      retry_context,
+      candidate,
+      exclusion_scope
+    )
   end
 
   defp candidate_resources(%{platform: "linux", vcpus: vcpus, memory_gb: memory_gb}, _fleet_name)
@@ -1097,7 +1093,7 @@ defmodule Tuist.Runners do
       {:error, {:repository_administration_permission_required, status, _body}} ->
         Logger.error("runners: GitHub App installation must accept repository administration permission",
           account: account.name,
-          repository: Map.get(candidate, :repository),
+          repo: Map.get(candidate, :repository),
           status: status,
           workflow_job_id: candidate.workflow_job_id
         )
@@ -1107,7 +1103,7 @@ defmodule Tuist.Runners do
       {:error, {:repository_jit_config_not_found, status, _body}} ->
         Logger.error("runners: GitHub repository runner endpoint returned not found",
           account: account.name,
-          repository: Map.get(candidate, :repository),
+          repo: Map.get(candidate, :repository),
           status: status,
           workflow_job_id: candidate.workflow_job_id
         )

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -373,7 +373,6 @@ defmodule Tuist.Runners do
     * `{:error, :no_pool_label}` — SA missing the fleet label.
     * `{:error, :unknown_account}` — claimed entry's account
       went away.
-    * `{:error, :github_mint_failed}` — GitHub refused the JIT.
     * `{:error, :not_in_cluster}` — server not running in-cluster.
     * `{:error, :drain}` — the polling Pod's image no longer
       matches its RunnerPool's `spec.image`. The Pod is idle
@@ -421,12 +420,22 @@ defmodule Tuist.Runners do
       fleet_name,
       node_name,
       [],
+      [],
       excluded_workflow_job_ids,
       @max_claim_attempts_per_dispatch
     )
   end
 
-  defp claim_and_serve(_namespace, sa_name, fleet_name, _node_name, _excluded_account_ids, _excluded_workflow_job_ids, 0) do
+  defp claim_and_serve(
+         _namespace,
+         sa_name,
+         fleet_name,
+         _node_name,
+         _excluded_account_ids,
+         _excluded_repositories,
+         _excluded_workflow_job_ids,
+         0
+       ) do
     Logger.debug("runners: claim attempts exhausted",
       fleet: fleet_name,
       sa: sa_name
@@ -441,10 +450,17 @@ defmodule Tuist.Runners do
          fleet_name,
          node_name,
          excluded_account_ids,
+         excluded_repositories,
          excluded_workflow_job_ids,
          attempts_left
        ) do
-    case pick_affine_candidate(fleet_name, node_name, excluded_account_ids, excluded_workflow_job_ids) do
+    case pick_affine_candidate(
+           fleet_name,
+           node_name,
+           excluded_account_ids,
+           excluded_repositories,
+           excluded_workflow_job_ids
+         ) do
       {:ok, candidate} ->
         claim_candidate(
           namespace,
@@ -453,6 +469,7 @@ defmodule Tuist.Runners do
           node_name,
           candidate,
           excluded_account_ids,
+          excluded_repositories,
           excluded_workflow_job_ids,
           attempts_left
         )
@@ -469,6 +486,7 @@ defmodule Tuist.Runners do
          node_name,
          candidate,
          excluded_account_ids,
+         excluded_repositories,
          excluded_workflow_job_ids,
          attempts_left
        ) do
@@ -483,6 +501,7 @@ defmodule Tuist.Runners do
           resources,
           %{
             excluded_account_ids: excluded_account_ids,
+            excluded_repositories: excluded_repositories,
             excluded_workflow_job_ids: excluded_workflow_job_ids,
             attempts_left: attempts_left
           }
@@ -500,7 +519,22 @@ defmodule Tuist.Runners do
 
         case Jobs.record_claimed(candidate, sa_name, claim.claimed_at) do
           :ok ->
-            serve_claim(namespace, sa_name, fleet_name, candidate, claim)
+            case serve_claim(namespace, sa_name, fleet_name, candidate, claim) do
+              {:error, {:github_mint_failed, exclusion_scope}}
+              when exclusion_scope in [:account, :repository, :workflow_job] ->
+                retry_claim_and_serve(
+                  namespace,
+                  sa_name,
+                  fleet_name,
+                  node_name,
+                  retry_context,
+                  candidate,
+                  exclusion_scope
+                )
+
+              result ->
+                result
+            end
 
           {:error, :completed} ->
             _ = Claims.release(candidate.workflow_job_id, claim.claimed_at)
@@ -615,6 +649,7 @@ defmodule Tuist.Runners do
          node_name,
          %{
            excluded_account_ids: excluded_account_ids,
+           excluded_repositories: excluded_repositories,
            excluded_workflow_job_ids: excluded_workflow_job_ids,
            attempts_left: attempts_left
          },
@@ -627,6 +662,7 @@ defmodule Tuist.Runners do
       fleet_name,
       node_name,
       excluded_account_ids,
+      excluded_repositories,
       [candidate.workflow_job_id | excluded_workflow_job_ids],
       attempts_left - 1
     )
@@ -639,6 +675,7 @@ defmodule Tuist.Runners do
          node_name,
          %{
            excluded_account_ids: excluded_account_ids,
+           excluded_repositories: excluded_repositories,
            excluded_workflow_job_ids: excluded_workflow_job_ids,
            attempts_left: attempts_left
          },
@@ -651,8 +688,35 @@ defmodule Tuist.Runners do
       fleet_name,
       node_name,
       [candidate.account_id | excluded_account_ids],
+      excluded_repositories,
       excluded_workflow_job_ids,
       attempts_left
+    )
+  end
+
+  defp retry_claim_and_serve(
+         namespace,
+         sa_name,
+         fleet_name,
+         node_name,
+         %{
+           excluded_account_ids: excluded_account_ids,
+           excluded_repositories: excluded_repositories,
+           excluded_workflow_job_ids: excluded_workflow_job_ids,
+           attempts_left: attempts_left
+         },
+         candidate,
+         :repository
+       ) do
+    claim_and_serve(
+      namespace,
+      sa_name,
+      fleet_name,
+      node_name,
+      excluded_account_ids,
+      [candidate.repository | excluded_repositories],
+      excluded_workflow_job_ids,
+      attempts_left - 1
     )
   end
 
@@ -660,10 +724,17 @@ defmodule Tuist.Runners do
   # pick the one to hand this node: the oldest affine candidate within the
   # age tolerance of the head, else the head. With no node identity or no
   # affinity, this is exactly today's "oldest queued job".
-  defp pick_affine_candidate(fleet_name, node_name, excluded_account_ids, excluded_workflow_job_ids) do
+  defp pick_affine_candidate(
+         fleet_name,
+         node_name,
+         excluded_account_ids,
+         excluded_repositories,
+         excluded_workflow_job_ids
+       ) do
     case Jobs.pick_queued_top_k(
            fleet_name,
            excluded_account_ids,
+           excluded_repositories,
            excluded_workflow_job_ids,
            volume_affinity_top_k()
          ) do
@@ -689,8 +760,11 @@ defmodule Tuist.Runners do
   # The dispatch poll loop only needs "nothing for you this tick", so
   # the empty-queue / claim-contention family collapses to the single
   # `:no_work_yet` the web layer and the polling Pod already handle.
-  # Every other reason — `:drain`, `:no_pool_label`, `:github_mint_failed`,
-  # … — passes through untouched.
+  # Every other reason — `:drain`, `:no_pool_label`, … — passes
+  # through untouched. A GitHub mint failure is handled inside the
+  # claim loop: the failed job is requeued and this poll tries the next
+  # eligible job, repository, or account, so one broken installation cannot
+  # monopolize every idle runner.
   defp to_caller_result({:error, reason}) when reason in [:empty, :lost_race, :pod_in_use], do: {:error, :no_work_yet}
 
   defp to_caller_result(result), do: result
@@ -709,7 +783,8 @@ defmodule Tuist.Runners do
              dispatch_label = pick_dispatch_label(candidate, pool_dispatch_label),
              github_org = github_org_login(candidate, account),
              :ok <- stamp_owner_label(namespace, pod_name, account),
-             {:ok, jit, runner_name} <- mint_jit(account, github_org, sa_name, dispatch_label, runner_labels),
+             {:ok, jit, runner_name} <-
+               mint_jit(account, github_org, candidate, sa_name, dispatch_label, runner_labels),
              :ok <- Claims.mark_running(candidate.workflow_job_id, runner_name),
              :ok <- record_running_safe(candidate.workflow_job_id, runner_name) do
           # Fork-exclusion: only a trusted (same-repo, non-fork) job may touch
@@ -831,7 +906,7 @@ defmodule Tuist.Runners do
   #     drop the PG row AND re-INSERT `queued` to CH on its
   #     normal recovery path.
   defp release_safely(candidate, claim, reason) do
-    Jobs.record_queued(candidate.workflow_job_id)
+    Jobs.record_queued(candidate)
   rescue
     e ->
       Logger.warning("runners: record_queued failed; leaving PG claim for stale-worker",
@@ -958,7 +1033,7 @@ defmodule Tuist.Runners do
 
   defp github_org_login(_candidate, account), do: account.name
 
-  defp mint_jit(account, github_org, sa_name, dispatch_label, runner_labels) do
+  defp mint_jit(account, github_org, candidate, sa_name, dispatch_label, runner_labels) do
     # GitHub's `create JIT config` API caps `name` at 64 characters.
     # Earlier versions prefixed `tuist-<account.name>-` — for macOS
     # pools that fit, but the Linux pool name is longer
@@ -1002,7 +1077,8 @@ defmodule Tuist.Runners do
            GitHubClient.generate_jit_config(installation, github_org, %{
              name: runner_name,
              labels: runner_labels ++ [dispatch_label],
-             work_folder: work_folder
+             work_folder: work_folder,
+             repository_full_handle: Map.get(candidate, :repository)
            }) do
       {:ok, jit, runner_name}
     else
@@ -1012,21 +1088,42 @@ defmodule Tuist.Runners do
           account_id: account.id
         )
 
-        {:error, :github_mint_failed}
+        {:error, {:github_mint_failed, :account}}
 
       {:error, :not_installed} ->
         Logger.warning("runners: GitHub App not installed on org", account: account.name)
-        {:error, :github_mint_failed}
+        {:error, {:github_mint_failed, :account}}
+
+      {:error, {:repository_administration_permission_required, status, _body}} ->
+        Logger.error("runners: GitHub App installation must accept repository administration permission",
+          account: account.name,
+          repository: Map.get(candidate, :repository),
+          status: status,
+          workflow_job_id: candidate.workflow_job_id
+        )
+
+        {:error, {:github_mint_failed, :account}}
+
+      {:error, {:repository_jit_config_not_found, status, _body}} ->
+        Logger.error("runners: GitHub repository runner endpoint returned not found",
+          account: account.name,
+          repository: Map.get(candidate, :repository),
+          status: status,
+          workflow_job_id: candidate.workflow_job_id
+        )
+
+        {:error, {:github_mint_failed, :repository}}
 
       {:error, reason} ->
         Logger.error("runners: GitHub jit mint failed",
           account: account.name,
           org: github_org,
           runner: runner_name,
-          reason: inspect(reason)
+          reason: inspect(reason),
+          workflow_job_id: candidate.workflow_job_id
         )
 
-        {:error, :github_mint_failed}
+        {:error, {:github_mint_failed, :workflow_job}}
     end
   end
 

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -261,7 +261,7 @@ defmodule Tuist.Runners.Jobs do
   caller's responsibility to then atomically claim it via
   `Tuist.Runners.Claims.attempt/5`.
 
-  `ineligible_account_ids` is an optional set of account_ids to
+  `ineligible_account_ids` is an optional set of account IDs to
   exclude from candidate selection. `excluded_workflow_job_ids`
   skips specific queued rows that are already claimed in Postgres or
   that this dispatch poll already lost a claim race for. Returns the
@@ -297,6 +297,16 @@ defmodule Tuist.Runners.Jobs do
   def pick_queued_top_k(fleet_name, ineligible_account_ids \\ [], excluded_workflow_job_ids \\ [], k \\ 20)
       when is_binary(fleet_name) and is_list(ineligible_account_ids) and is_list(excluded_workflow_job_ids) and
              is_integer(k) and k > 0 do
+    pick_queued_top_k(fleet_name, ineligible_account_ids, [], excluded_workflow_job_ids, k)
+  end
+
+  @doc """
+  Like `pick_queued_top_k/4`, while also excluding queued candidates
+  whose latest repository is in `excluded_repositories`.
+  """
+  def pick_queued_top_k(fleet_name, ineligible_account_ids, excluded_repositories, excluded_workflow_job_ids, k)
+      when is_binary(fleet_name) and is_list(ineligible_account_ids) and is_list(excluded_repositories) and
+             is_list(excluded_workflow_job_ids) and is_integer(k) and k > 0 do
     lookback_floor = queued_lookback_floor()
 
     from(j in Job,
@@ -322,6 +332,7 @@ defmodule Tuist.Runners.Jobs do
       }
     )
     |> exclude_accounts(ineligible_account_ids)
+    |> exclude_repositories(excluded_repositories)
     |> exclude_workflow_jobs(excluded_workflow_job_ids)
     |> order_by([j], asc: fragment("argMax(?, ?)", j.enqueued_at, j.updated_at), asc: j.workflow_job_id)
     |> limit(^k)
@@ -336,6 +347,12 @@ defmodule Tuist.Runners.Jobs do
 
   defp exclude_accounts(query, account_ids) when is_list(account_ids) do
     having(query, [j], fragment("argMax(?, ?)", j.account_id, j.updated_at) not in ^account_ids)
+  end
+
+  defp exclude_repositories(query, []), do: query
+
+  defp exclude_repositories(query, repositories) when is_list(repositories) do
+    having(query, [j], fragment("argMax(?, ?)", j.repository, j.updated_at) not in ^repositories)
   end
 
   defp exclude_workflow_jobs(query, []), do: query
@@ -438,9 +455,50 @@ defmodule Tuist.Runners.Jobs do
 
   @doc """
   Records the `queued` state — re-surfaces the workflow_job as
-  claimable after a release / stale-recovery. The caller is
-  responsible for having already DELETE'd the matching PG claim.
+  claimable after a release / stale-recovery.
+
+  The candidate-map variant is used by the dispatch hot path. It already
+  carries the stable job metadata selected by `pick_queued/3`, so it can write
+  the queued row without reading the current ClickHouse row first. This keeps
+  a failed dispatch releasable when ClickHouse is under read-memory pressure.
+
+  The workflow-job-id variant remains for recovery workers that do not retain
+  the original candidate metadata.
   """
+  def record_queued(%{workflow_job_id: workflow_job_id} = candidate) when is_integer(workflow_job_id) do
+    with_workflow_job_ordering_lock(workflow_job_id, fn ->
+      if completion_recorded?(workflow_job_id) do
+        :ok
+      else
+        now = DateTime.utc_now()
+
+        row =
+          Map.merge(candidate, %{
+            status: "queued",
+            conclusion: "",
+            claimed_at: nil,
+            started_at: nil,
+            completed_at: nil,
+            pod_name: "",
+            runner_name: "",
+            log_archived_at: nil,
+            updated_at: now
+          })
+
+        insert_row!(row)
+
+        :telemetry.execute(
+          Telemetry.event_name_job_requeued(),
+          %{count: 1},
+          %{fleet: Map.get(candidate, :fleet_name, "")}
+        )
+
+        broadcast_status_change(Map.get(candidate, :account_id), "queued")
+        :ok
+      end
+    end)
+  end
+
   def record_queued(workflow_job_id) when is_integer(workflow_job_id) do
     with_workflow_job_ordering_lock(workflow_job_id, fn ->
       if completion_recorded?(workflow_job_id) do
@@ -458,8 +516,13 @@ defmodule Tuist.Runners.Jobs do
               |> job_to_row()
               |> Map.merge(%{
                 status: "queued",
+                conclusion: "",
                 claimed_at: nil,
+                started_at: nil,
+                completed_at: nil,
                 pod_name: "",
+                runner_name: "",
+                log_archived_at: nil,
                 updated_at: now
               })
 

--- a/server/test/tuist/github/client_test.exs
+++ b/server/test/tuist/github/client_test.exs
@@ -28,6 +28,120 @@ defmodule Tuist.GitHub.ClientTest do
     :ok
   end
 
+  describe "generate_jit_config/3" do
+    test "uses the organization endpoint when it is available" do
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/orgs/tuist/actions/runners/generate-jitconfig"
+        assert opts[:headers] == @default_api_headers
+
+        assert opts[:json] == %{
+                 "labels" => ["self-hosted", "macOS", "ARM64", "tuist-macos"],
+                 "name" => "runner-1",
+                 "runner_group_id" => 1,
+                 "work_folder" => "/Users/runner/work"
+               }
+
+        {:ok,
+         %Req.Response{
+           status: 201,
+           body: %{
+             "encoded_jit_config" => "jit-config",
+             "runner" => %{"id" => 42, "name" => "runner-1"}
+           }
+         }}
+      end)
+
+      assert {:ok, %{encoded_jit_config: "jit-config", runner_id: 42, runner_name: "runner-1"}} =
+               Client.generate_jit_config(
+                 %{installation_id: "installation-id"},
+                 "tuist",
+                 %{
+                   name: "runner-1",
+                   labels: ["self-hosted", "macOS", "ARM64", "tuist-macos"],
+                   work_folder: "/Users/runner/work",
+                   repository_full_handle: "tuist/tuist"
+                 }
+               )
+    end
+
+    test "falls back to the repository endpoint for a personal account" do
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/orgs/2sem/actions/runners/generate-jitconfig"
+        {:ok, %Req.Response{status: 404, body: %{"message" => "Not Found"}}}
+      end)
+
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/repos/2sem/gersanghelper/actions/runners/generate-jitconfig"
+
+        {:ok,
+         %Req.Response{
+           status: 201,
+           body: %{
+             "encoded_jit_config" => "repository-jit-config",
+             "runner" => %{"id" => 43, "name" => "runner-2"}
+           }
+         }}
+      end)
+
+      assert {:ok, %{encoded_jit_config: "repository-jit-config", runner_id: 43, runner_name: "runner-2"}} =
+               Client.generate_jit_config(
+                 %{installation_id: "installation-id"},
+                 "2sem",
+                 %{
+                   name: "runner-2",
+                   labels: ["self-hosted", "macOS", "ARM64", "tuist-macos"],
+                   repository_full_handle: "2sem/gersanghelper"
+                 }
+               )
+    end
+
+    test "identifies a repository endpoint that returns not found" do
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/orgs/2sem/actions/runners/generate-jitconfig"
+        {:ok, %Req.Response{status: 404, body: %{"message" => "Not Found"}}}
+      end)
+
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/repos/2sem/gersanghelper/actions/runners/generate-jitconfig"
+        {:ok, %Req.Response{status: 404, body: %{"message" => "Not Found"}}}
+      end)
+
+      assert {:error, {:repository_jit_config_not_found, 404, %{"message" => "Not Found"}}} =
+               Client.generate_jit_config(
+                 %{installation_id: "installation-id"},
+                 "2sem",
+                 %{
+                   name: "runner-3",
+                   labels: ["self-hosted", "macOS", "ARM64", "tuist-macos"],
+                   repository_full_handle: "2sem/gersanghelper"
+                 }
+               )
+    end
+
+    test "identifies a repository installation that has not accepted the administration permission" do
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/orgs/2sem/actions/runners/generate-jitconfig"
+        {:ok, %Req.Response{status: 404, body: %{"message" => "Not Found"}}}
+      end)
+
+      expect(Req, :post, fn opts ->
+        assert opts[:url] == "https://api.github.com/repos/2sem/gersanghelper/actions/runners/generate-jitconfig"
+        {:ok, %Req.Response{status: 403, body: %{"message" => "Forbidden"}}}
+      end)
+
+      assert {:error, {:repository_administration_permission_required, 403, %{"message" => "Forbidden"}}} =
+               Client.generate_jit_config(
+                 %{installation_id: "installation-id"},
+                 "2sem",
+                 %{
+                   name: "runner-4",
+                   labels: ["self-hosted", "macOS", "ARM64", "tuist-macos"],
+                   repository_full_handle: "2sem/gersanghelper"
+                 }
+               )
+    end
+  end
+
   describe "get_comments/1" do
     test "returns comments" do
       # Given

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -525,6 +525,16 @@ defmodule Tuist.Runners.JobsTest do
       assert {:ok, %{workflow_job_id: 3102}} = Jobs.pick_queued("fleet-skip", [], [3101])
     end
 
+    test "skips excluded repositories without excluding the account" do
+      account = account_fixture()
+
+      :ok = enqueue_fixture(account, 3151, fleet: "fleet-repository", repository: "acme/unavailable")
+      :ok = enqueue_fixture(account, 3152, fleet: "fleet-repository", repository: "acme/available")
+
+      assert {:ok, [%{workflow_job_id: 3152}]} =
+               Jobs.pick_queued_top_k("fleet-repository", [], ["acme/unavailable"], [], 1)
+    end
+
     test "ignores queued rows enqueued beyond the lookback window" do
       account = account_fixture()
       recent = DateTime.add(DateTime.utc_now(), -60, :second)
@@ -586,6 +596,27 @@ defmodule Tuist.Runners.JobsTest do
   end
 
   describe "record_queued/1" do
+    test "re-surfaces a claimed candidate without re-reading its ClickHouse row" do
+      account = account_fixture()
+
+      :ok =
+        enqueue_fixture(account, 6000,
+          fleet: "fleet-q",
+          repository: "acme/releasable",
+          requested_dispatch_label: "tuist-release"
+        )
+
+      {:ok, candidate} = Jobs.pick_queued("fleet-q", [])
+      :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
+
+      assert :ok = Jobs.record_queued(candidate)
+
+      assert {:ok, requeued} = Jobs.pick_queued("fleet-q", [])
+      assert requeued.workflow_job_id == 6000
+      assert requeued.repository == "acme/releasable"
+      assert requeued.requested_dispatch_label == "tuist-release"
+    end
+
     test "re-surfaces a claimed row as queued (after release/stale)" do
       account = account_fixture()
       :ok = enqueue_fixture(account, 6001, fleet: "fleet-q")
@@ -597,6 +628,26 @@ defmodule Tuist.Runners.JobsTest do
       counts = Jobs.status_counts(account.id)
       assert Map.get(counts, "queued", 0) == 1
       assert Map.get(counts, "claimed", 0) == 0
+    end
+
+    test "clears stale execution fields when recovery requeues by workflow job id" do
+      account = account_fixture()
+      :ok = enqueue_fixture(account, 6003, fleet: "fleet-q")
+      {:ok, candidate} = Jobs.pick_queued("fleet-q", [])
+      :ok = Jobs.record_claimed(candidate, "pod-stale", DateTime.utc_now())
+      :ok = Jobs.record_running(6003, "runner-stale")
+
+      assert :ok = Jobs.record_queued(6003)
+
+      assert {:ok, requeued} = Jobs.get(6003)
+      assert requeued.status == "queued"
+      assert requeued.conclusion == ""
+      assert requeued.claimed_at == nil
+      assert requeued.started_at == nil
+      assert requeued.completed_at == nil
+      assert requeued.pod_name == ""
+      assert requeued.runner_name == ""
+      assert requeued.log_archived_at == nil
     end
 
     test "does not re-surface a terminal job as queued" do

--- a/server/test/tuist/runners_test.exs
+++ b/server/test/tuist/runners_test.exs
@@ -196,7 +196,7 @@ defmodule Tuist.RunnersTest do
         workflow_job_id: workflow_job_id,
         account_id: account.id,
         fleet_name: "fleet-a",
-        repository: "acme/cli",
+        repository: Keyword.get(opts, :repository, "acme/cli"),
         workflow_run_id: workflow_job_id * 10,
         run_attempt: 1,
         workflow_name: "CI",
@@ -249,7 +249,9 @@ defmodule Tuist.RunnersTest do
 
       expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> excluded_workflow_job_ids end)
 
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], ^excluded_workflow_job_ids, _k -> {:ok, [candidate]} end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], ^excluded_workflow_job_ids, _k ->
+        {:ok, [candidate]}
+      end)
 
       expect(Claims, :attempt, fn ^workflow_job_id, _account_id, "fleet-a", ^pod_name, resources ->
         assert resources == %{platform: :linux, vcpus: 4, memory_gb: 16}
@@ -292,6 +294,120 @@ defmodule Tuist.RunnersTest do
         assert String.starts_with?(runner_name, String.slice(pod_name, 0, 55))
         assert byte_size(runner_name) <= 64
         :ok
+      end)
+    end
+
+    defp stub_mint_failure_then_success(
+           failed_account,
+           failed_candidate,
+           eligible_account,
+           eligible_candidate,
+           mint_error,
+           exclusion_scope
+         ) do
+      pod_name = "pod-1"
+      first_claimed_at = DateTime.utc_now()
+      second_claimed_at = DateTime.add(first_claimed_at, 1, :microsecond)
+
+      expect(K8sClient, :get_pod, fn "tuist-runners", ^pod_name ->
+        {:ok, pod_with_image(pod_name, "ghcr.io/tuist/tuist-runner@sha256:current")}
+      end)
+
+      expect(K8sClient, :get_service_account, fn "tuist-runners", ^pod_name ->
+        {:ok, sa_with_pool_label(pod_name, "fleet-a")}
+      end)
+
+      expect(K8sClient, :get_runner_pool, fn "tuist-runners", "fleet-a" ->
+        {:error, :not_found}
+      end)
+
+      expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], [], _k -> {:ok, [failed_candidate]} end)
+
+      expect(Claims, :attempt, fn workflow_job_id, account_id, "fleet-a", ^pod_name, _resources ->
+        assert workflow_job_id == failed_candidate.workflow_job_id
+        assert account_id == failed_account.id
+        {:ok, %{claimed_at: first_claimed_at}}
+      end)
+
+      expect(Jobs, :record_claimed, fn candidate, ^pod_name, ^first_claimed_at ->
+        assert candidate == failed_candidate
+        :ok
+      end)
+
+      expect(Dispatch, :pool_summary_by_name, 2, fn "fleet-a" ->
+        {:ok, %{dispatch_label: "shape-linux-4vcpu-16gb", runner_labels: ["self-hosted", "Linux", "X64"]}}
+      end)
+
+      stub(K8sClient, :patch_pod, fn _namespace, _pod, _patch -> {:ok, %{}} end)
+
+      stub(VCS, :get_github_app_installation_for_account, fn _account_id ->
+        {:ok, %{installation_id: 42, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :generate_jit_config, fn _installation, _login, attrs ->
+        assert attrs.repository_full_handle == failed_candidate.repository
+        mint_error
+      end)
+
+      expect(Jobs, :record_queued, fn candidate ->
+        assert candidate == failed_candidate
+        :ok
+      end)
+
+      expect(Claims, :release, fn workflow_job_id, ^first_claimed_at ->
+        assert workflow_job_id == failed_candidate.workflow_job_id
+        :ok
+      end)
+
+      case exclusion_scope do
+        :account ->
+          expect(Jobs, :pick_queued_top_k, fn "fleet-a", excluded_account_ids, [], [], _k ->
+            assert excluded_account_ids == [failed_account.id]
+            {:ok, [eligible_candidate]}
+          end)
+
+        :repository ->
+          expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], excluded_repositories, [], _k ->
+            assert excluded_repositories == [failed_candidate.repository]
+            {:ok, [eligible_candidate]}
+          end)
+
+        :workflow_job ->
+          expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], excluded_workflow_job_ids, _k ->
+            assert excluded_workflow_job_ids == [failed_candidate.workflow_job_id]
+            {:ok, [eligible_candidate]}
+          end)
+      end
+
+      expect(Claims, :attempt, fn workflow_job_id, account_id, "fleet-a", ^pod_name, _resources ->
+        assert workflow_job_id == eligible_candidate.workflow_job_id
+        assert account_id == eligible_account.id
+        {:ok, %{claimed_at: second_claimed_at}}
+      end)
+
+      expect(Jobs, :record_claimed, fn candidate, ^pod_name, ^second_claimed_at ->
+        assert candidate == eligible_candidate
+        :ok
+      end)
+
+      expect(GitHubClient, :generate_jit_config, fn _installation, _login, attrs ->
+        assert attrs.repository_full_handle == eligible_candidate.repository
+        {:ok, %{encoded_jit_config: "jit-blob", runner_name: attrs.name}}
+      end)
+
+      expect(Claims, :mark_running, fn workflow_job_id, _runner_name ->
+        assert workflow_job_id == eligible_candidate.workflow_job_id
+        :ok
+      end)
+
+      expect(Jobs, :record_running, fn workflow_job_id, _runner_name ->
+        assert workflow_job_id == eligible_candidate.workflow_job_id
+        :ok
+      end)
+
+      stub(GitHubClient, :get_workflow_run, fn %{repository_full_handle: repository} ->
+        {:ok, %{"head_repository" => %{"full_name" => repository}, "repository" => %{"full_name" => repository}}}
       end)
     end
 
@@ -476,13 +592,13 @@ defmodule Tuist.RunnersTest do
 
       expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
 
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], _k -> {:ok, [stale_candidate]} end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], [], _k -> {:ok, [stale_candidate]} end)
 
       expect(Claims, :attempt, fn 90_001, _account_id, "fleet-a", ^pod_name, _resources ->
         {:error, :lost_race}
       end)
 
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [90_001], _k -> {:ok, [candidate]} end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], [90_001], _k -> {:ok, [candidate]} end)
 
       expect(Claims, :attempt, fn 90_002, _account_id, "fleet-a", ^pod_name, _resources ->
         {:ok, %{claimed_at: DateTime.utc_now()}}
@@ -521,6 +637,68 @@ defmodule Tuist.RunnersTest do
       assert "tuist-default" in labels
     end
 
+    test "skips an account whose GitHub App permission prevents minting and dispatches other work" do
+      failed_account = account_fixture()
+      eligible_account = account_fixture()
+      failed_candidate = candidate_with_label(failed_account, "tuist-default", workflow_job_id: 90_101)
+      eligible_candidate = candidate_with_label(eligible_account, "tuist-default", workflow_job_id: 90_102)
+
+      stub_mint_failure_then_success(
+        failed_account,
+        failed_candidate,
+        eligible_account,
+        eligible_candidate,
+        {:error, {:repository_administration_permission_required, 403, %{"message" => "Forbidden"}}},
+        :account
+      )
+
+      assert {:ok, %{workflow_job_id: 90_102}} = Runners.dispatch_for_sa("tuist-runners", "pod-1")
+    end
+
+    test "skips only the repository whose runner endpoint returns not found" do
+      account = account_fixture()
+
+      failed_candidate =
+        candidate_with_label(account, "tuist-default",
+          workflow_job_id: 90_151,
+          repository: "acme/unavailable"
+        )
+
+      eligible_candidate =
+        candidate_with_label(account, "tuist-default",
+          workflow_job_id: 90_152,
+          repository: "acme/available"
+        )
+
+      stub_mint_failure_then_success(
+        account,
+        failed_candidate,
+        account,
+        eligible_candidate,
+        {:error, {:repository_jit_config_not_found, 404, %{"message" => "Not Found"}}},
+        :repository
+      )
+
+      assert {:ok, %{workflow_job_id: 90_152}} = Runners.dispatch_for_sa("tuist-runners", "pod-1")
+    end
+
+    test "skips only the failed workflow job after a transient mint failure" do
+      account = account_fixture()
+      failed_candidate = candidate_with_label(account, "tuist-default", workflow_job_id: 90_201)
+      eligible_candidate = candidate_with_label(account, "tuist-default", workflow_job_id: 90_202)
+
+      stub_mint_failure_then_success(
+        account,
+        failed_candidate,
+        account,
+        eligible_candidate,
+        {:error, {:transport, :timeout}},
+        :workflow_job
+      )
+
+      assert {:ok, %{workflow_job_id: 90_202}} = Runners.dispatch_for_sa("tuist-runners", "pod-1")
+    end
+
     test "skips all queued work for an account that reached its platform limit" do
       capped_account = account_fixture()
       other_account = account_fixture()
@@ -541,7 +719,7 @@ defmodule Tuist.RunnersTest do
       end)
 
       expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], _k -> {:ok, [capped_candidate]} end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], [], _k -> {:ok, [capped_candidate]} end)
 
       expect(Claims, :attempt, fn 91_001, account_id, "fleet-a", ^pod_name, resources ->
         assert account_id == capped_account.id
@@ -556,7 +734,7 @@ defmodule Tuist.RunnersTest do
           }}}
       end)
 
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", excluded_account_ids, [], _k ->
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", excluded_account_ids, [], [], _k ->
         assert excluded_account_ids == [capped_account.id]
         assert other_candidate.account_id == other_account.id
         {:error, :empty}
@@ -583,14 +761,14 @@ defmodule Tuist.RunnersTest do
       end)
 
       expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], _k -> {:ok, [busy_candidate]} end)
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", [], [], [], _k -> {:ok, [busy_candidate]} end)
 
       expect(Claims, :attempt, fn 91_010, account_id, "fleet-a", ^pod_name, _resources ->
         assert account_id == busy_account.id
         {:error, :account_busy}
       end)
 
-      expect(Jobs, :pick_queued_top_k, fn "fleet-a", excluded_account_ids, [], _k ->
+      expect(Jobs, :pick_queued_top_k, fn "fleet-a", excluded_account_ids, [], [], _k ->
         assert excluded_account_ids == [busy_account.id]
         {:error, :empty}
       end)
@@ -625,7 +803,7 @@ defmodule Tuist.RunnersTest do
 
       expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
 
-      expect(Jobs, :pick_queued_top_k, 17, fn "fleet-a", excluded_account_ids, [], _k ->
+      expect(Jobs, :pick_queued_top_k, 17, fn "fleet-a", excluded_account_ids, [], [], _k ->
         candidate = Enum.find(candidates, &(&1.account_id not in excluded_account_ids))
         {:ok, [candidate]}
       end)


### PR DESCRIPTION
Related runner failure: <https://github.com/tuist/tuist/actions/runs/29766261140/job/88433129102>

Related Grafana alert: <https://tuist.grafana.net/alerting/grafana/afsd33dx5fhmoc/view?orgId=1>

## What changed

Runner registration now prefers the organization endpoint and falls back to the repository endpoint for personal GitHub accounts. Repository endpoint failures are scoped according to their impact: a missing administration permission excludes the account, a not-found response excludes only that repository, and transient failures exclude only the workflow job. Failed candidates are requeued without another ClickHouse read, and the same polling runner tries the next eligible candidate within a bounded retry loop.

Flaky-test rolling alert queries now run with two threads and a one-gigabyte memory limit. Alert evaluation also has a dedicated Oban queue with one worker per server pod.

## Why

macOS jobs were waiting even when runner hosts appeared idle. Production logs showed a personal account repeatedly reaching the organization runner endpoint, receiving a not-found response, and being selected again. This prevented the available macOS 26.5 runner from progressing to other eligible work.

At the same time, the Grafana alert showed memory-heavy ClickHouse aggregation competing with runner lifecycle queries.

## Root cause

Personal GitHub accounts cannot register organization-level runners, but the server only attempted the organization endpoint. When registration failed, dispatch requeued the candidate and returned, so the oldest broken candidate could monopolize every subsequent poll.

The alert queries merged large rolling aggregate states without query-level resource limits and shared the default background-job queue. This allowed several expensive evaluations to run concurrently on each server pod.

## Approach

The organization endpoint remains the preferred path because it uses the narrower organization runner permission. A not-found response triggers a repository-scoped fallback when the queued candidate contains a repository handle.

Dispatch exclusions are kept local to the bounded polling attempt. This lets another repository from the same account continue when one repository is unavailable, while preventing an unbounded loop across broken repositories. Account-wide permission failures still skip all work for that account during the attempt.

ClickHouse limits are applied only to the rolling alert queries, and queue isolation bounds aggregate concurrency without slowing unrelated background work.

## Impact

Personal accounts can receive repository-level runners after accepting the requested GitHub App permission. A broken repository or installation no longer blocks unrelated queued jobs from using the same runner. Existing organization registrations continue through the organization endpoint.

The alert queries have predictable processor and memory usage, leaving more ClickHouse headroom for runner state transitions. There is no schema migration or customer migration.

This does not change the current per-version macOS pool allocation, so idle capacity reserved by one operating-system pool is still not directly reusable by another pool.

## Validation

### How to test locally

- `env MIX_ENV=test mise exec -- mix do deps.loadpaths --no-deps-check + test test/tuist/github/client_test.exs test/tuist/runners/jobs_test.exs test/tuist/runners_test.exs`: 139 tests passed.
- Focused alert-monitor tests passed as part of the broader server validation.
- Formatting and `git diff --check` passed.
