### PR TITLE
fix(runner-image): install Metal Toolchain in Xcode base images

### DIFF
--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -52,8 +52,9 @@ ghcr.io/tuist/tuist-xcresult-processor:<server-semver>
 ```
 
 Why split this layer out: the Xcode install is ~30 min of work
-(unxip, license accept, runFirstLaunch, downloadAllPlatforms). If
-that lived in the runner-image / xcresult-processor packer files,
+(unxip, license accept, runFirstLaunch, Metal Toolchain, and
+downloadAllPlatforms). If that lived in the runner-image /
+xcresult-processor packer files,
 every `fix(runner-image): ...` commit on main would pay the cost
 again. With the split, Layer 2 builds re-clone Layer 1 and lay a
 thin runtime on top — ~2 min instead of ~30.
@@ -66,6 +67,8 @@ thin runtime on top — ~2 min instead of ~30.
   the same bundle.
 - iOS / tvOS / watchOS / visionOS simulator runtimes from
   `xcodebuild -downloadAllPlatforms`.
+- The Metal compiler toolchain from
+  `xcodebuild -downloadComponent MetalToolchain`.
 - Dev tools via brew: `xcodes`, `xcbeautify`, `swiftformat`,
   `swiftlint`, `swiftgen`, `licenseplist`, `mint`, `carthage`,
   `fastlane`, `cocoapods`, `libimobiledevice`, `ideviceinstaller`,

--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -52,8 +52,8 @@ ghcr.io/tuist/tuist-xcresult-processor:<server-semver>
 ```
 
 Why split this layer out: the Xcode install is ~30 min of work
-(unxip, license accept, runFirstLaunch, Metal Toolchain, and
-downloadAllPlatforms). If that lived in the runner-image /
+(unxip, license accept, runFirstLaunch, downloadAllPlatforms, and
+download Metal Toolchain). If that lived in the runner-image /
 xcresult-processor packer files,
 every `fix(runner-image): ...` commit on main would pay the cost
 again. With the split, Layer 2 builds re-clone Layer 1 and lay a

--- a/infra/macos-xcode-image/macos-xcode.pkr.hcl
+++ b/infra/macos-xcode-image/macos-xcode.pkr.hcl
@@ -157,6 +157,8 @@ build {
   # simulator runtimes at image build so the first job on a fresh
   # VM doesn't pay the runtime download cost. Matches what
   # GitHub-hosted's macos-26 image ships.
+  # `-downloadComponent MetalToolchain` then installs the optional
+  # Metal compiler toolchain required by Xcode 26 and newer.
   #
   # `echo 'admin' | sudo -S` on the first sudo call primes the
   # admin sudo timestamp cache; subsequent bare `sudo` calls in
@@ -176,6 +178,7 @@ build {
       "sudo xcodebuild -license accept",
       "sudo xcodebuild -runFirstLaunch",
       "sudo xcodebuild -downloadAllPlatforms",
+      "sudo xcodebuild -downloadComponent MetalToolchain",
       "/usr/bin/xcrun xcresulttool version || (echo 'xcresulttool not reachable after install' >&2 && exit 1)"
     ]
   }
@@ -252,8 +255,9 @@ build {
       # $PATH directly — it's reached via `xcrun xcresulttool`.
       # The `command -v` loop above checks `xcrun`'s presence;
       # the line below proves `xcrun` can actually resolve
-      # xcresulttool against the active developer dir.
-      "/bin/zsh -lc '/usr/bin/xcrun xcresulttool version'"
+      # Xcode tools against the active developer dir.
+      "/bin/zsh -lc '/usr/bin/xcrun xcresulttool version'",
+      "/bin/zsh -lc '/usr/bin/xcrun metal --version'"
     ]
   }
 }


### PR DESCRIPTION
## Why

Xcode 16 and earlier bundled the Metal compiler toolchain. [Starting with Xcode 26](https://developer.apple.com/documentation/updates/xcode), Apple made it an optional component downloaded only when needed. Tuist's macOS Xcode base image downloads platform runtimes but not this component, so jobs compiling `.metal` files fail because Xcode cannot execute `metal`.

## What changed

- Run `sudo xcodebuild -downloadComponent MetalToolchain` after downloading all platform runtimes.
- Fail the Packer build unless `xcrun metal --version` can execute the installed compiler.
- Record the component in the Layer 1 image inventory.

The runner and xcresult processor images both inherit this Layer 1 image, so their newly built VMs receive the toolchain without downloading it during jobs. Existing published images remain unchanged until rebuilt.

## Before merging

- [ ] Run the Xcode 26.6 Layer 1 build on a bare-metal `vm-image-builder`, confirm the Metal smoke check passes, and verify the refreshed Tart image publishes successfully.

## Validation

- `packer fmt -check -diff infra/macos-xcode-image/macos-xcode.pkr.hcl`
- `packer validate -syntax-only infra/macos-xcode-image/macos-xcode.pkr.hcl`
- `git diff --check`
- Confirmed Xcode 26 supports the component download and `xcrun metal --version` executes the locally installed compiler.