### PR TITLE
perf(server): scope test case run lookups to projects

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1282,11 +1282,11 @@ defmodule Tuist.Tests do
   end
 
   # Filter precedence for routing: a narrower scope wins so we use the
-  # most-selective MV available. `test_case_id` keeps the main table because
-  # its primary key `(project_id, test_case_id, ran_at, id)` already serves
-  # those queries cheaply. `project_id` falls through to the project MV when
-  # no narrower scope is present — without it, the listing query scans every
-  # row for the project.
+  # most-selective materialized view available. `test_case_id` keeps the main
+  # table because callers also scope it by `project_id`, matching the primary
+  # key prefix `(project_id, test_case_id)`. `project_id` falls through to the
+  # project materialized view when no narrower scope is present; without it,
+  # the listing query scans every row for the project.
   defp extract_mv_scope_filter(%{filters: filters}) when is_list(filters) do
     filters
     |> Enum.map(&filter_scope/1)

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -379,7 +379,8 @@ defmodule TuistWeb.TestCaseLive do
   end
 
   defp assign_test_case_runs(
-         %{assigns: %{test_case_id: test_case_id, available_filters: available_filters}} = socket,
+         %{assigns: %{selected_project: project, test_case_id: test_case_id, available_filters: available_filters}} =
+           socket,
          params
        ) do
     page = parse_page(params["page"])
@@ -397,7 +398,10 @@ defmodule TuistWeb.TestCaseLive do
       Tests.list_test_case_runs(%{
         page: page,
         page_size: @table_page_size,
-        filters: [%{field: :test_case_id, op: :==, value: test_case_id} | flop_filters],
+        filters: [
+          %{field: :project_id, op: :==, value: project.id},
+          %{field: :test_case_id, op: :==, value: test_case_id} | flop_filters
+        ],
         order_by: order_by,
         order_directions: order_directions
       })

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:503
+#: lib/tuist_web/live/test_case_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "Automatically by Tuist"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:496
+#: lib/tuist_web/live/test_case_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:489
+#: lib/tuist_web/live/test_case_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "First run of this test"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Mac device"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:505
+#: lib/tuist_web/live/test_case_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Manually by @%{name}"
 msgstr ""
@@ -650,7 +650,7 @@ msgstr ""
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:490
+#: lib/tuist_web/live/test_case_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -993,8 +993,8 @@ msgstr ""
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:393
 #: lib/tuist_web/live/shards_live.html.heex:583
 #: lib/tuist_web/live/test_case_live.ex:96
-#: lib/tuist_web/live/test_case_live.ex:464
-#: lib/tuist_web/live/test_case_live.ex:494
+#: lib/tuist_web/live/test_case_live.ex:468
+#: lib/tuist_web/live/test_case_live.ex:498
 #: lib/tuist_web/live/test_case_live.html.heex:84
 #: lib/tuist_web/live/test_case_live.html.heex:170
 #: lib/tuist_web/live/test_case_live.html.heex:546
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:491
+#: lib/tuist_web/live/test_case_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
@@ -1687,9 +1687,9 @@ msgstr ""
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:465
-#: lib/tuist_web/live/test_case_live.ex:493
-#: lib/tuist_web/live/test_case_live.ex:495
+#: lib/tuist_web/live/test_case_live.ex:469
+#: lib/tuist_web/live/test_case_live.ex:497
+#: lib/tuist_web/live/test_case_live.ex:499
 #: lib/tuist_web/live/test_case_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Enabled"
@@ -1708,8 +1708,8 @@ msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:63
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:350
-#: lib/tuist_web/live/test_case_live.ex:463
-#: lib/tuist_web/live/test_case_live.ex:492
+#: lib/tuist_web/live/test_case_live.ex:467
+#: lib/tuist_web/live/test_case_live.ex:496
 #: lib/tuist_web/live/test_case_live.html.heex:75
 #: lib/tuist_web/live/test_cases_live.ex:75
 #: lib/tuist_web/live/test_cases_live.html.heex:582
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "Skipped tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:501
+#: lib/tuist_web/live/test_case_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "By automation %{name}"
 msgstr ""

--- a/server/test/tuist_web/live/test_case_live_test.exs
+++ b/server/test/tuist_web/live/test_case_live_test.exs
@@ -41,6 +41,26 @@ defmodule TuistWeb.TestCaseLiveTest do
         live(conn, ~p"/#{account.name}/#{project.name}/tests/test-cases/#{test_case_run.test_case_id}")
     end
 
+    test "scopes test case runs to the selected project", %{
+      conn: conn,
+      account: account,
+      project: project
+    } do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id, account_id: account.id)
+      test_run = Tuist.ClickHouseRepo.preload(test_run, :test_case_runs)
+      [test_case_run | _] = test_run.test_case_runs
+
+      expect(Tuist.Tests, :list_test_case_runs, 2, fn attrs ->
+        assert %{field: :project_id, op: :==, value: project.id} in attrs.filters
+        assert %{field: :test_case_id, op: :==, value: test_case_run.test_case_id} in attrs.filters
+
+        Mimic.call_original(Tuist.Tests, :list_test_case_runs, [attrs])
+      end)
+
+      {:ok, _lv, _html} =
+        live(conn, ~p"/#{account.name}/#{project.name}/tests/test-cases/#{test_case_run.test_case_id}")
+    end
+
     test "muting a test case via set-state", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
## What changed

The test-case detail page now scopes test case run listings by both the selected project and the test case. The change also corrects the routing comment that described test-case-only lookups as cheap and adds regression coverage for both the static and connected page renders.

## Why

The [slow ClickHouse query alert](https://tuist.grafana.net/alerting/grafana/ffeb6l2ax5qtcf/view?orgId=1) kept firing for a query that returned 20 test case runs. Atlas showed 77 executions of the current query shape with a median duration of 391 milliseconds and a ninety-ninth percentile of 1,860 milliseconds. Each execution read roughly 24 to 28 million rows and 450 to 550 megabytes.

The alert evaluates the ninety-ninth percentile over a 30-minute window and keeps a recovered instance firing for two hours. Sparse traffic therefore makes one expensive request visible for a long time, but the underlying query was genuinely doing too much work.

## Root cause

The `test_case_runs` primary key starts with `(project_id, test_case_id, ran_at, id)`, while this page filtered only by `test_case_id`. ClickHouse could not use the leading primary-key field and fell back to a generic exclusion search across thousands of storage granules.

This is the same query family as earlier optimizations, with one remaining call-site defect:

- [Change #9140](https://github.com/tuist/tuist/pull/9140) added a projection for test-case-only lookups in January 2026.
- [Change #9900](https://github.com/tuist/tuist/pull/9900) reordered the table around `(project_id, test_case_id, ran_at, id)` in March 2026 and did not recreate that projection because of a [ClickHouse ReplacingMergeTree projection limitation](https://github.com/ClickHouse/ClickHouse/issues/46968). Callers were expected to provide the project scope.
- [Change #10952](https://github.com/tuist/tuist/pull/10952) routed project-only listings through a materialized view in May 2026, but its routing comment incorrectly described `test_case_id` alone as matching the primary key.
- [Change #11966](https://github.com/tuist/tuist/pull/11966) changed the selected hydration columns in July 2026. That produced a new normalized query hash, making the remaining unscoped access pattern look like a new alert instance.

The other request paths already supplied the project filter. The test-case detail page was the remaining exception.

## Approach

The page already has the selected project, so the listing now includes `project.id` alongside `test_case_id`. This matches the existing primary-key prefix without adding another projection, materialized view, or database migration. The regression test records that both filters must be present whenever the page loads.

## Benchmark

Atlas ran the production ClickHouse query planner against the same representative test case before and after adding the project predicate:

| Plan | Selected parts | Selected granules | Search algorithm |
| --- | ---: | ---: | --- |
| Before, test case only | 44 of 45 | 3,198 of 284,403 | Generic exclusion search |
| After, project and test case | 16 of 45 | 16 of 284,403 | Binary search |

The scoped plan selects about 200 times fewer storage granules and reduces the planned ranges from 2,095 to 16.

## Impact

Test-case detail pages should place substantially less read and memory pressure on ClickHouse while returning the same project-scoped results. There is no schema, migration, or visual user interface change, so no before-and-after screenshots apply.

## Validation

### How to test locally

```bash
cd server
mise exec -- mix test test/tuist_web/live/test_case_live_test.exs
```

The focused suite passed all 8 tests. `git diff --check` also completed successfully, and Atlas confirmed the production query-plan reduction shown above.
