### PR TITLE
fix(kura): set a bounded default memory limit

### DIFF
--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -83,7 +83,14 @@ persistence:
   storageClass: ""
   annotations: {}
 
-resources: {}
+# Kura derives every memory budget from the container limit. Keep the request
+# equal to the limit so a default install reserves the memory it may consume
+# instead of sizing itself from the shared node's physical memory.
+resources:
+  requests:
+    memory: 1Gi
+  limits:
+    memory: 1Gi
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## What changed

The Kura Helm chart now requests and limits each default pod to one gibibyte of memory.

## Why

The runtime admission controller derives its budgets from the container limit. A default chart installation should therefore provide an explicit limit and reserve the same amount from the scheduler.

## Root cause

The chart left resources empty by default. Without a container limit, Kura could size itself from the physical memory of a shared node, while the scheduler reserved no corresponding capacity.

## Approach

Set equal memory requests and limits in the default values. Installations that need a different size can continue to override the resource block.

## Impact

Default installations have predictable memory admission and scheduling. Existing installations with explicit resource overrides are unchanged.

## Validation

- `helm lint kura/ops/helm/kura`
- `helm template kura kura/ops/helm/kura --namespace kura`
- `git diff --check`

## Review order

Second in the Kura runtime stack. Review after [#12007](https://github.com/tuist/tuist/pull/12007), then continue with [#12009](https://github.com/tuist/tuist/pull/12009).