### PR TITLE
fix(cli): backport pruned selective test target handling to 4.202.x

### DIFF
--- a/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
+++ b/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
@@ -86,6 +86,16 @@ public struct FocusTargetsGraphMappers: GraphMapping {
                 excludedTargets: excludedTargets,
                 excludingExternalTargets: true
             )
+            let initialUserSpecifiedSourceTargets = environment.initialGraph.map { initialGraph in
+                let initialGraphTraverser = GraphTraverser(graph: initialGraph)
+                return initialGraphTraverser.filterIncludedTargets(
+                    basedOn: initialGraphTraverser.allTargets(),
+                    testPlan: testPlan,
+                    includedTargets: includedTargets,
+                    excludedTargets: excludedTargets,
+                    excludingExternalTargets: true
+                )
+            }
 
             let includedTargetNames: [String] = includedTargets.compactMap {
                 guard case let .named(name) = $0 else { return nil }
@@ -103,7 +113,13 @@ public struct FocusTargetsGraphMappers: GraphMapping {
                 throw FocusTargetsGraphMappersError.targetsNotFound(Array(unavailableIncludedTargets))
             }
 
-            if !includedTargets.isEmpty || !excludedTargets.isEmpty, userSpecifiedSourceTargets.isEmpty {
+            let allIncludedTargetsWerePrunedBySelectiveTesting = !includedTargets.isEmpty
+                && userSpecifiedSourceTargets.isEmpty
+                && initialUserSpecifiedSourceTargets?.isEmpty == false
+            if !includedTargets.isEmpty || !excludedTargets.isEmpty,
+               userSpecifiedSourceTargets.isEmpty,
+               !allIncludedTargetsWerePrunedBySelectiveTesting
+            {
                 throw FocusTargetsGraphMappersError.noTargetsFound
             }
 

--- a/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -529,6 +529,39 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         XCTAssertEmpty(gotSideEffects)
     }
 
+    func test_map_when_all_included_targets_were_pruned_by_selective_testing_does_not_throw() throws {
+        // Given
+        let appTarget = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let libTests = Target.test(name: "LibTests", product: .unitTests)
+        let subject = FocusTargetsGraphMappers(
+            includedTargets: [.named("AppTests"), .named("LibTests")]
+        )
+        let path = try temporaryPath()
+        let initialProject = Project.test(path: path, targets: [appTarget, appTests, libTests])
+        let initialGraph = Graph.test(
+            projects: [initialProject.path: initialProject],
+            dependencies: [
+                .target(name: appTests.name, path: path): [
+                    .target(name: appTarget.name, path: path),
+                ],
+            ]
+        )
+        let project = Project.test(path: path, targets: [appTarget])
+        let graph = Graph.test(projects: [project.path: project])
+        var environment = MapperEnvironment()
+        environment.initialGraph = initialGraph
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: environment)
+        let pruningTargets = gotGraph.projects.values.flatMap(\.targets.values).sorted()
+            .filter { $0.metadata.tags.contains("tuist:prunable") }
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertEqual(pruningTargets.map(\.name), [appTarget.name])
+    }
+
     func test_map_when_some_included_targets_were_pruned_and_others_do_not_exist_throws() throws {
         // Given
         let aTarget = Target.test(name: "App", product: .app)


### PR DESCRIPTION
Backport of #11731 to the `releases/4.202.x` line.

## What changed

`FocusTargetsGraphMappers` now also evaluates the user-provided target query against `environment.initialGraph`, not only against the current (already pruned) graph. When selective testing has removed every requested test target from the graph, the mapper treats the query as valid instead of throwing `No targets were found`. A regression test covers the all-requested-targets-pruned case.

## Why

On 4.202.x, `tuist test --test-targets ...` behaves differently depending on selective testing. With `--no-selective-testing` the requested test target is found and runs. With selective testing enabled, remote selective test data can prune that target before the focus mapper validates the query, so the CLI fails with:

```text
No targets were found. Ensure that the query is valid and matches targets in the graph.
```

The query was valid the whole time. It only looked empty because selective testing had already removed the targets from the generated graph.

## Root cause

The mapper validated `includedTargets` against the pruned graph only. The existing handling covered the partial case, where some requested targets were pruned and others survived, but not the case where all of them were pruned. In that all-pruned case `userSpecifiedSourceTargets` is empty, and the mapper raised the same error it uses for genuinely invalid target queries.

## Approach

The mapper re-runs the same included/excluded filtering against `environment.initialGraph` when one is available. If the current graph has no matching included targets but the initial graph did, that is selective testing having pruned them, so the `noTargetsFound` error is skipped. Truly invalid target names still fail, because they are missing from both the current and the initial graph.

The alternative of relaxing the `noTargetsFound` check unconditionally was rejected: it would have made typo'd target names silently succeed with an empty test run, which is worse than the bug being fixed.

This was applied as the effective diff of #11731 rather than a `git cherry-pick`, so no unrelated changes from `main` are pulled into the stable line. The resulting change is line-for-line identical to the upstream PR.

## Validation

- Ran `tuist install --force-resolved-versions` and `tuist generate tuist TuistKit TuistKitTests ProjectDescription --no-open`.
- Ran the full mapper suite: `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/FocusTargetsGraphMappersTests` (21 tests, 0 failures).
- Confirmed the regression test is not vacuous by reverting only the source change and re-running it: it fails with the original `No targets were found` error, and passes again with the fix in place.
- Ran `mise run lint`; no new warnings from the changed files.
