### PR TITLE
feat(server): serve runner dispatch queue reads from Postgres behind a kill switch

### DIFF
--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -83,6 +83,14 @@ defmodule Tuist.Runners.Jobs do
   # still-claimable job is never pruned out of view.
   @queued_lookback_seconds 7 * 86_400
 
+  # Kill switch for reading the dispatch queue from Postgres
+  # (`Tuist.Runners.WorkflowJobs`) instead of ClickHouse. Default OFF:
+  # the ClickHouse paths below stay authoritative, and disabling the
+  # flag is an instant rollback with no deploy. Gate flipping is
+  # driven by `Tuist.Runners.Workers.JobStateDriftWorker` reporting
+  # zero drift between the two stores.
+  @postgres_reads_flag :runner_dispatch_postgres_reads
+
   @doc """
   Serializes GitHub workflow_job events for a single `workflow_job_id`.
 
@@ -309,6 +317,33 @@ defmodule Tuist.Runners.Jobs do
   def pick_queued_top_k(fleet_name, ineligible_account_ids, excluded_repositories, excluded_workflow_job_ids, k)
       when is_binary(fleet_name) and is_list(ineligible_account_ids) and is_list(excluded_repositories) and
              is_list(excluded_workflow_job_ids) and is_integer(k) and k > 0 do
+    if postgres_reads_enabled?() do
+      WorkflowJobs.pick_queued_top_k(
+        fleet_name,
+        ineligible_account_ids,
+        excluded_repositories,
+        excluded_workflow_job_ids,
+        k,
+        queued_lookback_floor()
+      )
+    else
+      pick_queued_top_k_clickhouse(
+        fleet_name,
+        ineligible_account_ids,
+        excluded_repositories,
+        excluded_workflow_job_ids,
+        k
+      )
+    end
+  end
+
+  defp pick_queued_top_k_clickhouse(
+         fleet_name,
+         ineligible_account_ids,
+         excluded_repositories,
+         excluded_workflow_job_ids,
+         k
+       ) do
     lookback_floor = queued_lookback_floor()
 
     from(j in Job,
@@ -934,16 +969,20 @@ defmodule Tuist.Runners.Jobs do
   def queued_count_by_fleet(fleet_name) when is_binary(fleet_name) do
     lookback_floor = queued_lookback_floor()
 
-    inner =
-      from j in Job,
-        where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
-        group_by: j.workflow_job_id,
-        having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
-        select: j.workflow_job_id
+    if postgres_reads_enabled?() do
+      WorkflowJobs.queued_count_by_fleet(fleet_name, lookback_floor)
+    else
+      inner =
+        from j in Job,
+          where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
+          group_by: j.workflow_job_id,
+          having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
+          select: j.workflow_job_id
 
-    from(s in subquery(inner), select: count())
-    |> ClickHouseRepo.one()
-    |> Kernel.||(0)
+      from(s in subquery(inner), select: count())
+      |> ClickHouseRepo.one()
+      |> Kernel.||(0)
+    end
   end
 
   @doc """
@@ -956,22 +995,26 @@ defmodule Tuist.Runners.Jobs do
   def queued_count_by_fleet_and_account(fleet_name) when is_binary(fleet_name) do
     lookback_floor = queued_lookback_floor()
 
-    inner =
-      from j in Job,
-        where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
-        group_by: j.workflow_job_id,
-        having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
-        select: %{
-          workflow_job_id: j.workflow_job_id,
-          account_id: fragment("argMax(?, ?)", j.account_id, j.updated_at)
-        }
+    if postgres_reads_enabled?() do
+      WorkflowJobs.queued_count_by_fleet_and_account(fleet_name, lookback_floor)
+    else
+      inner =
+        from j in Job,
+          where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
+          group_by: j.workflow_job_id,
+          having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
+          select: %{
+            workflow_job_id: j.workflow_job_id,
+            account_id: fragment("argMax(?, ?)", j.account_id, j.updated_at)
+          }
 
-    from(s in subquery(inner),
-      group_by: s.account_id,
-      select: {s.account_id, count()}
-    )
-    |> ClickHouseRepo.all()
-    |> Map.new()
+      from(s in subquery(inner),
+        group_by: s.account_id,
+        select: {s.account_id, count()}
+      )
+      |> ClickHouseRepo.all()
+      |> Map.new()
+    end
   end
 
   @doc """
@@ -1419,6 +1462,10 @@ defmodule Tuist.Runners.Jobs do
 
   defp queued_lookback_floor do
     DateTime.add(DateTime.utc_now(), -@queued_lookback_seconds, :second)
+  end
+
+  defp postgres_reads_enabled? do
+    FunWithFlags.enabled?(@postgres_reads_flag)
   end
 
   defp latest_runner_runs_by_id(runs) do

--- a/server/lib/tuist/runners/workflow_jobs.ex
+++ b/server/lib/tuist/runners/workflow_jobs.ex
@@ -190,6 +190,79 @@ defmodule Tuist.Runners.WorkflowJobs do
   def record_execution(_runner_name, _executed_workflow_job_id, _account_id), do: :ok
 
   @doc """
+  Postgres twin of `Tuist.Runners.Jobs.pick_queued_top_k/5`, returning
+  the same candidate map shape in the same deterministic
+  `(enqueued_at ASC, workflow_job_id ASC)` order. `enqueued_floor`
+  mirrors the ClickHouse read's lookback bound so a flag flip cannot
+  resurface jobs the CH path had already aged out of view.
+  """
+  def pick_queued_top_k(
+        fleet_name,
+        ineligible_account_ids,
+        excluded_repositories,
+        excluded_workflow_job_ids,
+        k,
+        %DateTime{} = enqueued_floor
+      )
+      when is_binary(fleet_name) and is_integer(k) and k > 0 do
+    from(j in WorkflowJob,
+      where: j.fleet_name == ^fleet_name and j.status == "queued" and j.enqueued_at > ^enqueued_floor,
+      order_by: [asc: j.enqueued_at, asc: j.workflow_job_id],
+      limit: ^k,
+      select: %{
+        workflow_job_id: j.workflow_job_id,
+        account_id: j.account_id,
+        fleet_name: j.fleet_name,
+        platform: j.platform,
+        vcpus: j.vcpus,
+        memory_gb: j.memory_gb,
+        repository: j.repository,
+        workflow_run_id: j.workflow_run_id,
+        workflow_name: j.workflow_name,
+        run_attempt: j.run_attempt,
+        job_name: j.job_name,
+        head_branch: j.head_branch,
+        head_sha: j.head_sha,
+        enqueued_at: j.enqueued_at,
+        requested_dispatch_label: j.requested_dispatch_label
+      }
+    )
+    |> exclude_accounts(ineligible_account_ids)
+    |> exclude_repositories(excluded_repositories)
+    |> exclude_workflow_jobs(excluded_workflow_job_ids)
+    |> Repo.all()
+    |> case do
+      [] -> {:error, :empty}
+      candidates -> {:ok, candidates}
+    end
+  end
+
+  @doc """
+  Postgres twin of `Tuist.Runners.Jobs.queued_count_by_fleet/1`.
+  """
+  def queued_count_by_fleet(fleet_name, %DateTime{} = enqueued_floor) when is_binary(fleet_name) do
+    Repo.aggregate(
+      from(j in WorkflowJob,
+        where: j.fleet_name == ^fleet_name and j.status == "queued" and j.enqueued_at > ^enqueued_floor
+      ),
+      :count
+    )
+  end
+
+  @doc """
+  Postgres twin of `Tuist.Runners.Jobs.queued_count_by_fleet_and_account/1`.
+  """
+  def queued_count_by_fleet_and_account(fleet_name, %DateTime{} = enqueued_floor) when is_binary(fleet_name) do
+    from(j in WorkflowJob,
+      where: j.fleet_name == ^fleet_name and j.status == "queued" and j.enqueued_at > ^enqueued_floor,
+      group_by: j.account_id,
+      select: {j.account_id, count()}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
   Rows whose `updated_at` falls in `(updated_after, updated_before)`,
   newest first, capped at `limit`. Feeds the drift comparator: the
   upper bound keeps rows mid-transition (Postgres committed, the
@@ -268,6 +341,24 @@ defmodule Tuist.Runners.WorkflowJobs do
 
   defp blank_to_nil(""), do: nil
   defp blank_to_nil(value), do: value
+
+  defp exclude_accounts(query, []), do: query
+
+  defp exclude_accounts(query, account_ids) when is_list(account_ids) do
+    where(query, [j], j.account_id not in ^account_ids)
+  end
+
+  defp exclude_repositories(query, []), do: query
+
+  defp exclude_repositories(query, repositories) when is_list(repositories) do
+    where(query, [j], j.repository not in ^repositories)
+  end
+
+  defp exclude_workflow_jobs(query, []), do: query
+
+  defp exclude_workflow_jobs(query, workflow_job_ids) when is_list(workflow_job_ids) do
+    where(query, [j], j.workflow_job_id not in ^workflow_job_ids)
+  end
 
   defp completion_recorded?(workflow_job_id) do
     Repo.exists?(from(completion in JobCompletion, where: completion.workflow_job_id == ^workflow_job_id))

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.Runners.JobsTest do
   use TuistTestSupport.Cases.DataCase, async: true
 
   import Ecto.Query
+  import Mimic
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.IngestRepo
@@ -13,6 +14,7 @@ defmodule Tuist.Runners.JobsTest do
   alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Telemetry
   alias Tuist.Runners.WorkflowJob
+  alias Tuist.Runners.WorkflowJobs
   alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
@@ -1356,6 +1358,65 @@ defmodule Tuist.Runners.JobsTest do
       row = Repo.get!(WorkflowJob, 9603)
       assert row.status == "cancelled"
       assert row.conclusion == "cancelled"
+    end
+  end
+
+  describe "postgres dispatch reads behind :runner_dispatch_postgres_reads" do
+    setup do
+      stub(FunWithFlags, :enabled?, fn
+        :runner_dispatch_postgres_reads -> true
+        _other -> false
+      end)
+
+      :ok
+    end
+
+    test "pick_queued_top_k/5 serves candidates from the Postgres lifecycle table" do
+      account = account_fixture()
+      now = DateTime.utc_now()
+
+      :ok =
+        WorkflowJobs.upsert_queued(%{
+          workflow_job_id: 9610,
+          account_id: account.id,
+          fleet_name: "fleet-pg-reads",
+          platform: "linux",
+          vcpus: 4,
+          memory_gb: 16,
+          repository: "acme/cli",
+          workflow_run_id: 96_100,
+          workflow_name: "CI",
+          run_attempt: 1,
+          job_name: "build",
+          head_branch: "main",
+          head_sha: "deadbeef",
+          requested_dispatch_label: "tuist-linux",
+          enqueued_at: DateTime.add(now, -60, :second)
+        })
+
+      assert {:ok, [candidate]} = Jobs.pick_queued_top_k("fleet-pg-reads", [], [], [], 20)
+      assert candidate.workflow_job_id == 9610
+      assert candidate.fleet_name == "fleet-pg-reads"
+      assert candidate.platform == "linux"
+      assert candidate.requested_dispatch_label == "tuist-linux"
+
+      assert {:ok, ^candidate} = Jobs.pick_queued("fleet-pg-reads", [])
+    end
+
+    test "queued counts come from the Postgres lifecycle table" do
+      account = account_fixture()
+
+      for workflow_job_id <- [9620, 9621] do
+        :ok =
+          WorkflowJobs.upsert_queued(%{
+            workflow_job_id: workflow_job_id,
+            account_id: account.id,
+            fleet_name: "fleet-pg-counts"
+          })
+      end
+
+      assert Jobs.queued_count_by_fleet("fleet-pg-counts") == 2
+      assert Jobs.queued_count_by_fleet_and_account("fleet-pg-counts") == %{account.id => 2}
     end
   end
 end

--- a/server/test/tuist/runners/workflow_jobs_test.exs
+++ b/server/test/tuist/runners/workflow_jobs_test.exs
@@ -264,4 +264,87 @@ defmodule Tuist.Runners.WorkflowJobsTest do
       assert [%{status: "queued", enqueued_at: %DateTime{}}] = rows
     end
   end
+
+  describe "pick_queued_top_k/6" do
+    test "returns queued candidates in (enqueued_at, workflow_job_id) order with the CH candidate shape" do
+      account = account_fixture()
+      now = DateTime.utc_now()
+      floor = DateTime.add(now, -7 * 86_400, :second)
+
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_061, enqueued_at: DateTime.add(now, -60, :second)))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_060, enqueued_at: DateTime.add(now, -120, :second)))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_062, enqueued_at: DateTime.add(now, -30, :second)))
+
+      assert {:ok, [first, second, third]} = WorkflowJobs.pick_queued_top_k("fleet-a", [], [], [], 20, floor)
+
+      assert [first.workflow_job_id, second.workflow_job_id, third.workflow_job_id] == [910_060, 910_061, 910_062]
+
+      assert %{
+               workflow_job_id: 910_060,
+               account_id: _,
+               fleet_name: "fleet-a",
+               platform: "linux",
+               vcpus: 4,
+               memory_gb: 16,
+               repository: "acme/cli",
+               workflow_run_id: _,
+               workflow_name: "CI",
+               run_attempt: 1,
+               job_name: "build",
+               head_branch: "main",
+               head_sha: "deadbeef",
+               enqueued_at: %DateTime{},
+               requested_dispatch_label: "tuist-linux"
+             } = first
+    end
+
+    test "applies the account, repository, and workflow_job exclusions" do
+      account = account_fixture()
+      excluded_account = account_fixture()
+      floor = DateTime.add(DateTime.utc_now(), -7 * 86_400, :second)
+
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_070))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_071))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_072, repository: "acme/other"))
+      :ok = WorkflowJobs.upsert_queued(attrs(excluded_account, 910_073))
+
+      assert {:ok, [candidate]} =
+               WorkflowJobs.pick_queued_top_k("fleet-a", [excluded_account.id], ["acme/other"], [910_070], 20, floor)
+
+      assert candidate.workflow_job_id == 910_071
+    end
+
+    test "skips non-queued rows and rows older than the floor" do
+      account = account_fixture()
+      now = DateTime.utc_now()
+      floor = DateTime.add(now, -7 * 86_400, :second)
+
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_080))
+      :ok = WorkflowJobs.transition_claimed(910_080, "pod-1", now)
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_081, enqueued_at: DateTime.add(now, -8 * 86_400, :second)))
+
+      assert {:error, :empty} = WorkflowJobs.pick_queued_top_k("fleet-a", [], [], [], 20, floor)
+    end
+  end
+
+  describe "queued counts" do
+    test "count totals and per-account breakdown match the queued rows" do
+      account = account_fixture()
+      other_account = account_fixture()
+      floor = DateTime.add(DateTime.utc_now(), -7 * 86_400, :second)
+
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_090))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_091))
+      :ok = WorkflowJobs.upsert_queued(attrs(other_account, 910_092))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_093, fleet: "fleet-b"))
+      :ok = WorkflowJobs.transition_claimed(910_091, "pod-1", DateTime.utc_now())
+
+      assert WorkflowJobs.queued_count_by_fleet("fleet-a", floor) == 2
+
+      assert WorkflowJobs.queued_count_by_fleet_and_account("fleet-a", floor) == %{
+               account.id => 1,
+               other_account.id => 1
+             }
+    end
+  end
 end


### PR DESCRIPTION
Part 3/4 of the runner-state consolidation stack (Track A), split out of #12022. Stack: #12028 → #12029 → **this PR** → #12031 (CH outbox). Base is #12029's branch; retarget as the stack merges.

## What

Postgres implementations of the dispatch queue reads, behind a single FunWithFlags kill switch `:runner_dispatch_postgres_reads`, **default OFF**:

- `Jobs.pick_queued_top_k/5` — the dispatch hot path's candidate selection
- `Jobs.queued_count_by_fleet/1` and `queued_count_by_fleet_and_account/1` — the autoscaler's demand reads (the latter is #11981's dispatchable-demand read)

The Postgres twins return the exact candidate map shape in the same deterministic `(enqueued_at ASC, workflow_job_id ASC)` order, honor the same account/repository/workflow_job exclusions, and floor on the same 7-day `enqueued_at` lookback — so a flag flip cannot resurface jobs the ClickHouse path had already aged out of view, and a flip back is behaviorally seamless.

## Why a flag rather than a cutover

ClickHouse remains the default read path and the instant, no-deploy rollback. The flag only flips once #12029's drift comparator holds at zero over a bake window — that's the whole point of the ordering in this stack. Once flipped and baked, the follow-ups (out of scope here) are deleting the CH read path's anti-list, lookback floor, and head-blocking logic.

Worth noting what the PG read structurally fixes: the CH read needs the claims anti-list because CH can say `queued` while PG holds a live claim; the PG lifecycle row transitions to `claimed` in the claim's own transaction, so the queued scan and the claim state can't disagree. The anti-list still applies while the flag is on (kept for parity during rollout), it just stops being load-bearing.

## Validation

- 548 tests green across the runners suite, including flag-on tests proving `pick_queued_top_k`/`pick_queued` and both queued counts serve from Postgres, plus candidate-shape/ordering/exclusion/floor parity tests on the PG implementations.
- `mix compile --warnings-as-errors`, credo clean, formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
