### PR TITLE
fix(cli): accept deprecated SwiftPM flags and halve SwifterPM restore time

### DIFF
--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -255,6 +255,28 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         }
     }
 
+    func test_resolve_when_swifterpm_is_enabled_and_deprecatedSwiftPackageManagerArgument_is_passed_succeeds() async throws {
+        // Given
+        let path = try temporaryPath()
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { [:] }
+        )
+
+        // When
+        try await subject.resolve(
+            at: path,
+            arguments: ["--disable-prefetching", "--force-resolved-versions"],
+            printOutput: false
+        )
+
+        // Then
+        let request = try XCTUnwrap(swifterPM.resolveRequests.first)
+        XCTAssertTrue(request.forceResolvedVersions)
+    }
+
     func test_resolve_when_swifterpm_is_enabled_and_transformArgumentsConflict_fails() async throws {
         // Given
         let path = try temporaryPath()

--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -61,6 +61,25 @@ By default, `swifterpm` copies cached directories into the project scratch direc
 > [!NOTE]
 > `swifterpm resolve` writes `Package.resolved` with an `originHash` derived from `Package.swift`, while SwiftPM derives its hash from the dependency graph. Running `swift package resolve` after `swifterpm resolve` in the same checkout may treat the lockfile as stale and resolve again.
 
+## Continuous integration
+
+> [!IMPORTANT]
+> Cache `~/.cache/swifterpm` (or `$XDG_CACHE_HOME/swifterpm`). Without it, every CI run is a cold run.
+
+The order-of-magnitude numbers in [Benchmarks](#benchmarks-) all come from the warm global cache, not from resolution itself, which is still delegated to SwiftPM. Warm runs range from 8.96x to 201x faster than SwiftPM; cold runs range from 9.15x faster to 0.78x *slower*, depending on the graph. A pipeline that caches SwiftPM's directories but not this one therefore gives up the large wins and lands back in that cold range.
+
+The scratch directory (`.build`) is cold on every CI run regardless, since it lives in the freshly checked out workspace. The global cache is the only part that can carry over, and it is a new path that no pre-existing configuration knows about, so this bites hardest when switching an existing pipeline over:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.cache/swifterpm
+    key: swifterpm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+    restore-keys: swifterpm-${{ runner.os }}-
+```
+
+The cache is content-addressed by package identity, version, and revision, so a stale restore is safe: entries that no longer match are simply unused, and `restore-keys` lets a run start from the closest previous cache instead of from nothing.
+
 ## Bazel Swift package resolver
 
 `swifterpm` also ships a Bzlmod extension with the same resolver helper shape as `rules_swift_package_manager`:

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -286,14 +286,15 @@ public struct SwifterPMCommand: AsyncParsableCommand {
     }
 
     func makeCLI() throws -> CLI {
+        let arguments = DeprecatedSwiftPMOptions.strip(commandArguments)
         let command: CLI.Command
         switch action {
         case .resolve:
-            command = .resolve(try ResolveArguments.parse(commandArguments).makeOptions())
+            command = .resolve(try ResolveArguments.parse(arguments).makeOptions())
         case .update:
-            command = .update(try UpdateArguments.parse(commandArguments).makeOptions())
+            command = .update(try UpdateArguments.parse(arguments).makeOptions())
         case .restore:
-            command = .restore(try RestoreArguments.parse(commandArguments).makeOptions())
+            command = .restore(try RestoreArguments.parse(arguments).makeOptions())
         }
 
         return CLI(
@@ -332,7 +333,35 @@ extension SwifterPMCachedDirectoryMaterialization: ExpressibleByArgument {
 
 enum CLIParser {
     static func parse(_ args: [String]) throws -> CLI {
-        try SwifterPMCommand.parse(args).makeCLI()
+        try SwifterPMCommand.parse(DeprecatedSwiftPMOptions.strip(args)).makeCLI()
+    }
+}
+
+/// Swift Package Manager options that are still accepted but do nothing.
+///
+/// `tuist install` forwards its passthrough arguments here verbatim, so any flag
+/// SwiftPM tolerates has to be tolerated too: rejecting one turns an invocation
+/// that worked for years into a hard `Unknown option` failure the moment
+/// SwifterPM becomes the default resolver. Verified against Swift 6.3.3, where
+/// both of these exit 0 and print nothing, so we drop them silently rather than
+/// warning on every run.
+///
+/// This is deliberately an exact allowlist and not a blanket "ignore anything
+/// unrecognized": genuinely unknown options must still fail, the same way
+/// SwiftPM rejects e.g. `--enable-resolver-trace`.
+///
+/// Stripping happens at every entry point rather than only before the
+/// subcommand parse, because `.allUnrecognized` on `commandArguments` only
+/// collects arguments that trail the `action` positional, and `tuist install`
+/// forwards passthrough arguments ahead of it.
+public enum DeprecatedSwiftPMOptions {
+    static let ignored: Set<String> = [
+        "--disable-prefetching",
+        "--enable-prefetching",
+    ]
+
+    public static func strip(_ arguments: [String]) -> [String] {
+        arguments.filter { !ignored.contains($0) }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -388,13 +388,19 @@ enum WorkspaceRestorer {
             }
         }
 
-        for pin in resolved.pins {
-            guard PinKind.isSourceControl(pin.kind) || PinKind.isRegistry(pin.kind) else {
-                continue
-            }
-            let packagePath = try packagePathForPin(scratchDir: scratchDir, pin: pin)
-            contexts.append(
-                PackageContext(
+        // Each `packageRef` here shells out to `swift package dump-package` for
+        // its pin, so walking the pins serially puts N cold manifest compiles
+        // end to end before any of the concurrent work below starts. Fan out at
+        // the same limit `PackageInfoCacheWriter` already uses for the identical
+        // operation; `ConcurrentTasks.map` preserves input order, which the
+        // workspace state depends on.
+        let pinnedPackages = resolved.pins.filter {
+            PinKind.isSourceControl($0.kind) || PinKind.isRegistry($0.kind)
+        }
+        contexts.append(
+            contentsOf: try await ConcurrentTasks.map(pinnedPackages) { pin in
+                let packagePath = try packagePathForPin(scratchDir: scratchDir, pin: pin)
+                return PackageContext(
                     packageRef: try await packageRef(
                         pin,
                         packagePath: packagePath,
@@ -403,8 +409,8 @@ enum WorkspaceRestorer {
                     packagePath: packagePath,
                     canonicalizeLocalBinaryPaths: false
                 )
-            )
-        }
+            }
+        )
 
         return contexts
     }

--- a/swifterpm/Sources/swifterpmCLI/main.swift
+++ b/swifterpm/Sources/swifterpmCLI/main.swift
@@ -2,7 +2,9 @@ import ArgumentParser
 import SwifterPMCore
 
 do {
-    var command = try SwifterPMCommand.parse()
+    var command = try SwifterPMCommand.parse(
+        DeprecatedSwiftPMOptions.strip(Array(CommandLine.arguments.dropFirst()))
+    )
     try await command.runAsync()
 } catch {
     SwifterPMCommand.exit(withError: error)

--- a/swifterpm/Tests/swifterpmTests/CLITests.swift
+++ b/swifterpm/Tests/swifterpmTests/CLITests.swift
@@ -126,6 +126,27 @@ struct CLITests {
         }
     }
 
+    @Test(arguments: ["--disable-prefetching", "--enable-prefetching"])
+    func deprecatedSwiftPackageManagerOptionsAreAccepted(option: String) throws {
+        // `tuist install` forwards passthrough arguments verbatim and ahead of the
+        // action, and SwiftPM still exits 0 on these, so rejecting them would break
+        // working invocations the moment SwifterPM becomes the default resolver.
+        let cli = try CLIParser.parse(["--force-resolved-versions", option, "resolve"])
+
+        guard case .resolve = cli.command else {
+            Issue.record("expected resolve command")
+            return
+        }
+        #expect(cli.forceResolvedVersions)
+    }
+
+    @Test
+    func deprecatedSwiftPackageManagerOptionsDoNotSuppressUnknownOptions() {
+        #expect(throws: (any Error).self) {
+            try CLIParser.parse(["--disable-prefetching", "resolve", "--unknown-option"])
+        }
+    }
+
     @Test
     func publicCommandParserBuildsResolutionRequestFromResolveArguments() async throws {
         try await withTemporaryDirectory { root in


### PR DESCRIPTION
A customer reported that `tuist install` went from about 1m20s to over 4m after moving to a 4.203 canary. This fixes the two things behind that: a hard failure on flags SwiftPM still accepts, and a serial chain of manifest compiles in the restore path.

## What changed

- SwifterPM now accepts `--disable-prefetching` and `--enable-prefetching` and ignores them, instead of failing with `Unknown option`.
- `WorkspaceRestorer.packageContexts` fans its per-pin `swift package dump-package` calls out through `ConcurrentTasks.map` instead of running them one after another.
- The SwifterPM README gains a Continuous integration section covering the global cache path.

## Why

`tuist install` forwards its passthrough arguments to the resolver verbatim. Until 4.203 those went to `swift package resolve`, which exits 0 on `--disable-prefetching` (confirmed on Swift 6.3.3, exit 0 with no output). Once SwifterPM became the default resolver, the same command line started failing outright. The customer passes that flag, so their invocation was broken and not merely slow.

The performance half matters beyond this one report, because the serial chain is paid on every continuous integration run. The scratch directory lives in the freshly checked out workspace, so it is cold every time regardless of how caching is configured.

## Root cause

Two separate causes, and neither was what I expected going in.

The flag rejection is a parser placement problem. `SwifterPMCommand` collects unknown arguments with `.allUnrecognized`, but that strategy only picks up arguments trailing the `action` positional. `tuist install` forwards passthrough arguments ahead of the action, so they hit the top-level parser first and fail there, before the subcommand parse ever runs.

The slowness is `WorkspaceRestorer.packageContexts`, which looped over the resolved pins and called `packageRef` for each, and every one of those shells out to `swift package dump-package`. That is a real manifest compile per package, run end to end, at roughly 0.6s each. The restore was never network bound, it was bound on serial manifest compilation that scales linearly with package count. See Benchmarks below for the isolation.

Worth recording what was ruled out, since both looked like the obvious culprits. The extra `swift package resolve --force-resolved-versions` that `assertResolvedFileUpToDate` runs costs 0.66s against a restored workspace, so the existing comment claiming it is a fast precomputation is correct and it is left alone. The copy materialization on continuous integration is roughly 0.6s of a 1.6s warm run, real but secondary, and deliberate, so it is also untouched.

## Approach

For the flags, the strip happens at every entry point rather than only before the subcommand parse, which is what the `.allUnrecognized` behaviour above forces. The list is an exact allowlist rather than a blanket "tolerate anything unrecognized", so genuinely unknown options still fail the way SwiftPM rejects, for example, `--enable-resolver-trace`. The existing test asserting that unknown options are rejected still passes, and there is a new test pinning that a deprecated flag does not smuggle an unknown one through. SwiftPM prints no warning on these flags, so neither do we, to avoid noise on every run.

For the restore, `ConcurrentTasks.map` was already used elsewhere in the same file, and `PackageInfoCacheWriter` already fans out the identical `dump-package` operation at the same limit, so this makes the two consistent rather than introducing a new pattern. The map preserves input order, which the workspace state depends on.

## Impact

`tuist install --disable-prefetching` works again on SwifterPM. Restores get roughly twice as fast on a large graph, and the saving grows with package count, so bigger projects gain more.

The documentation change is the other half of the customer's regression and no code change can cover it: `~/.cache/swifterpm` is a new path, so a pipeline switching to SwifterPM keeps caching SwiftPM's directories and starts cold every run. That drops it into the cold range, where the benchmark table shows results running from 9.15x faster to 0.78x slower depending on the graph, instead of the warm range where the order-of-magnitude wins live.

No behaviour change to resolution itself, which is still delegated to SwiftPM.

## Benchmarks

All numbers from an Apple silicon laptop on Swift 6.3.3. Two graphs were used: a synthetic ten package graph resolved from GitHub, and the tuist monorepo's own `Package.swift` at 103 pins and 81 packages restored, with its lockfile refreshed first the way `mise run benchmark:resolution` does. Every SwiftPM invocation gets an explicit `--cache-path` so a warm user level cache never makes one arm look better than the other.

### Headline result

103 pins, `CI=true`, warm download cache and cold scratch, before and after interleaved to control for machine noise.

| run | before (serial dumps) | after (parallel dumps) |
|---|---|---|
| 1 | 25.9s | 12.2s |
| 2 | 26.9s | 14.0s |
| 3 | 21.5s | 12.1s |
| **mean** | **24.8s** | **12.8s** |

Roughly 2x, with no overlap between the two distributions.

### The isolated cost this change removes

`swift package dump-package` across ten packages with a cold manifest cache, run directly rather than through SwifterPM:

| | time |
|---|---|
| serial | 6.18s |
| parallel | 1.40s |
| network floor for the same graph (15 MB, 10 tarballs, parallel `curl`) | 2.9s |

The restore was never network bound. It was bound on serial manifest compilation, at about 0.6s per package, which scales linearly with package count. That is why the win grows with graph size: the ten package graph saves about 2.1s, the 81 package graph saves about 12s, which is roughly 0.2s and 0.15s per package respectively.

### Small graph, warm cache and cold scratch

Ten pins, four runs per arm, two rounds, same conditions as the headline table.

| arm | round 1 | round 2 |
|---|---|---|
| before | 3.92 / 3.22 / 3.78 / 3.99 | 2.66 / 2.85 / 2.46 / 2.54 |
| after | 1.51 / 7.14 / 1.89 / 1.22 | 1.18 / 1.32 / 1.47 / 1.62 |

The 7.14s is an outlier from a background process on the machine. Medians are about 3.5s before and 1.4s after.

### Reference points that shaped the diagnosis

Ten pin graph unless noted, `CI=true`.

| measurement | time |
|---|---|
| `assertResolvedFileUpToDate` against an already restored workspace | 0.66s |
| SwifterPM warm cache, copy materialization | 1.58 to 1.77s |
| SwifterPM warm cache, symlink materialization | 0.93 to 1.12s |
| SwiftPM `resolve --force-resolved-versions`, warm cache | 2.33 to 3.80s |
| full cold run, 103 pins, after this change | 103.6s |

The first row is why the extra `swift package resolve` under `--force-resolved-versions` is left in place. The next two put the copy versus symlink difference at about 0.6s of a 1.6s warm run, real but secondary, and it is deliberate so it is untouched. The fourth shows SwifterPM already beating SwiftPM once its cache is warm, which is the point of the documentation change: the cache has to survive between runs for any of this to matter.

### Caveat

Fully cold runs could not produce a usable comparison. Three interleaved cold runs on the 103 pin graph came in at 143.2s, 298.2s and 78.1s, because download time against the registry varies by about 4x, which swamps a 12s effect. The headline table therefore holds downloads constant and varies only what this change touches. That is a fair representation of the win, because the scratch directory is cold on every continuous integration run either way, so the saving applies whether or not the download cache is warm. It stacks with the download cost rather than replacing it.

## Validation

- `swift test` in `swifterpm/`: 123 tests in 19 suites pass, including two new cases for the deprecated flags.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/SwiftPackageManagerControllerTests`: 15 pass, including a new one covering the flags through the Tuist entry point.
- `mise x -- swiftformat cli/ --lint`: clean. `swifterpm/` is intentionally not formatted by this task, so it is left in its own style.
- Confirmed against Swift 6.3.3 that `swift package resolve --disable-prefetching` and `--enable-prefetching` both exit 0 and print nothing, which is what the allowlist is matching.
- Correctness of the fan out: `workspace-state.json` and `Package.resolved` come out byte-identical between the serial and parallel binaries across all 105 workspace entries.

### How to test locally

```sh
cd swifterpm
swift build --product swifterpm

# Previously failed with: Error: Unknown option '--disable-prefetching'
.build/debug/swifterpm --package-path /path/to/a/package \
  --disable-prefetching --force-resolved-versions resolve --restore

# Still rejects genuinely unknown options
.build/debug/swifterpm --package-path /path/to/a/package --bogus-option resolve
```

For the performance side, point it at a package with a large `Package.resolved`, prime the cache once, then time a run with the scratch directory removed and the cache left in place:

```sh
rm -rf .build && CI=true swifterpm --package-path . --force-resolved-versions --quiet resolve --restore
```
