### PR TITLE
fix(cli): scope cache hashes to the selected configuration

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -195,7 +195,7 @@ jobs:
   cli-unit-tests:
     name: Unit Tests
     runs-on: tuist-macos
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write

--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -68,22 +68,23 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
         excludedTargets: Set<String>,
         destination: SimulatorDeviceAndRuntime?
     ) async throws -> [GraphTarget: TargetContentHash] {
-        if let exportHashedGraphPath = Environment.current.variables["TUIST_EXPORT_HASHED_GRAPH_PATH"],
-           let exportPath = try? AbsolutePath(validating: exportHashedGraphPath)
-        {
-            try await fileSystem.writeAsJSON(graph, at: exportPath)
-            Logger.current.debug("Graph used for hashing exported to \(exportPath.pathString)")
-        }
-
-        let version = versionFetcher.version()
         let configuration = try defaultConfigurationFetcher.fetch(
             configuration: configuration,
             defaultConfiguration: defaultConfiguration,
             graph: graph
         )
+        let hashingGraph = graphByScopingSettings(in: graph, to: configuration)
 
+        if let exportHashedGraphPath = Environment.current.variables["TUIST_EXPORT_HASHED_GRAPH_PATH"],
+           let exportPath = try? AbsolutePath(validating: exportHashedGraphPath)
+        {
+            try await fileSystem.writeAsJSON(hashingGraph, at: exportPath)
+            Logger.current.debug("Graph used for hashing exported to \(exportPath.pathString)")
+        }
+
+        let version = versionFetcher.version()
         let hashes = try await graphContentHasher.contentHashes(
-            for: graph,
+            for: hashingGraph,
             include: {
                 isGraphTargetHashable(
                     $0,
@@ -98,7 +99,51 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
             ]
         )
 
-        return hashes
+        return Dictionary(uniqueKeysWithValues: hashes.map { target, hash in
+            guard let project = graph.projects[target.path],
+                  let originalTarget = project.targets[target.target.name]
+            else {
+                return (target, hash)
+            }
+            return (
+                GraphTarget(path: target.path, target: originalTarget, project: project),
+                hash
+            )
+        })
+    }
+
+    private func graphByScopingSettings(in graph: Graph, to configuration: String) -> Graph {
+        var hashingGraph = graph
+        hashingGraph.projects = graph.projects.mapValues { project in
+            guard let buildConfiguration = project.settings.configurations.keys
+                .first(where: { $0.name.caseInsensitiveCompare(configuration) == .orderedSame })
+            else {
+                return project
+            }
+
+            var project = project
+            project.settings = settings(project.settings, scopedTo: buildConfiguration)
+            project.targets = project.targets.mapValues { target in
+                guard let targetSettings = target.settings else { return target }
+                var target = target
+                target.settings = settings(targetSettings, scopedTo: buildConfiguration)
+                return target
+            }
+            return project
+        }
+        return hashingGraph
+    }
+
+    private func settings(_ settings: Settings, scopedTo buildConfiguration: BuildConfiguration) -> Settings {
+        Settings(
+            base: settings.base,
+            baseDebug: buildConfiguration.variant == .debug ? settings.baseDebug : [:],
+            configurations: settings.configurations.filter { $0.key == buildConfiguration },
+            defaultSettings: settings.defaultSettings,
+            defaultConfiguration: settings.defaultConfiguration.flatMap {
+                $0.caseInsensitiveCompare(buildConfiguration.name) == .orderedSame ? $0 : nil
+            }
+        )
     }
 
     private func isGraphTargetHashable(

--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -68,12 +68,15 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
         excludedTargets: Set<String>,
         destination: SimulatorDeviceAndRuntime?
     ) async throws -> [GraphTarget: TargetContentHash] {
-        let configuration = try defaultConfigurationFetcher.fetch(
+        let scopesSettingsToConfiguration = configuration != nil || defaultConfiguration != nil
+        let resolvedConfiguration = try defaultConfigurationFetcher.fetch(
             configuration: configuration,
             defaultConfiguration: defaultConfiguration,
             graph: graph
         )
-        let hashingGraph = graphByScopingSettings(in: graph, to: configuration)
+        let hashingGraph = scopesSettingsToConfiguration
+            ? graphByScopingSettings(in: graph, to: resolvedConfiguration)
+            : graph
 
         if let exportHashedGraphPath = Environment.current.variables["TUIST_EXPORT_HASHED_GRAPH_PATH"],
            let exportPath = try? AbsolutePath(validating: exportHashedGraphPath)
@@ -93,7 +96,7 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
             },
             destination: destination,
             additionalStrings: [
-                configuration,
+                resolvedConfiguration,
                 try await SwiftVersionProvider.current.swiftlangVersion(),
                 version.rawValue,
             ]

--- a/cli/Sources/TuistHasher/SettingsContentHasher.swift
+++ b/cli/Sources/TuistHasher/SettingsContentHasher.swift
@@ -25,9 +25,12 @@ public struct SettingsContentHasher: SettingsContentHashing {
 
     public func hash(settings: Settings) async throws -> String {
         let baseSettingsHash = try hash(settings.base)
+        let baseDebugSettingsHash = settings.baseDebug.isEmpty ? nil : try hash(settings.baseDebug)
         let configurationHash = try await hash(settings.configurations)
         let defaultSettingsHash = try hash(settings.defaultSettings)
-        return try contentHasher.hash([baseSettingsHash, configurationHash, defaultSettingsHash])
+        return try contentHasher.hash(
+            [baseSettingsHash, baseDebugSettingsHash, configurationHash, defaultSettingsHash].compactMap { $0 }
+        )
     }
 
     private func hash(_ configurations: [BuildConfiguration: Configuration?]) async throws -> String {

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -117,6 +117,7 @@ import XcodeGraph
             // Because we only need to pull the binaries, we don't generate a project in this step.
             let graph = try await generator.load(path: path, options: config.project.generatedProject?.generationOptions)
 
+            let requestedConfiguration = configuration
             let configuration = try defaultConfigurationFetcher.fetch(
                 configuration: configuration,
                 defaultConfiguration: config.project.generatedProject?.generationOptions.defaultConfiguration,
@@ -154,7 +155,7 @@ import XcodeGraph
 
             let cacheableTargets = try await cacheableTargets(
                 for: graph,
-                configuration: configuration,
+                configuration: requestedConfiguration,
                 config: config,
                 requestedTargetsToBinaryCache: requestedTargetsToBinaryCache,
                 cacheProfile: profile,
@@ -899,7 +900,7 @@ import XcodeGraph
 
         private func cacheableTargets(
             for graph: Graph,
-            configuration: String,
+            configuration: String?,
             config: Tuist,
             requestedTargetsToBinaryCache: Set<TargetQuery>,
             cacheProfile: CacheProfile,

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -284,7 +284,7 @@ struct ContentHashingIntegrationTests {
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController
-    ) func contentHashes_removingUnselectedConfigurationDoesNotChangeHash() async throws {
+    ) func contentHashes_scopesOnlyWhenConfigurationIsSelected() async throws {
         // Given
         let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
         let selectedConfiguration = BuildConfiguration.debug("Debug-SharedCache")
@@ -351,11 +351,29 @@ struct ContentHashingIntegrationTests {
             excludedTargets: [],
             destination: nil
         )
+        let implicitHashesWithUnrelatedConfiguration = try await subject.contentHashes(
+            for: graphWithUnrelatedConfiguration,
+            configuration: nil,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let implicitHashesWithoutUnrelatedConfiguration = try await subject.contentHashes(
+            for: graphWithoutUnrelatedConfiguration,
+            configuration: nil,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
 
         // Then
         #expect(
             hashesWithUnrelatedConfiguration[graphTargetWithUnrelatedConfiguration]?.hash
                 == hashesWithoutUnrelatedConfiguration[graphTargetWithoutUnrelatedConfiguration]?.hash
+        )
+        #expect(
+            implicitHashesWithUnrelatedConfiguration[graphTargetWithUnrelatedConfiguration]?.hash
+                != implicitHashesWithoutUnrelatedConfiguration[graphTargetWithoutUnrelatedConfiguration]?.hash
         )
     }
 

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -284,6 +284,206 @@ struct ContentHashingIntegrationTests {
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController
+    ) func contentHashes_removingUnselectedConfigurationDoesNotChangeHash() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let selectedConfiguration = BuildConfiguration.debug("Debug-SharedCache")
+        let unrelatedConfiguration = BuildConfiguration.debug("Debug-AppVariant-B")
+        let selectedSettings = Configuration(settings: ["SWIFT_VERSION": "5.10"])
+        let settingsWithUnrelatedConfiguration = Settings.test(
+            configurations: [
+                selectedConfiguration: selectedSettings,
+                unrelatedConfiguration: Configuration(settings: ["UNRELATED": "YES"]),
+            ]
+        )
+        let settingsWithoutUnrelatedConfiguration = Settings.test(
+            configurations: [
+                selectedConfiguration: selectedSettings,
+            ]
+        )
+        let frameworkWithUnrelatedConfiguration = makeFramework(
+            settings: settingsWithUnrelatedConfiguration,
+            sources: [source1]
+        )
+        let frameworkWithoutUnrelatedConfiguration = makeFramework(
+            settings: settingsWithoutUnrelatedConfiguration,
+            sources: [source1]
+        )
+        let projectWithUnrelatedConfiguration = Project.test(
+            path: temporaryPath.appending(component: "with-unrelated-configuration"),
+            settings: settingsWithUnrelatedConfiguration,
+            targets: [frameworkWithUnrelatedConfiguration]
+        )
+        let projectWithoutUnrelatedConfiguration = Project.test(
+            path: temporaryPath.appending(component: "without-unrelated-configuration"),
+            settings: settingsWithoutUnrelatedConfiguration,
+            targets: [frameworkWithoutUnrelatedConfiguration]
+        )
+        let graphWithUnrelatedConfiguration = Graph.test(
+            projects: [projectWithUnrelatedConfiguration.path: projectWithUnrelatedConfiguration]
+        )
+        let graphWithoutUnrelatedConfiguration = Graph.test(
+            projects: [projectWithoutUnrelatedConfiguration.path: projectWithoutUnrelatedConfiguration]
+        )
+        let graphTargetWithUnrelatedConfiguration = GraphTarget(
+            path: projectWithUnrelatedConfiguration.path,
+            target: frameworkWithUnrelatedConfiguration,
+            project: projectWithUnrelatedConfiguration
+        )
+        let graphTargetWithoutUnrelatedConfiguration = GraphTarget(
+            path: projectWithoutUnrelatedConfiguration.path,
+            target: frameworkWithoutUnrelatedConfiguration,
+            project: projectWithoutUnrelatedConfiguration
+        )
+
+        // When
+        let hashesWithUnrelatedConfiguration = try await subject.contentHashes(
+            for: graphWithUnrelatedConfiguration,
+            configuration: selectedConfiguration.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let hashesWithoutUnrelatedConfiguration = try await subject.contentHashes(
+            for: graphWithoutUnrelatedConfiguration,
+            configuration: selectedConfiguration.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        #expect(
+            hashesWithUnrelatedConfiguration[graphTargetWithUnrelatedConfiguration]?.hash
+                == hashesWithoutUnrelatedConfiguration[graphTargetWithoutUnrelatedConfiguration]?.hash
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController
+    ) func contentHashes_changingSelectedConfigurationChangesHash() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let selectedConfiguration = BuildConfiguration.debug("Debug-SharedCache")
+        let firstSettings = Settings.test(
+            configurations: [
+                selectedConfiguration: Configuration(settings: ["SWIFT_VERSION": "5.9"]),
+            ]
+        )
+        let secondSettings = Settings.test(
+            configurations: [
+                selectedConfiguration: Configuration(settings: ["SWIFT_VERSION": "6.0"]),
+            ]
+        )
+        let firstFramework = makeFramework(settings: firstSettings, sources: [source1])
+        let secondFramework = makeFramework(settings: secondSettings, sources: [source1])
+        let firstProject = Project.test(
+            path: temporaryPath.appending(component: "first-selected-configuration"),
+            settings: firstSettings,
+            targets: [firstFramework]
+        )
+        let secondProject = Project.test(
+            path: temporaryPath.appending(component: "second-selected-configuration"),
+            settings: secondSettings,
+            targets: [secondFramework]
+        )
+        let firstGraph = Graph.test(projects: [firstProject.path: firstProject])
+        let secondGraph = Graph.test(projects: [secondProject.path: secondProject])
+        let firstGraphTarget = GraphTarget(path: firstProject.path, target: firstFramework, project: firstProject)
+        let secondGraphTarget = GraphTarget(path: secondProject.path, target: secondFramework, project: secondProject)
+
+        // When
+        let firstHashes = try await subject.contentHashes(
+            for: firstGraph,
+            configuration: selectedConfiguration.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let secondHashes = try await subject.contentHashes(
+            for: secondGraph,
+            configuration: selectedConfiguration.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        #expect(firstHashes[firstGraphTarget]?.hash != secondHashes[secondGraphTarget]?.hash)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController
+    ) func contentHashes_baseDebugSettingsOnlyAffectDebugConfiguration() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let projectSettings = Settings.default
+        let firstTargetSettings = Settings.test(
+            baseDebug: ["ENABLE_TESTING_SEARCH_PATHS": "YES"]
+        )
+        let secondTargetSettings = Settings.test(
+            baseDebug: ["ENABLE_TESTING_SEARCH_PATHS": "NO"]
+        )
+        let firstFramework = makeFramework(settings: firstTargetSettings, sources: [source1])
+        let secondFramework = makeFramework(settings: secondTargetSettings, sources: [source1])
+        let firstProject = Project.test(
+            path: temporaryPath.appending(component: "first-base-debug"),
+            settings: projectSettings,
+            targets: [firstFramework]
+        )
+        let secondProject = Project.test(
+            path: temporaryPath.appending(component: "second-base-debug"),
+            settings: projectSettings,
+            targets: [secondFramework]
+        )
+        let firstGraph = Graph.test(projects: [firstProject.path: firstProject])
+        let secondGraph = Graph.test(projects: [secondProject.path: secondProject])
+        let firstGraphTarget = GraphTarget(path: firstProject.path, target: firstFramework, project: firstProject)
+        let secondGraphTarget = GraphTarget(path: secondProject.path, target: secondFramework, project: secondProject)
+
+        // When
+        let firstDebugHashes = try await subject.contentHashes(
+            for: firstGraph,
+            configuration: BuildConfiguration.debug.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let secondDebugHashes = try await subject.contentHashes(
+            for: secondGraph,
+            configuration: BuildConfiguration.debug.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let firstReleaseHashes = try await subject.contentHashes(
+            for: firstGraph,
+            configuration: BuildConfiguration.release.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+        let secondReleaseHashes = try await subject.contentHashes(
+            for: secondGraph,
+            configuration: BuildConfiguration.release.name,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        #expect(firstDebugHashes[firstGraphTarget]?.hash != secondDebugHashes[secondGraphTarget]?.hash)
+        #expect(firstReleaseHashes[firstGraphTarget]?.hash == secondReleaseHashes[secondGraphTarget]?.hash)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController
     ) func contentHashes_hashIsConsistent() async throws {
         // Given
         let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
@@ -326,8 +526,8 @@ struct ContentHashingIntegrationTests {
         )
 
         // Then
-        #expect(firstRun[framework1]?.hash == "22c15857bfbb35e160776d0bee674591")
-        #expect(firstRun[framework2]?.hash == "31e5e083c8d584a578ca4c5b151165af")
+        #expect(firstRun[framework1]?.hash == "ddb2a8a0a4663353ae43079cdf358016")
+        #expect(firstRun[framework2]?.hash == "bea9417f35911c3c83609e16fcfb8c36")
         #expect(firstRun[framework1]?.hash == secondRun[framework1]?.hash)
         #expect(firstRun[framework2]?.hash == secondRun[framework2]?.hash)
         #expect(firstRun[framework1]?.hash != firstRun[framework2]?.hash)
@@ -672,6 +872,7 @@ struct ContentHashingIntegrationTests {
         name: String = "Target",
         platform: Platform = .iOS,
         productName: String? = nil,
+        settings: Settings? = .test(),
         sources: [SourceFile] = [],
         resources: ResourceFileElements = .init([]),
         coreDataModels: [CoreDataModel] = [],
@@ -683,6 +884,7 @@ struct ContentHashingIntegrationTests {
             platform: platform,
             product: .framework,
             productName: productName,
+            settings: settings,
             sources: sources,
             resources: resources,
             coreDataModels: coreDataModels,

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -104,6 +104,129 @@ struct CacheGraphContentHasherTests {
 
     @Test(
         .withMockedSwiftVersionProvider
+    ) func contentHashes_scopesSettingsToDefaultConfiguration() async throws {
+        // Given
+        let defaultConfigurationName = "Debug-SharedCache"
+        let selectedConfiguration = BuildConfiguration.debug(defaultConfigurationName)
+        let unrelatedConfiguration = BuildConfiguration.debug("Debug-AppVariant-B")
+        let settings = Settings(
+            configurations: [
+                selectedConfiguration: Configuration(settings: ["SELECTED": "YES"]),
+                unrelatedConfiguration: Configuration(settings: ["UNRELATED": "YES"]),
+            ]
+        )
+        let target = Target.test(name: "Framework", product: .framework, settings: settings)
+        let project = Project.test(path: "/Project/Path", settings: settings, targets: [target])
+        let projectPath = project.path
+        let graph = Graph.test(path: projectPath, projects: [projectPath: project])
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn(defaultConfigurationName)
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: nil,
+            defaultConfiguration: defaultConfigurationName,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .matching { graph in
+                    guard let scopedProject = graph.projects[projectPath],
+                          let targetSettings = scopedProject.targets[target.name]?.settings
+                    else {
+                        return false
+                    }
+                    return Set(scopedProject.settings.configurations.keys) == [selectedConfiguration]
+                        && Set(targetSettings.configurations.keys) == [selectedConfiguration]
+                },
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider
+    ) func contentHashes_preservesAllSettingsWhenConfigurationIsImplicit() async throws {
+        // Given
+        let selectedConfiguration = BuildConfiguration.debug("Debug-SharedCache")
+        let unrelatedConfiguration = BuildConfiguration.debug("Debug-AppVariant-B")
+        let settings = Settings(
+            configurations: [
+                selectedConfiguration: Configuration(settings: ["SELECTED": "YES"]),
+                unrelatedConfiguration: Configuration(settings: ["UNRELATED": "YES"]),
+            ]
+        )
+        let target = Target.test(name: "Framework", product: .framework, settings: settings)
+        let project = Project.test(path: "/Project/Path", settings: settings, targets: [target])
+        let projectPath = project.path
+        let graph = Graph.test(path: projectPath, projects: [projectPath: project])
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn(selectedConfiguration.name)
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: nil,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .matching { graph in
+                    guard let unscopedProject = graph.projects[projectPath],
+                          let targetSettings = unscopedProject.targets[target.name]?.settings
+                    else {
+                        return false
+                    }
+                    return Set(unscopedProject.settings.configurations.keys) == [
+                        selectedConfiguration,
+                        unrelatedConfiguration,
+                    ]
+                        && Set(targetSettings.configurations.keys) == [
+                            selectedConfiguration,
+                            unrelatedConfiguration,
+                        ]
+                },
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider
     ) func contentHashes_when_no_excluded_targets_all_hashes_are_computed() async throws {
         // Given
         let includedTarget = GraphTarget(

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -32,6 +32,78 @@ struct CacheGraphContentHasherTests {
 
     @Test(
         .withMockedSwiftVersionProvider
+    ) func contentHashes_scopesSettingsToSelectedConfiguration() async throws {
+        // Given
+        let requestedConfigurationName = "Debug-SharedCache"
+        let selectedConfiguration = BuildConfiguration.debug("debug-sharedcache")
+        let unrelatedConfiguration = BuildConfiguration.debug("Debug-AppVariant-B")
+        let settings = Settings(
+            baseDebug: ["ENABLE_TESTING_SEARCH_PATHS": "YES"],
+            configurations: [
+                selectedConfiguration: Configuration(settings: ["SELECTED": "YES"]),
+                unrelatedConfiguration: Configuration(settings: ["UNRELATED": "YES"]),
+            ],
+            defaultConfiguration: unrelatedConfiguration.name
+        )
+        let target = Target.test(name: "Framework", product: .framework, settings: settings)
+        let project = Project.test(
+            path: "/Project/Path",
+            settings: settings,
+            targets: [target]
+        )
+        let projectPath = project.path
+        let graph = Graph.test(
+            path: projectPath,
+            projects: [projectPath: project]
+        )
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn(requestedConfigurationName)
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: requestedConfigurationName,
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .matching { graph in
+                    guard let scopedProject = graph.projects[projectPath],
+                          let targetSettings = scopedProject.targets[target.name]?.settings
+                    else {
+                        return false
+                    }
+                    return Set(scopedProject.settings.configurations.keys) == [selectedConfiguration]
+                        && Set(targetSettings.configurations.keys) == [selectedConfiguration]
+                        && scopedProject.settings.baseDebug == settings.baseDebug
+                        && targetSettings.baseDebug == settings.baseDebug
+                        && scopedProject.settings.defaultConfiguration == nil
+                        && targetSettings.defaultConfiguration == nil
+                },
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider
     ) func contentHashes_when_no_excluded_targets_all_hashes_are_computed() async throws {
         // Given
         let includedTarget = GraphTarget(

--- a/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mockable
 import Path
+import Testing
 import TuistCore
 import TuistSupport
 import TuistTesting
@@ -120,6 +121,38 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(
             hash,
             "OTHER_SWIFT_FLAGS:array([\"-Xfrontend\", \"-enable-actor-data-race-checks\", \"-O\"])-SWIFT_VERSION:string(\"5\")-hash;DebugdebugGCC_OPTIMIZATION_LEVEL:string(\"0\")-hash;none"
+        )
+    }
+}
+
+struct SettingsContentHasherBaseDebugTests {
+    @Test func hash_includesBaseDebugSettings() async throws {
+        // Given
+        let contentHasher = MockContentHashing()
+        let xcconfigHasher = MockXCConfigContentHashing()
+        let subject = SettingsContentHasher(contentHasher: contentHasher, xcconfigHasher: xcconfigHasher)
+        given(contentHasher)
+            .hash(Parameter<[String]>.any)
+            .willProduce { $0.joined(separator: ";") }
+        given(contentHasher)
+            .hash(Parameter<String>.any)
+            .willProduce { $0 + "-hash" }
+        let settings = Settings(
+            base: ["CURRENT_PROJECT_VERSION": SettingValue.string("1")],
+            baseDebug: ["ENABLE_TESTING_SEARCH_PATHS": SettingValue.string("YES")],
+            configurations: [
+                BuildConfiguration.debug("Debug"): nil,
+            ],
+            defaultSettings: .recommended
+        )
+
+        // When
+        let hash = try await subject.hash(settings: settings)
+
+        // Then
+        #expect(
+            hash
+                == "CURRENT_PROJECT_VERSION:string(\"1\")-hash;ENABLE_TESTING_SEARCH_PATHS:string(\"YES\")-hash;Debugdebug;recommended"
         )
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -64,8 +64,13 @@
                 .called(0)
         }
 
-        private func run(noUpload: Bool) async throws {
+        @Test(.inTemporaryDirectory) func run_passesRequestedConfigurationToContentHasher() async throws {
+            try await run(noUpload: false, configuration: "Release")
+        }
+
+        private func run(noUpload: Bool, configuration: String? = nil) async throws {
             let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+            let resolvedConfiguration = configuration ?? "Debug"
             let target = Target.test(name: "Fixtures", product: .bundle)
             let project = Project.test(path: temporaryDirectory, targets: [target], schemes: [])
             let graphTarget = GraphTarget(path: temporaryDirectory, target: target, project: project)
@@ -94,15 +99,15 @@
                 .willReturn(graph)
             given(defaultConfigurationFetcher)
                 .fetch(
-                    configuration: .value(nil),
+                    configuration: .value(configuration),
                     defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
                     graph: .value(graph)
                 )
-                .willReturn("Debug")
+                .willReturn(resolvedConfiguration)
             given(cacheGraphContentHasher)
                 .contentHashes(
                     for: .value(graph),
-                    configuration: .value("Debug"),
+                    configuration: .value(configuration),
                     defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
                     excludedTargets: .value([]),
                     destination: .value(nil)
@@ -115,7 +120,7 @@
                 .binaryCacheWarming(
                     config: .value(config),
                     targetsToBinaryCache: .any,
-                    configuration: .value("Debug"),
+                    configuration: .value(resolvedConfiguration),
                     cacheStorage: .any
                 )
                 .willReturn(generator)
@@ -134,7 +139,7 @@
 
             try await subject.run(
                 path: temporaryDirectory.pathString,
-                configuration: nil,
+                configuration: configuration,
                 targetsToBinaryCache: [],
                 externalOnly: false,
                 generateOnly: false,

--- a/server/priv/docs/en/guides/features/projects/hashing.md
+++ b/server/priv/docs/en/guides/features/projects/hashing.md
@@ -29,7 +29,7 @@ We hash the Swift version obtained from running the command `/usr/bin/xcrun swif
 
 #### Configuration {#configuration}
 
-When calculating cache hashes, `--configuration` scopes each project's and target's settings to the selected build configuration. Tuist hashes that configuration's name, variant, build settings, and configuration file contents together with the shared base settings that apply to it. Adding, removing, or changing another configuration does not affect the selected configuration's cache hashes.
+When calculating cache hashes, `--configuration` or the project's default configuration scopes each project's and target's settings to the selected build configuration. Tuist hashes that configuration's name, variant, build settings, and configuration file contents together with the shared base settings that apply to it. Adding, removing, or changing another configuration does not affect the selected configuration's cache hashes. When neither is set, Tuist continues to hash all configurations.
 
 ## Debugging {#debugging}
 

--- a/server/priv/docs/en/guides/features/projects/hashing.md
+++ b/server/priv/docs/en/guides/features/projects/hashing.md
@@ -29,7 +29,7 @@ We hash the Swift version obtained from running the command `/usr/bin/xcrun swif
 
 #### Configuration {#configuration}
 
-The idea behind the flag `-configuration` was to ensure debug binaries were not used in release builds and viceversa. However, we are still missing a mechanism to remove the other configurations from the projects to prevent them from being used.
+When calculating cache hashes, `--configuration` scopes each project's and target's settings to the selected build configuration. Tuist hashes that configuration's name, variant, build settings, and configuration file contents together with the shared base settings that apply to it. Adding, removing, or changing another configuration does not affect the selected configuration's cache hashes.
 
 ## Debugging {#debugging}
 
@@ -46,4 +46,3 @@ If the hashes are still non-deterministic, let us know and we can help with the 
 > **Better Debugging Experience Planned**
 >
 > Improving our debugging experience is in our roadmap. The print-hashes command, which lacks the context to understand the differences, will be replaced by a more user-friendly command that uses a tree-like structure to show the differences between the hashes.
-


### PR DESCRIPTION
Cache warming now hashes project and target settings for an explicitly selected build configuration without allowing unrelated configurations to invalidate shared module artifacts.

## What changed

- Scope settings when the command receives `--configuration` or the project declares a default configuration.
- Preserve the previous all-configuration hashing behavior when Tuist chooses a debug configuration implicitly.
- Keep cache warming's resolved configuration for building while forwarding the original configuration selection to hashing.
- Preserve shared settings and applicable debug-only settings, and remove stale default-configuration references from the scoped graph.
- Include debug-only base settings in settings hashes so changes to real build inputs invalidate affected artifacts.
- Return hashes keyed by the original graph targets and export the same graph used for hashing.
- Add regression coverage and update the English hashing documentation.

## Why

Teams can warm a shared configuration while retaining app-specific configurations for bundle identifiers, signing, entitlements, and environments. Shared frameworks may use identical settings across those variants, so adding or removing an app-only configuration should not invalidate an artifact warmed with a different selected configuration.

At the same time, omitting `--configuration` has historically made every declared configuration part of the hash. Keeping that behavior avoids silently narrowing cache validity for users who have not explicitly selected a configuration.

## Root cause

The selected configuration was added to the cache hash as a string, but project and target settings still contributed every declared configuration. Therefore, removing an unselected configuration changed framework hashes even when the selected configuration and its effective build settings were unchanged. Debug-only base settings were also omitted from settings hashing despite being applied during project generation.

## Approach

The fix scopes a temporary graph at the cache boundary before passing it to the generic graph hasher. Scoping is enabled only when configuration intent is explicit through the command or project default. When Tuist falls back to the first debug configuration, the complete graph is hashed as before. Projects that do not contain an explicitly selected configuration also remain unscoped so hashing stays conservative.

## Impact

Unselected configurations no longer affect hashes when a configuration is explicitly selected or configured as the project default. Changes to the selected configuration, its configuration file, shared settings, or applicable debug-only settings still invalidate the artifact. Calls without either form of selection continue to depend on all configurations. Explicitly scoped projects will experience a one-time cache miss and rewarm because their hashing inputs change.

## Validation

- `swiftformat` completed with no formatting changes.
- The focused cache hashing suites passed 25 tests, including explicit selection, project defaults, and the implicit all-configuration fallback.
- The enterprise cache-warm service suite passed its 3 focused tests, including forwarding explicit and implicit configuration intent.
- `git diff --check` passed.
- The supplied reproduction produced `a6c98fe6afe76b76f28a06e871329858` for `Debug-SharedCache` both with and without `Debug-AppVariant-B`, while the selected configuration's effective build settings remained identical.
