### PR TITLE
chore(infra): scrape not-Ready Kura pods so bootstrap metrics stay visible

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -895,6 +895,76 @@ k8s-monitoring:
             enabled = true
           }
         }
+        // annotationAutodiscovery only scrapes Ready pods: the upstream
+        // feature-annotation-autodiscovery template (_pods.alloy.tpl) hardcodes
+        // a __meta_kubernetes_pod_ready=true keep with no values knob to relax
+        // it. So a Kura replica that is Running but still bootstrapping (/ready
+        // 503s until the bootstrap gate passes) goes unscraped for the whole
+        // pull — exactly when its kura_bootstrap_* / memory metrics are
+        // diagnostic. /metrics, unlike /ready, is not readiness-gated, so
+        // scrape those pods here.
+        //
+        // Under the same job="kura" as the Ready scrape (not a separate job) so
+        // existing job="kura" queries/alerts keep covering the bootstrap
+        // window. The ready="false" label marks the window and keeps these
+        // series distinct from the Ready ones (which carry no ready label), so a
+        // transient double-match at the readiness flip can't collide.
+        discovery.kubernetes "tuist_kura_unready" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            label = "app.kubernetes.io/name=kura"
+          }
+        }
+
+        discovery.relabel "tuist_kura_unready" {
+          targets = discovery.kubernetes.tuist_kura_unready.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase", "__meta_kubernetes_pod_ready"]
+            separator = ";"
+            regex = "Running;false"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            regex = "http"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "__address__"
+            replacement = "$1:4000"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            target_label = "container"
+            replacement = "kura"
+          }
+          rule {
+            target_label = "ready"
+            replacement = "false"
+          }
+        }
+
+        prometheus.scrape "tuist_kura_unready" {
+          targets = discovery.relabel.tuist_kura_unready.output
+          forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+          job_name = "kura"
+          scrape_interval = "30s"
+          scrape_timeout = "10s"
+
+          clustering {
+            enabled = true
+          }
+        }
+
     # filesystem-log-reader mounts /var/log so the DaemonSet can tail pod
     # logs from disk (matches the podLogsViaLoki feature).
     alloy-logs:


### PR DESCRIPTION
## What

Adds a custom Alloy scrape in `infra/helm/k8s-monitoring/values.yaml` that scrapes **Running-but-not-Ready** Kura pods under the existing `job="kura"`, tagged `ready="false"`, closing the observability gap where a bootstrapping Kura replica is invisible to Prometheus.

## Why

Kura's `/ready` gates on bootstrap completion, so a replica doing a cold bootstrap is `Running` but not `Ready` for as long as the pull takes. During that window its `kura_bootstrap_*`, `kura_manifest_index_entries`, memory, and membership metrics are exactly what you'd want — and they're **dark**, because the chart's `annotationAutodiscovery` only keeps Ready pods.

The readiness filter is hardcoded in the upstream `feature-annotation-autodiscovery` template (`_pods.alloy.tpl`, v4.0.3), not a values knob:

```alloy
// Only keep pods that are running, ready, and not init containers.
rule {
  source_labels = ["__meta_kubernetes_pod_phase", "__meta_kubernetes_pod_ready", …]
  regex  = "Running;true;false"
  action = "keep"
}
```

A `keep` drops the target before any `extraRelabelRules` could re-include it, and no `prometheus.io/*` annotation overrides it — so there is no tag or annotationAutodiscovery setting that un-gates it, and this cluster has no `PodMonitor`/`ServiceMonitor` CRDs (it runs Alloy, not prometheus-operator).

**Confirmed live** during the 2026-07-21 `kura-tuist-eu-central-1` incident: while both pods were `0/1`, `up{job="kura"}` had 21 targets across the fleet — including `kura-tuist-scw-fr-par-0` on the *same* dedibox node — but **neither eu-central pod**. The `up` series is present (`=1`) whenever a pod is Ready and **absent entirely** while not-Ready — not `up=0`, so it's discovery-side exclusion, not a failed scrape. Kura's `/metrics` handler is **not** readiness-gated (unlike `/ready`), so these pods would serve metrics fine if only they were scraped.

## How

A `discovery.kubernetes role=pod` + `discovery.relabel` + `prometheus.scrape` block — the same `extraConfig` pattern already used in this file for CloudNativePG (which annotationAutodiscovery also can't reach) — selecting Kura pods via `app.kubernetes.io/name=kura` and keeping only `__meta_kubernetes_pod_phase=Running` + `__meta_kubernetes_pod_ready=false`:

- **Same `job="kura"`, tagged `ready="false"`.** Not-Ready pods land under the *same* job as Ready pods, so existing `job="kura"` dashboards/alerts keep working and pick up the bootstrap window automatically instead of silently dropping it. The bootstrap-only slice is `{job="kura", ready="false"}`. Ready pods carry no `ready` label (absent = Ready), so the `ready` label mirrors the `__meta_kubernetes_pod_ready=false` selector directly.
- **Disjoint on readiness, collision-safe.** annotationAutodiscovery owns `ready=true`; this owns `ready=false` — mutually exclusive keep criteria, so in steady state a pod matches exactly one path. At the brief readiness flip the two discovery caches can transiently both match a pod, but the `ready="false"` label keeps the two series identities distinct, so there is no duplicate-sample collision. Verified against live prod that Ready pods already carry `job="kura"` with a byte-identical label set (`namespace` / `pod` / `container="kura"` / `instance=<ip>:4000`), so the bootstrap-window series stitch cleanly onto the steady-state series once the pod goes Ready — `ready` is the only differing dimension.
- **Scoped to Kura** via `app.kubernetes.io/name=kura`; in environments/regions without Kura pods, discovery returns no targets (no-op).
- No metric keep-list: not-Ready pods are few and transient, and the whole point is diagnostic completeness during an incident. Can add one later if DPM warrants.

## Why `ready="false"` (and not the alternatives)

This started as a distinct `job="kura-unready"`; it was reworked to a `ready` label after review discussion:

- **Not a `job="kura-unready"` split.** `job` names *what* is scraped (the Kura service), not *what state* it's in. Splitting the job forces every consumer to remember `job=~"kura|kura-unready"`, and the failure mode is silent — existing `job="kura"` panels/alerts keep rendering while quietly dropping the bootstrap window. Reusing the job keeps naive queries complete; the `ready` label carries the state dimension instead.
- **Not `ready="0"`.** `0`/`1` is sample-value semantics; label values are strings. The source `__meta_kubernetes_pod_ready` is literally `"true"`/`"false"`, so `ready="false"` mirrors the token being selected on and reads unambiguously.
- **Not phase.** A bootstrapping pod is `phase=Running` (the scrape even keys on `Running;false`), identical to steady state, so phase cannot mark the window. Pod phase is separately available via kube-state-metrics `kube_pod_status_phase`; readiness is not (`kube_pod_status_ready` is absent from this cluster's KSM allowlist), which is why the readiness dimension has to come from this scrape.

## Validation

- YAML parses (`yq eval`, `ruby -ryaml`); Alloy brace balance checked.
- Live-verified against `grafanacloud-prom`: Ready Kura pods scrape under `job="kura"` with labels `{container="kura", instance="<ip>:4000", namespace="kura", pod=…}`; the new block produces the identical set plus `ready="false"`, so parity is exact except the intended `ready` dimension.
- Behavioral change is additive and label-scoped to Kura; no change to existing `annotationAutodiscovery` targets or any other workload.

## Rollout

`helm upgrade` of the `k8s-monitoring` release; Alloy hot-reloads the config. Applies to all envs (the block is a no-op where no Kura pods exist).

## Follow-up

Dashboards/alerts that want to *exclude* the bootstrap window (e.g. steady-state SLOs) can add `ready!="false"`; those that want it are already covered by plain `job="kura"`.

**Node identity** (the crux of the eu-central incident — which dedibox the bootstrapping pod co-tenants on) is deliberately *not* stamped on these series, to keep them label-identical to the Ready series bar `ready`. It isn't dark: the Ready `job="kura"` scrape carries no `node` label either (verified: 0 of 43 targets), and node is joinable for both via `kube_pod_info` — e.g. `kura_manifest_index_entries{ready="false"} * on(pod) group_left(node) kube_pod_info`.

Separately, adding `kube_pod_status_ready` to the kube-state-metrics allowlist would make readiness a joinable dimension cluster-wide (orthogonal to this PR, and it would still never expose `kura_bootstrap_*` during the dark window).

## Related

Implements the "scrape not-Ready pods" improvement from #11955 — and corrects that issue's suggested approach (`PodMonitor` / `publishNotReadyAddresses`), neither of which applies on this Alloy-based stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
