### PR TITLE
fix(server): size runner pools on dispatchable demand only

### DIFF
--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -58,6 +58,7 @@ defmodule Tuist.Runners do
   alias Tuist.Runners.CacheGrant
   alias Tuist.Runners.Catalog
   alias Tuist.Runners.Claims
+  alias Tuist.Runners.Concurrency
   alias Tuist.Runners.Dispatch
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.RunnerSessions
@@ -355,9 +356,52 @@ defmodule Tuist.Runners do
     %{
       fleet: fleet_name,
       claimed: Map.get(Claims.counts_per_fleet(), fleet_name, 0),
-      queued: Jobs.queued_count_by_fleet(fleet_name),
+      queued: dispatchable_queued_count(fleet_name),
       p95_concurrent_last_hour: Jobs.p95_concurrent_last_hour(fleet_name)
     }
+  end
+
+  # Queued jobs the fleet could actually be handed right now: each
+  # account's queue depth capped at its remaining concurrency headroom.
+  #
+  # Raw queue depth overstates demand whenever an account queues past its
+  # limit. Dispatch declines those jobs and leaves them queued, so they
+  # persist in the count while never becoming claimable, and the
+  # autoscaler sizes the pool for them. The resulting Pods can't serve
+  # them either, so they idle on hosts that pools with claimable work are
+  # then denied — one account at its cap quietly starves the fleet.
+  #
+  # Falls back to the raw count when the fleet's shape is unknown: an
+  # unrecognised fleet should size on the signal it has rather than
+  # silently report zero demand and scale itself to nothing.
+  defp dispatchable_queued_count(fleet_name) do
+    queued_by_account = Jobs.queued_count_by_fleet_and_account(fleet_name)
+    raw = queued_by_account |> Map.values() |> Enum.sum()
+
+    case Catalog.resources_for_fleet(fleet_name) do
+      {:ok, resources} ->
+        dispatchable =
+          Enum.reduce(queued_by_account, 0, fn {account_id, count}, acc ->
+            acc + min(count, Concurrency.headroom_jobs(account_id, resources))
+          end)
+
+        :telemetry.execute(
+          Telemetry.event_name_queue_withheld(),
+          %{count: raw - dispatchable},
+          %{fleet: fleet_name}
+        )
+
+        dispatchable
+
+      {:error, _reason} ->
+        :telemetry.execute(
+          Telemetry.event_name_queue_withheld(),
+          %{count: 0},
+          %{fleet: fleet_name}
+        )
+
+        raw
+    end
   end
 
   @doc """

--- a/server/lib/tuist/runners/concurrency.ex
+++ b/server/lib/tuist/runners/concurrency.ex
@@ -112,6 +112,50 @@ defmodule Tuist.Runners.Concurrency do
 
   def fits?(_used, _limit, _requested), do: false
 
+  @doc """
+  How many more jobs of shape `resources` the account could claim right
+  now before hitting its platform concurrency limit.
+
+  This is the *forward-looking* companion to `fits?/3`: `fits?/3` answers
+  "does one more fit" at claim time, this answers "how many more fit" for
+  callers that must size ahead of the claim. Both read the same usage and
+  limit, so a job counted here is a job `fits?/3` would admit.
+
+  The autoscaler is the caller that matters. Sizing a pool on raw queue
+  depth provisions Pods for jobs dispatch will refuse, and those Pods
+  then sit idle holding hosts that pools with claimable work cannot get.
+  Capping each account's contribution at its headroom keeps the demand
+  signal to what can actually be served.
+
+  Returns 0 for an unknown account, a missing limit row, or a malformed
+  shape: this runs on the autoscaler's poll path, where raising would
+  fail the whole fleet's signal over one bad account.
+  """
+  def headroom_jobs(account_id, %{platform: platform, vcpus: vcpus, memory_gb: memory_gb})
+      when is_integer(account_id) and platform in @platforms and is_integer(vcpus) and is_integer(memory_gb) and vcpus > 0 and
+             memory_gb > 0 do
+    case limit_for_platform(account_id, platform) do
+      {:ok, limit} ->
+        used = Map.get(usage_by_platform(account_id), platform, %{vcpus: 0, memory_gb: 0})
+
+        [div(limit.vcpus - used.vcpus, vcpus), div(limit.memory_gb - used.memory_gb, memory_gb)]
+        |> Enum.min()
+        |> max(0)
+
+      :error ->
+        0
+    end
+  end
+
+  def headroom_jobs(_account_id, _resources), do: 0
+
+  defp limit_for_platform(account_id, platform) do
+    case Repo.get_by(ConcurrencyLimit, account_id: account_id, platform: platform) do
+      nil -> :error
+      limit -> {:ok, limit_resources(limit)}
+    end
+  end
+
   defp valid_usage?(resources) do
     Enum.all?([resources.vcpus, resources.memory_gb], &(is_integer(&1) and &1 >= 0))
   end

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -945,6 +945,34 @@ defmodule Tuist.Runners.Jobs do
   end
 
   @doc """
+  Queued workflow_job counts for `fleet_name`, broken down by account.
+
+  Same rows `queued_count_by_fleet/1` totals, grouped so the caller can
+  weigh each account's share against what that account is actually
+  allowed to run concurrently. Returns `%{account_id => count}`.
+  """
+  def queued_count_by_fleet_and_account(fleet_name) when is_binary(fleet_name) do
+    lookback_floor = queued_lookback_floor()
+
+    inner =
+      from j in Job,
+        where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
+        group_by: j.workflow_job_id,
+        having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
+        select: %{
+          workflow_job_id: j.workflow_job_id,
+          account_id: fragment("argMax(?, ?)", j.account_id, j.updated_at)
+        }
+
+    from(s in subquery(inner),
+      group_by: s.account_id,
+      select: {s.account_id, count()}
+    )
+    |> ClickHouseRepo.all()
+    |> Map.new()
+  end
+
+  @doc """
   Computes the rolling p95 of concurrent (claimed + running) jobs
   on `fleet_name` over the last 60 minutes, in one-minute buckets.
 

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -251,6 +251,20 @@ defmodule Tuist.Runners.PromExPlugin do
             description: "Age of the oldest still-queued workflow job per fleet, in seconds (0 when the queue is empty).",
             measurement: :oldest_age_seconds,
             tags: [:fleet]
+          ),
+          # Emitted from the autoscaler's signal path, not this poll: it
+          # is the gap between raw queue depth and what dispatch would
+          # actually hand out. Depth alone reads the same whether a
+          # queue is deep with claimable work or deep because one
+          # account is parked at its concurrency cap, and only the
+          # second means "do not grow the fleet for this".
+          last_value(
+            @metric_prefix ++ [:queue, :withheld],
+            event_name: Telemetry.event_name_queue_withheld(),
+            description:
+              "Queued workflow jobs per fleet excluded from the autoscaler's demand signal because their account is at its concurrency limit.",
+            measurement: :count,
+            tags: [:fleet]
           )
         ]
       ),

--- a/server/lib/tuist/runners/telemetry.ex
+++ b/server/lib/tuist/runners/telemetry.ex
@@ -25,6 +25,13 @@ defmodule Tuist.Runners.Telemetry do
   def event_name_webhook, do: [:tuist, :runners, :webhook]
 
   def event_name_queue_length, do: [:tuist, :runners, :queue, :length]
+
+  # Queued jobs excluded from the autoscaler's demand signal because
+  # their account is at its concurrency limit. Sustained non-zero means
+  # a customer is queueing past their cap: the queue is deep but the
+  # fleet must not grow for it. Without this the withholding is
+  # invisible, since dispatch declines those jobs at `Logger.debug`.
+  def event_name_queue_withheld, do: [:tuist, :runners, :queue, :withheld]
   def event_name_claims_count, do: [:tuist, :runners, :claims, :count]
   def event_name_pool_replicas, do: [:tuist, :runners, :pool, :replicas]
 end

--- a/server/test/tuist/runners/concurrency_test.exs
+++ b/server/test/tuist/runners/concurrency_test.exs
@@ -316,4 +316,88 @@ defmodule Tuist.Runners.ConcurrencyTest do
     {:ok, datetime, 0} = DateTime.from_iso8601(value)
     %{datetime | microsecond: {0, 6}}
   end
+
+  describe "headroom_jobs/2" do
+    test "returns how many more jobs of the shape fit under the limit" do
+      account = account_fixture()
+
+      # Default macOS limit is 12 vCPU / 28 GB; a 6/14 shape fits twice.
+      assert Concurrency.headroom_jobs(account.id, %{platform: :macos, vcpus: 6, memory_gb: 14}) ==
+               2
+    end
+
+    test "shrinks as claims consume the limit and reaches 0 at the cap" do
+      account = account_fixture()
+      shape = %{platform: :macos, vcpus: 6, memory_gb: 14}
+
+      assert {:ok, _} =
+               Claims.attempt(11_001, account.id, "macos-pool", "macos-pod-1", shape)
+
+      assert Concurrency.headroom_jobs(account.id, shape) == 1
+
+      assert {:ok, _} =
+               Claims.attempt(11_002, account.id, "macos-pool", "macos-pod-2", shape)
+
+      assert Concurrency.headroom_jobs(account.id, shape) == 0
+    end
+
+    # The whole point of the function: it must admit exactly what
+    # `fits?/3` would admit, or the autoscaler sizes for jobs dispatch
+    # then refuses (or starves a pool that could have been served).
+    test "agrees with fits?/3 at the boundary" do
+      account = account_fixture()
+      shape = %{platform: :macos, vcpus: 6, memory_gb: 14}
+
+      assert {:ok, _} =
+               Claims.attempt(11_101, account.id, "macos-pool", "macos-pod-1", shape)
+
+      headroom = Concurrency.headroom_jobs(account.id, shape)
+      limit = Concurrency.limits_for(account.id, :macos)
+      used = Map.fetch!(Concurrency.usage_by_platform(account.id), :macos)
+
+      # `headroom` more jobs fit...
+      nth = %{vcpus: shape.vcpus * headroom, memory_gb: shape.memory_gb * headroom}
+      assert Concurrency.fits?(used, limit, nth)
+
+      # ...and one beyond that does not.
+      beyond = %{
+        vcpus: shape.vcpus * (headroom + 1),
+        memory_gb: shape.memory_gb * (headroom + 1)
+      }
+
+      refute Concurrency.fits?(used, limit, beyond)
+    end
+
+    test "is bounded by whichever resource runs out first" do
+      account = account_fixture()
+
+      # Default macOS limit 12 vCPU / 28 GB. This shape is cheap on CPU
+      # (12 fit) but memory-heavy (2 fit), so memory decides.
+      assert Concurrency.headroom_jobs(account.id, %{platform: :macos, vcpus: 1, memory_gb: 14}) ==
+               2
+    end
+
+    test "never returns negative when usage already exceeds the limit" do
+      account = account_fixture()
+      shape = %{platform: :macos, vcpus: 6, memory_gb: 14}
+
+      assert {:ok, _} = Claims.attempt(11_201, account.id, "macos-pool", "p1", shape)
+      assert {:ok, _} = Claims.attempt(11_202, account.id, "macos-pool", "p2", shape)
+
+      {:ok, _} = Concurrency.update_limits(account, %{"runner_macos_vcpus_limit" => "6"})
+
+      assert Concurrency.headroom_jobs(account.id, shape) == 0
+    end
+
+    # Runs on the autoscaler poll path: one bad account must not raise
+    # and take the whole fleet's demand signal down with it.
+    test "returns 0 for unknown accounts and malformed shapes" do
+      account = account_fixture()
+
+      assert Concurrency.headroom_jobs(-1, %{platform: :macos, vcpus: 6, memory_gb: 14}) == 0
+      assert Concurrency.headroom_jobs(account.id, %{platform: :macos, vcpus: 0, memory_gb: 14}) == 0
+      assert Concurrency.headroom_jobs(account.id, %{platform: :bsd, vcpus: 1, memory_gb: 1}) == 0
+      assert Concurrency.headroom_jobs(account.id, %{}) == 0
+    end
+  end
 end

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -1209,6 +1209,61 @@ defmodule Tuist.Runners.JobsTest do
     end
   end
 
+  describe "queued_count_by_fleet_and_account/1" do
+    test "groups the fleet's queued rows by account" do
+      account_a = account_fixture()
+      account_b = account_fixture()
+
+      :ok = enqueue_fixture(account_a, 8301, fleet: "fleet-qca")
+      :ok = enqueue_fixture(account_a, 8302, fleet: "fleet-qca")
+      :ok = enqueue_fixture(account_b, 8303, fleet: "fleet-qca")
+      :ok = enqueue_fixture(account_a, 8304, fleet: "fleet-qca-other")
+
+      assert Jobs.queued_count_by_fleet_and_account("fleet-qca") == %{
+               account_a.id => 2,
+               account_b.id => 1
+             }
+    end
+
+    test "totals to queued_count_by_fleet/1 so the two cannot drift" do
+      account_a = account_fixture()
+      account_b = account_fixture()
+
+      :ok = enqueue_fixture(account_a, 8311, fleet: "fleet-qca-sum")
+      :ok = enqueue_fixture(account_b, 8312, fleet: "fleet-qca-sum")
+      :ok = enqueue_fixture(account_b, 8313, fleet: "fleet-qca-sum")
+
+      by_account = Jobs.queued_count_by_fleet_and_account("fleet-qca-sum")
+
+      assert by_account |> Map.values() |> Enum.sum() ==
+               Jobs.queued_count_by_fleet("fleet-qca-sum")
+    end
+
+    test "excludes rows that have transitioned out of `queued`" do
+      account = account_fixture()
+      :ok = enqueue_fixture(account, 8321, fleet: "fleet-qca-trans")
+      {:ok, candidate} = Jobs.pick_queued("fleet-qca-trans", [])
+      :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
+
+      assert Jobs.queued_count_by_fleet_and_account("fleet-qca-trans") == %{}
+    end
+
+    test "returns an empty map for an unknown fleet" do
+      assert Jobs.queued_count_by_fleet_and_account("fleet-qca-none") == %{}
+    end
+
+    test "honours the same lookback window as the total" do
+      account = account_fixture()
+      recent = DateTime.add(DateTime.utc_now(), -60, :second)
+      stale = DateTime.add(DateTime.utc_now(), -8 * 86_400, :second)
+
+      :ok = enqueue_fixture(account, 8331, fleet: "fleet-qca-look", enqueued_at: recent)
+      :ok = enqueue_fixture(account, 8332, fleet: "fleet-qca-look", enqueued_at: stale)
+
+      assert Jobs.queued_count_by_fleet_and_account("fleet-qca-look") == %{account.id => 1}
+    end
+  end
+
   describe "p95_concurrent_last_hour/1" do
     test "returns 0 on a fleet with no history" do
       assert Jobs.p95_concurrent_last_hour("fleet-empty") == 0

--- a/server/test/tuist/runners_test.exs
+++ b/server/test/tuist/runners_test.exs
@@ -10,6 +10,7 @@ defmodule Tuist.RunnersTest do
   alias Tuist.Runners.CacheGrant
   alias Tuist.Runners.Catalog
   alias Tuist.Runners.Claims
+  alias Tuist.Runners.Concurrency
   alias Tuist.Runners.Dispatch
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.VolumeAffinities
@@ -1020,6 +1021,92 @@ defmodule Tuist.RunnersTest do
     test "errors when the account does not exist" do
       digest = String.duplicate("c", 40)
       assert :error = Runners.volume_master_upload_url(-1, digest)
+    end
+  end
+
+  describe "scaling_signals_for_fleet/1" do
+    defp queue_job(account, workflow_job_id, fleet_name, resources) do
+      :ok =
+        Jobs.enqueue(%{
+          workflow_job_id: workflow_job_id,
+          account_id: account.id,
+          fleet_name: fleet_name,
+          platform: Atom.to_string(resources.platform),
+          vcpus: resources.vcpus,
+          memory_gb: resources.memory_gb,
+          repository: "acme/cli",
+          workflow_run_id: workflow_job_id * 10,
+          run_attempt: 1,
+          workflow_name: "CI",
+          job_name: "build",
+          head_branch: "main",
+          head_sha: "deadbeef",
+          requested_dispatch_label: ""
+        })
+    end
+
+    test "reports full queue depth while the account has headroom" do
+      account = account_fixture()
+      fleet = "macos-signal-headroom"
+      {:ok, resources} = Catalog.resources_for_fleet(fleet)
+
+      queue_job(account, 91_001, fleet, resources)
+
+      assert %{queued: 1} = Runners.scaling_signals_for_fleet(fleet)
+    end
+
+    # The regression this exists for. An account that queues past its
+    # concurrency limit used to inflate the signal with jobs dispatch
+    # will refuse, so the autoscaler provisioned Pods that could never
+    # serve them and that then idled on hosts other pools needed.
+    test "caps the queue depth at what the account can actually claim" do
+      account = account_fixture()
+      fleet = "macos-signal-capped"
+      {:ok, resources} = Catalog.resources_for_fleet(fleet)
+
+      headroom = Concurrency.headroom_jobs(account.id, resources)
+      queued = headroom + 5
+
+      for i <- 1..queued do
+        queue_job(account, 91_100 + i, fleet, resources)
+      end
+
+      assert Jobs.queued_count_by_fleet(fleet) == queued
+      assert %{queued: ^headroom} = Runners.scaling_signals_for_fleet(fleet)
+    end
+
+    test "counts each account's headroom independently" do
+      account_a = account_fixture()
+      account_b = account_fixture()
+      fleet = "macos-signal-multi"
+      {:ok, resources} = Catalog.resources_for_fleet(fleet)
+
+      headroom = Concurrency.headroom_jobs(account_a.id, resources)
+
+      # A is parked over its cap; B queues a single claimable job. B's
+      # job must still register, or one capped customer would zero out
+      # the whole fleet's demand signal.
+      for i <- 1..(headroom + 3) do
+        queue_job(account_a, 91_200 + i, fleet, resources)
+      end
+
+      queue_job(account_b, 91_300, fleet, resources)
+
+      assert %{queued: signal} = Runners.scaling_signals_for_fleet(fleet)
+      assert signal == headroom + 1
+    end
+
+    # An unrecognised fleet has no shape to price headroom against.
+    # Reporting 0 there would scale the pool to nothing; fall back to
+    # the raw depth instead.
+    test "falls back to raw queue depth for a fleet with no known shape" do
+      account = account_fixture()
+      fleet = "not-a-known-prefix"
+
+      queue_job(account, 91_401, fleet, %{platform: :linux, vcpus: 4, memory_gb: 16})
+
+      assert {:error, _} = Catalog.resources_for_fleet(fleet)
+      assert %{queued: 1} = Runners.scaling_signals_for_fleet(fleet)
     end
   end
 end


### PR DESCRIPTION
## What

The runner autoscaler sized pools on raw queue depth. It now sizes on *dispatchable* queue depth: each account's queued jobs capped at the concurrency headroom it actually has left.

Also adds `tuist_runners_queue_withheld{fleet}`, the gap between the two, so the withholding is visible.

## Why

Today's macOS runner incident had a second act. After the dispatch fix in #11969 went out, `macos-26-6` still sat at target 9 with **zero** claimed jobs and 8 to 9 idle Pods, for over 90 minutes, holding 6 of the 9 Mac minis. `macos-26-3` had one genuinely claimable job and never got a host at all, so its Pod stayed Pending for 98 minutes. `macos-26-5` showed the same shape: idle Pods sitting next to 7 to 8 queued jobs in the same pool.

The loop:

1. An account queues more jobs than its plan's concurrency limit allows.
2. Dispatch correctly declines the excess and moves to the next account.
3. Those jobs stay `queued`.
4. `queued_count_by_fleet/1` counts them, because it counts every queued row.
5. The autoscaler sizes the pool for them and creates Pods.
6. Those Pods cannot serve those jobs either, so they idle on hosts.
7. Pools with claimable work are denied those hosts.

So one customer parked at their cap quietly starves the fleet, and it is not a transient: those rows stay queued for the full 7 day lookback.

This was invisible on every existing signal. Dispatch declines at `Logger.debug`, which production does not emit, and queue depth alone reads identically whether a queue is deep with claimable work or deep because someone is at their cap.

## How it was diagnosed

I could not read the accounts' limits directly (no in-cluster ClickHouse, `pods/exec` and `pods/portforward` both denied), so this is proof by elimination against the live cluster:

- `pick_queued_top_k` has exactly three filters: excluded workflow jobs (in-poll claim races only), excluded repositories, and ineligible accounts.
- Zero `github_mint_failed` and zero `dispatch_for_sa failed` across all server pods, so no repository was being excluded.
- Idle Pods and queued jobs coexisted **in the same pool** for 90+ minutes, with those Pods polling dispatch every second.
- `AllocateFleet` grants tier-1 load in full and funds floor/headroom only from what remains. Observed allocations summed to 19 on a 9 slot fleet, which is only possible if tiers 2 and 3 got nothing, which means allocated equals load exactly. That pins `queued(26-6) = 9` with `claimed = 0`.

Account-level ineligibility is the only mechanism left that produces that state. Consistent with it, `gamehelper` held exactly 2 claimed Pods while its pool reported 8 queued, flat, with claimed oscillating 0 to 2.

## Approaches considered

**Clamp `maxReplicas` on the hot pool.** This was my first instinct and it is wrong. It is a manual change that has to be remembered and reverted, it caps real `tuist-macos` demand, and it treats a condition that recurs every time any customer queues past their cap. It also would not reliably free a mini for the starved pool, which was competing with 7 other Pending Pods for whatever slot opened.

**Add a fairness floor to `AllocateFleet` so no pool can take the whole fleet.** Dropped after reading the allocator. Tier 1 already grants every pool its full load, so the starved pool *did* get target 1 and a Pod. The allocator is not the binding constraint, the Kubernetes scheduler is, because the other pool's Pods already occupy the minis. The version that would work, capping tier-1 at capacity, destroys the deliberate "excess goes Pending as the operator's add-a-host signal" behavior, and still cannot direct which pool receives a freed mini without PriorityClass preemption. With the demand signal corrected the target drops on its own, overflow reaps the idle Pods, and the hosts free naturally.

**Make the count exclude broken repositories too.** Not feasible as a query change. `excluded_repositories` is per-dispatch-call in-memory state accumulated during one poll's retry loop, with nothing persisted to join against. Doing it properly needs new durable state, which is a separate design. Concurrency caps are the dominant cause here and headroom *is* derivable, so this change covers that and leaves the rest alone.

**Reject jobs at enqueue when the account is over cap.** Wrong layer. The jobs are legitimately queued and will become claimable as the account's running jobs finish. The bug is counting them as demand *now*, not accepting them.

## Design notes

`Concurrency.headroom_jobs/2` reads the same usage and limit that `fits?/3` reads at claim time, so a job counted as demand is a job dispatch would admit. There is a test asserting agreement at the boundary (n fits, n+1 does not) specifically so the two cannot drift apart.

It returns 0 rather than raising for unknown accounts, missing limit rows, and malformed shapes, because it runs on the autoscaler poll path where raising would take down the whole fleet's signal over one bad account.

An unknown fleet shape falls back to raw depth rather than reporting 0, since reporting 0 would scale that pool to nothing.

The existing `p95_concurrent_last_hour` and `minWarmPoolFloor` terms still provide the lead-the-demand and warm-slack smoothing, so capping the queued term does not leave imminent work paying cold start.

## Validation

- `mix compile --warnings-as-errors` clean, `mix credo --strict` on all touched files reports no issues, `mise run format` applied
- `mix test test/tuist/runners/ test/tuist/runners_test.exs`: **475 passed**
- Confirmed the new tests are not vacuous: reverting `scaling_signals_for_fleet/1` to the raw count fails exactly the 2 tests that pin the new behavior (`6` vs `3` on the multi-account case), while the "has headroom" and "unknown fleet" cases correctly pass under both
- Coverage added for: per-account grouping, the grouped counts totalling to `queued_count_by_fleet/1` so they cannot drift, transitions out of queued, the lookback window, headroom shrinking to 0 at the cap, whichever resource runs out first bounding it, never going negative when usage exceeds a lowered limit, and the poll-path safety cases

Not yet verified in production, since the behavior only changes once this deploys. The thing to watch afterwards is `macos-26-6`'s target dropping toward its real claimable demand and its idle Pods being reaped by overflow.

Pairs with #11973, which makes the starved-versus-saturated distinction visible on the controller side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
