### PR TITLE
chore(kura): add public cache benchmark harness

### DIFF
--- a/.github/workflows/kura-cache-benchmark.yml
+++ b/.github/workflows/kura-cache-benchmark.yml
@@ -1,0 +1,69 @@
+name: Kura Cache Benchmark
+
+# Manually-dispatched Kura CAS benchmark (with an optional legacy A/B), run from a
+# GitHub-hosted runner. It hits Kura's public customer endpoint — the same path an
+# external CLI takes — from a datacenter-grade uplink, so throughput isn't bounded
+# by a laptop link. Note: in-cluster runners (tuist-linux) can't reach the box's
+# public endpoint (cluster egress to the box's public IP is blocked; in-cluster
+# cache clients use the private path instead), so this runs on ubuntu-latest.
+# See kura/benchmarks/cas_ab.sh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sizes_mb:
+        description: "Throughput blob sizes in MB, space-separated (each <= 24; CAS cap is 25MB)"
+        default: "1 8 24"
+      iters:
+        description: "Iterations per size for the throughput medians"
+        default: "6"
+      parallel:
+        description: "Concurrent streams for the aggregate-throughput probe"
+        default: "16"
+      latency_kb:
+        description: "Object size (KB) for the latency sweep"
+        default: "256"
+      legacy_url:
+        description: "Legacy cache base URL to A/B against (blank to benchmark Kura alone)"
+        default: ""
+      server_url:
+        description: "Tuist server the cache config and login resolve against"
+        default: "https://staging.tuist.dev"
+      full_handle:
+        description: "account/project the cache token is minted for"
+        default: "tuist/tuist"
+
+permissions:
+  contents: read
+  id-token: write # tuist auth login uses GitHub OIDC on CI runners
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_APP_GITHUB_TOKEN || github.token }}
+  MISE_GITHUB_ATTESTATIONS: 0
+
+concurrency:
+  group: kura-cache-benchmark-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: CAS A/B (Kura vs legacy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Run CAS A/B benchmark
+        env:
+          SIZES_MB: ${{ inputs.sizes_mb }}
+          ITERS: ${{ inputs.iters }}
+          PARALLEL: ${{ inputs.parallel }}
+          LATENCY_KB: ${{ inputs.latency_kb }}
+          BENCH_LEGACY_URL: ${{ inputs.legacy_url }}
+          BENCH_SERVER_URL: ${{ inputs.server_url }}
+          FULL_HANDLE: ${{ inputs.full_handle }}
+        run: bash kura/benchmarks/cas_ab.sh

--- a/kura/benchmarks/README.md
+++ b/kura/benchmarks/README.md
@@ -1,0 +1,38 @@
+# Kura cache benchmarks
+
+## `cas_ab.sh` — Kura vs legacy CAS A/B
+
+Compares the Kura cache (bare-metal, local-NVMe content-addressed store) against
+the legacy Kamal cache (S3 write-through) over the real customer HTTP plane, using
+the shared `/api/cache/cas/{id}` contract both implement.
+
+It measures three things:
+
+- **Hit latency** — small-object `GET` p50/p90/p99, warm (reused connection) and
+  cold (fresh TLS per request).
+- **Single-stream throughput** — `POST`/`GET` MB/s medians across a few blob sizes.
+- **Aggregate throughput** — many parallel streams, to find the real ceiling that a
+  single latency-bound stream hides.
+
+The aggregate probe reports successful transfer counts and response-code
+distributions alongside throughput. Failed requests therefore do not inflate the
+transferred-byte total, and controlled load shedding stays distinguishable from
+transport failures. Its download phase reads a separately seeded object, keeping
+read saturation independent from any rejected parallel uploads.
+
+Endpoints and auth are resolved from `tuist cache config` (the `kura` client feature
+flag selects the Kura endpoint; its absence selects legacy), so nothing is hardcoded.
+
+Run it via the `Kura Cache Benchmark` workflow (`.github/workflows/kura-cache-benchmark.yml`),
+which dispatches on `ubuntu-latest`. It hits Kura's **public customer endpoint** — the same
+path an external CLI takes — from a datacenter-grade uplink. (In-cluster `tuist-linux` runners
+can't reach the box's public IP: cluster egress to it is blocked, and in-cluster cache clients
+use the private path instead.) Results are written to the workflow job summary.
+
+Note the CI runner's distance to a region skews absolute latency/throughput; the A/B between
+the two backends from the same runner is the meaningful signal. For absolute numbers, run from
+a host close to the target region.
+
+It writes content-addressed junk blobs into the resolved account's **production** cache
+on both backends (modest volume, reclaimed by normal retention), so it is a manual,
+operator-run benchmark, not part of the automated suite.

--- a/kura/benchmarks/cas_ab.sh
+++ b/kura/benchmarks/cas_ab.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# Kura CAS benchmark (absolute performance, from an in-network runner), with an
+# optional A/B against the legacy Kamal cache.
+#
+# It exercises the /api/cache/cas/{id} contract: POST stores an object under an
+# opaque id (no server-side hash check), GET reads it back. Fresh random bytes per
+# PUT avoid dedup, so PUTs measure real writes.
+#
+# The auth token + Kura endpoint come from `tuist cache config` (the account is
+# routed to Kura server-side). The same account-scoped token also authorizes the
+# legacy backend, so if BENCH_LEGACY_URL is set the script benchmarks it too for a
+# side-by-side — otherwise it reports Kura alone. Primary question: is Kura as fast
+# as we expect from inside our network (saturates the pipe, low hit latency)?
+#
+# This writes junk blobs into the account's PRODUCTION cache (content-addressed,
+# modest volume, reclaimed by normal retention). Operator-run benchmark, not part
+# of the automated suite.
+#
+# Tunables (env):
+#   SIZES_MB         throughput blob sizes, space separated, each <= 24            [1 8 24]
+#   ITERS            iterations per size for the medians                           [6]
+#   PARALLEL         concurrent streams for the aggregate-throughput probe         [16]
+#   LATENCY_KB       object size for the latency sweep                             [256]
+#   BENCH_LEGACY_URL legacy cache base URL to A/B against ("" to skip)             [https://cache-eu-central.tuist.dev]
+#   FULL_HANDLE      account/project the cache token is minted for                 [tuist/tuist]
+set -uo pipefail
+
+SIZES_MB=${SIZES_MB:-"1 8 24"}
+ITERS=${ITERS:-6}
+PARALLEL=${PARALLEL:-16}
+LATENCY_KB=${LATENCY_KB:-256}
+LEGACY_URL=${BENCH_LEGACY_URL-https://cache-eu-central.tuist.dev}
+[ "$LEGACY_URL" = none ] && LEGACY_URL=""   # sentinel to benchmark Kura alone
+
+# The tuist-linux runner ships the repo's mise dev environment, which points the CLI
+# at a local dev server. Neutralize it so auth + cache config target production.
+unset TUIST_SERVER_URL TUIST_URL TUIST_CACHE_SERVER_URL TUIST_CONFIG_URL TUIST_CACHE_CONFIG_SERVER_URL 2>/dev/null || true
+FULL_HANDLE=${FULL_HANDLE:-tuist/tuist}
+SERVER_URL=${BENCH_SERVER_URL:-https://tuist.dev}
+
+# On CI this authenticates via GitHub OIDC (needs id-token: write). Always scope
+# the login to SERVER_URL: without it the CLI targets production, which would
+# authenticate (and benchmark) against the wrong environment.
+tuist auth login --url "$SERVER_URL" >/dev/null 2>&1 || true
+
+redact() { sed -E 's/("token"[[:space:]]*:[[:space:]]*")[^"]*/\1<redacted>/'; }
+json_field() { grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed -E "s/.*:[[:space:]]*\"([^\"]*)\"\$/\1/"; }
+unesc() { sed 's#\\/#/#g'; }
+
+cfg=$(tuist cache config "$FULL_HANDLE" --url "$SERVER_URL" --json 2>&1) || true
+TOKEN=$(printf '%s' "$cfg" | json_field token)
+ACC=$(printf '%s' "$cfg" | json_field account_handle)
+PROJ=$(printf '%s' "$cfg" | json_field project_handle)
+URL_KURA=$(printf '%s' "$cfg" | json_field url | unesc)
+
+if [ -z "$TOKEN" ] || [ -z "$URL_KURA" ]; then
+  echo "failed to resolve cache config (token/url). Raw output (token redacted):" >&2
+  printf '%s\n' "$cfg" | redact >&2
+  exit 1
+fi
+[ -n "${GITHUB_ACTIONS:-}" ] && echo "::add-mask::$TOKEN"
+
+# Backends: Kura always; legacy only if a distinct URL was provided.
+# Plain function rather than an associative array: macOS ships bash 3.2, which
+# has no `declare -A`, and this repo's primary dev platform is macOS.
+names=(kura)
+if [ -n "$LEGACY_URL" ] && [ "$LEGACY_URL" != "$URL_KURA" ]; then
+  names+=(legacy)
+fi
+url_for() {
+  case "$1" in
+    kura) printf '%s' "$URL_KURA" ;;
+    legacy) printf '%s' "$LEGACY_URL" ;;
+  esac
+}
+
+Q="account_handle=${ACC}&project_handle=${PROJ}"
+AUTH=(-H "Authorization: Bearer $TOKEN")
+CT=(--connect-timeout 10 --max-time 180)   # no request may hang the whole job
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+med()  { sort -n | awk '{a[NR]=$1} END{if(NR==0){print 0;exit} print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'; }
+pctl() { sort -n | awk -v p="$1" '{a[NR]=$1} END{if(NR==0){print 0;exit} i=int(p/100*NR); if(i<1)i=1; print a[i]}'; }
+now_seconds() { python3 -c 'import time; print(time.time())'; }
+cas_put() { curl -sS "${CT[@]}" -o /dev/null "${AUTH[@]}" -H "Content-Type: application/octet-stream" -X POST --data-binary @"$2" -w '%{http_code} %{speed_upload}' "$1/api/cache/cas/$3?$Q"; }
+cas_get() { curl -sS "${CT[@]}" -o /dev/null "${AUTH[@]}" -w '%{http_code} %{speed_download}' "$1/api/cache/cas/$2?$Q"; }
+response_counts() {
+  awk 'NF {counts[$1]++} END {for (code in counts) print code ":" counts[code]}' "$@" | sort -n | paste -sd ',' -
+}
+
+# Reachability probe: fail fast + loud if the runner can't reach a backend, rather
+# than hanging until the job timeout.
+echo "== reachability =="
+for n in "${names[@]}"; do
+  if probe=$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w '%{http_code} %{time_total}s' "$(url_for "$n")/up" 2>&1); then
+    echo "  $n $(url_for "$n")/up -> $probe"
+  else
+    echo "  $n $(url_for "$n")/up -> UNREACHABLE ($probe)"
+    if [ "$n" = kura ]; then
+      echo "Kura endpoint unreachable from this runner; aborting." >&2
+      exit 1
+    fi
+  fi
+done
+echo
+
+SUMMARY=$(mktemp)
+emit() { echo "$1"; echo "$1" >> "$SUMMARY"; }
+
+emit "## Kura CAS benchmark (public CI runner)"
+emit ""
+if [ "${#names[@]}" -gt 1 ]; then
+  emit "Kura \`$URL_KURA\` vs legacy \`$(url_for legacy)\`, account \`${ACC}/${PROJ}\`."
+else
+  emit "Kura \`$URL_KURA\`, account \`${ACC}/${PROJ}\` (legacy A/B skipped)."
+fi
+emit "Sizes [$SIZES_MB]MB, iters $ITERS, parallel $PARALLEL, latency object ${LATENCY_KB}KB."
+emit ""
+
+# --- 1) small-object hit latency -------------------------------------------------
+emit "### Hit latency (${LATENCY_KB}KB object, ms)"
+emit ""
+emit "| backend | mode | p50 | p90 | p99 |"
+emit "|---|---|---:|---:|---:|"
+head -c $((LATENCY_KB*1024)) /dev/urandom > "$TMP/small"
+for name in "${names[@]}"; do
+  base="$(url_for "$name")"
+  id="lat-$name-$RANDOM-$(date +%s)"
+  cas_put "$base" "$TMP/small" "$id" >/dev/null
+  args=(); for _ in $(seq 1 60); do args+=(-o /dev/null "$base/api/cache/cas/$id?$Q"); done
+  curl -sS --connect-timeout 10 --max-time 120 "${AUTH[@]}" -w '%{time_starttransfer}\n' "${args[@]}" > "$TMP/warm_$name" 2>/dev/null
+  w=$(tail -n +2 "$TMP/warm_$name")
+  wp50=$(printf '%s\n' "$w" | med); wp90=$(printf '%s\n' "$w" | pctl 90); wp99=$(printf '%s\n' "$w" | pctl 99)
+  : > "$TMP/cold_$name"
+  for _ in $(seq 1 20); do curl -sS --connect-timeout 10 --max-time 20 -o /dev/null "${AUTH[@]}" -w '%{time_starttransfer}\n' "$base/api/cache/cas/$id?$Q" >> "$TMP/cold_$name"; done
+  cp50=$(med < "$TMP/cold_$name"); cp90=$(pctl 90 < "$TMP/cold_$name"); cp99=$(pctl 99 < "$TMP/cold_$name")
+  emit "$(awk -v b="$name" -v a="$wp50" -v c="$wp90" -v d="$wp99" 'BEGIN{printf "| %s | warm | %.0f | %.0f | %.0f |", b, a*1000, c*1000, d*1000}')"
+  emit "$(awk -v b="$name" -v a="$cp50" -v c="$cp90" -v d="$cp99" 'BEGIN{printf "| %s | cold | %.0f | %.0f | %.0f |", b, a*1000, c*1000, d*1000}')"
+done
+emit ""
+
+# --- 2) single-stream throughput -------------------------------------------------
+emit "### Single-stream throughput (median MB/s, n=$ITERS)"
+emit ""
+emit "| size | backend | upload | download |"
+emit "|---|---|---:|---:|"
+for size in $SIZES_MB; do
+  bytes=$((size*1024*1024))
+  for name in "${names[@]}"; do
+    base="$(url_for "$name")"; ups=""; downs=""
+    for i in $(seq 1 "$ITERS"); do
+      head -c "$bytes" /dev/urandom > "$TMP/blob"
+      id="tp-${size}m-${name}-${i}-${RANDOM}-$(date +%s)"
+      read -r pc pu < <(cas_put "$base" "$TMP/blob" "$id"); [ "$pc" = 204 ] && ups+="$pu"$'\n'
+      read -r gc gd < <(cas_get "$base" "$id");            [ "$gc" = 200 ] && downs+="$gd"$'\n'
+    done
+    um=$(printf '%s' "$ups" | med); dm=$(printf '%s' "$downs" | med)
+    emit "$(awk -v s="$size" -v b="$name" -v u="$um" -v d="$dm" 'BEGIN{m=1048576; printf "| %sMB | %s | %.1f | %.1f |", s, b, u/m, d/m}')"
+  done
+done
+emit ""
+
+# --- 3) parallel aggregate throughput -------------------------------------------
+emit "### Aggregate throughput, ${PARALLEL} parallel streams of 8MB (MB/s)"
+emit ""
+emit "| backend | upload | successful uploads | upload responses | download | successful downloads | download responses |"
+emit "|---|---:|---:|---|---:|---:|---|"
+head -c $((8*1024*1024)) /dev/urandom > "$TMP/p8"
+for name in "${names[@]}"; do
+  base="$(url_for "$name")"
+  ids=(); for k in $(seq 1 "$PARALLEL"); do ids+=("par-$name-$k-$RANDOM-$(date +%s)"); done
+  download_id="par-download-$name-$RANDOM-$(date +%s)"
+  read -r seed_code _ < <(cas_put "$base" "$TMP/p8" "$download_id")
+  if [ "$seed_code" != 204 ]; then
+    echo "failed to seed aggregate download object for $name (response $seed_code)" >&2
+    exit 1
+  fi
+
+  s=$(now_seconds)
+  put_pids=()
+  for k in $(seq 1 "$PARALLEL"); do
+    cas_put "$base" "$TMP/p8" "${ids[$((k-1))]}" > "$TMP/par-put-$name-$k" &
+    put_pids+=("$!")
+  done
+  for pid in "${put_pids[@]}"; do wait "$pid" || true; done
+  e=$(now_seconds)
+  put_ok=$(awk '$1 == 204 {count++} END {print count+0}' "$TMP"/par-put-"$name"-*)
+  put_responses=$(response_counts "$TMP"/par-put-"$name"-*)
+  up=$(awk -v s="$s" -v e="$e" -v ok="$put_ok" 'BEGIN{printf "%.1f", (ok*8)/(e-s)}')
+
+  s=$(now_seconds)
+  get_pids=()
+  for k in $(seq 1 "$PARALLEL"); do
+    cas_get "$base" "$download_id" > "$TMP/par-get-$name-$k" &
+    get_pids+=("$!")
+  done
+  for pid in "${get_pids[@]}"; do wait "$pid" || true; done
+  e=$(now_seconds)
+  get_ok=$(awk '$1 == 200 {count++} END {print count+0}' "$TMP"/par-get-"$name"-*)
+  get_responses=$(response_counts "$TMP"/par-get-"$name"-*)
+  dn=$(awk -v s="$s" -v e="$e" -v ok="$get_ok" 'BEGIN{printf "%.1f", (ok*8)/(e-s)}')
+
+  emit "| $name | $up | $put_ok/$PARALLEL | $put_responses | $dn | $get_ok/$PARALLEL | $get_responses |"
+done
+emit ""
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"; fi
+rm -f "$SUMMARY"


### PR DESCRIPTION
## What changed

This adds a manually dispatched benchmark for the public Kura cache path. It measures hit latency, single-stream throughput, and parallel upload and download throughput while reporting successful transfer counts and response distributions.

The download phase uses a separately seeded object so rejected uploads do not turn into misleading missing-object results.

## Why

Kura needs a repeatable way to validate real customer-path behavior under pressure. The previous ad hoc commands did not preserve comparable inputs or distinguish controlled load shedding from transport failures.

## Approach

The workflow resolves the staging-scoped endpoint and credential through the Tuist command-line client, runs from a public GitHub runner, and leaves generated content to normal cache retention. The script remains runnable from macOS Bash for local investigations.

## Impact

This is operator tooling only. It does not change Kura runtime behavior or run automatically.

## Validation

- `bash -n kura/benchmarks/cas_ab.sh`
- ShellCheck 0.11.0
- Actionlint 1.7.7
- Live staging runs with 128 and 256 parallel streams verified response accounting and independent download pressure.