### PR TITLE
fix(cli): backport local package test targets to 4.197

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -99,8 +99,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Lint
         run: |
           mise x swiftformat -- swiftformat cli/ app/ --lint
@@ -137,8 +136,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Build
         run: swift build --configuration debug --replace-scm-with-registry --force-resolved-versions
 
@@ -177,8 +175,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Cache
         run: tuist cache
       - name: Save cache
@@ -223,8 +220,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Run tests
         run: tuist test TuistUnitTests -- -retry-tests-on-failure -test-iterations 4
 
@@ -265,8 +261,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -316,8 +311,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -357,8 +351,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Install Tuist dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: tuist install
+        run: tuist install --force-resolved-versions
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -395,7 +388,6 @@ jobs:
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
       - name: Resolve dependencies
-        if: steps.cache-restore.outputs.cache-hit != 'true'
         run: swift package resolve --replace-scm-with-registry
       - name: Build tuist CLI
         run: swift build --target tuist --replace-scm-with-registry --force-resolved-versions
@@ -425,7 +417,6 @@ jobs:
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
       - name: Resolve dependencies
-        if: steps.cache-restore.outputs.cache-hit != 'true'
         run: swift package resolve --replace-scm-with-registry
       - name: Run unit tests
         run: swift test --replace-scm-with-registry

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -226,7 +226,7 @@ jobs:
 
   cli-acceptance-tests-build:
     name: Build Acceptance Tests
-    runs-on: tuist-macos
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     permissions:
       contents: read
@@ -274,7 +274,7 @@ jobs:
 
   cli-acceptance-tests:
     name: Acceptance Tests
-    runs-on: tuist-macos
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     needs: cli-acceptance-tests-build
     permissions:
@@ -332,7 +332,7 @@ jobs:
 
   cli-acceptance-tests-fork:
     name: Acceptance Tests (Fork)
-    runs-on: tuist-macos
+    runs-on: tuist-macos-26-5
     timeout-minutes: 60
     if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork == true
     steps:

--- a/cli/Sources/ProjectDescription/PackageSettings.swift
+++ b/cli/Sources/ProjectDescription/PackageSettings.swift
@@ -54,7 +54,8 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// Whether test targets from local path packages declared as external dependencies are included in generated projects.
     ///
     /// Packages loaded directly as local projects always include their test targets. Remote package test targets are never
-    /// included. An included test target must depend only on targets from the same package. The default value is `false`.
+    /// included. An included test target must depend only on targets from the same package. The default value is `true` on
+    /// the 4.197 release line to preserve its existing behavior.
     public var includeLocalPackageTestTargets: Bool
 
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
@@ -75,7 +76,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: Settings] = [:],
         projectOptions: [String: Project.Options] = [:],
-        includeLocalPackageTestTargets: Bool = false
+        includeLocalPackageTestTargets: Bool = true
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -114,7 +115,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: SettingsDictionary],
         projectOptions: [String: Project.Options] = [:],
-        includeLocalPackageTestTargets: Bool = false
+        includeLocalPackageTestTargets: Bool = true
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType

--- a/cli/Sources/ProjectDescription/PackageSettings.swift
+++ b/cli/Sources/ProjectDescription/PackageSettings.swift
@@ -51,6 +51,12 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.
     public var projectOptions: [String: Project.Options]
 
+    /// Whether test targets from local path packages declared as external dependencies are included in generated projects.
+    ///
+    /// Packages loaded directly as local projects always include their test targets. Remote package test targets are never
+    /// included. An included test target must depend only on targets from the same package. The default value is `false`.
+    public var includeLocalPackageTestTargets: Bool
+
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
     /// - Parameters:
     ///     - productTypes: The custom `Product` types to be used for SPM targets.
@@ -60,6 +66,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - expectedSignatures: Expected signatures keyed by binary target name.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - includeLocalPackageTestTargets: Whether to include test targets from local path package dependencies.
     public init(
         productTypes: [String: Product] = [:],
         baseProductType: Product = .staticFramework,
@@ -67,7 +74,8 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         baseSettings: Settings = .settings(),
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: Settings] = [:],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -76,6 +84,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
         dumpIfNeeded(self)
     }
 
@@ -88,6 +97,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - expectedSignatures: Expected signatures keyed by binary target name.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - includeLocalPackageTestTargets: Whether to include test targets from local path package dependencies.
     @available(
         *,
         deprecated,
@@ -103,7 +113,8 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         baseSettings: Settings = .settings(),
         expectedSignatures: [String: XCFrameworkSignature] = [:],
         targetSettings: [String: SettingsDictionary],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -112,6 +123,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings.mapValues { .settings(base: $0) }
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
         dumpIfNeeded(self)
     }
 }

--- a/cli/Sources/TuistCore/Models/PackageSettings.swift
+++ b/cli/Sources/TuistCore/Models/PackageSettings.swift
@@ -42,7 +42,7 @@ public struct PackageSettings: Equatable, Codable {
         expectedSignatures: [String: XCFrameworkSignature],
         targetSettings: [String: Settings],
         projectOptions: [String: XcodeGraph.Project.Options] = [:],
-        includeLocalPackageTestTargets: Bool = false
+        includeLocalPackageTestTargets: Bool = true
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -63,7 +63,7 @@ public struct PackageSettings: Equatable, Codable {
             expectedSignatures: [String: XCFrameworkSignature] = [:],
             targetSettings: [String: Settings] = [:],
             projectOptions: [String: XcodeGraph.Project.Options] = [:],
-            includeLocalPackageTestTargets: Bool = false
+            includeLocalPackageTestTargets: Bool = true
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,

--- a/cli/Sources/TuistCore/Models/PackageSettings.swift
+++ b/cli/Sources/TuistCore/Models/PackageSettings.swift
@@ -24,6 +24,9 @@ public struct PackageSettings: Equatable, Codable {
     /// The custom project options for each project generated from a swift package.
     public let projectOptions: [String: XcodeGraph.Project.Options]
 
+    /// Whether test targets from local path package dependencies are included in generated projects.
+    public let includeLocalPackageTestTargets: Bool
+
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
@@ -38,7 +41,8 @@ public struct PackageSettings: Equatable, Codable {
         baseSettings: Settings,
         expectedSignatures: [String: XCFrameworkSignature],
         targetSettings: [String: Settings],
-        projectOptions: [String: XcodeGraph.Project.Options] = [:]
+        projectOptions: [String: XcodeGraph.Project.Options] = [:],
+        includeLocalPackageTestTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.baseProductType = baseProductType
@@ -47,6 +51,7 @@ public struct PackageSettings: Equatable, Codable {
         self.expectedSignatures = expectedSignatures
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.includeLocalPackageTestTargets = includeLocalPackageTestTargets
     }
 
     #if DEBUG
@@ -57,7 +62,8 @@ public struct PackageSettings: Equatable, Codable {
             baseSettings: Settings = Settings.default,
             expectedSignatures: [String: XCFrameworkSignature] = [:],
             targetSettings: [String: Settings] = [:],
-            projectOptions: [String: XcodeGraph.Project.Options] = [:]
+            projectOptions: [String: XcodeGraph.Project.Options] = [:],
+            includeLocalPackageTestTargets: Bool = false
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,
@@ -66,7 +72,8 @@ public struct PackageSettings: Equatable, Codable {
                 baseSettings: baseSettings,
                 expectedSignatures: expectedSignatures,
                 targetSettings: targetSettings,
-                projectOptions: projectOptions
+                projectOptions: projectOptions,
+                includeLocalPackageTestTargets: includeLocalPackageTestTargets
             )
         }
     #endif

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -32,7 +32,8 @@ extension TuistCore.PackageSettings {
             baseSettings: baseSettings,
             expectedSignatures: expectedSignatures,
             targetSettings: targetSettings,
-            projectOptions: projectOptions
+            projectOptions: projectOptions,
+            includeLocalPackageTestTargets: manifest.includeLocalPackageTestTargets
         )
     }
 }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -42,6 +42,9 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
     /// Thrown when an included local package test target depends on a product from another package.
     case unsupportedExternalProductInLocalPackageTest(package: String, target: String, product: String)
 
+    /// Thrown when an included local package test target depends on an executable target that is not mapped.
+    case unsupportedExecutableTargetInLocalPackageTest(package: String, target: String, executable: String)
+
     /// Thrown when unsupported `PackageInfo.Target.TargetBuildSettingDescription` `Tool`/`SettingName` pair is found.
     case unsupportedSetting(
         PackageInfo.Target.TargetBuildSettingDescription.Tool,
@@ -74,6 +77,12 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
             The test target `\(target)` in the local package `\(package)` depends on the external product `\(product)`. \
             Tuist can include local package test targets only when all their dependencies belong to the same package. Remove \
             the external product dependency, or set `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
+            """
+        case let .unsupportedExecutableTargetInLocalPackageTest(package, target, executable):
+            return """
+            The test target `\(target)` in the local package `\(package)` depends on the executable target `\(executable)`, \
+            which Tuist omits when mapping local package dependencies. Remove the executable target dependency, or set \
+            `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
             """
         case let .unsupportedSetting(tool, setting):
             return "The \(tool) and \(setting) pair is not a supported setting."
@@ -746,6 +755,24 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 package: packageInfo.name,
                 target: target.name,
                 product: productName
+            )
+        }
+
+        if target.type == .test,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           let executableName = target.dependencies.compactMap({ dependency -> String? in
+               switch dependency {
+               case let .target(name, _), let .byName(name, _):
+                   return targetsByName[name]?.type == .executable ? name : nil
+               case .product:
+                   return nil
+               }
+           }).first
+        {
+            throw PackageInfoMapperError.unsupportedExecutableTargetInLocalPackageTest(
+                package: packageInfo.name,
+                target: target.name,
+                executable: executableName
             )
         }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -107,11 +107,11 @@ public enum PackageType {
 
     fileprivate func includesTestTargets(includeLocalPackageTestTargets: Bool) -> Bool {
         switch self {
-        case .local, .external(origin: .local, artifactPaths: _, packagePrebuilts: _):
+        case .local:
             return true
-        case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
+        case .external(origin: .local, artifactPaths: _, packagePrebuilts: _):
             return includeLocalPackageTestTargets
-        case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
+        case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _):
             return false
         }
     }
@@ -738,8 +738,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
             return nil
         }
 
+        let targetsByName = Dictionary(uniqueKeysWithValues: packageInfo.targets.map { ($0.name, $0) })
+
         if target.type == .test,
-           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _) = packageType,
            let productName = target.dependencies.compactMap({ dependency -> String? in
                switch dependency {
                case let .product(name, package: _, moduleAliases: _, condition: _):
@@ -759,7 +761,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         }
 
         if target.type == .test,
-           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _) = packageType,
            let executableName = target.dependencies.compactMap({ dependency -> String? in
                switch dependency {
                case let .target(name, _), let .byName(name, _):

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -39,6 +39,9 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
     /// Thrown when a target defined in a product is not present in the package
     case unknownProductTarget(package: String, product: String, target: String)
 
+    /// Thrown when an included local package test target depends on a product from another package.
+    case unsupportedExternalProductInLocalPackageTest(package: String, target: String, product: String)
+
     /// Thrown when unsupported `PackageInfo.Target.TargetBuildSettingDescription` `Tool`/`SettingName` pair is found.
     case unsupportedSetting(
         PackageInfo.Target.TargetBuildSettingDescription.Tool,
@@ -66,6 +69,12 @@ enum PackageInfoMapperError: LocalizedError, Equatable {
             return "The product \(name) of package \(package) cannot be found."
         case let .unknownProductTarget(package, product, target):
             return "The target \(target) of product \(product) cannot be found in package \(package)."
+        case let .unsupportedExternalProductInLocalPackageTest(package, target, product):
+            return """
+            The test target `\(target)` in the local package `\(package)` depends on the external product `\(product)`. \
+            Tuist can include local package test targets only when all their dependencies belong to the same package. Remove \
+            the external product dependency, or set `includeLocalPackageTestTargets` to `false` in `PackageSettings`.
+            """
         case let .unsupportedSetting(tool, setting):
             return "The \(tool) and \(setting) pair is not a supported setting."
         case let .modulemapMissing(moduleMapPath, package, target):
@@ -87,11 +96,13 @@ public enum PackageType {
         packagePrebuilts: [String: [String: SwiftPackageManagerPrebuilt]] = [:]
     )
 
-    fileprivate var includesTestTargets: Bool {
+    fileprivate func includesTestTargets(includeLocalPackageTestTargets: Bool) -> Bool {
         switch self {
         case .local, .external(origin: .local, artifactPaths: _, packagePrebuilts: _):
             return true
-        case .external:
+        case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
+            return includeLocalPackageTestTargets
+        case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
             return false
         }
     }
@@ -698,7 +709,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
         // Ignores or passes a target based on the `type` and the `packageType`.
         // After that, it assumes that no target is ignored.
         switch target.type {
-        case .test where !packageType.includesTestTargets:
+        case .test where !packageType.includesTestTargets(
+            includeLocalPackageTestTargets: packageSettings.includeLocalPackageTestTargets
+        ):
             Logger.current.debug("Target \(target.name) of type \(target.type) ignored")
             return nil
         case .regular, .system, .macro, .test:
@@ -714,6 +727,26 @@ public struct PackageInfoMapper: PackageInfoMapping {
         default:
             Logger.current.debug("Target \(target.name) of type \(target.type) ignored")
             return nil
+        }
+
+        if target.type == .test,
+           case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = packageType,
+           let productName = target.dependencies.compactMap({ dependency -> String? in
+               switch dependency {
+               case let .product(name, package: _, moduleAliases: _, condition: _):
+                   return name
+               case let .byName(name, condition: _) where targetsByName[name] == nil:
+                   return name
+               case .target, .byName:
+                   return nil
+               }
+           }).first
+        {
+            throw PackageInfoMapperError.unsupportedExternalProductInLocalPackageTest(
+                package: packageInfo.name,
+                target: target.name,
+                product: productName
+            )
         }
 
         let products = targetToProducts[target.name] ?? Set()

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -744,8 +744,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
            case .external(origin: .local, artifactPaths: _, packagePrebuilts: _) = packageType,
            let productName = target.dependencies.compactMap({ dependency -> String? in
                switch dependency {
-               case let .product(name, package: _, moduleAliases: _, condition: _):
-                   return name
+               case let .product(name, package, moduleAliases: _, condition: _):
+                   return packageType.prebuilt(targetPackage: package, product: name) == nil ? name : nil
                case let .byName(name, condition: _) where targetsByName[name] == nil:
                    return name
                case .target, .byName:

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -255,6 +255,10 @@ struct DependenciesAcceptanceTestIosAppWithLocalSPMPackageGenerate {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+        try TuistTest.expectContainsTarget(
+            "LocalLibTests",
+            inXcodeProj: fixtureDirectory.appending(components: "LocalPackage", "LocalPackage.xcodeproj")
+        )
     }
 }
 

--- a/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
@@ -167,7 +167,8 @@ final class ManifestLoaderTests: TuistTestCase {
         import ProjectDescription
 
         let packageSettings = PackageSettings(
-            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]]
+            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]],
+            includeLocalPackageTestTargets: true
         )
 
         #endif
@@ -202,7 +203,8 @@ final class ManifestLoaderTests: TuistTestCase {
                     "TargetA": .settings(base: [
                         "OTHER_LDFLAGS": "-ObjC",
                     ]),
-                ]
+                ],
+                includeLocalPackageTestTargets: true
             )
         )
     }

--- a/cli/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -61,7 +61,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
 
         given(manifestLoader)
             .loadPackageSettings(at: .any, disableSandbox: .any)
-            .willReturn(.test())
+            .willReturn(.init(includeLocalPackageTestTargets: true))
 
         given(swiftPackageManagerController)
             .getToolsVersion(at: .any)
@@ -85,7 +85,8 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                 defaultSettings: .recommended
             ),
             expectedSignatures: [:],
-            targetSettings: [:]
+            targetSettings: [:],
+            includeLocalPackageTestTargets: true
         )
         verify(manifestLoader)
             .register(plugins: .any)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4958,7 +4958,107 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenExternalRemoteSwiftPackageHasTestTarget() async throws {
+    ) func map_whenExternalLocalSwiftPackageHasTestTarget_andTestsAreEnabled_includesTestTarget() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "TargetTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .external(origin: .local, artifactPaths: [:]),
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
+                    ],
+                    targets: [
+                        .test(name: "Target"),
+                        .test(
+                            name: "TargetTests",
+                            type: .test,
+                            dependencies: [.target(name: "Target", condition: nil)]
+                        ),
+                    ],
+                    platforms: [.ios]
+                ),
+            ],
+            packageSettings: .test(
+                baseSettings: .default,
+                includeLocalPackageTestTargets: true
+            )
+        )
+
+        // Then
+        #expect(project != nil)
+        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target", "TargetTests"]))
+        let testTarget = project?.targets.first(where: { $0.name == "TargetTests" })
+        #expect(testTarget?.product == .unitTests)
+        #expect(testTarget?.metadata.tags.contains(TargetTags.localSwiftPackageTest) == true)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenEnabledExternalLocalPackageTestDependsOnExternalProduct_throwsConcreteError() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "TargetTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When / Then
+        await #expect(
+            throws: PackageInfoMapperError.unsupportedExternalProductInLocalPackageTest(
+                package: "Package",
+                target: "TargetTests",
+                product: "TestSupport"
+            )
+        ) {
+            _ = try await subject.map(
+                package: "Package",
+                basePath: basePath,
+                packageType: .external(origin: .local, artifactPaths: [:]),
+                packageInfos: [
+                    "Package": .test(
+                        name: "Package",
+                        products: [
+                            .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
+                        ],
+                        targets: [
+                            .test(name: "Target"),
+                            .test(
+                                name: "TargetTests",
+                                type: .test,
+                                dependencies: [
+                                    .target(name: "Target", condition: nil),
+                                    .product(
+                                        name: "TestSupport",
+                                        package: "TestSupportPackage",
+                                        moduleAliases: nil,
+                                        condition: nil
+                                    ),
+                                ]
+                            ),
+                        ],
+                        platforms: [.ios]
+                    ),
+                ],
+                packageSettings: .test(includeLocalPackageTestTargets: true)
+            )
+        }
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenExternalRemoteSwiftPackageHasTestTarget_andTestsAreEnabled_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
@@ -4987,7 +5087,8 @@ struct PackageInfoMapperTests {
                     ],
                     platforms: [.ios]
                 ),
-            ]
+            ],
+            packageSettings: .test(includeLocalPackageTestTargets: true)
         )
 
         // Then

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4958,7 +4958,7 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenExternalLocalSwiftPackageHasTestTarget_andTestsAreEnabled_includesTestTarget() async throws {
+    ) func map_whenExternalLocalSwiftPackageHasTestTarget_andTestsAreDisabled_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
@@ -4990,16 +4990,13 @@ struct PackageInfoMapperTests {
             ],
             packageSettings: .test(
                 baseSettings: .default,
-                includeLocalPackageTestTargets: true
+                includeLocalPackageTestTargets: false
             )
         )
 
         // Then
         #expect(project != nil)
-        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target", "TargetTests"]))
-        let testTarget = project?.targets.first(where: { $0.name == "TargetTests" })
-        #expect(testTarget?.product == .unitTests)
-        #expect(testTarget?.metadata.tags.contains(TargetTags.localSwiftPackageTest) == true)
+        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target"]))
     }
 
     @Test(

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5058,6 +5058,51 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_whenEnabledExternalLocalPackageTestDependsOnExecutableTarget_throwsConcreteError() async throws {
+        // Given
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(components: ["Package", "Sources", "MyTool"])
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        let testsPath = basePath.appending(components: ["Package", "Tests", "MyToolTests"])
+        try await fileSystem.makeDirectory(at: testsPath)
+
+        // When / Then
+        await #expect(
+            throws: PackageInfoMapperError.unsupportedExecutableTargetInLocalPackageTest(
+                package: "Package",
+                target: "MyToolTests",
+                executable: "MyTool"
+            )
+        ) {
+            _ = try await subject.map(
+                package: "Package",
+                basePath: basePath,
+                packageType: .external(origin: .local, artifactPaths: [:]),
+                packageInfos: [
+                    "Package": .test(
+                        name: "Package",
+                        products: [
+                            .init(name: "MyTool", type: .executable, targets: ["MyTool"]),
+                        ],
+                        targets: [
+                            .test(name: "MyTool", type: .executable),
+                            .test(
+                                name: "MyToolTests",
+                                type: .test,
+                                dependencies: [.target(name: "MyTool", condition: nil)]
+                            ),
+                        ],
+                        platforms: [.macos]
+                    ),
+                ],
+                packageSettings: .test(includeLocalPackageTestTargets: true)
+            )
+        }
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenExternalRemoteSwiftPackageHasTestTarget_andTestsAreEnabled_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)

--- a/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Package.swift
@@ -9,5 +9,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "LocalLib"),
+        .testTarget(name: "LocalLibTests", dependencies: ["LocalLib"]),
     ]
 )

--- a/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Tests/LocalLibTests/LocalLibTests.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/LocalPackage/Tests/LocalLibTests/LocalLibTests.swift
@@ -1,0 +1,6 @@
+import LocalLib
+import Testing
+
+@Test func localLibraryCanBeCreated() {
+    _ = LocalLib()
+}

--- a/examples/xcode/generated_ios_app_with_local_spm_package/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_spm_package/Tuist/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 #if TUIST
     import struct ProjectDescription.PackageSettings
 
-    let packageSettings = PackageSettings(productTypes: [:])
+    let packageSettings = PackageSettings(
+        productTypes: [:],
+        includeLocalPackageTestTargets: true
+    )
 #endif
 
 let package = Package(


### PR DESCRIPTION
## What changed

This backports the local Swift Package Manager test-target controls and dependency validation onto `releases/4.197.x`, based on `4.197.2`.

It adds `includeLocalPackageTestTargets` to `PackageSettings`, maps the setting into the generated package project, and reports concrete errors when an included test target depends on an external product or an executable target that is not generated.

## Why

PhonePe is currently pinned to `4.197.2` and needs this behavior on the `4.197.x` release line without upgrading to a newer minor version.

## Root cause

The mainline fix was written after local external package tests had been disabled by default. Version `4.197.2` predates that regression and already includes those tests by default. Applying the mainline commits without adaptation would therefore disable behavior that is currently working for users on this release line.

The release line also uses an older package mapper shape, so the mainline pattern matching and target lookup could not compile unchanged.

## Approach

The two original fix commits were cherry-picked in order. A release-specific compatibility commit keeps test inclusion enabled by default on `4.197.x`, adds an explicit opt-out through `includeLocalPackageTestTargets: false`, and adapts the validation to the older mapper model.

The command-line acceptance test added on main was omitted because its fixture does not exist on the `4.197.x` line. The existing local-package fixture continues to cover test-target inclusion.

## Impact

Existing `4.197.x` users retain the current default behavior. Projects can explicitly disable local external package tests, while unsupported external-product and executable-target dependencies now fail with actionable errors.

After this pull request is reviewed and merged, the backport release workflow can publish `4.197.3`.

## Validation

- `mise run cli:lint --fix`
- Generated a focused workspace for `TuistLoaderTests`; six selected loader tests passed.
- Generated a focused workspace for `TuistDependenciesAcceptanceTests`; the local Swift package generation acceptance test passed.
