### PR TITLE
fix(infra): bound macOS runner host disk fill (golden GC + DiskPressure + Failed alert)

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/macos/machine_metrics.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/machine_metrics.go
@@ -1,0 +1,52 @@
+package macos
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+)
+
+// machinePhaseGauge publishes each ScalewayAppleSiliconMachine's current
+// lifecycle phase as a 1-valued series. Exactly one series exists per
+// machine (recordMachinePhase clears the machine's prior series before
+// setting the new one), so a transition — e.g. Failed -> Running after a
+// recovery — never leaves a stale Failed series alerting forever.
+//
+// The operator's `/metrics` (:8080) is scraped into Grafana Cloud via the
+// pod's prometheus.io/scrape annotation; the "machine stuck Failed" alert
+// keys off `phase="Failed"` persisting for a machine (which is how a host
+// stuck in terminal TartKubeletUpdateExceededRetries surfaces — the CR
+// status is otherwise only visible via `kubectl get machine`).
+var machinePhaseGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "capt_scaleway_applesilicon_machine_phase",
+	Help: "Current lifecycle phase of each ScalewayAppleSiliconMachine as a 1-valued series. Labels: machine, fleet, phase (Pending|Adopting|Provisioning|Bootstrapping|Ready|Deleting|Failed), failure_reason (set on terminal Failed, e.g. TartKubeletUpdateExceededRetries). Exactly one series per machine.",
+}, []string{"machine", "fleet", "phase", "failure_reason"})
+
+func init() {
+	metrics.Registry.MustRegister(machinePhaseGauge)
+}
+
+// recordMachinePhase publishes exactly one 1-valued series for the
+// machine's current phase, first clearing any prior phase series for it so
+// a transition doesn't strand a stale series (a recovered machine would
+// otherwise keep alerting on its old Failed series). Called from a deferred
+// hook in Reconcile so it reflects the phase set by this reconcile pass.
+func recordMachinePhase(m *infrav1.ScalewayAppleSiliconMachine) {
+	machinePhaseGauge.DeletePartialMatch(prometheus.Labels{"machine": m.Name})
+	phase := m.Status.Phase
+	if phase == "" {
+		phase = "Pending"
+	}
+	reason := ""
+	if m.Status.FailureReason != nil {
+		reason = *m.Status.FailureReason
+	}
+	machinePhaseGauge.WithLabelValues(m.Name, m.Spec.FleetName, phase, reason).Set(1)
+}
+
+// forgetMachinePhase drops a machine's phase series once its CR is gone, so
+// a deleted machine stops emitting a phantom phase.
+func forgetMachinePhase(name string) {
+	machinePhaseGauge.DeletePartialMatch(prometheus.Labels{"machine": name})
+}

--- a/infra/cluster-api-provider-tuist/controllers/macos/machine_metrics_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/machine_metrics_test.go
@@ -1,0 +1,60 @@
+package macos
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+)
+
+func TestRecordMachinePhaseKeepsOneSeriesPerMachine(t *testing.T) {
+	machinePhaseGauge.Reset()
+	defer machinePhaseGauge.Reset()
+
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "runner-1"},
+		Spec:       infrav1.ScalewayAppleSiliconMachineSpec{FleetName: "tuist-tuist-runners-fleet"},
+	}
+	reason := "TartKubeletUpdateExceededRetries"
+	m.Status.Phase = "Failed"
+	m.Status.FailureReason = &reason
+	recordMachinePhase(m)
+
+	if got := testutil.CollectAndCount(machinePhaseGauge); got != 1 {
+		t.Fatalf("series after first record = %d, want 1", got)
+	}
+
+	// Recovery: the machine transitions out of Failed. The stale Failed
+	// series must be cleared so the alert stops firing.
+	m.Status.Phase = "Ready"
+	m.Status.FailureReason = nil
+	recordMachinePhase(m)
+
+	if got := testutil.CollectAndCount(machinePhaseGauge); got != 1 {
+		t.Fatalf("series after transition = %d, want 1 (stale Failed series not cleared)", got)
+	}
+	if v := testutil.ToFloat64(machinePhaseGauge.WithLabelValues("runner-1", "tuist-tuist-runners-fleet", "Ready", "")); v != 1 {
+		t.Fatalf("Ready gauge = %v, want 1", v)
+	}
+
+	forgetMachinePhase("runner-1")
+	if got := testutil.CollectAndCount(machinePhaseGauge); got != 0 {
+		t.Fatalf("series after forget = %d, want 0", got)
+	}
+}
+
+func TestRecordMachinePhaseDefaultsEmptyPhaseToPending(t *testing.T) {
+	machinePhaseGauge.Reset()
+	defer machinePhaseGauge.Reset()
+
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "runner-2"},
+	}
+	recordMachinePhase(m)
+
+	if v := testutil.ToFloat64(machinePhaseGauge.WithLabelValues("runner-2", "", "Pending", "")); v != 1 {
+		t.Fatalf("empty phase should record as Pending=1, got %v", v)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -278,6 +278,10 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 	machine := &infrav1.ScalewayAppleSiliconMachine{}
 	if getErr := r.Get(ctx, req.NamespacedName, machine); getErr != nil {
 		if apierrors.IsNotFound(getErr) {
+			// CR is gone; drop its phase series so a deleted machine
+			// stops emitting a phantom phase (and never alerts on a
+			// stale Failed).
+			forgetMachinePhase(req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, getErr
@@ -292,6 +296,13 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 			err = patchErr
 		}
 	}()
+
+	// Publish the phase this reconcile leaves the machine in, so a host
+	// stuck terminal Failed (TartKubeletUpdateExceededRetries) is alertable
+	// instead of only visible via `kubectl get machine`. Deferred so it
+	// reads the final status set below (including the delete path's
+	// Deleting; the NotFound branch above forgets it once fully gone).
+	defer recordMachinePhase(machine)
 
 	// Resolve the parent CAPI Machine, if there is one. The chart
 	// renders MachineDeployment → MachineSet → Machine →

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -373,9 +373,14 @@ k8s-monitoring:
   # terminal Failed and stops receiving operator updates while its Node may
   # still serve — otherwise only visible via `kubectl get machine`:
   #
-  #   max by (machine, fleet) (
+  #   max by (cluster, machine, fleet, failure_reason) (
   #     capt_scaleway_applesilicon_machine_phase{phase="Failed", fleet="tuist-tuist-runners-fleet"}
   #   ) == 1
+  #
+  # Group by failure_reason (and cluster) so the alert keeps that label —
+  # dropping it would render the summary's {{ $labels.failure_reason }} empty.
+  # phase and failure_reason move together (one series per machine), so
+  # grouping on failure_reason never splits a machine into two alerts.
   #
   # Recommended config:
   #   - For: 30m   (a transient roll failure self-heals via the retry cap /

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -363,6 +363,31 @@ k8s-monitoring:
   # this chart and the embedded Prometheus that self-hosters opt into
   # via observability.enabled in the main Tuist chart.
   #
+  # This is what scrapes the capi-scaleway-applesilicon operator's :8080
+  # (annotated in infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml),
+  # including its custom capt_scaleway_applesilicon_machine_phase gauge.
+  #
+  # Alert to create in Grafana Cloud (PromQL) — runner host stuck terminal
+  # Failed. A host whose tart-kubelet config roll keeps failing (e.g.
+  # TartKubeletUpdateExceededRetries from a full disk or wedged sshd) goes
+  # terminal Failed and stops receiving operator updates while its Node may
+  # still serve — otherwise only visible via `kubectl get machine`:
+  #
+  #   max by (machine, fleet) (
+  #     capt_scaleway_applesilicon_machine_phase{phase="Failed", fleet="tuist-tuist-runners-fleet"}
+  #   ) == 1
+  #
+  # Recommended config:
+  #   - For: 30m   (a transient roll failure self-heals via the retry cap /
+  #                 config-drift clear; 30m means genuinely stuck)
+  #   - Severity: warning
+  #   - Summary: "Runner machine {{ $labels.machine }} stuck Failed
+  #              ({{ $labels.failure_reason }}) — not receiving operator
+  #              updates. Read the operator log for the real error before
+  #              clearing status.failureReason."
+  #   - Note: exactly one series per machine (recordMachinePhase clears the
+  #     prior phase on transition), so a recovered machine stops matching.
+  #
   # metricsPortName narrows the discovery output to a single target per
   # pod when the pod declares more than one container port. Without it,
   # Kubernetes pod-role discovery emits one target per declared port
@@ -600,6 +625,32 @@ k8s-monitoring:
       # materialise these Services, so the discovery returns zero
       # targets and the scrape jobs are no-ops. No need to gate this
       # block behind a values flag.
+      #
+      # Alert to create in Grafana Cloud (PromQL) — runner-host disk buffer.
+      # The Mac minis accumulate Tart golden base images (~68G each) on the
+      # root APFS container; at ~6 goldens the disk fills and every operator
+      # SSH config update fails with "No space left on device" while the Node
+      # still reports Ready (tart-kubelet now also reports DiskPressure + a
+      # golden GC reclaims at 15% free, but the alert is the backstop). Keep
+      # at least a 10% free buffer:
+      #
+      #   100 * (
+      #     node_filesystem_avail_bytes{job="tuist-macos-node-exporter", instance=~"tuist-tuist-runners-fleet-.*", mountpoint="/"}
+      #     /
+      #     node_filesystem_size_bytes{job="tuist-macos-node-exporter", instance=~"tuist-tuist-runners-fleet-.*", mountpoint="/"}
+      #   ) < 10
+      #
+      # Recommended config:
+      #   - For: 15m   (ride out a scrape gap; well under the fill timescale)
+      #   - Severity: warning
+      #   - Summary: "Runner host {{ $labels.instance }} root disk
+      #              {{ $value | printf \"%.0f\" }}% free (< 10% buffer) —
+      #              Tart goldens filling the disk; the golden GC should be
+      #              reclaiming. Check tart-kubelet DiskPressure + ~/.tart/vms."
+      #   - Note: node_* series carry no fleet label; the machine-name prefix
+      #     `instance=~"tuist-tuist-runners-fleet-.*"` scopes to the runners
+      #     fleet (vs -macos-fleet-/-builders-fleet-). Add env="production"
+      #     to scope by environment.
       extraConfig: |
         // Discover all Services labelled tuist.dev/macmini-egress=true.
         // Materialised by infra/helm/tailscale-operator/templates/

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -315,6 +315,15 @@ spec:
       {{- include "tuist.componentLabels" (dict "root" . "component" "capi-scaleway-applesilicon") | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Scrape the operator's controller-runtime + custom metrics
+        # (capt_scaleway_applesilicon_machine_phase) into Grafana Cloud via
+        # the k8s-monitoring chart's annotation autodiscovery. Without this
+        # the :8080 endpoint is served but never scraped, so the
+        # machine-stuck-Failed alert has no metric to fire on.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
       labels:
         {{- include "tuist.componentLabels" (dict "root" . "component" "capi-scaleway-applesilicon") | nindent 8 }}
     spec:

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -38,6 +38,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/tuist/tuist/infra/tart-kubelet/internal/envresolver"
+	"github.com/tuist/tuist/infra/tart-kubelet/internal/hostdisk"
 	"github.com/tuist/tuist/infra/tart-kubelet/internal/nodeagent"
 	"github.com/tuist/tuist/infra/tart-kubelet/internal/podagent"
 	"github.com/tuist/tuist/infra/tart-kubelet/internal/satoken"
@@ -386,6 +387,14 @@ func main() {
 		MaxPods:    maxPods,
 		Heartbeat:  30 * time.Second,
 		DiskPressure: func(ctx context.Context) (bool, string, error) {
+			// Host root volume first: it holds every Tart golden + clone,
+			// and a fill there silently breaks the operator's SSH config
+			// updates while the guest volumes still look fine — which the
+			// guest-only probe below can't see. A statvfs error falls
+			// through to the guest check rather than failing the probe.
+			if st, err := hostdisk.Root("/"); err == nil && st.FreePercent() < hostDiskPressureFreePercent {
+				return true, fmt.Sprintf("host root volume %.1f%% free (below %g%% floor)", st.FreePercent(), hostDiskPressureFreePercent), nil
+			}
 			return diskPressureFromGuests(ctx, tartClient, diskPressureThresholdPercent)
 		},
 		DynamicLabels: goldenLabelProvider,
@@ -613,6 +622,15 @@ func pickThisNode(nodeName string) fields.Selector {
 // condition fires (stopping new scheduling and triggering alerts) before
 // the guest actually starts failing writes with ENOSPC.
 const diskPressureThresholdPercent = 90
+
+// hostDiskPressureFreePercent is the host root-volume free-space floor
+// below which the Node reports DiskPressure. The Tart golden bases + clones
+// live here, and a full host disk silently breaks the operator's SSH config
+// updates while guests still look fine — so this is checked in addition to
+// the guest-volume probe. Kept at 10% to match the disk-buffer alert; the
+// golden GC reclaims at 15% (defaultGoldenReclaimFreeFloor), so pressure
+// only trips if reclaim can't keep up (all bases live-backed).
+const hostDiskPressureFreePercent = 10.0
 
 // diskPressureFromGuests reports DiskPressure=True when any running VM's
 // guest root volume is at or above the threshold. Each probe is bounded

--- a/infra/tart-kubelet/internal/hostdisk/hostdisk.go
+++ b/infra/tart-kubelet/internal/hostdisk/hostdisk.go
@@ -1,0 +1,43 @@
+// Package hostdisk reports the tart-kubelet host's root-volume usage.
+//
+// Every Tart artifact — golden base images and running clones — lives on
+// the Mac mini's root APFS container, so a fill there silently breaks the
+// CAPI operator's SSH-driven config updates ("No space left on device")
+// while the Node still reports Ready. Two callers measure it through here:
+// the golden-image GC (podagent), which reclaims bases before the disk
+// fills, and the Node's DiskPressure + ephemeral-storage reporting
+// (nodeagent), which makes a fill visible to the scheduler and alerting.
+package hostdisk
+
+import "golang.org/x/sys/unix"
+
+// Stats is a point-in-time root-volume measurement.
+type Stats struct {
+	TotalBytes uint64
+	FreeBytes  uint64 // available to the caller (statfs f_bavail)
+}
+
+// FreePercent is FreeBytes as a percentage of TotalBytes. It returns 100
+// when the total is unknown so a bad measurement never reads as "full"
+// and trips a reclaim or DiskPressure on a false signal.
+func (s Stats) FreePercent() float64 {
+	if s.TotalBytes == 0 {
+		return 100
+	}
+	return 100 * float64(s.FreeBytes) / float64(s.TotalBytes)
+}
+
+// Root measures the filesystem backing path. Pass "/" for the root APFS
+// container that holds ~/.tart on a Mac mini host. f_bavail (not f_bfree)
+// is used so the figure matches `df` and excludes root-reserved blocks.
+func Root(path string) (Stats, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return Stats{}, err
+	}
+	bsize := uint64(st.Bsize)
+	return Stats{
+		TotalBytes: st.Blocks * bsize,
+		FreeBytes:  st.Bavail * bsize,
+	}, nil
+}

--- a/infra/tart-kubelet/internal/hostdisk/hostdisk_test.go
+++ b/infra/tart-kubelet/internal/hostdisk/hostdisk_test.go
@@ -1,0 +1,40 @@
+package hostdisk
+
+import "testing"
+
+func TestFreePercent(t *testing.T) {
+	cases := []struct {
+		name  string
+		stats Stats
+		want  float64
+	}{
+		{"half", Stats{TotalBytes: 100, FreeBytes: 50}, 50},
+		{"empty-total-reads-as-full", Stats{TotalBytes: 0, FreeBytes: 0}, 100},
+		{"nearly-full", Stats{TotalBytes: 1000, FreeBytes: 50}, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stats.FreePercent(); got != tc.want {
+				t.Fatalf("FreePercent() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRootMeasuresRealRoot(t *testing.T) {
+	// Sanity: statvfs of "/" on the test host returns a positive total and
+	// a free figure that never exceeds it.
+	st, err := Root("/")
+	if err != nil {
+		t.Fatalf("Root(/): %v", err)
+	}
+	if st.TotalBytes == 0 {
+		t.Fatal("TotalBytes = 0, want > 0")
+	}
+	if st.FreeBytes > st.TotalBytes {
+		t.Fatalf("FreeBytes %d > TotalBytes %d", st.FreeBytes, st.TotalBytes)
+	}
+	if p := st.FreePercent(); p < 0 || p > 100 {
+		t.Fatalf("FreePercent() = %v, out of [0,100]", p)
+	}
+}

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/tuist/tuist/infra/tart-kubelet/internal/hostdisk"
 )
 
 // Maintainer is a controller-runtime Runnable. Owns the Node object's
@@ -303,6 +305,22 @@ func (m *Maintainer) configureNode(node *corev1.Node, dynamicLabels map[string]s
 		list[corev1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%d", cpu))
 		list[corev1.ResourceMemory] = resource.MustParse(fmt.Sprintf("%dMi", mem))
 		list[corev1.ResourcePods] = resource.MustParse(fmt.Sprintf("%d", maxPods))
+	}
+
+	// Ephemeral storage = the root APFS container that holds every Tart
+	// golden base + clone. A real kubelet reports this; without it the
+	// host disk is absent from `kubectl describe node` and invisible to
+	// ephemeral-storage-aware tooling, so a fill (which silently breaks
+	// the operator's SSH config updates) can't be seen at the k8s layer.
+	// We report the filesystem size for both capacity and allocatable —
+	// tart-kubelet does no ephemeral-storage request accounting, so the
+	// dynamic fill signal is the DiskPressure condition (applyDiskPressure),
+	// not a shrinking allocatable. A statvfs error just omits the resource
+	// this heartbeat rather than failing the whole status update.
+	if st, err := hostdisk.Root("/"); err == nil && st.TotalBytes > 0 {
+		q := resource.NewQuantity(int64(st.TotalBytes), resource.BinarySI)
+		node.Status.Capacity[corev1.ResourceEphemeralStorage] = *q
+		node.Status.Allocatable[corev1.ResourceEphemeralStorage] = *q
 	}
 
 	now := metav1.Now()

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -179,6 +179,30 @@ func TestConfigureNodeSeedsDiskPressureFalse(t *testing.T) {
 	}
 }
 
+func TestConfigureNodeReportsEphemeralStorage(t *testing.T) {
+	m := &Maintainer{NodeName: "mac-mini-1"}
+	node := &corev1.Node{}
+
+	m.configureNode(node, nil)
+
+	// configureNode statvfs's the real "/" of the test host, so the value
+	// is environment-dependent but must be present and positive in both
+	// Capacity and Allocatable — the gap that left a full host disk
+	// invisible at the k8s layer.
+	for name, list := range map[string]corev1.ResourceList{
+		"Capacity":    node.Status.Capacity,
+		"Allocatable": node.Status.Allocatable,
+	} {
+		q, ok := list[corev1.ResourceEphemeralStorage]
+		if !ok {
+			t.Fatalf("ephemeral-storage missing from %s", name)
+		}
+		if q.Value() <= 0 {
+			t.Fatalf("ephemeral-storage in %s = %s, want > 0", name, q.String())
+		}
+	}
+}
+
 func TestConfigureNodeMergesDynamicLabels(t *testing.T) {
 	m := &Maintainer{
 		NodeName:   "mac-mini-1",

--- a/infra/tart-kubelet/internal/podagent/garbage.go
+++ b/infra/tart-kubelet/internal/podagent/garbage.go
@@ -169,6 +169,22 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 		retention = defaultGoldenRetention
 	}
 
+	// Host-disk pressure escalates this whole pass to aggressive. Goldens are
+	// APFS copy-on-write clones of their pulled OCI image (tart clone), so
+	// reaping a golden while the normal pass KEEPS its referenced OCI source
+	// frees only metadata — the ~68 GiB of backing blocks stay alive as long
+	// as the OCI entry references them. Aggressive mode also evicts the OCI
+	// cache (reconstructible by re-pull), so the golden and its source both
+	// go and the blocks are actually released. The referenced-golden reclaim
+	// below then handles the bases keepGolden pins. A probe error just skips
+	// the escalation this pass (the periodic retention behaviour still runs).
+	floor := c.goldenReclaimFreeFloor()
+	free, freeErr := c.hostDiskFree()
+	underPressure := freeErr == nil && free < floor
+	if underPressure {
+		aggressive = true
+	}
+
 	var droppedClones, droppedImages, droppedGoldens int
 	for _, vm := range vms {
 		switch vm.Source {
@@ -233,29 +249,34 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 	}
 
 	// The retention pass above never reaps a referenced golden; enforce the
-	// host-disk bound that actually keeps the mini from filling.
-	c.reclaimGoldensUnderDiskPressure(ctx, expected, vms)
+	// host-disk bound that actually keeps the mini from filling. Only under
+	// pressure — the aggressive main loop already freed what it could.
+	if underPressure {
+		c.reclaimGoldensUnderDiskPressure(ctx, expected, floor)
+	}
 }
 
 // reclaimGoldensUnderDiskPressure is the bound the retention pass lacks:
-// when the host root volume drops below the free-space floor, it reaps
-// golden bases even if a Pod still references their digest (keepGolden
-// always keeps those, so a warm Pod per Xcode pool otherwise pins every
-// golden and the disk fills unbounded). It reaps least-valuable first —
-// unreferenced goldens (superseded digests), then referenced ones whose
-// clone isn't currently running (idle warm-pool bases) — never touches a
-// golden that backs a live clone, spares any golden with a live `tart run`,
-// keeps at least MinGoldensKept, and stops the moment free space recovers.
-// A reaped golden re-pulls on its pool's next launch; that one cold clone
-// is the deliberate price of not letting the disk fill and silently break
-// the operator's SSH-driven config updates.
-func (c *Collector) reclaimGoldensUnderDiskPressure(ctx context.Context, expected *expectedSet, vms []tart.VM) {
+// while the host root volume is below the free-space floor, it reaps golden
+// bases even if a Pod still references their digest (keepGolden always keeps
+// those, so a warm Pod per Xcode pool otherwise pins every golden and the
+// disk fills unbounded). It reaps least-valuable first — unreferenced
+// goldens (superseded digests), then referenced ones whose clone isn't
+// currently running (idle warm-pool bases) — never touches a golden that
+// backs a live clone, spares any golden with a live `tart run`, keeps at
+// least MinGoldensKept, and stops the moment free space recovers. A reaped
+// golden re-pulls on its pool's next launch; that one cold clone is the
+// deliberate price of not letting the disk fill and silently break the
+// operator's SSH-driven config updates.
+//
+// The caller runs the aggressive main loop first (which evicts the OCI
+// sources these goldens clone from, so a golden delete actually releases
+// blocks rather than metadata), then this re-measures: if evicting the OCI
+// cache + unreferenced goldens already cleared the pressure, the warm
+// referenced goldens are left alone.
+func (c *Collector) reclaimGoldensUnderDiskPressure(ctx context.Context, expected *expectedSet, floor float64) {
 	logger := log.FromContext(ctx).WithName("gc")
 
-	floor := c.HostDiskFreeFloor
-	if floor <= 0 {
-		floor = defaultGoldenReclaimFreeFloor
-	}
 	free, err := c.hostDiskFree()
 	if err != nil {
 		logger.Error(err, "measure host disk free; skipping golden disk-pressure reclaim")
@@ -268,6 +289,16 @@ func (c *Collector) reclaimGoldensUnderDiskPressure(ctx context.Context, expecte
 	minKept := c.MinGoldensKept
 	if minKept <= 0 {
 		minKept = defaultMinGoldensKept
+	}
+
+	// Re-list rather than reuse the caller's inventory: the aggressive main
+	// loop just deleted unreferenced goldens + OCI entries, so a stale list
+	// would count already-deleted goldens toward `total` (their re-delete
+	// fails without advancing `reaped`) and could delete the last real base.
+	vms, err := c.Tart.List(ctx)
+	if err != nil {
+		logger.Error(err, "re-list tart entries for golden disk-pressure reclaim")
+		return
 	}
 
 	// Reap order: unreferenced (stalest) first, then referenced-but-idle.
@@ -317,6 +348,15 @@ func (c *Collector) reclaimGoldensUnderDiskPressure(ctx context.Context, expecte
 		logger.Info("host disk below free floor but no reclaimable golden bases (all live-backed or at minimum kept)",
 			"host_free_percent", free, "floor", floor, "min_kept", minKept)
 	}
+}
+
+// goldenReclaimFreeFloor is the root-volume free-space percent below which
+// the disk-pressure golden reclaim runs, defaulting when unset.
+func (c *Collector) goldenReclaimFreeFloor() float64 {
+	if c.HostDiskFreeFloor > 0 {
+		return c.HostDiskFreeFloor
+	}
+	return defaultGoldenReclaimFreeFloor
 }
 
 // hostDiskFree returns the host root volume's free-space percent, using the

--- a/infra/tart-kubelet/internal/podagent/garbage.go
+++ b/infra/tart-kubelet/internal/podagent/garbage.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/tuist/tuist/infra/tart-kubelet/internal/hostdisk"
 	"github.com/tuist/tuist/infra/tart-kubelet/internal/tart"
 )
 
@@ -57,6 +58,30 @@ type Collector struct {
 	// ignores it.
 	GoldenRetention time.Duration
 
+	// HostDiskFreeFloor is the root-volume free-space percentage below
+	// which the collector reclaims golden bases even when a Pod still
+	// references their digest. This is the only bound on golden
+	// accumulation: keepGolden always keeps a referenced golden, and the
+	// runners-controller pins a warm Pod per Xcode-version pool to a host
+	// (golden node-affinity), so every golden stays permanently referenced
+	// and the retention pass never reaps it — the disk fills to 100% (~6
+	// goldens on a 460GiB mini) and every operator SSH update then fails
+	// with "No space left on device" while the Node still looks Ready. Set
+	// above the DiskPressure floor so reclaim runs before the node reports
+	// pressure. Zero falls back to defaultGoldenReclaimFreeFloor.
+	HostDiskFreeFloor float64
+
+	// HostDiskFree probes the host root volume's free-space percent.
+	// Overridable in tests (statvfs isn't stubbable via the Tart binary);
+	// defaults to a real statvfs of "/".
+	HostDiskFree func() (float64, error)
+
+	// MinGoldensKept floors how many golden bases the disk-pressure
+	// reclaim leaves behind, so a wedged measurement or a pathological
+	// host never strands it with zero warm bases (every subsequent launch
+	// cold-pulls). Zero falls back to defaultMinGoldensKept.
+	MinGoldensKept int
+
 	// Now is overridable in tests; defaults to time.Now.
 	Now func() time.Time
 
@@ -82,6 +107,16 @@ type Collector struct {
 // from it rather than re-pulling, short enough that a rolled-out digest's
 // golden is reclaimed within a day.
 const defaultGoldenRetention = 24 * time.Hour
+
+// defaultGoldenReclaimFreeFloor keeps the host above 15% free by reclaiming
+// golden bases, leaving headroom above the 10% DiskPressure/alert floor so
+// the disk-pressure reclaim fires and frees space before the Node ever
+// reports pressure.
+const defaultGoldenReclaimFreeFloor = 15.0
+
+// defaultMinGoldensKept never lets the disk-pressure reclaim strand a host
+// with zero warm bases.
+const defaultMinGoldensKept = 1
 
 // Start blocks until ctx is cancelled. Conforms to manager.Runnable.
 func (c *Collector) Start(ctx context.Context) error {
@@ -196,6 +231,129 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 			"stale_oci_images", droppedImages,
 			"stale_golden_bases", droppedGoldens)
 	}
+
+	// The retention pass above never reaps a referenced golden; enforce the
+	// host-disk bound that actually keeps the mini from filling.
+	c.reclaimGoldensUnderDiskPressure(ctx, expected, vms)
+}
+
+// reclaimGoldensUnderDiskPressure is the bound the retention pass lacks:
+// when the host root volume drops below the free-space floor, it reaps
+// golden bases even if a Pod still references their digest (keepGolden
+// always keeps those, so a warm Pod per Xcode pool otherwise pins every
+// golden and the disk fills unbounded). It reaps least-valuable first —
+// unreferenced goldens (superseded digests), then referenced ones whose
+// clone isn't currently running (idle warm-pool bases) — never touches a
+// golden that backs a live clone, spares any golden with a live `tart run`,
+// keeps at least MinGoldensKept, and stops the moment free space recovers.
+// A reaped golden re-pulls on its pool's next launch; that one cold clone
+// is the deliberate price of not letting the disk fill and silently break
+// the operator's SSH-driven config updates.
+func (c *Collector) reclaimGoldensUnderDiskPressure(ctx context.Context, expected *expectedSet, vms []tart.VM) {
+	logger := log.FromContext(ctx).WithName("gc")
+
+	floor := c.HostDiskFreeFloor
+	if floor <= 0 {
+		floor = defaultGoldenReclaimFreeFloor
+	}
+	free, err := c.hostDiskFree()
+	if err != nil {
+		logger.Error(err, "measure host disk free; skipping golden disk-pressure reclaim")
+		return
+	}
+	if free >= floor {
+		return
+	}
+
+	minKept := c.MinGoldensKept
+	if minKept <= 0 {
+		minKept = defaultMinGoldensKept
+	}
+
+	// Reap order: unreferenced (stalest) first, then referenced-but-idle.
+	// Goldens backing a live clone are excluded entirely.
+	liveBacked := c.liveBackedGoldens(ctx)
+	var unreferenced, idleReferenced []string
+	total := 0
+	for _, vm := range vms {
+		if vm.Source != "local" || !isGoldenVMName(vm.Name) {
+			continue
+		}
+		total++
+		if _, backed := liveBacked[vm.Name]; backed {
+			continue
+		}
+		if _, ref := expected.vms[vm.Name]; ref {
+			idleReferenced = append(idleReferenced, vm.Name)
+		} else {
+			unreferenced = append(unreferenced, vm.Name)
+		}
+	}
+
+	reaped := 0
+	for _, name := range append(unreferenced, idleReferenced...) {
+		if free >= floor || total-reaped <= minKept {
+			break
+		}
+		if c.live(ctx, name) {
+			continue
+		}
+		if err := c.Tart.Delete(ctx, name); err != nil {
+			logger.Error(err, "delete golden under host disk pressure", "name", name)
+			continue
+		}
+		c.forgetGolden(name)
+		reaped++
+		if f, ferr := c.hostDiskFree(); ferr == nil {
+			free = f
+		}
+	}
+
+	switch {
+	case reaped > 0:
+		logger.Info("reclaimed golden bases under host disk pressure",
+			"reaped", reaped, "host_free_percent", free, "floor", floor)
+	case free < floor:
+		logger.Info("host disk below free floor but no reclaimable golden bases (all live-backed or at minimum kept)",
+			"host_free_percent", free, "floor", floor, "min_kept", minKept)
+	}
+}
+
+// hostDiskFree returns the host root volume's free-space percent, using the
+// injected probe when set (tests) or a real statvfs of "/".
+func (c *Collector) hostDiskFree() (float64, error) {
+	if c.HostDiskFree != nil {
+		return c.HostDiskFree()
+	}
+	st, err := hostdisk.Root("/")
+	if err != nil {
+		return 0, err
+	}
+	return st.FreePercent(), nil
+}
+
+// liveBackedGoldens returns the set of golden base VM names whose clone is
+// currently running a Pod on this Node — the bases a disk-pressure reclaim
+// must not reap, since deleting them would force the active pool to
+// cold-pull its next launch. A List error yields the empty set: with no
+// evidence a golden is in use, the reclaim's other guards (live probe,
+// MinGoldensKept) still hold.
+func (c *Collector) liveBackedGoldens(ctx context.Context) map[string]struct{} {
+	out := map[string]struct{}{}
+	pods := &corev1.PodList{}
+	if err := c.K8s.List(ctx, pods, client.MatchingFields{"spec.nodeName": c.NodeName}); err != nil {
+		return out
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.DeletionTimestamp != nil || len(pod.Spec.Containers) != 1 {
+			continue
+		}
+		if c.live(ctx, VMNameForPod(pod)) {
+			out[goldenVMName(pod.Spec.Containers[0].Image)] = struct{}{}
+		}
+	}
+	return out
 }
 
 // keepGolden decides whether to retain a golden base VM this pass and

--- a/infra/tart-kubelet/internal/podagent/garbage_test.go
+++ b/infra/tart-kubelet/internal/podagent/garbage_test.go
@@ -241,10 +241,6 @@ func TestRunOnceReapsOrphanDespiteSimilarlyNamedRunningVM(t *testing.T) {
 // clone and keeping at least MinGoldensKept.
 func TestReclaimGoldensUnderDiskPressure(t *testing.T) {
 	const node = "mini-1"
-	imgA := "reg/runner@sha256:aaa" // podA live  -> golden live-backed (spare)
-	imgB := "reg/runner@sha256:bbb" // podB idle  -> golden idle-referenced (reap)
-	imgC := "reg/runner@sha256:ccc" // no pod     -> golden unreferenced (reap first)
-	gA, gB, gC := goldenVMName(imgA), goldenVMName(imgB), goldenVMName(imgC)
 
 	pod := func(name, image string) *corev1.Pod {
 		return &corev1.Pod{
@@ -256,19 +252,45 @@ func TestReclaimGoldensUnderDiskPressure(t *testing.T) {
 		}
 	}
 
-	newCollector := func(t *testing.T, hostFree func() (float64, error), running func(string) bool) (*Collector, func(t *testing.T) string) {
+	// newCollector builds a Collector over a *stateful* fake tart: `list`
+	// enumerates a VM directory and `delete` removes from it, so a golden the
+	// aggressive main loop reaps is gone from the reclaim pass's re-list.
+	// A static list would let reclaim count already-deleted goldens toward the
+	// keep floor and over-delete the last real base.
+	newCollector := func(t *testing.T, vms map[string]string, hostFree func() (float64, error), running func(string) bool, pods ...*corev1.Pod) (*Collector, func(t *testing.T) []string) {
 		t.Helper()
 		dir := t.TempDir()
+		vmdir := filepath.Join(dir, "vms")
+		if err := os.MkdirAll(vmdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, src := range vms {
+			if err := os.WriteFile(filepath.Join(vmdir, name), []byte(src), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
 		deletes := filepath.Join(dir, "deletes.txt")
 		bin := filepath.Join(dir, "faketart")
-		body := fmt.Sprintf("#!/bin/sh\n"+
-			"if [ \"$1\" = \"list\" ]; then\n"+
-			"  printf '%%s' '[{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68},"+
-			"{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68},"+
-			"{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68}]'\n"+
-			"elif [ \"$1\" = \"delete\" ]; then\n"+
-			"  printf '%%s\\n' \"$2\" >> %q\n"+
-			"fi\n", gA, gB, gC, deletes)
+		body := fmt.Sprintf(`#!/bin/sh
+VMDIR=%q
+DELETES=%q
+if [ "$1" = "list" ]; then
+  printf '['
+  first=1
+  for f in "$VMDIR"/*; do
+    [ -e "$f" ] || continue
+    name=$(basename "$f")
+    src=$(cat "$f")
+    if [ "$first" -eq 0 ]; then printf ','; fi
+    printf '{"Name":"%%s","Source":"%%s","State":"stopped","CPU":4,"Memory":8192,"Size":68}' "$name" "$src"
+    first=0
+  done
+  printf ']'
+elif [ "$1" = "delete" ]; then
+  rm -f "$VMDIR/$2"
+  printf '%%s\n' "$2" >> "$DELETES"
+fi
+`, vmdir, deletes)
 		if err := os.WriteFile(bin, []byte(body), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -276,8 +298,12 @@ func TestReclaimGoldensUnderDiskPressure(t *testing.T) {
 		if err := corev1.AddToScheme(scheme); err != nil {
 			t.Fatalf("add core scheme: %v", err)
 		}
+		objs := make([]client.Object, 0, len(pods))
+		for _, p := range pods {
+			objs = append(objs, p)
+		}
 		k := fake.NewClientBuilder().WithScheme(scheme).
-			WithObjects(pod("pod-a", imgA), pod("pod-b", imgB)).
+			WithObjects(objs...).
 			WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
 				return []string{o.(*corev1.Pod).Spec.NodeName}
 			}).Build()
@@ -288,61 +314,90 @@ func TestReclaimGoldensUnderDiskPressure(t *testing.T) {
 			HostDiskFree: hostFree,
 			IsRunning:    func(_ context.Context, name string) (bool, error) { return running(name), nil },
 		}
-		read := func(t *testing.T) string {
+		read := func(t *testing.T) []string {
 			t.Helper()
 			b, err := os.ReadFile(deletes)
 			if errors.Is(err, os.ErrNotExist) {
-				return ""
+				return nil
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
-			return string(b)
+			return strings.Fields(string(b))
 		}
 		return c, read
 	}
 
-	// running(name) reports podA's VM (def-pod-a) as live so gA is
-	// live-backed; goldens themselves are never running here.
-	podALive := func(name string) bool { return name == "default-pod-a" }
+	contains := func(xs []string, want string) bool {
+		for _, x := range xs {
+			if x == want {
+				return true
+			}
+		}
+		return false
+	}
 
 	t.Run("reaps referenced+unreferenced under pressure, spares live-backed", func(t *testing.T) {
-		c, read := newCollector(t, func() (float64, error) { return 5, nil }, podALive)
+		imgA := "reg/runner@sha256:aaa" // podA live  -> golden live-backed (spare)
+		imgB := "reg/runner@sha256:bbb" // podB idle  -> golden idle-referenced (reap)
+		imgC := "reg/runner@sha256:ccc" // no pod     -> golden unreferenced (reap first)
+		gA, gB, gC := goldenVMName(imgA), goldenVMName(imgB), goldenVMName(imgC)
+		// gC is unreferenced, so the aggressive main loop reaps it; gB is
+		// referenced-but-idle, so only the disk-pressure reclaim reaps it;
+		// gA backs podA's live clone, so it must survive both.
+		c, read := newCollector(t, map[string]string{gA: "local", gB: "local", gC: "local"},
+			func() (float64, error) { return 5, nil },
+			func(name string) bool { return name == "default-pod-a" },
+			pod("pod-a", imgA), pod("pod-b", imgB))
 		c.RunOnce(context.Background())
 		got := read(t)
-		if !strings.Contains(got, gC) {
-			t.Errorf("unreferenced golden %q not reaped under disk pressure; deletes=%q", gC, got)
+		if !contains(got, gC) {
+			t.Errorf("unreferenced golden %q not reaped under disk pressure; deletes=%v", gC, got)
 		}
-		if !strings.Contains(got, gB) {
-			t.Errorf("idle referenced golden %q not reaped under disk pressure; deletes=%q", gB, got)
+		if !contains(got, gB) {
+			t.Errorf("idle referenced golden %q not reaped under disk pressure; deletes=%v", gB, got)
 		}
-		if strings.Contains(got, gA) {
-			t.Errorf("live-backed golden %q was reaped; deletes=%q", gA, got)
+		if contains(got, gA) {
+			t.Errorf("live-backed golden %q was reaped; deletes=%v", gA, got)
 		}
 	})
 
 	t.Run("stops reaping once free recovers", func(t *testing.T) {
+		imgB1, imgB2 := "reg/runner@sha256:b11", "reg/runner@sha256:b22"
+		gB1, gB2 := goldenVMName(imgB1), goldenVMName(imgB2)
 		calls := 0
 		hostFree := func() (float64, error) {
 			calls++
-			if calls == 1 {
-				return 5, nil // start: under floor
+			// runOnce probe (1) + reclaim's post-main-loop probe (2) are
+			// both under the floor; the probe after the first reap (3+)
+			// shows recovery, so exactly one golden is reaped.
+			if calls <= 2 {
+				return 5, nil
 			}
-			return 50, nil // after first delete: recovered
+			return 50, nil
 		}
-		c, read := newCollector(t, hostFree, podALive)
+		// Both goldens are referenced by idle pods, so the aggressive main
+		// loop keeps both and only the reclaim pass reaps — isolating the
+		// "stop as soon as free recovers" behaviour to one deletion.
+		c, read := newCollector(t, map[string]string{gB1: "local", gB2: "local"}, hostFree,
+			func(string) bool { return false },
+			pod("pod-b1", imgB1), pod("pod-b2", imgB2))
 		c.RunOnce(context.Background())
-		lines := strings.Fields(read(t))
-		if len(lines) != 1 {
-			t.Fatalf("expected exactly one reap once free recovered, got %v", lines)
+		if got := read(t); len(got) != 1 {
+			t.Fatalf("expected exactly one reap once free recovered, got %v", got)
 		}
 	})
 
 	t.Run("no-op when above floor", func(t *testing.T) {
-		c, read := newCollector(t, func() (float64, error) { return 50, nil }, podALive)
+		imgA, imgB, imgC := "reg/runner@sha256:aaa", "reg/runner@sha256:bbb", "reg/runner@sha256:ccc"
+		gA, gB, gC := goldenVMName(imgA), goldenVMName(imgB), goldenVMName(imgC)
+		c, read := newCollector(t, map[string]string{gA: "local", gB: "local", gC: "local"},
+			func() (float64, error) { return 50, nil },
+			func(string) bool { return false },
+			pod("pod-a", imgA), pod("pod-b", imgB))
 		c.RunOnce(context.Background())
-		if got := read(t); got != "" {
-			t.Fatalf("reaped goldens despite ample free space; deletes=%q", got)
+		if got := read(t); len(got) != 0 {
+			t.Fatalf("reaped goldens despite ample free space; deletes=%v", got)
 		}
 	})
 }

--- a/infra/tart-kubelet/internal/podagent/garbage_test.go
+++ b/infra/tart-kubelet/internal/podagent/garbage_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -230,4 +231,118 @@ func TestRunOnceReapsOrphanDespiteSimilarlyNamedRunningVM(t *testing.T) {
 	if !strings.Contains(string(b), orphan) {
 		t.Fatalf("orphan %q was not reaped despite only %q running", orphan, running)
 	}
+}
+
+// Golden bases stay "referenced" forever when a warm Pod per Xcode pool
+// pins each one (keepGolden never reaps a referenced golden), so retention
+// alone can't stop the disk filling. reclaimGoldensUnderDiskPressure is the
+// bound that does: below the host free-space floor it reaps referenced
+// goldens too — least-valuable first, sparing the golden that backs a live
+// clone and keeping at least MinGoldensKept.
+func TestReclaimGoldensUnderDiskPressure(t *testing.T) {
+	const node = "mini-1"
+	imgA := "reg/runner@sha256:aaa" // podA live  -> golden live-backed (spare)
+	imgB := "reg/runner@sha256:bbb" // podB idle  -> golden idle-referenced (reap)
+	imgC := "reg/runner@sha256:ccc" // no pod     -> golden unreferenced (reap first)
+	gA, gB, gC := goldenVMName(imgA), goldenVMName(imgB), goldenVMName(imgC)
+
+	pod := func(name, image string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name},
+			Spec: corev1.PodSpec{
+				NodeName:   node,
+				Containers: []corev1.Container{{Name: "c", Image: image}},
+			},
+		}
+	}
+
+	newCollector := func(t *testing.T, hostFree func() (float64, error), running func(string) bool) (*Collector, func(t *testing.T) string) {
+		t.Helper()
+		dir := t.TempDir()
+		deletes := filepath.Join(dir, "deletes.txt")
+		bin := filepath.Join(dir, "faketart")
+		body := fmt.Sprintf("#!/bin/sh\n"+
+			"if [ \"$1\" = \"list\" ]; then\n"+
+			"  printf '%%s' '[{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68},"+
+			"{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68},"+
+			"{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":68}]'\n"+
+			"elif [ \"$1\" = \"delete\" ]; then\n"+
+			"  printf '%%s\\n' \"$2\" >> %q\n"+
+			"fi\n", gA, gB, gC, deletes)
+		if err := os.WriteFile(bin, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add core scheme: %v", err)
+		}
+		k := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(pod("pod-a", imgA), pod("pod-b", imgB)).
+			WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+				return []string{o.(*corev1.Pod).Spec.NodeName}
+			}).Build()
+		c := &Collector{
+			K8s:          k,
+			Tart:         &tart.Client{Binary: bin},
+			NodeName:     node,
+			HostDiskFree: hostFree,
+			IsRunning:    func(_ context.Context, name string) (bool, error) { return running(name), nil },
+		}
+		read := func(t *testing.T) string {
+			t.Helper()
+			b, err := os.ReadFile(deletes)
+			if errors.Is(err, os.ErrNotExist) {
+				return ""
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			return string(b)
+		}
+		return c, read
+	}
+
+	// running(name) reports podA's VM (def-pod-a) as live so gA is
+	// live-backed; goldens themselves are never running here.
+	podALive := func(name string) bool { return name == "default-pod-a" }
+
+	t.Run("reaps referenced+unreferenced under pressure, spares live-backed", func(t *testing.T) {
+		c, read := newCollector(t, func() (float64, error) { return 5, nil }, podALive)
+		c.RunOnce(context.Background())
+		got := read(t)
+		if !strings.Contains(got, gC) {
+			t.Errorf("unreferenced golden %q not reaped under disk pressure; deletes=%q", gC, got)
+		}
+		if !strings.Contains(got, gB) {
+			t.Errorf("idle referenced golden %q not reaped under disk pressure; deletes=%q", gB, got)
+		}
+		if strings.Contains(got, gA) {
+			t.Errorf("live-backed golden %q was reaped; deletes=%q", gA, got)
+		}
+	})
+
+	t.Run("stops reaping once free recovers", func(t *testing.T) {
+		calls := 0
+		hostFree := func() (float64, error) {
+			calls++
+			if calls == 1 {
+				return 5, nil // start: under floor
+			}
+			return 50, nil // after first delete: recovered
+		}
+		c, read := newCollector(t, hostFree, podALive)
+		c.RunOnce(context.Background())
+		lines := strings.Fields(read(t))
+		if len(lines) != 1 {
+			t.Fatalf("expected exactly one reap once free recovered, got %v", lines)
+		}
+	})
+
+	t.Run("no-op when above floor", func(t *testing.T) {
+		c, read := newCollector(t, func() (float64, error) { return 50, nil }, podALive)
+		c.RunOnce(context.Background())
+		if got := read(t); got != "" {
+			t.Fatalf("reaped goldens despite ample free space; deletes=%q", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

macOS runner minis accumulate Tart golden base images (~68G each) on the root APFS volume; at ~6 goldens the 460GiB disk fills, and a full disk makes every CAPI operator SSH config update fail with `No space left on device` while the Node still reports `Ready` / `DiskPressure=False`. That is the invisible, fleet-wide fill that stuck the runners fleet on 2026-07-20, where the only recovery was deleting goldens host-by-host over SSH (pure whack-a-mole). This PR makes the fleet self-bound the disk, and makes a fill (or a host stuck terminal `Failed`) visible and alertable.

## What changed & why

**1. Golden GC now bounds disk** — `infra/tart-kubelet/internal/podagent/garbage.go`
Root cause: the existing GC never reaps a *referenced* golden (`keepGolden`), and the runners-controller pins a warm Pod per Xcode-version pool to each host via golden node-affinity, so every golden stays permanently referenced and retention never fires — nothing bounds count or disk. New `reclaimGoldensUnderDiskPressure` pass reaps referenced-but-idle goldens once host root free drops below 15%: unreferenced (stalest) first, then referenced-but-not-backing-a-live-clone, sparing any golden a running clone depends on (APFS CoW keeps live clones intact regardless) and keeping at least one. Host measurement via a new `internal/hostdisk` package (statvfs of `/`).

**2. Host disk is now visible** — `infra/tart-kubelet/internal/nodeagent/node.go`, `cmd/tart-kubelet/main.go`
The Node reports `ephemeral-storage` capacity/allocatable, and the `DiskPressure` probe ORs in the **host** root volume (< 10% free). Previously the probe inspected only *guest* VM volumes, which is why a full host disk left the Node `Ready` with `DiskPressure=False`.

**3. Terminal-`Failed` is now alertable** — `infra/cluster-api-provider-tuist/controllers/macos/machine_metrics.go`, `infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml`
New `capt_scaleway_applesilicon_machine_phase{machine,fleet,phase,failure_reason}` gauge (exactly one series per machine, cleared on transition so a recovered host stops alerting), set via a `defer` in `Reconcile`. The operator Deployment gains `prometheus.io/scrape` annotations so its `:8080` is actually scraped into Grafana Cloud. A host stuck terminal `Failed` (`TartKubeletUpdateExceededRetries`) was previously only visible via `kubectl get machine`.

**4. Two Grafana Cloud alerts** — PromQL documented in `infra/helm/k8s-monitoring/values.yaml`
This repo authors alerts in the Grafana UI (not as code), per the existing convention. Both are created, with the PromQL documented next to the scrape config that produces each metric:
- **Runner Host Disk Buffer** — runners-fleet host < 10% free for 15m (live now; validated against real `node_filesystem_*` data).
- **Runner Machine Stuck Failed** — machine terminal `Failed` for 30m; `no_data_state=OK` so it stays quiet until the operator ships metric #3.

## Reviewer notes

- Thresholds are deliberately staggered: GC reclaims at **15% free** (proactive), while `DiskPressure` + both alerts trip at **10% free** (the buffer) — so reclaim keeps hosts above the pressure floor and the alert is the backstop for when it can't (e.g. every golden backs a live clone).
- The two alert rules already exist in Grafana Cloud (folder Alerts, group Runners, receiver "Slack #notifications 2"); this PR carries only the enabling code (metric + scrape) and the documented PromQL.
- Nothing takes effect until the operator + tart-kubelet images roll: metric #3 populates then; the disk alert already has data from the existing node_exporter scrape.

### How to test locally

```
cd infra/tart-kubelet && go test ./internal/hostdisk/ ./internal/nodeagent/ ./internal/podagent/
cd infra/cluster-api-provider-tuist && go test ./controllers/macos/ -run TestRecordMachinePhase
```

The GC test covers reaping referenced-but-idle goldens under pressure, sparing the live-backed one, stopping once free recovers, and no-op above the floor. The nodeagent test asserts `ephemeral-storage` is reported; the operator test asserts one series per machine and that a transition clears the stale `Failed` series. Both modules `go build ./... && go vet ./...` clean.
