### PR TITLE
fix(cli): configure debugging for cached modules

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -482,6 +482,18 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                     return .screenRecording
                 }
             }
+        let customLLDBInitFile: String? = if let customLLDBInitFile = testAction.customLLDBInitFile,
+                                             let targetReference = testAction.expandVariableFromTarget
+                                             ?? testAction.targets.first?.target,
+                                             let graphTarget = graphTraverser.target(
+                                                 path: targetReference.projectPath,
+                                                 name: targetReference.name
+                                             )
+        {
+            "$(SRCROOT)/\(customLLDBInitFile.relative(to: graphTarget.project.path).pathString)"
+        } else {
+            testAction.customLLDBInitFile?.pathString
+        }
 
         return XCScheme.TestAction(
             buildConfiguration: testAction.configurationName,
@@ -505,7 +517,8 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             environmentVariables: environments,
             language: language,
             region: region,
-            preferredScreenCaptureFormat: preferredScreenCaptureFormat
+            preferredScreenCaptureFormat: preferredScreenCaptureFormat,
+            customLLDBInitFile: customLLDBInitFile
         )
     } // swiftlint:enable function_body_length
 

--- a/cli/Sources/TuistGenerator/Mappers/CachedModulesDebuggingGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/CachedModulesDebuggingGraphMapper.swift
@@ -100,7 +100,9 @@ public struct CachedModulesDebuggingGraphMapper: GraphMapping {
             }
 
             if var testAction = scheme.testAction, testAction.attachDebugger {
-                let testTargets = testAction.targets.map(\.target)
+                let testTargets = testAction.targets.map(\.target) + (testAction.testPlans ?? []).flatMap {
+                    $0.testTargets.map(\.target)
+                }
                 let artifacts = try testTargets.reduce(into: Set<AbsolutePath>()) { artifacts, target in
                     artifacts.formUnion(try cachedArtifacts(
                         reachableFrom: target,

--- a/cli/Sources/TuistGenerator/Mappers/CachedModulesDebuggingGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/CachedModulesDebuggingGraphMapper.swift
@@ -1,0 +1,398 @@
+import Foundation
+import Path
+import TuistConstants
+import TuistCore
+import XcodeGraph
+
+/// Configures Xcode schemes so the [Low-Level Debugger (LLDB)](https://lldb.llvm.org/) can load
+/// Swift modules that were replaced with artifacts from Tuist's module cache.
+///
+/// The generated pre-action follows the approach used by rules_xcodeproj: it refreshes a
+/// project-local debugger initialization file using the selected target's resolved build settings.
+public struct CachedModulesDebuggingGraphMapper: GraphMapping {
+    private static let updateActionTitle = "Update Tuist cache debugger settings"
+
+    public init() {}
+
+    public func map(
+        graph: Graph,
+        environment: MapperEnvironment
+    ) throws -> (Graph, [SideEffectDescriptor], MapperEnvironment) {
+        guard let graphWithSources = environment.initialGraphWithSources else {
+            return (graph, [], environment)
+        }
+
+        let cachedArtifactPaths = precompiledPaths(in: graph).subtracting(precompiledPaths(in: graphWithSources))
+        guard !cachedArtifactPaths.isEmpty else {
+            return (graph, [], environment)
+        }
+
+        let graphTraverser = GraphTraverser(graph: graph)
+        var sideEffects: [SideEffectDescriptor] = []
+
+        let projects = try Dictionary(uniqueKeysWithValues: graph.projects.map { path, project in
+            var project = project
+            project.schemes = try mappedSchemes(
+                project.schemes,
+                scope: "project-\(project.name)",
+                graph: graph,
+                graphTraverser: graphTraverser,
+                cachedArtifactPaths: cachedArtifactPaths,
+                sideEffects: &sideEffects
+            )
+            return (path, project)
+        })
+
+        var workspace = graph.workspace
+        workspace.schemes = try mappedSchemes(
+            workspace.schemes,
+            scope: "workspace-\(workspace.name)",
+            graph: graph,
+            graphTraverser: graphTraverser,
+            cachedArtifactPaths: cachedArtifactPaths,
+            sideEffects: &sideEffects
+        )
+        var mappedGraph = graph
+        mappedGraph.projects = projects
+        mappedGraph.workspace = workspace
+
+        return (mappedGraph, sideEffects, environment)
+    }
+
+    private func mappedSchemes(
+        _ schemes: [Scheme],
+        scope: String,
+        graph: Graph,
+        graphTraverser: GraphTraversing,
+        cachedArtifactPaths: Set<AbsolutePath>,
+        sideEffects: inout [SideEffectDescriptor]
+    ) throws -> [Scheme] {
+        try schemes.map { scheme in
+            var scheme = scheme
+
+            if let runAction = scheme.runAction,
+               runAction.attachDebugger,
+               let target = try runTarget(
+                   for: scheme,
+                   graphTraverser: graphTraverser,
+                   cachedArtifactPaths: cachedArtifactPaths
+               )
+            {
+                let artifacts = try cachedArtifacts(
+                    reachableFrom: target,
+                    graphTraverser: graphTraverser,
+                    cachedArtifactPaths: cachedArtifactPaths
+                )
+                let configuration = try debuggerConfiguration(
+                    scope: scope,
+                    schemeName: scheme.name,
+                    actionName: "run",
+                    target: target,
+                    originalLLDBInitFile: runAction.customLLDBInitFile,
+                    artifacts: artifacts,
+                    graph: graph
+                )
+                scheme.runAction = runAction.with(
+                    customLLDBInitFile: configuration.lldbInitPath,
+                    preActions: prepending(configuration.preAction, to: runAction.preActions)
+                )
+                sideEffects.append(.file(configuration.initialLLDBInitFile))
+            }
+
+            if var testAction = scheme.testAction, testAction.attachDebugger {
+                let testTargets = testAction.targets.map(\.target)
+                let artifacts = try testTargets.reduce(into: Set<AbsolutePath>()) { artifacts, target in
+                    artifacts.formUnion(try cachedArtifacts(
+                        reachableFrom: target,
+                        graphTraverser: graphTraverser,
+                        cachedArtifactPaths: cachedArtifactPaths
+                    ))
+                }
+                if let target = testAction.expandVariableFromTarget ?? testTargets.first,
+                   !artifacts.isEmpty
+                {
+                    let configuration = try debuggerConfiguration(
+                        scope: scope,
+                        schemeName: scheme.name,
+                        actionName: "test",
+                        target: target,
+                        originalLLDBInitFile: testAction.customLLDBInitFile,
+                        artifacts: artifacts,
+                        graph: graph
+                    )
+                    testAction.customLLDBInitFile = configuration.lldbInitPath
+                    testAction.preActions = prepending(configuration.preAction, to: testAction.preActions)
+                    scheme.testAction = testAction
+                    sideEffects.append(.file(configuration.initialLLDBInitFile))
+                }
+            }
+
+            return scheme
+        }
+    }
+
+    private func runTarget(
+        for scheme: Scheme,
+        graphTraverser: GraphTraversing,
+        cachedArtifactPaths: Set<AbsolutePath>
+    ) throws -> TargetReference? {
+        guard let target = scheme.runAction?.executable ?? scheme.buildAction?.targets.first else {
+            return nil
+        }
+        let artifacts = try cachedArtifacts(
+            reachableFrom: target,
+            graphTraverser: graphTraverser,
+            cachedArtifactPaths: cachedArtifactPaths
+        )
+        return artifacts.isEmpty ? nil : target
+    }
+
+    private func cachedArtifacts(
+        reachableFrom target: TargetReference,
+        graphTraverser: GraphTraversing,
+        cachedArtifactPaths: Set<AbsolutePath>
+    ) throws -> Set<AbsolutePath> {
+        try Set(
+            graphTraverser
+                .searchablePathDependencies(path: target.projectPath, name: target.name)
+                .compactMap(\.precompiledPath)
+                .filter(cachedArtifactPaths.contains)
+        )
+    }
+
+    private func debuggerConfiguration(
+        scope: String,
+        schemeName: String,
+        actionName: String,
+        target: TargetReference,
+        originalLLDBInitFile: AbsolutePath?,
+        artifacts: Set<AbsolutePath>,
+        graph: Graph
+    ) throws -> DebuggerConfiguration {
+        guard let project = graph.projects[target.projectPath] else {
+            throw CachedModulesDebuggingGraphMapperError.missingProject(target.projectPath)
+        }
+
+        let fileName = safeFileName("\(scope)-\(schemeName)-\(actionName)")
+        let directory = project.sourceRootPath.appending(
+            components: Constants.DerivedDirectory.name,
+            "TuistCacheDebugging"
+        )
+        let lldbInitPath = directory.appending(component: "\(fileName).lldbinit")
+        let overlayPath = directory.appending(component: "\(fileName)-prefix-remap.yaml")
+        let searchPaths = Set(artifacts.map(\.parentDirectory)).sorted()
+        let initialContents = lldbInitContents(
+            originalLLDBInitFile: originalLLDBInitFile,
+            frameworkSearchPaths: searchPaths,
+            moduleSearchPaths: searchPaths
+        )
+        let preAction = ExecutionAction(
+            title: Self.updateActionTitle,
+            scriptText: debuggerUpdateScript(
+                lldbInitPath: lldbInitPath,
+                overlayPath: overlayPath,
+                originalLLDBInitFile: originalLLDBInitFile,
+                searchPaths: searchPaths
+            ),
+            target: target,
+            shellPath: "/bin/sh",
+            showEnvVarsInLog: false
+        )
+        return DebuggerConfiguration(
+            lldbInitPath: lldbInitPath,
+            initialLLDBInitFile: FileDescriptor(
+                path: lldbInitPath,
+                contents: Data(initialContents.utf8)
+            ),
+            preAction: preAction
+        )
+    }
+
+    private func prepending(_ action: ExecutionAction, to actions: [ExecutionAction]) -> [ExecutionAction] {
+        [action] + actions.filter { $0.title != Self.updateActionTitle }
+    }
+
+    private func precompiledPaths(in graph: Graph) -> Set<AbsolutePath> {
+        Set(
+            (Array(graph.dependencies.keys) + graph.dependencies.values.flatMap(Array.init))
+                .compactMap(precompiledPath)
+        )
+    }
+
+    private func precompiledPath(of dependency: GraphDependency) -> AbsolutePath? {
+        switch dependency {
+        case let .foreignBuildOutput(output): output.path
+        case let .xcframework(xcframework): xcframework.path
+        case let .framework(path, _, _, _, _, _, _): path
+        case let .library(path, _, _, _, _): path
+        case .bundle, .macro, .packageProduct, .sdk, .target: nil
+        }
+    }
+
+    private func lldbInitContents(
+        originalLLDBInitFile: AbsolutePath?,
+        frameworkSearchPaths: [AbsolutePath],
+        moduleSearchPaths: [AbsolutePath]
+    ) -> String {
+        var lines: [String] = []
+        if let originalLLDBInitFile {
+            lines.append("command source -s 0 \(lldbQuoted(originalLLDBInitFile.pathString))")
+        }
+        lines.append(lldbSetting("target.swift-framework-search-paths", values: frameworkSearchPaths.map(\.pathString)))
+        lines.append(lldbSetting("target.swift-module-search-paths", values: moduleSearchPaths.map(\.pathString)))
+        lines.append("settings set symbols.use-swift-explicit-module-loader false")
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func lldbSetting(_ setting: String, values: [String]) -> String {
+        "settings set \(setting) " + values.map(lldbQuoted).joined(separator: " ")
+    }
+
+    private func lldbQuoted(_ value: String) -> String {
+        "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"") + "\""
+    }
+
+    private func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+
+    private func safeFileName(_ value: String) -> String {
+        value.utf8.map { byte in
+            switch byte {
+            case 45, 48 ... 57, 65 ... 90, 95, 97 ... 122:
+                String(UnicodeScalar(byte))
+            default:
+                String(format: "_%02X", byte)
+            }
+        }.joined()
+    }
+
+    private func debuggerUpdateScript(
+        lldbInitPath: AbsolutePath,
+        overlayPath: AbsolutePath,
+        originalLLDBInitFile: AbsolutePath?,
+        searchPaths: [AbsolutePath]
+    ) -> String {
+        let initialSearchPathArguments = searchPaths.map { shellQuoted($0.pathString) }.joined(separator: " ")
+        let sourceOriginal = originalLLDBInitFile.map {
+            "lldb_setting command-source \(shellQuoted($0.pathString))"
+        } ?? ""
+
+        return """
+        set -eu
+
+        lldb_init_file=\(shellQuoted(lldbInitPath.pathString))
+        overlay_file=\(shellQuoted(overlayPath.pathString))
+        mkdir -p "$(dirname "$lldb_init_file")"
+
+        lldb_escape() {
+          printf '%s' "$1" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g'
+        }
+
+        lldb_setting() {
+          setting="$1"
+          shift
+          if [ "$setting" = "command-source" ]; then
+            printf 'command source -s 0 "%s"\\n' "$(lldb_escape "$1")"
+            return
+          fi
+          printf 'settings set %s' "$setting"
+          for value in "$@"; do
+            printf ' "%s"' "$(lldb_escape "$value")"
+          done
+          printf '\\n'
+        }
+
+        json_escape() {
+          printf '%s' "$1" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g'
+        }
+
+        {
+          \(sourceOriginal)
+          set -- \(initialSearchPathArguments)
+          for path in "${TARGET_BUILD_DIR:-}" "${BUILT_PRODUCTS_DIR:-}" "${CONFIGURATION_BUILD_DIR:-}"; do
+            if [ -n "$path" ]; then
+              set -- "$@" "$path"
+            fi
+          done
+          lldb_setting target.swift-framework-search-paths "$@"
+          lldb_setting target.swift-module-search-paths "$@"
+          printf 'settings set symbols.use-swift-explicit-module-loader false\n'
+
+          if [ "${COMPILATION_CACHE_ENABLE_CACHING:-NO}" = "YES" ]; then
+            derived_data_dir="${BUILD_DIR%%/Build/*}"
+            cache_kind=builtin
+            if [ "${COMPILATION_CACHE_ENABLE_PLUGIN:-NO}" = "YES" ]; then
+              cache_kind=plugin
+            fi
+            cas_path="$derived_data_dir/CompilationCache.noindex/$cache_kind"
+            plugin_path="${COMPILATION_CACHE_PLUGIN_PATH:-${DEVELOPER_DIR:-}/usr/lib/libToolchainCASPlugin.dylib}"
+            lldb_setting symbols.cas-path "$cas_path"
+            lldb_setting symbols.cas-plugin-path "$plugin_path"
+
+            set --
+            if [ -n "${COMPILATION_CACHE_REMOTE_SERVICE_PATH:-}" ]; then
+              set -- "$@" "remote-service-path=$COMPILATION_CACHE_REMOTE_SERVICE_PATH"
+            fi
+            expects_plugin_option=NO
+            for flag in ${OTHER_SWIFT_FLAGS:-}; do
+              if [ "$expects_plugin_option" = "YES" ]; then
+                set -- "$@" "$flag"
+                expects_plugin_option=NO
+              elif [ "$flag" = "-cas-plugin-option" ]; then
+                expects_plugin_option=YES
+              fi
+            done
+            if [ "$#" -gt 0 ]; then
+              lldb_setting symbols.cas-plugin-options "$@"
+            fi
+
+            sdk_path="${SDKROOT:-}"
+            developer_path="${DEVELOPER_DIR:-}"
+            toolchain_path="$developer_path/Toolchains/XcodeDefault.xctoolchain"
+            printf '{"version":0,"case-sensitive":"false","redirecting-with":"fallthrough","roots":[' > "$overlay_file"
+            printf '{"type":"directory-remap","name":"/^sdk","external-contents":"%s"},' "$(json_escape "$sdk_path")" >> "$overlay_file"
+            printf '{"type":"directory-remap","name":"/^toolchain","external-contents":"%s"},' "$(json_escape "$toolchain_path")" >> "$overlay_file"
+            printf '{"type":"directory-remap","name":"/^xcode","external-contents":"%s"}]}' "$(json_escape "$developer_path")" >> "$overlay_file"
+            printf 'settings set target.swift-extra-clang-flags -- -ivfsoverlay "%s"\\n' "$(lldb_escape "$overlay_file")"
+          fi
+        } > "$lldb_init_file"
+        """
+    }
+}
+
+private struct DebuggerConfiguration {
+    let lldbInitPath: AbsolutePath
+    let initialLLDBInitFile: FileDescriptor
+    let preAction: ExecutionAction
+}
+
+private enum CachedModulesDebuggingGraphMapperError: Error {
+    case missingProject(AbsolutePath)
+}
+
+extension RunAction {
+    fileprivate func with(customLLDBInitFile: AbsolutePath, preActions: [ExecutionAction]) -> RunAction {
+        RunAction(
+            configurationName: configurationName,
+            attachDebugger: attachDebugger,
+            customLLDBInitFile: customLLDBInitFile,
+            preActions: preActions,
+            postActions: postActions,
+            executable: executable,
+            filePath: filePath,
+            arguments: arguments,
+            options: options,
+            diagnosticsOptions: diagnosticsOptions,
+            metalOptions: metalOptions,
+            expandVariableFromTarget: expandVariableFromTarget,
+            askForAppToLaunch: askForAppToLaunch,
+            launchStyle: launchStyle,
+            appClipInvocationURL: appClipInvocationURL,
+            customWorkingDirectory: customWorkingDirectory,
+            useCustomWorkingDirectory: useCustomWorkingDirectory
+        )
+    }
+}

--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -203,6 +203,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
 
             mappers.append(FrameworkSearchPathsGraphMapper())
             mappers.append(ForeignBuildSideEffectGraphMapper())
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }
@@ -252,6 +253,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         .testInsightsDisabled ?? true
                 )
             )
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }
@@ -315,6 +317,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         .testInsightsDisabled ?? true
                 )
             )
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }
@@ -362,6 +365,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         .testInsightsDisabled ?? true
                 )
             )
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }
@@ -386,6 +390,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         .testInsightsDisabled ?? true
                 )
             )
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }
@@ -409,6 +414,7 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         .testInsightsDisabled ?? true
                 )
             )
+            mappers.append(CachedModulesDebuggingGraphMapper())
 
             return mappers
         }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TestAction.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TestAction.swift
@@ -9,6 +9,7 @@ public struct TestAction: Equatable, Codable, Sendable {
     public var arguments: Arguments?
     public var configurationName: String
     public var attachDebugger: Bool
+    public var customLLDBInitFile: AbsolutePath?
     public var coverage: Bool
     public var codeCoverageTargets: [TargetReference]
     public var expandVariableFromTarget: TargetReference?
@@ -37,13 +38,15 @@ public struct TestAction: Equatable, Codable, Sendable {
         region: String? = nil,
         preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
         testPlans: [TestPlan]? = nil,
-        skippedTests: [String]? = nil
+        skippedTests: [String]? = nil,
+        customLLDBInitFile: AbsolutePath? = nil
     ) {
         self.testPlans = testPlans
         self.targets = targets
         self.arguments = arguments
         self.configurationName = configurationName
         self.attachDebugger = attachDebugger
+        self.customLLDBInitFile = customLLDBInitFile
         self.coverage = coverage
         self.preActions = preActions
         self.postActions = postActions
@@ -76,7 +79,8 @@ public struct TestAction: Equatable, Codable, Sendable {
             region: String? = nil,
             preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
             testPlans: [TestPlan]? = nil,
-            skippedTests: [String]? = nil
+            skippedTests: [String]? = nil,
+            customLLDBInitFile: AbsolutePath? = nil
         ) -> TestAction {
             TestAction(
                 targets: targets,
@@ -93,7 +97,8 @@ public struct TestAction: Equatable, Codable, Sendable {
                 region: region,
                 preferredScreenCaptureFormat: preferredScreenCaptureFormat,
                 testPlans: testPlans,
-                skippedTests: skippedTests
+                skippedTests: skippedTests,
+                customLLDBInitFile: customLLDBInitFile
             )
         }
     #endif

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -540,6 +540,27 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
     }
 
+    func test_schemeTestAction_withCustomLLDBInitFile() throws {
+        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Project")
+        let lldbInitPath = projectPath.appending(components: "Derived", "TuistCacheDebugging", "test.lldbinit")
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+        let project = Project.test(path: projectPath, targets: [testTarget])
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            customLLDBInitFile: lldbInitPath
+        )
+        let scheme = Scheme.test(testAction: testAction)
+
+        let result = try XCTUnwrap(subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: GraphTraverser(graph: Graph.test(projects: [projectPath: project])),
+            rootPath: projectPath,
+            generatedProjects: createGeneratedProjects(projects: [project])
+        ))
+
+        XCTAssertEqual(result.customLLDBInitFile, "$(SRCROOT)/Derived/TuistCacheDebugging/test.lldbinit")
+    }
+
     func test_schemeTestAction_gpxSimulatedLocation() throws {
         // Given
         let workspacePath = try AbsolutePath(validating: "/somepath/Workspace")

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -540,27 +540,6 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
     }
 
-    func test_schemeTestAction_withCustomLLDBInitFile() throws {
-        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Project")
-        let lldbInitPath = projectPath.appending(components: "Derived", "TuistCacheDebugging", "test.lldbinit")
-        let testTarget = Target.test(name: "AppTests", product: .unitTests)
-        let project = Project.test(path: projectPath, targets: [testTarget])
-        let testAction = TestAction.test(
-            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
-            customLLDBInitFile: lldbInitPath
-        )
-        let scheme = Scheme.test(testAction: testAction)
-
-        let result = try XCTUnwrap(subject.schemeTestAction(
-            scheme: scheme,
-            graphTraverser: GraphTraverser(graph: Graph.test(projects: [projectPath: project])),
-            rootPath: projectPath,
-            generatedProjects: createGeneratedProjects(projects: [project])
-        ))
-
-        XCTAssertEqual(result.customLLDBInitFile, "$(SRCROOT)/Derived/TuistCacheDebugging/test.lldbinit")
-    }
-
     func test_schemeTestAction_gpxSimulatedLocation() throws {
         // Given
         let workspacePath = try AbsolutePath(validating: "/somepath/Workspace")
@@ -2600,6 +2579,38 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             runAction: runAction,
             profileAction: profileAction
         )
+    }
+}
+
+struct SchemeDescriptorsGeneratorDebuggerTests {
+    private let subject = SchemeDescriptorsGenerator()
+
+    @Test func schemeTestAction_withCustomLLDBInitFile() throws {
+        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Project")
+        let lldbInitPath = projectPath.appending(components: "Derived", "TuistCacheDebugging", "test.lldbinit")
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+        let project = Project.test(path: projectPath, targets: [testTarget])
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            customLLDBInitFile: lldbInitPath
+        )
+        let scheme = Scheme.test(testAction: testAction)
+        let generatedProject = GeneratedProject(
+            pbxproj: .init(),
+            path: project.xcodeProjPath,
+            targets: [testTarget.name: PBXNativeTarget(name: testTarget.name)],
+            name: project.xcodeProjPath.basename
+        )
+
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: GraphTraverser(graph: Graph.test(projects: [projectPath: project])),
+            rootPath: projectPath,
+            generatedProjects: [project.xcodeProjPath: generatedProject]
+        )
+        let result = try #require(got)
+
+        #expect(result.customLLDBInitFile == "$(SRCROOT)/Derived/TuistCacheDebugging/test.lldbinit")
     }
 }
 

--- a/cli/Tests/TuistGeneratorTests/Mappers/CachedModulesDebuggingGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/CachedModulesDebuggingGraphMapperTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Path
+import TuistCore
+import TuistSupport
+import TuistTesting
+import XcodeGraph
+import XCTest
+@testable import TuistGenerator
+
+final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
+    private var subject: CachedModulesDebuggingGraphMapper!
+
+    override func setUp() {
+        super.setUp()
+        subject = CachedModulesDebuggingGraphMapper()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_map_configuresRunAndTestActionsThatUseCachedModules() async throws {
+        let projectPath = try temporaryPath()
+        let originalLLDBInitFile = projectPath.appending(components: "Debugger", "custom.lldbinit")
+        let cachedFrameworkPath = projectPath.appending(
+            components: ".tuist-cache", "hash", "Feature.xcframework"
+        )
+        let cachedUIFrameworkPath = projectPath.appending(
+            components: ".tuist-cache", "ui-hash", "UIFeature.xcframework"
+        )
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let uiTests = Target.test(name: "AppUITests", product: .uiTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let uiFeature = Target.test(name: "UIFeature", product: .framework)
+        let scheme = Scheme.test(
+            name: "App Scheme",
+            buildAction: BuildAction(targets: [TargetReference(projectPath: projectPath, name: "App")]),
+            testAction: TestAction.test(
+                targets: [
+                    TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests")),
+                    TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppUITests")),
+                ]
+            ),
+            runAction: RunAction.test(
+                customLLDBInitFile: originalLLDBInitFile,
+                executable: TargetReference(projectPath: projectPath, name: "App")
+            )
+        )
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            targets: [app, tests, uiTests, feature, uiFeature],
+            schemes: [scheme]
+        )
+        let cachedFramework = GraphDependency.testXCFramework(path: cachedFrameworkPath, linking: .dynamic)
+        let cachedUIFramework = GraphDependency.testXCFramework(path: cachedUIFrameworkPath, linking: .dynamic)
+        let workspace = Workspace.test(path: projectPath, projects: [projectPath], schemes: [scheme])
+        let sourceGraph = Graph.test(
+            workspace: workspace,
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "AppTests", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "AppUITests", path: projectPath): [.target(name: "UIFeature", path: projectPath)],
+                .target(name: "Feature", path: projectPath): [],
+                .target(name: "UIFeature", path: projectPath): [],
+            ]
+        )
+        let cachedGraph = Graph.test(
+            workspace: workspace,
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [cachedFramework],
+                .target(name: "AppTests", path: projectPath): [cachedFramework],
+                .target(name: "AppUITests", path: projectPath): [cachedUIFramework],
+                cachedFramework: [],
+                cachedUIFramework: [],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = sourceGraph
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(
+            graph: cachedGraph,
+            environment: environment
+        )
+
+        let mappedScheme = try XCTUnwrap(mappedGraph.projects[projectPath]?.schemes.first)
+        let runAction = try XCTUnwrap(mappedScheme.runAction)
+        let testAction = try XCTUnwrap(mappedScheme.testAction)
+        XCTAssertEqual(runAction.preActions.first?.title, "Update Tuist cache debugger settings")
+        XCTAssertEqual(testAction.preActions.first?.title, "Update Tuist cache debugger settings")
+        XCTAssertEqual(runAction.preActions.first?.target?.name, "App")
+        XCTAssertEqual(testAction.preActions.first?.target?.name, "AppTests")
+        XCTAssertTrue(runAction.customLLDBInitFile?.pathString.hasSuffix("-run.lldbinit") == true)
+        XCTAssertTrue(testAction.customLLDBInitFile?.pathString.hasSuffix("-test.lldbinit") == true)
+        XCTAssertNotNil(mappedGraph.workspace.schemes.first?.runAction?.customLLDBInitFile)
+        XCTAssertNotNil(mappedGraph.workspace.schemes.first?.testAction?.customLLDBInitFile)
+
+        let runFile = try XCTUnwrap(fileDescriptor(at: runAction.customLLDBInitFile, in: sideEffects))
+        let runContents = try XCTUnwrap(String(data: try XCTUnwrap(runFile.contents), encoding: .utf8))
+        XCTAssertTrue(runContents.contains("command source -s 0 \"\(originalLLDBInitFile.pathString)\""))
+        XCTAssertTrue(runContents.contains(cachedFrameworkPath.parentDirectory.pathString))
+        XCTAssertTrue(runContents.contains("settings set symbols.use-swift-explicit-module-loader false"))
+
+        let testFile = try XCTUnwrap(fileDescriptor(at: testAction.customLLDBInitFile, in: sideEffects))
+        let testContents = try XCTUnwrap(String(data: try XCTUnwrap(testFile.contents), encoding: .utf8))
+        XCTAssertTrue(testContents.contains(cachedFrameworkPath.parentDirectory.pathString))
+        XCTAssertTrue(testContents.contains(cachedUIFrameworkPath.parentDirectory.pathString))
+        XCTAssertFalse(testContents.contains("command source"))
+
+        let script = try XCTUnwrap(runAction.preActions.first?.scriptText)
+        XCTAssertTrue(script.contains("symbols.cas-path"))
+        XCTAssertTrue(script.contains("symbols.cas-plugin-path"))
+        XCTAssertTrue(script.contains("symbols.cas-plugin-options"))
+        XCTAssertTrue(script.contains("target.swift-framework-search-paths"))
+        XCTAssertTrue(script.contains("target.swift-module-search-paths"))
+        XCTAssertTrue(script.contains("target.swift-extra-clang-flags"))
+        XCTAssertTrue(script.contains("/^sdk"))
+        XCTAssertTrue(script.contains("symbols.use-swift-explicit-module-loader false"))
+    }
+
+    func test_map_doesNotConfigureRunActionUsingCachedModulesFromALaterBuildTarget() async throws {
+        let projectPath = try temporaryPath()
+        let cachedFrameworkPath = projectPath.appending(
+            components: ".tuist-cache", "hash", "Feature.xcframework"
+        )
+        let primaryApp = Target.test(name: "PrimaryApp", product: .app)
+        let secondaryApp = Target.test(name: "SecondaryApp", product: .app)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let scheme = Scheme.test(
+            buildAction: BuildAction(targets: [
+                TargetReference(projectPath: projectPath, name: "PrimaryApp"),
+                TargetReference(projectPath: projectPath, name: "SecondaryApp"),
+            ]),
+            testAction: nil,
+            runAction: RunAction.test(
+                executable: nil,
+                expandVariableFromTarget: TargetReference(projectPath: projectPath, name: "SecondaryApp")
+            )
+        )
+        let project = Project.test(
+            path: projectPath,
+            targets: [primaryApp, secondaryApp, feature],
+            schemes: [scheme]
+        )
+        let cachedFramework = GraphDependency.testXCFramework(path: cachedFrameworkPath, linking: .dynamic)
+        let sourceGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "PrimaryApp", path: projectPath): [],
+                .target(name: "SecondaryApp", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "Feature", path: projectPath): [],
+            ]
+        )
+        let cachedGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "PrimaryApp", path: projectPath): [],
+                .target(name: "SecondaryApp", path: projectPath): [cachedFramework],
+                cachedFramework: [],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = sourceGraph
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: cachedGraph, environment: environment)
+
+        XCTAssertNil(mappedGraph.projects[projectPath]?.schemes.first?.runAction?.customLLDBInitFile)
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    func test_map_doesNotConfigureActionsWhenDebuggerAttachmentIsDisabled() async throws {
+        let projectPath = try temporaryPath()
+        let cachedFrameworkPath = projectPath.appending(
+            components: ".tuist-cache", "hash", "Feature.xcframework"
+        )
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let scheme = Scheme.test(
+            buildAction: BuildAction(targets: [TargetReference(projectPath: projectPath, name: "App")]),
+            testAction: TestAction.test(
+                targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+                attachDebugger: false
+            ),
+            runAction: RunAction.test(
+                attachDebugger: false,
+                executable: TargetReference(projectPath: projectPath, name: "App")
+            )
+        )
+        let project = Project.test(path: projectPath, targets: [app, tests, feature], schemes: [scheme])
+        let cachedFramework = GraphDependency.testXCFramework(path: cachedFrameworkPath, linking: .dynamic)
+        let sourceGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "AppTests", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "Feature", path: projectPath): [],
+            ]
+        )
+        let cachedGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [cachedFramework],
+                .target(name: "AppTests", path: projectPath): [cachedFramework],
+                cachedFramework: [],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = sourceGraph
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: cachedGraph, environment: environment)
+
+        XCTAssertEqual(mappedGraph, cachedGraph)
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    func test_map_doesNotConfigureSchemesForPrecompiledDependenciesThatWereAlreadyInTheSourceGraph() async throws {
+        let projectPath = try temporaryPath()
+        let frameworkPath = projectPath.appending(components: "Frameworks", "Vendor.xcframework")
+        let app = Target.test(name: "App", product: .app)
+        let scheme = Scheme.test(
+            buildAction: BuildAction(targets: [TargetReference(projectPath: projectPath, name: "App")]),
+            testAction: nil,
+            runAction: RunAction.test(executable: TargetReference(projectPath: projectPath, name: "App"))
+        )
+        let project = Project.test(path: projectPath, targets: [app], schemes: [scheme])
+        let vendorFramework = GraphDependency.testXCFramework(path: frameworkPath, linking: .dynamic)
+        let graph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [vendorFramework],
+                vendorFramework: [],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = graph
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: environment)
+
+        XCTAssertEqual(mappedGraph, graph)
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    func test_map_doesNothingWithoutTheSourceGraph() async throws {
+        let graph = Graph.test()
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(
+            graph: graph,
+            environment: MapperEnvironment()
+        )
+
+        XCTAssertEqual(mappedGraph, graph)
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    private func fileDescriptor(
+        at path: AbsolutePath?,
+        in sideEffects: [SideEffectDescriptor]
+    ) -> FileDescriptor? {
+        sideEffects.compactMap { sideEffect in
+            guard case let .file(file) = sideEffect, file.path == path else { return nil }
+            return file
+        }.first
+    }
+}

--- a/cli/Tests/TuistGeneratorTests/Mappers/CachedModulesDebuggingGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/CachedModulesDebuggingGraphMapperTests.swift
@@ -1,27 +1,19 @@
+import FileSystem
+import FileSystemTesting
 import Foundation
 import Path
+import Testing
 import TuistCore
-import TuistSupport
 import TuistTesting
 import XcodeGraph
-import XCTest
 @testable import TuistGenerator
 
-final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
-    private var subject: CachedModulesDebuggingGraphMapper!
+struct CachedModulesDebuggingGraphMapperTests {
+    private let subject = CachedModulesDebuggingGraphMapper()
 
-    override func setUp() {
-        super.setUp()
-        subject = CachedModulesDebuggingGraphMapper()
-    }
-
-    override func tearDown() {
-        subject = nil
-        super.tearDown()
-    }
-
-    func test_map_configuresRunAndTestActionsThatUseCachedModules() async throws {
-        let projectPath = try temporaryPath()
+    @Test(.inTemporaryDirectory)
+    func map_configuresRunAndTestActionsThatUseCachedModules() async throws {
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let originalLLDBInitFile = projectPath.appending(components: "Debugger", "custom.lldbinit")
         let cachedFrameworkPath = projectPath.appending(
             components: ".tuist-cache", "hash", "Feature.xcframework"
@@ -87,43 +79,96 @@ final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
             environment: environment
         )
 
-        let mappedScheme = try XCTUnwrap(mappedGraph.projects[projectPath]?.schemes.first)
-        let runAction = try XCTUnwrap(mappedScheme.runAction)
-        let testAction = try XCTUnwrap(mappedScheme.testAction)
-        XCTAssertEqual(runAction.preActions.first?.title, "Update Tuist cache debugger settings")
-        XCTAssertEqual(testAction.preActions.first?.title, "Update Tuist cache debugger settings")
-        XCTAssertEqual(runAction.preActions.first?.target?.name, "App")
-        XCTAssertEqual(testAction.preActions.first?.target?.name, "AppTests")
-        XCTAssertTrue(runAction.customLLDBInitFile?.pathString.hasSuffix("-run.lldbinit") == true)
-        XCTAssertTrue(testAction.customLLDBInitFile?.pathString.hasSuffix("-test.lldbinit") == true)
-        XCTAssertNotNil(mappedGraph.workspace.schemes.first?.runAction?.customLLDBInitFile)
-        XCTAssertNotNil(mappedGraph.workspace.schemes.first?.testAction?.customLLDBInitFile)
+        let mappedScheme = try #require(mappedGraph.projects[projectPath]?.schemes.first)
+        let runAction = try #require(mappedScheme.runAction)
+        let testAction = try #require(mappedScheme.testAction)
+        #expect(runAction.preActions.first?.title == "Update Tuist cache debugger settings")
+        #expect(testAction.preActions.first?.title == "Update Tuist cache debugger settings")
+        #expect(runAction.preActions.first?.target?.name == "App")
+        #expect(testAction.preActions.first?.target?.name == "AppTests")
+        #expect(runAction.customLLDBInitFile?.pathString.hasSuffix("-run.lldbinit") == true)
+        #expect(testAction.customLLDBInitFile?.pathString.hasSuffix("-test.lldbinit") == true)
+        #expect(mappedGraph.workspace.schemes.first?.runAction?.customLLDBInitFile != nil)
+        #expect(mappedGraph.workspace.schemes.first?.testAction?.customLLDBInitFile != nil)
 
-        let runFile = try XCTUnwrap(fileDescriptor(at: runAction.customLLDBInitFile, in: sideEffects))
-        let runContents = try XCTUnwrap(String(data: try XCTUnwrap(runFile.contents), encoding: .utf8))
-        XCTAssertTrue(runContents.contains("command source -s 0 \"\(originalLLDBInitFile.pathString)\""))
-        XCTAssertTrue(runContents.contains(cachedFrameworkPath.parentDirectory.pathString))
-        XCTAssertTrue(runContents.contains("settings set symbols.use-swift-explicit-module-loader false"))
+        let runFile = try #require(fileDescriptor(at: runAction.customLLDBInitFile, in: sideEffects))
+        let runData = try #require(runFile.contents)
+        let runContents = try #require(String(data: runData, encoding: .utf8))
+        #expect(runContents.contains("command source -s 0 \"\(originalLLDBInitFile.pathString)\""))
+        #expect(runContents.contains(cachedFrameworkPath.parentDirectory.pathString))
+        #expect(runContents.contains("settings set symbols.use-swift-explicit-module-loader false"))
 
-        let testFile = try XCTUnwrap(fileDescriptor(at: testAction.customLLDBInitFile, in: sideEffects))
-        let testContents = try XCTUnwrap(String(data: try XCTUnwrap(testFile.contents), encoding: .utf8))
-        XCTAssertTrue(testContents.contains(cachedFrameworkPath.parentDirectory.pathString))
-        XCTAssertTrue(testContents.contains(cachedUIFrameworkPath.parentDirectory.pathString))
-        XCTAssertFalse(testContents.contains("command source"))
+        let testFile = try #require(fileDescriptor(at: testAction.customLLDBInitFile, in: sideEffects))
+        let testData = try #require(testFile.contents)
+        let testContents = try #require(String(data: testData, encoding: .utf8))
+        #expect(testContents.contains(cachedFrameworkPath.parentDirectory.pathString))
+        #expect(testContents.contains(cachedUIFrameworkPath.parentDirectory.pathString))
+        #expect(!testContents.contains("command source"))
 
-        let script = try XCTUnwrap(runAction.preActions.first?.scriptText)
-        XCTAssertTrue(script.contains("symbols.cas-path"))
-        XCTAssertTrue(script.contains("symbols.cas-plugin-path"))
-        XCTAssertTrue(script.contains("symbols.cas-plugin-options"))
-        XCTAssertTrue(script.contains("target.swift-framework-search-paths"))
-        XCTAssertTrue(script.contains("target.swift-module-search-paths"))
-        XCTAssertTrue(script.contains("target.swift-extra-clang-flags"))
-        XCTAssertTrue(script.contains("/^sdk"))
-        XCTAssertTrue(script.contains("symbols.use-swift-explicit-module-loader false"))
+        let script = try #require(runAction.preActions.first?.scriptText)
+        #expect(script.contains("symbols.cas-path"))
+        #expect(script.contains("symbols.cas-plugin-path"))
+        #expect(script.contains("symbols.cas-plugin-options"))
+        #expect(script.contains("target.swift-framework-search-paths"))
+        #expect(script.contains("target.swift-module-search-paths"))
+        #expect(script.contains("target.swift-extra-clang-flags"))
+        #expect(script.contains("/^sdk"))
+        #expect(script.contains("symbols.use-swift-explicit-module-loader false"))
     }
 
-    func test_map_doesNotConfigureRunActionUsingCachedModulesFromALaterBuildTarget() async throws {
-        let projectPath = try temporaryPath()
+    @Test(.inTemporaryDirectory)
+    func map_configuresTestActionsUsingCachedModulesFromTestPlans() async throws {
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
+        let cachedFrameworkPath = projectPath.appending(
+            components: ".tuist-cache", "hash", "Feature.xcframework"
+        )
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let testTarget = TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))
+        let scheme = Scheme.test(
+            testAction: TestAction.test(
+                targets: [],
+                testPlans: [TestPlan(
+                    path: projectPath.appending(component: "App.xctestplan"),
+                    testTargets: [testTarget],
+                    isDefault: true
+                )]
+            ),
+            runAction: nil
+        )
+        let project = Project.test(path: projectPath, targets: [tests, feature], schemes: [scheme])
+        let cachedFramework = GraphDependency.testXCFramework(path: cachedFrameworkPath, linking: .dynamic)
+        let sourceGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "AppTests", path: projectPath): [.target(name: "Feature", path: projectPath)],
+                .target(name: "Feature", path: projectPath): [],
+            ]
+        )
+        let cachedGraph = Graph.test(
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "AppTests", path: projectPath): [cachedFramework],
+                cachedFramework: [],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = sourceGraph
+
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: cachedGraph, environment: environment)
+
+        let testAction = try #require(mappedGraph.projects[projectPath]?.schemes.first?.testAction)
+        #expect(testAction.preActions.first?.title == "Update Tuist cache debugger settings")
+        #expect(testAction.preActions.first?.target == testTarget.target)
+        let testFile = try #require(fileDescriptor(at: testAction.customLLDBInitFile, in: sideEffects))
+        let testData = try #require(testFile.contents)
+        let testContents = try #require(String(data: testData, encoding: .utf8))
+        #expect(testContents.contains(cachedFrameworkPath.parentDirectory.pathString))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func map_doesNotConfigureRunActionUsingCachedModulesFromALaterBuildTarget() async throws {
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let cachedFrameworkPath = projectPath.appending(
             components: ".tuist-cache", "hash", "Feature.xcframework"
         )
@@ -168,12 +213,13 @@ final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
 
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: cachedGraph, environment: environment)
 
-        XCTAssertNil(mappedGraph.projects[projectPath]?.schemes.first?.runAction?.customLLDBInitFile)
-        XCTAssertTrue(sideEffects.isEmpty)
+        #expect(mappedGraph.projects[projectPath]?.schemes.first?.runAction?.customLLDBInitFile == nil)
+        #expect(sideEffects.isEmpty)
     }
 
-    func test_map_doesNotConfigureActionsWhenDebuggerAttachmentIsDisabled() async throws {
-        let projectPath = try temporaryPath()
+    @Test(.inTemporaryDirectory)
+    func map_doesNotConfigureActionsWhenDebuggerAttachmentIsDisabled() async throws {
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let cachedFrameworkPath = projectPath.appending(
             components: ".tuist-cache", "hash", "Feature.xcframework"
         )
@@ -214,12 +260,13 @@ final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
 
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: cachedGraph, environment: environment)
 
-        XCTAssertEqual(mappedGraph, cachedGraph)
-        XCTAssertTrue(sideEffects.isEmpty)
+        #expect(mappedGraph == cachedGraph)
+        #expect(sideEffects.isEmpty)
     }
 
-    func test_map_doesNotConfigureSchemesForPrecompiledDependenciesThatWereAlreadyInTheSourceGraph() async throws {
-        let projectPath = try temporaryPath()
+    @Test(.inTemporaryDirectory)
+    func map_doesNotConfigureSchemesForPrecompiledDependenciesThatWereAlreadyInTheSourceGraph() async throws {
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let frameworkPath = projectPath.appending(components: "Frameworks", "Vendor.xcframework")
         let app = Target.test(name: "App", product: .app)
         let scheme = Scheme.test(
@@ -241,11 +288,11 @@ final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
 
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: environment)
 
-        XCTAssertEqual(mappedGraph, graph)
-        XCTAssertTrue(sideEffects.isEmpty)
+        #expect(mappedGraph == graph)
+        #expect(sideEffects.isEmpty)
     }
 
-    func test_map_doesNothingWithoutTheSourceGraph() async throws {
+    @Test func map_doesNothingWithoutTheSourceGraph() async throws {
         let graph = Graph.test()
 
         let (mappedGraph, sideEffects, _) = try await subject.map(
@@ -253,8 +300,8 @@ final class CachedModulesDebuggingGraphMapperTests: TuistUnitTestCase {
             environment: MapperEnvironment()
         )
 
-        XCTAssertEqual(mappedGraph, graph)
-        XCTAssertTrue(sideEffects.isEmpty)
+        #expect(mappedGraph == graph)
+        #expect(sideEffects.isEmpty)
     }
 
     private func fileDescriptor(


### PR DESCRIPTION
## What changed

Generated Xcode schemes now receive a project-local [Low-Level Debugger](https://lldb.llvm.org/) initialization file when Tuist replaces source targets with cached module artifacts. Launch and test actions configure module search paths, Xcode compilation cache settings, and virtual toolchain path mappings before the debugger starts. Existing custom debugger initialization is sourced first.

Test schemes collect cached artifacts from every test target. Launch schemes follow Xcode's executable or first-build-target selection.

## Why

Swift debugger expressions such as `po` could fail in generated projects that combined Tuist's module cache with Xcode explicit modules and compilation caching. Developers had to maintain machine-specific settings in their global debugger configuration.

## Root cause

The cached producer modules were available to the build, but generated schemes did not provide the debugger with the corresponding cache location, module paths, or virtual toolchain path mappings. The explicit module loader could therefore encounter module references that it could not resolve.

## Approach

The graph mapper compares the original source graph with the final mapped graph. This limits configuration to artifacts introduced by Tuist cache replacement and leaves ordinary precompiled dependencies unchanged. It writes action-specific files under `Derived/TuistCacheDebugging` and refreshes build-setting-dependent values in a scheme pre-action.

## Impact

Projects using cached modules can evaluate Swift expressions without a developer-specific global debugger configuration. Projects without cache replacement are unchanged.

## Validation

- Ran the Tuist command-line interface formatter and linter with `mise run cli:lint --fix`.
- Passed focused mapper and scheme generation tests with `xcodebuild test`.
- Built the Tuist command-line interface with `xcodebuild build`.
- Warmed the Tuist cache, generated the example project with explicit Swift modules and Xcode compilation caching, and built it from cached artifacts.
- Evaluated `po` expressions against cached framework and dynamic library modules in a headless debugger session without module import errors.
