### PR TITLE
perf(server): stop restamping unchanged marketing locale cookies

### DIFF
--- a/server/lib/tuist_web/marketing/localization.ex
+++ b/server/lib/tuist_web/marketing/localization.ex
@@ -34,12 +34,8 @@ defmodule TuistWeb.Marketing.Localization do
       Gettext.put_locale(locale)
 
       conn
-      |> put_session(:locale, locale)
-      |> put_resp_cookie("user_locale_preference", locale,
-        max_age: 60 * 60 * 24 * 365,
-        http_only: true,
-        same_site: "Lax"
-      )
+      |> maybe_put_locale_session(locale)
+      |> maybe_put_locale_cookie(locale)
     end
   end
 
@@ -118,6 +114,32 @@ defmodule TuistWeb.Marketing.Localization do
     |> get_req_header("accept-language")
     |> List.first()
     |> Locale.locale_from_accept_language()
+  end
+
+  # Marketing responses declare `public, max-age=60, stale-while-revalidate=86400`,
+  # but a CDN will not store a response carrying `Set-Cookie`. Re-stamping an
+  # unchanged locale on every request made the entire marketing site
+  # uncacheable at the edge, so only write when the value actually changes.
+  defp maybe_put_locale_session(conn, locale) do
+    if get_session(conn, :locale) == locale do
+      conn
+    else
+      put_session(conn, :locale, locale)
+    end
+  end
+
+  defp maybe_put_locale_cookie(conn, locale) do
+    conn = fetch_cookies(conn)
+
+    if Map.get(conn.req_cookies, "user_locale_preference") == locale do
+      conn
+    else
+      put_resp_cookie(conn, "user_locale_preference", locale,
+        max_age: 60 * 60 * 24 * 365,
+        http_only: true,
+        same_site: "Lax"
+      )
+    end
   end
 
   defp has_user_locale_preference?(conn) do


### PR DESCRIPTION
Marketing pages ask to be cached at the edge but never are, so every anonymous visit and every crawler hit renders in Elixir.

## What changed

`TuistWeb.Marketing.Localization` only writes the session locale and the `user_locale_preference` cookie when the incoming request does not already carry that exact value. Behaviour for a visitor whose locale is changing is unchanged; the difference is that a visitor who already has the right locale now gets a response with no `Set-Cookie` header at all.

## Why

While looking into reports of tuist.dev being slow to load I checked what the edge was doing with the marketing pages. The origin asks for them to be cached:

```
cache-control: public, max-age=60, stale-while-revalidate=86400
```

but every response, warm or cold, came back as:

```
cf-cache-status: DYNAMIC
```

So the 60 second edge cache and the 24 hour stale-while-revalidate window have never done anything, and 100% of marketing traffic reaches the origin. The pages are indexable (`x-robots-tag: index, follow`), so that includes crawler traffic.

## Root cause

A content delivery network will not store a response that carries a `Set-Cookie` header, and every marketing response carried two:

```
set-cookie: user_locale_preference=en; path=/; max-age=31536000; ...
set-cookie: _tuist_key=SFMyNTY...
```

The locale plug wrote both unconditionally on every request. I confirmed it re-stamped the cookie even when the request already sent back the identical value, which also meant the session was rewritten every time and so the session cookie was re-sent too.

## Approach

The smallest change that makes the response cacheable: compare before writing, in both the session and the cookie.

This works through repeat visitors rather than first-time ones. A first-time visitor still receives both cookies, because they genuinely need them. A returning visitor now produces a cookie-free response, and that is the one the edge stores and then serves to everyone.

I deliberately did not remove the session or the forgery protection from the marketing pipeline. That would take cookies off the very first response too, but the marketing pages include LiveView routes that need a token for the socket connection, so it is a larger change than it looks and it belongs in its own pull request if we want it.

## Impact

On its own this changes nothing observable, but it unblocks the largest latency win available on the marketing site, so it is worth more than the diff suggests.

Synthetic probes fetching `https://tuist.dev` right now, single request, connect plus handshake plus processing plus transfer:

| Probe | Time | Probe | Time |
| --- | ---: | --- | ---: |
| Frankfurt | 87ms | Singapore | 726ms |
| Paris | 97ms | Tokyo | 886ms |
| London | 129ms | Sydney | 932ms |
| Spain | 199ms | Seoul | 1,372ms |
| NorthVirginia | 369ms | Mumbai | 1,426ms |

Frankfurt to Mumbai is a 16x spread tracking distance to Falkenstein. That is what serving every request from a single origin looks like. Cloudflare has a point of presence in all of those cities, so a cached page would land in a flat 30 to 80ms band everywhere, the way the digested assets already do.

For reference, the origin renders this page in 8ms at the median. Of the 199ms a visitor in Spain waits, roughly 8ms is the application and the rest is a round trip to Germany plus 86 KB of body. No query is involved and no amount of application optimisation moves it. It is a prerequisite, not the fix, and I want to be explicit about that because I initially assumed otherwise.

Cloudflare is not declining to cache these pages because of the cookies. It is declining because HTML is not eligible under the default cache level, which caches by file extension. The evidence is the difference in status between an asset and a page:

```
/marketing/assets/bundle.css   cf-cache-status: MISS
/images/error_image_light.png  cf-cache-status: MISS
/                              cf-cache-status: DYNAMIC
```

`MISS` means eligible and attempted. `DYNAMIC` means never eligible. Caching the marketing pages needs an explicit Cache Rule using Cache Everything, and there is no such rule in this repository or in any Terraform or wrangler configuration, so it is dashboard-managed or absent.

This pull request is the half that has to land first, and the caching it unblocks is worth roughly 2x for European visitors and up to 16x for Asian ones. Once a Cache Rule exists, a response still carrying `Set-Cookie: _tuist_key=...` is a response Cloudflare is being asked to store and replay to other visitors. It normally refuses and reports `BYPASS`, but that is a safety net I would rather not depend on for a session cookie. Remove the cookie first, add the rule second.

Two things to settle when the rule is written:

- Scope it to the controller-rendered pages. `/` and `/pricing` and their locale prefixes send `public, max-age=60, stale-while-revalidate=86400`. The LiveView marketing routes such as `/blog` and `/changelog` send `max-age=0, private, must-revalidate`, so either exclude them or configure the rule to respect origin cache-control and let them exclude themselves.
- A cached page carries one Content Security Policy nonce and one cross-site request forgery token for up to 60 seconds, shared across everyone served that cache entry, and visitors served from cache do not receive `user_locale_preference`, which is what `redirect_to_localized_route` uses to remember an opt-out of the automatic locale redirect. Both follow from caching the page at all rather than from this change, but both want a decision before the rule goes live.

## Validation

- `mix compile --warnings-as-errors` clean.
- `mix test test/tuist_web/localization_test.exs test/tuist_web/controllers/marketing_controller_test.exs`: 14 of 15 passed. The one failure, `renders the localized Hyperconnect case study`, is pre-existing and unrelated. I confirmed it by stashing this change and rerunning, with the identical result. It fails because the test environment compiles only the English locale unless `TUIST_DEV_ALL_LOCALES=1` is set.
- `mix credo` clean on the changed file.
- The `cf-cache-status: DYNAMIC` and `Set-Cookie` behaviour described above was observed against production tuist.dev, including a request that sent `user_locale_preference` back and still received it re-stamped.

This change has no direct test coverage. There is no test asserting on the cookie-writing behaviour of this plug today, and I did not add one because asserting "no `Set-Cookie` was written" is only meaningful end to end against the edge. That is also why the real verification below matters.

### How to test locally

```
cd server
mix test test/tuist_web/localization_test.exs
```

The behaviour this changes is easier to see over the wire than in a unit test. Against a running instance, request a marketing page twice, sending the cookies back on the second request, and confirm the second response carries no `Set-Cookie`:

```
curl -sS -D- -o /dev/null -c cookies.txt https://<host>/ | grep -i set-cookie
curl -sS -D- -o /dev/null -b cookies.txt https://<host>/ | grep -i set-cookie   # expect no output
```

Do not expect `cf-cache-status` to change when this ships. It will stay `DYNAMIC` until a Cache Rule exists, for the reasons in the Impact section above. The correct check after this deploys is the `Set-Cookie` one above, on a real edge-served response:

```
curl -sS -D- -o /dev/null -b cookies.txt https://<canary-host>/ | grep -i set-cookie
```

Once that is reliably empty for a returning visitor, the Cache Rule becomes safe to add, and `cf-cache-status` is the thing to watch at that point rather than this one.
