### PR TITLE
fix(cli): allow including local package test targets

### DIFF
--- a/cli/Sources/ProjectDescription/PackageSettings.swift
+++ b/cli/Sources/ProjectDescription/PackageSettings.swift
@@ -51,6 +51,12 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.
     public var projectOptions: [String: Project.Options]
 
+    /// Whether test targets from local path packages declared as external dependencies are included in generated projects.
+    ///
+    /// Packages loaded directly as local projects always include their test targets. Remote package test targets are never
+    /// included. An included test target must depend only on targets from the same package. The default value is `false`.
+    public var includeLocalPackageTestTargets: Bool
+
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
     /// - Parameters:
     ///     - productTypes: The custom `Product` types to be used for SPM targets.
@@ -60,6 +66,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - expectedSignatures: Expected signatures keyed by binary target name.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - includeLocalPackageTestTargets: Whether to include test targets from local path package dependencies.
     public init(
         productTypes: [String: Product] = [:],
         baseProductType: Product = .staticFramework,
@@ -67,7 +74,8 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         baseSettings: Settings = .settings(),
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: Settings] = [:],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -76,6 +84,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
         dumpIfNeeded(self)
     }
 
@@ -88,6 +97,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - expectedSignatures: Expected signatures keyed by binary target name.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - includeLocalPackageTestTargets: Whether to include test targets from local path package dependencies.
     @available(
         *,
         deprecated,
@@ -103,7 +113,8 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         baseSettings: Settings = .settings(),
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: SettingsDictionary],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -112,6 +123,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings.mapValues { .settings(base: $0) }
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
         dumpIfNeeded(self)
     }
 }

--- a/cli/Sources/TuistCore/Models/PackageSettings.swift
+++ b/cli/Sources/TuistCore/Models/PackageSettings.swift
@@ -24,6 +24,9 @@ public struct PackageSettings: Equatable, Codable {
     /// The custom project options for each project generated from a swift package.
     public let projectOptions: [String: XcodeGraph.Project.Options]
 
+    /// Whether test targets from local path package dependencies are included in generated projects.
+    public let includeLocalPackageTestTargets: Bool
+
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
@@ -38,7 +41,8 @@ public struct PackageSettings: Equatable, Codable {
         baseSettings: Settings,
         expectedSignatures: [String: XCFrameworkSignature],
         targetSettings: [String: Settings],
-        projectOptions: [String: XcodeGraph.Project.Options] = [:]
+        projectOptions: [String: XcodeGraph.Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -47,6 +51,7 @@ public struct PackageSettings: Equatable, Codable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
     }
 
     #if DEBUG
@@ -57,7 +62,8 @@ public struct PackageSettings: Equatable, Codable {
             baseSettings: Settings = Settings.default,
             expectedSignatures: [String: XCFrameworkSignature] = [:],
             targetSettings: [String: Settings] = [:],
-            projectOptions: [String: XcodeGraph.Project.Options] = [:]
+            projectOptions: [String: XcodeGraph.Project.Options] = [:],
+            includeLocalPackageTestTargets: Bool = false
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,
@@ -66,7 +72,8 @@ public struct PackageSettings: Equatable, Codable {
                 baseSettings: baseSettings,
                 expectedSignatures: expectedSignatures,
                 targetSettings: targetSettings,
-                projectOptions: projectOptions
+                projectOptions: projectOptions,
+                includeLocalPackageTestTargets: includeLocalPackageTestTargets
             )
         }
     #endif

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -32,7 +32,8 @@ extension TuistCore.PackageSettings {
             baseSettings: baseSettings,
             expectedSignatures: expectedSignatures,
             targetSettings: targetSettings,
-            projectOptions: projectOptions
+            projectOptions: projectOptions,
+            includeLocalPackageTestTargets: manifest.includeLocalPackageTestTargets
         )
     }
 }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -43,6 +43,9 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
     /// Thrown when an included local package test target depends on a product from another package.
     case unsupportedExternalProductInLocalPackageTest(package: String, target: String, product: String)
 
+    /// Thrown when an included local package test target depends on an executable target that is not mapped.
+    case unsupportedExecutableTargetInLocalPackageTest(package: String, target: String, executable: String)
+
     /// Thrown when unsupported `PackageInfo.Target.TargetBuildSettingDescription` `Tool`/`SettingName` pair is found.
     case unsupportedSetting(
         PackageInfo.Target.TargetBuildSettingDescription.Tool,
@@ -75,6 +78,12 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
             The test target `\(target)` in the local package `\(package)` depends on the external product `\(product)`. \
             Tuist can include local package test targets only when all their dependencies belong to the same package. Remove \
             the external product dependency, or set `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
+            """
+        case let .unsupportedExecutableTargetInLocalPackageTest(package, target, executable):
+            return """
+            The test target `\(target)` in the local package `\(package)` depends on the executable target `\(executable)`, \
+            which Tuist omits when mapping local package dependencies. Remove the executable target dependency, or set \
+            `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
             """
         case let .unsupportedSetting(tool, setting):
             return "The \(tool) and \(setting) pair is not a supported setting."
@@ -767,6 +776,24 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 package: packageInfo.name,
                 target: target.name,
                 product: productName
+            )
+        }
+
+        if target.type == .test,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           let executableName = target.dependencies.compactMap({ dependency -> String? in
+               switch dependency {
+               case let .target(name, _), let .byName(name, _):
+                   return targetsByName[name]?.type == .executable ? name : nil
+               case .product:
+                   return nil
+               }
+           }).first
+        {
+            throw PackageInfoMapperError.unsupportedExecutableTargetInLocalPackageTest(
+                package: packageInfo.name,
+                target: target.name,
+                executable: executableName
             )
         }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -40,6 +40,9 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
     /// Thrown when a target defined in a product is not present in the package
     case unknownProductTarget(package: String, product: String, target: String)
 
+    /// Thrown when an included local package test target depends on a product from another package.
+    case unsupportedExternalProductInLocalPackageTest(package: String, target: String, product: String)
+
     /// Thrown when unsupported `PackageInfo.Target.TargetBuildSettingDescription` `Tool`/`SettingName` pair is found.
     case unsupportedSetting(
         PackageInfo.Target.TargetBuildSettingDescription.Tool,
@@ -67,6 +70,12 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
             return "The product \(name) of package \(package) cannot be found."
         case let .unknownProductTarget(package, product, target):
             return "The target \(target) of product \(product) cannot be found in package \(package)."
+        case let .unsupportedExternalProductInLocalPackageTest(package, target, product):
+            return """
+            The test target `\(target)` in the local package `\(package)` depends on the external product `\(product)`. \
+            Tuist can include local package test targets only when all their dependencies belong to the same package. Remove \
+            the external product dependency, or set `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
+            """
         case let .unsupportedSetting(tool, setting):
             return "The \(tool) and \(setting) pair is not a supported setting."
         case let .modulemapMissing(moduleMapPath, package, target):
@@ -89,11 +98,13 @@ public enum PackageType {
         derivedXCFrameworksPath: AbsolutePath? = nil
     )
 
-    fileprivate var includesTestTargets: Bool {
+    fileprivate func includesTestTargets(includeLocalPackageTestTargets: Bool) -> Bool {
         switch self {
         case .local:
             return true
-        case .external:
+        case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
+            return includeLocalPackageTestTargets
+        case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
             return false
         }
     }
@@ -719,7 +730,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
         // Ignores or passes a target based on the `type` and the `packageType`.
         // After that, it assumes that no target is ignored.
         switch target.type {
-        case .test where !packageType.includesTestTargets:
+        case .test where !packageType.includesTestTargets(
+            includeLocalPackageTestTargets: packageSettings.includeLocalPackageTestTargets
+        ):
             Logger.current.debug("Target \(target.name) of type \(target.type) ignored")
             return nil
         case .regular, .system, .macro, .test:
@@ -735,6 +748,26 @@ public struct PackageInfoMapper: PackageInfoMapping {
         default:
             Logger.current.debug("Target \(target.name) of type \(target.type) ignored")
             return nil
+        }
+
+        if target.type == .test,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           let productName = target.dependencies.compactMap({ dependency -> String? in
+               switch dependency {
+               case let .product(name, package: _, moduleAliases: _, condition: _):
+                   return name
+               case let .byName(name, condition: _) where targetsByName[name] == nil:
+                   return name
+               case .target, .byName:
+                   return nil
+               }
+           }).first
+        {
+            throw PackageInfoMapperError.unsupportedExternalProductInLocalPackageTest(
+                package: packageInfo.name,
+                target: target.name,
+                product: productName
+            )
         }
 
         let products = targetToProducts[target.name] ?? Set()

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -255,6 +255,10 @@ struct DependenciesAcceptanceTestIosAppWithLocalSPMPackageGenerate {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+        try TuistTest.expectContainsTarget(
+            "LocalLibTests",
+            inXcodeProj: fixtureDirectory.appending(components: "LocalPackage", "LocalPackage.xcodeproj")
+        )
     }
 }
 
@@ -271,6 +275,61 @@ struct DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies
             ["--path", fixtureDirectory.pathString, "--force-resolved-versions"]
         )
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+    }
+
+    @Test(
+        .withFixture("generated_command_line_tool_with_local_spm_test_only_dependencies"),
+        .inTemporaryDirectory,
+        .timeLimit(.minutes(1))
+    )
+    func install_then_generate_whenLocalPackageTestsAreEnabled_failsForExternalProductDependency() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        try await FileSystem().writeText(
+            """
+            // swift-tools-version: 5.10
+            import PackageDescription
+
+            #if TUIST
+                import struct ProjectDescription.PackageSettings
+
+                let packageSettings = PackageSettings(
+                    productTypes: [
+                        "RuntimeLib": .staticFramework,
+                    ],
+                    includeLocalPackageTestTargets: true
+                )
+            #endif
+
+            let package = Package(
+                name: "CommandLineToolDependencies",
+                dependencies: [
+                    .package(path: "../RuntimePackage"),
+                ]
+            )
+            """,
+            at: fixtureDirectory.appending(components: "Tuist", "Package.swift"),
+            options: [.overwrite]
+        )
+        try await TuistTest.run(
+            InstallCommand.self,
+            ["--path", fixtureDirectory.pathString, "--force-resolved-versions"]
+        )
+
+        do {
+            try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+        } catch {
+            #expect(
+                error.localizedDescription
+                    == """
+                    The test target `RuntimeLibTests` in the local package `RuntimePackage` depends on the external product \
+                    `TestSupport`. Tuist can include local package test targets only when all their dependencies belong to the \
+                    same package. Remove the external product dependency, or set `includeLocalPackageTestTargets` to `false` \
+                    in `PackageSettings`.
+                    """
+            )
+            return
+        }
+        Issue.record("Generate should have failed.")
     }
 }
 

--- a/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
@@ -167,7 +167,8 @@ final class ManifestLoaderTests: TuistTestCase {
         import ProjectDescription
 
         let packageSettings = PackageSettings(
-            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]]
+            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]],
+            includeLocalPackageTestTargets: true
         )
 
         #endif
@@ -202,7 +203,8 @@ final class ManifestLoaderTests: TuistTestCase {
                     "TargetA": .settings(base: [
                         "OTHER_LDFLAGS": "-ObjC",
                     ]),
-                ]
+                ],
+                includeLocalPackageTestTargets: true
             )
         )
     }

--- a/cli/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -61,7 +61,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
 
         given(manifestLoader)
             .loadPackageSettings(at: .any, disableSandbox: .any)
-            .willReturn(.test())
+            .willReturn(.init(includeLocalPackageTestTargets: true))
 
         given(swiftPackageManagerController)
             .getToolsVersion(at: .any)
@@ -85,7 +85,8 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                 defaultSettings: .recommended
             ),
             expectedSignatures: [:],
-            targetSettings: [:]
+            targetSettings: [:],
+            includeLocalPackageTestTargets: true
         )
         verify(manifestLoader)
             .register(plugins: .any)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5501,6 +5501,51 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_whenEnabledExternalLocalPackageTestDependsOnExecutableTarget_throwsConcreteError() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "MyTool"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "MyToolTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When / Then
+        await #expect(
+            throws: PackageInfoMapperError.unsupportedExecutableTargetInLocalPackageTest(
+                package: "Package",
+                target: "MyToolTests",
+                executable: "MyTool"
+            )
+        ) {
+            _ = try await subject.map(
+                package: "Package",
+                basePath: basePath,
+                packageType: .external(origin: .local, artifactPaths: [:]),
+                packageInfos: [
+                    "Package": .test(
+                        name: "Package",
+                        products: [
+                            .init(name: "MyTool", type: .executable, targets: ["MyTool"]),
+                        ],
+                        targets: [
+                            .test(name: "MyTool", type: .executable),
+                            .test(
+                                name: "MyToolTests",
+                                type: .test,
+                                dependencies: [.target(name: "MyTool", condition: nil)]
+                            ),
+                        ],
+                        platforms: [.macos]
+                    ),
+                ],
+                packageSettings: .test(includeLocalPackageTestTargets: true)
+            )
+        }
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenExternalRemoteSwiftPackageHasTestTarget_andTestsAreEnabled_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5401,7 +5401,107 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenExternalRemoteSwiftPackageHasTestTarget() async throws {
+    ) func map_whenExternalLocalSwiftPackageHasTestTarget_andTestsAreEnabled_includesTestTarget() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "TargetTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .external(origin: .local, artifactPaths: [:]),
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
+                    ],
+                    targets: [
+                        .test(name: "Target"),
+                        .test(
+                            name: "TargetTests",
+                            type: .test,
+                            dependencies: [.target(name: "Target", condition: nil)]
+                        ),
+                    ],
+                    platforms: [.ios]
+                ),
+            ],
+            packageSettings: .test(
+                baseSettings: .default,
+                includeLocalPackageTestTargets: true
+            )
+        )
+
+        // Then
+        #expect(project != nil)
+        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target", "TargetTests"]))
+        let testTarget = project?.targets.first(where: { $0.name == "TargetTests" })
+        #expect(testTarget?.product == .unitTests)
+        #expect(testTarget?.metadata.tags.contains(TargetTags.localSwiftPackageTest) == true)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenEnabledExternalLocalPackageTestDependsOnExternalProduct_throwsConcreteError() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "TargetTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When / Then
+        await #expect(
+            throws: PackageInfoMapperError.unsupportedExternalProductInLocalPackageTest(
+                package: "Package",
+                target: "TargetTests",
+                product: "TestSupport"
+            )
+        ) {
+            _ = try await subject.map(
+                package: "Package",
+                basePath: basePath,
+                packageType: .external(origin: .local, artifactPaths: [:]),
+                packageInfos: [
+                    "Package": .test(
+                        name: "Package",
+                        products: [
+                            .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
+                        ],
+                        targets: [
+                            .test(name: "Target"),
+                            .test(
+                                name: "TargetTests",
+                                type: .test,
+                                dependencies: [
+                                    .target(name: "Target", condition: nil),
+                                    .product(
+                                        name: "TestSupport",
+                                        package: "TestSupportPackage",
+                                        moduleAliases: nil,
+                                        condition: nil
+                                    ),
+                                ]
+                            ),
+                        ],
+                        platforms: [.ios]
+                    ),
+                ],
+                packageSettings: .test(includeLocalPackageTestTargets: true)
+            )
+        }
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenExternalRemoteSwiftPackageHasTestTarget_andTestsAreEnabled_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
@@ -5430,7 +5530,8 @@ struct PackageInfoMapperTests {
                     ],
                     platforms: [.ios]
                 ),
-            ]
+            ],
+            packageSettings: .test(includeLocalPackageTestTargets: true)
         )
 
         // Then

--- a/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Package.swift
@@ -9,5 +9,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "LocalLib"),
+        .testTarget(name: "LocalLibTests", dependencies: ["LocalLib"]),
     ]
 )

--- a/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Tests/LocalLibTests/LocalLibTests.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Tests/LocalLibTests/LocalLibTests.swift
@@ -1,0 +1,6 @@
+import LocalLib
+import Testing
+
+@Test func localLibraryCanBeCreated() {
+    _ = LocalLib()
+}

--- a/examples/xcode/generated_ios_app_with_local_spm_package/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/Tuist/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 #if TUIST
     import struct ProjectDescription.PackageSettings
 
-    let packageSettings = PackageSettings(productTypes: [:])
+    let packageSettings = PackageSettings(
+        productTypes: [:],
+        includeLocalPackageTestTargets: true
+    )
 #endif
 
 let package = Package(


### PR DESCRIPTION
## What changed

`PackageSettings` now exposes `includeLocalPackageTestTargets`, defaulting to `false`. When enabled, Tuist includes test targets from local-path packages declared as external dependencies. Tests from remote packages remain excluded.

Generation now stops with a concrete error when an included test target depends on a product from another package. The error identifies the package, test target, and external product, then explains how to proceed.

## Why

PhonePe relied on local package test targets being present in generated projects. [Pull request #11667](https://github.com/tuist/tuist/pull/11667) fixed a generation failure by excluding those targets entirely, which also removed valid tests whose dependencies all belong to the same package.

We want to restore that supported case without silently producing an incomplete dependency graph.

## Root cause

Local-path packages declared through `Tuist/Package.swift` use the external-package generation path. Their test targets can depend on products from other packages, but those test-only products can later be pruned from the generated graph. The previous fix avoided that broken graph by dropping every test target, including tests that only use targets from their own package.

## Approach

The behavior is explicit and backward compatible:

- Existing projects continue to exclude local external package tests by default.
- Projects can opt in through `includeLocalPackageTestTargets: true`.
- Directly loaded local packages continue to include tests as before.
- Remote package tests remain excluded even when the setting is enabled.
- Opted-in tests with cross-package product dependencies fail early with an actionable error.

## Impact

There is no behavior change unless a project enables the new setting. Projects such as PhonePe can restore same-package tests in their generated projects, while unsupported cross-package test dependencies are reported instead of producing a partially usable project.

## Validation

- `mise run cli:lint`
- Focused Xcode tests covering settings loading, package mapping, remote-package exclusion, successful local test inclusion, and the external-product failure path.
- Dependency acceptance tests covering the default behavior, successful test-target generation, and the concrete cross-package dependency error.
