### PR TITLE
fix(infra): widen tart push retry budget with growing backoff

### DIFF
--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -53,7 +53,7 @@ jobs:
     # push the build step alone past 50 min (26.6 took ~54 min) and
     # leave no room to push before a 60-min cap. 90 gives headroom for
     # the slow first build of a new major plus the multi-GB GHCR push.
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 
@@ -196,24 +196,35 @@ jobs:
         # Direct tart push. Cirrus uses the same path to publish
         # macos-tahoe-xcode at the same size; the prior bridge through
         # a local registry + skopeo was added after failures on a
-        # different host whose network was structurally bad. Outer 3x
-        # retry stays as belt-and-braces; blob uploads are content-
-        # addressed so a re-push only re-uploads layers that didn't
-        # make it on the previous attempt.
+        # different host whose network was structurally bad. 5 attempts
+        # with growing backoff — blob uploads are content-addressed so
+        # each retry only re-uploads layers that didn't land on the
+        # previous attempt, and the backoff spreads attempts past
+        # upload-path degradation windows (see
+        # server-production-deployment.yml's
+        # release-xcresult-processor-image push step).
         run: |
           set -euo pipefail
           TAG="${{ steps.build.outputs.tag }}"
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
             if tart push macos-tahoe-xcode "ghcr.io/tuist/macos-tahoe-xcode:${TAG}"; then
               echo "Pushed ghcr.io/tuist/macos-tahoe-xcode:${TAG} on attempt ${attempt}"
               exit 0
             fi
-            echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-            sleep 60
+            if [ "$attempt" = 5 ]; then
+              echo "tart push failed five times in a row" >&2
+              exit 1
+            fi
+            case "$attempt" in
+              1) delay=60 ;;
+              2) delay=120 ;;
+              3) delay=300 ;;
+              *) delay=600 ;;
+            esac
+            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+            sleep "$delay"
           done
-          echo "tart push failed three times in a row" >&2
-          exit 1
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 60
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@v4
 
@@ -146,27 +146,37 @@ jobs:
         # Direct tart push. Cirrus uses the same path to publish
         # macos-tahoe-xcode at the same size; the prior bridge through
         # a local registry was an unsuccessful workaround on a
-        # different host's structurally bad network. Outer 3× retry
-        # stays as belt-and-braces; blob uploads are content-
-        # addressed so a re-push only re-uploads layers that didn't
-        # make it on the previous attempt.
+        # different host's structurally bad network. 5 attempts with
+        # growing backoff — blob uploads are content-addressed so each
+        # retry only re-uploads layers that didn't land on the previous
+        # attempt, and the backoff spreads attempts past upload-path
+        # degradation windows (see server-production-deployment.yml's
+        # release-xcresult-processor-image push step).
         run: |
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"
           PROFILE="${{ steps.build.outputs.profile }}"
           TAG="${PROFILE}-${GIT_SHA}"
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
             if tart push tuist-runner "ghcr.io/tuist/tuist-runner:${TAG}"; then
               echo "Pushed ghcr.io/tuist/tuist-runner:${TAG} on attempt ${attempt}"
               echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-            sleep 60
+            if [ "$attempt" = 5 ]; then
+              echo "tart push failed five times in a row" >&2
+              exit 1
+            fi
+            case "$attempt" in
+              1) delay=60 ;;
+              2) delay=120 ;;
+              3) delay=300 ;;
+              *) delay=600 ;;
+            esac
+            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+            sleep "$delay"
           done
-          echo "tart push failed three times in a row" >&2
-          exit 1
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -929,7 +929,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.xcresult-processor-image-should-release == 'true'
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 60
+    timeout-minutes: 100
     env:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       MISE_GITHUB_TOKEN: ${{ github.token }}
@@ -1047,32 +1047,42 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Direct tart push with a 3x retry — identical shape to
-        # macos-xcode-image.yml, which publishes the same-size image via
-        # the same path and is the only large tart push that pushes
-        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
-        # and a clone-the-base "restore nvram.bin" step; both failed to
-        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
-        # and the disk-heavy restore made it worse (the whole VM bundle
-        # vanished mid-push). Blob uploads are content-addressed, so a
-        # re-push only re-uploads layers that didn't land last time.
+        # Direct tart push, 5 attempts per tag with growing backoff.
+        # Blob uploads are content-addressed, so attempts are the unit
+        # of forward progress: each retry skips layers that already
+        # landed and uploads the next chunk. Pushes stall when upload
+        # flows to GitHub's edge die mid-request (host/IP-path
+        # dependent, can persist for tens of minutes), so the backoff
+        # spreads attempts past a degradation window instead of
+        # burning them all inside one. Earlier attempts here layered
+        # on TART_NO_AUTO_PRUNE and a clone-the-base "restore
+        # nvram.bin" step; both failed to fix the intermittent
+        # `Error: The file "nvram.bin" doesn't exist` and the
+        # disk-heavy restore made it worse (the whole VM bundle
+        # vanished mid-push).
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
           for dest_tag in "${VERSION}" "latest"; do
             DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
-            for attempt in 1 2 3; do
+            for attempt in 1 2 3 4 5; do
               echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
               if tart push tuist-xcresult-processor "$DST"; then
                 echo "Pushed ${DST} on attempt ${attempt}"
                 break
               fi
-              if [ "$attempt" = 3 ]; then
-                echo "tart push failed three times for ${dest_tag}" >&2
+              if [ "$attempt" = 5 ]; then
+                echo "tart push failed five times for ${dest_tag}" >&2
                 exit 1
               fi
-              echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-              sleep 60
+              case "$attempt" in
+                1) delay=60 ;;
+                2) delay=120 ;;
+                3) delay=300 ;;
+                *) delay=600 ;;
+              esac
+              echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+              sleep "$delay"
             done
           done
 
@@ -1117,7 +1127,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.runner-image-should-release == 'true'
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 60
+    timeout-minutes: 100
     strategy:
       # If any profile build fails, abort sibling builds so the chart
       # pin doesn't move to a partially-published set.
@@ -1212,28 +1222,36 @@ jobs:
         # Push both the immutable per-version tag and the rolling
         # `:<profile>` tag so the chart's tag template stays valid
         # without overrides while operators can still pin to a
-        # specific version when they need to roll back. 3× retry per
-        # tag — blob uploads are content-addressed so a re-push only
-        # re-uploads layers that didn't make it on the previous
-        # attempt.
+        # specific version when they need to roll back. 5 attempts
+        # per tag with growing backoff — blob uploads are content-
+        # addressed so each retry only re-uploads layers that didn't
+        # land on the previous attempt, and the backoff spreads
+        # attempts past upload-path degradation windows (see the
+        # release-xcresult-processor-image push step).
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.runner-image-next-version-number }}"
           PROFILE="${{ steps.build.outputs.profile }}"
           for dest_tag in "${PROFILE}-${VERSION}" "${PROFILE}"; do
             DST="ghcr.io/tuist/tuist-runner:${dest_tag}"
-            for attempt in 1 2 3; do
+            for attempt in 1 2 3 4 5; do
               echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
               if tart push tuist-runner "$DST"; then
                 echo "Pushed ${DST} on attempt ${attempt}"
                 break
               fi
-              if [ "$attempt" = 3 ]; then
-                echo "tart push failed three times for ${dest_tag}" >&2
+              if [ "$attempt" = 5 ]; then
+                echo "tart push failed five times for ${dest_tag}" >&2
                 exit 1
               fi
-              echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-              sleep 60
+              case "$attempt" in
+                1) delay=60 ;;
+                2) delay=120 ;;
+                3) delay=300 ;;
+                *) delay=600 ;;
+              esac
+              echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+              sleep "$delay"
             done
           done
 

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 60
+    timeout-minutes: 100
     env:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       MISE_VERSION: "2026.5.15"
@@ -139,32 +139,41 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Direct tart push with a 3x retry — identical shape to
-        # macos-xcode-image.yml, which publishes the same-size image via
-        # the same path and is the only large tart push that pushes
-        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
-        # and a clone-the-base "restore nvram.bin" step; both failed to
-        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
-        # and the disk-heavy restore made it worse (the whole VM bundle
-        # vanished mid-push). Blob uploads are content-addressed, so a
-        # re-push only re-uploads layers that didn't land last time.
+        # Direct tart push, 5 attempts with growing backoff — blob
+        # uploads are content-addressed so each retry only re-uploads
+        # layers that didn't land on the previous attempt, and the
+        # backoff spreads attempts past upload-path degradation windows
+        # (see server-production-deployment.yml's
+        # release-xcresult-processor-image push step). Earlier attempts
+        # here layered on TART_NO_AUTO_PRUNE and a clone-the-base
+        # "restore nvram.bin" step; both failed to fix the intermittent
+        # `Error: The file "nvram.bin" doesn't exist` and the disk-heavy
+        # restore made it worse (the whole VM bundle vanished mid-push).
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"
           DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
             if tart push tuist-xcresult-processor "$DST"; then
               echo "Pushed ${DST} on attempt ${attempt}"
               exit 0
             fi
-            echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-            sleep 60
+            if [ "$attempt" = 5 ]; then
+              echo "tart push failed five times in a row" >&2
+              exit 1
+            fi
+            case "$attempt" in
+              1) delay=60 ;;
+              2) delay=120 ;;
+              3) delay=300 ;;
+              *) delay=600 ;;
+            esac
+            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+            sleep "$delay"
           done
-          echo "tart push failed three times in a row" >&2
-          exit 1
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## What changed

All five `tart push` retry loops (the two builder-fleet push steps in `server-production-deployment.yml`, plus `runner-image.yml`, `xcresult-processor-image.yml`, and `macos-xcode-image.yml`) go from 3 attempts with a flat 60s sleep to 5 attempts with growing backoff (60/120/300/600s). The affected job timeouts move from 60 to 100 minutes (`macos-xcode-image` from 90 to 120) to cover the wider budget.

## Why

The "Release xcresult processor image" job failed its push again in [run 29949005455](https://github.com/tuist/tuist/actions/runs/29949005455/job/89038891407), the latest of several such failures. Investigation (node network metrics for both builder hosts across every push attempt that day, plus live SSH debugging on the host mid-stall) pinned down the actual failure mode:

- The builder host itself is healthy: 1 Gbps link with zero interface errors, 765 Mbps measured uplink to a non-GitHub target, GHCR downloads at 500+ Mbps.
- Upload TCP flows to GitHub's registry ingest die mid-request: caught live as a connection in FIN_WAIT_1 with 4 MB un-ACKed in the send queue and 12 seconds of total wire silence on the flows while tart sat in its 60s request-timeout loop. ICMP to the same endpoints stays clean.
- It is host/egress-IP specific: the sibling builder pushed ~12 GB at ~400 Mbps with zero retries during the same minutes, and conversely the failing host's push crawled at ~5 Mbps while the sibling was fully idle. It is not fleet bandwidth contention, so serializing the parallel bakes would not help (the 2-host parallel design stays).
- tart's in-attempt retries never recover once a flow stalls. Only a fresh outer attempt makes progress: blob uploads are content-addressed, so each attempt fast-forwards past layers that already landed and uploads the next few GB. A healthy-path push needed 2 attempts per tag; the failing evening needed more than 3 attempts inside a degradation window that lasted over an hour.

## Why this fix

Attempts are the unit of forward progress, so the fix is more attempts spread over more wall-clock: 5 attempts with growing backoff puts ~18 minutes of spread between the first and last attempt instead of 2 minutes, letting the budget escape a degradation window rather than burning entirely inside one. New attempts also open new connections, which matters when the problem is per-flow path behavior.

Job-level serialization was considered and rejected: the evidence above shows the failures are independent of what the sibling builder is doing, and the fleet is deliberately sized so the runner-image and xcresult bakes run in parallel.

If one host keeps hitting this, the remaining lever is recycling its CAPI Machine to roll the public IP; the Mac itself is fine.

## Validation

- All four workflow files parse as valid YAML.
- The retry/backoff shell logic was exercised standalone with a mocked failing push: attempts 1-4 sleep 60/120/300/600s, attempt 5 exits 1.
- The same evening's re-run of the failed job demonstrated the progress-across-attempts mechanism end to end: the version tag failed attempt 1 and pushed successfully on attempt 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)