### PR TITLE
refactor(server): stop writing legacy test case state columns

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -814,17 +814,12 @@ defmodule Tuist.Tests do
           last_ran_at: data.ran_at,
           last_ran_at_ci: last_ran_at_ci,
           last_ran_at_local: last_ran_at_local,
-          # Legacy columns. Nothing in this release reads them, but pods still
-          # running the previous one do, so they keep being carried forward
-          # exactly as before for the length of the rollout. That carry-forward
-          # is the stale snapshot this whole change exists to remove, and it
-          # still loses races here — which is fine, because it only affects a
-          # column that old pods read and that behaves no worse than it does
-          # today. The follow-up release drops the carry-forward and the
-          # columns with it.
-          is_flaky: Map.get(existing, :legacy_is_flaky, false),
+          # Legacy columns, now inert: every pod reads `test_case_states`, so
+          # there is nothing left to carry forward for. Written as the schema
+          # defaults until a follow-up drops the columns outright.
+          is_flaky: false,
           last_run_id: test_run_id,
-          state: Map.get(existing, :legacy_state, "enabled"),
+          state: "enabled",
           inserted_at: now,
           recent_durations: new_durations,
           avg_duration: new_avg
@@ -977,9 +972,7 @@ defmodule Tuist.Tests do
         recent_durations: tc.recent_durations,
         last_ran_at_ci: tc.last_ran_at_ci,
         last_ran_at_local: tc.last_ran_at_local,
-        inserted_at: tc.inserted_at,
-        legacy_state: tc.state,
-        legacy_is_flaky: tc.is_flaky
+        inserted_at: tc.inserted_at
       }
     )
   end
@@ -1116,21 +1109,6 @@ defmodule Tuist.Tests do
       ensure_projectable!(test_case)
 
       updated_test_case = Map.merge(test_case, filtered_attrs)
-
-      # Legacy mirror, kept only so pods still running the previous release
-      # (which read these columns) stay in agreement for the length of the
-      # rollout. It republishes the whole `test_cases` row, which is why a state
-      # change can roll `last_ran_at` / `recent_durations` back to whatever the
-      # read saw when a buffered ingestion write hasn't landed yet. That's
-      # existing behaviour, and the follow-up release drops this write.
-      legacy_attrs =
-        test_case
-        |> Map.from_struct()
-        |> Map.delete(:__meta__)
-        |> Map.merge(filtered_attrs)
-        |> Map.put(:inserted_at, NaiveDateTime.utc_now())
-
-      IngestRepo.insert_all(TestCase, [legacy_attrs])
 
       event_types = determine_test_case_events(test_case, filtered_attrs)
       record_test_case_events(test_case, event_types, actor_id, alert_id)

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -3387,51 +3387,6 @@ defmodule Tuist.TestsTest do
       assert not_flaky |> Enum.map(& &1.name) |> Enum.sort() == ["mutedTest", "plainTest"]
     end
 
-    test "keeps carrying the legacy columns forward for pods on the previous release" do
-      # Reads move to `test_case_states` in this release, but pods still running
-      # the previous one read `state` off `test_cases`. Ingestion has to keep
-      # carrying that column forward or those pods would see every muted test
-      # flip back to enabled the moment a report lands, for the length of the
-      # rollout — including on the quarantined list the CLI and Gradle plugin
-      # consume, which would put muted tests back into CI runs.
-      # Given
-      project = ProjectsFixtures.project_fixture()
-
-      test_modules = fn duration ->
-        [
-          %{
-            name: "TestModule",
-            status: "success",
-            duration: 1000,
-            test_cases: [%{name: "testOne", status: "success", duration: duration}]
-          }
-        ]
-      end
-
-      {:ok, _} = RunsFixtures.test_fixture(project_id: project.id, test_modules: test_modules.(100))
-      TestCase.Buffer.flush()
-
-      {[test_case], _meta} = Tests.list_test_cases(project.id, %{})
-      {:ok, _} = Tests.update_test_case(test_case.id, %{state: "muted"})
-
-      # When - a pod running this release ingests another report
-      {:ok, _} = RunsFixtures.test_fixture(project_id: project.id, test_modules: test_modules.(200))
-      TestCase.Buffer.flush()
-
-      # Then - the legacy column an older pod reads still says muted
-      legacy_state =
-        ClickHouseRepo.one(
-          from(t in TestCase,
-            where: t.id == ^test_case.id,
-            order_by: [desc: t.inserted_at],
-            limit: 1,
-            select: t.state
-          )
-        )
-
-      assert legacy_state == "muted"
-    end
-
     test "preserves state when an in-flight ingestion read the row before the mute" do
       # Ingestion snapshots the existing test case rows once per report and only
       # stamps `inserted_at` later, per module. A mute landing inside that window


### PR DESCRIPTION
Last of three pull requests moving `state` and `is_flaky` off `test_cases`. Pure cleanup, no behaviour change.

Stacked on #11978, which must merge and deploy fully first. The base is set to that branch so the diff here shows only the removal; retarget to `main` once #11978 lands. There is no rush on this one, it can sit until the read cutover has soaked.

## Why

#11978 made `test_case_states` the source of truth for these two columns but kept writing the copies on `test_cases`, so pods still running #11977 (which read those columns) stayed in agreement for the length of that rollout. Once #11978 is fully out, nothing reads them and the mirror is dead weight.

Merging this before #11978 has finished deploying would remove the mirror out from under pods that are still reading it, which is exactly the window the three way split exists to avoid.

## What changed

Drops the legacy write from `update_test_case/3`.

That also removes the last whole row republish of a `test_cases` row from the control plane. The republish was a second, quieter bug: it echoed back whatever run data the read happened to see, so muting a test case could roll `last_ran_at` and `recent_durations` backwards when a buffered ingestion write had not landed yet.

## Approach

Ingestion still writes the columns as inert defaults, because they remain in the Ecto schema.

Dropping them from the table is deliberately left as a separate follow up rather than bundled here: it forces the schema, the buffered insert, and every fixture that round trips a `TestCase` struct to change together, and none of that belongs in a change whose only job is to stop a write. Until they are dropped, the columns are also what a rollback would fall back to reading, which is worth keeping for a while.

## Impact

None visible. No behaviour change, no user interface change, nothing to screenshot. One fewer write per control plane action.

## Validation

- `mix test test/tuist/tests_test.exs`: 239 passing.
- `mix credo` clean on the changed file.

### How to test locally

```sh
cd server
mix test test/tuist/tests_test.exs
```

Everything should pass unchanged from #11978, since nothing reads the column being dropped by that point.


## Rollback constraint

**Do not roll back past #11978 once this has been live.**

This release stops writing `test_cases.state` / `is_flaky`, and ingestion writes them as inert defaults on every report. Within a single ingestion cycle the legacy values are gone for any actively running test. Rolling back to #11977, which reads those columns, would therefore read `enabled` for everything and silently un-quarantine every muted test case.

Rolling back to #11978 is safe at any time: it reads the projection, same as this release.
