### PR TITLE
perf(server): preload Kura manifest entitlements

### DIFF
--- a/server/lib/tuist/billing/entitlements.ex
+++ b/server/lib/tuist/billing/entitlements.ex
@@ -66,7 +66,7 @@ defmodule Tuist.Billing.Entitlements do
     |> Enum.filter(&(&1.status in ["active", "trialing"]))
     |> case do
       [] -> :air
-      active -> active |> Enum.max_by(&{&1.inserted_at, &1.id}) |> Map.fetch!(:plan)
+      active -> active |> latest_subscription() |> Map.fetch!(:plan)
     end
   end
 
@@ -78,4 +78,14 @@ defmodule Tuist.Billing.Entitlements do
   end
 
   defp current_plan(_), do: :air
+
+  defp latest_subscription([subscription | subscriptions]) do
+    Enum.reduce(subscriptions, subscription, fn candidate, latest ->
+      case NaiveDateTime.compare(candidate.inserted_at, latest.inserted_at) do
+        :gt -> candidate
+        :lt -> latest
+        :eq -> if candidate.id > latest.id, do: candidate, else: latest
+      end
+    end)
+  end
 end

--- a/server/lib/tuist/billing/entitlements.ex
+++ b/server/lib/tuist/billing/entitlements.ex
@@ -20,7 +20,28 @@ defmodule Tuist.Billing.Entitlements do
   Returns true when the account's plan grants access to `feature`.
   """
   def allows?(account, feature) do
-    not Environment.tuist_hosted?() or plan_allows?(current_plan(account), feature)
+    MapSet.member?(allowed_features(account, [feature]), feature)
+  end
+
+  @doc """
+  Returns the requested features granted by the account's current plan.
+
+  The plan is resolved once for the complete feature set. When subscriptions
+  are preloaded on the account, the lookup stays in memory so batch callers do
+  not issue one subscription query per account.
+  """
+  def allowed_features(_account, []), do: MapSet.new()
+
+  def allowed_features(account, features) when is_list(features) do
+    if Environment.tuist_hosted?() do
+      plan = current_plan(account)
+
+      features
+      |> Enum.filter(&plan_allows?(plan, &1))
+      |> MapSet.new()
+    else
+      MapSet.new(features)
+    end
   end
 
   # Enterprise gets everything.
@@ -39,6 +60,15 @@ defmodule Tuist.Billing.Entitlements do
   defp plan_allows?(_plan, :guaranteed_egress_floor), do: false
 
   defp plan_allows?(_plan, _feature), do: false
+
+  defp current_plan(%Account{subscriptions: subscriptions}) when is_list(subscriptions) do
+    subscriptions
+    |> Enum.filter(&(&1.status in ["active", "trialing"]))
+    |> case do
+      [] -> :air
+      active -> active |> Enum.max_by(&{&1.inserted_at, &1.id}) |> Map.fetch!(:plan)
+    end
+  end
 
   defp current_plan(%Account{} = account) do
     case Billing.get_current_active_subscription(account) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -55,10 +55,11 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
          %{image_tag: image_tag, account: account, server: %Server{} = server, region: %Regions{} = region} = inputs
        ) do
     with {:ok, hook_script} <- hook_script(inputs) do
-      external_peers = self_hosted_peers(account, region)
+      entitlements = manifest_entitlements(account, region)
+      external_peers = self_hosted_peers(account, region, entitlements)
 
       case apply_manifests(
-             [manifest(name, image_tag, account, region, server, hook_script, external_peers)],
+             [render_manifest(name, image_tag, account, region, server, hook_script, external_peers, entitlements)],
              region
            ) do
         :ok -> :ok
@@ -191,7 +192,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   @impl true
   def manifest_revision(account, %Regions{} = region) do
-    manifest_revision_string(account, region, self_hosted_peers(account, region))
+    entitlements = manifest_entitlements(account, region)
+    manifest_revision_string(region, self_hosted_peers(account, region, entitlements), entitlements)
   end
 
   @doc "The base manifest revision, independent of dynamic per-account inputs."
@@ -228,9 +230,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
 
   @doc false
   def manifest(name, image_tag, account, %Regions{} = region, %Server{} = server, hook_script, external_peers \\ []) do
+    entitlements = manifest_entitlements(account, region)
+    render_manifest(name, image_tag, account, region, server, hook_script, external_peers, entitlements)
+  end
+
+  defp render_manifest(name, image_tag, account, region, server, hook_script, external_peers, entitlements) do
     account_handle = dns_handle(account.name)
-    external_peers = entitled_self_hosted_peers(account, region, external_peers)
-    revision = manifest_revision_string(account, region, external_peers)
+    external_peers = entitled_self_hosted_peers(region, external_peers, entitlements)
+    revision = manifest_revision_string(region, external_peers, entitlements)
     annotations = %{@manifest_revision_annotation => revision}
 
     %{
@@ -271,14 +278,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
           "exposeNodePort" => Regions.node_port_data_plane?(region),
           "clientCIDRs" => client_cidrs(region),
           "podAnnotations" => pod_annotations(region),
-          "egressGuaranteedMbps" => egress_guaranteed_mbps(account, region),
+          "egressGuaranteedMbps" => egress_guaranteed_mbps(region, entitlements),
           "storageClassName" => storage_class(region),
           "storageSize" => storage_size(region),
           "replicas" => replicas(region),
           "nodeSelector" => instance_node_selector(region, server),
           "tolerations" => tolerations(region),
           "extensionScript" => hook_script,
-          "extraEnv" => extension_env(account, region)
+          "extraEnv" => extension_env(region, entitlements)
         }
         |> Enum.reject(fn {_key, value} -> value in [nil, "", false] end)
         |> Map.new()
@@ -329,29 +336,40 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # actually join a peer. An account that cannot self-host has a fully static
   # roster (its managed peers, baked into the manifest), so it has nothing
   # dynamic to under-replicate to and must not arm Kura's peer-view boot gate.
-  defp mesh_peers_sync_enabled?(account, %Regions{} = region) do
-    mesh_enabled?(region) and Entitlements.allows?(account, :self_hosted_cache)
+  defp manifest_entitlements(account, %Regions{} = region) do
+    features =
+      []
+      |> maybe_request_entitlement(mesh_enabled?(region), :self_hosted_cache)
+      |> maybe_request_entitlement(guaranteed_egress_configured?(region), :guaranteed_egress_floor)
+    Entitlements.allowed_features(account, features)
   end
 
-  defp self_hosted_peers(account, %Regions{} = region) do
-    if mesh_peers_sync_enabled?(account, region) do
+  defp maybe_request_entitlement(features, true, feature), do: [feature | features]
+  defp maybe_request_entitlement(features, false, _feature), do: features
+
+  defp mesh_peers_sync_enabled?(%Regions{} = region, entitlements) do
+    mesh_enabled?(region) and MapSet.member?(entitlements, :self_hosted_cache)
+  end
+
+  defp self_hosted_peers(account, %Regions{} = region, entitlements) do
+    if mesh_peers_sync_enabled?(region, entitlements) do
       Mesh.self_hosted_peer_urls(account)
     else
       []
     end
   end
 
-  defp entitled_self_hosted_peers(account, %Regions{} = region, peer_urls) do
-    if mesh_peers_sync_enabled?(account, region), do: peer_urls, else: []
+  defp entitled_self_hosted_peers(%Regions{} = region, peer_urls, entitlements) do
+    if mesh_peers_sync_enabled?(region, entitlements), do: peer_urls, else: []
   end
 
   # The desired revision the reconciler compares against the live CR's
   # annotation. Both the reconcile check (manifest_revision/2) and the applied
   # manifest (manifest/7) build it here so they can never disagree and loop.
-  defp manifest_revision_string(account, %Regions{} = region, peer_urls) do
+  defp manifest_revision_string(%Regions{} = region, peer_urls, entitlements) do
     @manifest_revision <>
       peers_revision_suffix(peer_urls) <>
-      mesh_peers_sync_revision_suffix(account, region)
+      mesh_peers_sync_revision_suffix(region, entitlements)
   end
 
   # Folded into the manifest revision so enrolling or dropping a self-hosted
@@ -371,7 +389,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   end
 
   # Whether KURA_MESH_PEERS_SYNC is set has to be part of the revision, or a
-  # plan change that flips mesh_peers_sync_enabled?/2 would alter the desired
+  # plan change that flips the preloaded entitlement would alter the desired
   # env without altering the revision, and the reconciler (which converges on
   # the revision alone) would never re-apply — an account upgraded to a
   # self-hosting plan would keep serving without the peer-view gate armed, the
@@ -380,8 +398,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # enabled state and every non-mesh region byte-identical to today's revision,
   # so nothing that already runs with the right env is rolled — only the
   # mesh-region instances that should shed the variable change revision.
-  defp mesh_peers_sync_revision_suffix(account, region) do
-    if mesh_enabled?(region) and not mesh_peers_sync_enabled?(account, region) do
+  defp mesh_peers_sync_revision_suffix(region, entitlements) do
+    if mesh_enabled?(region) and not mesh_peers_sync_enabled?(region, entitlements) do
       "+nosync"
     else
       ""
@@ -450,7 +468,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # that ever runs Kura. The controller's envFrom on the StatefulSet
   # picks up that Secret automatically. Non-secret knobs such as the
   # introspection client ID are safe to keep in the spec.
-  defp extension_env(account, %Regions{} = region) do
+  defp extension_env(%Regions{} = region, entitlements) do
     [
       env_var("KURA_EXTENSION_FAIL_CLOSED_AUTHENTICATE", "true"),
       env_var("KURA_EXTENSION_FAIL_CLOSED_AUTHORIZE", "true"),
@@ -465,7 +483,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
         Environment.kura_control_plane_client_id()
       ) ++
       cas_capacity_env(region) ++
-      mesh_peers_sync_env(account, region) ++
+      mesh_peers_sync_env(region, entitlements) ++
       telemetry_env(region)
   end
 
@@ -578,13 +596,13 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # self-hosted peer list from the control plane at boot and on cadence, so a
   # self-hosted peer joining or leaving propagates without rolling the fleet.
   # The variable also arms Kura's peer-view boot gate, so it is set only for
-  # accounts that can have such peers (see mesh_peers_sync_enabled?/2); folding
+  # accounts that can have such peers; folding
   # the flag into the manifest revision (mesh_peers_sync_revision_suffix/2)
   # keeps a plan change from silently leaving a running instance ungated. Once
   # the whole fleet runs an image that fetches, the peers digest can be dropped
   # from the manifest revision.
-  defp mesh_peers_sync_env(account, region) do
-    if mesh_peers_sync_enabled?(account, region) do
+  defp mesh_peers_sync_env(region, entitlements) do
+    if mesh_peers_sync_enabled?(region, entitlements) do
       [env_var("KURA_MESH_PEERS_SYNC", "true")]
     else
       []
@@ -674,12 +692,17 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # is bursty, so non-enterprise tenants run best-effort under the Cilium burst
   # ceiling alone and pack densely. nil (dropped) when the region has no floor or
   # the account isn't entitled.
-  defp egress_guaranteed_mbps(account, %Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}})
+  defp guaranteed_egress_configured?(%Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}})
+       when is_integer(mbps) and mbps > 0, do: true
+
+  defp guaranteed_egress_configured?(_region), do: false
+
+  defp egress_guaranteed_mbps(%Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}}, entitlements)
        when is_integer(mbps) and mbps > 0 do
-    if Entitlements.allows?(account, :guaranteed_egress_floor), do: mbps
+    if MapSet.member?(entitlements, :guaranteed_egress_floor), do: mbps
   end
 
-  defp egress_guaranteed_mbps(_account, _region), do: nil
+  defp egress_guaranteed_mbps(_region, _entitlements), do: nil
 
   # Whether the region's shared gateway runs host-network (directly on the
   # bare-metal box NIC) rather than as an LB-fronted controller. Drives the

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -278,7 +278,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
           "exposeNodePort" => Regions.node_port_data_plane?(region),
           "clientCIDRs" => client_cidrs(region),
           "podAnnotations" => pod_annotations(region),
-          "egressGuaranteedMbps" => egress_guaranteed_mbps(region, entitlements),
+          "egressGuaranteedMbps" => entitlements.egress_guaranteed_mbps,
           "storageClassName" => storage_class(region),
           "storageSize" => storage_size(region),
           "replicas" => replicas(region),
@@ -337,18 +337,29 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # roster (its managed peers, baked into the manifest), so it has nothing
   # dynamic to under-replicate to and must not arm Kura's peer-view boot gate.
   defp manifest_entitlements(account, %Regions{} = region) do
+    configured_egress_mbps = configured_egress_guaranteed_mbps(region)
+
     features =
       []
       |> maybe_request_entitlement(mesh_enabled?(region), :self_hosted_cache)
-      |> maybe_request_entitlement(guaranteed_egress_configured?(region), :guaranteed_egress_floor)
-    Entitlements.allowed_features(account, features)
+      |> maybe_request_entitlement(not is_nil(configured_egress_mbps), :guaranteed_egress_floor)
+
+    allowed_features = Entitlements.allowed_features(account, features)
+
+    egress_guaranteed_mbps =
+      case configured_egress_mbps do
+        nil -> nil
+        mbps -> if MapSet.member?(allowed_features, :guaranteed_egress_floor), do: mbps, else: 0
+      end
+
+    %{allowed_features: allowed_features, egress_guaranteed_mbps: egress_guaranteed_mbps}
   end
 
   defp maybe_request_entitlement(features, true, feature), do: [feature | features]
   defp maybe_request_entitlement(features, false, _feature), do: features
 
   defp mesh_peers_sync_enabled?(%Regions{} = region, entitlements) do
-    mesh_enabled?(region) and MapSet.member?(entitlements, :self_hosted_cache)
+    mesh_enabled?(region) and MapSet.member?(entitlements.allowed_features, :self_hosted_cache)
   end
 
   defp self_hosted_peers(account, %Regions{} = region, entitlements) do
@@ -690,19 +701,12 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # tuist.dev/egress-mbps extended resource so the scheduler bin-packs the pod
   # against the node's advertised budget. Enterprise-only — the default pattern
   # is bursty, so non-enterprise tenants run best-effort under the Cilium burst
-  # ceiling alone and pack densely. nil (dropped) when the region has no floor or
-  # the account isn't entitled.
-  defp guaranteed_egress_configured?(%Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}})
-       when is_integer(mbps) and mbps > 0, do: true
+  # ceiling alone and pack densely. A configured floor renders as zero for an
+  # unentitled account, while nil drops the field when the region has no floor.
+  defp configured_egress_guaranteed_mbps(%Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}})
+       when is_integer(mbps) and mbps > 0, do: mbps
 
-  defp guaranteed_egress_configured?(_region), do: false
-
-  defp egress_guaranteed_mbps(%Regions{provisioner_config: %{egress_guaranteed_mbps: mbps}}, entitlements)
-       when is_integer(mbps) and mbps > 0 do
-    if MapSet.member?(entitlements, :guaranteed_egress_floor), do: mbps
-  end
-
-  defp egress_guaranteed_mbps(_region, _entitlements), do: nil
+  defp configured_egress_guaranteed_mbps(_region), do: nil
 
   # Whether the region's shared gateway runs host-network (directly on the
   # bare-metal box NIC) rather than as an LB-fronted controller. Drives the

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -55,6 +55,7 @@ defmodule Tuist.Kura.Reconciler do
   import Ecto.Query
 
   alias Oban.Job
+  alias Tuist.Billing.Subscription
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
@@ -410,6 +411,12 @@ defmodule Tuist.Kura.Reconciler do
   # drifted ones surface the drift. Bounded by the same converge
   # ceiling as the rest of the loop; the rest is picked up next tick.
   defp reconcile_observed_servers(handled_server_ids) do
+    active_subscriptions_query =
+      from(s in Subscription,
+        where: s.status in ["active", "trialing"],
+        order_by: [desc: s.inserted_at, desc: s.id]
+      )
+
     servers =
       Server
       |> where([s], s.status in ^@present_intent_statuses)
@@ -420,7 +427,7 @@ defmodule Tuist.Kura.Reconciler do
       |> where([s], s.move_phase == :none)
       |> order_by([s], asc: s.updated_at, asc: s.id)
       |> limit(^@reconcile_batch_size)
-      |> preload(:account)
+      |> preload([s], account: [subscriptions: ^active_subscriptions_query])
       |> Repo.all()
       |> Enum.reject(&MapSet.member?(handled_server_ids, &1.id))
 

--- a/server/test/tuist/billing/entitlements_test.exs
+++ b/server/test/tuist/billing/entitlements_test.exs
@@ -131,5 +131,30 @@ defmodule Tuist.Billing.EntitlementsTest do
       assert Entitlements.allowed_features(account, [:self_hosted_cache]) ==
                MapSet.new([:self_hosted_cache])
     end
+
+    test "selects the newest preloaded subscription across a month boundary" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+      older =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :air,
+          inserted_at: ~N[2026-01-31 23:59:59]
+        )
+
+      newer =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :enterprise,
+          inserted_at: ~N[2026-02-01 00:00:00]
+        )
+
+      account = %{account | subscriptions: [older, newer]}
+      reject(&Tuist.Billing.get_current_active_subscription/1)
+
+      assert Entitlements.allowed_features(account, [:self_hosted_cache]) ==
+               MapSet.new([:self_hosted_cache])
+    end
   end
 end

--- a/server/test/tuist/billing/entitlements_test.exs
+++ b/server/test/tuist/billing/entitlements_test.exs
@@ -105,4 +105,31 @@ defmodule Tuist.Billing.EntitlementsTest do
       assert Entitlements.allows?(nil, :github_enterprise_server)
     end
   end
+
+  describe "allowed_features/2" do
+    test "resolves one plan for multiple hosted features" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+      expect(Tuist.Billing, :get_current_active_subscription, 1, fn ^account ->
+        %{plan: :enterprise}
+      end)
+
+      assert Entitlements.allowed_features(account, [
+               :self_hosted_cache,
+               :guaranteed_egress_floor
+             ]) == MapSet.new([:self_hosted_cache, :guaranteed_egress_floor])
+    end
+
+    test "uses preloaded subscriptions without another lookup" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      account = AccountsFixtures.organization_fixture(preload: [:account]).account
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      account = Tuist.Repo.preload(account, :subscriptions)
+      reject(&Tuist.Billing.get_current_active_subscription/1)
+
+      assert Entitlements.allowed_features(account, [:self_hosted_cache]) ==
+               MapSet.new([:self_hosted_cache])
+    end
+  end
 end

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -101,7 +101,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert spec["podAnnotations"] == %{"kubernetes.io/egress-bandwidth" => "1500M"}
     end
 
-    test "withholds the egress floor from non-enterprise accounts (burst ceiling only)" do
+    test "renders a zero egress floor for non-enterprise accounts" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 
       stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
@@ -125,9 +125,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         )
 
       spec = manifest["spec"]
-      # No floor for the bursty default tenant ...
-      refute Map.has_key?(spec, "egressGuaranteedMbps")
-      # ... but the burst ceiling still applies.
+      # Zero keeps the effective value explicit without requesting the extended resource.
+      assert spec["egressGuaranteedMbps"] == 0
+      # The burst ceiling still applies.
       assert spec["podAnnotations"] == %{"kubernetes.io/egress-bandwidth" => "1500M"}
     end
 
@@ -176,15 +176,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(non_entitled_env, "KURA_MESH_PEERS_SYNC")
     end
 
-    test "withholds the peer-view sync outside a mesh region even for a self-hosting account" do
+    test "does not resolve entitlements when the region has no gated manifest fields" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 
       stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
         "00000000-0000-0000-0000-000000000001"
       end)
 
-      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      reject(&Tuist.Billing.get_current_active_subscription/1)
 
       manifest =
         KubernetesController.manifest(
@@ -198,6 +197,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
       refute Map.has_key?(env, "KURA_MESH_PEERS_SYNC")
+      refute Map.has_key?(manifest["spec"], "egressGuaranteedMbps")
     end
 
     test "emits the mesh flag only when the region enables the per-account peer mesh" do

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -279,6 +279,39 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(non_entitled["spec"], "meshExternalPeers")
     end
 
+    test "resolves the subscription once for every entitlement-dependent manifest field" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      account = %Account{id: 1, name: "tuist"}
+
+      expect(Tuist.Billing, :get_current_active_subscription, 1, fn ^account ->
+        %{plan: :enterprise}
+      end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          account,
+          eu_region(%{mesh: true, egress_guaranteed_mbps: 25}),
+          %Server{},
+          "return true",
+          ["https://kura.acme.example:7443"]
+        )
+
+      assert manifest["spec"]["meshExternalPeers"] == ["https://kura.acme.example:7443"]
+      assert manifest["spec"]["egressGuaranteedMbps"] == 25
+
+      assert Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})[
+               "KURA_MESH_PEERS_SYNC"
+             ] == "true"
+    end
+
     test "withholds peer-view sync outside a mesh region" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -10,6 +10,7 @@ defmodule Tuist.Kura.ReconcilerTest do
   alias Tuist.Kura.Server
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.BillingFixtures
 
   @moduletag capture_log: true
 
@@ -207,6 +208,27 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert :ok = Reconciler.reconcile()
 
     assert %Server{status: :active, url: "http://172.16.0.5:32000"} = Repo.get!(Server, server.id)
+  end
+
+  test "preloads active subscriptions for manifest reconciliation" do
+    {account, server, deployment} = create_server()
+    BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+    {:ok, _server} = Kura.activate_server(server, deployment.image_tag)
+    mark_deployment_succeeded(deployment)
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:ok, deployment.image_tag}
+    end)
+
+    expect(Provisioner, :manifest_revision, fn %Server{account: loaded_account} ->
+      assert [%{plan: :enterprise}] = loaded_account.subscriptions
+      {:ok, nil}
+    end)
+
+    stub(Provisioner, :current_manifest_revision, fn _ -> {:ok, nil} end)
+
+    assert :ok = Reconciler.reconcile()
   end
 
   test "marks destroying servers destroyed after the KuraInstance disappears" do


### PR DESCRIPTION
## What changed

The Kura reconciler now loads active and trialing subscriptions once, selects the newest subscription for each account with deterministic timestamp ordering, and passes that lookup into manifest generation.

Manifest generation resolves the account plan once and derives all plan-dependent fields from that result. A configured egress floor is applied to entitled plans, while non-entitled plans retain an explicit zero value.

## Why

A reconciliation pass can inspect many accounts. Resolving the plan separately for every observed server made the number of database queries grow with the account count.

## Root cause

Manifest generation called the single-account entitlement path from inside the observed-server loop. The initial preload also depended on database row order and used the configured egress floor without first applying plan entitlement.

## Approach

Load relevant subscriptions in one query before constructing manifests, reduce them to the newest active or trialing subscription per account with an explicit chronological comparison, and resolve each account from the in-memory lookup. Skip billing resolution entirely when the manifest has no plan-dependent fields.

The existing single-account entitlement path remains available to other callers.

## Impact

Kura reconciliation performs a bounded number of billing queries instead of one query per account. Month-boundary ordering is deterministic, and configured egress values cannot grant capacity to a plan that is not entitled to it.

## Validation

- `mix test test/tuist/billing/entitlements_test.exs test/tuist/kura/provisioner/kubernetes_controller_test.exs test/tuist/kura/reconciler_test.exs` with 102 tests passed
- `mix credo --strict` on all six changed Elixir source and test files
- `mix format --check-formatted` on every changed Elixir source and test file
- `git diff --check`

## Review order

Final pull request in the server stack, after [#12005](https://github.com/tuist/tuist/pull/12005).
