### PR TITLE
fix(server): tear down Kura servers in retired regions

### DIFF
--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -12,14 +12,16 @@ defmodule Tuist.Kura.Reconciler do
   independently-mutated state machine. Each tick:
 
     1. schedule runtime-image drift for active servers,
-    2. finalise destroys after the custom resource disappears,
-    3. apply open deployments (the rollout fast path), and
-    4. project every other present-intent server: observe the backing
+    2. schedule teardown for servers stranded in retired regions,
+    3. finalise destroys after the custom resource disappears,
+    4. drain the source of completed moves,
+    5. apply open deployments (the rollout fast path), and
+    6. project every other present-intent server: observe the backing
        `KuraInstance`, record the observation (`observed_image_tag` /
        `last_observed_at`), and re-derive `status` from
        `(latest deployment intent, observed image, endpoint readiness)`.
 
-  Because step 4 re-derives `status` from observation every tick,
+  Because step 6 re-derives `status` from observation every tick,
   `:failed` is never a sticky terminal sink: a server whose backing
   resource recovers and reports the intended image with a serving
   endpoint heals back to `:active` in place, with no new deployment row
@@ -83,6 +85,7 @@ defmodule Tuist.Kura.Reconciler do
     RunnerCache.reconcile()
 
     schedule_runtime_image_deployments()
+    reconcile_retired_region_servers()
     reconcile_destroying_servers()
     reconcile_moving_out_servers()
     handled = reconcile_deployments()
@@ -162,6 +165,47 @@ defmodule Tuist.Kura.Reconciler do
   defp log_scheduled_deployments(deployments) do
     Logger.info("[Kura.Reconciler] scheduled #{length(deployments)} runtime image deployment(s)")
     :ok
+  end
+
+  # Retiring a region leaves its servers stranded. The catalog tombstone exists
+  # so the reconciler can still resolve their cluster identity, but nothing ever
+  # scheduled their teardown, so the rows kept their status, their KuraInstances
+  # kept being reconciled, and their pods sat unschedulable forever against a
+  # node pool that was deleted with the region. Scheduling destruction here is
+  # what the tombstone was always for; `reconcile_destroying_servers` then runs
+  # the same teardown an operator-initiated destroy uses.
+  defp reconcile_retired_region_servers do
+    case Regions.retired_ids() do
+      [] ->
+        :ok
+
+      retired_ids ->
+        Server
+        |> where([s], s.region in ^retired_ids)
+        |> where([s], s.status not in [:destroying, :destroyed])
+        |> order_by([s], asc: s.updated_at, asc: s.id)
+        |> limit(^@reconcile_batch_size)
+        |> Repo.all()
+        |> Enum.each(&destroy_retired_region_server/1)
+
+        :ok
+    end
+  end
+
+  defp destroy_retired_region_server(%Server{} = server) do
+    case Kura.destroy_server(server) do
+      {:ok, _server} ->
+        Logger.info("[Kura.Reconciler] scheduled destruction of server #{server.id} in retired region #{server.region}")
+
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[Kura.Reconciler] could not schedule destruction of server #{server.id} in retired region #{server.region}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
   end
 
   defp reconcile_destroying_servers do

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -309,6 +309,18 @@ defmodule Tuist.Kura.Regions do
   def retired?(_), do: false
 
   @doc """
+  Ids of regions kept only as catalog tombstones. A tombstone exists so the
+  reconciler can still resolve a stored server's cluster identity long enough
+  to tear its resources down; servers left in one can never schedule, because
+  the node pool the tombstone names is gone.
+  """
+  def retired_ids do
+    all()
+    |> Enum.filter(&retired?/1)
+    |> Enum.map(& &1.id)
+  end
+
+  @doc """
   True iff this private region's runner fleet dials a node-published
   endpoint (`http://<node address>:<NodePort>`) instead of cluster
   Service DNS — the data plane for fleets that share a network with

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -616,6 +616,34 @@ defmodule Tuist.Kura.ReconcilerTest do
     {account, source}
   end
 
+  test "schedules destruction for servers stranded in a retired region" do
+    {_account, server, _deployment} = create_server()
+
+    {:ok, server} =
+      server
+      |> Ecto.Changeset.change(region: "hetzner-staging-runners")
+      |> Repo.update()
+
+    stub(Provisioner, :current_image_tag, fn _server -> {:error, :not_found} end)
+
+    Reconciler.reconcile()
+
+    # A retired region only stays in the catalog so its leftovers can be torn
+    # down. Without this the row keeps its status forever and its pod sits
+    # unschedulable against a node pool that was deleted with the region.
+    assert %Server{status: :destroyed} = Repo.reload!(server)
+  end
+
+  test "leaves servers in live regions alone" do
+    {_account, server, _deployment} = create_server()
+
+    stub(Provisioner, :current_image_tag, fn _server -> {:ok, "0.5.2"} end)
+
+    Reconciler.reconcile()
+
+    refute Repo.reload!(server).status in [:destroying, :destroyed]
+  end
+
   defp create_server do
     user = AccountsFixtures.user_fixture()
     account = Accounts.get_account_from_user(user)


### PR DESCRIPTION
## What changed

This adds a dedicated reconciliation pass for Kura servers whose regions remain in the catalog only as retirement tombstones. It moves those servers through the existing destruction path in bounded batches.

## Why

Retired-region rows can outlive the node pool and cluster resources they originally targeted. Without an explicit cleanup pass, their Kura instances remain unschedulable and are retried indefinitely.

## Root cause

The region tombstone made old cluster identity resolvable, but no reconciliation step converted stranded servers into destruction work.

## Approach

The reconciler queries non-destroyed servers in retired regions, schedules destruction through the standard server transition, and lets the existing teardown reconciliation remove their cluster resources.

## Impact

Old retired-region workloads converge to deletion without a one-off operator script. Active regions are unaffected.

## Validation

- 64 focused server tests passed
- `mix format --check-formatted`
- `mix credo --strict`
- `git diff --check`

## Review order

Fourth in the server stack. Review after [#12004](https://github.com/tuist/tuist/pull/12004), then continue with [#12006](https://github.com/tuist/tuist/pull/12006).