### PR TITLE
fix(cli): ensure cache daemon starts during setup

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/CacheSocketService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/CacheSocketService.swift
@@ -1,0 +1,75 @@
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+import Foundation
+import Mockable
+import Path
+
+@Mockable
+protocol CacheSocketServicing {
+    func waitUntilListening(at path: AbsolutePath, timeout: Duration) async -> Bool
+}
+
+struct CacheSocketService: CacheSocketServicing {
+    func waitUntilListening(at path: AbsolutePath, timeout: Duration) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        repeat {
+            if canConnect(to: path.pathString) {
+                return true
+            }
+            if clock.now >= deadline || Task.isCancelled {
+                return false
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        } while true
+    }
+
+    private func canConnect(to path: String) -> Bool {
+        #if canImport(Darwin)
+            let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        #else
+            let descriptor = Glibc.socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        #endif
+        guard descriptor >= 0 else { return false }
+        defer { close(descriptor) }
+
+        var address = sockaddr_un()
+        #if canImport(Darwin)
+            address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        #endif
+        address.sun_family = sa_family_t(AF_UNIX)
+
+        let pathBytes = Array(path.utf8)
+        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+            return false
+        }
+
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: UInt8.self, repeating: 0)
+            buffer.copyBytes(from: pathBytes)
+        }
+
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                #if canImport(Darwin)
+                    Darwin.connect(
+                        descriptor,
+                        socketAddress,
+                        socklen_t(MemoryLayout<sockaddr_un>.size)
+                    )
+                #else
+                    Glibc.connect(
+                        descriptor,
+                        socketAddress,
+                        socklen_t(MemoryLayout<sockaddr_un>.size)
+                    )
+                #endif
+            }
+        }
+        return result == 0
+    }
+}

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -16,6 +16,7 @@ import TuistSupport
 enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     case missingFullHandle
     case notAuthenticated
+    case cacheDaemonNotReady(label: String, socketPath: String, logPath: String)
     case registryNotReplaced(String, Int32)
     case registryNotLocked(String, Int32)
 
@@ -27,6 +28,9 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
         case .notAuthenticated:
             return
                 "You must be authenticated to set up the cache. Run `tuist auth login` (or set the `TUIST_TOKEN` environment variable) and run `tuist setup cache` again."
+        case let .cacheDaemonNotReady(label, socketPath, logPath):
+            return
+                "The Xcode cache daemon '\(label)' did not start listening at \(socketPath), so its launch agent was stopped. Check the daemon log at \(logPath), address the reported error, and run `tuist setup cache` again."
         case let .registryNotReplaced(path, code):
             return "Could not update the cache proxy's registry at \(path) (errno \(code))."
         case let .registryNotLocked(path, code):
@@ -85,6 +89,8 @@ struct SetupCacheCommandService {
     private let fileSystem: FileSysteming
     private let getProjectService: GetProjectServicing
     private let gitController: GitControlling
+    private let cacheSocketService: CacheSocketServicing
+    private let cacheDaemonStartupTimeout: Duration
 
     init(
         launchAgentService: LaunchAgentServicing = LaunchAgentService(),
@@ -94,7 +100,9 @@ struct SetupCacheCommandService {
         manifestLoader: ManifestLoading = ManifestLoader.current,
         fileSystem: FileSysteming = FileSystem(),
         getProjectService: GetProjectServicing = GetProjectService(),
-        gitController: GitControlling = GitController()
+        gitController: GitControlling = GitController(),
+        cacheSocketService: CacheSocketServicing = CacheSocketService(),
+        cacheDaemonStartupTimeout: Duration = .seconds(10)
     ) {
         self.launchAgentService = launchAgentService
         self.configLoader = configLoader
@@ -104,6 +112,8 @@ struct SetupCacheCommandService {
         self.fileSystem = fileSystem
         self.getProjectService = getProjectService
         self.gitController = gitController
+        self.cacheSocketService = cacheSocketService
+        self.cacheDaemonStartupTimeout = cacheDaemonStartupTimeout
     }
 
     /// The project's default branch, which is what a trunk-scoped cache snapshot is
@@ -239,6 +249,41 @@ struct SetupCacheCommandService {
         }
         defer { flock(descriptor, LOCK_UN) }
         try await body()
+    }
+
+    private func ensureCacheDaemonIsListening(label: String, socketPath: AbsolutePath) async throws {
+        if await cacheSocketService.waitUntilListening(
+            at: socketPath,
+            timeout: cacheDaemonStartupTimeout
+        ) {
+            return
+        }
+
+        Logger.current.debug(
+            "The Xcode cache daemon did not start listening at \(socketPath.pathString). Restarting \(label) once."
+        )
+        do {
+            try await launchAgentService.restartLaunchAgent(label: label)
+            if await cacheSocketService.waitUntilListening(
+                at: socketPath,
+                timeout: cacheDaemonStartupTimeout
+            ) {
+                return
+            }
+        } catch {
+            Logger.current.debug("Could not restart \(label): \(error.localizedDescription)")
+        }
+
+        try? await launchAgentService.teardownLaunchAgent(
+            label: label,
+            plistFileName: "\(label).plist"
+        )
+        let logPath = Environment.current.stateDirectory.appending(component: "\(label).stderr.log")
+        throw SetupCacheCommandServiceError.cacheDaemonNotReady(
+            label: label,
+            socketPath: socketPath.pathString,
+            logPath: logPath.pathString
+        )
     }
 
     func run(
@@ -435,6 +480,10 @@ struct SetupCacheCommandService {
             programArguments: programArguments,
             environmentVariables: environmentVariables
         )
+        try await ensureCacheDaemonIsListening(
+            label: label,
+            socketPath: Environment.current.casProxySocketPath()
+        )
     }
 
     /// Installs the legacy per-project CAS daemon (non-kura path): one launchd
@@ -477,6 +526,10 @@ struct SetupCacheCommandService {
             plistFileName: "\(label).plist",
             programArguments: programArguments,
             environmentVariables: environmentVariables
+        )
+        try await ensureCacheDaemonIsListening(
+            label: label,
+            socketPath: Environment.current.cacheSocketPath(for: fullHandle)
         )
     }
 }

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -33,6 +33,8 @@ public protocol LaunchAgentServicing {
         label: String,
         plistFileName: String
     ) async throws
+
+    func restartLaunchAgent(label: String) async throws
 }
 
 public struct LaunchAgentService: LaunchAgentServicing {
@@ -64,16 +66,13 @@ public struct LaunchAgentService: LaunchAgentServicing {
             try await fileSystem.makeDirectory(at: launchAgentsDir)
         }
 
-        if try await fileSystem.exists(plistPath) {
+        if try await launchctlController.isLoaded(label: label) {
             Logger.current.debug("Existing LaunchAgent found. Booting out...")
+            try await launchctlController.bootout(label: label)
+        }
+
+        if try await fileSystem.exists(plistPath) {
             try await fileSystem.remove(plistPath)
-            do {
-                try await launchctlController.bootout(label: label)
-            } catch {
-                Logger.current.debug(
-                    "Failed to boot out existing LaunchAgent: \(error.localizedDescription)"
-                )
-            }
         }
 
         let fullArguments = [tuistBinaryPath.pathString] + programArguments
@@ -102,19 +101,13 @@ public struct LaunchAgentService: LaunchAgentServicing {
             try await launchctlController.bootstrap(plistPath: plistPath)
             Logger.current.debug("Bootstrapped LaunchAgent")
         } catch let commandError as CommandError {
-            switch commandError {
-            case .terminated(5, _, _):
-                Logger.current
-                    .debug("LaunchAgent already bootstrapped by launchd, skipping explicit bootstrap")
-            default:
-                var message = String(describing: commandError)
-                if let stderrContent = try? await fileSystem.readTextFile(at: stderrLogPath),
-                   !stderrContent.isEmpty
-                {
-                    message += "\nDaemon stderr log:\n\(stderrContent)"
-                }
-                throw LaunchAgentServiceError.failedToLoadLaunchAgent(message)
+            var message = String(describing: commandError)
+            if let stderrContent = try? await fileSystem.readTextFile(at: stderrLogPath),
+               !stderrContent.isEmpty
+            {
+                message += "\nDaemon stderr log:\n\(stderrContent)"
             }
+            throw LaunchAgentServiceError.failedToLoadLaunchAgent(message)
         } catch {
             var message = String(describing: error)
             if let stderrContent = try? await fileSystem.readTextFile(at: stderrLogPath),
@@ -126,6 +119,11 @@ public struct LaunchAgentService: LaunchAgentServicing {
         }
 
         Logger.current.debug("LaunchAgent configured and loaded successfully")
+    }
+
+    public func restartLaunchAgent(label: String) async throws {
+        try await launchctlController.kickstart(label: label)
+        Logger.current.debug("Restarted LaunchAgent \(label)")
     }
 
     public func teardownLaunchAgent(

--- a/cli/Sources/TuistLaunchctl/LaunchctlController.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchctlController.swift
@@ -12,6 +12,9 @@ public protocol LaunchctlControlling {
     /// Boots out a LaunchAgent by label from the current user's GUI domain.
     func bootout(label: String) async throws
 
+    /// Restarts a LaunchAgent by label in the current user's GUI domain.
+    func kickstart(label: String) async throws
+
     /// Returns whether a LaunchAgent with the given label is currently loaded in the
     /// current user's GUI domain.
     func isLoaded(label: String) async throws -> Bool
@@ -43,6 +46,19 @@ public struct LaunchctlController: LaunchctlControlling {
             arguments: [
                 "/bin/launchctl",
                 "bootout",
+                "gui/\(uid)/\(label)",
+            ]
+        )
+        .awaitCompletion()
+    }
+
+    public func kickstart(label: String) async throws {
+        let uid = getuid()
+        _ = try await commandRunner.run(
+            arguments: [
+                "/bin/launchctl",
+                "kickstart",
+                "-k",
                 "gui/\(uid)/\(label)",
             ]
         )

--- a/cli/Tests/TuistKitTests/Services/Setup/CacheSocketServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/CacheSocketServiceTests.swift
@@ -1,0 +1,69 @@
+import Darwin
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistKit
+
+struct CacheSocketServiceTests {
+    private let fileSystem = FileSystem()
+    private let subject = CacheSocketService()
+
+    @Test(.inTemporaryDirectory)
+    func waitUntilListening_returnsTrueForAListeningSocket() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let shortDirectoryPath = try AbsolutePath(validating: "/tmp/\(UUID().uuidString)")
+        try await fileSystem.createSymbolicLink(from: shortDirectoryPath, to: temporaryDirectory)
+        let socketPath = shortDirectoryPath.appending(component: "cache.sock")
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(descriptor >= 0)
+        defer {
+            close(descriptor)
+            unlink(socketPath.pathString)
+            unlink(shortDirectoryPath.pathString)
+        }
+
+        var address = sockaddr_un()
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        address.sun_family = sa_family_t(AF_UNIX)
+        try #require(socketPath.pathString.utf8.count < MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: UInt8.self, repeating: 0)
+            buffer.copyBytes(from: socketPath.pathString.utf8)
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(
+                    descriptor,
+                    socketAddress,
+                    socklen_t(MemoryLayout<sockaddr_un>.size)
+                )
+            }
+        }
+        try #require(bindResult == 0)
+        try #require(Darwin.listen(descriptor, 1) == 0)
+
+        #expect(
+            await subject.waitUntilListening(
+                at: socketPath,
+                timeout: .milliseconds(100)
+            )
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func waitUntilListening_returnsFalseWhenNothingIsListening() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let socketPath = temporaryDirectory.appending(component: "missing.sock")
+
+        #expect(
+            await !subject.waitUntilListening(
+                at: socketPath,
+                timeout: .zero
+            )
+        )
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -29,6 +29,7 @@ struct SetupCacheCommandServiceTests {
     private let manifestLoader = MockManifestLoading()
     private let getProjectService = MockGetProjectServicing()
     private let gitController = MockGitControlling()
+    private let cacheSocketService = MockCacheSocketServicing()
 
     init() {
         subject = SetupCacheCommandService(
@@ -38,7 +39,9 @@ struct SetupCacheCommandServiceTests {
             serverAuthenticationController: serverAuthenticationController,
             manifestLoader: manifestLoader,
             getProjectService: getProjectService,
-            gitController: gitController
+            gitController: gitController,
+            cacheSocketService: cacheSocketService,
+            cacheDaemonStartupTimeout: .zero
         )
 
         // Every kura-path setup resolves the project's default branch to record the
@@ -76,6 +79,10 @@ struct SetupCacheCommandServiceTests {
         given(launchAgentService)
             .teardownLaunchAgent(label: .any, plistFileName: .any)
             .willReturn()
+
+        given(cacheSocketService)
+            .waitUntilListening(at: .any, timeout: .any)
+            .willReturn(true)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger()) func setupCache_withTuistProject() async throws {
@@ -114,7 +121,6 @@ struct SetupCacheCommandServiceTests {
                 environmentVariables: .any
             )
             .called(1)
-
         let success = try #require(alertController.success().last)
         #expect(success.message.plain().contains("Xcode Cache has been enabled 🎉"))
         #expect(success.takeaways.contains { $0.plain().contains("Xcode Cache is set up") })
@@ -488,6 +494,78 @@ struct SetupCacheCommandServiceTests {
                     "--no-upload",
                 ]),
                 environmentVariables: .value(["TUIST_TOKEN": token])
+            )
+            .called(1)
+        verify(cacheSocketService)
+            .waitUntilListening(
+                at: .value(environment.cacheSocketPath(for: "organization/project")),
+                timeout: .value(.zero)
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupCache_restartsTheAgentWhenTheSocketDoesNotStartListening() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        var checks = 0
+        cacheSocketService.reset()
+        given(cacheSocketService)
+            .waitUntilListening(at: .any, timeout: .any)
+            .willProduce { _, _ in
+                checks += 1
+                return checks == 2
+            }
+        given(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .willReturn()
+
+        try await subject.run(path: nil)
+
+        verify(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .called(1)
+        verify(cacheSocketService)
+            .waitUntilListening(
+                at: .value(environment.casProxySocketPath()),
+                timeout: .value(.zero)
+            )
+            .called(2)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupCache_failsWhenTheSocketDoesNotListenAfterRestart() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        cacheSocketService.reset()
+        given(cacheSocketService)
+            .waitUntilListening(at: .any, timeout: .any)
+            .willReturn(false)
+        given(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .willReturn()
+        let socketPath = environment.casProxySocketPath()
+        let logPath = environment.stateDirectory.appending(component: "tuist.cas-proxy.stderr.log")
+
+        await #expect(
+            throws: SetupCacheCommandServiceError.cacheDaemonNotReady(
+                label: "tuist.cas-proxy",
+                socketPath: socketPath.pathString,
+                logPath: logPath.pathString
+            )
+        ) {
+            try await subject.run(path: nil)
+        }
+
+        verify(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .called(1)
+        verify(launchAgentService)
+            .teardownLaunchAgent(
+                label: .value("tuist.cas-proxy"),
+                plistFileName: .value("tuist.cas-proxy.plist")
             )
             .called(1)
     }

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -22,6 +22,9 @@ struct LaunchAgentServiceTests {
             fileSystem: fileSystem,
             launchctlController: launchctlController
         )
+        given(launchctlController)
+            .isLoaded(label: .any)
+            .willReturn(false)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
@@ -129,6 +132,11 @@ struct LaunchAgentServiceTests {
         try await fileSystem.makeDirectory(at: expectedPlistPath.parentDirectory)
         try await fileSystem.writeText("existing plist", at: expectedPlistPath)
 
+        launchctlController.reset()
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willReturn(true)
+
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
             .willReturn()
@@ -153,7 +161,7 @@ struct LaunchAgentServiceTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupLaunchAgent_continuesWhenUnloadFails() async throws {
+    func setupLaunchAgent_preservesExistingPlistAndThrowsWhenUnloadFails() async throws {
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
@@ -165,10 +173,41 @@ struct LaunchAgentServiceTests {
         try await fileSystem.makeDirectory(at: expectedPlistPath.parentDirectory)
         try await fileSystem.writeText("existing plist", at: expectedPlistPath)
 
+        launchctlController.reset()
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willReturn(true)
+
         given(launchctlController)
             .bootout(label: .any)
             .willThrow(NSError(domain: "test", code: 1))
 
+        await #expect(throws: NSError.self) {
+            try await subject.setupLaunchAgent(
+                label: "tuist.test",
+                plistFileName: "tuist.test.plist",
+                programArguments: ["test-start"]
+            )
+        }
+
+        verify(launchctlController)
+            .bootstrap(plistPath: .any)
+            .called(0)
+        #expect(try await fileSystem.readTextFile(at: expectedPlistPath) == "existing plist")
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_unloadsLoadedAgentWhenPlistIsMissing() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        launchctlController.reset()
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willReturn(true)
+        given(launchctlController)
+            .bootout(label: .value("tuist.test"))
+            .willReturn()
         given(launchctlController)
             .bootstrap(plistPath: .any)
             .willReturn()
@@ -180,7 +219,10 @@ struct LaunchAgentServiceTests {
         )
 
         verify(launchctlController)
-            .bootstrap(plistPath: .value(expectedPlistPath))
+            .bootout(label: .value("tuist.test"))
+            .called(1)
+        verify(launchctlController)
+            .bootstrap(plistPath: .any)
             .called(1)
     }
 
@@ -263,6 +305,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.makeDirectory(at: plistPath.parentDirectory)
         try await fileSystem.writeText("existing plist", at: plistPath)
 
+        launchctlController.reset()
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -291,6 +334,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.makeDirectory(at: plistPath.parentDirectory)
         try await fileSystem.writeText("existing plist", at: plistPath)
 
+        launchctlController.reset()
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(false)
@@ -321,6 +365,7 @@ struct LaunchAgentServiceTests {
             command: ["/bin/launchctl", "bootout", "gui/501/tuist.test"]
         )
 
+        launchctlController.reset()
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -342,6 +387,7 @@ struct LaunchAgentServiceTests {
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
     func teardownLaunchAgent_succeedsWhenPlistIsMissing() async throws {
+        launchctlController.reset()
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(false)
@@ -382,5 +428,17 @@ struct LaunchAgentServiceTests {
         )
         let plistContent = try await fileSystem.readTextFile(at: expectedPlistPath)
         #expect(plistContent.contains(currentMisePath.pathString.replacingOccurrences(of: "/private", with: "")))
+    }
+
+    @Test func restartLaunchAgent_kickstartsLoadedAgent() async throws {
+        given(launchctlController)
+            .kickstart(label: .value("tuist.test"))
+            .willReturn()
+
+        try await subject.restartLaunchAgent(label: "tuist.test")
+
+        verify(launchctlController)
+            .kickstart(label: .value("tuist.test"))
+            .called(1)
     }
 }

--- a/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
@@ -83,6 +83,37 @@ struct LaunchctlControllerTests {
             .called(1)
     }
 
+    @Test func kickstart_label() async throws {
+        let label = "tuist.cache.org_project"
+        let uid = getuid()
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.finish()
+            })
+
+        try await subject.kickstart(label: label)
+
+        verify(commandRunner)
+            .run(
+                arguments: .value(
+                    [
+                        "/bin/launchctl",
+                        "kickstart",
+                        "-k",
+                        "gui/\(uid)/\(label)",
+                    ]
+                ),
+                environment: .any,
+                workingDirectory: .any
+            )
+            .called(1)
+    }
+
     @Test func isLoaded_returnsTrueWhenLaunchctlPrintSucceeds() async throws {
         // Given
         let label = "tuist.cache.org_project"


### PR DESCRIPTION
## What changed

Tuist's [command-line interface](https://en.wikipedia.org/wiki/Command-line_interface) cache setup now treats daemon readiness as part of a successful setup.

- Replaces loaded launch agents even when their property-list file is missing.
- Verifies that the exact Unix-domain socket accepts connections after installing either the Kura proxy or the legacy per-project daemon.
- Restarts an unresponsive agent once, checks the socket again, and tears the agent down if recovery fails.
- Reports the exact socket and standard-error log paths when startup cannot be recovered.
- Adds focused coverage for stale launch agents, restart recovery, unrecoverable startup, and real socket connections.

## Why

A customer had to add an Xcode scheme pre-action that repeatedly tore down, set up, and restarted the cache daemon. Without that watchdog, a daemon that appeared configured but was not listening caused every Xcode task to enter its own cache retry cycle.

Cache setup should own startup recovery and only report success once Xcode can connect to the configured endpoint.

## Root cause

Setup tied launch-agent replacement to the presence of its property-list file. A loaded job whose file was missing could therefore survive setup unchanged. It also treated launchctl bootstrap status 5 as proof that the daemon was already running and returned without checking whether the configured socket was actually listening.

That combination allowed setup to succeed while leaving a loaded but stopped, stale, or otherwise unresponsive daemon behind.

## Approach

Launch-agent setup now checks launchctl state independently of file state and boots out an existing job before replacing its configuration. A failed bootout preserves the existing property-list file and stops setup instead of continuing with ambiguous state.

After bootstrap, setup polls the exact socket for up to ten seconds. If it is unavailable, setup uses launchctl to restart the job once and polls again. A second failure removes the unhealthy launch agent and returns an actionable error that points to its log.

## Impact

A successful `tuist setup cache` now means the cache endpoint is accepting connections for both Kura and legacy configurations. Customers should no longer need scheme pre-actions to compensate for startup-time failures.

Healthy setup remains fast. An unhealthy daemon can add up to twenty seconds before setup fails with recovery guidance. There is no migration required.

## Validation

- `mise run cli:lint --fix`
- Focused Xcode tests covering 43 cases across cache setup, socket readiness, launch-agent lifecycle, and launchctl command construction.
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`

The stale launch-agent state was also reproduced against a real `launchd` job. The job remained loaded after its property-list file was deleted, and bootstrapping the same label returned status 5. The updated setup logic removed the stale job, installed its replacement, and accepted a real Unix socket connection. The focused test passed in 0.174 seconds.

`TuistCacheEECanaryAcceptanceTests/generated_project_with_caching_enabled()` passed against the canary environment in 34.149 seconds. The cold build missed the cache, and the clean rebuild reached 124 hits out of 124 cacheable tasks. This canary starts the cache server directly, so it validates the complete remote-cache flow while the focused reproduction validates the setup and `launchd` boundary.

The wider three-test canary suite completed with the requested cache test and `multiplatform_app_selective_testing()` passing. `multiplatform_app_module_cache()` could not complete because the local Xcode installation does not include the watchOS 26.5 simulator runtime.
