### PR TITLE
fix(server): harden dashboard rate limiting

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -1207,16 +1207,30 @@ defmodule Tuist.Environment do
   end
 
   @doc """
+  Returns the bucket size for the dashboard route rate limiter.
+
+  The default values are:
+  - 300 requests per route for canary environments
+  - 60 requests per route for other environments (production, staging, dev)
+  """
+  def dashboard_rate_limit_bucket_size(secrets \\ secrets()) do
+    case get([:dashboard_rate_limit, :bucket_size], secrets) do
+      bucket_size when is_binary(bucket_size) -> String.to_integer(bucket_size)
+      _ -> if can?(), do: 300, else: 60
+    end
+  end
+
+  @doc """
   Returns the bucket size for the MCP rate limiter.
 
   The default values are:
-  - 600 requests for canary environments
-  - 120 requests for other environments (production, staging, dev)
+  - 300 requests for canary environments
+  - 60 requests for other environments (production, staging, dev)
   """
   def mcp_rate_limit_bucket_size(secrets \\ secrets()) do
     case get([:mcp_rate_limit, :bucket_size], secrets) do
       bucket_size when is_binary(bucket_size) -> String.to_integer(bucket_size)
-      _ -> if can?(), do: 600, else: 120
+      _ -> if can?(), do: 300, else: 60
     end
   end
 

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -1224,13 +1224,13 @@ defmodule Tuist.Environment do
   Returns the bucket size for the MCP rate limiter.
 
   The default values are:
-  - 300 requests for canary environments
-  - 60 requests for other environments (production, staging, dev)
+  - 600 requests for canary environments
+  - 120 requests for other environments (production, staging, dev)
   """
   def mcp_rate_limit_bucket_size(secrets \\ secrets()) do
     case get([:mcp_rate_limit, :bucket_size], secrets) do
       bucket_size when is_binary(bucket_size) -> String.to_integer(bucket_size)
-      _ -> if can?(), do: 300, else: 60
+      _ -> if can?(), do: 600, else: 120
     end
   end
 

--- a/server/lib/tuist_web/rate_limit/in_memory.ex
+++ b/server/lib/tuist_web/rate_limit/in_memory.ex
@@ -49,12 +49,14 @@ defmodule TuistWeb.RateLimit.InMemory do
     end
   end
 
-  def rate_limit(%Plug.Conn{} = conn, _opts) do
+  def rate_limit(%Plug.Conn{} = conn, opts) do
     if Environment.tuist_hosted?() do
       scale_ms = to_timeout(minute: 1)
-      limit = 1_000
+      limit = opts[:limit] || Environment.dashboard_rate_limit_bucket_size()
+      route = route_pattern(conn)
+      key = "dashboard:#{conn.method}:#{route}:ip:#{TuistWeb.RemoteIp.get(conn)}"
 
-      case hit(TuistWeb.RemoteIp.get(conn), scale_ms, limit) do
+      case hit(key, scale_ms, limit) do
         {:allow, _count} ->
           conn
 
@@ -64,6 +66,19 @@ defmodule TuistWeb.RateLimit.InMemory do
       end
     else
       conn
+    end
+  end
+
+  defp route_pattern(conn) do
+    case conn.private[:phoenix_router] do
+      nil ->
+        conn.request_path
+
+      router ->
+        case Phoenix.Router.route_info(router, conn.method, conn.path_info, conn.host) do
+          %{route: route} -> route
+          :error -> conn.request_path
+        end
     end
   end
 

--- a/server/lib/tuist_web/rate_limit/in_memory.ex
+++ b/server/lib/tuist_web/rate_limit/in_memory.ex
@@ -7,6 +7,8 @@ defmodule TuistWeb.RateLimit.InMemory do
   broadcasting mechanism to keep counters in sync across nodes in a cluster.
   """
   alias Tuist.Environment
+  alias TuistWeb.Authentication
+  alias TuistWeb.RemoteIp
 
   defmodule Local do
     @moduledoc false
@@ -31,7 +33,7 @@ defmodule TuistWeb.RateLimit.InMemory do
     def start_link(opts) do
       pubsub = Keyword.fetch!(opts, :pubsub)
       topic = Keyword.fetch!(opts, :topic)
-      GenServer.start_link(__MODULE__, {pubsub, topic})
+      GenServer.start_link(__MODULE__, {pubsub, topic}, name: __MODULE__)
     end
 
     @impl true
@@ -54,7 +56,7 @@ defmodule TuistWeb.RateLimit.InMemory do
       scale_ms = to_timeout(minute: 1)
       limit = opts[:limit] || Environment.dashboard_rate_limit_bucket_size()
       route = route_pattern(conn)
-      key = "dashboard:#{conn.method}:#{route}:ip:#{TuistWeb.RemoteIp.get(conn)}"
+      key = "dashboard:#{conn.method}:#{route}:#{requester_key(conn)}"
 
       case hit(key, scale_ms, limit) do
         {:allow, _count} ->
@@ -66,6 +68,13 @@ defmodule TuistWeb.RateLimit.InMemory do
       end
     else
       conn
+    end
+  end
+
+  defp requester_key(conn) do
+    case Authentication.current_user(conn) do
+      %{id: id} -> "user:#{id}"
+      nil -> "ip:#{RemoteIp.get(conn)}"
     end
   end
 
@@ -87,7 +96,8 @@ defmodule TuistWeb.RateLimit.InMemory do
 
   # Sends a message to other nodes in the cluster to synchronize rate-limiting information.
   defp broadcast(message) do
-    Phoenix.PubSub.broadcast(@pubsub, @topic, message)
+    listener = Process.whereis(Listener)
+    Phoenix.PubSub.broadcast_from(@pubsub, listener, @topic, message)
   end
 
   def child_spec(opts) do

--- a/server/lib/tuist_web/remote_ip.ex
+++ b/server/lib/tuist_web/remote_ip.ex
@@ -3,13 +3,54 @@ defmodule TuistWeb.RemoteIp do
   A module that provides functions for getting the remote IP address.
 
   Originally taken from: https://websymphony.net/blog/how-to-get-remote-ip-from-x-forwarded-for-in-phoenix/
+
+  Cloudflare ranges mirror https://www.cloudflare.com/ips/ so the connecting header is only
+  accepted from Cloudflare or from the trusted private ingress directly behind it.
   """
 
+  import Bitwise
+
+  @cloudflare_ranges [
+    {{173, 245, 48, 0}, 20},
+    {{103, 21, 244, 0}, 22},
+    {{103, 22, 200, 0}, 22},
+    {{103, 31, 4, 0}, 22},
+    {{141, 101, 64, 0}, 18},
+    {{108, 162, 192, 0}, 18},
+    {{190, 93, 240, 0}, 20},
+    {{188, 114, 96, 0}, 20},
+    {{197, 234, 240, 0}, 22},
+    {{198, 41, 128, 0}, 17},
+    {{162, 158, 0, 0}, 15},
+    {{104, 16, 0, 0}, 13},
+    {{104, 24, 0, 0}, 14},
+    {{172, 64, 0, 0}, 13},
+    {{131, 0, 72, 0}, 22},
+    {{0x2400, 0xCB00, 0, 0, 0, 0, 0, 0}, 32},
+    {{0x2606, 0x4700, 0, 0, 0, 0, 0, 0}, 32},
+    {{0x2803, 0xF800, 0, 0, 0, 0, 0, 0}, 32},
+    {{0x2405, 0xB500, 0, 0, 0, 0, 0, 0}, 32},
+    {{0x2405, 0x8100, 0, 0, 0, 0, 0, 0}, 32},
+    {{0x2A06, 0x98C0, 0, 0, 0, 0, 0, 0}, 29},
+    {{0x2C0F, 0xF248, 0, 0, 0, 0, 0, 0}, 32}
+  ]
+
   def get(conn) do
-    cloudflare_ip = header(conn, "cf-connecting-ip")
-    forwarded_ip = conn |> header("x-forwarded-for") |> first_forwarded_ip()
+    forwarded_for = header(conn, "x-forwarded-for")
+    cloudflare_ip = cloudflare_ip(conn, forwarded_for)
+    forwarded_ip = first_forwarded_ip(forwarded_for)
 
     cloudflare_ip || forwarded_ip || format_ip(conn.remote_ip)
+  end
+
+  defp cloudflare_ip(conn, forwarded_for) do
+    with value when not is_nil(value) <- header(conn, "cf-connecting-ip"),
+         {:ok, address} <- parse_address(value),
+         true <- trusted_cloudflare_hop?(conn.remote_ip, forwarded_for) do
+      format_ip(address)
+    else
+      _ -> nil
+    end
   end
 
   defp header(conn, name) do
@@ -27,14 +68,71 @@ defmodule TuistWeb.RemoteIp do
 
   defp first_forwarded_ip(forwarded_for) do
     forwarded_for
-    |> String.split(",")
-    |> Enum.find_value(fn value ->
-      case String.trim(value) do
-        "" -> nil
-        value -> value
-      end
-    end)
+    |> forwarded_ips()
+    |> List.first()
   end
+
+  defp trusted_cloudflare_hop?(peer_address, forwarded_for) do
+    cloudflare_address?(peer_address) or
+      (private_address?(peer_address) and cloudflare_address?(last_forwarded_ip(forwarded_for)))
+  end
+
+  defp last_forwarded_ip(nil), do: nil
+  defp last_forwarded_ip(forwarded_for), do: forwarded_for |> forwarded_ips() |> List.last()
+
+  defp forwarded_ips(forwarded_for) do
+    forwarded_for
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp parse_address(value), do: :inet.parse_address(String.to_charlist(value))
+
+  defp cloudflare_address?(nil), do: false
+
+  defp cloudflare_address?(address) when is_binary(address) do
+    case parse_address(address) do
+      {:ok, parsed_address} -> cloudflare_address?(parsed_address)
+      {:error, _reason} -> false
+    end
+  end
+
+  defp cloudflare_address?(address) do
+    Enum.any?(@cloudflare_ranges, &address_in_range?(address, &1))
+  end
+
+  defp address_in_range?(address, {network, prefix}) do
+    with {address_integer, bits} <- address_to_integer(address),
+         {network_integer, ^bits} <- address_to_integer(network) do
+      address_integer >>> (bits - prefix) == network_integer >>> (bits - prefix)
+    else
+      _ -> false
+    end
+  end
+
+  defp address_to_integer(address) when tuple_size(address) == 4 do
+    integer = Enum.reduce(Tuple.to_list(address), 0, fn octet, acc -> acc <<< 8 ||| octet end)
+    {integer, 32}
+  end
+
+  defp address_to_integer(address) when tuple_size(address) == 8 do
+    integer = Enum.reduce(Tuple.to_list(address), 0, fn segment, acc -> acc <<< 16 ||| segment end)
+    {integer, 128}
+  end
+
+  defp address_to_integer(_address), do: :error
+
+  defp private_address?({10, _, _, _}), do: true
+  defp private_address?({127, _, _, _}), do: true
+  defp private_address?({169, 254, _, _}), do: true
+  defp private_address?({172, second, _, _}) when second in 16..31, do: true
+  defp private_address?({192, 168, _, _}), do: true
+  defp private_address?({100, second, _, _}) when second in 64..127, do: true
+  defp private_address?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp private_address?({first, _, _, _, _, _, _, _}) when first in 0xFC00..0xFDFF, do: true
+  defp private_address?({first, _, _, _, _, _, _, _}) when first in 0xFE80..0xFEBF, do: true
+  defp private_address?(_address), do: false
 
   defp format_ip(ip), do: ip |> :inet_parse.ntoa() |> to_string()
 end

--- a/server/lib/tuist_web/remote_ip.ex
+++ b/server/lib/tuist_web/remote_ip.ex
@@ -6,20 +6,35 @@ defmodule TuistWeb.RemoteIp do
   """
 
   def get(conn) do
-    forwarded_for =
-      conn
-      |> Plug.Conn.get_req_header("x-forwarded-for")
-      |> List.first()
+    cloudflare_ip = header(conn, "cf-connecting-ip")
+    forwarded_ip = conn |> header("x-forwarded-for") |> first_forwarded_ip()
 
-    if forwarded_for do
-      forwarded_for
-      |> String.split(",")
-      |> Enum.map(&String.trim/1)
-      |> List.first()
-    else
-      conn.remote_ip
-      |> :inet_parse.ntoa()
-      |> to_string()
-    end
+    cloudflare_ip || forwarded_ip || format_ip(conn.remote_ip)
   end
+
+  defp header(conn, name) do
+    conn
+    |> Plug.Conn.get_req_header(name)
+    |> Enum.find_value(fn value ->
+      case String.trim(value) do
+        "" -> nil
+        value -> value
+      end
+    end)
+  end
+
+  defp first_forwarded_ip(nil), do: nil
+
+  defp first_forwarded_ip(forwarded_for) do
+    forwarded_for
+    |> String.split(",")
+    |> Enum.find_value(fn value ->
+      case String.trim(value) do
+        "" -> nil
+        value -> value
+      end
+    end)
+  end
+
+  defp format_ip(ip), do: ip |> :inet_parse.ntoa() |> to_string()
 end

--- a/server/test/tuist_web/rate_limit/in_memory_test.exs
+++ b/server/test/tuist_web/rate_limit/in_memory_test.exs
@@ -3,8 +3,11 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
   use Mimic
 
   alias Hammer.ETS.FixWindow
+  alias Tuist.Accounts.User
   alias Tuist.Environment
+  alias TuistWeb.Authentication
   alias TuistWeb.RateLimit.InMemory
+  alias TuistWeb.RemoteIp
 
   describe "rate_limit/2" do
     test "allows the request when the rate limit is not reached" do
@@ -42,6 +45,29 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
       end
     end
 
+    test "uses the authenticated user in the key" do
+      # Given
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      Mimic.reject(&RemoteIp.get/1)
+
+      expect(FixWindow, :hit, fn _table, "dashboard:GET:/:account_handle:user:123", _window, 60, 1 ->
+        {:allow, 1}
+      end)
+
+      conn =
+        :get
+        |> build_conn("/tuist")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Authentication.put_current_user(%User{id: 123})
+
+      # When
+      got = InMemory.rate_limit(conn, %{})
+
+      # Then
+      assert conn == got
+    end
+
     test "allows a route-specific limit override" do
       # Given
       expect(Environment, :tuist_hosted?, fn -> true end)
@@ -68,6 +94,21 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
 
       # Then
       assert conn == got
+    end
+  end
+
+  describe "hit/4" do
+    test "counts a hit once on the serving node" do
+      # Given
+      key = "local-hit-#{System.unique_integer([:positive])}"
+      scale = to_timeout(minute: 1)
+
+      # When
+      assert {:allow, 1} = InMemory.hit(key, scale, 10)
+      :sys.get_state(InMemory.Listener)
+
+      # Then
+      assert {:allow, 2} = InMemory.Local.hit(key, scale, 10)
     end
   end
 end

--- a/server/test/tuist_web/rate_limit/in_memory_test.exs
+++ b/server/test/tuist_web/rate_limit/in_memory_test.exs
@@ -10,8 +10,17 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
     test "allows the request when the rate limit is not reached" do
       # Given
       expect(Environment, :tuist_hosted?, fn -> true end)
-      expect(FixWindow, :hit, fn _table, _ip, _window, _limit, _increment -> {:allow, 1} end)
-      conn = build_conn()
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+
+      expect(FixWindow, :hit, fn
+        _table, "dashboard:GET:/:account_handle/:project_handle/bundles/:bundle_id:ip:127.0.0.1", _window, 60, 1 ->
+          {:allow, 1}
+      end)
+
+      conn =
+        :get
+        |> build_conn("/tuist/ios_app_with_frameworks/bundles/01973a7f")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
 
       # When
       got = InMemory.rate_limit(conn, %{})
@@ -23,13 +32,28 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
     test "raises TooManyRequestsError when the rate limit is reached" do
       # Given
       expect(Environment, :tuist_hosted?, fn -> true end)
-      expect(FixWindow, :hit, fn _table, _ip, _window, _limit, _increment -> {:deny, 1} end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      expect(FixWindow, :hit, fn _table, _key, _window, 60, _increment -> {:deny, 1} end)
       conn = build_conn()
 
       # When
       assert_raise TuistWeb.Errors.TooManyRequestsError, fn ->
         InMemory.rate_limit(conn, %{})
       end
+    end
+
+    test "allows a route-specific limit override" do
+      # Given
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      Mimic.reject(&Environment.dashboard_rate_limit_bucket_size/0)
+      expect(FixWindow, :hit, fn _table, _key, _window, 10, _increment -> {:allow, 1} end)
+      conn = build_conn()
+
+      # When
+      got = InMemory.rate_limit(conn, limit: 10)
+
+      # Then
+      assert conn == got
     end
 
     test "does not check rate limit when on premise" do

--- a/server/test/tuist_web/remote_ip_test.exs
+++ b/server/test/tuist_web/remote_ip_test.exs
@@ -5,18 +5,60 @@ defmodule TuistWeb.RemoteIpTest do
   describe "get/1" do
     test "prefers the Cloudflare connecting IP header" do
       # Given
-      conn = build_conn()
-
       conn =
-        conn
-        |> Plug.Conn.put_req_header("cf-connecting-ip", " cloudflare-ip ")
-        |> Plug.Conn.put_req_header("x-forwarded-for", "spoofed-ip, forwarded-ip")
+        build_conn()
+        |> Plug.Conn.put_req_header("cf-connecting-ip", " 203.0.113.10 ")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "spoofed-ip, 173.245.48.10")
 
       # When
       got = TuistWeb.RemoteIp.get(conn)
 
       # Then
-      assert got == "cloudflare-ip"
+      assert got == "203.0.113.10"
+    end
+
+    test "prefers the Cloudflare header when directly connected to a Cloudflare IPv6 address" do
+      # Given
+      conn =
+        build_conn()
+        |> Map.put(:remote_ip, {0x2606, 0x4700, 0, 0, 0, 0, 0, 1})
+        |> Plug.Conn.put_req_header("cf-connecting-ip", "2001:db8::1")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "spoofed-ip")
+
+      # When
+      got = TuistWeb.RemoteIp.get(conn)
+
+      # Then
+      assert got == "2001:db8::1"
+    end
+
+    test "ignores the Cloudflare header from an untrusted hop" do
+      # Given
+      conn =
+        build_conn()
+        |> Map.put(:remote_ip, {203, 0, 113, 20})
+        |> Plug.Conn.put_req_header("cf-connecting-ip", "198.51.100.10")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "forwarded-ip, 198.51.100.20")
+
+      # When
+      got = TuistWeb.RemoteIp.get(conn)
+
+      # Then
+      assert got == "forwarded-ip"
+    end
+
+    test "ignores an invalid Cloudflare address from a trusted hop" do
+      # Given
+      conn =
+        build_conn()
+        |> Plug.Conn.put_req_header("cf-connecting-ip", "not-an-ip")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "forwarded-ip, 173.245.48.10")
+
+      # When
+      got = TuistWeb.RemoteIp.get(conn)
+
+      # Then
+      assert got == "forwarded-ip"
     end
 
     test "falls back to the first forwarded IP when the Cloudflare header is not present" do

--- a/server/test/tuist_web/remote_ip_test.exs
+++ b/server/test/tuist_web/remote_ip_test.exs
@@ -3,10 +3,26 @@ defmodule TuistWeb.RemoteIpTest do
   use Mimic
 
   describe "get/1" do
-    test "gets ip from the forwarder-for header when there's only one" do
+    test "prefers the Cloudflare connecting IP header" do
       # Given
       conn = build_conn()
-      conn = Plug.Conn.put_req_header(conn, "x-forwarded-for", "ip-one")
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("cf-connecting-ip", " cloudflare-ip ")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "spoofed-ip, forwarded-ip")
+
+      # When
+      got = TuistWeb.RemoteIp.get(conn)
+
+      # Then
+      assert got == "cloudflare-ip"
+    end
+
+    test "falls back to the first forwarded IP when the Cloudflare header is not present" do
+      # Given
+      conn = build_conn()
+      conn = Plug.Conn.put_req_header(conn, "x-forwarded-for", " ip-one, ip-two")
 
       # When
       got = TuistWeb.RemoteIp.get(conn)
@@ -15,19 +31,21 @@ defmodule TuistWeb.RemoteIpTest do
       assert got == "ip-one"
     end
 
-    test "gets ip from the forwarder-for header when there are multiple" do
+    test "ignores empty forwarding headers" do
       # Given
-      conn = build_conn()
-      conn = Plug.Conn.put_req_header(conn, "x-forwarded-for", "ip-one, ip-two")
+      conn =
+        build_conn()
+        |> Plug.Conn.put_req_header("cf-connecting-ip", "  ")
+        |> Plug.Conn.put_req_header("x-forwarded-for", " , ip-two")
 
       # When
       got = TuistWeb.RemoteIp.get(conn)
 
       # Then
-      assert got == "ip-one"
+      assert got == "ip-two"
     end
 
-    test "gets default value when the x-forwarded-for headre is not present" do
+    test "gets the connection address when forwarding headers are not present" do
       # Given
       conn = build_conn()
 


### PR DESCRIPTION
The server now accepts Cloudflare's `CF-Connecting-IP` header only when it contains a valid client Internet Protocol address and the request arrived directly from Cloudflare or through the trusted private ingress with a final Cloudflare hop. Requests outside that trust boundary continue to fall back to `X-Forwarded-For` and then the connection address. See [Cloudflare's request header reference](https://developers.cloudflare.com/fundamentals/reference/http-headers/) and [published network ranges](https://www.cloudflare.com/ips/) for the source data.

Dashboard limits are scoped to the matched route pattern, request method, and requester. Authenticated requests use the current user identifier, while anonymous requests use the client address. Hosted production, staging, and development environments allow 60 requests per route and minute, while canary allows 300. Individual routes can override that default.

The [Model Context Protocol](https://modelcontextprotocol.io) retains its separate defaults of 120 requests per minute and 600 in canary because concurrent authenticated sessions share a subject-level bucket.

A crawler could overwhelm a public dashboard route because the application trusted the first `X-Forwarded-For` value, which a client can influence when Cloudflare appends its own value. The previous shared ceiling of 1,000 requests per minute also did not reflect the lower request volume expected from human-facing dashboard routes.

Cross-server counters remain eventually consistent. The cluster broadcast now excludes the local listener, preventing the serving node from counting the same request once from the broadcast and again from the direct hit.

### How to test locally

From `server/`:

```sh
mise exec -- mix test test/tuist_web/remote_ip_test.exs test/tuist_web/rate_limit/in_memory_test.exs test/tuist_web/rate_limit/mcp_test.exs
```

The targeted suite passes with 17 tests and no failures. `git diff --check` also passes.
