### PR TITLE
fix(server): self-heal missing Kura cache endpoint mirror row

### DIFF
--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -1011,6 +1011,40 @@ defmodule Tuist.Kura do
     {:ok, server}
   end
 
+  @doc """
+  True iff the server's client-facing cache endpoint is already mirrored into
+  `account_cache_endpoints` (the table the CLI resolves).
+
+  Private regions never mirror — their URL is in-cluster only and reachable
+  solely by runner dispatch — so they are always reported as mirrored.
+
+  Public regions must carry the derived `:kura` endpoint row for their current
+  URL. The mirror is written once, when the server transitions into `:active`
+  (`activate_server/2`); the steady-state reconcile otherwise treats a server
+  whose stored URL matches the rendered host as converged and never re-derives
+  it. A public server missing its row — activated before the mirror existed, or
+  with a row pruned out of band — would therefore stay invisible to the CLI
+  forever. Reporting the absent row as out of sync (see `Reconciler`) routes the
+  server back through activation, which re-runs the idempotent mirror insert and
+  self-heals it on the next tick.
+  """
+  def cache_endpoint_mirrored?(%Server{region: region_id} = server) do
+    case Regions.fetch(region_id) do
+      {:ok, region} -> Regions.private?(region) or cache_endpoint_row_present?(server)
+      {:error, _} -> true
+    end
+  end
+
+  defp cache_endpoint_row_present?(%Server{account_id: account_id, url: url}) when is_binary(url) do
+    Repo.exists?(
+      from(e in AccountCacheEndpoint,
+        where: e.account_id == ^account_id and e.technology == :kura and e.url == ^url
+      )
+    )
+  end
+
+  defp cache_endpoint_row_present?(%Server{}), do: true
+
   defp ensure_cache_endpoint(_account, nil), do: :ok
 
   defp ensure_cache_endpoint(account, url) do

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -482,6 +482,14 @@ defmodule Tuist.Kura.Reconciler do
   # not re-written every tick. A non-binary render (e.g. unknown region) leaves
   # the existing `converged?` behaviour untouched.
   #
+  # A matching URL is necessary but not sufficient: the derived `:kura` endpoint
+  # row must also be present. An active public server whose row is missing (e.g.
+  # activated before the mirror existed, or the row pruned out of band) would
+  # otherwise stay converged and invisible to the CLI forever, since the mirror
+  # is only written on the transition into `:active`. `Kura.cache_endpoint_mirrored?/1`
+  # reports the absent row as out of sync so activation re-runs the idempotent
+  # insert and backfills it on the next tick.
+  #
   # Node-port regions are the exception: their dispatch `url` is the
   # node-published `http://<pn-ip>:<node-port>`, which the cluster-DNS template
   # `public_url/2` renders never matches, so this would report drift on every
@@ -493,7 +501,7 @@ defmodule Tuist.Kura.Reconciler do
       true
     else
       case Provisioner.public_url(server.account, server) do
-        url when url == server.url -> true
+        url when url == server.url -> Kura.cache_endpoint_mirrored?(server)
         rendered when is_binary(rendered) -> false
         _ -> true
       end

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -176,6 +176,49 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert [%{url: "http://localhost:4200"}] = Accounts.list_account_cache_endpoints(account, :kura)
   end
 
+  test "re-activates an active public server whose cache-endpoint mirror row is missing" do
+    {account, server, deployment} = create_server()
+    {:ok, server} = Kura.activate_server(server, deployment.image_tag)
+    mark_deployment_succeeded(deployment)
+
+    # The mirror row goes missing while the server stays active on a URL that
+    # still matches the rendered host (activated before the mirror existed, or
+    # the row pruned out of band). The URL matches, so only the mirror-presence
+    # check forces the server back through activation to re-derive the row.
+    [endpoint] = Accounts.list_account_cache_endpoints(account, :kura)
+    {:ok, _} = Accounts.delete_account_cache_endpoint(endpoint)
+    assert [] = Accounts.list_account_cache_endpoints(account, :kura)
+
+    stub(Provisioner, :current_image_tag, fn _ -> {:ok, "0.5.2"} end)
+    stub(Provisioner, :manifest_revision, fn _ -> {:ok, nil} end)
+    stub(Provisioner, :current_manifest_revision, fn _ -> {:ok, "rev"} end)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert %Server{status: :active, url: "http://localhost:4100"} = Repo.get!(Server, server.id)
+    assert [%{url: "http://localhost:4100"}] = Accounts.list_account_cache_endpoints(account, :kura)
+  end
+
+  test "leaves a converged public server with its mirror row present untouched" do
+    {account, server, deployment} = create_server()
+    {:ok, _server} = Kura.activate_server(server, deployment.image_tag)
+    mark_deployment_succeeded(deployment)
+
+    assert [%{url: "http://localhost:4100"}] = Accounts.list_account_cache_endpoints(account, :kura)
+
+    stub(Provisioner, :current_image_tag, fn _ -> {:ok, "0.5.2"} end)
+    stub(Provisioner, :manifest_revision, fn _ -> {:ok, nil} end)
+    stub(Provisioner, :current_manifest_revision, fn _ -> {:ok, "rev"} end)
+
+    # URL matches and the row is present, so the server is converged: it must not
+    # be routed back through activation (no per-tick DB write or broadcast).
+    reject(&Kura.activate_server/2)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert [%{url: "http://localhost:4100"}] = Accounts.list_account_cache_endpoints(account, :kura)
+  end
+
   test "refreshes a converged node-port server instead of re-activating it every tick" do
     {_account, server, deployment} = create_server()
     {:ok, server} = Kura.activate_server(server, deployment.image_tag)

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -631,6 +631,48 @@ defmodule Tuist.KuraTest do
     end
   end
 
+  describe "cache_endpoint_mirrored?/1" do
+    test "is true for a private region regardless of any mirror row" do
+      server = %Server{region: "scw-fr-par-runners", account_id: Ecto.UUID.generate(), url: "http://in-cluster:4000"}
+
+      assert Kura.cache_endpoint_mirrored?(server)
+    end
+
+    test "is true for an unknown region" do
+      server = %Server{region: "moon", account_id: Ecto.UUID.generate(), url: "https://x.kura.tuist.dev"}
+
+      assert Kura.cache_endpoint_mirrored?(server)
+    end
+
+    test "is false for a public region whose mirror row is absent" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      server = %Server{
+        region: "eu-central",
+        account_id: account.id,
+        url: "https://#{account.name}-eu-central-1.kura.tuist.dev"
+      }
+
+      refute Kura.cache_endpoint_mirrored?(server)
+    end
+
+    test "is true for a public region whose mirror row is present" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      url = "https://#{account.name}-eu-central-1.kura.tuist.dev"
+
+      {:ok, _} =
+        %AccountCacheEndpoint{}
+        |> AccountCacheEndpoint.create_changeset(%{account_id: account.id, url: url, technology: :kura})
+        |> Repo.insert()
+
+      server = %Server{region: "eu-central", account_id: account.id, url: url}
+
+      assert Kura.cache_endpoint_mirrored?(server)
+    end
+  end
+
   describe "refresh_private_server_url/1" do
     setup do
       stub(Tuist.Environment, :dev?, fn -> false end)


### PR DESCRIPTION
## What changed

The Kura reconciler now self-heals a missing `account_cache_endpoints` mirror row for an active public region, instead of only writing it once at activation. A new `Kura.cache_endpoint_mirrored?/1` reports whether the derived `:kura` endpoint row exists for a server's current URL, and the reconciler's `endpoint_in_sync?/1` consults it in the URL-matches branch rather than returning a bare `true`.

## Why it changed (the bug)

A Tuist-managed Kura region can be **Active** (its `kura_servers` row healthy, its public `<account>-<region>.kura.tuist.dev` host serving `/up`) while the CLI never routes to it. `GET /api/cache/endpoints` with the `kura` client feature flag returns only the legacy `cache-<region>.tuist.dev` regionals, so `tuist setup cache` and subsequent builds keep using the legacy cache and the Kura node sits unused. This blocks the trunk-scoped Xcode CAS snapshot feature (#11866), which needs the account routed to its Kura node to be validated at real WAN RTT.

## Root cause

This is a mirror gap, not deploy skew. The observed deployed server already includes the commit that dropped the `:kura_cache` feature flag (#11944), so the read path is ungated and simply queries `AccountCacheEndpoint(technology: :kura)`.

That derived row is written only once, when a server transitions into `:active` (`Kura.activate_server/2` calls `ensure_cache_endpoint/2`). The steady-state reconciler re-derives status every tick, but `converge/2` short-circuits when `converged? and endpoint_in_sync?`. The problem: `endpoint_in_sync?/1` only compared the rendered `public_url` against `kura_servers.url`. It never checked that the mirror row actually exists.

So an active public server whose stored URL matches the rendered host but whose mirror row is absent (activated before the mirror logic existed, or the row pruned out of band during a URL change or handoff) is treated as in sync forever. `ensure_cache_endpoint/2` never re-runs, the row stays missing, and the account is silently pinned to the legacy cache with no self-heal path.

### Regression source

The incomplete convergence check was introduced in #11270 ("scope managed-region public hosts per environment"). That PR added the `converged? and endpoint_in_sync?` gate and `endpoint_in_sync?/1` itself to re-derive the mirror when a managed region's public host is renamed, and in the same change added `prune_superseded_cache_endpoint/3`, a `Repo.delete_all` that removes the old mirror row during such a rename. It paired a row-deletion path with a heal check that keys only on the URL: once the server settles on a URL that matches the render, an absent row is never re-created. This change extends that same `endpoint_in_sync?/1` to also require the row's presence.

Separately, #11944 ("make Kura cache routing CLI-driven and drop the :kura_cache flag") made CLI routing depend solely on the mirror row (no feature-flag gate), which is what turns a missing row into a user-visible routing regression rather than an account that was simply not opted in.

## Why this solution

The reconciler is already the authority that re-derives state every tick, and it already has a precedent for routing a converged server back through activation when its URL drifts. Extending the same in-sync gate to also require the mirror row keeps a single convergence path and reuses the existing idempotent (`on_conflict: :nothing`) insert. A missing row now reports out of sync, the server routes through the endpoint-gated `activate_server`, and the row is rewritten. This means:

- The stranded row backfills automatically within one reconcile tick (~30s) after deploy, with no manual production DB write.
- Any other account in the same state is fixed by the same mechanism.
- Steady-state nodes with the row present stay a per-tick no-op (no extra DB write or broadcast), and private regions (which deliberately never mirror) are always reported as mirrored.

The obvious alternative, a one-off backfill migration for the affected account, would fix the symptom for one account without closing the recurrence, and would still leave the reconciler unable to heal the class of failure.

## Impact

- Accounts with a healthy managed Kura region but a missing mirror row start being surfaced to the CLI, so `tuist setup cache` and builds route to Kura instead of the legacy cache.
- No schema or API changes; no data-export surface change.

## Validation

`mix test test/tuist/kura/reconciler_test.exs test/tuist/kura_test.exs` passes (93 tests), `mix credo` clean on the changed modules. New coverage:

- Reconciler re-activates an active public server whose mirror row was deleted and re-derives the row.
- Reconciler leaves a converged public server with its row present untouched (no re-activation).
- `cache_endpoint_mirrored?/1` returns true for private and unknown regions and reflects row presence for public regions.

Final production validation (the CLI resolving `<account>-<region>.kura.tuist.dev` and a non-404 `get_snapshot`) lands once this deploys and the reconciler heals the row on the running server.
