### PR TITLE
fix(server): make documentation cache loading concurrent and bounded

### DIFF
--- a/server/lib/tuist/content_cache.ex
+++ b/server/lib/tuist/content_cache.ex
@@ -3,14 +3,29 @@ defmodule Tuist.ContentCache do
 
   use GenServer
 
+  @default_max_concurrency 4
+  @default_load_timeout to_timeout(minute: 1)
+
+  defmodule LoadError do
+    @moduledoc false
+    defexception [:message]
+  end
+
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    GenServer.start_link(__MODULE__, %{}, name: name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+    %{id: name, start: {__MODULE__, :start_link, [opts]}}
   end
 
   def get(name, key, loader) when is_atom(name) and is_function(loader, 0) do
     if pid = Process.whereis(name) do
-      GenServer.call(pid, {:get, key, loader}, 60_000)
+      pid
+      |> GenServer.call({:get, key, loader}, :infinity)
+      |> unwrap()
     else
       loader.()
     end
@@ -18,34 +33,237 @@ defmodule Tuist.ContentCache do
 
   def reload(name) when is_atom(name) do
     if pid = Process.whereis(name) do
-      GenServer.cast(pid, :reload)
+      GenServer.call(pid, :reload)
+    end
+
+    :ok
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    max_concurrency = Keyword.get(opts, :max_concurrency, @default_max_concurrency)
+    load_timeout = Keyword.get(opts, :load_timeout, @default_load_timeout)
+
+    true = is_integer(max_concurrency) and max_concurrency > 0
+    true = is_integer(load_timeout) and load_timeout > 0
+
+    {:ok,
+     %{
+       generation: 0,
+       load_timeout: load_timeout,
+       loads: %{},
+       max_concurrency: max_concurrency,
+       queue: :queue.new(),
+       running: 0,
+       values: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call({:get, key, loader}, from, state) do
+    case Map.fetch(state.values, key) do
+      {:ok, value} ->
+        {:reply, {:ok, value}, state}
+
+      :error ->
+        state = enqueue_load(state, key, loader, from)
+        {:noreply, start_available_loads(state)}
     end
   end
 
-  @impl true
-  def init(state) do
-    {:ok, state}
+  def handle_call(:reload, _from, state) do
+    state =
+      state
+      |> restart_pending_loads()
+      |> start_available_loads()
+
+    {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:get, key, loader}, _from, state) do
-    case state do
-      %{^key => %{value: value}} ->
-        {:reply, value, state}
+  def handle_info({:content_cache_loaded, key, generation, id, worker, result}, state) do
+    case Map.get(state.loads, key) do
+      %{generation: ^generation, id: ^id, worker: ^worker} = load ->
+        cancel_load_monitoring(load)
+        reply_waiters(load.waiters, result)
+
+        values =
+          case result do
+            {:ok, value} -> Map.put(state.values, key, value)
+            _ -> state.values
+          end
+
+        state = %{state | loads: Map.delete(state.loads, key), running: state.running - 1, values: values}
+        {:noreply, start_available_loads(state)}
 
       _ ->
-        value = loader.()
-        {:reply, value, Map.put(state, key, %{loader: loader, value: value})}
+        {:noreply, state}
     end
   end
 
-  @impl true
-  def handle_cast(:reload, state) do
-    state =
-      Map.new(state, fn {key, %{loader: loader}} ->
-        {key, %{loader: loader, value: loader.()}}
+  def handle_info({:content_cache_timeout, key, generation, id}, state) do
+    case Map.get(state.loads, key) do
+      %{generation: ^generation, id: ^id} = load ->
+        stop_worker(load)
+        reply_waiters(load.waiters, {:error, :timeout})
+
+        running = if load.worker, do: state.running - 1, else: state.running
+        state = %{state | loads: Map.delete(state.loads, key), running: running}
+        {:noreply, start_available_loads(state)}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, monitor, :process, _worker, reason}, state) do
+    case Enum.find(state.loads, fn {_key, load} -> load.monitor == monitor end) do
+      {key, load} ->
+        cancel_timeout(load)
+        reply_waiters(load.waiters, {:error, {:exit, reason}})
+
+        state = %{state | loads: Map.delete(state.loads, key), running: state.running - 1}
+        {:noreply, start_available_loads(state)}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  # Worker monitors report failures; links only ensure workers stop with the cache.
+  def handle_info({:EXIT, _worker, _reason}, state) do
+    {:noreply, state}
+  end
+
+  defp enqueue_load(state, key, loader, from) do
+    case Map.get(state.loads, key) do
+      nil ->
+        id = make_ref()
+
+        timeout =
+          Process.send_after(self(), {:content_cache_timeout, key, state.generation, id}, state.load_timeout)
+
+        load = %{
+          generation: state.generation,
+          id: id,
+          loader: loader,
+          monitor: nil,
+          timeout: timeout,
+          waiters: [from],
+          worker: nil
+        }
+
+        %{state | loads: Map.put(state.loads, key, load), queue: :queue.in(key, state.queue)}
+
+      load ->
+        %{state | loads: Map.put(state.loads, key, %{load | waiters: [from | load.waiters]})}
+    end
+  end
+
+  defp start_available_loads(%{running: running, max_concurrency: max_concurrency} = state)
+       when running >= max_concurrency do
+    state
+  end
+
+  defp start_available_loads(state) do
+    case :queue.out(state.queue) do
+      {{:value, key}, queue} ->
+        state = %{state | queue: queue}
+
+        case Map.get(state.loads, key) do
+          %{worker: nil} = load ->
+            parent = self()
+
+            {worker, monitor} =
+              :erlang.spawn_opt(
+                fn ->
+                  result = run_loader(load.loader)
+                  send(parent, {:content_cache_loaded, key, load.generation, load.id, self(), result})
+                end,
+                [:link, :monitor]
+              )
+
+            load = %{load | monitor: monitor, worker: worker}
+            state = %{state | loads: Map.put(state.loads, key, load), running: state.running + 1}
+            start_available_loads(state)
+
+          _ ->
+            start_available_loads(state)
+        end
+
+      {:empty, _queue} ->
+        state
+    end
+  end
+
+  defp run_loader(loader) do
+    {:ok, loader.()}
+  rescue
+    error -> {:error, {:exception, error, __STACKTRACE__}}
+  catch
+    kind, reason -> {:error, {kind, reason, __STACKTRACE__}}
+  end
+
+  defp restart_pending_loads(state) do
+    Enum.each(state.loads, fn {_key, load} ->
+      cancel_load_monitoring(load)
+
+      if load.worker do
+        Process.exit(load.worker, :kill)
+      end
+    end)
+
+    generation = state.generation + 1
+
+    {loads, queue} =
+      Enum.reduce(state.loads, {%{}, :queue.new()}, fn {key, load}, {loads, queue} ->
+        id = make_ref()
+        timeout = Process.send_after(self(), {:content_cache_timeout, key, generation, id}, state.load_timeout)
+
+        load = %{load | generation: generation, id: id, monitor: nil, timeout: timeout, worker: nil}
+        {Map.put(loads, key, load), :queue.in(key, queue)}
       end)
 
-    {:noreply, state}
+    %{state | generation: generation, loads: loads, queue: queue, running: 0, values: %{}}
+  end
+
+  defp stop_worker(load) do
+    if load.monitor do
+      Process.demonitor(load.monitor, [:flush])
+    end
+
+    if load.worker do
+      Process.exit(load.worker, :kill)
+    end
+  end
+
+  defp cancel_load_monitoring(load) do
+    cancel_timeout(load)
+
+    if load.monitor do
+      Process.demonitor(load.monitor, [:flush])
+    end
+  end
+
+  defp cancel_timeout(load) do
+    if load.timeout do
+      Process.cancel_timer(load.timeout)
+    end
+  end
+
+  defp reply_waiters(waiters, result) do
+    Enum.each(waiters, &GenServer.reply(&1, result))
+  end
+
+  defp unwrap({:ok, value}), do: value
+  defp unwrap({:error, {:exception, error, stack}}), do: reraise(error, stack)
+  defp unwrap({:error, :timeout}), do: raise(LoadError, "Content cache load timed out")
+  defp unwrap({:error, {:exit, reason}}), do: raise(LoadError, "Content cache loader exited: #{inspect(reason)}")
+  defp unwrap({:error, {kind, reason, stack}}), do: raise(LoadError, load_error_message(kind, reason, stack))
+
+  defp load_error_message(kind, reason, stack) do
+    "Content cache load failed with #{kind}: #{Exception.format_banner(kind, reason, stack)}"
   end
 end

--- a/server/lib/tuist/docs/nimble_publisher/cache.ex
+++ b/server/lib/tuist/docs/nimble_publisher/cache.ex
@@ -13,33 +13,33 @@ defmodule Tuist.Docs.NimblePublisher.Cache do
   end
 
   def pages do
-    current().pages
+    ContentCache.get(__MODULE__, :pages, fn ->
+      {pages, _source_paths} = Loader.load_pages!()
+      pages
+    end)
   end
 
   def slugs do
-    ContentCache.get(__MODULE__, :slugs, &Loader.load_slugs!/0)
+    page_sources()
+    |> Map.keys()
+    |> Enum.sort()
   end
 
   def get_page(slug) do
-    ContentCache.get(__MODULE__, {:page, slug}, fn -> Loader.load_page!(slug) end)
+    case Map.fetch(page_sources(), slug) do
+      {:ok, page_source} ->
+        ContentCache.get(__MODULE__, {:page, slug}, fn -> Loader.load_page_source!(page_source) end)
+
+      :error ->
+        nil
+    end
   end
 
   def reload do
     ContentCache.reload(__MODULE__)
   end
 
-  defp current do
-    ContentCache.get(__MODULE__, :docs, &load/0)
-  end
-
-  defp load do
-    {pages, _source_paths} = Loader.load_pages!()
-    pages_by_slug = Map.new(pages, &{&1.slug, &1})
-
-    %{
-      pages: pages,
-      pages_by_slug: pages_by_slug,
-      slugs: pages_by_slug |> Map.keys() |> Enum.sort()
-    }
+  defp page_sources do
+    ContentCache.get(__MODULE__, :page_sources, &Loader.load_page_sources!/0)
   end
 end

--- a/server/lib/tuist/docs_loader.ex
+++ b/server/lib/tuist/docs_loader.ex
@@ -81,37 +81,32 @@ defmodule Tuist.Docs.Loader do
   end
 
   def load_slugs! do
-    docs_slugs =
-      Enum.map(source_paths(), fn source_path ->
-        source_path
-        |> Path.relative_to(docs_root())
-        |> source_to_slug()
-      end)
-
-    example_slugs = Enum.map(example_readmes(), &example_slug/1)
-
-    Enum.sort(docs_slugs ++ example_slugs)
+    load_page_sources!()
+    |> Map.keys()
+    |> Enum.sort()
   end
 
-  def load_page!(slug) do
-    source_path =
-      Enum.find(source_paths(), fn source_path ->
-        source_path
-        |> Path.relative_to(docs_root())
-        |> source_to_slug() == slug
+  def load_page_sources! do
+    page_sources =
+      Map.new(source_paths(), fn source_path ->
+        slug = source_path |> Path.relative_to(docs_root()) |> source_to_slug()
+        {slug, {:page, source_path}}
       end)
 
-    cond do
-      source_path != nil ->
-        build_page!(source_path)
-
-      readme_path = Enum.find(example_readmes(), &(example_slug(&1) == slug)) ->
-        build_example_page!(readme_path)
-
-      true ->
-        nil
-    end
+    Enum.reduce(example_readmes(), page_sources, fn readme_path, page_sources ->
+      Map.put(page_sources, example_slug(readme_path), {:example, readme_path})
+    end)
   end
+
+  def load_page!(slug, page_sources \\ load_page_sources!()) do
+    page_sources
+    |> Map.get(slug)
+    |> load_page_source!()
+  end
+
+  def load_page_source!({:page, source_path}), do: build_page!(source_path)
+  def load_page_source!({:example, readme_path}), do: build_example_page!(readme_path)
+  def load_page_source!(nil), do: nil
 
   def load_example_items! do
     Enum.map(example_readmes(), fn readme_path ->

--- a/server/lib/tuist/docs_loader.ex
+++ b/server/lib/tuist/docs_loader.ex
@@ -88,13 +88,13 @@ defmodule Tuist.Docs.Loader do
 
   def load_page_sources! do
     page_sources =
-      Map.new(source_paths(), fn source_path ->
+      Enum.reduce(source_paths(), %{}, fn source_path, page_sources ->
         slug = source_path |> Path.relative_to(docs_root()) |> source_to_slug()
-        {slug, {:page, source_path}}
+        Map.put_new(page_sources, slug, {:page, source_path})
       end)
 
     Enum.reduce(example_readmes(), page_sources, fn readme_path, page_sources ->
-      Map.put(page_sources, example_slug(readme_path), {:example, readme_path})
+      Map.put_new(page_sources, example_slug(readme_path), {:example, readme_path})
     end)
   end
 

--- a/server/test/tuist/content_cache_test.exs
+++ b/server/test/tuist/content_cache_test.exs
@@ -1,0 +1,188 @@
+defmodule Tuist.ContentCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.ContentCache
+  alias Tuist.ContentCache.LoadError
+
+  setup do
+    {:ok, cache: start_cache()}
+  end
+
+  test "caches loaded values", %{cache: cache} do
+    loads = :counters.new(1, [:atomics])
+
+    loader = fn ->
+      :counters.add(loads, 1, 1)
+      "value"
+    end
+
+    assert ContentCache.get(cache, :key, loader) == "value"
+    assert ContentCache.get(cache, :key, loader) == "value"
+    assert :counters.get(loads, 1) == 1
+  end
+
+  test "caches nil values", %{cache: cache} do
+    loads = :counters.new(1, [:atomics])
+
+    loader = fn ->
+      :counters.add(loads, 1, 1)
+      nil
+    end
+
+    assert ContentCache.get(cache, :missing, loader) == nil
+    assert ContentCache.get(cache, :missing, loader) == nil
+    assert :counters.get(loads, 1) == 1
+  end
+
+  test "shares an in-progress load for the same key", %{cache: cache} do
+    test_process = self()
+
+    loader = fn ->
+      send(test_process, {:loader_started, self()})
+
+      receive do
+        :continue -> "value"
+      end
+    end
+
+    first = Task.async(fn -> ContentCache.get(cache, :key, loader) end)
+    assert_receive {:loader_started, loader_process}
+
+    second = Task.async(fn -> ContentCache.get(cache, :key, loader) end)
+    refute_receive {:loader_started, _}, 100
+
+    send(loader_process, :continue)
+
+    assert Task.await(first) == "value"
+    assert Task.await(second) == "value"
+  end
+
+  test "loads different keys concurrently", %{cache: cache} do
+    test_process = self()
+
+    blocked =
+      Task.async(fn ->
+        ContentCache.get(cache, :blocked, fn ->
+          send(test_process, {:blocked_loader_started, self()})
+
+          receive do
+            :continue -> "blocked"
+          end
+        end)
+      end)
+
+    assert_receive {:blocked_loader_started, blocked_loader}
+
+    assert ContentCache.get(cache, :independent, fn -> "independent" end) == "independent"
+
+    send(blocked_loader, :continue)
+    assert Task.await(blocked) == "blocked"
+  end
+
+  test "bounds concurrent loads for different keys" do
+    cache = start_cache(max_concurrency: 2)
+    test_process = self()
+
+    tasks =
+      Enum.map(1..3, fn index ->
+        Task.async(fn ->
+          ContentCache.get(cache, index, fn ->
+            send(test_process, {:loader_started, index, self()})
+
+            receive do
+              :continue -> index
+            end
+          end)
+        end)
+      end)
+
+    started =
+      Enum.map(1..2, fn _ ->
+        assert_receive {:loader_started, index, loader}
+        {index, loader}
+      end)
+
+    refute_receive {:loader_started, _, _}, 100
+
+    {_index, first_loader} = List.first(started)
+    send(first_loader, :continue)
+    assert_receive {:loader_started, _index, third_loader}
+
+    started
+    |> Enum.drop(1)
+    |> Enum.each(fn {_index, loader} -> send(loader, :continue) end)
+
+    send(third_loader, :continue)
+
+    assert tasks |> Task.await_many() |> Enum.sort() == [1, 2, 3]
+  end
+
+  test "clears values without eagerly reloading them", %{cache: cache} do
+    loads = :counters.new(1, [:atomics])
+
+    loader = fn ->
+      :counters.add(loads, 1, 1)
+      :counters.get(loads, 1)
+    end
+
+    assert ContentCache.get(cache, :key, loader) == 1
+    assert ContentCache.reload(cache) == :ok
+    assert :counters.get(loads, 1) == 1
+    assert ContentCache.get(cache, :key, loader) == 2
+  end
+
+  test "restarts in-progress loads when clearing the cache", %{cache: cache} do
+    test_process = self()
+    loads = :counters.new(1, [:atomics])
+
+    loader = fn ->
+      :counters.add(loads, 1, 1)
+      load = :counters.get(loads, 1)
+      send(test_process, {:loader_started, load, self()})
+
+      receive do
+        :continue -> load
+      end
+    end
+
+    task = Task.async(fn -> ContentCache.get(cache, :key, loader) end)
+    assert_receive {:loader_started, 1, first_loader}
+    first_loader_monitor = Process.monitor(first_loader)
+
+    assert ContentCache.reload(cache) == :ok
+    assert_receive {:loader_started, 2, second_loader}
+    assert_receive {:DOWN, ^first_loader_monitor, :process, ^first_loader, :killed}
+
+    send(second_loader, :continue)
+
+    assert Task.await(task) == 2
+    assert ContentCache.get(cache, :key, loader) == 2
+    assert :counters.get(loads, 1) == 2
+  end
+
+  test "times out a load and releases its key" do
+    cache = start_cache(load_timeout: 25)
+
+    assert_raise LoadError, "Content cache load timed out", fn ->
+      ContentCache.get(cache, :key, fn -> Process.sleep(:infinity) end)
+    end
+
+    assert ContentCache.get(cache, :key, fn -> "recovered" end) == "recovered"
+  end
+
+  test "preserves loader exceptions", %{cache: cache} do
+    assert_raise RuntimeError, "loading failed", fn ->
+      ContentCache.get(cache, :key, fn -> raise "loading failed" end)
+    end
+  end
+
+  test "loads directly when the cache is not running" do
+    assert ContentCache.get(:missing_content_cache, :key, fn -> "value" end) == "value"
+  end
+
+  defp start_cache(opts \\ []) do
+    cache = String.to_atom("content_cache_#{System.unique_integer([:positive])}")
+    start_supervised!({ContentCache, Keyword.put(opts, :name, cache)})
+    cache
+  end
+end

--- a/server/test/tuist/docs_test.exs
+++ b/server/test/tuist/docs_test.exs
@@ -4,6 +4,7 @@ defmodule Tuist.DocsTest do
 
   alias Tuist.Docs
   alias Tuist.Docs.CLI
+  alias Tuist.Docs.NimblePublisher.Cache
   alias Tuist.Docs.Page
 
   describe "get_page/1" do
@@ -77,6 +78,15 @@ defmodule Tuist.DocsTest do
 
       assert page.body =~
                ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
+    end
+
+    test "does not cache missing pages" do
+      slug = "/en/guides/does-not-exist-#{System.unique_integer([:positive])}"
+
+      assert Docs.get_page(slug) == nil
+
+      cache_state = :sys.get_state(Cache)
+      refute Map.has_key?(cache_state.values, {:page, slug})
     end
   end
 

--- a/server/test/tuist/docs_test.exs
+++ b/server/test/tuist/docs_test.exs
@@ -22,6 +22,7 @@ defmodule Tuist.DocsTest do
 
       assert root_page.slug == "/en"
       assert selective_testing_page.slug == "/en/guides/features/selective-testing"
+      assert selective_testing_page.source_path == "en/guides/features/selective-testing.md"
     end
 
     test "loads static CLI documentation pages" do


### PR DESCRIPTION
## What changed

The content cache now runs lazy loaders outside the cache process, shares one in-progress load between requests for the same key, and limits distinct concurrent loads to four. It also applies a one-minute deadline across queueing and execution, preserves loader errors, and ties worker lifetimes to the cache.

Documentation loading now builds a lightweight source index once and renders only the requested page. Missing documentation paths bypass the page cache instead of storing permanent negative entries.

Reloading clears cached values and restarts pending work under a new generation, so work started before a reload cannot restore stale content afterward.

## Why

Documentation should remain lazy without allowing a cold cache or crawler traffic to serialize unrelated requests, start an unbounded number of renderers, or grow memory through unique missing paths.

## Root cause

The previous cache executed each loader inside its single cache process. One slow Markdown render therefore blocked cache hits and unrelated misses behind it, and callers failed after the synchronous 60-second call deadline. Running every distinct miss without coordination would remove that serialization but replace it with unbounded processor and memory pressure.

## Approach

The cache now coordinates a bounded first-in, first-out queue while workers perform the expensive rendering. It keeps same-key request coalescing, gives queued and running loads one shared deadline, and uses generation identifiers during reloads. The documentation cache resolves paths before submitting work, which keeps unknown paths out of the cache and avoids copying the complete source index into each worker.

## Impact

Documentation remains request-driven, so application startup does not render the full site. Cold traffic can make progress across different pages with a fixed resource ceiling, cached pages remain fast, repeated missing paths do not consume page-cache entries, and development reloads cannot publish stale results.

## Validation

- The focused cache and documentation tests passed with 20 tests.
- The broader documentation suite passed with 74 tests.
- The cache concurrency suite passed 70 repeated randomized runs.
- Strict Credo analysis, formatting checks, and the Git whitespace check passed.
- Live local requests returned status 200 for cold and cached documentation pages and status 404 for repeated missing paths. Server processing for the cached page dropped from 358 milliseconds to 6 milliseconds.

### How to test locally

Run:

```sh
cd server
mise exec -- mix test test/tuist/content_cache_test.exs test/tuist/docs_test.exs
```

Then start the server with `mise exec -- mix phx.server` and request `/en/docs/guides/install-tuist` twice. Both requests should return status 200, with the second request served from the page cache. A missing path such as `/en/docs/guides/does-not-exist` should continue to return status 404 without creating a page-cache entry.
