### PR TITLE
chore(infra): remove obsolete server-SA rollout workarounds post UID-stability fix

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -819,48 +819,6 @@ jobs:
           # so dependent pods (Pending or otherwise) go with the Job.
           echo "$stale_jobs" | xargs -r kubectl -n "$NAMESPACE" delete job \
             --ignore-not-found --cascade=foreground --timeout=2m
-      - name: Adopt server ServiceAccount into the Helm release
-        # One-time migration guard. The server ServiceAccount used to render
-        # as a Helm *hook* (before-hook-creation), which churned its UID every
-        # deploy and broke bound-token auth. It is now a normal release
-        # resource, but a hook-created object carries no `meta.helm.sh/release-*`
-        # ownership annotations, so the first `helm upgrade` after the switch
-        # would fail its import check with "invalid ownership metadata". Stamp
-        # the ownership annotations + managed-by label (and strip the now-stale
-        # hook annotations) so helm adopts the live SA in place, preserving its
-        # UID. Runs in every environment because the production cascade deploys
-        # canary first — a production-only manual step would not gate it.
-        #
-        # Self-skipping: once helm owns the SA it re-stamps these annotations
-        # itself, so the step short-circuits with no API write on every deploy
-        # after the one that adopts a given cluster (and tolerates first
-        # installs where the SA does not exist). Safe to delete once every
-        # managed cluster has adopted. SA name is `server.serviceAccount.name`
-        # in values-managed-common.yaml.
-        run: |
-          set -euo pipefail
-          SA_NAME=tuist-server
-
-          if ! kubectl -n "$NAMESPACE" get serviceaccount "$SA_NAME" >/dev/null 2>&1; then
-            echo "ServiceAccount $SA_NAME not present yet (first install); nothing to adopt."
-            exit 0
-          fi
-
-          owner="$(kubectl -n "$NAMESPACE" get serviceaccount "$SA_NAME" \
-            -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)"
-          if [ "$owner" = "$HELM_RELEASE_NAME" ]; then
-            echo "ServiceAccount $SA_NAME already adopted by release $HELM_RELEASE_NAME; nothing to do."
-            exit 0
-          fi
-
-          echo "Adopting ServiceAccount $SA_NAME into Helm release $HELM_RELEASE_NAME."
-          kubectl -n "$NAMESPACE" annotate serviceaccount "$SA_NAME" \
-            "meta.helm.sh/release-name=$HELM_RELEASE_NAME" \
-            "meta.helm.sh/release-namespace=$NAMESPACE" --overwrite
-          kubectl -n "$NAMESPACE" label serviceaccount "$SA_NAME" \
-            app.kubernetes.io/managed-by=Helm --overwrite
-          kubectl -n "$NAMESPACE" annotate serviceaccount "$SA_NAME" \
-            helm.sh/hook- helm.sh/hook-weight- helm.sh/hook-delete-policy-
       - name: helm upgrade --install
         # App secrets never pass through --set: the chart runs in
         # `server.managedSecrets: true` mode, which reads DATABASE_URL /

--- a/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
+++ b/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
@@ -29,9 +29,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9091"
         prometheus.io/port-name: metrics
-        {{- if and .Values.server.serviceAccount.create .Values.server.migrationJob.asHook }}
-        tuist.dev/server-service-account-revision: {{ .Release.Revision | quote }}
-        {{- end }}
         {{- with .Values.swiftRegistrySync.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## What changed

Follow-up cleanup to #11920 (stop server ServiceAccount UID churn causing intermittent K8s 401s), now that it has shipped and been verified on every managed cluster. Removes two pieces that only existed to work around the UID churn:

- **`.github/workflows/server-deployment.yml`** — deletes the one-time "Adopt server ServiceAccount into the Helm release" step.
- **`infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`** — deletes the `tuist.dev/server-service-account-revision: {{ .Release.Revision }}` pod annotation.

## Why

### Adoption step is now a permanent no-op

The step imported the hook-created `tuist-server` SA into the Helm release so the first `helm upgrade` after the hook→normal-resource switch wouldn't fail its ownership import check. It was written to self-skip once a cluster is adopted. Every managed cluster is now adopted — verified live (read-only kubectl):

| Cluster | `meta.helm.sh/release-name` | `helm.sh/hook` |
|---|---|---|
| production (`tuist`) | `tuist` | *(stripped)* |
| canary (`tuist-canary`) | `tuist` | *(stripped)* |
| staging (`tuist-staging`) | `tuist` | *(stripped)* |

So the step short-circuits on every run and can be removed. Helm continues to own the SA (`resource-policy: keep`) and re-stamps the ownership annotations itself. Fresh installs render the SA as a normal resource from the start, so there is nothing to adopt there either.

### Overlooked force-rollout annotation

`swift-registry-sync-deployment.yaml` mounts the **same server SA** (`serviceAccountName: …-server`) and carried the same `server-service-account-revision: {{ .Release.Revision }}` annotation that #11920 removed from the server and processor deployments — it forces a rollout every deploy so pods re-mint SA tokens after the (now-eliminated) UID churn. This one was missed. Its gate (`server.migrationJob.asHook`) is still true in managed envs, so it currently renders and rolls swift-registry-sync on every single deploy for no reason. With a stable SA UID it is dead weight.

## Impact

No behavior change beyond removing per-deploy churn: the deploy workflow drops a no-op step, and swift-registry-sync stops rolling every deploy (one final roll when this annotation removal lands, then quiet).

## Validation

- Verified all three managed clusters carry `meta.helm.sh/release-name=tuist` on their `tuist-server` SA before removing the adoption step (see table).
- `actionlint .github/workflows/server-deployment.yml` — no new findings.
- `helm template` of swift-registry-sync renders with `serviceAccountName: tuist-tuist-server` and **no** `service-account-revision` annotation.
- Repo-wide grep for `server-service-account-revision` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
