### PR TITLE
fix(server): tolerate repeated refresh token persistence

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -108,6 +108,7 @@ config :fun_with_flags, :persistence,
   ecto_primary_key_type: :binary_id
 
 config :guardian, Guardian.DB,
+  adapter: Tuist.GuardianDatabaseAdapter,
   repo: Tuist.Repo,
   schema_name: "guardian_tokens",
   token_types: ["refresh"]

--- a/server/lib/tuist/guardian_database_adapter.ex
+++ b/server/lib/tuist/guardian_database_adapter.ex
@@ -1,0 +1,41 @@
+defmodule Tuist.GuardianDatabaseAdapter do
+  @moduledoc """
+  Stores Guardian tokens while allowing the same signed token to be persisted more than once.
+  """
+
+  @behaviour Guardian.DB.Adapter
+
+  alias Guardian.DB.EctoAdapter
+
+  @default_schema_name "guardian_tokens"
+
+  @impl true
+  defdelegate one(claims, options), to: EctoAdapter
+
+  @impl true
+  def insert(changeset, options) do
+    prefix = Keyword.get(options, :prefix)
+    repo = Keyword.fetch!(options, :repo)
+
+    data =
+      changeset
+      |> Map.fetch!(:data)
+      |> Ecto.put_meta(source: Keyword.get(options, :schema_name, @default_schema_name))
+      |> Ecto.put_meta(prefix: prefix)
+
+    repo.insert(%{changeset | data: data},
+      prefix: prefix,
+      on_conflict: :nothing,
+      conflict_target: [:jti, :aud]
+    )
+  end
+
+  @impl true
+  defdelegate delete(record, options), to: EctoAdapter
+
+  @impl true
+  defdelegate delete_by_sub(subject, options), to: EctoAdapter
+
+  @impl true
+  defdelegate purge_expired_tokens(timestamp, options), to: EctoAdapter
+end

--- a/server/test/tuist/guardian_database_adapter_test.exs
+++ b/server/test/tuist/guardian_database_adapter_test.exs
@@ -1,0 +1,24 @@
+defmodule Tuist.GuardianDatabaseAdapterTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+
+  alias Guardian.DB.Token
+
+  test "storing the same token twice keeps the original record" do
+    claims = %{
+      "aud" => "tuist",
+      "exp" => DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.to_unix(),
+      "iss" => "tuist",
+      "jti" => UUIDv7.generate(),
+      "sub" => "1",
+      "typ" => "refresh"
+    }
+
+    assert {:ok, {:resource, "refresh", ^claims, "first-hash"}} =
+             Guardian.DB.after_encode_and_sign(:resource, "refresh", claims, "first-hash")
+
+    assert {:ok, {:resource, "refresh", ^claims, "second-hash"}} =
+             Guardian.DB.after_encode_and_sign(:resource, "refresh", claims, "second-hash")
+
+    assert %Token{jwt: "first-hash"} = Token.find_by_claims(claims)
+  end
+end


### PR DESCRIPTION
## What changed

Added a Guardian database adapter that treats repeated refresh-token persistence as a successful no-op while preserving the existing token record. Guardian now uses this adapter for refresh-token storage, with regression coverage for storing the same token twice.

## Why

An authentication request in the canary environment failed with a database constraint error when the same refresh token was persisted more than once. This change prevents that retry from turning an otherwise valid authentication operation into a server error.

The failure was reported in [Sentry](https://tuist.sentry.io/issues/135620313/).

## Root cause

Guardian's default Ecto adapter always performs a plain insert. The token table uses the token identifier and audience as its composite primary key, so a repeated write raised a constraint error instead of reusing the record that was already present.

## Approach

The custom adapter keeps Guardian's existing lookup, deletion, and expiry behavior. Its insert uses the existing composite primary key as the conflict target and ignores only that duplicate, making repeated persistence atomic and safe while retaining the original record.

## Impact

Repeated refresh-token persistence no longer fails authentication. The change requires no database migration and does not alter normal token creation or revocation behavior.

## Validation

- `mise exec -- mix test test/tuist/guardian_database_adapter_test.exs test/tuist/guardian_test.exs test/tuist_web/controllers/api/auth_controller_test.exs` passed with 30 tests.
- `mise exec -- mix format --check-formatted config/config.exs lib/tuist/guardian_database_adapter.ex test/tuist/guardian_database_adapter_test.exs` passed.
- `mise exec -- mix credo --strict lib/tuist/guardian_database_adapter.ex test/tuist/guardian_database_adapter_test.exs` reported no issues.
