### PR TITLE
fix(server): use self-hosted origin for agent authentication

### DIFF
--- a/server/lib/tuist_web/controllers/agent_auth_controller.ex
+++ b/server/lib/tuist_web/controllers/agent_auth_controller.ex
@@ -694,7 +694,7 @@ defmodule TuistWeb.AgentAuthController do
   # app URL, never from request headers — otherwise a caller could spoof
   # `X-Forwarded-Host` and have Tuist email a secret claim-view link to
   # an attacker-controlled origin.
-  defp canonical_origin, do: Environment.app_url()
+  defp canonical_origin, do: Environment.app_url(route_type: :app)
 
   defp claim_view_url(claim_view_token) do
     "#{canonical_origin()}/agent/auth/claim/view?token=#{URI.encode_www_form(claim_view_token)}"

--- a/server/lib/tuist_web/controllers/oauth/token_controller.ex
+++ b/server/lib/tuist_web/controllers/oauth/token_controller.ex
@@ -17,7 +17,11 @@ defmodule TuistWeb.Oauth.TokenController do
   def oauth_module, do: Application.get_env(:tuist, :oauth_module, Boruta.Oauth)
 
   def token(%Plug.Conn{} = conn, %{"grant_type" => @jwt_bearer_grant, "assertion" => assertion} = params) do
-    case Accounts.exchange_protocol_agent_assertion(assertion, Environment.app_url(), Map.get(params, "resource")) do
+    case Accounts.exchange_protocol_agent_assertion(
+           assertion,
+           Environment.app_url(route_type: :app),
+           Map.get(params, "resource")
+         ) do
       {:ok, response} -> oauth_json(conn, response)
       {:error, :invalid_target} -> oauth_error(conn, "invalid_target", "The requested resource is not supported.")
       {:error, _reason} -> oauth_error(conn, "invalid_grant", "The identity assertion is invalid or expired.")
@@ -29,7 +33,7 @@ defmodule TuistWeb.Oauth.TokenController do
   end
 
   def token(%Plug.Conn{} = conn, %{"grant_type" => @claim_grant, "claim_token" => claim_token}) do
-    case Accounts.poll_protocol_agent_claim(claim_token, Environment.app_url()) do
+    case Accounts.poll_protocol_agent_claim(claim_token, Environment.app_url(route_type: :app)) do
       {:ok, response} ->
         oauth_json(conn, response)
 

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -118,7 +118,7 @@ defmodule TuistWeb.WellKnownController do
   Returns OAuth Authorization Server metadata.
   """
   def oauth_authorization_server(conn, _params) do
-    issuer = Environment.app_url()
+    issuer = Environment.app_url(route_type: :app)
 
     configuration = %{
       resource: "#{issuer}#{@mcp_path}",
@@ -172,7 +172,7 @@ defmodule TuistWeb.WellKnownController do
   Returns OAuth Protected Resource metadata.
   """
   def oauth_protected_resource(conn, params) do
-    app_url = Environment.app_url()
+    app_url = Environment.app_url(route_type: :app)
 
     case Map.get(params, "resource_path", []) do
       [] ->

--- a/server/test/tuist_web/controllers/agent_auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/agent_auth_controller_test.exs
@@ -22,7 +22,16 @@ defmodule TuistWeb.AgentAuthControllerTest do
     stub(Tuist.Environment, :mailing_from_address, fn -> "noreply@tuist.dev" end)
     stub(Tuist.Environment, :email_icon_url, fn -> "https://tuist.dev/icon.png" end)
     stub(Tuist.Environment, :agent_auth_trusted_providers, fn -> [] end)
-    stub(Tuist.Environment, :app_url, fn -> "http://www.example.com" end)
+    stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+    stub(Tuist.Environment, :app_url, fn options ->
+      if Keyword.get(options, :route_type) == :app do
+        "http://www.example.com"
+      else
+        "https://tuist.dev#{Keyword.get(options, :path, "")}"
+      end
+    end)
+
     stub(AgentAuth, :hit, fn _conn -> {:allow, 1} end)
     stub(AgentAuth, :hit, fn _conn, _subject -> {:allow, 1} end)
     stub(AgentAuth, :hit_registration, fn _conn, _registration_type -> {:allow, 1} end)

--- a/server/test/tuist_web/controllers/auth_md_protocol_controller_test.exs
+++ b/server/test/tuist_web/controllers/auth_md_protocol_controller_test.exs
@@ -20,7 +20,16 @@ defmodule TuistWeb.AuthMdProtocolControllerTest do
 
   setup do
     stub(Tuist.Environment, :agent_auth_trusted_providers, fn -> [] end)
-    stub(Tuist.Environment, :app_url, fn -> "http://www.example.com" end)
+    stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+    stub(Tuist.Environment, :app_url, fn options ->
+      if Keyword.get(options, :route_type) == :app do
+        "http://www.example.com"
+      else
+        "https://tuist.dev#{Keyword.get(options, :path, "")}"
+      end
+    end)
+
     stub(AgentAuthRateLimit, :hit, fn _conn -> {:allow, 1} end)
     stub(AgentAuthRateLimit, :hit, fn _conn, _subject -> {:allow, 1} end)
     stub(AgentAuthRateLimit, :hit_registration, fn _conn, _registration_type -> {:allow, 1} end)
@@ -58,7 +67,11 @@ defmodule TuistWeb.AuthMdProtocolControllerTest do
 
     assert claim["status"] == "initiated"
     assert claim["claim_attempt"]["user_code"] =~ ~r/^\d{6}$/
-    assert claim["claim_attempt"]["verification_uri"] =~ "/agent/identity/claim?claim_attempt_token="
+
+    assert String.starts_with?(
+             claim["claim_attempt"]["verification_uri"],
+             "http://www.example.com/agent/identity/claim?claim_attempt_token="
+           )
 
     claim_page_conn =
       build_conn()

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -6,7 +6,16 @@ defmodule TuistWeb.WellKnownControllerTest do
   alias TuistWeb.AgentSkillsDiscovery
 
   setup do
-    stub(Environment, :app_url, fn -> "http://www.example.com" end)
+    stub(Environment, :app_url, fn -> "https://tuist.dev" end)
+
+    stub(Environment, :app_url, fn options ->
+      if Keyword.get(options, :route_type) == :app do
+        "http://www.example.com"
+      else
+        "https://tuist.dev#{Keyword.get(options, :path, "")}"
+      end
+    end)
+
     :ok
   end
 


### PR DESCRIPTION
## What changed

- Made authorization discovery, token exchange, and agent claim links use the configured application origin explicitly.
- Added regression coverage that keeps the marketing origin distinct from a self-hosted application origin.

## Why

Self-hosted installations could advertise `https://tuist.dev/mcp` while a client was connecting to the deployment-specific `/mcp` endpoint. Strict [Model Context Protocol](https://modelcontextprotocol.io/) clients reject that host mismatch before starting authentication.

## Root cause

`Environment.app_url()` infers a route type from its default `/` path. On self-hosted installations, that root is a marketing route, and marketing links intentionally resolve to the production `tuist.dev` site. The authentication flow used that inferred origin even though its discovery metadata, token validation, and claim links belong to the application origin.

## Approach

The affected paths now call `Environment.app_url(route_type: :app)`. This keeps the configured application origin as the source of truth without deriving security-sensitive links from client-supplied request headers.

## Impact

Self-hosted installations now publish consistent addresses across protected-resource metadata, authorization-server metadata, token handling, and the claim ceremony. Hosted behavior is unchanged, and no configuration or migration changes are required.

## Validation

- `mise x -- mix test test/tuist_web/controllers/well_known_controller_test.exs test/tuist_web/controllers/agent_auth_controller_test.exs test/tuist_web/controllers/auth_md_protocol_controller_test.exs`
  - 40 tests passed.
- `mise x -- mix format --check-formatted` for all six changed files.
- Started the server in self-hosted mode and verified the protected-resource discovery response with headless Google Chrome.

| Before | After |
| --- | --- |
| Advertised `https://tuist.dev/mcp` | Advertises the configured self-hosted origin |
| ![Before the fix, the discovery response uses tuist.dev](https://gist.githubusercontent.com/pepicrft/8f6fc24ec7514928d6daa28272f79e0d/raw/358513089f4c83c89da11f50bd83db3c5740b21f/before.svg) | ![After the fix, the discovery response uses the configured self-hosted origin](https://gist.githubusercontent.com/pepicrft/8f6fc24ec7514928d6daa28272f79e0d/raw/55ca3f4dc9a94c70a6088b6a4cdda57be573452e/after.svg) |
