### PR TITLE
fix(server): harden Kura deployment reconciliation

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -83,6 +83,11 @@ config :tuist, TuistWeb.Endpoint,
   secret_key_base: "pbaHQK0N946e06chs5G1/RUJnkI//2QshGgUvJQkADTV3AiQHV/dXlLdjnaQxtxx",
   server: false
 
+# Production builds keep warm handoffs disabled until the public customer
+# endpoint is owned by a stable account-region binding. Tests enable the
+# transition machinery so its invariants remain covered while that work lands.
+config :tuist, :kura_warm_handoffs_enabled, true
+
 config :tuist,
   api_pipeline_producer_module: Broadway.DummyProducer,
   api_pipeline_producer_options: []

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -51,6 +51,7 @@ defmodule Tuist.Kura do
   # to rescue and forces manual intervention. Only terminal servers
   # (`:destroying`/`:destroyed`) are skipped.
   @version_rollout_statuses [:provisioning, :replicating, :active, :failed]
+  @version_rollout_batch_size 100
 
   @doc "Reconciles desired Kura server rows with the observed Kubernetes state."
   def reconcile_orphaned_deployments, do: Reconciler.reconcile()
@@ -155,9 +156,15 @@ defmodule Tuist.Kura do
   end
 
   defp servers_needing_version_query(image_tag) do
-    deployment_exists_query =
+    deployment_for_image_exists_query =
       from(d in Deployment,
         where: parent_as(:server).id == d.kura_server_id and d.image_tag == ^image_tag,
+        select: 1
+      )
+
+    open_deployment_exists_query =
+      from(d in Deployment,
+        where: parent_as(:server).id == d.kura_server_id and d.status in [:pending, :running],
         select: 1
       )
 
@@ -171,7 +178,10 @@ defmodule Tuist.Kura do
       where: s.move_phase == :none,
       where: s.status in @version_rollout_statuses,
       where: s.current_image_tag != ^image_tag,
-      where: not exists(deployment_exists_query)
+      where: not exists(deployment_for_image_exists_query),
+      where: not exists(open_deployment_exists_query),
+      order_by: [asc: s.updated_at, asc: s.id],
+      limit: ^@version_rollout_batch_size
     )
   end
 
@@ -1150,7 +1160,7 @@ defmodule Tuist.Kura do
       Repo.transaction(fn ->
         server
         |> lock_server_or_rollback()
-        |> maybe_insert_scheduled_deployment(region, image_tag)
+        |> insert_scheduled_deployment(region, image_tag)
       end)
     end
   end
@@ -1162,15 +1172,32 @@ defmodule Tuist.Kura do
     end
   end
 
-  defp maybe_insert_scheduled_deployment(server, region, image_tag) do
-    if deployment_for_image_exists?(server.id, image_tag) or open_deployment_exists?(server.id) do
-      nil
-    else
-      case insert_deployment(server, region, image_tag) do
-        {:ok, deployment} -> deployment
-        {:error, reason} -> Repo.rollback(reason)
-      end
+  defp insert_scheduled_deployment(server, region, image_tag) do
+    case insert_deployment(server, region, image_tag) do
+      {:ok, deployment} ->
+        deployment
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if open_deployment_conflict?(changeset) do
+          nil
+        else
+          Repo.rollback(changeset)
+        end
+
+      {:error, reason} ->
+        Repo.rollback(reason)
     end
+  end
+
+  defp open_deployment_conflict?(changeset) do
+    Enum.any?(changeset.errors, fn
+      {:kura_server_id, {_message, metadata}} ->
+        metadata[:constraint] == :unique and
+          metadata[:constraint_name] == "kura_deployments_one_open_per_server_index"
+
+      _error ->
+        false
+    end)
   end
 
   defp insert_deployment(%Server{} = server, region, image_tag) do
@@ -1181,14 +1208,6 @@ defmodule Tuist.Kura do
     }
     |> Deployment.create_changeset()
     |> Repo.insert()
-  end
-
-  defp deployment_for_image_exists?(server_id, image_tag) do
-    Repo.exists?(
-      from(d in Deployment,
-        where: d.kura_server_id == ^server_id and d.image_tag == ^image_tag
-      )
-    )
   end
 
   defp open_deployment_exists?(server_id) do

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -42,6 +42,7 @@ defmodule Tuist.Kura do
   @public_endpoint_timeout 5_000
   @provisioner_node_ref_format ~r/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
   @provisioner_node_ref_max_length 53
+  @warm_handoffs_enabled Application.compile_env(:tuist, :kura_warm_handoffs_enabled, false)
 
   # A version change is a deliberate fix delivery, so it must reach
   # degraded servers, not only healthy ones. A `:failed` or `:replicating`
@@ -93,7 +94,7 @@ defmodule Tuist.Kura do
   """
   def schedule_runtime_image_deployments do
     case runtime_image_tag() do
-      nil -> {:ok, []}
+      nil -> {:ok, %{scheduled: [], failures: []}}
       image_tag -> schedule_runtime_image_deployments(image_tag)
     end
   end
@@ -126,16 +127,31 @@ defmodule Tuist.Kura do
   end
 
   def schedule_version_deployments(image_tag) when is_binary(image_tag) do
-    deployments =
+    {scheduled, failures} =
       image_tag
       |> servers_needing_version_query()
       |> Repo.all()
-      |> Enum.map(&create_deployment(&1, image_tag))
+      |> Enum.reduce({[], []}, fn server, {scheduled, failures} ->
+        case schedule_version_deployment(server, image_tag) do
+          {:ok, nil} ->
+            {scheduled, failures}
 
-    case Enum.find(deployments, &match?({:error, _}, &1)) do
-      nil -> {:ok, Enum.map(deployments, fn {:ok, deployment} -> deployment end)}
-      {:error, reason} -> {:error, reason}
-    end
+          {:ok, deployment} ->
+            {[deployment | scheduled], failures}
+
+          {:error, reason} ->
+            failure = %{
+              account_id: server.account_id,
+              reason: reason,
+              region: server.region,
+              server_id: server.id
+            }
+
+            {scheduled, [failure | failures]}
+        end
+      end)
+
+    {:ok, %{scheduled: Enum.reverse(scheduled), failures: Enum.reverse(failures)}}
   end
 
   defp servers_needing_version_query(image_tag) do
@@ -846,14 +862,25 @@ defmodule Tuist.Kura do
 
   defp retry_server_transaction(server, region, image_tag) do
     Repo.transaction(fn ->
-      with {:ok, server} <-
-             server |> Server.status_changeset(%{status: :provisioning}) |> Repo.update(),
-           {:ok, _deployment} <- insert_initial_deployment(server, region, image_tag) do
-        server
+      locked_server = lock_retryable_server_or_rollback(server)
+
+      with :ok <- ensure_no_open_deployment(locked_server.id),
+           {:ok, locked_server} <-
+             locked_server |> Server.status_changeset(%{status: :provisioning}) |> Repo.update(),
+           {:ok, _deployment} <- insert_initial_deployment(locked_server, region, image_tag) do
+        locked_server
       else
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+  end
+
+  defp lock_retryable_server_or_rollback(server) do
+    case lock_server(server.id, server.account_id) do
+      %Server{status: :failed, current_image_tag: nil} = locked_server -> locked_server
+      %Server{} -> Repo.rollback(:not_retryable)
+      nil -> Repo.rollback(:not_found)
+    end
   end
 
   @doc """
@@ -867,12 +894,25 @@ defmodule Tuist.Kura do
   `:moving_in -> :none`, so the account's customer host flips to the target box
   with no cold-cache dip. The source then drains and is destroyed.
 
-  Only steady-state (`:none`, `:active`) servers in a host-network (multi-box
+  Production builds keep this transition disabled until a stable account-region
+  endpoint binding can switch customer traffic atomically. Test builds enable
+  the transition machinery so its invariants remain covered. Once enabled,
+  only steady-state (`:none`, `:active`) servers in a host-network (multi-box
   bare-metal) region can move; there is no move in a single-endpoint cloud
   region. Returns `{:ok, moving_in_server}` or `{:error, reason}`.
   """
   def move_server(%Server{status: :active, move_phase: :none, region: region_id} = source, target_node)
       when is_binary(target_node) and target_node != "" do
+    if @warm_handoffs_enabled do
+      do_move_server(source, region_id, target_node)
+    else
+      {:error, :stable_endpoint_binding_required}
+    end
+  end
+
+  def move_server(%Server{}, _target_node), do: {:error, :not_movable}
+
+  defp do_move_server(source, region_id, target_node) do
     with {:ok, region} <- Regions.fetch(region_id),
          :ok <- ensure_movable_region(region),
          {:ok, account} <- Accounts.get_account_by_id(source.account_id),
@@ -882,8 +922,6 @@ defmodule Tuist.Kura do
       insert_move_target(source, region, ref, target_node)
     end
   end
-
-  def move_server(%Server{}, _target_node), do: {:error, :not_movable}
 
   # Moves only apply to multi-box bare-metal (host-network) regions; a cloud LB
   # region is a single logical endpoint with nothing to move between.
@@ -941,17 +979,32 @@ defmodule Tuist.Kura do
   to it: the source drops the host (`:none -> :moving_out`) and the target gains
   it (`:moving_in -> :none`).
 
-  Both ownership manifests are applied FIRST — rendered at the phases they will
-  hold, so the target gains the customer host (Ingress/DNS/Certificate) and the
-  source loses it — and only once both converge is the Postgres phase swap
-  committed. A failed apply returns an error with the DB untouched, so the
-  reconciler simply retries the promotion next tick (target still `:moving_in`)
-  rather than stranding a promoted target without its host or leaving two
-  instances claiming the host. Idempotent: a crash between apply and swap
-  re-converges next tick (the applied target already serves the host).
-  Reconciler-only.
+  Both ownership manifests are submitted first, rendered at the phases they will
+  hold, and the Postgres phase swap is committed only after both submissions are
+  accepted. Submission is not cluster convergence: the controllers can observe
+  the two resources in either order. The target is submitted first so the source
+  is never asked to relinquish publication before target intent exists. The peer
+  demultiplexer tolerates the possible overlap while the controllers converge.
+
+  A failed submission leaves the database phases untouched, so the reconciler
+  retries on the next tick. A crash between submission and the phase swap is
+  likewise retried from the durable `:moving_in` row. This is idempotent
+  containment, not an atomic public-endpoint cutover; strict ownership will move
+  to a stable account-region endpoint resource.
+  Production builds return `{:error, :stable_endpoint_binding_required}` before
+  changing either manifest. Reconciler-only.
   """
   def promote_move(%Server{move_phase: :moving_in, region: region_id} = target) do
+    if @warm_handoffs_enabled do
+      do_promote_move(target, region_id)
+    else
+      {:error, :stable_endpoint_binding_required}
+    end
+  end
+
+  def promote_move(%Server{}), do: {:error, :not_moving_in}
+
+  defp do_promote_move(target, region_id) do
     with {:ok, region} <- Regions.fetch(region_id),
          {:ok, account} <- Accounts.get_account_by_id(target.account_id),
          %Server{} = source <- move_source_for(target),
@@ -966,8 +1019,6 @@ defmodule Tuist.Kura do
       {:error, reason} -> {:error, reason}
     end
   end
-
-  def promote_move(%Server{}), do: {:error, :not_moving_in}
 
   defp swap_move_phases(source, target) do
     Repo.transaction(fn ->
@@ -1080,19 +1131,76 @@ defmodule Tuist.Kura do
   Inserts a `Deployment` record for the reconciler to apply.
   """
   def create_deployment(%Server{} = server, image_tag) when is_binary(image_tag) do
-    insert_deployment(server, image_tag)
+    with {:ok, region} <- Regions.fetch(server.region) do
+      Repo.transaction(fn ->
+        locked_server = lock_server_or_rollback(server)
+
+        with :ok <- ensure_no_open_deployment(locked_server.id),
+             {:ok, deployment} <- insert_deployment(locked_server, region, image_tag) do
+          deployment
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+    end
   end
 
-  defp insert_deployment(%Server{} = server, image_tag) do
+  defp schedule_version_deployment(%Server{} = server, image_tag) do
     with {:ok, region} <- Regions.fetch(server.region) do
-      %{
-        cluster_id: deployment_cluster_id(region),
-        image_tag: image_tag,
-        kura_server_id: server.id
-      }
-      |> Deployment.create_changeset()
-      |> Repo.insert()
+      Repo.transaction(fn ->
+        server
+        |> lock_server_or_rollback()
+        |> maybe_insert_scheduled_deployment(region, image_tag)
+      end)
     end
+  end
+
+  defp lock_server_or_rollback(server) do
+    case lock_server(server.id, server.account_id) do
+      %Server{} = locked_server -> locked_server
+      nil -> Repo.rollback(:not_found)
+    end
+  end
+
+  defp maybe_insert_scheduled_deployment(server, region, image_tag) do
+    if deployment_for_image_exists?(server.id, image_tag) or open_deployment_exists?(server.id) do
+      nil
+    else
+      case insert_deployment(server, region, image_tag) do
+        {:ok, deployment} -> deployment
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end
+  end
+
+  defp insert_deployment(%Server{} = server, region, image_tag) do
+    %{
+      cluster_id: deployment_cluster_id(region),
+      image_tag: image_tag,
+      kura_server_id: server.id
+    }
+    |> Deployment.create_changeset()
+    |> Repo.insert()
+  end
+
+  defp deployment_for_image_exists?(server_id, image_tag) do
+    Repo.exists?(
+      from(d in Deployment,
+        where: d.kura_server_id == ^server_id and d.image_tag == ^image_tag
+      )
+    )
+  end
+
+  defp open_deployment_exists?(server_id) do
+    Repo.exists?(
+      from(d in Deployment,
+        where: d.kura_server_id == ^server_id and d.status in [:pending, :running]
+      )
+    )
+  end
+
+  defp ensure_no_open_deployment(server_id) do
+    if open_deployment_exists?(server_id), do: {:error, :deployment_in_progress}, else: :ok
   end
 
   @doc "Returns deployment records for the account, newest first."

--- a/server/lib/tuist/kura/deployment.ex
+++ b/server/lib/tuist/kura/deployment.ex
@@ -64,6 +64,10 @@ defmodule Tuist.Kura.Deployment do
     |> validate_format(:image_tag, @image_tag_format, message: @image_tag_message)
     |> validate_length(:image_tag, max: 128)
     |> foreign_key_constraint(:kura_server_id)
+    |> unique_constraint(:kura_server_id,
+      name: :kura_deployments_one_open_per_server_index,
+      message: "already has an open deployment"
+    )
   end
 
   def status_changeset(deployment, attrs) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -19,8 +19,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   alias Tuist.Kura.Server
 
   @namespace "kura"
-  @manifest_revision "2026-07-16-cas-capacity-v1"
+  @manifest_revision "2026-07-19-peer-publication-v1"
   @manifest_revision_annotation "tuist.dev/kura-manifest-revision"
+  @warm_handoffs_enabled Application.compile_env(:tuist, :kura_warm_handoffs_enabled, false)
   # Mirrors Kura's DEFAULT_TMP_DIR_MAX_BYTES (kura/src/constants.rs): 4 x
   # MAX_REPLICATION_BODY_BYTES, itself 4 x MAX_SEGMENT_BYTES. We never set
   # KURA_TMP_DIR_MAX_BYTES, so this default is what upload staging can reach
@@ -41,10 +42,18 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   end
 
   @impl true
-  def rollout(
-        name,
-        %{image_tag: image_tag, account: account, server: %Server{} = server, region: %Regions{} = region} = inputs
-      ) do
+  def rollout(name, %{server: %Server{} = server} = inputs) do
+    if @warm_handoffs_enabled or server.move_phase == :none do
+      do_rollout(name, inputs)
+    else
+      {:error, :stable_endpoint_binding_required}
+    end
+  end
+
+  defp do_rollout(
+         name,
+         %{image_tag: image_tag, account: account, server: %Server{} = server, region: %Regions{} = region} = inputs
+       ) do
     with {:ok, hook_script} <- hook_script(inputs) do
       external_peers = self_hosted_peers(account, region)
 
@@ -243,15 +252,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
           "tenantID" => account_handle,
           "region" => region.id,
           "image" => "ghcr.io/tuist/kura:#{image_tag}",
-          # Only the steady-state (`:none`) server owns the account's customer
-          # host. A `:moving_in` target warms with the customer plane withheld
-          # (peer plane only, so it bootstraps from the source without two
-          # instances claiming the same host), and a `:moving_out` source has
-          # already handed the host to the promoted target. The kura-controller
-          # leaves the public Ingress/DNS/Certificate unreconciled for an empty
-          # publicHost, so host ownership stays with exactly one instance.
-          "publicHost" => if(owns_customer_host?(server), do: public_host(account_handle, region)),
-          "grpcPublicHost" => if(owns_customer_host?(server), do: grpc_public_host(account_handle, region)),
+          # Only the steady-state (`:none`) server publishes the account's
+          # customer and peer endpoints. A moving target keeps the peer hostname
+          # as certificate identity while its publication flag is false, so it
+          # can warm over the account mesh without adding a second public route.
+          # A moving-out source likewise retains the identity while the promoted
+          # target takes publication ownership.
+          "publicHost" => if(owns_public_endpoints?(server), do: public_host(account_handle, region)),
+          "grpcPublicHost" => if(owns_public_endpoints?(server), do: grpc_public_host(account_handle, region)),
           "ingressClassName" => ingress_class_name(region),
           "publicHostNetwork" => public_host_network?(region),
           "peerTLSSecretName" => peer_tls_secret_name(region),
@@ -276,6 +284,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
         }
         |> Enum.reject(fn {_key, value} -> value in [nil, "", false] end)
         |> Map.new()
+        |> put_mesh_public_peer_publication(region, server)
     }
   end
 
@@ -376,6 +385,19 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   defp mesh_public_peer_host(handle, region) do
     if mesh_enabled?(region), do: Regions.peer_public_host(handle, region)
+  end
+
+  # Keep the public peer hostname on every move phase because it is also part of
+  # the instance certificate identity. Publication is a separate boolean so a
+  # warming or draining instance does not claim the regional public route. The
+  # controller treats a missing field as the legacy publish-by-host behavior,
+  # which keeps the controller-first rollout backward compatible.
+  defp put_mesh_public_peer_publication(spec, region, server) do
+    if mesh_enabled?(region) do
+      Map.put(spec, "meshPublicPeerPublished", owns_public_endpoints?(server))
+    else
+      spec
+    end
   end
 
   defp mesh_external_peers(region, external_peers) do
@@ -620,11 +642,11 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   defp node_selector(_), do: nil
 
-  # Only the steady-state (`:none`) server publishes the account's customer host.
-  # See the `publicHost` gating in `manifest/8`.
-  defp owns_customer_host?(%Server{move_phase: :moving_in}), do: false
-  defp owns_customer_host?(%Server{move_phase: :moving_out}), do: false
-  defp owns_customer_host?(%Server{}), do: true
+  # Only the steady-state (`:none`) server publishes the account's customer and
+  # peer endpoints. See the endpoint fields in `manifest/7`.
+  defp owns_public_endpoints?(%Server{move_phase: :moving_in}), do: false
+  defp owns_public_endpoints?(%Server{move_phase: :moving_out}), do: false
+  defp owns_public_endpoints?(%Server{}), do: true
 
   # A `:moving_in` target is pinned to the destination box (its `target_node`)
   # so the warm handoff lands the account on the intended box, layered on top of

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -41,14 +41,23 @@ defmodule Tuist.Kura.Reconciler do
   this loop observes the same rows on the next tick and converges again.
   """
 
-  use Oban.Worker, queue: :default, max_attempts: 3
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [
+      fields: [:worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
   import Ecto.Query
 
+  alias Oban.Job
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
   alias Tuist.Kura.Regions
+  alias Tuist.Kura.RunnerCache
   alias Tuist.Kura.Server
   alias Tuist.Repo
 
@@ -63,7 +72,7 @@ defmodule Tuist.Kura.Reconciler do
   @reconcile_batch_size 200
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
+  def perform(%Job{}) do
     reconcile()
   end
 
@@ -71,15 +80,42 @@ defmodule Tuist.Kura.Reconciler do
     # Converge runner-cache nodes with runner enablement before the rest
     # of the loop so a freshly enabled account's node enters the normal
     # provisioning/observation path within the same tick.
-    Tuist.Kura.RunnerCache.reconcile()
+    RunnerCache.reconcile()
 
-    with {:ok, scheduled} <- Kura.schedule_runtime_image_deployments() do
-      log_scheduled_deployments(scheduled)
-      reconcile_destroying_servers()
-      reconcile_moving_out_servers()
-      handled = reconcile_deployments()
-      reconcile_observed_servers(handled)
-    end
+    schedule_runtime_image_deployments()
+    reconcile_destroying_servers()
+    reconcile_moving_out_servers()
+    handled = reconcile_deployments()
+    reconcile_observed_servers(handled)
+  end
+
+  defp schedule_runtime_image_deployments do
+    {:ok, %{scheduled: scheduled, failures: failures}} = Kura.schedule_runtime_image_deployments()
+    log_scheduled_deployments(scheduled)
+    Enum.each(failures, &report_scheduling_failure/1)
+
+    :ok
+  end
+
+  defp report_scheduling_failure(failure) do
+    detail = inspect(failure.reason)
+    kind = failure_kind(failure.reason)
+
+    Logger.error(
+      "[Kura.Reconciler] could not schedule runtime image deployment for server #{failure.server_id} in #{failure.region}: #{detail}"
+    )
+
+    Sentry.capture_message("Kura deployment scheduling failed",
+      level: :error,
+      tags: %{failure_kind: kind, region: failure.region},
+      extra: %{
+        account_id: failure.account_id,
+        failure_detail: detail,
+        failure_kind: kind,
+        region: failure.region,
+        server_id: failure.server_id
+      }
+    )
   end
 
   # Drain window a promoted move's source keeps serving before teardown, so
@@ -570,26 +606,37 @@ defmodule Tuist.Kura.Reconciler do
   defp fail(deployment, server, reason) do
     message = if is_binary(reason), do: reason, else: inspect(reason)
 
-    capture_deploy_failure(deployment, server, message)
+    capture_deploy_failure(deployment, server, reason, message)
 
     {:ok, _} = Kura.mark_failed(deployment, message)
     if server, do: Kura.fail_server(server)
     :ok
   end
 
-  defp capture_deploy_failure(deployment, server, message) do
+  defp capture_deploy_failure(deployment, server, reason, message) do
+    kind = failure_kind(reason)
+
     Sentry.capture_message("Kura deploy failed",
       level: :error,
+      tags: %{failure_kind: kind, region: server && server.region},
       extra: %{
         deployment_id: deployment.id,
         image_tag: deployment.image_tag,
         server_id: server && server.id,
         account_id: server && server.account_id,
         region: server && server.region,
-        reason: message
+        failure_detail: message,
+        failure_kind: kind
       }
     )
   end
+
+  defp failure_kind(:not_found), do: "not_found"
+  defp failure_kind({kind, _}) when is_atom(kind), do: Atom.to_string(kind)
+  defp failure_kind({kind, _, _}) when is_atom(kind), do: Atom.to_string(kind)
+  defp failure_kind(%{__struct__: module}), do: module |> Module.split() |> List.last() |> Macro.underscore()
+  defp failure_kind(reason) when is_binary(reason), do: "provisioner_error"
+  defp failure_kind(_reason), do: "unknown"
 
   defp server_status(:server_destroying), do: "destroying"
   defp server_status(:server_destroyed), do: "destroyed"

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -24,7 +24,7 @@ defmodule Tuist.Kura.Regions do
 
   alias Tuist.Kura.Provisioner.KubernetesController
 
-  defstruct [:id, :display_name, :provisioner, :provisioner_config, :runner_platforms]
+  defstruct [:id, :display_name, :provisioner, :provisioner_config, :runner_platforms, retired: false]
 
   # The local controller region's kind cluster + forwarded port are derived from
   # `TUIST_DEV_INSTANCE` so each worktree is isolated. Worktree
@@ -242,6 +242,21 @@ defmodule Tuist.Kura.Regions do
       tolerations: [
         %{"key" => "tuist.dev/runner-cache", "operator" => "Exists", "effect" => "NoSchedule"}
       ]
+    },
+    # A catalog tombstone for runner-cache rows created before the staging
+    # Hetzner runner pool was retired. It is never offered for provisioning,
+    # but keeping the original cluster identity lets the reconciler observe and
+    # delete the old KuraInstance resources instead of failing every tick with
+    # `:not_found` while resolving their stored region.
+    %{
+      id: "hetzner-staging-runners",
+      display_name: "Hetzner staging (retired runner cache)",
+      cluster_id: "staging",
+      node_pool: "kura",
+      storage_class: @managed_region_storage_class,
+      storage_size: "20Gi",
+      runner_platforms: [:linux],
+      retired: true
     }
   ]
 
@@ -261,7 +276,7 @@ defmodule Tuist.Kura.Regions do
     else
       available_region_ids = MapSet.new(Tuist.Environment.kura_available_region_ids())
 
-      Enum.filter(managed_regions(), &MapSet.member?(available_region_ids, &1.id))
+      Enum.filter(managed_regions(), &(not retired?(&1) and MapSet.member?(available_region_ids, &1.id)))
     end
   end
 
@@ -288,6 +303,10 @@ defmodule Tuist.Kura.Regions do
   """
   def private?(%__MODULE__{provisioner_config: config}), do: config[:private] == true
   def private?(_), do: false
+
+  @doc "True iff the region remains in the catalog only to clean up stored resources."
+  def retired?(%__MODULE__{retired: retired}), do: retired
+  def retired?(_), do: false
 
   @doc """
   True iff this private region's runner fleet dials a node-published
@@ -336,6 +355,8 @@ defmodule Tuist.Kura.Regions do
   platform, so a region pinned next to one fleet can't leak its
   in-cluster URL to a fleet on the wrong side of a WAN.
   """
+  def serves_runner_platform?(%__MODULE__{retired: true}, _platform), do: false
+
   def serves_runner_platform?(%__MODULE__{runner_platforms: platforms}, platform) when is_list(platforms) do
     platform in platforms
   end
@@ -451,6 +472,7 @@ defmodule Tuist.Kura.Regions do
       id: spec.id,
       display_name: spec.display_name,
       runner_platforms: spec.runner_platforms,
+      retired: Map.get(spec, :retired, false),
       provisioner: KubernetesController,
       provisioner_config: %{
         cluster_id: spec.cluster_id,

--- a/server/lib/tuist/kura/runner_cache.ex
+++ b/server/lib/tuist/kura/runner_cache.ex
@@ -71,8 +71,16 @@ defmodule Tuist.Kura.RunnerCache do
         # percentage gates, but those gates are unsafe for durable, per-account
         # infrastructure. Preserve every existing node and provision nothing
         # until the flag returns to an explicit actor-only shape.
+        detail = inspect(reason)
+
         Logger.error("kura.runner_cache: refusing to reconcile an unsafe runner-cache cohort",
-          reason: inspect(reason)
+          reason: detail
+        )
+
+        Sentry.capture_message("Kura runner-cache reconciliation paused",
+          level: :error,
+          tags: %{failure_kind: cohort_failure_kind(reason)},
+          extra: %{failure_detail: detail}
         )
     end
 
@@ -239,6 +247,10 @@ defmodule Tuist.Kura.RunnerCache do
   defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :percentage_of_actors}), do: true
   defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :group, enabled: true}), do: true
   defp unsafe_infrastructure_gate?(_gate), do: false
+
+  defp cohort_failure_kind({:feature_flag_unavailable, _reason}), do: "feature_flag_unavailable"
+  defp cohort_failure_kind({:unsupported_runner_actor, _actor}), do: "unsupported_runner_actor"
+  defp cohort_failure_kind(:non_actor_runner_gate), do: "non_actor_runner_gate"
 
   defp parse_account_actor("account:" <> id) do
     case Integer.parse(id) do

--- a/server/lib/tuist/kura/runner_cache.ex
+++ b/server/lib/tuist/kura/runner_cache.ex
@@ -7,8 +7,8 @@ defmodule Tuist.Kura.RunnerCache do
   region:
 
     * an account with at least one Runner Profile whose platform the
-      region serves (`Regions.runner_platforms`) AND an explicit
-      `:runners` FunWithFlags toggle should have exactly one
+      region serves (`Regions.runner_platforms`) AND an explicit enabled
+      account-actor gate on the `:runners` flag should have exactly one
       non-destroyed Kura server in that region, and
     * an account with no such profiles — or without the flag — should
       have none there.
@@ -22,12 +22,13 @@ defmodule Tuist.Kura.RunnerCache do
   node even while its Linux profiles keep a node in a Linux-serving
   region.
 
-  The flag check is the explicit `FunWithFlags.enabled?(:runners, for:
-  account)` gate, deliberately NOT `FeatureFlags.runners_enabled?/1` —
-  that helper short-circuits to `true` outside production, which here
-  would provision a cache node for every dev account with auto-created
-  profiles and exhaust the kura node pool. A dedicated infra node is an
-  explicit opt-in in every environment.
+  Runner Profiles are auto-created for every account, so the candidate
+  query starts from the flag's explicit account actors instead of scanning
+  the full accounts table and evaluating the flag one row at a time. Global,
+  group, and percentage gates are intentionally rejected: they are suitable
+  for choosing request-time code paths, but they must not create or destroy
+  durable infrastructure for a broad or unstable cohort. When an unsafe gate
+  is present the reconciler preserves existing nodes and provisions nothing.
 
   This runs inside `Tuist.Kura.Reconciler`'s tick rather than on its own
   cron, so it shares the same cadence and self-heals after a BEAM
@@ -46,6 +47,7 @@ defmodule Tuist.Kura.RunnerCache do
 
   alias Tuist.Accounts.Account
   alias Tuist.Kura
+  alias Tuist.Kura.Deployment
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
   alias Tuist.Repo
@@ -53,38 +55,47 @@ defmodule Tuist.Kura.RunnerCache do
 
   require Logger
 
-  @provision_page_size 100
-  # Backstop against a pathological candidate set (e.g. the flag
-  # globally enabled in an env where every auto-profile account
-  # matches): a tick scans at most this many pages before deferring
-  # the rest to the next tick.
-  @max_provision_pages_per_tick 50
+  @retry_backoff_seconds [60, 300, 900, 3600]
 
   @doc """
   Converges runner-cache nodes with runner enablement. Safe to call on
   every reconciler tick; returns `:ok`.
   """
   def reconcile do
-    Enum.each(runner_cache_regions(), &reconcile_region/1)
+    case runner_cache_cohort() do
+      {:ok, account_ids} ->
+        Enum.each(runner_cache_regions(), &reconcile_region(&1, account_ids))
+
+      {:error, reason} ->
+        # The runner feature flag can control request paths with global or
+        # percentage gates, but those gates are unsafe for durable, per-account
+        # infrastructure. Preserve every existing node and provision nothing
+        # until the flag returns to an explicit actor-only shape.
+        Logger.error("kura.runner_cache: refusing to reconcile an unsafe runner-cache cohort",
+          reason: inspect(reason)
+        )
+    end
+
+    :ok
   end
 
-  defp reconcile_region(%Regions{id: region_id} = region) do
+  defp reconcile_region(%Regions{id: region_id} = region, account_ids) do
     # Tear down first so an account that flips runners off frees its node
     # even when no image tag is configured to provision new ones.
-    Enum.each(nodes_to_tear_down(region), &tear_down/1)
+    Enum.each(nodes_to_tear_down(region, account_ids), &tear_down/1)
 
     case image_tag() do
       nil ->
         :ok
 
       image_tag ->
-        Enum.each(accounts_needing_node(region), &provision(&1, region_id, image_tag))
+        Enum.each(accounts_needing_node(region, account_ids), &provision(&1, region_id, image_tag))
         # A node that failed before its first successful deployment
         # (transient apiserver error, missing CRD field, ...) would
         # otherwise strand its account forever: the server row exists,
         # so provisioning never re-runs, and nothing else retries
         # failed servers. Self-heal them on the same cadence.
-        Enum.each(nodes_to_retry(region_id), &retry(&1, image_tag))
+        Enum.each(nodes_to_retry(region_id, image_tag), &retry(&1, image_tag))
     end
 
     :ok
@@ -123,7 +134,7 @@ defmodule Tuist.Kura.RunnerCache do
     end
   end
 
-  defp accounts_needing_node(%Regions{id: region_id} = region) do
+  defp accounts_needing_node(%Regions{id: region_id} = region, account_ids) do
     platforms = region_platforms(region)
 
     server_exists =
@@ -141,61 +152,19 @@ defmodule Tuist.Kura.RunnerCache do
         select: 1
       )
 
-    # The SQL narrows to "has profiles, lacks a node"; the flag check
-    # runs per account in Elixir because FunWithFlags gates are
-    # actor-scoped (and can be set via a global boolean gate, so they
-    # can't be pre-joined as a column). Since default profiles are
-    # auto-created for every account, non-enabled accounts dominate
-    # the candidate set and never leave it (no node ever gets
-    # provisioned for them) — so a single capped page would return
-    # the same non-enabled rows every tick and permanently starve an
-    # enabled account that sorts after them. Keyset-page through the
-    # whole set instead, with a page backstop so a pathological env
-    # still yields a bounded tick.
-    base =
+    Repo.all(
       from(a in Account,
         as: :account,
+        where: a.id in ^MapSet.to_list(account_ids),
         where: exists(profile_exists),
         where: not exists(server_exists),
         order_by: [asc: a.id],
-        limit: @provision_page_size
+        select: a.id
       )
-
-    collect_enabled_candidates(base, region_id, nil, [], @max_provision_pages_per_tick)
-  end
-
-  defp collect_enabled_candidates(_base, region_id, _cursor, enabled_ids, 0) do
-    Logger.warning("kura.runner_cache: provision candidate scan hit the per-tick page cap",
-      cap: @max_provision_pages_per_tick,
-      region: region_id
     )
-
-    Enum.reverse(enabled_ids)
   end
 
-  defp collect_enabled_candidates(base, region_id, cursor, enabled_ids, pages_left) do
-    page =
-      base
-      |> after_cursor(cursor)
-      |> Repo.all()
-
-    enabled_ids =
-      page
-      |> Enum.filter(&runner_cache_enabled?/1)
-      |> Enum.map(& &1.id)
-      |> Enum.reverse(enabled_ids)
-
-    if length(page) < @provision_page_size do
-      Enum.reverse(enabled_ids)
-    else
-      collect_enabled_candidates(base, region_id, List.last(page).id, enabled_ids, pages_left - 1)
-    end
-  end
-
-  defp after_cursor(query, nil), do: query
-  defp after_cursor(query, cursor), do: where(query, [a], a.id > ^cursor)
-
-  defp nodes_to_tear_down(%Regions{id: region_id} = region) do
+  defp nodes_to_tear_down(%Regions{id: region_id} = region, account_ids) do
     platforms = region_platforms(region)
 
     profile_exists =
@@ -216,22 +185,69 @@ defmodule Tuist.Kura.RunnerCache do
         )
       )
 
-    flag_off =
-      from(s in Server,
-        as: :server,
-        join: a in assoc(s, :account),
-        where: s.region == ^region_id,
-        where: s.status not in [:destroying, :destroyed],
-        where: exists(profile_exists),
-        preload: [account: a]
-      )
-      |> Repo.all()
-      |> Enum.reject(&runner_cache_enabled?(&1.account))
+    cohort_ids = MapSet.to_list(account_ids)
 
-    no_profiles ++ flag_off
+    outside_cohort =
+      Repo.all(
+        from(s in Server,
+          as: :server,
+          where: s.region == ^region_id,
+          where: s.status not in [:destroying, :destroyed],
+          where: exists(profile_exists),
+          where: s.account_id not in ^cohort_ids,
+          select: s
+        )
+      )
+
+    Enum.uniq_by(no_profiles ++ outside_cohort, & &1.id)
   end
 
-  defp runner_cache_enabled?(account), do: FunWithFlags.enabled?(:runners, for: account)
+  defp runner_cache_cohort do
+    case FunWithFlags.get_flag(:runners) do
+      nil ->
+        {:ok, MapSet.new()}
+
+      {:error, reason} ->
+        {:error, {:feature_flag_unavailable, reason}}
+
+      %FunWithFlags.Flag{gates: gates} ->
+        if Enum.any?(gates, &unsafe_infrastructure_gate?/1) do
+          {:error, :non_actor_runner_gate}
+        else
+          actor_account_ids(gates)
+        end
+    end
+  end
+
+  defp actor_account_ids(gates) do
+    gates
+    |> Enum.filter(&match?(%FunWithFlags.Gate{type: :actor, enabled: true}, &1))
+    |> collect_actor_account_ids(MapSet.new())
+  end
+
+  defp collect_actor_account_ids([], account_ids), do: {:ok, account_ids}
+
+  defp collect_actor_account_ids([gate | gates], account_ids) do
+    case parse_account_actor(gate.for) do
+      {:ok, account_id} -> collect_actor_account_ids(gates, MapSet.put(account_ids, account_id))
+      :error -> {:error, {:unsupported_runner_actor, gate.for}}
+    end
+  end
+
+  defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :boolean, enabled: true}), do: true
+  defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :percentage_of_time}), do: true
+  defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :percentage_of_actors}), do: true
+  defp unsafe_infrastructure_gate?(%FunWithFlags.Gate{type: :group, enabled: true}), do: true
+  defp unsafe_infrastructure_gate?(_gate), do: false
+
+  defp parse_account_actor("account:" <> id) do
+    case Integer.parse(id) do
+      {account_id, ""} -> {:ok, account_id}
+      _ -> :error
+    end
+  end
+
+  defp parse_account_actor(_actor), do: :error
 
   defp provision(account_id, region_id, image_tag) do
     case Kura.create_server(%{account_id: account_id, region: region_id, image_tag: image_tag}) do
@@ -252,7 +268,14 @@ defmodule Tuist.Kura.RunnerCache do
   # (`current_image_tag` nil) — the only state `Kura.retry_server/2`
   # accepts. Failures after a successful deploy keep their node and are
   # an operator concern, not ours.
-  defp nodes_to_retry(region_id) do
+  defp nodes_to_retry(region_id, image_tag) do
+    servers = failed_first_deploy_servers(region_id)
+    failure_histories = retry_failure_histories(servers, image_tag)
+
+    Enum.filter(servers, &retry_due?(&1, Map.get(failure_histories, &1.id, [])))
+  end
+
+  defp failed_first_deploy_servers(region_id) do
     Repo.all(
       from(s in Server,
         where: s.region == ^region_id,
@@ -261,6 +284,60 @@ defmodule Tuist.Kura.RunnerCache do
         select: s
       )
     )
+  end
+
+  defp retry_failure_histories([], _image_tag), do: %{}
+
+  defp retry_failure_histories(servers, image_tag) do
+    server_ids = Enum.map(servers, & &1.id)
+
+    ranked_failures =
+      from(d in Deployment,
+        where: d.kura_server_id in ^server_ids,
+        where: d.image_tag == ^image_tag,
+        where: d.status == :failed,
+        windows: [
+          per_server: [
+            partition_by: d.kura_server_id,
+            order_by: [desc: d.finished_at, desc: d.inserted_at, desc: d.id]
+          ]
+        ],
+        select: %{
+          finished_at: d.finished_at,
+          rank: over(row_number(), :per_server),
+          server_id: d.kura_server_id
+        }
+      )
+
+    ranked_failures
+    |> subquery()
+    |> where([failure], failure.rank <= ^length(@retry_backoff_seconds))
+    |> order_by([failure], asc: failure.server_id, asc: failure.rank)
+    |> select([failure], {failure.server_id, failure.finished_at})
+    |> Repo.all()
+    |> Enum.group_by(fn {server_id, _finished_at} -> server_id end, fn {_server_id, finished_at} -> finished_at end)
+  end
+
+  defp retry_due?(%Server{} = server, failures) do
+    case failures do
+      [] ->
+        true
+
+      [nil | _] ->
+        false
+
+      [last_failed_at | _] ->
+        delay = retry_delay_seconds(server.id, length(failures))
+        retry_at = DateTime.add(last_failed_at, delay, :second)
+        DateTime.compare(DateTime.utc_now(), retry_at) != :lt
+    end
+  end
+
+  defp retry_delay_seconds(server_id, failure_count) do
+    base_delay = Enum.at(@retry_backoff_seconds, failure_count - 1)
+    jitter_window = div(base_delay, 10)
+    jitter = :erlang.phash2(server_id, jitter_window * 2 + 1) - jitter_window
+    min(base_delay + jitter, List.last(@retry_backoff_seconds))
   end
 
   defp retry(%Server{} = server, image_tag) do

--- a/server/priv/repo/migrations/20260719120000_retire_hetzner_staging_runner_cache_servers.exs
+++ b/server/priv/repo/migrations/20260719120000_retire_hetzner_staging_runner_cache_servers.exs
@@ -1,0 +1,22 @@
+defmodule Tuist.Repo.Migrations.RetireHetznerStagingRunnerCacheServers do
+  use Ecto.Migration
+
+  @retired_region "hetzner-staging-runners"
+  @destroying_status 3
+  @destroyed_status 4
+
+  def up do
+    # This data migration intentionally targets the exact retired fleet rows.
+    # credo:disable-for-next-line ExcellentMigrations.CredoCheck.MigrationsSafety
+    execute("""
+    UPDATE kura_servers
+    SET status = #{@destroying_status}, updated_at = NOW()
+    WHERE region = '#{@retired_region}'
+      AND status <> #{@destroyed_status}
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/server/priv/repo/migrations/20260719121000_enforce_one_open_kura_deployment_per_server.exs
+++ b/server/priv/repo/migrations/20260719121000_enforce_one_open_kura_deployment_per_server.exs
@@ -1,0 +1,49 @@
+defmodule Tuist.Repo.Migrations.EnforceOneOpenKuraDeploymentPerServer do
+  use Ecto.Migration
+
+  def up do
+    # Keep an old server process from creating another open deployment between
+    # the repair and the constraint becoming active. The table is operational
+    # history and small enough that a brief write pause is safer than a
+    # concurrent index whose build can race the version this deploy replaces.
+    # credo:disable-for-next-line ExcellentMigrations.CredoCheck.MigrationsSafety
+    execute("LOCK TABLE kura_deployments IN SHARE ROW EXCLUSIVE MODE")
+
+    # The ranking query cannot be expressed through the migration helpers.
+    # credo:disable-for-next-line ExcellentMigrations.CredoCheck.MigrationsSafety
+    execute("""
+    WITH ranked AS (
+      SELECT id,
+             ROW_NUMBER() OVER (
+               PARTITION BY kura_server_id
+               ORDER BY inserted_at DESC, id DESC
+             ) AS position
+      FROM kura_deployments
+      WHERE status IN (0, 1)
+    )
+    UPDATE kura_deployments AS deployment
+    SET status = 4,
+        error_message = 'cancelled while enforcing one open deployment per Kura server',
+        finished_at = NOW(),
+        updated_at = NOW()
+    FROM ranked
+    WHERE deployment.id = ranked.id
+      AND ranked.position > 1
+    """)
+
+    # The index must be created while the transaction still owns the table lock.
+    # credo:disable-for-next-line ExcellentMigrations.CredoCheck.MigrationsSafety
+    create unique_index(:kura_deployments, [:kura_server_id],
+             name: :kura_deployments_one_open_per_server_index,
+             where: "status IN (0, 1)"
+           )
+  end
+
+  def down do
+    # Keep the rollback in the same transaction as the rest of this migration.
+    # credo:disable-for-next-line ExcellentMigrations.CredoCheck.MigrationsSafety
+    drop_if_exists index(:kura_deployments, [:kura_server_id],
+                     name: :kura_deployments_one_open_per_server_index
+                   )
+  end
+end

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -232,6 +232,72 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(unmeshed["spec"], "mesh")
     end
 
+    test "arms peer-view sync only for a self-hosting-capable account in a mesh region" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      region = eu_region(%{mesh: true})
+      account = %Account{id: 1, name: "tuist"}
+
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+
+      entitled =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          account,
+          region,
+          %Server{},
+          "return true"
+        )
+
+      entitled_env = Map.new(entitled["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      assert entitled_env["KURA_MESH_PEERS_SYNC"] == "true"
+
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+
+      non_entitled =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          account,
+          region,
+          %Server{},
+          "return true"
+        )
+
+      non_entitled_env = Map.new(non_entitled["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      refute Map.has_key?(non_entitled_env, "KURA_MESH_PEERS_SYNC")
+    end
+
+    test "withholds peer-view sync outside a mesh region" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %Account{id: 1, name: "tuist"},
+          eu_region(),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+      refute Map.has_key?(env, "KURA_MESH_PEERS_SYNC")
+    end
+
     test "emits the public peer host and external peers for a meshed region" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 
@@ -251,6 +317,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         )
 
       assert bridged["spec"]["meshPublicPeerHost"] == "peer.tuist-eu-central-1.kura.tuist.dev"
+      assert bridged["spec"]["meshPublicPeerPublished"] == true
       assert bridged["spec"]["meshExternalPeers"] == ["https://kura.acme.example:7443"]
 
       assert bridged["spec"]["meshPublicPeerLoadBalancerAnnotations"] == %{
@@ -269,6 +336,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         )
 
       refute Map.has_key?(unbridged["spec"], "meshPublicPeerHost")
+      refute Map.has_key?(unbridged["spec"], "meshPublicPeerPublished")
       refute Map.has_key?(unbridged["spec"], "meshExternalPeers")
     end
 
@@ -321,7 +389,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         "00000000-0000-0000-0000-000000000001"
       end)
 
-      region = eu_region(%{gateway: :host_network})
+      region = eu_region(%{gateway: :host_network, mesh: true})
 
       moving_in =
         KubernetesController.manifest(
@@ -338,6 +406,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       # source keeps sole ownership until the target is promoted.
       refute Map.has_key?(moving_in["spec"], "publicHost")
       refute Map.has_key?(moving_in["spec"], "grpcPublicHost")
+      assert moving_in["spec"]["meshPublicPeerHost"] == "peer.tuist-eu-central-1.kura.tuist.dev"
+      assert moving_in["spec"]["meshPublicPeerPublished"] == false
       # And it is pinned to the destination box.
       assert moving_in["spec"]["nodeSelector"]["kubernetes.io/hostname"] == "box-2"
 
@@ -353,7 +423,21 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       # The steady-state (:none) server owns the customer host.
       assert is_binary(steady_state["spec"]["publicHost"])
+      assert steady_state["spec"]["meshPublicPeerPublished"] == true
       refute Map.get(steady_state["spec"]["nodeSelector"] || %{}, "kubernetes.io/hostname")
+
+      moving_out =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1-source",
+          "0.5.2",
+          %{name: "tuist"},
+          region,
+          %Server{move_phase: :moving_out},
+          "return true"
+        )
+
+      assert moving_out["spec"]["meshPublicPeerHost"] == "peer.tuist-eu-central-1.kura.tuist.dev"
+      assert moving_out["spec"]["meshPublicPeerPublished"] == false
     end
 
     test "omits external peers for a meshed region with no self-hosted nodes" do

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -265,7 +265,9 @@ defmodule Tuist.Kura.ReconcilerTest do
       assert extra.deployment_id == deployment.id
       assert extra.server_id == server.id
       assert extra.region == server.region
-      assert extra.reason == "apply failed"
+      assert extra.failure_detail == "apply failed"
+      assert extra.failure_kind == "provisioner_error"
+      assert opts[:tags].failure_kind == "provisioner_error"
       :ignored
     end)
 
@@ -285,7 +287,8 @@ defmodule Tuist.Kura.ReconcilerTest do
 
     expect(Sentry, :capture_message, fn "Kura deploy failed", opts ->
       assert opts[:level] == :error
-      assert opts[:extra].reason == "Kubernetes API unavailable"
+      assert opts[:extra].failure_detail == "Kubernetes API unavailable"
+      assert opts[:extra].failure_kind == "provisioner_error"
       :ignored
     end)
 
@@ -297,6 +300,43 @@ defmodule Tuist.Kura.ReconcilerTest do
            } = Repo.get!(Deployment, deployment.id)
 
     assert %Server{status: :failed, current_image_tag: nil} = Repo.get!(Server, server.id)
+  end
+
+  test "continues later reconciliation phases after one server cannot schedule" do
+    {_account, stale, stale_deployment} = create_server()
+    {:ok, stale} = Kura.activate_server(stale, stale_deployment.image_tag)
+    mark_deployment_succeeded(stale_deployment)
+    stale = stale |> Ecto.Changeset.change(region: "removed-region") |> Repo.update!()
+
+    {_account, destroying, destroying_deployment} = create_server()
+    {:ok, destroying} = Kura.activate_server(destroying, destroying_deployment.image_tag)
+    mark_deployment_succeeded(destroying_deployment)
+    {:ok, destroying} = Kura.destroy_server(destroying)
+
+    stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
+
+    stub(Provisioner, :current_image_tag, fn
+      %Server{id: id} when id == destroying.id -> {:error, :not_found}
+      %Server{id: id} when id == stale.id -> {:error, :not_found}
+    end)
+
+    expect(Sentry, :capture_message, fn "Kura deployment scheduling failed", opts ->
+      assert opts[:extra].server_id == stale.id
+      assert opts[:extra].region == "removed-region"
+      assert opts[:extra].failure_kind == "not_found"
+      :ignored
+    end)
+
+    assert :ok = Reconciler.reconcile()
+    assert %Server{status: :destroyed} = Repo.get!(Server, destroying.id)
+  end
+
+  test "deduplicates overlapping reconciler jobs" do
+    assert {:ok, first} = Oban.insert(Reconciler.new(%{}))
+    assert {:ok, second} = Oban.insert(Reconciler.new(%{}))
+
+    assert second.conflict?
+    assert second.id == first.id
   end
 
   test "keeps an active server at :failed when a drift rollout fails so the working endpoint stays up" do

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -235,6 +235,17 @@ defmodule Tuist.Kura.RegionsTest do
 
       assert Enum.map(Regions.available(), & &1.id) == ["eu-central"]
     end
+
+    test "never makes a retired cleanup region available" do
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["hetzner-staging-runners"]
+      end)
+
+      assert Regions.available() == []
+    end
   end
 
   describe "private runner-cache regions" do
@@ -254,9 +265,15 @@ defmodule Tuist.Kura.RegionsTest do
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)
 
-      # The only private region. Linux runners have no cache region of their
-      # own: the Hetzner-backed staging one was removed with its node pool.
-      assert Regions.all() |> Enum.filter(&Regions.private?/1) |> Enum.map(& &1.id) == ["scw-fr-par-runners"]
+      # The retired Hetzner entry remains fetchable only so old resources can
+      # be deleted. It is not an available serving region.
+      assert Regions.all() |> Enum.filter(&Regions.private?/1) |> Enum.map(& &1.id) == [
+               "scw-fr-par-runners",
+               "hetzner-staging-runners"
+             ]
+
+      assert Regions.retired?(Regions.get("hetzner-staging-runners"))
+      refute Regions.retired?(Regions.get("scw-fr-par-runners"))
     end
   end
 

--- a/server/test/tuist/kura/runner_cache_test.exs
+++ b/server/test/tuist/kura/runner_cache_test.exs
@@ -3,6 +3,8 @@ defmodule Tuist.Kura.RunnerCacheTest do
   use Mimic
 
   alias Tuist.Accounts
+  alias Tuist.Kura
+  alias Tuist.Kura.Deployment
   alias Tuist.Kura.RunnerCache
   alias Tuist.Kura.Server
   alias Tuist.Repo
@@ -53,8 +55,13 @@ defmodule Tuist.Kura.RunnerCacheTest do
   end
 
   defp enable_runners_for(account_ids) do
-    stub(FunWithFlags, :enabled?, fn :runners, [for: %{id: account_id}] ->
-      account_id in account_ids
+    gates =
+      Enum.map(account_ids, fn account_id ->
+        %FunWithFlags.Gate{type: :actor, for: "account:#{account_id}", enabled: true}
+      end)
+
+    stub(FunWithFlags, :get_flag, fn :runners ->
+      %FunWithFlags.Flag{name: :runners, gates: gates}
     end)
   end
 
@@ -108,12 +115,10 @@ defmodule Tuist.Kura.RunnerCacheTest do
     assert server_regions(account) == []
   end
 
-  test "an enabled account beyond the first candidate page still gets a node" do
-    # Default profiles are auto-created for every account, so
-    # non-enabled accounts dominate the candidate set and never leave
-    # it. The enabled account is created LAST (highest id): a single
-    # capped page ordered by id would return only non-enabled rows
-    # forever and starve it.
+  test "provisions an explicit actor without scanning preceding accounts" do
+    # Default profiles are auto-created for every account. The explicit actor
+    # cohort lets this account provision directly even when many non-enabled
+    # accounts sort before it.
     now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
     now_utc = DateTime.truncate(DateTime.utc_now(), :second)
 
@@ -177,5 +182,159 @@ defmodule Tuist.Kura.RunnerCacheTest do
     # with), but the profile-less account's nodes are still freed.
     assert server_regions(fresh) == []
     assert server_regions(account) == []
+  end
+
+  test "preserves existing nodes and provisions nothing for an unsafe global gate" do
+    existing = account_with_profiles([:macos])
+    candidate = account_with_profiles([:macos])
+    enable_runners_for([existing.id])
+
+    assert :ok = RunnerCache.reconcile()
+    assert server_regions(existing) == ["scw-fr-par-runners"]
+
+    stub(FunWithFlags, :get_flag, fn :runners ->
+      %FunWithFlags.Flag{
+        name: :runners,
+        gates: [%FunWithFlags.Gate{type: :boolean, for: nil, enabled: true}]
+      }
+    end)
+
+    assert :ok = RunnerCache.reconcile()
+    assert server_regions(existing) == ["scw-fr-par-runners"]
+    assert server_regions(candidate) == []
+  end
+
+  test "preserves existing nodes for a percentage-of-time gate" do
+    account = account_with_profiles([:macos])
+    enable_runners_for([account.id])
+
+    assert :ok = RunnerCache.reconcile()
+
+    stub(FunWithFlags, :get_flag, fn :runners ->
+      %FunWithFlags.Flag{
+        name: :runners,
+        gates: [%FunWithFlags.Gate{type: :percentage_of_time, for: 0.5, enabled: true}]
+      }
+    end)
+
+    assert :ok = RunnerCache.reconcile()
+    assert server_regions(account) == ["scw-fr-par-runners"]
+  end
+
+  test "preserves existing nodes for an unsupported actor gate" do
+    account = account_with_profiles([:macos])
+    enable_runners_for([account.id])
+
+    assert :ok = RunnerCache.reconcile()
+
+    stub(FunWithFlags, :get_flag, fn :runners ->
+      %FunWithFlags.Flag{
+        name: :runners,
+        gates: [%FunWithFlags.Gate{type: :actor, for: "user:123", enabled: true}]
+      }
+    end)
+
+    assert :ok = RunnerCache.reconcile()
+    assert server_regions(account) == ["scw-fr-par-runners"]
+  end
+
+  test "waits for the retry backoff before retrying the same image" do
+    account = account_with_profiles([:macos])
+    enable_runners_for([account.id])
+    assert :ok = RunnerCache.reconcile()
+
+    server = Repo.get_by!(Server, account_id: account.id, region: "scw-fr-par-runners")
+    deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, deployment} = Kura.mark_failed(deployment, "temporary failure")
+    {:ok, _server} = Kura.fail_server(server)
+
+    assert :ok = RunnerCache.reconcile()
+    assert open_deployment_count(server) == 0
+
+    old_failure = minutes_ago(2)
+    deployment |> Ecto.Changeset.change(finished_at: old_failure) |> Repo.update!()
+
+    assert :ok = RunnerCache.reconcile()
+    assert open_deployment_count(server) == 1
+  end
+
+  test "caps repeated same-image retries at one hour" do
+    account = account_with_profiles([:macos])
+    enable_runners_for([account.id])
+    assert :ok = RunnerCache.reconcile()
+
+    server = Repo.get_by!(Server, account_id: account.id, region: "scw-fr-par-runners")
+    initial = Repo.get_by!(Deployment, kura_server_id: server.id)
+    {:ok, initial} = Kura.mark_running(initial)
+    {:ok, initial} = Kura.mark_failed(initial, "temporary failure")
+
+    initial
+    |> Ecto.Changeset.change(finished_at: minutes_ago(240))
+    |> Repo.update!()
+
+    {:ok, _server} = Kura.fail_server(server)
+
+    for minutes <- [180, 120, 50] do
+      Repo.insert!(%Deployment{
+        cluster_id: "scw-fr-par",
+        image_tag: "0.5.2",
+        kura_server_id: server.id,
+        status: :failed,
+        error_message: "temporary failure",
+        finished_at: minutes_ago(minutes)
+      })
+    end
+
+    assert :ok = RunnerCache.reconcile()
+    assert open_deployment_count(server) == 0
+
+    latest =
+      Deployment
+      |> where([d], d.kura_server_id == ^server.id and d.status == :failed)
+      |> order_by([d], desc: d.finished_at)
+      |> limit(1)
+      |> Repo.one!()
+
+    latest
+    |> Ecto.Changeset.change(finished_at: minutes_ago(61))
+    |> Repo.update!()
+
+    assert :ok = RunnerCache.reconcile()
+    assert open_deployment_count(server) == 1
+  end
+
+  test "retries immediately when the configured image changes" do
+    account = account_with_profiles([:macos])
+    enable_runners_for([account.id])
+    assert :ok = RunnerCache.reconcile()
+
+    server = Repo.get_by!(Server, account_id: account.id, region: "scw-fr-par-runners")
+    deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, _deployment} = Kura.mark_failed(deployment, "broken image")
+    {:ok, _server} = Kura.fail_server(server)
+
+    stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
+
+    assert :ok = RunnerCache.reconcile()
+
+    assert %Deployment{image_tag: "0.5.3", status: :pending} =
+             Repo.get_by!(Deployment, kura_server_id: server.id, status: :pending)
+  end
+
+  defp open_deployment_count(server) do
+    Repo.aggregate(
+      from(d in Deployment,
+        where: d.kura_server_id == ^server.id and d.status in [:pending, :running]
+      ),
+      :count
+    )
+  end
+
+  defp minutes_ago(minutes) do
+    DateTime.utc_now()
+    |> DateTime.add(-minutes, :minute)
+    |> DateTime.truncate(:second)
   end
 end

--- a/server/test/tuist/kura/runner_cache_test.exs
+++ b/server/test/tuist/kura/runner_cache_test.exs
@@ -22,6 +22,7 @@ defmodule Tuist.Kura.RunnerCacheTest do
   setup do
     stub(Tuist.Environment, :dev?, fn -> false end)
     stub(Tuist.Environment, :test?, fn -> false end)
+    stub(Sentry, :capture_message, fn _message, _opts -> :ignored end)
 
     stub(Tuist.Environment, :kura_available_region_ids, fn ->
       ["scw-fr-par-runners"]
@@ -197,6 +198,13 @@ defmodule Tuist.Kura.RunnerCacheTest do
         name: :runners,
         gates: [%FunWithFlags.Gate{type: :boolean, for: nil, enabled: true}]
       }
+    end)
+
+    expect(Sentry, :capture_message, fn "Kura runner-cache reconciliation paused", opts ->
+      assert opts[:level] == :error
+      assert opts[:tags] == %{failure_kind: "non_actor_runner_gate"}
+      assert opts[:extra] == %{failure_detail: ":non_actor_runner_gate"}
+      :ignored
     end)
 
     assert :ok = RunnerCache.reconcile()

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -4,6 +4,7 @@ defmodule Tuist.KuraTest do
   import Mimic
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
@@ -229,6 +230,52 @@ defmodule Tuist.KuraTest do
                Kura.schedule_runtime_image_deployments()
 
       assert deployment.kura_server_id == server.id
+    end
+
+    test "schedules runtime image deployments in bounded batches" do
+      account_now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+      server_now = DateTime.utc_now()
+
+      account_rows =
+        for index <- 1..101 do
+          %{
+            name: "kura-rollout-#{index}",
+            billing_email: "kura-rollout-#{index}@example.com",
+            created_at: account_now,
+            updated_at: account_now
+          }
+        end
+
+      {101, accounts} = Repo.insert_all(Account, account_rows, returning: [:id])
+
+      server_rows =
+        accounts
+        |> Enum.with_index(1)
+        |> Enum.map(fn {account, index} ->
+          %{
+            id: Ecto.UUID.generate(),
+            account_id: account.id,
+            region: "local-controller",
+            status: :active,
+            current_image_tag: "0.5.2",
+            provisioner_node_ref: "kura-rollout-#{index}",
+            move_phase: :none,
+            inserted_at: server_now,
+            updated_at: server_now
+          }
+        end)
+
+      {101, nil} = Repo.insert_all(Server, server_rows)
+
+      assert {:ok, %{scheduled: first_batch, failures: []}} =
+               Kura.schedule_version_deployments("0.5.3")
+
+      assert length(first_batch) == 100
+
+      assert {:ok, %{scheduled: second_batch, failures: []}} =
+               Kura.schedule_version_deployments("0.5.3")
+
+      assert length(second_batch) == 1
     end
   end
 

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -66,10 +66,11 @@ defmodule Tuist.KuraTest do
         })
 
       {:ok, server} = Kura.activate_server(server, "0.5.2")
+      mark_initial_deployment_succeeded(server)
 
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "sha-abcdef123456" end)
 
-      assert {:ok, [%Deployment{image_tag: "sha-abcdef123456"} = deployment]} =
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "sha-abcdef123456"} = deployment], failures: []}} =
                Kura.schedule_runtime_image_deployments()
 
       assert deployment.kura_server_id == server.id
@@ -87,13 +88,14 @@ defmodule Tuist.KuraTest do
         })
 
       {:ok, server} = Kura.activate_server(server, "0.5.2")
+      mark_initial_deployment_succeeded(server)
       {:ok, server} = Kura.fail_server(server)
 
       assert %Server{status: :failed, current_image_tag: "0.5.2"} = server
 
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "sha-abcdef123456" end)
 
-      assert {:ok, [%Deployment{image_tag: "sha-abcdef123456"} = deployment]} =
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "sha-abcdef123456"} = deployment], failures: []}} =
                Kura.schedule_runtime_image_deployments()
 
       assert deployment.kura_server_id == server.id
@@ -113,11 +115,13 @@ defmodule Tuist.KuraTest do
       {:ok, server} =
         Kura.record_observation(server, %{status: :replicating, current_image_tag: "0.5.2"})
 
+      mark_initial_deployment_succeeded(server)
+
       assert %Server{status: :replicating, current_image_tag: "0.5.2"} = server
 
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "sha-abcdef123456" end)
 
-      assert {:ok, [%Deployment{image_tag: "sha-abcdef123456"} = deployment]} =
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "sha-abcdef123456"} = deployment], failures: []}} =
                Kura.schedule_runtime_image_deployments()
 
       assert deployment.kura_server_id == server.id
@@ -138,7 +142,7 @@ defmodule Tuist.KuraTest do
 
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
 
-      assert {:ok, []} = Kura.schedule_runtime_image_deployments()
+      assert {:ok, %{scheduled: [], failures: []}} = Kura.schedule_runtime_image_deployments()
     end
 
     test "schedules a version only once per server" do
@@ -153,17 +157,54 @@ defmodule Tuist.KuraTest do
         })
 
       {:ok, server} = Kura.activate_server(server, "0.5.2")
+      mark_initial_deployment_succeeded(server)
       {:ok, _existing} = Kura.create_deployment(server, "0.5.3")
 
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
 
-      assert {:ok, []} = Kura.schedule_runtime_image_deployments()
+      assert {:ok, %{scheduled: [], failures: []}} = Kura.schedule_runtime_image_deployments()
     end
 
     test "does not create deployments when no runtime image tag is configured" do
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> nil end)
 
-      assert {:ok, []} = Kura.schedule_runtime_image_deployments()
+      assert {:ok, %{scheduled: [], failures: []}} = Kura.schedule_runtime_image_deployments()
+    end
+
+    test "returns per-server failures without discarding successfully scheduled deployments" do
+      first_account = Accounts.get_account_from_user(AccountsFixtures.user_fixture())
+      stale_account = Accounts.get_account_from_user(AccountsFixtures.user_fixture())
+
+      {:ok, healthy} =
+        Kura.create_server(%{
+          account_id: first_account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      {:ok, stale} =
+        Kura.create_server(%{
+          account_id: stale_account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      {:ok, healthy} = Kura.activate_server(healthy, "0.5.2")
+      {:ok, stale} = Kura.activate_server(stale, "0.5.2")
+      mark_initial_deployment_succeeded(healthy)
+      mark_initial_deployment_succeeded(stale)
+      stale = stale |> Ecto.Changeset.change(region: "removed-region") |> Repo.update!()
+
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
+
+      assert {:ok, %{scheduled: [deployment], failures: [failure]}} =
+               Kura.schedule_runtime_image_deployments()
+
+      assert deployment.kura_server_id == healthy.id
+      assert failure.server_id == stale.id
+      assert failure.account_id == stale.account_id
+      assert failure.region == "removed-region"
+      assert failure.reason == :not_found
     end
 
     test "schedules the deploy-configured runtime image tag outside dev and test" do
@@ -178,12 +219,13 @@ defmodule Tuist.KuraTest do
         })
 
       {:ok, server} = Kura.activate_server(server, "0.5.1")
+      mark_initial_deployment_succeeded(server)
 
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.2" end)
 
-      assert {:ok, [%Deployment{image_tag: "0.5.2"} = deployment]} =
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "0.5.2"} = deployment], failures: []}} =
                Kura.schedule_runtime_image_deployments()
 
       assert deployment.kura_server_id == server.id
@@ -213,6 +255,18 @@ defmodule Tuist.KuraTest do
 
       assert deployment.kura_server_id == server.id
       assert deployment.cluster_id == "local-controller"
+    end
+
+    test "allows only one open deployment per server", %{server: server} do
+      assert {:ok, %Deployment{}} = Kura.create_deployment(server, "0.5.2")
+      assert {:error, :deployment_in_progress} = Kura.create_deployment(server, "0.5.3")
+
+      assert Repo.aggregate(
+               from(d in Deployment,
+                 where: d.kura_server_id == ^server.id and d.status in [:pending, :running]
+               ),
+               :count
+             ) == 1
     end
 
     test "rejects an invalid OCI image tag", %{server: server} do
@@ -247,6 +301,8 @@ defmodule Tuist.KuraTest do
         |> Repo.insert()
 
       {:ok, d1} = Kura.create_deployment(server_a, "0.5.0")
+      {:ok, d1} = Kura.mark_running(d1)
+      {:ok, _d1} = Kura.mark_succeeded(d1)
       {:ok, d2} = Kura.create_deployment(server_a, "0.5.1")
       {:ok, _other} = Kura.create_deployment(server_b, "0.5.0")
 
@@ -391,6 +447,39 @@ defmodule Tuist.KuraTest do
 
     test "rejects moving a server that is not a steady-state active server", %{source: source} do
       assert {:error, :not_movable} = Kura.move_server(%{source | status: :provisioning}, "box-2")
+    end
+
+    test "submits target ownership before source relinquishment and then swaps phases", %{source: source} do
+      {:ok, target} = Kura.move_server(source, "box-2")
+      test_process = self()
+
+      expect(Provisioner, :rollout, 2, fn server, inputs ->
+        send(test_process, {:rollout, server.id, inputs.server.move_phase})
+        :ok
+      end)
+
+      assert {:ok, %Server{id: promoted_id, move_phase: :none}} = Kura.promote_move(target)
+      assert promoted_id == target.id
+
+      assert_receive {:rollout, target_id, :none}
+      assert target_id == target.id
+      assert_receive {:rollout, source_id, :moving_out}
+      assert source_id == source.id
+
+      assert %Server{move_phase: :none} = Repo.get!(Server, target.id)
+      assert %Server{move_phase: :moving_out} = Repo.get!(Server, source.id)
+    end
+
+    test "keeps database ownership unchanged when a manifest submission fails", %{source: source} do
+      {:ok, target} = Kura.move_server(source, "box-2")
+
+      expect(Provisioner, :rollout, 2, fn server, _inputs ->
+        if server.id == target.id, do: :ok, else: {:error, :source_submission_failed}
+      end)
+
+      assert {:error, :source_submission_failed} = Kura.promote_move(target)
+      assert %Server{move_phase: :moving_in} = Repo.get!(Server, target.id)
+      assert %Server{move_phase: :none} = Repo.get!(Server, source.id)
     end
   end
 
@@ -981,6 +1070,7 @@ defmodule Tuist.KuraTest do
           image_tag: "0.5.2"
         })
 
+      mark_initial_deployment_failed(server)
       {:ok, failed} = Kura.fail_server(server)
 
       assert {:ok, %Server{id: id, status: :provisioning, region: "local-controller"} = retried} =
@@ -1011,11 +1101,36 @@ defmodule Tuist.KuraTest do
 
       assert_receive {:kura_server, :created, _}
 
+      mark_initial_deployment_failed(server)
       {:ok, failed} = Kura.fail_server(server)
       {:ok, _retried} = Kura.retry_server(failed, "0.5.3")
 
       assert_receive {:kura_server, :updated, %{id: id, status: :provisioning}}
       assert id == server.id
+    end
+
+    test "rechecks the locked server before appending a retry deployment" do
+      account = Accounts.get_account_from_user(AccountsFixtures.user_fixture())
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      mark_initial_deployment_failed(server)
+      {:ok, failed} = Kura.fail_server(server)
+
+      assert {:ok, _retried} = Kura.retry_server(failed, "0.5.3")
+      assert {:error, :not_retryable} = Kura.retry_server(failed, "0.5.3")
+
+      assert Repo.aggregate(
+               from(d in Deployment,
+                 where: d.kura_server_id == ^server.id and d.status in [:pending, :running]
+               ),
+               :count
+             ) == 1
     end
 
     test "refuses to retry a previously-active server" do
@@ -1078,6 +1193,18 @@ defmodule Tuist.KuraTest do
   # A public server as `activate_server/2` leaves it: active, public
   # `url`, and the URL mirrored into `account_cache_endpoints`. The
   # fallback intersects mirror and active servers, so tests need both.
+  defp mark_initial_deployment_succeeded(server) do
+    deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, _deployment} = Kura.mark_succeeded(deployment)
+  end
+
+  defp mark_initial_deployment_failed(server) do
+    deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, _deployment} = Kura.mark_failed(deployment, "apply failed")
+  end
+
   defp activate_public_server!(account, region) do
     handle = String.downcase(account.name)
     url = "https://#{handle}-#{region}-1.kura.tuist.dev"


### PR DESCRIPTION
## What changed

This makes Kura deployment scheduling transactional per server, limits each pass to 100 eligible servers, prevents more than one open deployment for a server, contains failures to the affected server, and makes runner-cache reconciliation retryable and idempotent. It also keeps retired-region identity available for teardown and disables warm handoffs in production until a stable account-region binding can own publication atomically.

## Why

A single scheduling collision could abort a whole reconciliation pass, concurrent retries could race to create duplicate open deployments, and an unbounded pass would perform work proportional to every Kura server at once. Partial runner-cache operations could also strand state. Warm handoffs assume stronger endpoint ownership guarantees than the controller currently provides.

## Root cause

The reconciler treated batch scheduling and multi-step provisioning as if they were atomic even though database and cluster operations converge independently. Warm handoffs also tied endpoint publication to a server row instead of a stable account-region identity that survives a move.

## Approach

The eligibility query excludes servers that already have the requested image or an open deployment, orders candidates deterministically, and limits each pass to 100 servers. Each selected server is then locked and scheduled independently, with database uniqueness preserving the concurrency invariant. Reconciliation work remains unique, and multi-step runner-cache operations preserve retryable state.

The existing warm-handoff machinery remains testable but is gated off in production. [#12020](https://github.com/tuist/tuist/issues/12020), assigned to Pepicrft, owns production enablement with these explicit gates:

1. Introduce a stable account-region binding that owns the customer endpoint independently of either source or target server row.
2. Make promotion transfer that binding atomically, then derive endpoint publication from the binding.
3. Exercise forced moves in staging while continuously reading and writing through the customer endpoint, including retries and controller restarts at every phase.
4. Enable one staging account, then a small production allowlist, and expand only after endpoint continuity and rollback alerts remain clean.

Until those gates are implemented and validated, production configuration stays disabled and move requests fail closed.

## Impact

Healthy servers continue reconciling when another server fails. Repeated work converges without duplicate deployments, large fleets roll forward in bounded passes, and unsafe warm handoffs remain unavailable in production.

## Validation

- 69 focused tests in `test/tuist/kura_test.exs` passed
- `mix credo --strict lib/tuist/kura.ex test/tuist/kura_test.exs`
- `mix format` on the changed source and test files
- `git diff --check`

## Review order

Second in the server stack. Review after [#12001](https://github.com/tuist/tuist/pull/12001), then continue with [#12004](https://github.com/tuist/tuist/pull/12004).
