### PR TITLE
fix(server): release runner claims held past a recorded completion

### DIFF
--- a/server/lib/tuist/runners/claims.ex
+++ b/server/lib/tuist/runners/claims.ex
@@ -338,14 +338,14 @@ defmodule Tuist.Runners.Claims do
   end
 
   @doc """
-  Deletes claims whose workflow_job already has a recorded completion
-  and whose `claimed_at` predates `threshold`. Returns the row count.
+  Deletes claims with nothing left to run: every workflow_job attached to
+  the claim has a recorded completion, and `claimed_at` predates
+  `threshold`. Returns the row count.
 
-  A `runner_job_completions` row is proof the job is over: it is written
-  from the `workflow_job.completed` webhook, which is the same handler
-  that releases the claim. A claim still present alongside one is a slot
-  held for a job that finished, and every other recovery path is blind
-  to it:
+  A `runner_job_completions` row is proof a job is over. It is written
+  from the `workflow_job.completed` webhook, the same handler that
+  releases the claim, so a claim still present alongside one is a slot
+  held for work that finished. Every other recovery path is blind to it:
 
     * `list_stale/1` filters `lifecycle_state = 'claimed'`, and these
       sit in `running`.
@@ -354,9 +354,24 @@ defmodule Tuist.Runners.Claims do
       that state, so the scan never returns it.
 
   That leaves the row consuming the account's concurrency budget
-  permanently. Because the completion is independent proof rather than
-  a timeout, this can safely release `running` claims that the
-  time-based sweep must not touch.
+  permanently. Because a completion is independent proof rather than a
+  timeout, this can safely release `running` claims that the time-based
+  sweep must not touch.
+
+  ## Why the claimed job alone is not enough
+
+  GitHub hands a queued job to any label-eligible runner, so the Pod that
+  *claimed* job A is often executing job B (`executed_workflow_job_id`,
+  learned from `workflow_job.in_progress`). Keying release on the claimed
+  job's completion alone would delete a live runner's reservation the
+  moment A finished elsewhere, pushing the account over cap while B is
+  still running. This is the same trap `complete/1` warns about and that
+  `executing?/1` guards for the queued-side recovery.
+
+  So the claim is released only when the claimed job AND the executed job
+  (when the runner took one) are both complete. A runner minted for a
+  single-shot JIT runs at most one job, so those two cover everything the
+  claim can be holding the slot for.
 
   `threshold` only avoids racing the webhook's own release between the
   completion insert and the delete; it is not the staleness signal.
@@ -367,7 +382,11 @@ defmodule Tuist.Runners.Claims do
     {count, _} =
       Repo.delete_all(
         from(c in Claim,
-          where: c.claimed_at < ^threshold and c.workflow_job_id in subquery(completed)
+          where: c.claimed_at < ^threshold,
+          where: c.workflow_job_id in subquery(completed),
+          where:
+            is_nil(c.executed_workflow_job_id) or
+              c.executed_workflow_job_id in subquery(completed)
         )
       )
 

--- a/server/lib/tuist/runners/claims.ex
+++ b/server/lib/tuist/runners/claims.ex
@@ -66,6 +66,7 @@ defmodule Tuist.Runners.Claims do
   alias Tuist.Runners.Claim
   alias Tuist.Runners.Concurrency
   alias Tuist.Runners.ConcurrencyLimit
+  alias Tuist.Runners.JobCompletion
 
   @doc """
   Attempts to claim `workflow_job_id` for `pod_name` on behalf of
@@ -334,6 +335,43 @@ defmodule Tuist.Runners.Claims do
   def complete(workflow_job_id) when is_integer(workflow_job_id) do
     Repo.delete_all(from(c in Claim, where: c.workflow_job_id == ^workflow_job_id))
     :ok
+  end
+
+  @doc """
+  Deletes claims whose workflow_job already has a recorded completion
+  and whose `claimed_at` predates `threshold`. Returns the row count.
+
+  A `runner_job_completions` row is proof the job is over: it is written
+  from the `workflow_job.completed` webhook, which is the same handler
+  that releases the claim. A claim still present alongside one is a slot
+  held for a job that finished, and every other recovery path is blind
+  to it:
+
+    * `list_stale/1` filters `lifecycle_state = 'claimed'`, and these
+      sit in `running`.
+    * `OrphanedRunnersWorker` drives off ClickHouse rows still in
+      `status = 'running'`. The completion already moved the row out of
+      that state, so the scan never returns it.
+
+  That leaves the row consuming the account's concurrency budget
+  permanently. Because the completion is independent proof rather than
+  a timeout, this can safely release `running` claims that the
+  time-based sweep must not touch.
+
+  `threshold` only avoids racing the webhook's own release between the
+  completion insert and the delete; it is not the staleness signal.
+  """
+  def release_completed(%DateTime{} = threshold) do
+    completed = from(completion in JobCompletion, select: completion.workflow_job_id)
+
+    {count, _} =
+      Repo.delete_all(
+        from(c in Claim,
+          where: c.claimed_at < ^threshold and c.workflow_job_id in subquery(completed)
+        )
+      )
+
+    count
   end
 
   @doc """

--- a/server/lib/tuist/runners/workers/stale_claims_worker.ex
+++ b/server/lib/tuist/runners/workers/stale_claims_worker.ex
@@ -14,6 +14,20 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
   `lifecycle_state = 'claimed'` so a long-running build is
   invisible to this worker.
 
+  ## Second pass: claims held past a recorded completion
+
+  A `running` claim IS released when its workflow_job has a
+  `runner_job_completions` row (`Claims.release_completed/1`). That is
+  proof the job is over rather than a timeout, so the objection above
+  does not apply.
+
+  This pass exists because such a claim is invisible to every other
+  recovery path: the sweep above only sees `claimed`, and
+  `OrphanedRunnersWorker` drives off ClickHouse rows still in
+  `status = 'running'` — recording the completion already moved the row
+  out of that state, so its scan never returns it. The slot would be
+  held until the account is deleted.
+
   ## Why CH first
 
   Order matters. If we DELETEd the PG row first and then crashed
@@ -76,6 +90,8 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
       )
     end
 
+    release_completed_claims(threshold)
+
     # Opportunistically prune volume-affinity rows past their retention
     # window. Cheap indexed range delete, usually 0 rows;
     # piggybacks on this periodic runner-maintenance sweep rather than
@@ -83,6 +99,39 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
     VolumeAffinities.prune()
 
     :ok
+  end
+
+  # Second pass: claims whose workflow_job already has a recorded
+  # completion. Unlike the sweep above these are usually in `running`,
+  # which the time-based pass must never touch — but here the completion
+  # row is independent proof the job is over, not a timeout guess.
+  #
+  # Nothing else reclaims them. `list_stale/1` only sees `claimed`, and
+  # `OrphanedRunnersWorker` scans ClickHouse rows still in
+  # `status = 'running'` — the completion already moved the row out of
+  # that state, so it never appears there. The slot would otherwise be
+  # held for the account's lifetime.
+  #
+  # No ClickHouse write and no GitHub call: the job is already recorded
+  # complete on both sides, so there is nothing to requeue or confirm.
+  defp release_completed_claims(threshold) do
+    case Claims.release_completed(threshold) do
+      0 ->
+        :ok
+
+      count ->
+        Logger.warning("runners: released claims held past a recorded completion",
+          count: count
+        )
+
+        :telemetry.execute(
+          Telemetry.event_name_recovery(),
+          %{count: count},
+          %{kind: "completed_claim"}
+        )
+
+        :ok
+    end
   end
 
   defp recover_one(%{workflow_job_id: id, claimed_at: handle}) do

--- a/server/test/tuist/runners/claims_test.exs
+++ b/server/test/tuist/runners/claims_test.exs
@@ -8,6 +8,7 @@ defmodule Tuist.Runners.ClaimsTest do
   alias Tuist.Runners.Claim
   alias Tuist.Runners.Claims
   alias Tuist.Runners.ConcurrencyLimit
+  alias Tuist.Runners.JobCompletion
 
   @linux_resources %{platform: :linux, vcpus: 1, memory_gb: 1}
 
@@ -492,6 +493,93 @@ defmodule Tuist.Runners.ClaimsTest do
 
     test "returns :error when no live claim exists for the workflow_job_id" do
       assert Claims.by_workflow_job_id(9_999_999) == :error
+    end
+  end
+
+  describe "release_completed/1" do
+    defp completion_fixture(workflow_job_id, account) do
+      Repo.insert_all(JobCompletion, [
+        %{
+          workflow_job_id: workflow_job_id,
+          account_id: account.id,
+          conclusion: "success",
+          completed_at: DateTime.truncate(DateTime.utc_now(), :second),
+          inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
+          updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+        }
+      ])
+    end
+
+    defp backdate_claim(workflow_job_id, seconds) do
+      Repo.update_all(
+        from(c in Claim, where: c.workflow_job_id == ^workflow_job_id),
+        set: [claimed_at: DateTime.add(DateTime.utc_now(), -seconds, :second)]
+      )
+    end
+
+    # The leak this exists for: the completion webhook recorded the job as
+    # finished but the claim survived, so the slot stayed consumed. It sits
+    # in `running`, which the time-based sweep must never touch, and its
+    # ClickHouse row has already left `status = 'running'`, so the orphan
+    # worker's scan cannot see it either.
+    test "releases a running claim whose job has a recorded completion" do
+      account = account_fixture()
+
+      assert {:ok, _} = Claims.attempt(7001, account.id, "fleet-a", "pod-1", @linux_resources)
+      assert :ok = Claims.mark_running(7001, "runner-1")
+      completion_fixture(7001, account)
+      backdate_claim(7001, 600)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 1
+      refute Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7001))
+    end
+
+    # The discriminator has to be the completion row, not age. A long build
+    # legitimately holds its slot for hours, and reaping it would push the
+    # account over its cap while a runner is still working.
+    test "leaves a running claim with no recorded completion" do
+      account = account_fixture()
+
+      assert {:ok, _} = Claims.attempt(7002, account.id, "fleet-a", "pod-1", @linux_resources)
+      assert :ok = Claims.mark_running(7002, "runner-1")
+      backdate_claim(7002, 86_400)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 0
+      assert Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7002))
+    end
+
+    # The threshold only avoids racing the webhook's own release between
+    # the completion insert and the delete. It is not the staleness signal.
+    test "leaves a freshly claimed row inside the grace window" do
+      account = account_fixture()
+
+      assert {:ok, _} = Claims.attempt(7003, account.id, "fleet-a", "pod-1", @linux_resources)
+      completion_fixture(7003, account)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 0
+      assert Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7003))
+    end
+
+    test "releases every stale claim and frees the account's capacity" do
+      account = account_fixture()
+
+      for id <- [7101, 7102, 7103] do
+        assert {:ok, _} = Claims.attempt(id, account.id, "fleet-a", "pod-#{id}", @linux_resources)
+        assert :ok = Claims.mark_running(id, "runner-#{id}")
+        completion_fixture(id, account)
+        backdate_claim(id, 600)
+      end
+
+      assert {:ok, _} = Claims.attempt(7104, account.id, "fleet-a", "pod-live", @linux_resources)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 3
+
+      remaining = Repo.all(from(c in Claim, select: c.workflow_job_id))
+      assert remaining == [7104]
+    end
+
+    test "is a no-op when nothing is held past a completion" do
+      assert Claims.release_completed(DateTime.utc_now()) == 0
     end
   end
 end

--- a/server/test/tuist/runners/claims_test.exs
+++ b/server/test/tuist/runners/claims_test.exs
@@ -578,6 +578,43 @@ defmodule Tuist.Runners.ClaimsTest do
       assert remaining == [7104]
     end
 
+    # The trap this nearly walked into. GitHub hands a queued job to any
+    # label-eligible runner, so the Pod that claimed job A is frequently
+    # executing job B. Releasing on A's completion alone would delete a
+    # live runner's reservation mid-job and push the account over cap.
+    # Production had two claims in exactly this shape.
+    test "leaves a claim whose runner is executing an unfinished job" do
+      account = account_fixture()
+
+      assert {:ok, _} = Claims.attempt(7201, account.id, "fleet-a", "pod-1", @linux_resources)
+      assert :ok = Claims.mark_running(7201, "runner-busy")
+      assert :mismatch = Claims.record_execution("runner-busy", 7299, account.id)
+
+      # The CLAIMED job finished; the job the runner actually took has not.
+      completion_fixture(7201, account)
+      backdate_claim(7201, 86_400)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 0
+      assert Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7201))
+    end
+
+    # Once the executed job finishes too, the runner has nothing left and
+    # the slot is genuinely leaked, so it must be reclaimed.
+    test "releases once both the claimed and executed jobs are complete" do
+      account = account_fixture()
+
+      assert {:ok, _} = Claims.attempt(7202, account.id, "fleet-a", "pod-1", @linux_resources)
+      assert :ok = Claims.mark_running(7202, "runner-done")
+      assert :mismatch = Claims.record_execution("runner-done", 7298, account.id)
+
+      completion_fixture(7202, account)
+      completion_fixture(7298, account)
+      backdate_claim(7202, 600)
+
+      assert Claims.release_completed(DateTime.add(DateTime.utc_now(), -300, :second)) == 1
+      refute Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7202))
+    end
+
     test "is a no-op when nothing is held past a completion" do
       assert Claims.release_completed(DateTime.utc_now()) == 0
     end


### PR DESCRIPTION
## What

Adds a second pass to `StaleClaimsWorker` that deletes `runner_claims` rows whose workflow_job already has a `runner_job_completions` row.

Deploying this drains the existing leak on its own. The worker runs every minute, so no manual database writes are needed.

## Why

Our macOS CI has been serializing behind a single concurrency slot, and the cause is leaked claim rows.

Production, account 3:

```
platform | stale_claims | vcpus | memory_gb | oldest
---------+--------------+-------+-----------+---------------------
linux    |      9       |  26   |    104    | 2026-07-16 20:55
macos    |      3       |  18   |     42    | 2026-07-20 16:45
```

All twelve have a recorded completion. The three macOS ones are the ones that hurt: against a 32 vCPU / 64 GB limit and a 6 / 14 job shape, they left `min((32-18)/6, (64-42)/14)` = **1** concurrent macOS job for the whole org, on a fleet of 9 Mac minis. That is why acceptance tests queued for an hour, why the backward-compatibility job never ran, and why the Kura darwin builds sat queued for 45 minutes next to 9 idle warm Pods.

Verified for each leaked row that GitHub reports the job `completed` with conclusion `success`, that its Pod no longer exists in the cluster, and that a `runner_job_completions` row exists. The one legitimate claim has no completion row, so the discriminator separates them exactly.

## Root cause

The completion webhook records the completion and releases the claim in the same handler. When the release does not match a row, the completion is still recorded and the claim survives. Nothing reclaims it after that, because every recovery path is looking somewhere else:

- `StaleClaimsWorker` filters `lifecycle_state = 'claimed'`. These sit in `running`.
- `OrphanedRunnersWorker` drives off `Jobs.list_orphaned_running/1`, which scans ClickHouse for rows still in `status = 'running'`. Recording the completion already moved the row out of that state, so the scan never returns it. Its `handle_gh_status("completed", ...)` branch is correct and would do the right thing, but it is unreachable for these rows.

So the slot is held until the account is deleted. The oldest row here is from 2026-07-16, the day after concurrency limits shipped in #11836, which is when a leaked claim first started having a cost.


## How release worked before, and why this class exists

Worth reading alongside #11864, because this fix complements that change rather than second-guessing it.

**Before #11864**, the completion webhook released job-keyed:

```elixir
:ok = Claims.complete(workflow_job_id)
```

Simple, and it never leaked. But it was wrong under the claim-versus-execution mismatch: it freed a slot still held by a runner executing someone else's claimed job, under-counting the account's live runners.

**#11864 changed it to executor-keyed**, releasing the claim held by the runner GitHub says actually ran the job:

```elixir
if account_id, do: Claims.complete_by_runner_name(runner_name, account_id)
```

That is the correct fix for the mismatch, and it knowingly left a class behind. From the commit itself:

> A job cancelled while queued has no `runner_name` - nothing ran, so nothing is released; the claiming Pod keeps its slot until it stops (idle timeout -> pod-stop -> `Claims.release_by_pod_name/1`). Note `OrphanedRunnersWorker` cannot reach this class: `Jobs.complete/2` below flips the ClickHouse row to `completed`, and the worker only lists rows still `running` - so the watchdog is what frees it.

So the class was deliberately delegated to the pod-stop watchdog, and the unreachability of `OrphanedRunnersWorker` was already understood.

**The watchdog does not always fire.** `PodLifecycleReconciler` skips the stopped event entirely when the Pod is already gone from the apiserver:

```go
if apierrors.IsNotFound(err) {
    // Pod is fully gone from the apiserver. If we never
    // reported it stopped (controller raced the reap), the
    // server-side max-lifetime safety clamp in
    // `Tuist.Runners.Billing` bounds the over-bill
```

The race is documented and its consequence bounded, but only for **billing**. There is a max-lifetime clamp for over-billing and no equivalent for the concurrency claim, so the same missed event leaks a slot permanently.

That is why this fix reconciles from durable Postgres state rather than trying to make the Kubernetes notification reliable. The notification races a reaper in a different process; a periodic sweep over rows that are already durable does not.

## Timeline

| when (UTC) | what | how confirmed |
|---|---|---|
| 2026-07-15 16:31 | #11836 merges, adding concurrency limits. A leaked claim gains a cost for the first time. | `git log` |
| 2026-07-16 15:57 | #11864 merges, moving release from job-keyed to executor-keyed. | `git log` |
| 2026-07-16 15:57 | That PR's own production deployment run **fails**; the change ships on a later run. | Actions run conclusion |
| 2026-07-16 20:55 | First leaked claim, fleet-wide. | `min(claimed_at)` over stale claims |
| 2026-07-16 -> 07-21 | Leak accumulates silently. Linux absorbs it behind a 256/512 limit; macOS crosses zero headroom. | 12 stale claims across both platforms |

Two honesty notes on that table:

- I could not confirm the exact production deploy time of #11864. Its own run failed, ReplicaSet history in the cluster only reaches 2026-07-19, and the Helm release secrets are not readable with my access. The 15:57 row is the merge, not the deploy.
- The "first leaked claim" row rests on the fix's own premise: nothing reclaims these rows, so the oldest surviving leak is the first leak. Fleet-wide the oldest is 2026-07-16 20:55, which places the start of this class after #11864 merged and not before.

## Approach

Release on completion rows, not on age, and only when the claim has nothing left to run.

A `runner_job_completions` row is proof the job is over. That is what makes it safe to touch `running` claims, which the time-based sweep must never do: a long build legitimately holds its slot for hours, and reaping it would push the account over cap while a runner is still working. Age cannot distinguish those two cases, and a completion row can.

The claimed job alone is not a sufficient signal. GitHub hands a queued job to any label-eligible runner, so the Pod that claimed job A is frequently executing job B. Releasing on A's completion alone would delete a live runner's reservation mid-job, which is the very bug #11864 fixed. The claim is released only when the claimed job and the executed job (when the runner took one) are both complete.

No ClickHouse write and no GitHub call. The job is already terminal on both sides, so there is nothing to requeue or confirm. This is also why the CH-first ordering documented on `Claims.list_stale/1` does not apply: that rule exists so a job can be made claimable again, and these jobs are finished.

The 5 minute threshold is inherited from the existing sweep and only avoids racing the webhook's own release between the completion insert and the delete. It is not the staleness signal.

## Approaches considered

**Delete the rows by hand.** Recovers today and leaves the hole open. Rejected in favour of something that both drains the backlog and prevents recurrence, and that does not require imperative writes against production.

**Extend `OrphanedRunnersWorker` instead.** Its `completed` branch already does the right thing. The problem is reachability, not logic: it is driven by ClickHouse `running` rows and these are not in that set. Fixing it there means changing what drives its scan, which would also make it issue a GitHub API call per row to re-derive something Postgres already knows. Reconciling in Postgres, where both the claim and the completion live, is cheaper and has no external dependency.

**Fix the release path so claims never leak.** Worth doing, but it is a different change and it cannot recover the rows already stranded. This pass is the backstop that makes a missed release self-correcting rather than permanent, and it is worth keeping even after the release path is hardened.

**Bound claims by a maximum age.** Would reap real long-running builds and push accounts over cap. The completion row avoids guessing.

## Validation

- `mix compile --warnings-as-errors` clean, `mix credo --strict` on both touched files reports no issues, formatted
- `mix test test/tuist/runners/ test/tuist/runners_test.exs`: **480 passed**
- Confirmed the new tests are not vacuous: neutering the delete predicate fails the 2 tests that assert removal, while the 3 guard tests that assert non-removal correctly still pass
- Coverage: releases a `running` claim with a recorded completion, leaves a `running` claim without one even at 24h old, respects the grace window, releases several while leaving the live claim untouched, and is a no-op on a clean table

Re-validated against production after adding the executed-job guard: the predicate releases the 12 genuine leaks and protects 4 claims whose runners are executing unfinished jobs, which the first version of this PR would have deleted.

Post-deploy this should show `runners: released claims held past a recorded completion count=12` within a minute, and account 3's macOS headroom should go from 0 to 3 concurrent jobs. The queued Kura darwin builds should then dispatch onto the idle Pods that are already warm.

Related: #11981 stops the autoscaler sizing pools for work a capped account cannot run. This PR is what makes the cap itself honest, and it is the one that recovers the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
