### PR TITLE
fix(server): raise xcresult processor capacity in production

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -426,6 +426,31 @@ xcresultProcessor:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  # Raised from the chart default of 4 (8 slots fleet-wide) because that no
+  # longer covers production load. Measured on 2026-07-21: arrivals into
+  # `:process_xcresult` stepped from ~10/hour to 300-545/hour between 10:00 and
+  # 11:00 UTC and stayed there, while throughput held at ~200/hour. The queue
+  # settled ~5 hours behind with ~2,200 jobs `available`, every worker slot
+  # busy, and jobs sitting at `attempt=0` with no errors. Nothing was failing;
+  # there simply were not enough consumers.
+  #
+  # 10 per pod x 2 pods = 20 slots, ~2.5x the previous ceiling, which matches
+  # the measured shortfall. Replica count can't absorb this instead: hostPort
+  # 9091 plus the topology spread pin one Pod per Mac mini and the fleet has
+  # two hosts, so more replicas means more hardware first.
+  queueConcurrency: 10
+  # Sized to keep the per-job budget roughly flat while tripling the slot
+  # count: memory stays at ~1Gi per concurrent job, CPU goes from ~0.75 to
+  # ~0.6, which the workload tolerates because a job spends much of its time on
+  # S3 download, unzip and ClickHouse writes rather than in `xcresulttool`.
+  # Still inside the Mac mini's 8 CPU / 14Gi allocatable, with headroom.
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "4Gi"
+    limits:
+      cpu: "6000m"
+      memory: "10Gi"
   # Opt into the Tailscale-fronted URL the processor's ExternalSecret
   # renders when postgresql.cnpg.pooler.tailscale.enabled is true.
   # Linux processors keep the direct in-cluster URL via the default


### PR DESCRIPTION
One value file, two settings. This is the change that actually fixes test runs sitting on `processing` for hours.

## What changed

Raises `xcresultProcessor.queueConcurrency` from the chart default of 4 to 10, and lifts the pod's resource limits from 3 CPU / 4Gi to 6 CPU / 10Gi (requests from 1 CPU / 2Gi to 2 CPU / 4Gi). Scoped to `values-managed-production.yaml` only.

Fleet-wide that moves the xcresult processor from 8 concurrent job slots to 20.

## Why

On 2026-07-21 test runs were showing `processing` for hours. The instinct was that the macOS processors were wedged, but the queue says otherwise:

- ~2,200 jobs `available`
- All 8 worker slots busy, running healthy jobs 15s to 4min old
- The stalled jobs sitting at `attempt=0` with `errors={}`, meaning never picked up even once

Nothing was failing. There were not enough consumers.

## Root cause

Arrivals into `:process_xcresult`, per hour that day:

```
07:00 →   2      12:00 → 351
08:00 →  15      13:00 → 433
09:00 →   7      14:00 → 545
10:00 →  90      15:00 → 372 (partial, ~545/hr pace)
11:00 → 296
```

Load stepped up roughly 40x between 10:00 and 11:00 UTC and stayed there. Capacity did not move. Throughput measured at ~200 jobs/hour against ~500/hour of arrivals, so the queue settled about five hours behind and held there. Two consecutive samples had the queue head advancing 319 seconds of ingest per 471 seconds of wall clock, confirming it was not draining on its own.

Worth someone confirming separately whether that step change is real customer growth or something on our side generating extra uploads, because that decides whether this is enough or whether the fleet also needs to grow.

## Approach

Concurrency was the lever with the most headroom. Each Mac mini has 8 CPU and 14Gi allocatable, and the pod was capped at 3 CPU / 4Gi running 4 workers, so most of the hardware was sitting idle.

The resource bump is sized to keep the per-job budget roughly flat rather than to squeeze more out of each job: memory stays at about 1Gi per concurrent job, and CPU goes from about 0.75 to about 0.6. That tighter CPU slice is acceptable because a job spends much of its life downloading from object storage, unzipping and writing to ClickHouse rather than inside `xcresulttool`. The new limits still leave headroom against the node's allocatable.

Adding replicas was considered and rejected as the first move. The container declares `hostPort: 9091` and the Deployment carries a `DoNotSchedule` topology spread, which together pin exactly one Pod per Mac mini. The production fleet has two hosts, so `replicaCount` cannot go above 2 without provisioning more hardware. That remains the follow-up if ~500/hour turns out to be the new baseline rather than a spike.

This is deliberately scoped to the managed production values instead of the chart default. The sizing reflects this fleet's load, and a self-hosted install with a single Mac mini should not silently inherit a concurrency of 10.

## Prior art and constraints

Checked whether the existing numbers were deliberate before changing them.

`queueConcurrency: 4` carries no rationale. It arrived in 9df8424ea3, the commit that introduced this Deployment, with a purely descriptive comment ("Total parallelism = replicaCount * concurrency"), and `Tuist.Environment.process_xcresult_queue_concurrency/1` defaults to a bare `4` as well. It reads as a starting value rather than a tuned limit.

The resource change is not just Kubernetes accounting. `vmResourcesFromPod` in tart-kubelet feeds `Tart.Set(vmName, cpu, memMB)`, so pod limits resize the actual guest virtual machine (CPU rounded to whole cores, memory to whole megabytes).

There is a documented hard ceiling, and this change stays inside it. `macosFleet.machine` pins the hosts to Scaleway `M2-L` (M2 Pro, 10 cores, 16 GB) and declares:

```yaml
# Leave 2 CPU + 2 GB for the macOS host + Apple
# Virtualization.framework reserve. Asking for the host's full
# 10 CPU / 16 GB on `tart run` fails with
# `memorySize > maximumAllowedMemorySize`.
hostCPU: 8
hostMemoryMB: 14336
```

6 CPU / 10Gi sits under that 8 CPU / 14Gi ceiling with margin. Worth noting the current 3 CPU / 4Gi is actually *below* the Packer image's own defaults (`cpu_count = 4`, `memory_gb = 8`), so the pods have been running a guest smaller than the image was built for.

Disk was the other thing worth checking, since bundles are downloaded and unzipped inside the guest and DiskPressure trips at 90% of the guest root volume. The guest inherits a 140 GB disk from `macos-xcode-image`, of which roughly 60 GB goes to Xcode, the brew layer and simulator runtimes, leaving ~80 GB free. `XCResultProcessor.cleanup_temp/1` removes the extracted directory with `File.rm_rf` and the downloaded archive is deleted in an `after` block, so temp usage is bounded by in-flight jobs. Ten concurrent bundles is comfortable against that headroom.

The closest precedent is #10556, which unblocked the Linux build processor crashlooping under concurrent xcactivitylog parses and sized temp storage per slot ("16 GiB gives ~3 GiB per slot at queueConcurrency = 5"). Same class of failure to respect, which is why the per-job memory budget here is held flat rather than stretched.

## Impact

Backlog should drain once this rolls out, and the five-hour lag closes without further intervention. No behaviour changes: same code, same queue, more consumers.

Rollout carries the usual constraint for this Deployment. `maxSurge: 0` plus the hostPort reservation means replicas are replaced one Mac mini at a time, so the fleet runs at reduced capacity during the roll and `progressDeadlineSeconds: 1800` gives a full macOS virtual machine cycle room to complete.

Fully reversible by reverting this commit. Worth watching memory on the Mac minis for the first hour after rollout, since 10 concurrent `xcresulttool` parses of large result bundles is the part of this sizing with the least direct evidence behind it.

## Validation

The values file parses and both keys resolve to the paths the Deployment template consumes:

```
queueConcurrency: 10
resources: {'requests': {'cpu': '2000m', 'memory': '4Gi'},
            'limits': {'cpu': '6000m', 'memory': '10Gi'}}
```

`xcresult-processor-deployment.yaml` reads exactly these at line 132 (`TUIST_PROCESS_XCRESULT_QUEUE_CONCURRENCY`) and line 226 (`resources`).

A full `helm template` render needs values that only continuous integration supplies (`runnersFleet.runnerImageSemver` and a literal database URL), so it was not run end to end locally. The change adds two keys to an existing block and introduces no new templating.

### How to test locally

```sh
cd infra/helm/tuist
python3 -c "import yaml; print(yaml.safe_load(open('values-managed-production.yaml'))['xcresultProcessor'])"
```

After deploying, confirm the setting reached the pods and watch the queue drain:

```sh
kubectl -n tuist get deploy tuist-tuist-xcresult-processor -o json \
  | jq -r '.spec.template.spec.containers[0].env[]
           | select(.name=="TUIST_PROCESS_XCRESULT_QUEUE_CONCURRENCY")'
```

```sql
select state, count(*), now() - min(scheduled_at) filter (where state='available') as lag
from oban_jobs where queue = 'process_xcresult' group by 1;
```

The `available` count and the lag should both fall steadily rather than hold flat.
