### PR TITLE
fix(server): prevent oversized operator grant sessions

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -90,6 +90,9 @@ server:
   # any POST endpoint with a non-trivial body (cache, runs, webhooks).
   ingress:
     annotations:
+      # Authorization redirects combine a signed session cookie with a long
+      # Location header. Keep enough response-header headroom for both.
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
       nginx.ingress.kubernetes.io/proxy-body-size: "50m"
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -125,6 +125,8 @@ config :logger, :console,
     # Operator project-access grant (forensic join key for the audit trail)
     :operator_grant_jti,
     :operator_grant_sub,
+    :session_payload_bytes,
+    :warning_threshold_bytes,
     # Tuist.Runners structured fields
     :pod_uid,
     :pod_name,

--- a/server/lib/tuist_web/operator_grant.ex
+++ b/server/lib/tuist_web/operator_grant.ex
@@ -10,9 +10,12 @@ defmodule TuistWeb.OperatorGrant do
     * `verify/1` — verifies that token OFFLINE with the configured
       Ed25519 public key (no runtime call to ops). EdDSA-strict, with
       `exp`, max-TTL ceiling, and `iss`/`aud` pinning.
+    * `prune_operator_grants/2` — removes expired grants and fields that
+      are not needed for authorization before the session cookie is written.
     * `accept_operator_grant/2` — a plug in `:browser_app` that takes
       the `?operator_grant=` token on the redirect-back, verifies it,
-      pins the resolved `account_id` into the claims, stores them in
+      pins the resolved `account_id` into the claims, stores the minimal
+      authorization fields in
       the session, and immediately redirects to strip the token from
       the URL (so it never lands in a rendered page, Referer, or the
       observability logs).
@@ -23,11 +26,11 @@ defmodule TuistWeb.OperatorGrant do
       non-member operator with no grant to the reason form instead of
       404ing them.
 
-  The grant claims stored on the user are a normalised, atom-keyed map
-  the authorization checks rely on:
+  The session stores only the normalised, atom-keyed fields that the
+  authorization checks and audit logging rely on:
 
       %{tier: :read | :admin, account_id: integer, account_handle: string,
-        sub: string, reason: string, jti: string, iat: integer, exp: integer}
+        sub: string, jti: string, exp: integer}
 
   Revocation is by short TTL (re-checked on every request) plus signing
   key rotation as the break-glass; there is deliberately no server→ops
@@ -46,6 +49,8 @@ defmodule TuistWeb.OperatorGrant do
 
   @issuer "ops.tuist.dev"
   @session_key "operator_grants"
+  @session_grant_keys [:tier, :account_id, :account_handle, :sub, :jti, :exp]
+  @session_payload_warning_bytes 3_000
   # Tolerance for clock drift between the ops signer and this server.
   @clock_skew_seconds 60
   # Account handles are alphanumeric + dashes (mirrors the server's name
@@ -174,6 +179,33 @@ defmodule TuistWeb.OperatorGrant do
   # --- handoff plug (runs in :browser_app) -------------------------------
 
   @doc """
+  Removes expired grants and compacts active grants before the browser
+  session is written back to the cookie.
+  """
+  def prune_operator_grants(conn, _opts) do
+    case get_session(conn, @session_key) do
+      grants when is_map(grants) ->
+        compacted_grants = compact_active_grants(grants)
+
+        cond do
+          compacted_grants == grants ->
+            conn
+
+          map_size(compacted_grants) == 0 ->
+            delete_session(conn, @session_key)
+
+          true ->
+            conn
+            |> put_session(@session_key, compacted_grants)
+            |> maybe_warn_session_payload_size()
+        end
+
+      _ ->
+        conn
+    end
+  end
+
+  @doc """
   If the request carries `?operator_grant=`, verify it, pin the
   account, store it in the session, and redirect to the same path with
   the token stripped. No-ops otherwise.
@@ -194,11 +226,12 @@ defmodule TuistWeb.OperatorGrant do
       grants =
         conn
         |> get_session(@session_key)
-        |> normalize_grants()
-        |> Map.put(grant_key(claims.account_handle), Map.put(claims, :account_id, account_id))
+        |> compact_active_grants()
+        |> Map.put(grant_key(claims.account_handle), session_grant(claims, account_id))
 
       conn
       |> put_session(@session_key, grants)
+      |> maybe_warn_session_payload_size()
       |> redirect(to: stripped_path(conn))
       |> halt()
     else
@@ -237,8 +270,43 @@ defmodule TuistWeb.OperatorGrant do
 
   defp emails_match?(_, _), do: false
 
-  defp normalize_grants(grants) when is_map(grants), do: grants
-  defp normalize_grants(_), do: %{}
+  defp compact_active_grants(grants) when is_map(grants) do
+    now = System.system_time(:second)
+
+    Enum.reduce(grants, %{}, fn
+      {handle, %{exp: exp} = grant}, compacted when is_binary(handle) and is_integer(exp) and exp > now ->
+        Map.put(compacted, grant_key(handle), Map.take(grant, @session_grant_keys))
+
+      _, compacted ->
+        compacted
+    end)
+  end
+
+  defp compact_active_grants(_), do: %{}
+
+  defp session_grant(claims, account_id) do
+    claims
+    |> Map.take(@session_grant_keys)
+    |> Map.put(:account_id, account_id)
+  end
+
+  defp maybe_warn_session_payload_size(conn) do
+    payload_size =
+      conn
+      |> get_session()
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+      |> byte_size()
+
+    if payload_size >= @session_payload_warning_bytes do
+      Logger.warning("operator grant session payload is approaching the cookie size limit",
+        session_payload_bytes: payload_size,
+        warning_threshold_bytes: @session_payload_warning_bytes
+      )
+    end
+
+    conn
+  end
 
   defp stripped_path(conn) do
     query =

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -59,6 +59,7 @@ defmodule TuistWeb.Router do
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
+    plug :prune_operator_grants
     plug LocalePlug
     plug TuistWeb.Plugs.TimezonePlug
     plug :fetch_live_flash

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -96,6 +96,7 @@ defmodule TuistWeb.Router do
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
+    plug :prune_operator_grants
     plug LocalePlug
     plug :fetch_live_flash
     plug :protect_from_forgery
@@ -111,6 +112,7 @@ defmodule TuistWeb.Router do
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
+    plug :prune_operator_grants
     plug LocalePlug
     plug :fetch_live_flash
     plug :put_root_layout, html: {TuistWeb.Layouts, :app}

--- a/server/test/tuist_web/operator_grant_plugs_test.exs
+++ b/server/test/tuist_web/operator_grant_plugs_test.exs
@@ -8,6 +8,7 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.OperatorGrant
+  alias TuistWeb.Router
 
   describe "redirect_to_ops_if_operator/2" do
     setup do
@@ -250,6 +251,14 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
       assert get_session(conn, "operator_grants") == nil
     end
 
+    test "prunes expired grants in the Ueberauth request pipeline" do
+      assert_auth_pipeline_prunes_expired_grants(:ueberauth)
+    end
+
+    test "prunes expired grants in the unprotected authentication callback pipeline" do
+      assert_auth_pipeline_prunes_expired_grants(:unprotected_browser_app)
+    end
+
     test "warns when the compacted session payload reaches the size guardrail" do
       now = System.system_time(:second)
 
@@ -391,6 +400,30 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
       sub: user.email,
       exp: Keyword.get(opts, :exp, now + 600)
     }
+  end
+
+  defp assert_auth_pipeline_prunes_expired_grants(pipeline) do
+    now = System.system_time(:second)
+
+    conn =
+      :get
+      |> Phoenix.ConnTest.build_conn("/")
+      |> Plug.Test.init_test_session(%{
+        "operator_grants" => %{
+          "expired-account" => %{
+            tier: :read,
+            account_id: 1,
+            account_handle: "expired-account",
+            sub: "operator@tuist.dev",
+            jti: "expired-grant",
+            exp: now - 1
+          }
+        }
+      })
+
+    conn = apply(Router, pipeline, [conn, []])
+
+    assert get_session(conn, "operator_grants") == nil
   end
 
   defp operator_user do

--- a/server/test/tuist_web/operator_grant_plugs_test.exs
+++ b/server/test/tuist_web/operator_grant_plugs_test.exs
@@ -2,6 +2,7 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
   use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
+  import ExUnit.CaptureLog
   import Plug.Conn
 
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -122,6 +123,10 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
       grant = get_session(conn, "operator_grants")[account.name]
       assert grant.tier == :read
       assert grant.account_id == account.id
+
+      assert grant
+             |> Map.keys()
+             |> Enum.sort() == [:account_handle, :account_id, :exp, :jti, :sub, :tier]
     end
 
     test "rejects a grant when the session is not Google-authenticated", %{signer: signer} do
@@ -188,6 +193,94 @@ defmodule TuistWeb.OperatorGrantPlugsTest do
 
       assert conn.halted
       assert get_session(conn, "operator_grants") == nil
+    end
+  end
+
+  describe "prune_operator_grants/2" do
+    test "removes expired grants and fields that are not needed for authorization" do
+      now = System.system_time(:second)
+
+      active_grant = %{
+        tier: :read,
+        account_id: 1,
+        account_handle: "active-account",
+        sub: "operator@tuist.dev",
+        reason: "investigating",
+        jti: "active-grant",
+        iat: now - 60,
+        exp: now + 600
+      }
+
+      expired_grant = %{active_grant | account_handle: "expired-account", jti: "expired-grant", exp: now - 1}
+
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> Plug.Test.init_test_session(%{
+          "operator_grants" => %{
+            "active-account" => active_grant,
+            "expired-account" => expired_grant
+          }
+        })
+        |> OperatorGrant.prune_operator_grants([])
+
+      assert get_session(conn, "operator_grants") == %{
+               "active-account" => Map.take(active_grant, [:tier, :account_id, :account_handle, :sub, :jti, :exp])
+             }
+    end
+
+    test "deletes the operator grants session entry when every grant is expired" do
+      now = System.system_time(:second)
+
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> Plug.Test.init_test_session(%{
+          "operator_grants" => %{
+            "expired-account" => %{
+              tier: :read,
+              account_id: 1,
+              account_handle: "expired-account",
+              sub: "operator@tuist.dev",
+              jti: "expired-grant",
+              exp: now - 1
+            }
+          }
+        })
+        |> OperatorGrant.prune_operator_grants([])
+
+      assert get_session(conn, "operator_grants") == nil
+    end
+
+    test "warns when the compacted session payload reaches the size guardrail" do
+      now = System.system_time(:second)
+
+      grants =
+        Map.new(1..40, fn index ->
+          handle = "account-#{index}"
+
+          {handle,
+           %{
+             tier: :read,
+             account_id: index,
+             account_handle: handle,
+             sub: "operator@tuist.dev",
+             reason: "removed during compaction",
+             jti: "grant-#{index}",
+             iat: now,
+             exp: now + 600
+           }}
+        end)
+
+      log =
+        capture_log(fn ->
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> Plug.Test.init_test_session(%{"operator_grants" => grants})
+            |> OperatorGrant.prune_operator_grants([])
+
+          assert map_size(get_session(conn, "operator_grants")) == 40
+        end)
+
+      assert log =~ "operator grant session payload is approaching the cookie size limit"
     end
   end
 


### PR DESCRIPTION
## What changed

Operator grants stored in the browser session are now compacted to the fields required for authorization and audit correlation. Expired grants are removed on each browser application request, and the session entry is deleted when no grants remain.

The server logs a warning when the estimated serialized session reaches 3,000 bytes. The managed server ingress also receives a scoped 16-kilobyte response-header buffer to provide operational headroom for authorization redirects.

## Why

Signing in through the Tuist integration could fail with a bad gateway response once an operator session accumulated enough grants. The change restores a reliable login flow while keeping the authorization state bounded and observable.

## Root cause

Every accepted operator grant was retained in the cookie-backed session, including expired grants. Each entry also included the justification and issuance timestamp even though neither field is needed after the grant has been verified. Over time, the serialized cookie and the redirect response headers could exceed the Nginx proxy buffer.

## Approach

The application now addresses the unbounded growth directly by pruning expired entries and retaining only the account, operator, access tier, grant identifier, and expiration fields. The ingress buffer increase is limited to the managed server ingress and serves as defensive headroom rather than the primary fix.

The justification remains available in the operations audit trail and is no longer copied into the browser session.

## Impact

Existing operator sessions are compacted on their next browser request. New grants use the smaller representation immediately. There is no database migration or user action required, and self-hosted ingress defaults are unchanged.

## Validation

- `mix test test/tuist_web/operator_grant_plugs_test.exs`: 21 tests passed.
- `mix test test/tuist_web/operator_grant_test.exs`: 14 tests passed.
- `mix format --check-formatted lib/tuist_web/operator_grant.ex lib/tuist_web/router.ex test/tuist_web/operator_grant_plugs_test.exs`
- Rendered `templates/server-ingress.yaml` with the managed Helm values and verified `nginx.ingress.kubernetes.io/proxy-buffer-size: 16k`.
- Loaded `/users/log_in` successfully with headless Chrome against the local Phoenix test server.
- `git diff --check`
