### PR TITLE
feat(cli): strip release binaries

### DIFF
--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -97,6 +97,14 @@ bundle_swift_runtime_libraries() {
     fi
 }
 
+strip_release_binaries() {
+    strip -rSTx \
+        "$BUILD_DIRECTORY/tuist" \
+        "$BUILD_DIRECTORY/ProjectDescription.framework/ProjectDescription" \
+        "$BUILD_DIRECTORY/libtuist_cas_plugin.dylib" \
+        "$BUILD_DIRECTORY/tuist-cas-proxy"
+}
+
 # Builds the cas-plugin (Xcode compilation-cache CAS plugin) as a universal
 # dylib, plus the per-machine proxy binary, both bundled next to `tuist`. The
 # CLI points Xcode's compilation caching at the dylib via
@@ -142,6 +150,9 @@ build_cas_plugin
 
 echo "$(format_subsection "Bundling Swift runtime libraries")"
 bundle_swift_runtime_libraries
+
+echo "$(format_subsection "Stripping release binaries")"
+strip_release_binaries
 
 echo "$(format_section "Copying assets")"
 


### PR DESCRIPTION
### What changed

The CLI bundling task now strips the Tuist executable, ProjectDescription framework, CAS plugin, and CAS proxy before signing and notarization.

The `-rSTx` parameters are based on the [Emerge Tools Strip Binary Symbols (iOS)](https://docs.emergetools.com/docs/strip-binary-symbols). The stripping step runs after runtime-library setup, including install_name_tool changes, and before codesigning so the resulting signatures remain valid. ProjectDescription.dSYM remains bundled for crash symbolication.

### Why it changed
Release artifacts retain unnecessary local, debug, and Swift symbols. Stripping them reduces the distributed size without changing the release build configuration.

| Binary | Original | Stripped | Reduction |
| --- | ---: | ---: | ---: |
| tuist | 232.56 MB | 93.94 MB | 138.62 MB (59.61%) |
| ProjectDescription | 10.99 MB | 2.97 MB | 8.02 MB (72.96%) |
| libtuist_cas_plugin.dylib | 1.27 MB | 1.05 MB | 0.22 MB (17.36%) |
| tuist-cas-proxy | 14.86 MB | 12.94 MB | 1.93 MB (12.96%) |