### PR TITLE
fix(server): style the Kura and cache endpoint settings card sections

### DIFF
--- a/server/assets/app/css/pages/account_settings.css
+++ b/server/assets/app/css/pages/account_settings.css
@@ -39,26 +39,97 @@
     & > [data-part="content"] {
       padding: var(--noora-spacing-8);
     }
+  }
 
-    & .noora-modal {
-      & [data-part="body"] {
+  /* Stacked card sections: a header, an action button beside it, and a
+     full-width table underneath. The row layout above centres a single
+     content block next to the header, which would sit the table alongside
+     the title instead of below it. */
+  & > [data-part="kura-servers-card-section"],
+  & > [data-part="cache-endpoints-card-section"] {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    border-radius: var(--noora-radius-8);
+    padding: var(--noora-spacing-0);
+
+    & > [data-part="header"] {
+      display: flex;
+      grid-column: 1;
+      flex-direction: column;
+      gap: var(--noora-spacing-2);
+      padding: var(--noora-spacing-8);
+      min-width: 0;
+
+      /* The cache-endpoints title is nested in a toggle row, the Kura one
+         is a direct child, so match both depths. */
+      & [data-part="title"] {
+        color: var(--noora-surface-label-primary);
+        font: var(--noora-font-weight-medium) var(--noora-font-heading-medium);
+      }
+
+      & > [data-part="subtitle"] {
+        color: var(--noora-surface-label-secondary);
+        font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+      }
+
+      & > [data-part="toggle-row"] {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: var(--noora-spacing-3);
+      }
+    }
+
+    & > [data-part="button-container"] {
+      grid-column: 2;
+      padding: var(--noora-spacing-8);
+    }
+
+    & > [data-part="content"] {
+      grid-column: 1 / -1;
+      padding: 0 var(--noora-spacing-8) var(--noora-spacing-8);
+
+      & > .noora-table {
+        box-sizing: border-box;
+        width: 100%;
+      }
+    }
+
+    @media (max-width: 768px) {
+      & {
+        grid-template-columns: 1fr;
+      }
+
+      & > [data-part="header"] {
+        padding-bottom: var(--noora-spacing-4);
+      }
+
+      & > [data-part="button-container"] {
+        grid-column: 1;
+        padding-top: 0;
+      }
+    }
+  }
+
+  & > [data-part$="card-section"] .noora-modal {
+    & [data-part="body"] {
+      display: flex;
+      flex-direction: column;
+      gap: var(--noora-spacing-8);
+      min-width: 392px;
+
+      @media (max-width: 768px) {
+        & {
+          min-width: 80vw;
+        }
+      }
+
+      & [data-part="content"] {
         display: flex;
         flex-direction: column;
         gap: var(--noora-spacing-8);
-        min-width: 392px;
-
-        @media (max-width: 768px) {
-          & {
-            min-width: 80vw;
-          }
-        }
-
-        & [data-part="content"] {
-          display: flex;
-          flex-direction: column;
-          gap: var(--noora-spacing-8);
-          padding: var(--noora-spacing-8) var(--noora-spacing-2) var(--noora-spacing-9) var(--noora-spacing-2);
-        }
+        padding: var(--noora-spacing-8) var(--noora-spacing-2) var(--noora-spacing-9) var(--noora-spacing-2);
       }
     }
   }


### PR DESCRIPTION
The "Kura cache servers" and "Cache endpoints" sections on the account settings page render unstyled: the section title and its subtitle collapse onto a single line as plain body text, so the heading reads as one run-on sentence ("Kura cache servers Deploy regional Kura cache servers for this account…"). Their modals are unstyled for the same reason.

### What changed

`server/assets/app/css/pages/account_settings.css` targets its card sections through an explicit list of `data-part` names. The page renders seven card sections; the list named five. The two it omitted are exactly the two that render wrong:

- `kura-servers-card-section`
- `cache-endpoints-card-section`

With no rule matching them, their `header` received no layout and the `title` and `subtitle` stayed bare inline `<span>` elements, so they flowed together as body copy. The markup was never at fault. It is the same shape as the "Storage region" card immediately above, which renders correctly.

The shared modal rule was nested inside that same five-section block, so both sections' modals were also unstyled.

This adds a grid rule covering the two sections and lifts the modal rule out to every card section on the page.

### Why

This is the surface used to deploy and tear down regional cache servers for an account, so it is customer-facing and it is also what we look at when provisioning a server during onboarding. A heading that reads as a run-on sentence makes the section hard to scan and looks unfinished.

Beyond the immediate visual bug, the styling was keyed to a hand-maintained allowlist of section names. Any section added to the page renders unstyled unless someone remembers to also edit the stylesheet, with no build or test failure to catch the omission. That is the underlying reason these two were missed.

### Root cause

The selector list at the top of the stylesheet was never updated when the Kura and cache endpoint sections were added to the page. Because the sections still rendered, just without typography or layout, nothing failed loudly.

### Approach

The obvious fix, adding the two names to the existing selector list, is wrong. That rule lays a card out as a row with `align-items: center`, which suits a card whose content is a single control beside the header, such as the region picker. Applied to these sections it would place the servers table alongside the heading rather than beneath it.

So the two sections get their own rule, laid out as a grid:

```
┌─────────────────────────┬──────────────────┐
│ header (title/subtitle) │ button-container │
├─────────────────────────┴──────────────────┤
│ content (full-width table)                 │
└────────────────────────────────────────────┘
```

This puts the action button beside the heading instead of orphaned below it, which is how the cache page already renders its equivalent "Cache servers" card, and collapses to a single column under 768px. The title is matched as a descendant rather than a direct child because the cache endpoints title is nested inside a toggle row while the Kura one is a direct child of the header.

The modal rule moves from the five-section block out to `[data-part$="card-section"]`. That is what fixes the two unstyled modals, and it means a section added later inherits modal styling rather than silently getting none.

### Impact

Visual only. No template, LiveView, or behavior changes, and no change to any other section on the page. The two affected sections gain correct heading typography, the action button moves up beside the heading, and their modals pick up the styling the other sections already had.

### Screenshots

Captured by bundling the stylesheet at each revision and rendering the page's real markup in headless Chrome. The buttons, badges, table, and toggle are rendered by the real Noora stylesheet from the same bundle, not by stand-in styling, so the only thing differing between the two images is this change.

**Before**

![before](https://raw.githubusercontent.com/tuist/tuist/8043afa9db42323cadb478dfb561d7f941d4af29/before.png)

**After**

![after](https://raw.githubusercontent.com/tuist/tuist/8043afa9db42323cadb478dfb561d7f941d4af29/after.png)

The "Storage region" card at the top is included in both as a control, since it was already rendering correctly and is unchanged.

### Validation

- `mix esbuild app` succeeds, and all three rules (`kura-servers-card-section`, `cache-endpoints-card-section`, and the lifted `[data-part$="card-section"] .noora-modal`) are present in the emitted `bundle.css`.
- `prettier --check` passes on the modified stylesheet.
- Verified that all seven card sections on the page end in `card-section`, so the broadened modal selector covers exactly the intended set and adds only the two sections that were previously missing it.

### How to test locally

1. Run the server with `mise run dev` and sign in.
2. Open an organization's settings page at `/<account>/settings`.
3. The "Kura cache servers" section needs a Kura region available in the runtime to appear, which is gated by `TUIST_KURA_AVAILABLE_REGIONS`. Without one, the "Cache endpoints" section below exercises the same rule and shows the same fix.
4. Confirm the section title renders as a heading with the description as a separate secondary line beneath it, the action button sits to the right of the heading, and the table spans the full card width. Narrow the window below 768px to confirm the button drops beneath the heading.
