### PR TITLE
test(server): stabilize runners dashboard async rendering

### DIFF
--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -80,7 +80,7 @@ defmodule TuistWeb.RunnersLiveTest do
     complete_run(account, 70_003, 700_021, "cancelled")
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
-    html = render_async(lv)
+    html = render_async(lv, @render_async_timeout)
 
     # The cancelled run carries no real duration, so it must not draw a
     # bar. Only the succeeded run remains on each chart.


### PR DESCRIPTION
## What changed

The runners dashboard test for completed charts now waits up to one second for asynchronous LiveView assigns, matching the other asynchronous assertions in the same test module.

## Why

The [GitHub Actions test job](https://github.com/tuist/tuist/actions/runs/29912879883/job/88899749253) failed intermittently while the full server test suite was under load, even though the asynchronous rendering completed normally outside the default deadline.

## Root cause

This test was the only runners dashboard test still calling `render_async/1`, which uses a 100-millisecond deadline. The surrounding tests already use the module's explicit one-second timeout because the dashboard widgets depend on analytics-backed asynchronous work.

## Approach

Reuse the existing `@render_async_timeout` module attribute for the inconsistent call. This keeps a bounded deadline while allowing the same expected scheduling variance as the other runners dashboard tests.

## Impact

The test remains sensitive to genuine asynchronous rendering failures, but no longer fails when valid work takes slightly longer under suite-level contention. Production behavior is unchanged.

## Validation

- `mix test test/tuist_web/live/runners_live_test.exs:78 --repeat-until-failure 20`
- `mix test test/tuist_web/live/runners_live_test.exs`: 5 tests passed
- `mix format --check-formatted test/tuist_web/live/runners_live_test.exs`
- `git diff --check`
