### PR TITLE
fix(infra): chunk xcresult processor image uploads

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1043,47 +1043,42 @@ jobs:
             xcresult-processor.pkr.hcl
 
       - name: Push image to GHCR
+        timeout-minutes: 55
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Direct tart push, 5 attempts per tag with growing backoff.
-        # Blob uploads are content-addressed, so attempts are the unit
-        # of forward progress: each retry skips layers that already
-        # landed and uploads the next chunk. Pushes stall when upload
-        # flows to GitHub's edge die mid-request (host/IP-path
-        # dependent, can persist for tens of minutes), so the backoff
-        # spreads attempts past a degradation window instead of
-        # burning them all inside one. Earlier attempts here layered
-        # on TART_NO_AUTO_PRUNE and a clone-the-base "restore
-        # nvram.bin" step; both failed to fix the intermittent
-        # `Error: The file "nvram.bin" doesn't exist` and the
-        # disk-heavy restore made it worse (the whole VM bundle
-        # vanished mid-push).
+        # Tart otherwise sends each compressed disk layer as one request.
+        # A layer can exceed 500 megabytes, while Tart's URLSession uses
+        # the default 60-second idle timeout. Use 3-megabyte chunks, below
+        # GitHub Container Registry's 4-megabyte limit, so slow uploads
+        # keep making observable request progress. Send both tags in one
+        # invocation so Tart compresses and uploads the disk only once.
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          for dest_tag in "${VERSION}" "latest"; do
-            DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
-            for attempt in 1 2 3 4 5; do
-              echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
-              if tart push tuist-xcresult-processor "$DST"; then
-                echo "Pushed ${DST} on attempt ${attempt}"
-                break
-              fi
-              if [ "$attempt" = 5 ]; then
-                echo "tart push failed five times for ${dest_tag}" >&2
-                exit 1
-              fi
-              case "$attempt" in
-                1) delay=60 ;;
-                2) delay=120 ;;
-                3) delay=300 ;;
-                *) delay=600 ;;
-              esac
-              echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-              sleep "$delay"
-            done
+          DESTINATIONS=(
+            "ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
+            "ghcr.io/tuist/tuist-xcresult-processor:latest"
+          )
+          for attempt in 1 2 3 4 5; do
+            echo "tart push attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+            if tart push --chunk-size 3 tuist-xcresult-processor "${DESTINATIONS[@]}"; then
+              echo "Pushed ${DESTINATIONS[*]} on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "tart push failed five times" >&2
+              exit 1
+            fi
+            case "$attempt" in
+              1) delay=60 ;;
+              2) delay=120 ;;
+              3) delay=300 ;;
+              *) delay=600 ;;
+            esac
+            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
+            sleep "$delay"
           done
 
       - name: Upload xcresult-processor-image artifacts

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -135,20 +135,14 @@ jobs:
             xcresult-processor.pkr.hcl
 
       - name: Push image to GHCR
+        timeout-minutes: 55
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Direct tart push, 5 attempts with growing backoff — blob
-        # uploads are content-addressed so each retry only re-uploads
-        # layers that didn't land on the previous attempt, and the
-        # backoff spreads attempts past upload-path degradation windows
-        # (see server-production-deployment.yml's
-        # release-xcresult-processor-image push step). Earlier attempts
-        # here layered on TART_NO_AUTO_PRUNE and a clone-the-base
-        # "restore nvram.bin" step; both failed to fix the intermittent
-        # `Error: The file "nvram.bin" doesn't exist` and the disk-heavy
-        # restore made it worse (the whole VM bundle vanished mid-push).
+        # Match the production release workflow's chunked upload path.
+        # Tart's default monolithic uploads can exceed its 60-second
+        # URLSession idle timeout when registry throughput drops.
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.
@@ -157,7 +151,7 @@ jobs:
           DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
           for attempt in 1 2 3 4 5; do
             echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
-            if tart push tuist-xcresult-processor "$DST"; then
+            if tart push --chunk-size 3 tuist-xcresult-processor "$DST"; then
               echo "Pushed ${DST} on attempt ${attempt}"
               exit 0
             fi


### PR DESCRIPTION
## What changed

The xcresult processor image publishing paths now:

- use Tart's chunked upload mode with 3-megabyte chunks in both the production release and manual image workflows
- publish the versioned and `latest` tags in one Tart invocation during production releases
- cap each push step at 55 minutes while retaining the existing retry and backoff behavior

## Why

Server production deployments have repeatedly stalled while pushing the xcresult processor image to GitHub Container Registry. In the affected runs, Tart stayed at `0%` and emitted repeated `The request timed out` errors before the workflow's broader retry budget expired. The latest example is [run 30006116239](https://github.com/tuist/tuist/actions/runs/30006116239/job/89214692915).

## Root cause

Tart 2.32.1 sends each compressed disk layer as one monolithic registry request by default. These layers can exceed 500 megabytes, while Tart's network client uses Foundation's default 60-second idle timeout. When registry throughput drops, none of the four concurrent layer requests completes before that timeout.

The observed failures did not include a status code 429 response or another explicit rate-limit response. GitHub documents a separate 10-minute upload limit, but Tart's client-side timeout is reached first under this failure mode.

## Approach

A 3-megabyte chunk size stays below Tart's documented 4-megabyte limit for GitHub Container Registry and ensures that slow transfers receive regular responses instead of holding one large request open.

The production workflow now passes both destination tags to one Tart invocation. Tart can upload the content once and attach both manifests, avoiding a second full compression and registry check pass. The existing content-addressed retries remain useful because subsequent attempts skip chunks that already landed.

A step-level timeout provides a clear upper bound without consuming the entire 100-minute job budget.

## Impact

Image contents and tag names do not change. Successful releases should perform less duplicate work, and degraded registry connections should make incremental progress instead of repeatedly timing out whole layers.

Chunked uploads create more registry requests, which is the intended tradeoff for avoiding fragile long-running requests.

## Validation

- `git diff --check`
- parsed both changed workflow files with Ruby's workflow parser
- `mise x actionlint@latest shellcheck@latest -- actionlint` against both changed workflows, excluding only existing custom-runner-label, legacy artifact-output, and unrelated shell warnings elsewhere in the production workflow