### PR TITLE
fix(infra): pace Linux runner provisioning

### DIFF
--- a/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
+++ b/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
@@ -127,6 +127,33 @@ spec:
                     sidecar to every Linux runner Pod. The microVM keeps
                     the sidecar's privileged surface off the bare-metal
                     host.
+                provisioning:
+                  type: object
+                  description: |
+                    Linux Kata sandbox admission controls. Sibling pools that
+                    share `(os, fleetSelector)` also share one provisioning
+                    budget. The controller uses the lowest sibling maximum so
+                    one mismatched pool cannot weaken the fleet safety limit.
+                    Ignored for macOS pools.
+                  properties:
+                    maxConcurrentPerFleetSelector:
+                      type: integer
+                      default: 4
+                      minimum: 1
+                      description: |
+                        Maximum Linux runner Pods across the shared fleet that
+                        may be waiting for their dispatch poller to start.
+                        Excess replica demand remains uncreated and is retried
+                        as existing sandboxes become ready.
+                    startTimeoutSeconds:
+                      type: integer
+                      default: 300
+                      minimum: 0
+                      description: |
+                        Maximum time a Linux runner Pod that is already bound
+                        to a node may wait for its dispatch poller to start.
+                        Timed-out Pods are reaped. Unscheduled Pods are not
+                        timed out. 0 disables the timeout.
                 autoscaling:
                   type: object
                   description: |

--- a/infra/helm/tuist/templates/runner-pool.yaml
+++ b/infra/helm/tuist/templates/runner-pool.yaml
@@ -211,6 +211,7 @@ spec:
 {{- $runnerLabels := $pool.runnerLabels | default $defaultRunnerLabels }}
 {{- $autoscaling := $pool.autoscaling }}
 {{- $runtimeClass := $pool.runtimeClass | default "" }}
+{{- $provisioning := mergeOverwrite (deepCopy ($.Values.runnersFleetLinux.provisioning | default dict)) (default dict $pool.provisioning) }}
 {{- $poolName := printf "%s-%s" (include "tuist.componentName" (dict "root" $ "component" "runner-pool-linux")) $name }}
 ---
 apiVersion: tuist.dev/v1alpha1
@@ -243,6 +244,9 @@ spec:
   {{- if $runtimeClass }}
   runtimeClass: {{ $runtimeClass | quote }}
   {{- end }}
+  provisioning:
+    maxConcurrentPerFleetSelector: {{ dig "maxConcurrentPerFleetSelector" 4 $provisioning }}
+    startTimeoutSeconds: {{ dig "startTimeoutSeconds" 300 $provisioning }}
   {{- if $autoscaling }}
   autoscaling:
     enabled: {{ dig "enabled" false $autoscaling }}
@@ -285,6 +289,7 @@ autoscaling per-shape (a popular shape may want a higher floor).
 {{- $podMem := mul $memoryGb 1024 }}
 {{- $isDefault := dig "default" false $shape }}
 {{- $autoscaling := mergeOverwrite (deepCopy $shapeAutoscalingDefaults) (default dict $shape.autoscaling) }}
+{{- $provisioning := mergeOverwrite (deepCopy ($.Values.runnersFleetLinux.provisioning | default dict)) (default dict $shape.provisioning) }}
 ---
 apiVersion: tuist.dev/v1alpha1
 kind: RunnerPool
@@ -322,6 +327,9 @@ spec:
   {{- if $shapeRuntimeClass }}
   runtimeClass: {{ $shapeRuntimeClass | quote }}
   {{- end }}
+  provisioning:
+    maxConcurrentPerFleetSelector: {{ dig "maxConcurrentPerFleetSelector" 4 $provisioning }}
+    startTimeoutSeconds: {{ dig "startTimeoutSeconds" 300 $provisioning }}
   autoscaling:
     enabled: {{ dig "enabled" true $autoscaling }}
     minWarmPoolFloor: {{ dig "minWarmPoolFloor" 1 $autoscaling }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1642,6 +1642,15 @@ runnersFleetLinux:
   # split shape the watchdog runs in the credential-free `run-job.sh`
   # runner container. 0 disables it.
   idleTimeoutSeconds: 300
+  # Linux Kata sandbox admission is shared across every pool using this
+  # fleet selector. Keeping only four sandboxes in the pre-poller start
+  # phase prevents a queue spike from asking both bare-metal kubelets to
+  # boot dozens of virtual machines at once. Per-pool / per-shape values
+  # override these defaults; the controller enforces the lowest sibling maximum.
+  provisioning:
+    maxConcurrentPerFleetSelector: 4
+    # Starts after the scheduler binds the Pod to a node. 0 disables.
+    startTimeoutSeconds: 300
   # Value of the `node.cluster.x-k8s.io/pool=` label CAPI's
   # label-sync propagates from the runner MachineDeployment to
   # each runner Node. Must match the
@@ -1679,6 +1688,9 @@ runnersFleetLinux:
     #   # the kata-qemu microVM is the safety boundary that keeps
     #   # the privileged sidecar off the bare-metal host kernel.
     #   runtimeClass: kata-qemu
+    #   provisioning:
+    #     maxConcurrentPerFleetSelector: 4
+    #     startTimeoutSeconds: 300
     #   autoscaling:
     #     enabled: true
     #     minWarmPoolFloor: 3

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -60,11 +60,46 @@ independent workqueues:
     mini under the Virtualization.framework SLA). The allocator
     apportions the host budget across competing Xcode pools.
 
+  Only nodes that report `Ready=True`, remain schedulable, and have no
+  memory, disk, or process identifier pressure contribute to either
+  budget. A fleet filtered to zero capacity still takes the existing
+  per-pool fallback, so a transient node roll never triggers a mass
+  scale-down of warm Pods. Pod creation has a separate fail-closed
+  healthy-node gate described below.
+
   The reconciler reads nodes via the cluster-scoped `nodes` verb in
   the ClusterRole. Any failure gathering the fleet view falls back to
   the per-pool target — a node-read blip must never trigger a mass
   scale-down. A pool with an unrecognised `OS` (or without autoscaling
   enabled) skips the allocator entirely.
+
+  **Linux Kata provisioning admission.** Capacity and creation velocity
+  are separate safety boundaries. A queue spike can fit within the
+  fleet's memory budget while still asking kubelet and Kata to start too
+  many sandboxes together. Before filling a Linux Kata pool's replica
+  gap, `RunnerPoolReconciler` counts every alive, unclaimed Pod whose
+  dispatch poller has not started across sibling pools sharing
+  the same operating system and `FleetSelector`. It creates only up to
+  `spec.provisioning.maxConcurrentPerFleetSelector` (default 4), using
+  the lowest sibling value so one mismatched pool cannot weaken the
+  fleet boundary. Excess demand remains a replica gap and is retried
+  every five seconds. macOS pools skip this gate.
+
+  Pod creates are visible to the cached client asynchronously. The
+  reconciler therefore keeps a 30-second in-process reservation for each
+  successful create and counts it until the cache observes the Pod. This
+  prevents an immediate reconcile from admitting a second full batch in
+  the cache-lag window. The controller keeps its default single reconcile
+  worker; raising that concurrency requires revisiting the admission
+  invariant.
+
+  A Linux Pod that is bound to a node but whose poller has not started
+  within `spec.provisioning.startTimeoutSeconds` (default 300, 0 disables)
+  is reaped with a warning event and node-condition log. Unscheduled Pods
+  are not recycled because recreation cannot solve a scheduler capacity
+  wait. Claimed Pods and Pods whose poller has terminated are protected.
+  Terminal cleanup and idle scale-down run before admission and are never
+  blocked by the provisioning ceiling.
 
   **Allocation observability (`internal/metrics`).** Each tick the
   reconciler publishes the squeeze on the controller's existing
@@ -85,6 +120,13 @@ independent workqueues:
   Kubernetes phase (`Pending`, `Running`, `Unknown`). This preserves the
   runner dashboard's macOS ready vs cold-booting split without relying
   on pod-scoped kube-state-metrics series.
+
+  Provisioning safety publishes
+  `tuist_runners_pool_pending_provisioning_pods{pool}`,
+  `tuist_runners_pool_admission_blocked_total{pool,reason}`,
+  `tuist_runners_fleet_ready_nodes{fleet_selector,operating_system}`,
+  `tuist_runners_fleet_filtered_nodes{fleet_selector,operating_system,reason}`,
+  and `tuist_runners_pool_pod_start_timeouts_total{pool,reason}`.
 
   Alongside it, `tuist_runners_pool_oldest_pending_pod_age_seconds{pool}`
   is how long the pool's oldest un-`Running` Pod has been waiting (0 when

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -97,6 +97,17 @@ type RunnerPoolSpec struct {
 	// +optional
 	RuntimeClass string `json:"runtimeClass,omitempty"`
 
+	// Provisioning bounds how many Linux Kata sandboxes may be starting at
+	// once across pools that share this pool's FleetSelector, and how long a
+	// bound Pod may take to start its dispatch poller. The controller uses the
+	// lowest maxConcurrentPerFleetSelector configured by sibling pools so a
+	// mismatched pool cannot weaken the shared safety boundary.
+	//
+	// Linux only. macOS runner Pods use the Tart host lifecycle and do not
+	// participate in this admission gate.
+	// +optional
+	Provisioning *RunnerPoolProvisioning `json:"provisioning,omitempty"`
+
 	// IdleTimeoutSeconds bounds how long a runner that has registered
 	// with GitHub but has not been handed a job stays alive. The runner
 	// image's watchdog reads it as `TUIST_RUNNER_IDLE_TIMEOUT_SECONDS`:
@@ -202,6 +213,51 @@ type RunnerPoolAutoscaling struct {
 	// via ScaleDownCooldownSecondsOrDefault.
 	// +optional
 	ScaleDownCooldownSeconds *int32 `json:"scaleDownCooldownSeconds,omitempty"`
+}
+
+const (
+	defaultMaxConcurrentProvisioningPerFleetSelector int32 = 4
+	defaultProvisioningStartTimeoutSeconds           int32 = 300
+)
+
+// RunnerPoolProvisioning carries the Linux Kata sandbox admission knobs.
+// Pointer fields preserve a deliberate zero for startTimeoutSeconds while
+// allowing the custom-resource defaults to distinguish an omitted value.
+type RunnerPoolProvisioning struct {
+	// MaxConcurrentPerFleetSelector is the maximum number of Linux runner
+	// Pods that may be waiting for their dispatch poller to start across all
+	// sibling pools sharing the same operating system and FleetSelector. The lowest sibling value is
+	// authoritative for the shared fleet. Default 4.
+	// +kubebuilder:default=4
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	MaxConcurrentPerFleetSelector *int32 `json:"maxConcurrentPerFleetSelector,omitempty"`
+
+	// StartTimeoutSeconds bounds how long a Linux runner Pod that has been
+	// assigned to a node may wait for its dispatch poller to start. Timed-out
+	// Pods are reaped so failed Kata sandboxes release their admission slot.
+	// Unscheduled Pods are not timed out. Default 300; 0 disables the timeout.
+	// +kubebuilder:default=300
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	StartTimeoutSeconds *int32 `json:"startTimeoutSeconds,omitempty"`
+}
+
+func (p *RunnerPoolProvisioning) MaxConcurrentPerFleetSelectorOrDefault() int32 {
+	// The custom-resource schema rejects 0. Keep the non-positive fallback
+	// defensive for typed test clients and clusters whose schema has not yet
+	// been upgraded; unlike StartTimeoutSeconds, zero never disables this cap.
+	if p == nil || p.MaxConcurrentPerFleetSelector == nil || *p.MaxConcurrentPerFleetSelector <= 0 {
+		return defaultMaxConcurrentProvisioningPerFleetSelector
+	}
+	return *p.MaxConcurrentPerFleetSelector
+}
+
+func (p *RunnerPoolProvisioning) StartTimeoutSecondsOrDefault() int32 {
+	if p == nil || p.StartTimeoutSeconds == nil {
+		return defaultProvisioningStartTimeoutSeconds
+	}
+	return *p.StartTimeoutSeconds
 }
 
 // MinWarmPoolFloorOrDefault returns the configured floor, or the CRD

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
@@ -116,3 +116,41 @@ func TestAutoscalingOrDefaultAccessors(t *testing.T) {
 		t.Errorf("nil-receiver MinWarmPoolFloor = %d, want CRD default 1", got)
 	}
 }
+
+func TestProvisioningOrDefaultAccessors(t *testing.T) {
+	unset := &RunnerPoolProvisioning{}
+	if got := unset.MaxConcurrentPerFleetSelectorOrDefault(); got != 4 {
+		t.Errorf("unset MaxConcurrentPerFleetSelector = %d, want 4", got)
+	}
+	if got := unset.StartTimeoutSecondsOrDefault(); got != 300 {
+		t.Errorf("unset StartTimeoutSeconds = %d, want 300", got)
+	}
+
+	configured := &RunnerPoolProvisioning{
+		MaxConcurrentPerFleetSelector: ptr.To[int32](2),
+		StartTimeoutSeconds:           ptr.To[int32](0),
+	}
+	if got := configured.MaxConcurrentPerFleetSelectorOrDefault(); got != 2 {
+		t.Errorf("configured MaxConcurrentPerFleetSelector = %d, want 2", got)
+	}
+	if got := configured.StartTimeoutSecondsOrDefault(); got != 0 {
+		t.Errorf("explicit-zero StartTimeoutSeconds = %d, want 0", got)
+	}
+
+	var nilProvisioning *RunnerPoolProvisioning
+	if got := nilProvisioning.MaxConcurrentPerFleetSelectorOrDefault(); got != 4 {
+		t.Errorf("nil MaxConcurrentPerFleetSelector = %d, want 4", got)
+	}
+}
+
+func TestProvisioningExplicitZeroStartTimeoutReachesTheWire(t *testing.T) {
+	payload, err := json.Marshal(RunnerPoolProvisioning{
+		StartTimeoutSeconds: ptr.To[int32](0),
+	})
+	if err != nil {
+		t.Fatalf("marshal provisioning: %v", err)
+	}
+	if got := string(payload); !strings.Contains(got, `"startTimeoutSeconds":0`) {
+		t.Fatalf("explicit zero start timeout dropped from serialized provisioning: %s", got)
+	}
+}

--- a/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -81,10 +81,37 @@ func (in *RunnerPoolSpec) DeepCopyInto(out *RunnerPoolSpec) {
 		out.Autoscaling = new(RunnerPoolAutoscaling)
 		in.Autoscaling.DeepCopyInto(out.Autoscaling)
 	}
+	if in.Provisioning != nil {
+		out.Provisioning = new(RunnerPoolProvisioning)
+		in.Provisioning.DeepCopyInto(out.Provisioning)
+	}
 	if in.Rollout != nil {
 		out.Rollout = new(RunnerPoolRollout)
 		in.Rollout.DeepCopyInto(out.Rollout)
 	}
+}
+
+func (in *RunnerPoolProvisioning) DeepCopyInto(out *RunnerPoolProvisioning) {
+	*out = *in
+	if in.MaxConcurrentPerFleetSelector != nil {
+		in, out := &in.MaxConcurrentPerFleetSelector, &out.MaxConcurrentPerFleetSelector
+		*out = new(int32)
+		**out = **in
+	}
+	if in.StartTimeoutSeconds != nil {
+		in, out := &in.StartTimeoutSeconds, &out.StartTimeoutSeconds
+		*out = new(int32)
+		**out = **in
+	}
+}
+
+func (in *RunnerPoolProvisioning) DeepCopy() *RunnerPoolProvisioning {
+	if in == nil {
+		return nil
+	}
+	out := new(RunnerPoolProvisioning)
+	in.DeepCopyInto(out)
+	return out
 }
 
 func (in *RunnerPoolAutoscaling) DeepCopyInto(out *RunnerPoolAutoscaling) {

--- a/infra/runners-controller/cmd/manager/main.go
+++ b/infra/runners-controller/cmd/manager/main.go
@@ -114,6 +114,7 @@ func main() {
 		RegistryMirror:      registryMirror,
 		ClusterDNSIP:        clusterDNSIP,
 		ClusterDomain:       clusterDomain,
+		Recorder:            mgr.GetEventRecorderFor("runnerpool-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup RunnerPool reconciler")
 		os.Exit(1)

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -374,7 +374,12 @@ func (r *AutoscalerReconciler) fleetAllocatableMemory(ctx context.Context, fleet
 	}
 
 	var total int64
+	ready, filtered := summarizeFleetNodes(nodes.Items)
+	metrics.RecordFleetNodes(fleetSelector, "linux", ready, filtered)
 	for i := range nodes.Items {
+		if nodeFilterReason(&nodes.Items[i]) != "" {
+			continue
+		}
 		if mem := nodes.Items[i].Status.Allocatable.Memory(); mem != nil {
 			total += mem.Value()
 		}
@@ -401,7 +406,9 @@ func (r *AutoscalerReconciler) fleetHostCount(ctx context.Context, fleetSelector
 	}); err != nil {
 		return 0, fmt.Errorf("list macOS fleet nodes: %w", err)
 	}
-	return int64(len(nodes.Items)), nil
+	ready, filtered := summarizeFleetNodes(nodes.Items)
+	metrics.RecordFleetNodes(fleetSelector, "darwin", ready, filtered)
+	return int64(ready), nil
 }
 
 func (r *AutoscalerReconciler) applyReplicas(ctx context.Context, pool *tuistv1.RunnerPool, desired int32) error {

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,6 +310,10 @@ func linuxNode(name string, allocatableGiB int64) *corev1.Node {
 			Labels: map[string]string{"node.cluster.x-k8s.io/pool": "runners-linux"},
 		},
 		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionTrue,
+			}},
 			Allocatable: corev1.ResourceList{
 				corev1.ResourceMemory: *resource.NewQuantity(allocatableGiB*1024*1024*1024, resource.BinarySI),
 			},
@@ -410,6 +415,92 @@ func macosNode(name, fleetSelector string) *corev1.Node {
 				macosNodeOSLabel: macosNodeOSDarwin,
 			},
 		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+}
+
+func TestAutoscaler_FleetCapacityExcludesUnhealthyNodes(t *testing.T) {
+	pool := linuxFleetPool("linux", 1, 8192, 1, 30)
+	ready := linuxNode("ready", 64)
+	notReady := linuxNode("not-ready", 64)
+	notReady.Status.Conditions[0].Status = corev1.ConditionFalse
+	unschedulable := linuxNode("unschedulable", 64)
+	unschedulable.Spec.Unschedulable = true
+	pressured := linuxNode("pressured", 64)
+	pressured.Status.Conditions = append(pressured.Status.Conditions, corev1.NodeCondition{
+		Type:   corev1.NodeMemoryPressure,
+		Status: corev1.ConditionTrue,
+	})
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = tuistv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, ready, notReady, unschedulable, pressured).
+		Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme, MemReserveFraction: 1}
+
+	got, err := r.fleetAllocatableMemory(context.Background(), pool.Spec.FleetSelector)
+	if err != nil {
+		t.Fatalf("fleetAllocatableMemory: %v", err)
+	}
+	want := int64(64 * 1024 * 1024 * 1024)
+	if got != want {
+		t.Fatalf("fleetAllocatableMemory = %d, want only Ready node memory %d", got, want)
+	}
+}
+
+func TestAutoscaler_MacosFleetCountExcludesUnhealthyNodes(t *testing.T) {
+	const fleet = "runners-macos"
+	ready := macosNode("ready", fleet)
+	notReady := macosNode("not-ready", fleet)
+	notReady.Status.Conditions[0].Status = corev1.ConditionUnknown
+	pressured := macosNode("pressured", fleet)
+	pressured.Status.Conditions = append(pressured.Status.Conditions, corev1.NodeCondition{
+		Type:   corev1.NodeDiskPressure,
+		Status: corev1.ConditionTrue,
+	})
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ready, notReady, pressured).
+		Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	got, err := r.fleetHostCount(context.Background(), fleet)
+	if err != nil {
+		t.Fatalf("fleetHostCount: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("fleetHostCount = %d, want 1 Ready node", got)
+	}
+}
+
+func TestAutoscaler_FilteredZeroCapacityFallsBackToPerPoolTarget(t *testing.T) {
+	pool := linuxFleetPool("linux", 5, 8192, 1, 30)
+	node := linuxNode("not-ready", 64)
+	node.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = tuistv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node).
+		Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme, MemReserveFraction: 1}
+	signals := scaling.Signals{Fleet: pool.Name, Claimed: 7}
+	knobs := scaling.PolicyKnobs{MinWarmPoolFloor: 1, MaxReplicas: 30}
+
+	got := r.allocate(context.Background(), pool, signals, knobs, 8, logr.Discard())
+	if got != 8 {
+		t.Fatalf("allocate with every node filtered = %d, want per-pool fallback 8", got)
 	}
 }
 

--- a/infra/runners-controller/controllers/helpers.go
+++ b/infra/runners-controller/controllers/helpers.go
@@ -2,8 +2,73 @@ package controllers
 
 import corev1 "k8s.io/api/core/v1"
 
+const (
+	nodeFilteredUnschedulable  = "unschedulable"
+	nodeFilteredNotReady       = "not_ready"
+	nodeFilteredMemoryPressure = "memory_pressure"
+	nodeFilteredDiskPressure   = "disk_pressure"
+	nodeFilteredPIDPressure    = "pid_pressure"
+)
+
+var nodeFilterReasons = []string{
+	nodeFilteredUnschedulable,
+	nodeFilteredNotReady,
+	nodeFilteredMemoryPressure,
+	nodeFilteredDiskPressure,
+	nodeFilteredPIDPressure,
+}
+
 // corev1LocalRef is the obvious shorthand. We refer to the pool by
 // name from the assignment; same namespace, no kind ambiguity.
 func corev1LocalRef(name string) corev1.LocalObjectReference {
 	return corev1.LocalObjectReference{Name: name}
+}
+
+// nodeFilterReason returns why a node must not contribute runner-fleet
+// capacity. An empty result means the node is Ready, schedulable, and free
+// from the pressure conditions that make starting another virtual machine
+// unsafe. Ready must be explicitly true: an absent or unknown condition is
+// not usable capacity.
+func nodeFilterReason(node *corev1.Node) string {
+	if node.Spec.Unschedulable {
+		return nodeFilteredUnschedulable
+	}
+
+	ready := false
+	for _, condition := range node.Status.Conditions {
+		switch condition.Type {
+		case corev1.NodeReady:
+			ready = condition.Status == corev1.ConditionTrue
+		case corev1.NodeMemoryPressure:
+			if condition.Status == corev1.ConditionTrue {
+				return nodeFilteredMemoryPressure
+			}
+		case corev1.NodeDiskPressure:
+			if condition.Status == corev1.ConditionTrue {
+				return nodeFilteredDiskPressure
+			}
+		case corev1.NodePIDPressure:
+			if condition.Status == corev1.ConditionTrue {
+				return nodeFilteredPIDPressure
+			}
+		}
+	}
+	if !ready {
+		return nodeFilteredNotReady
+	}
+	return ""
+}
+
+func summarizeFleetNodes(nodes []corev1.Node) (int, map[string]int) {
+	ready := 0
+	filtered := make(map[string]int, len(nodeFilterReasons))
+	for i := range nodes {
+		reason := nodeFilterReason(&nodes[i])
+		if reason == "" {
+			ready++
+			continue
+		}
+		filtered[reason]++
+	}
+	return ready, filtered
 }

--- a/infra/runners-controller/controllers/provisioning.go
+++ b/infra/runners-controller/controllers/provisioning.go
@@ -1,0 +1,223 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
+	"github.com/tuist/tuist/infra/runners-controller/internal/metrics"
+)
+
+const (
+	provisioningRequeueAfter      = 5 * time.Second
+	creationReservationLifetime   = 30 * time.Second
+	pollerNotStartedTimeoutReason = "poller_not_started"
+)
+
+type creationReservation struct {
+	namespace     string
+	pool          string
+	fleetSelector string
+	expiresAt     time.Time
+}
+
+// creationReservationStore closes the informer-cache window after a Pod
+// create. Without it, an immediate reconcile can observe the old Pod list and
+// admit another full batch before the watch event for the first batch lands.
+// Reservations disappear as soon as the cache observes the Pod, or after a
+// short fail-safe lifetime if a watch event is lost.
+type creationReservationStore struct {
+	mu     sync.Mutex
+	byName map[string]creationReservation
+}
+
+func (s *creationReservationStore) add(namespace, name, pool, fleetSelector string, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byName == nil {
+		s.byName = map[string]creationReservation{}
+	}
+	s.byName[namespace+"/"+name] = creationReservation{
+		namespace:     namespace,
+		pool:          pool,
+		fleetSelector: fleetSelector,
+		expiresAt:     now.Add(creationReservationLifetime),
+	}
+}
+
+func (s *creationReservationStore) reconcile(
+	namespace string,
+	fleetSelector string,
+	observed map[string]struct{},
+	now time.Time,
+) (int, map[string]int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	total := 0
+	byPool := map[string]int{}
+	for key, reservation := range s.byName {
+		if _, ok := observed[key]; ok || !now.Before(reservation.expiresAt) {
+			delete(s.byName, key)
+			continue
+		}
+		if reservation.namespace != namespace || reservation.fleetSelector != fleetSelector {
+			continue
+		}
+		total++
+		byPool[reservation.pool]++
+	}
+	return total, byPool
+}
+
+type provisioningAdmission struct {
+	available       int
+	pendingForPool  int
+	pendingForFleet int
+	cap             int
+	healthyNodes    int
+	blockedReason   string
+}
+
+func isLinuxKataPool(pool *tuistv1.RunnerPool) bool {
+	return pool.Spec.OS == "linux" && pool.Spec.RuntimeClass == "kata-qemu"
+}
+
+// isLinuxProvisioningPod is true until the dispatch poller starts. A
+// terminated poller has already claimed or drained, and isIdle deliberately
+// excludes it. Deleting and terminal Pods are excluded by isAlive.
+func isLinuxProvisioningPod(pod *corev1.Pod) bool {
+	return isAlive(pod) && isIdle(pod) && !pollerRunning(pod)
+}
+
+func (r *RunnerPoolReconciler) provisioningAdmission(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+) (provisioningAdmission, error) {
+	var pools tuistv1.RunnerPoolList
+	if err := r.List(ctx, &pools, client.InNamespace(pool.Namespace)); err != nil {
+		return provisioningAdmission{}, fmt.Errorf("list sibling runner pools: %w", err)
+	}
+
+	poolNames := map[string]struct{}{pool.Name: {}}
+	capN := int(pool.Spec.Provisioning.MaxConcurrentPerFleetSelectorOrDefault())
+	for i := range pools.Items {
+		sibling := &pools.Items[i]
+		if !isLinuxKataPool(sibling) || sibling.Spec.FleetSelector != pool.Spec.FleetSelector {
+			continue
+		}
+		poolNames[sibling.Name] = struct{}{}
+		if siblingCap := int(sibling.Spec.Provisioning.MaxConcurrentPerFleetSelectorOrDefault()); siblingCap < capN {
+			capN = siblingCap
+		}
+	}
+
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods,
+		client.InNamespace(pool.Namespace),
+		client.MatchingLabels{"tuist.dev/runner": "true"},
+	); err != nil {
+		return provisioningAdmission{}, fmt.Errorf("list fleet runner pods: %w", err)
+	}
+
+	observed := make(map[string]struct{}, len(pods.Items))
+	pendingForFleet := 0
+	pendingForPool := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		observed[pod.Namespace+"/"+pod.Name] = struct{}{}
+		if _, ok := poolNames[pod.Labels["tuist.dev/runner-pool"]]; !ok || !isLinuxProvisioningPod(pod) {
+			continue
+		}
+		pendingForFleet++
+		if pod.Labels["tuist.dev/runner-pool"] == pool.Name {
+			pendingForPool++
+		}
+	}
+
+	reserved, reservedByPool := r.creationReservations.reconcile(
+		pool.Namespace,
+		pool.Spec.FleetSelector,
+		observed,
+		r.now(),
+	)
+	pendingForFleet += reserved
+	pendingForPool += reservedByPool[pool.Name]
+
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes, client.MatchingLabels{
+		fleetNodePoolLabel: pool.Spec.FleetSelector,
+	}); err != nil {
+		return provisioningAdmission{}, fmt.Errorf("list Linux fleet nodes: %w", err)
+	}
+	healthyNodes, filtered := summarizeFleetNodes(nodes.Items)
+	metrics.RecordFleetNodes(pool.Spec.FleetSelector, pool.Spec.OS, healthyNodes, filtered)
+	metrics.RecordPendingProvisioningPods(pool.Name, pendingForPool)
+
+	admission := provisioningAdmission{
+		pendingForPool:  pendingForPool,
+		pendingForFleet: pendingForFleet,
+		cap:             capN,
+		healthyNodes:    healthyNodes,
+	}
+	if healthyNodes == 0 {
+		admission.blockedReason = "no_healthy_node"
+		return admission, nil
+	}
+	if pendingForFleet >= capN {
+		admission.blockedReason = "fleet_cap"
+		return admission, nil
+	}
+	admission.available = capN - pendingForFleet
+	return admission, nil
+}
+
+func (r *RunnerPoolReconciler) reserveCreatedRunner(pool *tuistv1.RunnerPool, name string) {
+	r.creationReservations.add(pool.Namespace, name, pool.Name, pool.Spec.FleetSelector, r.now())
+}
+
+func startTimedOut(pod *corev1.Pod, pool *tuistv1.RunnerPool, now time.Time) bool {
+	if !isLinuxKataPool(pool) || !isLinuxProvisioningPod(pod) {
+		return false
+	}
+	timeoutSeconds := pool.Spec.Provisioning.StartTimeoutSecondsOrDefault()
+	if timeoutSeconds <= 0 {
+		return false
+	}
+	startedAt, ok := linuxProvisioningStartedAt(pod)
+	return ok && now.Sub(startedAt) >= time.Duration(timeoutSeconds)*time.Second
+}
+
+// linuxProvisioningStartedAt uses the scheduler's transition timestamp rather
+// than Pod creation time. A Pod may legitimately wait unscheduled for much
+// longer than the sandbox-start timeout; starting the clock earlier would reap
+// it immediately after it finally binds.
+func linuxProvisioningStartedAt(pod *corev1.Pod) (time.Time, bool) {
+	if pod.Spec.NodeName == "" {
+		return time.Time{}, false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionTrue && !condition.LastTransitionTime.IsZero() {
+			return condition.LastTransitionTime.Time, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func (r *RunnerPoolReconciler) nodeConditionSummary(ctx context.Context, nodeName string) string {
+	node := &corev1.Node{}
+	if err := r.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		return "unavailable: " + err.Error()
+	}
+	conditions := make([]string, 0, len(node.Status.Conditions))
+	for _, condition := range node.Status.Conditions {
+		conditions = append(conditions, string(condition.Type)+"="+string(condition.Status))
+	}
+	return strings.Join(conditions, ",")
+}

--- a/infra/runners-controller/controllers/provisioning_test.go
+++ b/infra/runners-controller/controllers/provisioning_test.go
@@ -1,0 +1,61 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreationReservationStoreReleasesObservedPod(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := creationReservationStore{}
+	store.add("tuist-runners", "runner-a", "linux", "runners-linux", now)
+
+	total, _ := store.reconcile("tuist-runners", "runners-linux", map[string]struct{}{
+		"tuist-runners/runner-a": {},
+	}, now)
+	if total != 0 {
+		t.Fatalf("observed reservation count = %d, want 0", total)
+	}
+	if len(store.byName) != 0 {
+		t.Fatalf("observed reservation remained in store: %+v", store.byName)
+	}
+}
+
+func TestCreationReservationStoreExpiresUnobservedPod(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := creationReservationStore{}
+	store.add("tuist-runners", "runner-a", "linux", "runners-linux", now)
+
+	total, _ := store.reconcile(
+		"tuist-runners",
+		"runners-linux",
+		map[string]struct{}{},
+		now.Add(creationReservationLifetime),
+	)
+	if total != 0 {
+		t.Fatalf("expired reservation count = %d, want 0", total)
+	}
+	if len(store.byName) != 0 {
+		t.Fatalf("expired reservation remained in store: %+v", store.byName)
+	}
+}
+
+func TestProvisioningAdmissionUsesLowestSiblingCap(t *testing.T) {
+	scheme := mustScheme(t)
+	poolA := newLinuxKataPool("linux-a", 8, 4)
+	poolB := newLinuxKataPool("linux-b", 8, 2)
+	node := readyLinuxRunnerNode("runner-node", poolA.Spec.FleetSelector)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(poolA, poolB, node).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), poolA)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.cap != 2 || admission.available != 2 {
+		t.Fatalf("admission = %+v, want sibling minimum cap and availability 2", admission)
+	}
+}

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -13,9 +13,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -88,6 +90,10 @@ type RunnerPoolReconciler struct {
 	// DNS and never need these. Empty disables the env injection.
 	ClusterDNSIP  string
 	ClusterDomain string
+
+	Recorder record.EventRecorder
+
+	creationReservations creationReservationStore
 
 	// Now is overridable in tests; defaults to time.Now.
 	Now func() time.Time
@@ -212,6 +218,30 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var stalePendingCandidates []*corev1.Pod
 	for i := range pods.Items {
 		p := &pods.Items[i]
+		if startTimedOut(p, pool, r.now()) {
+			startedAt, _ := linuxProvisioningStartedAt(p)
+			nodeConditions := r.nodeConditionSummary(ctx, p.Spec.NodeName)
+			logger.Info("reap runner pod whose dispatch poller did not start",
+				"pod", p.Name,
+				"node", p.Spec.NodeName,
+				"bound", true,
+				"age", r.now().Sub(startedAt).String(),
+				"nodeConditions", nodeConditions,
+			)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(p, corev1.EventTypeWarning, "RunnerPodStartTimedOut",
+					"Dispatch poller did not start within %d seconds after binding to node %s; node conditions: %s",
+					pool.Spec.Provisioning.StartTimeoutSecondsOrDefault(), p.Spec.NodeName, nodeConditions)
+			}
+			metrics.RecordPodStartTimeout(pool.Name, pollerNotStartedTimeoutReason)
+			if err := r.reapRunner(ctx, p); err != nil {
+				logger.Error(err, "reap runner pod after start timeout; will retry", "pod", p.Name)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			phaseReplicas.remove(p)
+			reaped++
+			continue
+		}
 
 		switch {
 		case isAlive(p):
@@ -340,12 +370,58 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		"idleAlive", len(idleAlive),
 	)
 
-	for i := 0; i < gap; i++ {
-		if err := r.createRunner(ctx, pool); err != nil {
+	createLimit := gap
+	admissionBlocked := false
+	pendingProvisioningForPool := 0
+	if isLinuxKataPool(pool) {
+		admission, err := r.provisioningAdmission(ctx, pool)
+		if err != nil {
+			logger.Error(err, "read Linux provisioning admission; leaving replica gap")
+			createLimit = 0
+			admissionBlocked = gap > 0
+			if admissionBlocked {
+				metrics.RecordAdmissionBlocked(pool.Name, "fleet_view_error")
+			}
+		} else if admission.available < createLimit {
+			pendingProvisioningForPool = admission.pendingForPool
+			createLimit = admission.available
+			admissionBlocked = gap > createLimit
+			if admissionBlocked {
+				reason := admission.blockedReason
+				if reason == "" {
+					reason = "fleet_cap"
+				}
+				metrics.RecordAdmissionBlocked(pool.Name, reason)
+				logger.Info("Linux provisioning admission left replica gap",
+					"reason", reason,
+					"gap", gap,
+					"creating", createLimit,
+					"pendingForPool", admission.pendingForPool,
+					"pendingForFleet", admission.pendingForFleet,
+					"cap", admission.cap,
+					"healthyNodes", admission.healthyNodes,
+				)
+			}
+		} else {
+			pendingProvisioningForPool = admission.pendingForPool
+		}
+	}
+
+	created := 0
+	for i := 0; i < createLimit; i++ {
+		name, err := r.createRunner(ctx, pool)
+		if err != nil {
 			logger.Error(err, "create runner; will retry")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
+		if isLinuxKataPool(pool) {
+			r.reserveCreatedRunner(pool, name)
+		}
+		created++
 		phaseReplicas.pending++
+	}
+	if isLinuxKataPool(pool) {
+		metrics.RecordPendingProvisioningPods(pool.Name, pendingProvisioningForPool+created)
 	}
 
 	// Scale-down: alive > target. Delete IDLE Pods first — those
@@ -368,7 +444,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		scaledDown++
 	}
 
-	observed := alive - scaledDown + gap
+	observed := alive - scaledDown + created
 	pool.Status.ObservedReplicas = int32(observed)
 	pool.Status.LastReconcile = metav1.Now()
 	if err := r.Status().Update(ctx, pool); err != nil {
@@ -380,6 +456,9 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Steady-state requeue: re-run every 60 s as a safety net for
 	// missed events. Pod-event-driven reconcile via Owns() is the
 	// primary trigger; this is the catch-all.
+	if admissionBlocked {
+		return ctrl.Result{RequeueAfter: provisioningRequeueAfter}, nil
+	}
 	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 }
 
@@ -445,33 +524,33 @@ func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv
 // both owned by the RunnerPool. Pod and SA share the same name so
 // the dispatch endpoint can look up "which Pod is this SA mounted
 // on" from the validated SA name alone.
-func (r *RunnerPoolReconciler) createRunner(ctx context.Context, pool *tuistv1.RunnerPool) error {
+func (r *RunnerPoolReconciler) createRunner(ctx context.Context, pool *tuistv1.RunnerPool) (string, error) {
 	suffix, err := randHex(4)
 	if err != nil {
-		return fmt.Errorf("generate suffix: %w", err)
+		return "", fmt.Errorf("generate suffix: %w", err)
 	}
 	name := fmt.Sprintf("%s-runner-%s", pool.Name, suffix)
 
 	sa := podtemplate.BuildServiceAccount(pool, name)
 	if err := controllerutil.SetControllerReference(pool, sa, r.Scheme); err != nil {
-		return fmt.Errorf("sa owner ref: %w", err)
+		return "", fmt.Errorf("sa owner ref: %w", err)
 	}
 	if err := r.Create(ctx, sa); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create sa: %w", err)
+		return "", fmt.Errorf("create sa: %w", err)
 	}
 
 	pod, err := podtemplate.Build(pool, name, name, r.DispatchURL, r.DispatchInternalURL, r.DindImage, r.RegistryMirror, r.ClusterDNSIP, r.ClusterDomain)
 	if err != nil {
-		return fmt.Errorf("build pod: %w", err)
+		return "", fmt.Errorf("build pod: %w", err)
 	}
 	if err := controllerutil.SetControllerReference(pool, pod, r.Scheme); err != nil {
-		return fmt.Errorf("pod owner ref: %w", err)
+		return "", fmt.Errorf("pod owner ref: %w", err)
 	}
 	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create pod: %w", err)
+		return "", fmt.Errorf("create pod: %w", err)
 	}
 
-	return nil
+	return name, nil
 }
 
 // reapRunner deletes a Pod and its same-named ServiceAccount.
@@ -758,6 +837,10 @@ func (r *RunnerPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&tuistv1.RunnerPool{}).
 		Owns(&corev1.Pod{}, builder.WithPredicates(runnerLabelPredicate())).
 		Owns(&corev1.ServiceAccount{}).
+		// The shared provisioning admission reads the fleet count and then
+		// creates Pods. Keep that decision serial within the elected manager;
+		// raising this requires an atomic cross-reconcile reservation step.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }
 

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -47,6 +49,32 @@ func newPool(name, image string, replicas int32) *tuistv1.RunnerPool {
 			PodCPUMilli:   8000,
 			PodMemoryMB:   14336,
 		},
+	}
+}
+
+func newLinuxKataPool(name string, replicas, maxProvisioning int32) *tuistv1.RunnerPool {
+	pool := newPool(name, "ghcr.io/tuist/tuist-linux-runner:test", replicas)
+	pool.Spec.OS = "linux"
+	pool.Spec.RuntimeClass = "kata-qemu"
+	pool.Spec.Provisioning = &tuistv1.RunnerPoolProvisioning{
+		MaxConcurrentPerFleetSelector: ptr.To(maxProvisioning),
+		StartTimeoutSeconds:           ptr.To[int32](300),
+	}
+	return pool
+}
+
+func readyLinuxRunnerNode(name, fleetSelector string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				fleetNodePoolLabel: fleetSelector,
+			},
+		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
 	}
 }
 
@@ -1076,5 +1104,239 @@ func TestIdleReplicasExcludesWaitingLinuxPoller(t *testing.T) {
 
 	if got := idleReplicasGauge(t, poolName); got != 0 {
 		t.Fatalf("idle replicas = %v, want 0 (a waiting poller is not warm)", got)
+	}
+}
+
+func TestReconcileCapsLinuxKataProvisioningAcrossSiblingPools(t *testing.T) {
+	scheme := mustScheme(t)
+	poolA := newLinuxKataPool("linux-a", 8, 4)
+	poolB := newLinuxKataPool("linux-b", 8, 4)
+	node := readyLinuxRunnerNode("runner-node", poolA.Spec.FleetSelector)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(poolA, poolB, node).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(poolA.Namespace, poolA.Name)})
+	if err != nil {
+		t.Fatalf("reconcile first pool: %v", err)
+	}
+	if result.RequeueAfter != provisioningRequeueAfter {
+		t.Fatalf("first pool requeue = %s, want %s while gap remains", result.RequeueAfter, provisioningRequeueAfter)
+	}
+
+	var pods corev1.PodList
+	if err := c.List(context.Background(), &pods); err != nil {
+		t.Fatalf("list first pool pods: %v", err)
+	}
+	if len(pods.Items) != 4 {
+		t.Fatalf("first reconcile created %d Pods, want shared cap 4", len(pods.Items))
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(poolB.Namespace, poolB.Name)}); err != nil {
+		t.Fatalf("reconcile sibling pool: %v", err)
+	}
+	pods = corev1.PodList{}
+	if err := c.List(context.Background(), &pods); err != nil {
+		t.Fatalf("list sibling pool pods: %v", err)
+	}
+	if len(pods.Items) != 4 {
+		t.Fatalf("sibling reconcile exceeded shared cap: got %d Pods, want 4", len(pods.Items))
+	}
+
+	gotPool := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(poolA.Namespace, poolA.Name), gotPool); err != nil {
+		t.Fatalf("get first pool: %v", err)
+	}
+	if gotPool.Status.ObservedReplicas != 4 {
+		t.Fatalf("ObservedReplicas = %d, want only the 4 Pods actually created", gotPool.Status.ObservedReplicas)
+	}
+}
+
+func TestReconcileLinuxKataProvisioningAdvancesWhenPollerStarts(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 6, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	var pods corev1.PodList
+	if err := c.List(context.Background(), &pods); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 4 {
+		t.Fatalf("initial Pods = %d, want 4", len(pods.Items))
+	}
+
+	started := pods.Items[0].DeepCopy()
+	started.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "poller",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
+	if err := c.Status().Update(context.Background(), started); err != nil {
+		t.Fatalf("mark poller running: %v", err)
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile after poller start: %v", err)
+	}
+	pods = corev1.PodList{}
+	if err := c.List(context.Background(), &pods); err != nil {
+		t.Fatalf("list replenished pods: %v", err)
+	}
+	if len(pods.Items) != 5 {
+		t.Fatalf("Pods after one poller started = %d, want 5", len(pods.Items))
+	}
+}
+
+func TestProvisioningAdmissionCountsLocalCreateReservations(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 2, 1)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool, node).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, Now: func() time.Time { return time.Unix(1000, 0) }}
+	r.reserveCreatedRunner(pool, "not-in-cache-yet")
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.pendingForFleet != 1 || admission.available != 0 || admission.blockedReason != "fleet_cap" {
+		t.Fatalf("admission with local reservation = %+v, want pending=1 available=0 fleet_cap", admission)
+	}
+}
+
+func TestReconcileDoesNotCreateLinuxKataPodWithoutHealthyNode(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 3, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	node.Status.Conditions[0].Status = corev1.ConditionFalse
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter != provisioningRequeueAfter {
+		t.Fatalf("requeue = %s, want %s", result.RequeueAfter, provisioningRequeueAfter)
+	}
+	var pods corev1.PodList
+	if err := c.List(context.Background(), &pods); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("created %d Pods with no healthy node, want 0", len(pods.Items))
+	}
+}
+
+func TestReconcileReapsBoundLinuxPodWhosePollerNeverStarts(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 1, 4)
+	pool.Spec.Provisioning.StartTimeoutSeconds = ptr.To[int32](300)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	pod := linuxPod("linux-runner-stuck", pool.Name, nil)
+	pod.Spec.NodeName = node.Name
+	pod.CreationTimestamp = metav1.NewTime(now.Add(-6 * time.Minute))
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(now.Add(-6 * time.Minute)),
+	}}
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace}}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node, pod, sa).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	recorder := record.NewFakeRecorder(1)
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+		Now:         func() time.Time { return now },
+		Recorder:    recorder,
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if err := c.Get(context.Background(), nn(pod.Namespace, pod.Name), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("timed-out Pod get error = %v, want NotFound", err)
+	}
+	select {
+	case event := <-recorder.Events:
+		if event == "" {
+			t.Fatal("empty timeout event")
+		}
+	default:
+		t.Fatal("expected RunnerPodStartTimedOut event")
+	}
+}
+
+func TestStartTimeoutIgnoresUnboundAndClaimedPods(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	pool := newLinuxKataPool("linux", 1, 4)
+
+	unbound := linuxPod("unbound", pool.Name, nil)
+	unbound.CreationTimestamp = metav1.NewTime(now.Add(-time.Hour))
+	if startTimedOut(unbound, pool, now) {
+		t.Fatal("unbound Pod timed out; scheduler waiting must not churn")
+	}
+
+	recentlyBound := linuxPod("recently-bound", pool.Name, nil)
+	recentlyBound.Spec.NodeName = "runner-node"
+	recentlyBound.CreationTimestamp = metav1.NewTime(now.Add(-time.Hour))
+	recentlyBound.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(now.Add(-time.Minute)),
+	}}
+	if startTimedOut(recentlyBound, pool, now) {
+		t.Fatal("recently bound Pod inherited its unscheduled age instead of starting a fresh timeout clock")
+	}
+
+	claimed := linuxPod("claimed", pool.Name, nil)
+	claimed.Spec.NodeName = "runner-node"
+	claimed.CreationTimestamp = metav1.NewTime(now.Add(-time.Hour))
+	claimed.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(now.Add(-time.Hour)),
+	}}
+	claimed.Labels["tuist.dev/runner-pool-owner"] = "account"
+	if startTimedOut(claimed, pool, now) {
+		t.Fatal("claimed Pod timed out; customer work must be protected")
 	}
 }

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -19,11 +19,17 @@ import (
 )
 
 const (
-	poolLabel  = "pool"
-	phaseLabel = "phase"
+	poolLabel            = "pool"
+	phaseLabel           = "phase"
+	reasonLabel          = "reason"
+	fleetSelectorLabel   = "fleet_selector"
+	operatingSystemLabel = "operating_system"
 )
 
 var podPhaseLabels = []string{"Pending", "Running", "Unknown"}
+var admissionBlockReasons = []string{"fleet_cap", "no_healthy_node", "fleet_view_error"}
+var fleetNodeFilterReasons = []string{"unschedulable", "not_ready", "memory_pressure", "disk_pressure", "pid_pressure"}
+var podStartTimeoutReasons = []string{"poller_not_started"}
 
 var (
 	// target is the per-pool replica count the autoscaler policy wants
@@ -155,10 +161,35 @@ var (
 		Name: "tuist_runners_pool_idle_replicas",
 		Help: "Alive current-image runner Pods with no claim (warm capacity available to take work).",
 	}, []string{poolLabel})
+
+	pendingProvisioningPods = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_pool_pending_provisioning_pods",
+		Help: "Linux Kata runner Pods waiting for their dispatch poller to start, including local create reservations not yet observed by the cache.",
+	}, []string{poolLabel})
+
+	admissionBlockedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "tuist_runners_pool_admission_blocked_total",
+		Help: "Runner reconciliations that left a replica gap because Linux Kata provisioning admission was blocked.",
+	}, []string{poolLabel, reasonLabel})
+
+	fleetReadyNodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_fleet_ready_nodes",
+		Help: "Ready, schedulable, pressure-free nodes contributing capacity to a runner fleet.",
+	}, []string{fleetSelectorLabel, operatingSystemLabel})
+
+	fleetFilteredNodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_fleet_filtered_nodes",
+		Help: "Runner-fleet nodes excluded from capacity or provisioning admission, grouped by reason.",
+	}, []string{fleetSelectorLabel, operatingSystemLabel, reasonLabel})
+
+	podStartTimeoutsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "tuist_runners_pool_pod_start_timeouts_total",
+		Help: "Bound Linux runner Pods reaped after failing to start their dispatch poller within the configured timeout.",
+	}, []string{poolLabel, reasonLabel})
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, queuedJobs, idleReplicas)
+	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, queuedJobs, idleReplicas, pendingProvisioningPods, admissionBlockedTotal, fleetReadyNodes, fleetFilteredNodes, podStartTimeoutsTotal)
 }
 
 // RecordAllocation publishes one pool's allocation outcome for this
@@ -190,6 +221,31 @@ func RecordIdleReplicas(pool string, idle int) {
 		idle = 0
 	}
 	idleReplicas.WithLabelValues(pool).Set(float64(idle))
+}
+
+func RecordPendingProvisioningPods(pool string, pending int) {
+	if pending < 0 {
+		pending = 0
+	}
+	pendingProvisioningPods.WithLabelValues(pool).Set(float64(pending))
+}
+
+func RecordAdmissionBlocked(pool, reason string) {
+	admissionBlockedTotal.WithLabelValues(pool, reason).Inc()
+}
+
+func RecordFleetNodes(fleetSelector, operatingSystem string, ready int, filtered map[string]int) {
+	if ready < 0 {
+		ready = 0
+	}
+	fleetReadyNodes.WithLabelValues(fleetSelector, operatingSystem).Set(float64(ready))
+	for _, reason := range fleetNodeFilterReasons {
+		fleetFilteredNodes.WithLabelValues(fleetSelector, operatingSystem, reason).Set(float64(filtered[reason]))
+	}
+}
+
+func RecordPodStartTimeout(pool, reason string) {
+	podStartTimeoutsTotal.WithLabelValues(pool, reason).Inc()
 }
 
 // RecordRoll publishes a pool's image-roll progress for this reconcile
@@ -242,6 +298,13 @@ func ClearRunnerPool(pool string) {
 	rollCap.DeleteLabelValues(pool)
 	oldestPendingPodAge.DeleteLabelValues(pool)
 	idleReplicas.DeleteLabelValues(pool)
+	pendingProvisioningPods.DeleteLabelValues(pool)
+	for _, reason := range admissionBlockReasons {
+		admissionBlockedTotal.DeleteLabelValues(pool, reason)
+	}
+	for _, reason := range podStartTimeoutReasons {
+		podStartTimeoutsTotal.DeleteLabelValues(pool, reason)
+	}
 	for _, phase := range podPhaseLabels {
 		phaseReplicas.DeleteLabelValues(pool, phase)
 	}

--- a/infra/runners-controller/internal/metrics/metrics_test.go
+++ b/infra/runners-controller/internal/metrics/metrics_test.go
@@ -127,6 +127,39 @@ func TestRecordOldestPendingPodAgeClampsNegative(t *testing.T) {
 	}
 }
 
+func TestRecordProvisioningSafetyMetrics(t *testing.T) {
+	const pool = "linux"
+	pendingProvisioningPods.Reset()
+	admissionBlockedTotal.Reset()
+	podStartTimeoutsTotal.Reset()
+	fleetReadyNodes.Reset()
+	fleetFilteredNodes.Reset()
+
+	RecordPendingProvisioningPods(pool, 3)
+	RecordAdmissionBlocked(pool, "fleet_cap")
+	RecordPodStartTimeout(pool, "poller_not_started")
+	RecordFleetNodes("runners-linux", "linux", 2, map[string]int{"not_ready": 1})
+
+	if got := testutil.ToFloat64(pendingProvisioningPods.WithLabelValues(pool)); got != 3 {
+		t.Fatalf("pending provisioning pods = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(admissionBlockedTotal.WithLabelValues(pool, "fleet_cap")); got != 1 {
+		t.Fatalf("fleet-cap blocks = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(podStartTimeoutsTotal.WithLabelValues(pool, "poller_not_started")); got != 1 {
+		t.Fatalf("pod start timeouts = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(fleetReadyNodes.WithLabelValues("runners-linux", "linux")); got != 2 {
+		t.Fatalf("ready fleet nodes = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(fleetFilteredNodes.WithLabelValues("runners-linux", "linux", "not_ready")); got != 1 {
+		t.Fatalf("not-ready fleet nodes = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(fleetFilteredNodes.WithLabelValues("runners-linux", "linux", "disk_pressure")); got != 0 {
+		t.Fatalf("disk-pressure fleet nodes = %v, want 0", got)
+	}
+}
+
 func TestClearDropsOldestPendingPodAge(t *testing.T) {
 	const pool = "p"
 


### PR DESCRIPTION
## What changed

The runners controller now paces Linux [Kata Containers](https://katacontainers.io/) sandbox creation across every sibling runner pool that targets the same fleet. The default fleet-wide limit is four sandboxes waiting for their dispatch poller to start.

The change also:

- filters nodes that are not ready, schedulable, or free of resource pressure from provisioning capacity
- keeps short-lived local reservations so the controller cache cannot admit a second creation burst before newly created [Kubernetes Pods](https://kubernetes.io/docs/concepts/workloads/pods/) become visible
- reaps bound sandboxes when their dispatch poller has not started within five minutes
- exposes provisioning, node health, admission blocking, and start-timeout metrics
- adds chart configuration, custom resource schema, tests, and operational guidance for the new behavior

## Why

Two hosted [GitHub Actions](https://docs.github.com/en/actions) jobs lost their runner connection during rapid Linux fleet scale-up. Protecting the hosts during these bursts is more important than starting every requested sandbox simultaneously. A small amount of queued work can recover naturally, while a failed host virtualization layer disconnects jobs already running on it.

Production investigation found that the GitHub message was delayed by approximately ten minutes after each runner had already failed. Both affected Kata virtual machines crashed with the same host virtualization error:

```text
error: kvm run failed Bad address
```

Kata then reported a dead guest agent and `guest failure: internal-error`. Kubernetes recorded the runner container exiting with code 255.

## Root cause

The immediate cause of both runner disconnections was a crash in the QEMU and [Kernel-based Virtual Machine](https://docs.kernel.org/6.15/virt/kvm/api.html) virtualization path, not a loss of the bare-metal hosts' physical network connectivity.

| GitHub job | Bare-metal node | Virtual machine failure | Kubernetes terminal state | GitHub disconnection report |
| --- | --- | --- | --- | --- |
| [Run 29916673439](https://github.com/tuist/tuist/actions/runs/29916673439) | `bm-tuist-runners-linux-pvv5b-249nj-vl8jt` | 11:44:54 Coordinated Universal Time | 11:45:00, exit code 255 | 11:53:57 |
| [Job 88910581773](https://github.com/tuist/tuist/actions/runs/29916219616/job/88910581773) | `bm-tuist-runners-linux-pvv5b-249nj-bkzxh` | 11:55:44 Coordinated Universal Time | 11:55:47, exit code 255 | 12:05:06 |

The two failures had the same guest instruction address and instruction bytes. Grafana Cloud journals found 34 unique Kata sandboxes with the exact `kvm run failed Bad address` signature on July 22: 21 on `vl8jt` and 13 on `bkzxh`. The previous seven days contained 11 unique occurrences, all on `bkzxh`.

The fleet attempted 196 runner sandbox starts between 11:35 and 12:15 Coordinated Universal Time. The peak was 15 starts in one minute, including 12 on one node. The resulting failures and replacements amplified the provisioning burst.

Node `vl8jt` experienced a broad Linux kernel soft-lockup storm during the burst. Kubelet authentication and container-runtime operations timed out while processor cores were stuck. Node `bkzxh` encountered the identical virtual machine failure without matching soft lockups, so the lockups demonstrate severe host pressure but are not the universal direct cause.

Host journals showed no physical interface link-down, carrier-loss, route-failure, adapter-reset, or transmit-timeout events on either node. Cilium remained running, and journal telemetry did not show a persistent multi-minute node disappearance.

The evidence therefore supports concurrent sandbox provisioning and host pressure as a trigger that exposes an unresolved Linux Kernel-based Virtual Machine, QEMU, or Kata memory fault or race. It does not identify the exact low-level defect. The existing controller behavior made the trigger more likely because sibling pools independently applied their full replica gaps to the same host fleet.

This is separate from the registry incident later that day. The registry failure began at 12:28:49 Coordinated Universal Time on a Hetzner cloud server, showed persistent network loss, and ended with Kubernetes machine-health remediation replacing that server. The runner incidents occurred earlier on two bare-metal nodes and have an exact virtual machine crash signature.

## Approach

Admission is calculated across Linux Kata pools with the same fleet selector. The lowest configured sibling limit wins, which keeps mixed configuration safe during rollout. A controller-local reservation closes the short interval between creating a Pod and observing it through the controller cache.

Only ready, schedulable, pressure-free nodes allow new sandboxes. Existing work and already claimed Pods remain protected. The start timeout begins only after a Pod has been assigned to a node, so work waiting for scheduling is not incorrectly reaped.

A per-node limit was not selected because node placement happens after Pod creation. Enforcing that model would require changing scheduling or reserving placement before admission. The fleet-wide gate addresses the observed burst without coupling the controller to scheduler internals.

This pull request intentionally mitigates the trigger and the failure/replacement feedback loop. It does not upgrade Linux, Kata, or QEMU and therefore does not claim to fix the underlying virtualization fault. The operational follow-up is to alert on the exact `kvm run failed Bad address` signature, correlate future events with host and sandbox versions, and symbolize the repeated guest instruction address.

A separate headless Claude review reached the same diagnosis after examining the updated evidence. It considers the pacing change worth shipping but recommends keeping the pull request in draft until the exact crash-signature alert is in place.

## Impact

Rapid scale-up can take longer when more than four sandboxes are starting, but running jobs are less likely to be disconnected by host-wide contention. The limit and timeout are configurable. macOS runner behavior is unchanged.

The new metrics make provisioning pressure and blocked admission visible. An alert for the low-level crash signature remains necessary because each occurrence means a customer's isolated runner machine has died.

## References

### Incident evidence and diagnosis

- [Gradle Cache Acceptance run 29916673439](https://github.com/tuist/tuist/actions/runs/29916673439), which reported that the self-hosted runner lost communication with GitHub Actions
- [Job 88910581773 in run 29916219616](https://github.com/tuist/tuist/actions/runs/29916219616/job/88910581773), which showed the same runner disconnection pattern
- [Linux Kernel-based Virtual Machine application programming interface](https://docs.kernel.org/6.15/virt/kvm/api.html), used to interpret the failed `KVM_RUN` operation and `EFAULT` result represented by `Bad address`
- [QEMU issue 2574](https://gitlab.com/qemu-project/qemu/-/issues/2574), reviewed as a similar `kvm run failed: Bad address` signature from a different workload, not as proof of the same underlying defect
- [Kata Containers 3.30.0 release](https://github.com/kata-containers/kata-containers/releases/tag/3.30.0), matching the version deployed on the affected nodes
- [Linux kernel lockup watchdog documentation](https://www.kernel.org/doc/html/latest/admin-guide/lockup-watchdogs.html), used to interpret the soft-lockup messages observed in Grafana Cloud
- [Grafana Loki query documentation](https://grafana.com/docs/loki/latest/query/), used to query retained host journals and deduplicate failures by Kata sandbox

### Comparable runner systems

- [Semaphore open-source platform](https://github.com/semaphoreio/semaphore) and [Semaphore autoscaling agent stack](https://docs.semaphore.io/EE/using-semaphore/self-hosted-aws), reviewed for its demand-driven agent-pool model and bounded fleet configuration
- [GitHub Actions Runner Controller scale-set configuration](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets), reviewed for maximum runner limits, pending-runner metrics, and startup-duration metrics
- [GitLab Runner Kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes/), reviewed for its bounded Pod connection timeout and queueing behavior when cluster capacity is constrained

### Kubernetes behavior

- [Kubernetes node status](https://kubernetes.io/docs/reference/node/node-status/), used for ready, unschedulable, memory-pressure, disk-pressure, and process-pressure filtering
- [Kubernetes Pod conditions](https://kubernetes.io/docs/concepts/workloads/pods/pod-condition/), used to start the timeout from the `PodScheduled` transition rather than Pod creation

## Validation

### Production investigation

- mapped both GitHub jobs to their runner Pods and bare-metal nodes
- correlated GitHub, runner, Kata, QEMU, Kubernetes controller, and host-journal timestamps
- counted unique crash signatures across the fleet and the previous seven days
- inspected both nodes for Linux kernel soft lockups, container-runtime stalls, physical network failures, and Cilium restarts
- compared the runner failures with the later registry network incident

### How to test locally

The following checks passed:

- `mise x go@1.25 -- go test ./...`
- `mise x go@1.25 -- go vet ./...`
- `mise x go@1.25 -- go test -race ./controllers ./internal/metrics`
- `helm lint infra/helm/tuist -f infra/helm/tuist/values-ci.yaml`
- staging chart rendering with the managed common, staging, and validation values
- production chart rendering with the managed common, production, and validation values
- `git diff --check`
