### PR TITLE
feat(kura): add per-peer bootstrap pass-progress metrics

### DIFF
--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -94,6 +94,9 @@ pub struct Metrics {
     bootstrap_runs: Family<BootstrapResultLabels, Counter>,
     bootstrap_duration: Histogram,
     bootstrap_applied_items: Family<BootstrapItemLabels, Counter>,
+    bootstrap_pass_buckets_divergent: Family<BootstrapPassLabels, Gauge>,
+    bootstrap_pass_buckets_reconciled: Family<BootstrapPassLabels, Gauge>,
+    bootstrap_current_bucket_manifests_walked: Family<BootstrapPassLabels, Gauge>,
     analytics_events: Family<AnalyticsLabels, Counter>,
     analytics_batches: Family<AnalyticsLabels, Counter>,
     analytics_batch_duration: Family<AnalyticsRouteLabels, Histogram>,
@@ -241,6 +244,10 @@ impl Metrics {
         let bootstrap_runs = Family::<BootstrapResultLabels, Counter>::default();
         let bootstrap_duration = Histogram::new(exponential_buckets(0.001, 2.0, 16));
         let bootstrap_applied_items = Family::<BootstrapItemLabels, Counter>::default();
+        let bootstrap_pass_buckets_divergent = Family::<BootstrapPassLabels, Gauge>::default();
+        let bootstrap_pass_buckets_reconciled = Family::<BootstrapPassLabels, Gauge>::default();
+        let bootstrap_current_bucket_manifests_walked =
+            Family::<BootstrapPassLabels, Gauge>::default();
         let analytics_events = Family::<AnalyticsLabels, Counter>::default();
         let analytics_batches = Family::<AnalyticsLabels, Counter>::default();
         let analytics_batch_duration =
@@ -601,6 +608,21 @@ impl Metrics {
             bootstrap_inflight_peers.clone(),
         );
         registry.register(
+            "kura_bootstrap_pass_buckets_divergent",
+            "Divergent manifest buckets identified for the peer's current bootstrap pass",
+            bootstrap_pass_buckets_divergent.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_pass_buckets_reconciled",
+            "Divergent manifest buckets reconciled so far in the peer's current bootstrap pass",
+            bootstrap_pass_buckets_reconciled.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_current_bucket_manifests_walked",
+            "Manifest entries walked in the bucket currently being reconciled for the peer",
+            bootstrap_current_bucket_manifests_walked.clone(),
+        );
+        registry.register(
             "kura_bootstrap_runs_total",
             "Bootstrap runs from newly discovered peers by result",
             bootstrap_runs.clone(),
@@ -908,6 +930,9 @@ impl Metrics {
             bootstrap_runs,
             bootstrap_duration,
             bootstrap_applied_items,
+            bootstrap_pass_buckets_divergent,
+            bootstrap_pass_buckets_reconciled,
+            bootstrap_current_bucket_manifests_walked,
             analytics_events,
             analytics_batches,
             analytics_batch_duration,
@@ -1366,6 +1391,48 @@ impl Metrics {
         self.bootstrap_known_peers.set(known as i64);
         self.bootstrap_completed_peers.set(completed as i64);
         self.bootstrap_inflight_peers.set(inflight as i64);
+    }
+
+    pub fn set_bootstrap_pass_buckets_divergent(&self, peer: &str, mode: &str, divergent: usize) {
+        self.bootstrap_pass_buckets_divergent
+            .get_or_create(&BootstrapPassLabels {
+                peer: peer.to_owned(),
+                mode: mode.to_owned(),
+            })
+            .set(divergent as i64);
+    }
+
+    pub fn set_bootstrap_pass_buckets_reconciled(&self, peer: &str, mode: &str, reconciled: usize) {
+        self.bootstrap_pass_buckets_reconciled
+            .get_or_create(&BootstrapPassLabels {
+                peer: peer.to_owned(),
+                mode: mode.to_owned(),
+            })
+            .set(reconciled as i64);
+    }
+
+    pub fn set_bootstrap_current_bucket_manifests_walked(
+        &self,
+        peer: &str,
+        mode: &str,
+        walked: usize,
+    ) {
+        self.bootstrap_current_bucket_manifests_walked
+            .get_or_create(&BootstrapPassLabels {
+                peer: peer.to_owned(),
+                mode: mode.to_owned(),
+            })
+            .set(walked as i64);
+    }
+
+    // Zero the pass-progress gauges for a peer when its pass ends, so a
+    // finished or abandoned pass is not left frozen at its last mid-pass value
+    // (which would read as a live wedge). Makes "divergent > 0" imply an
+    // in-flight pass for that peer.
+    pub fn clear_bootstrap_pass_progress(&self, peer: &str, mode: &str) {
+        self.set_bootstrap_pass_buckets_divergent(peer, mode, 0);
+        self.set_bootstrap_pass_buckets_reconciled(peer, mode, 0);
+        self.set_bootstrap_current_bucket_manifests_walked(peer, mode, 0);
     }
 
     pub fn record_bootstrap_run(
@@ -1839,6 +1906,15 @@ struct BootstrapItemLabels {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct BootstrapPassLabels {
+    peer: String,
+    // "digest" for the per-bucket anti-entropy path, "full_walk" for the
+    // digest-less fallback — the fallback walks the whole keyspace as one
+    // range, which otherwise renders like a single wedged digest bucket.
+    mode: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct AnalyticsLabels {
     pipeline: String,
     result: String,
@@ -1958,6 +2034,9 @@ mod tests {
         metrics.update_multipart_uploads(2);
         metrics.update_discovered_peer_nodes(3);
         metrics.update_bootstrap_peers(3, 2, 1);
+        metrics.set_bootstrap_pass_buckets_divergent("https://peer.example", "digest", 12);
+        metrics.set_bootstrap_pass_buckets_reconciled("https://peer.example", "digest", 3);
+        metrics.set_bootstrap_current_bucket_manifests_walked("https://peer.example", "digest", 40);
         metrics.record_bootstrap_run("ok", Duration::from_millis(6), 2, 5);
         metrics.update_analytics_queue(1000, 2);
         metrics.record_analytics_event("xcode", "sent", 2);
@@ -2060,6 +2139,9 @@ mod tests {
         assert!(rendered.contains("kura_bootstrap_known_peers"));
         assert!(rendered.contains("kura_bootstrap_completed_peers"));
         assert!(rendered.contains("kura_bootstrap_inflight_peers"));
+        assert!(rendered.contains("kura_bootstrap_pass_buckets_divergent"));
+        assert!(rendered.contains("kura_bootstrap_pass_buckets_reconciled"));
+        assert!(rendered.contains("kura_bootstrap_current_bucket_manifests_walked"));
         assert!(rendered.contains("kura_bootstrap_runs_total"));
         assert!(rendered.contains("kura_bootstrap_duration_seconds"));
         assert!(rendered.contains("kura_bootstrap_applied_items_total"));

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -446,9 +446,14 @@ async fn bootstrap_manifests_from_peer(
                 .set_bootstrap_pass_buckets_reconciled(peer, "digest", 0);
             let mut reconciled = 0;
             for prefix in divergent {
-                let (range_applied, range_failed) =
-                    bootstrap_manifest_range_from_peer(state, peer, Some(&prefix), progress)
-                        .await?;
+                let (range_applied, range_failed) = bootstrap_manifest_range_from_peer(
+                    state,
+                    peer,
+                    Some(&prefix),
+                    "digest",
+                    progress,
+                )
+                .await?;
                 applied += range_applied;
                 failed += range_failed;
                 reconciled += 1;
@@ -471,7 +476,8 @@ async fn bootstrap_manifests_from_peer(
                 .metrics
                 .set_bootstrap_pass_buckets_reconciled(peer, "full_walk", 0);
             let (range_applied, range_failed) =
-                bootstrap_manifest_range_from_peer(state, peer, None, progress).await?;
+                bootstrap_manifest_range_from_peer(state, peer, None, "full_walk", progress)
+                    .await?;
             applied += range_applied;
             failed += range_failed;
             state
@@ -524,13 +530,12 @@ async fn bootstrap_manifest_range_from_peer(
     state: &SharedState,
     peer: &str,
     prefix: Option<&str>,
+    // Passed by the caller (which already labels its pass gauge and Drop guard
+    // with the same value) so the mode has a single source of truth: a walked
+    // value and its clear can never end up under different labels.
+    mode: &'static str,
     progress: &AtomicU64,
 ) -> Result<(u64, u64), String> {
-    let mode = if prefix.is_some() {
-        "digest"
-    } else {
-        "full_walk"
-    };
     let mut after = None;
     let mut applied = 0_u64;
     let mut failed = 0_u64;
@@ -2950,9 +2955,10 @@ mod tests {
             "digest path walks only diverging buckets, got {digest_page_count} pages"
         );
 
-        // Pass-progress gauges clear when a pass returns, so a finished digest
-        // pass reads present-with-mode="digest" at zero rather than frozen at
-        // its last mid-pass value. Also fails if the pass call sites are removed.
+        // After the pass returns the Drop guard has zeroed these, so this pins
+        // only the mode label and the pass-end clearing (present with
+        // mode="digest", at 0) — not that progress was reported. The reporting
+        // of the walked gauge is pinned by range_walk_reports_manifests_walked.
         let pass_gauge = |rendered: &str, name: &str, mode: &str| -> Option<i64> {
             rendered
                 .lines()
@@ -3028,6 +3034,85 @@ mod tests {
         assert!(
             digest_page_count < full_page_count,
             "range digest walks fewer pages than the full walk ({digest_page_count} < {full_page_count}); at prod scale (1.4M) the full walk is ~5652 pages while the digest path stays == delta"
+        );
+    }
+
+    #[tokio::test]
+    async fn range_walk_reports_manifests_walked() {
+        // The range walk is not wrapped by the pass Drop guard, so its gauge is
+        // observable after the call — this is what actually pins the reporting,
+        // which the guard-cleared pass-level assertions cannot.
+        const N: usize = 5;
+        let remote = test_context(|_| {}).await;
+        for i in 0..N {
+            remote
+                .state
+                .store
+                .persist_artifact_from_bytes(
+                    ArtifactProducer::Xcode,
+                    "ios",
+                    &format!("key-{i}"),
+                    "application/octet-stream",
+                    b"payload",
+                )
+                .await
+                .expect("remote artifact should persist");
+        }
+        let (remote_url, _server) = spawn_server(router(remote.state.clone())).await;
+
+        let local = test_context(|_| {}).await;
+        let walked = || -> Option<i64> {
+            let peer_needle = format!("peer=\"{remote_url}\"");
+            local
+                .state
+                .metrics
+                .render()
+                .lines()
+                .find(|line| {
+                    line.starts_with("kura_bootstrap_current_bucket_manifests_walked")
+                        && line.contains(&peer_needle)
+                })
+                .and_then(|line| line.rsplit(' ').next())
+                .and_then(|value| value.trim().parse::<i64>().ok())
+        };
+
+        // Seed a stale value; the walk must overwrite it with exactly the N
+        // manifests it sees. Removing the per-page setter leaves the gauge stuck
+        // at 999 and fails here.
+        local
+            .state
+            .metrics
+            .set_bootstrap_current_bucket_manifests_walked(&remote_url, "full_walk", 999);
+        bootstrap_manifest_range_from_peer(
+            &local.state,
+            &remote_url,
+            None,
+            "full_walk",
+            &AtomicU64::new(0),
+        )
+        .await
+        .expect("range walk succeeds");
+        assert_eq!(
+            walked(),
+            Some(N as i64),
+            "walked reports the manifests seen this walk"
+        );
+
+        // A second walk of the same peer reports N again, not 2N — each walk
+        // counts fresh rather than accumulating.
+        bootstrap_manifest_range_from_peer(
+            &local.state,
+            &remote_url,
+            None,
+            "full_walk",
+            &AtomicU64::new(0),
+        )
+        .await
+        .expect("second range walk succeeds");
+        assert_eq!(
+            walked(),
+            Some(N as i64),
+            "each walk counts fresh, not cumulatively"
         );
     }
 

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -27,6 +27,7 @@ use crate::{
         MAX_INLINE_REPLICATION_BODY_BYTES, MAX_REPLICATION_BODY_BYTES, REPLICATION_RETRY_SECS,
     },
     failpoints::FailpointName,
+    metrics::Metrics,
     state::SharedState,
     store::{
         ArtifactApplyOutcome, ManifestBucketDigest, ManifestDigest, ManifestPage,
@@ -379,6 +380,34 @@ async fn bootstrap_namespace_tombstones_from_peer(
     }
 }
 
+/// Zeroes the per-peer bootstrap pass-progress gauges when a pass ends —
+/// including the `?` and watchdog-cancellation paths, via `Drop` — so a
+/// finished or abandoned pass reads as zero rather than freezing at its last
+/// mid-pass value, which would be indistinguishable from a live wedge. A
+/// still-running pass never drops the guard, so the wedge stays visible.
+struct BootstrapPassGauges {
+    metrics: Metrics,
+    peer: String,
+    mode: &'static str,
+}
+
+impl BootstrapPassGauges {
+    fn new(metrics: &Metrics, peer: &str, mode: &'static str) -> Self {
+        Self {
+            metrics: metrics.clone(),
+            peer: peer.to_owned(),
+            mode,
+        }
+    }
+}
+
+impl Drop for BootstrapPassGauges {
+    fn drop(&mut self) {
+        self.metrics
+            .clear_bootstrap_pass_progress(&self.peer, self.mode);
+    }
+}
+
 async fn bootstrap_manifests_from_peer(
     state: &SharedState,
     peer: &str,
@@ -396,6 +425,7 @@ async fn bootstrap_manifests_from_peer(
     // timeout fires.
     match fetch_bootstrap_digest(state, peer, prefix_len).await? {
         Some(peer_digest) => {
+            let _pass = BootstrapPassGauges::new(&state.metrics, peer, "digest");
             progress.fetch_add(1, Ordering::Relaxed);
             let local_digest = state.store.manifests_digest(prefix_len)?;
             let divergent = divergent_prefixes(&local_digest, &peer_digest.buckets);
@@ -408,22 +438,45 @@ async fn bootstrap_manifests_from_peer(
                 "bootstrap from {peer}: {walked}/{} manifest buckets diverged, {matched} matched and skipped",
                 peer_digest.buckets.len()
             );
+            state
+                .metrics
+                .set_bootstrap_pass_buckets_divergent(peer, "digest", divergent.len());
+            state
+                .metrics
+                .set_bootstrap_pass_buckets_reconciled(peer, "digest", 0);
+            let mut reconciled = 0;
             for prefix in divergent {
                 let (range_applied, range_failed) =
                     bootstrap_manifest_range_from_peer(state, peer, Some(&prefix), progress)
                         .await?;
                 applied += range_applied;
                 failed += range_failed;
+                reconciled += 1;
+                state
+                    .metrics
+                    .set_bootstrap_pass_buckets_reconciled(peer, "digest", reconciled);
             }
         }
         None => {
             // Peer predates the digest endpoint (one-version-skew during a
             // rollout, or a mixed-version mesh): fall back to a full keyspace
-            // walk, exactly as before.
+            // walk, exactly as before. Labeled mode="full_walk" so this
+            // whole-keyspace walk is never read as a single wedged digest
+            // bucket.
+            let _pass = BootstrapPassGauges::new(&state.metrics, peer, "full_walk");
+            state
+                .metrics
+                .set_bootstrap_pass_buckets_divergent(peer, "full_walk", 1);
+            state
+                .metrics
+                .set_bootstrap_pass_buckets_reconciled(peer, "full_walk", 0);
             let (range_applied, range_failed) =
                 bootstrap_manifest_range_from_peer(state, peer, None, progress).await?;
             applied += range_applied;
             failed += range_failed;
+            state
+                .metrics
+                .set_bootstrap_pass_buckets_reconciled(peer, "full_walk", 1);
         }
     }
 
@@ -473,9 +526,18 @@ async fn bootstrap_manifest_range_from_peer(
     prefix: Option<&str>,
     progress: &AtomicU64,
 ) -> Result<(u64, u64), String> {
+    let mode = if prefix.is_some() {
+        "digest"
+    } else {
+        "full_walk"
+    };
     let mut after = None;
     let mut applied = 0_u64;
     let mut failed = 0_u64;
+    let mut manifests_walked = 0;
+    state
+        .metrics
+        .set_bootstrap_current_bucket_manifests_walked(peer, mode, 0);
 
     loop {
         let page = fetch_bootstrap_manifests_page(state, peer, after.as_deref(), prefix).await?;
@@ -483,6 +545,10 @@ async fn bootstrap_manifest_range_from_peer(
         // warm re-walk or an already-present range), so the no-progress watchdog
         // never abandons a bootstrap that is still advancing through the walk.
         progress.fetch_add(1, Ordering::Relaxed);
+        manifests_walked += page.manifests.len();
+        state
+            .metrics
+            .set_bootstrap_current_bucket_manifests_walked(peer, mode, manifests_walked);
         state
             .store
             .hit_failpoint(FailpointName::AfterBootstrapManifestPageFetchBeforeApply)
@@ -2884,6 +2950,28 @@ mod tests {
             "digest path walks only diverging buckets, got {digest_page_count} pages"
         );
 
+        // Pass-progress gauges clear when a pass returns, so a finished digest
+        // pass reads present-with-mode="digest" at zero rather than frozen at
+        // its last mid-pass value. Also fails if the pass call sites are removed.
+        let pass_gauge = |rendered: &str, name: &str, mode: &str| -> Option<i64> {
+            rendered
+                .lines()
+                .find(|line| line.starts_with(name) && line.contains(&format!("mode=\"{mode}\"")))
+                .and_then(|line| line.rsplit(' ').next())
+                .and_then(|value| value.trim().parse::<i64>().ok())
+        };
+        for name in [
+            "kura_bootstrap_pass_buckets_divergent",
+            "kura_bootstrap_pass_buckets_reconciled",
+            "kura_bootstrap_current_bucket_manifests_walked",
+        ] {
+            assert_eq!(
+                pass_gauge(&rendered, name, "digest"),
+                Some(0),
+                "{name} present with mode=digest and cleared after the pass"
+            );
+        }
+
         // --- Old path (A/B control): identical peer, but the digest endpoint
         // 404s so the joining node takes the legacy full walk. Same ~99%-in-sync
         // local, yet it must page the entire keyspace to apply the same delta. ---
@@ -2915,6 +3003,21 @@ mod tests {
             applied_old, MISSING as u64,
             "fallback applies the same delta"
         );
+
+        // The digest-less fallback labels its pass mode="full_walk", so a
+        // healthy whole-keyspace pull is never read as a wedged digest bucket.
+        let rendered_old = local_old.state.metrics.render();
+        for name in [
+            "kura_bootstrap_pass_buckets_divergent",
+            "kura_bootstrap_pass_buckets_reconciled",
+            "kura_bootstrap_current_bucket_manifests_walked",
+        ] {
+            assert_eq!(
+                pass_gauge(&rendered_old, name, "full_walk"),
+                Some(0),
+                "{name} present with mode=full_walk and cleared after the fallback pass"
+            );
+        }
 
         let full_page_count = full_pages.load(Ordering::SeqCst);
         let expected_full_walk = TOTAL.div_ceil(BOOTSTRAP_PAGE_LIMIT);


### PR DESCRIPTION
## What

Adds three peer-labeled Prometheus gauges to Kura's bootstrap path that expose the progress of an **in-flight** bootstrap pass at the digest-bucket level:

| Metric | Meaning |
|---|---|
| `kura_bootstrap_pass_buckets_divergent{peer,mode}` | divergent manifest buckets identified for the peer's current pass |
| `kura_bootstrap_pass_buckets_reconciled{peer,mode}` | divergent buckets fully walked so far in the current pass |
| `kura_bootstrap_current_bucket_manifests_walked{peer,mode}` | manifest entries walked in the bucket currently being reconciled |

All three are gauges labeled by `peer` and `mode` (`digest` for the per-bucket anti-entropy path, `full_walk` for the digest-less fallback). They advance during a pass and are **zeroed when the pass ends** — including the `?` and watchdog-cancellation paths, via a `Drop` guard — so a finished or abandoned pass reads as zero instead of freezing at its last mid-pass value. A still-running pass never clears, so `divergent > 0` for a peer means a pass is in flight for it.

## Why

This is **diagnostic instrumentation to confirm (or refute) a specific hypothesis before writing a fix** — see #11955 and [this comment](https://github.com/tuist/tuist/issues/11955#issuecomment-5042404510).

Bootstrap reconciles a peer with a digest sweep over 4096 buckets (`BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN = 3`): for each divergent bucket, `bootstrap_manifest_range_from_peer` walks the peer's manifest range until `next_after: None`. That walk reads the peer's **live** state and has no snapshot/endpoint bound, so if a bucket keeps gaining manifests after the cursor — from live writes and/or mutual mesh replication — faster than the walk drains them, the walk never terminates. The pass never completes, the peer is never marked bootstrapped, and the node stays NotReady with **no error** and **no watchdog abandonment** (the no-progress watchdog is defeated because pages keep flowing).

Today's metrics (`completed_peers`, `applied`/`ignored_stale`) are *consistent with* this but can't distinguish it from a pass that is simply slow-but-progressing. These gauges add the missing discriminator.

## How to read them (the validating signature)

For a stuck peer, over a range (filter `mode="digest"` — the fallback is a different shape):

- `kura_bootstrap_pass_buckets_reconciled{peer=X, mode="digest"}` — **flat** (below `divergent`) for a long time while the peer is inflight ⇒ parked on a bucket, not advancing.
- `kura_bootstrap_current_bucket_manifests_walked{peer=X, mode="digest"}` — **climbing into the thousands** (vs. a ~40 manifests/bucket average on a ~160K-manifest dataset) and never resetting ⇒ the bucket is *growing under the walk*, not merely large.

That combination is the non-terminating-walk mechanism, directly observed. A healthy slow pull instead shows `reconciled` climbing steadily and `current_bucket_manifests_walked` resetting per bucket.

## Notes

- **No behavior change** — purely additive gauges; the bootstrap logic is untouched (rollout-safe under version skew).
- **Cardinality** — labeled by `peer` (a handful per mesh) × `mode` (2 values), never by bucket prefix (would be 4096 series). HELP text is kept neutral; interpretation lives here and in the runbook.
- These double as a permanent runbook signal (separating "slow" from "wedged") and as the way to verify a future snapshot-endpoint fix actually terminates passes.

## Addressed from review

- **`mode` label** (`digest` / `full_walk`) — the digest-less fallback walks the whole keyspace as one range, which otherwise renders identically to a single wedged digest bucket; the label keeps the two unambiguous (and `mode="full_walk"` is itself a useful version-skew signal). It's passed as a single parameter from the caller into both the pass gauges and the range walk, so the label has one source of truth — a `walked` value can't end up under a mode the pass-end clear never touches.
- **Gauge lifecycle** — the gauges are zeroed when a pass ends (via a `Drop` guard, so the `?` and watchdog-cancellation paths are covered too). A finished pass, or a peer that has left the mesh, no longer lingers frozen at `reconciled < divergent` with a nonzero `walked` — the exact shape this PR teaches operators to read as wedged.
- **Test coverage** — the after-pass assertions pin the `mode` label and the pass-end clearing, but (because the guard's own `Drop` recreates the series at 0) they don't pin that progress was *reported*. That's now covered by `range_walk_reports_manifests_walked`, which drives the range walk directly — unguarded, so its gauge is observable — and asserts it reports the manifests seen and counts fresh per walk. Verified to fail when the reporting setter is removed.
- **Dashboard panel** — deferred to a separately-validated change: the dashboard is a Grafana schema-v2 `Dashboard` CR (`spec.elements` + `spec.layout`, no classic `panels` array), so a panel is an element cross-referenced by a layout — too high-risk to hand-edit blind without a render check. Better added via a Grafana export, and the gauges now clear to 0 between passes so the panel is best designed against the confirmed live signal.

## Validation

- `cargo check --lib` ✅
- `cargo clippy --lib --tests -- -D warnings` ✅ (clean)
- `cargo fmt -- --check` ✅
- `render_includes_recorded_metrics` extended to set + assert the three new metrics ✅

Draft: opened to gather production data validating the #11955 hypothesis before the fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
