### PR TITLE
test(cli): stabilize package trait encoding assertion

### DIFF
--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Package+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Package+ManifestMapperTests.swift
@@ -257,7 +257,9 @@ struct PackageManifestMapperTests {
             path: "Package",
             traits: ["FeatureA", "FeatureB"]
         )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
 
-        #expect(try JSONEncoder().encode(first) == JSONEncoder().encode(second))
+        #expect(try encoder.encode(first) == encoder.encode(second))
     }
 }


### PR DESCRIPTION
## What changed

The package trait encoding test now configures Swift's `JSONEncoder`, the [JavaScript Object Notation](https://www.json.org/json-en.html) encoder, to sort object keys before comparing encoded bytes.

## Why

The test failed repeatedly in GitHub Actions even though package traits were already serialized deterministically. Its assertion also depended on the unrelated ordering of nested object keys.

## Root cause

The test reversed the trait inputs and compared the raw encoded bytes produced by a default encoder. Trait ordering was normalized correctly, but object key ordering is not guaranteed, so equivalent nested values could produce different byte sequences.

## Approach

The reversed trait inputs remain unchanged, preserving the behavior under test. Sorting encoded object keys removes the unrelated source of nondeterminism and matches the production dependency hashing path.

## Impact

There is no production behavior change. The test now fails only when package trait encoding becomes nondeterministic.

## Validation

- The affected test passed 50 consecutive runs with `xcodebuild test-without-building`.
- The complete `PackageManifestMapperTests` suite passed all 11 tests.
- `mise run cli:lint` passed.
