### PR TITLE
feat(server): scope automation triggers and recovery by test case state

### DIFF
--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -41,6 +41,13 @@ defmodule Tuist.Automations.Alerts.Alert do
   def max_rolling_window_size, do: @max_rolling_window_size
 
   @doc """
+  The states a test case can be in. Also the accepted values for a
+  `change_state` action's target and for the optional `test_case_states`
+  precondition on `trigger_config` / `recovery_config`.
+  """
+  def valid_states, do: @valid_states
+
+  @doc """
   Event-driven monitors (`test_updated`) fire from
   `Tuist.Automations.dispatch_test_case_event/2` the instant a test case
   changes and keep their own one-shot ledger. They are not scheduled and have
@@ -224,7 +231,28 @@ defmodule Tuist.Automations.Alerts.Alert do
 
     changeset
     |> validate_comparison(trigger_config)
+    |> validate_test_case_states(:trigger_config, trigger_config)
     |> validate_recovery_config()
+  end
+
+  # Optional precondition gating whether trigger/recovery actions run based on
+  # the test case's current state. Absent means "any state" (unchanged
+  # behaviour); when present it must be a non-empty list of valid states.
+  defp validate_test_case_states(changeset, field, config) do
+    case Map.get(config, "test_case_states") do
+      nil ->
+        changeset
+
+      states when is_list(states) and states != [] ->
+        if Enum.all?(states, &(&1 in @valid_states)) do
+          changeset
+        else
+          add_error(changeset, field, "test_case_states must only contain: #{Enum.join(@valid_states, ", ")}")
+        end
+
+      _ ->
+        add_error(changeset, field, "test_case_states must be a non-empty list of: #{Enum.join(@valid_states, ", ")}")
+    end
   end
 
   defp validate_test_updated_config(changeset, trigger_config) do
@@ -299,7 +327,7 @@ defmodule Tuist.Automations.Alerts.Alert do
       recovery_config = get_field(changeset, :recovery_config) || %{}
 
       case validate_window_shape(recovery_config) do
-        :ok -> changeset
+        :ok -> validate_test_case_states(changeset, :recovery_config, recovery_config)
         {:error, message} -> add_error(changeset, :recovery_config, message)
       end
     else

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -11,6 +11,7 @@ defmodule Tuist.Automations.Alerts.Alert do
   @monitor_types @recovery_ledger_monitor_types ++ @event_driven_monitor_types
   @comparisons ~w(gte gt lt lte)
   @valid_states ~w(enabled muted skipped)
+  @condition_types ~w(test_case_state)
   @test_updated_events ~w(
     marked_flaky
     unmarked_flaky
@@ -42,10 +43,18 @@ defmodule Tuist.Automations.Alerts.Alert do
 
   @doc """
   The states a test case can be in. Also the accepted values for a
-  `change_state` action's target and for the optional `test_case_states`
-  precondition on `trigger_config` / `recovery_config`.
+  `change_state` action's target and for a `test_case_state` condition's
+  `states` list.
   """
   def valid_states, do: @valid_states
+
+  @doc """
+  Recognised `type` values for entries in a `trigger_config` /
+  `recovery_config` `conditions` list. A condition scopes the automation to the
+  test cases it matches; all conditions must hold (AND). Currently only
+  `test_case_state` (the test's current state is one of a `states` list).
+  """
+  def condition_types, do: @condition_types
 
   @doc """
   Event-driven monitors (`test_updated`) fire from
@@ -231,29 +240,36 @@ defmodule Tuist.Automations.Alerts.Alert do
 
     changeset
     |> validate_comparison(trigger_config)
-    |> validate_test_case_states(:trigger_config, trigger_config)
+    |> validate_conditions(:trigger_config, trigger_config)
     |> validate_recovery_config()
   end
 
-  # Optional precondition gating whether trigger/recovery actions run based on
-  # the test case's current state. Absent means "any state" (unchanged
-  # behaviour); when present it must be a non-empty list of valid states.
-  defp validate_test_case_states(changeset, field, config) do
-    case Map.get(config, "test_case_states") do
+  # Optional list of conditions scoping which test cases the automation acts on.
+  # Absent means "no scoping" (unchanged behaviour); when present it must be a
+  # list of well-formed, known-type conditions. All conditions AND together at
+  # evaluation time.
+  defp validate_conditions(changeset, field, config) do
+    case Map.get(config, "conditions") do
       nil ->
         changeset
 
-      states when is_list(states) and states != [] ->
-        if Enum.all?(states, &(&1 in @valid_states)) do
+      conditions when is_list(conditions) ->
+        if Enum.all?(conditions, &valid_condition?/1) do
           changeset
         else
-          add_error(changeset, field, "test_case_states must only contain: #{Enum.join(@valid_states, ", ")}")
+          add_error(changeset, field, "conditions must each be a valid #{Enum.join(@condition_types, "/")} condition")
         end
 
       _ ->
-        add_error(changeset, field, "test_case_states must be a non-empty list of: #{Enum.join(@valid_states, ", ")}")
+        add_error(changeset, field, "conditions must be a list")
     end
   end
+
+  defp valid_condition?(%{"type" => "test_case_state", "states" => states}) do
+    is_list(states) and states != [] and Enum.all?(states, &(&1 in @valid_states))
+  end
+
+  defp valid_condition?(_), do: false
 
   defp validate_test_updated_config(changeset, trigger_config) do
     case Map.get(trigger_config, "events") do
@@ -327,7 +343,7 @@ defmodule Tuist.Automations.Alerts.Alert do
       recovery_config = get_field(changeset, :recovery_config) || %{}
 
       case validate_window_shape(recovery_config) do
-        :ok -> validate_test_case_states(changeset, :recovery_config, recovery_config)
+        :ok -> validate_conditions(changeset, :recovery_config, recovery_config)
         {:error, message} -> add_error(changeset, :recovery_config, message)
       end
     else

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -137,7 +137,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   defp eligible_triggered_ids(alert, triggered_ids) do
     alert
     |> reject_unvalidated_test_cases(triggered_ids)
-    |> then(&reject_test_cases_outside_states(alert, &1, state_filter(alert.trigger_config)))
+    |> then(&filter_by_conditions(alert, &1, conditions(alert.trigger_config)))
   end
 
   # A test case that has never had a successful, non-flaky run on the project's
@@ -150,8 +150,8 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   # trigger window) so an established test that passed long ago stays eligible.
   #
   # Recovery is not subject to this default-branch validation gate; recovery is
-  # instead constrained (when the user opts in) by the `test_case_states`
-  # precondition in `handle_recovery`.
+  # instead constrained (when the user opts in) by the `conditions` scope in
+  # `handle_recovery`.
   defp reject_unvalidated_test_cases(_alert, []), do: []
 
   defp reject_unvalidated_test_cases(alert, triggered_ids) do
@@ -163,38 +163,45 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     Enum.filter(triggered_ids, &MapSet.member?(validated, &1))
   end
 
-  # `trigger_config.test_case_states` / `recovery_config.test_case_states` are an
-  # optional precondition: only act on a test case whose CURRENT state is one of
-  # the listed values. Absent (the default) means "any state" and keeps the
-  # legacy behaviour. Example: a mute automation set to trigger only on
+  # `trigger_config.conditions` / `recovery_config.conditions` are an optional
+  # list of filters scoping which test cases the automation acts on. Absent (the
+  # default) means "no scoping" and keeps the legacy behaviour. Every condition
+  # must hold (they AND together). The only condition type today is
+  # `test_case_state` — the test's CURRENT state is one of a `states` list.
+  # Example: a mute automation scoped to trigger only on `test_case_state`
   # `["enabled"]` and recover only on `["muted"]` won't re-mute an
   # already-quarantined test, and won't revert a state (a manual skip, or
   # another automation's change) it doesn't own.
-  defp state_filter(config) when is_map(config) do
-    case Map.get(config, "test_case_states") do
-      states when is_list(states) and states != [] -> states
-      _ -> nil
+  defp conditions(config) when is_map(config) do
+    case Map.get(config, "conditions") do
+      conditions when is_list(conditions) -> conditions
+      _ -> []
     end
   end
 
-  defp state_filter(_), do: nil
+  defp conditions(_), do: []
 
-  defp reject_test_cases_outside_states(_alert, ids, nil), do: ids
-  defp reject_test_cases_outside_states(_alert, [], _states), do: []
+  defp filter_by_conditions(_alert, ids, []), do: ids
+  defp filter_by_conditions(_alert, [], _conditions), do: []
 
-  defp reject_test_cases_outside_states(alert, ids, states) do
-    eligible = state_eligible_id_set(alert.project_id, ids, states)
-    Enum.filter(ids, &MapSet.member?(eligible, &1))
+  defp filter_by_conditions(alert, ids, conditions) do
+    Enum.reduce(conditions, ids, fn condition, acc ->
+      apply_condition(alert.project_id, acc, condition)
+    end)
   end
 
-  defp state_eligible_id_set(project_id, ids, states) do
+  defp apply_condition(_project_id, [], _condition), do: []
+
+  defp apply_condition(project_id, ids, %{"type" => "test_case_state", "states" => states}) do
     allowed = MapSet.new(states)
     current = Tests.test_case_states(project_id, ids)
-
-    ids
-    |> Enum.filter(fn id -> MapSet.member?(allowed, Map.get(current, id)) end)
-    |> MapSet.new()
+    Enum.filter(ids, fn id -> MapSet.member?(allowed, Map.get(current, id)) end)
   end
+
+  # An unknown condition type is dropped by changeset validation before it can
+  # be persisted, so it should never reach here; treat it as a no-op rather than
+  # silently excluding every candidate.
+  defp apply_condition(_project_id, ids, _condition), do: ids
 
   # First evaluation after the alert was created: every test case currently
   # matching the condition is part of the established state. Record them as
@@ -278,13 +285,13 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
         {candidates, []}
       end
 
-    # A `recovery_config.test_case_states` precondition withholds the recovery
-    # ACTIONS from candidates whose current state isn't one it's configured to
-    # own (e.g. a mute automation that only recovers `muted` tests skips one a
-    # human has since skipped or unmuted). Those candidates still re-arm below —
-    # their `recovered` event is appended so the next rising edge can fire — they
-    # just don't get their state/label reverted. Only consulted when recovery is
-    # enabled; the disabled path already runs no actions.
+    # A `recovery_config.conditions` scope withholds the recovery ACTIONS from
+    # candidates that no longer match (e.g. a mute automation that only recovers
+    # `muted` tests skips one a human has since skipped or unmuted). Those
+    # candidates still re-arm below — their `recovered` event is appended so the
+    # next rising edge can fire — they just don't get their state/label reverted.
+    # Only consulted when recovery is enabled; the disabled path already runs no
+    # actions.
     action_eligible_ids =
       if alert.recovery_enabled do
         recovery_action_eligible_ids(alert, recovered)
@@ -323,9 +330,9 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   defp recovery_action_eligible_ids(alert, recovered) do
     ids = Enum.map(recovered, & &1.test_case_id)
 
-    case state_filter(alert.recovery_config) do
-      nil -> MapSet.new(ids)
-      states -> state_eligible_id_set(alert.project_id, ids, states)
+    case conditions(alert.recovery_config) do
+      [] -> MapSet.new(ids)
+      conditions -> MapSet.new(filter_by_conditions(alert, ids, conditions))
     end
   end
 

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -125,13 +125,19 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   end
 
   defp execute_evaluation(alert, triggered_ids, test_case_ids) do
-    triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
+    triggered_ids = eligible_triggered_ids(alert, triggered_ids)
 
     if alert.baseline_established_at == nil do
       establish_baseline(alert, triggered_ids)
     else
       run_transitions(alert, triggered_ids, test_case_ids)
     end
+  end
+
+  defp eligible_triggered_ids(alert, triggered_ids) do
+    alert
+    |> reject_unvalidated_test_cases(triggered_ids)
+    |> then(&reject_test_cases_outside_states(alert, &1, state_filter(alert.trigger_config)))
   end
 
   # A test case that has never had a successful, non-flaky run on the project's
@@ -143,7 +149,9 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   # accrues a passing default-branch run. The check is all-time (not the
   # trigger window) so an established test that passed long ago stays eligible.
   #
-  # Recovery is intentionally not filtered: unmuting is always safe.
+  # Recovery is not subject to this default-branch validation gate; recovery is
+  # instead constrained (when the user opts in) by the `test_case_states`
+  # precondition in `handle_recovery`.
   defp reject_unvalidated_test_cases(_alert, []), do: []
 
   defp reject_unvalidated_test_cases(alert, triggered_ids) do
@@ -153,6 +161,39 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       MapSet.new(Tests.test_case_ids_with_successful_default_branch_run(alert.project_id, triggered_ids, default_branch))
 
     Enum.filter(triggered_ids, &MapSet.member?(validated, &1))
+  end
+
+  # `trigger_config.test_case_states` / `recovery_config.test_case_states` are an
+  # optional precondition: only act on a test case whose CURRENT state is one of
+  # the listed values. Absent (the default) means "any state" and keeps the
+  # legacy behaviour. Example: a mute automation set to trigger only on
+  # `["enabled"]` and recover only on `["muted"]` won't re-mute an
+  # already-quarantined test, and won't revert a state (a manual skip, or
+  # another automation's change) it doesn't own.
+  defp state_filter(config) when is_map(config) do
+    case Map.get(config, "test_case_states") do
+      states when is_list(states) and states != [] -> states
+      _ -> nil
+    end
+  end
+
+  defp state_filter(_), do: nil
+
+  defp reject_test_cases_outside_states(_alert, ids, nil), do: ids
+  defp reject_test_cases_outside_states(_alert, [], _states), do: []
+
+  defp reject_test_cases_outside_states(alert, ids, states) do
+    eligible = state_eligible_id_set(alert.project_id, ids, states)
+    Enum.filter(ids, &MapSet.member?(eligible, &1))
+  end
+
+  defp state_eligible_id_set(project_id, ids, states) do
+    allowed = MapSet.new(states)
+    current = Tests.test_case_states(project_id, ids)
+
+    ids
+    |> Enum.filter(fn id -> MapSet.member?(allowed, Map.get(current, id)) end)
+    |> MapSet.new()
   end
 
   # First evaluation after the alert was created: every test case currently
@@ -237,14 +278,29 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
         {candidates, []}
       end
 
+    # A `recovery_config.test_case_states` precondition withholds the recovery
+    # ACTIONS from candidates whose current state isn't one it's configured to
+    # own (e.g. a mute automation that only recovers `muted` tests skips one a
+    # human has since skipped or unmuted). Those candidates still re-arm below —
+    # their `recovered` event is appended so the next rising edge can fire — they
+    # just don't get their state/label reverted. Only consulted when recovery is
+    # enabled; the disabled path already runs no actions.
+    action_eligible_ids =
+      if alert.recovery_enabled do
+        recovery_action_eligible_ids(alert, recovered)
+      else
+        MapSet.new(Enum.map(recovered, & &1.test_case_id))
+      end
+
     Enum.each(recovered, fn event ->
       entity = %{type: :test_case, id: event.test_case_id}
+      actions = if MapSet.member?(action_eligible_ids, event.test_case_id), do: recovery_actions, else: []
 
       # Run recovery actions BEFORE appending the "recovered" event. If we
       # flipped the order, a failure in the Slack ping / label removal /
       # state reset would leave the rule visually resolved while the user's
       # intended side effects never happened.
-      case ActionExecutor.execute_actions(recovery_actions, alert, entity) do
+      case ActionExecutor.execute_actions(actions, alert, entity) do
         :ok ->
           now = NaiveDateTime.utc_now()
 
@@ -262,6 +318,15 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
           )
       end
     end)
+  end
+
+  defp recovery_action_eligible_ids(alert, recovered) do
+    ids = Enum.map(recovered, & &1.test_case_id)
+
+    case state_filter(alert.recovery_config) do
+      nil -> MapSet.new(ids)
+      states -> state_eligible_id_set(alert.project_id, ids, states)
+    end
   end
 
   # A scoped evaluation only re-checked `scoped_test_case_ids`, so a triggered

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1847,6 +1847,43 @@ defmodule Tuist.Tests do
     )
   end
 
+  @test_case_states_batch_size 2_000
+
+  @doc """
+  Returns a `%{test_case_id => state}` map with the current `state`
+  (`"enabled"` | `"muted"` | `"skipped"`) of each given test case, resolved
+  from the `test_case_states` projection. A test case with no recorded state
+  change resolves to `"enabled"`. Used by automation evaluation to gate
+  trigger/recovery actions on the test case's current state.
+  """
+  def test_case_states(_project_id, []), do: %{}
+
+  def test_case_states(project_id, test_case_ids) do
+    recorded =
+      test_case_ids
+      |> Enum.chunk_every(@test_case_states_batch_size)
+      |> Enum.reduce(%{}, fn ids_chunk, acc ->
+        Map.merge(acc, fetch_test_case_states_chunk(project_id, ids_chunk))
+      end)
+
+    Map.new(test_case_ids, fn id -> {id, normalize_state(Map.get(recorded, id))} end)
+  end
+
+  # Same per-column resolution as `resolve_test_case_state/2`, batched. The ids
+  # bind as a single `Array(UUID)` parameter (not `in ^ids_chunk`, which
+  # expands to one bound parameter per id and overflows ClickHouse's request
+  # limits on large sets), matching `fetch_validated_test_case_ids_chunk`.
+  defp fetch_test_case_states_chunk(project_id, ids_chunk) do
+    from(s in TestCaseState,
+      where: s.project_id == ^project_id,
+      where: fragment("? IN (?)", s.test_case_id, type(^ids_chunk, {:array, Ecto.UUID})),
+      group_by: s.test_case_id,
+      select: {s.test_case_id, fragment("argMaxIf(?, ?, isNotNull(?))", s.state, s.inserted_at, s.state)}
+    )
+    |> ClickHouseRepo.all(multipart: true)
+    |> Map.new()
+  end
+
   defp create_test_suites(test, module_id, test_suites, test_cases, test_case_run_data, shard_plan, shard_index) do
     test_cases_by_suite =
       Enum.group_by(test_cases, fn case_attrs ->

--- a/server/lib/tuist_web/api/schemas/automation_alert.ex
+++ b/server/lib/tuist_web/api/schemas/automation_alert.ex
@@ -23,9 +23,9 @@ defmodule TuistWeb.API.Schemas.AutomationAlert do
       trigger_config: %Schema{
         type: :object,
         description:
-          "Monitor-specific trigger parameters (e.g. threshold, window). May include an optional " <>
-            "\"test_case_states\" list (subset of enabled/muted/skipped) that gates trigger actions to " <>
-            "test cases currently in one of those states."
+          "Monitor-specific trigger parameters such as threshold and window. May include an optional " <>
+            "conditions list that scopes which test cases the automation acts on; every condition must match. " <>
+            "The only condition type today is test_case_state, whose states is a subset of enabled/muted/skipped."
       },
       cadence: %Schema{type: :string, description: "Evaluation cadence (e.g. \"5m\")."},
       trigger_actions: %Schema{type: :array, items: AutomationAlertAction},
@@ -33,9 +33,9 @@ defmodule TuistWeb.API.Schemas.AutomationAlert do
       recovery_config: %Schema{
         type: :object,
         description:
-          "Recovery parameters (e.g. window). May include an optional \"test_case_states\" list (subset of " <>
-            "enabled/muted/skipped) that gates recovery actions to test cases currently in one of those states; " <>
-            "candidates outside it still re-arm but keep their state."
+          "Recovery parameters (e.g. window). May include an optional \"conditions\" list (same shape as " <>
+            "trigger_config.conditions) scoping recovery actions; candidates that no longer match still re-arm " <>
+            "but keep their state."
       },
       recovery_actions: %Schema{type: :array, items: AutomationAlertAction}
     },

--- a/server/lib/tuist_web/api/schemas/automation_alert.ex
+++ b/server/lib/tuist_web/api/schemas/automation_alert.ex
@@ -20,11 +20,23 @@ defmodule TuistWeb.API.Schemas.AutomationAlert do
         enum: ["flakiness_rate", "flaky_run_count", "reliability_rate"],
         description: "The monitor type that evaluates the condition."
       },
-      trigger_config: %Schema{type: :object, description: "Monitor-specific trigger parameters (e.g. threshold, window)."},
+      trigger_config: %Schema{
+        type: :object,
+        description:
+          "Monitor-specific trigger parameters (e.g. threshold, window). May include an optional " <>
+            "\"test_case_states\" list (subset of enabled/muted/skipped) that gates trigger actions to " <>
+            "test cases currently in one of those states."
+      },
       cadence: %Schema{type: :string, description: "Evaluation cadence (e.g. \"5m\")."},
       trigger_actions: %Schema{type: :array, items: AutomationAlertAction},
       recovery_enabled: %Schema{type: :boolean},
-      recovery_config: %Schema{type: :object, description: "Recovery parameters (e.g. window)."},
+      recovery_config: %Schema{
+        type: :object,
+        description:
+          "Recovery parameters (e.g. window). May include an optional \"test_case_states\" list (subset of " <>
+            "enabled/muted/skipped) that gates recovery actions to test cases currently in one of those states; " <>
+            "candidates outside it still re-arm but keep their state."
+      },
       recovery_actions: %Schema{type: :array, items: AutomationAlertAction}
     },
     required: [:id, :name, :enabled, :monitor_type, :trigger_config, :cadence, :trigger_actions]

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -65,11 +65,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     |> assign(create_automation_form_window: "30d")
     |> assign(create_automation_form_rolling_window_size: "100")
     |> assign(create_automation_form_events: ["marked_flaky"])
+    |> assign(create_automation_form_trigger_states: [])
     |> assign(create_automation_form_trigger_actions: [default_add_label_action()])
     |> assign(create_automation_form_recovery_enabled: false)
     |> assign(create_automation_form_recovery_window_type: "last_days")
     |> assign(create_automation_form_recovery_window: "14d")
     |> assign(create_automation_form_recovery_rolling_window_size: "100")
+    |> assign(create_automation_form_recovery_states: [])
     |> assign(create_automation_form_recovery_actions: [default_remove_label_action()])
   end
 
@@ -121,11 +123,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
       window: automation.trigger_config["window"] || "30d",
       rolling_window_size: to_string(automation.trigger_config["rolling_window_size"] || 100),
       events: parse_events(automation.trigger_config["events"]),
+      trigger_states: parse_states(automation.trigger_config["test_case_states"]),
       trigger_actions: automation.trigger_actions,
       recovery_enabled: automation.recovery_enabled,
       recovery_window_type: parse_window_type(automation.recovery_config["window_type"]),
       recovery_window: automation.recovery_config["window"] || "14d",
       recovery_rolling_window_size: to_string(automation.recovery_config["rolling_window_size"] || 100),
+      recovery_states: parse_states(automation.recovery_config["test_case_states"]),
       recovery_actions: automation.recovery_actions,
       enabled: automation.enabled
     }
@@ -136,6 +140,12 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   defp parse_events(_), do: ["marked_flaky"]
+
+  defp parse_states(states) when is_list(states) do
+    Enum.filter(Alert.valid_states(), &(&1 in states))
+  end
+
+  defp parse_states(_), do: []
 
   defp parse_comparison(comparison) when comparison in @comparisons, do: comparison
   defp parse_comparison(_), do: "gte"
@@ -172,11 +182,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
         |> assign(create_automation_form_window: form.window)
         |> assign(create_automation_form_rolling_window_size: form.rolling_window_size)
         |> assign(create_automation_form_events: form.events)
+        |> assign(create_automation_form_trigger_states: form.trigger_states)
         |> assign(create_automation_form_trigger_actions: form.trigger_actions)
         |> assign(create_automation_form_recovery_enabled: form.recovery_enabled)
         |> assign(create_automation_form_recovery_window_type: form.recovery_window_type)
         |> assign(create_automation_form_recovery_window: form.recovery_window)
         |> assign(create_automation_form_recovery_rolling_window_size: form.recovery_rolling_window_size)
+        |> assign(create_automation_form_recovery_states: form.recovery_states)
         |> assign(create_automation_form_recovery_actions: form.recovery_actions)
         |> push_event("open-modal", %{id: "create-automation-modal"})
 
@@ -233,6 +245,16 @@ defmodule TuistWeb.ProjectAutomationsLive do
       end
 
     {:noreply, assign(socket, create_automation_form_events: next)}
+  end
+
+  def handle_event("toggle_create_automation_form_trigger_state", %{"data" => state}, socket) do
+    states = toggle_state(socket.assigns.create_automation_form_trigger_states, state)
+    {:noreply, assign(socket, create_automation_form_trigger_states: states)}
+  end
+
+  def handle_event("toggle_create_automation_form_recovery_state", %{"data" => state}, socket) do
+    states = toggle_state(socket.assigns.create_automation_form_recovery_states, state)
+    {:noreply, assign(socket, create_automation_form_recovery_states: states)}
   end
 
   def handle_event("update_create_automation_form_threshold", %{"value" => value}, socket) do
@@ -512,23 +534,37 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   defp trigger_config_for(metric, assigns) do
-    build_trigger_config(
-      parse_threshold(metric, assigns.create_automation_form_threshold),
+    metric
+    |> parse_threshold(assigns.create_automation_form_threshold)
+    |> build_trigger_config(
       assigns.create_automation_form_comparison,
       assigns.create_automation_form_window_type,
       assigns.create_automation_form_window,
       assigns.create_automation_form_rolling_window_size
     )
+    |> maybe_put_test_case_states(assigns.create_automation_form_trigger_states)
   end
 
   defp recovery_config_for("test_updated", _assigns), do: %{}
 
   defp recovery_config_for(_metric, assigns) do
-    build_recovery_config(
-      assigns.create_automation_form_recovery_window_type,
+    assigns.create_automation_form_recovery_window_type
+    |> build_recovery_config(
       assigns.create_automation_form_recovery_window,
       assigns.create_automation_form_recovery_rolling_window_size
     )
+    |> maybe_put_test_case_states(assigns.create_automation_form_recovery_states)
+  end
+
+  defp maybe_put_test_case_states(config, states) when is_list(states) and states != [] do
+    Map.put(config, "test_case_states", states)
+  end
+
+  defp maybe_put_test_case_states(config, _states), do: config
+
+  defp toggle_state(states, state) do
+    next = if state in states, do: List.delete(states, state), else: [state | states]
+    Enum.filter(Alert.valid_states(), &(&1 in next))
   end
 
   defp build_trigger_config(threshold, comparison, "rolling", _window, rolling_window_size) do
@@ -635,6 +671,22 @@ defmodule TuistWeb.ProjectAutomationsLive do
     do: dgettext("dashboard_projects", "Fires when a test is skipped entirely.")
 
   def test_updated_event_description(_), do: ""
+
+  def test_case_states, do: Alert.valid_states()
+
+  def test_case_state_label("enabled"), do: dgettext("dashboard_projects", "Enabled")
+  def test_case_state_label("muted"), do: dgettext("dashboard_projects", "Muted")
+  def test_case_state_label("skipped"), do: dgettext("dashboard_projects", "Skipped")
+  def test_case_state_label(_), do: dgettext("dashboard_projects", "Unknown")
+
+  def test_case_state_description("enabled"), do: dgettext("dashboard_projects", "The test runs and its failures count.")
+
+  def test_case_state_description("muted"),
+    do: dgettext("dashboard_projects", "The test runs but its failures are ignored.")
+
+  def test_case_state_description("skipped"), do: dgettext("dashboard_projects", "The test is skipped entirely.")
+
+  def test_case_state_description(_), do: ""
 
   def comparison_label("gte"), do: dgettext("dashboard_projects", "Greater or equal")
   def comparison_label("gt"), do: dgettext("dashboard_projects", "Greater than")

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -65,13 +65,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     |> assign(create_automation_form_window: "30d")
     |> assign(create_automation_form_rolling_window_size: "100")
     |> assign(create_automation_form_events: ["marked_flaky"])
-    |> assign(create_automation_form_trigger_states: [])
+    |> assign(create_automation_form_trigger_conditions: [])
     |> assign(create_automation_form_trigger_actions: [default_add_label_action()])
     |> assign(create_automation_form_recovery_enabled: false)
     |> assign(create_automation_form_recovery_window_type: "last_days")
     |> assign(create_automation_form_recovery_window: "14d")
     |> assign(create_automation_form_recovery_rolling_window_size: "100")
-    |> assign(create_automation_form_recovery_states: [])
+    |> assign(create_automation_form_recovery_conditions: [])
     |> assign(create_automation_form_recovery_actions: [default_remove_label_action()])
   end
 
@@ -123,13 +123,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
       window: automation.trigger_config["window"] || "30d",
       rolling_window_size: to_string(automation.trigger_config["rolling_window_size"] || 100),
       events: parse_events(automation.trigger_config["events"]),
-      trigger_states: parse_states(automation.trigger_config["test_case_states"]),
+      trigger_conditions: parse_conditions(automation.trigger_config["conditions"]),
       trigger_actions: automation.trigger_actions,
       recovery_enabled: automation.recovery_enabled,
       recovery_window_type: parse_window_type(automation.recovery_config["window_type"]),
       recovery_window: automation.recovery_config["window"] || "14d",
       recovery_rolling_window_size: to_string(automation.recovery_config["rolling_window_size"] || 100),
-      recovery_states: parse_states(automation.recovery_config["test_case_states"]),
+      recovery_conditions: parse_conditions(automation.recovery_config["conditions"]),
       recovery_actions: automation.recovery_actions,
       enabled: automation.enabled
     }
@@ -141,11 +141,20 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   defp parse_events(_), do: ["marked_flaky"]
 
-  defp parse_states(states) when is_list(states) do
-    Enum.filter(Alert.valid_states(), &(&1 in states))
+  defp parse_conditions(conditions) when is_list(conditions) do
+    Enum.flat_map(conditions, &normalize_condition/1)
   end
 
-  defp parse_states(_), do: []
+  defp parse_conditions(_), do: []
+
+  defp normalize_condition(%{"type" => "test_case_state", "states" => states}) when is_list(states) do
+    case Enum.filter(Alert.valid_states(), &(&1 in states)) do
+      [] -> []
+      valid -> [%{"type" => "test_case_state", "states" => valid}]
+    end
+  end
+
+  defp normalize_condition(_), do: []
 
   defp parse_comparison(comparison) when comparison in @comparisons, do: comparison
   defp parse_comparison(_), do: "gte"
@@ -182,13 +191,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
         |> assign(create_automation_form_window: form.window)
         |> assign(create_automation_form_rolling_window_size: form.rolling_window_size)
         |> assign(create_automation_form_events: form.events)
-        |> assign(create_automation_form_trigger_states: form.trigger_states)
+        |> assign(create_automation_form_trigger_conditions: form.trigger_conditions)
         |> assign(create_automation_form_trigger_actions: form.trigger_actions)
         |> assign(create_automation_form_recovery_enabled: form.recovery_enabled)
         |> assign(create_automation_form_recovery_window_type: form.recovery_window_type)
         |> assign(create_automation_form_recovery_window: form.recovery_window)
         |> assign(create_automation_form_recovery_rolling_window_size: form.recovery_rolling_window_size)
-        |> assign(create_automation_form_recovery_states: form.recovery_states)
+        |> assign(create_automation_form_recovery_conditions: form.recovery_conditions)
         |> assign(create_automation_form_recovery_actions: form.recovery_actions)
         |> push_event("open-modal", %{id: "create-automation-modal"})
 
@@ -247,14 +256,46 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, assign(socket, create_automation_form_events: next)}
   end
 
-  def handle_event("toggle_create_automation_form_trigger_state", %{"data" => state}, socket) do
-    states = toggle_state(socket.assigns.create_automation_form_trigger_states, state)
-    {:noreply, assign(socket, create_automation_form_trigger_states: states)}
+  def handle_event("add_create_automation_form_trigger_condition", %{"data" => type}, socket) do
+    conditions = socket.assigns.create_automation_form_trigger_conditions ++ [new_condition(type, :trigger)]
+    {:noreply, assign(socket, create_automation_form_trigger_conditions: conditions)}
   end
 
-  def handle_event("toggle_create_automation_form_recovery_state", %{"data" => state}, socket) do
-    states = toggle_state(socket.assigns.create_automation_form_recovery_states, state)
-    {:noreply, assign(socket, create_automation_form_recovery_states: states)}
+  def handle_event("delete_create_automation_form_trigger_condition", %{"index" => index}, socket) do
+    conditions = List.delete_at(socket.assigns.create_automation_form_trigger_conditions, String.to_integer(index))
+    {:noreply, assign(socket, create_automation_form_trigger_conditions: conditions)}
+  end
+
+  def handle_event("toggle_create_automation_form_trigger_condition_state", %{"data" => state, "index" => index}, socket) do
+    conditions =
+      update_condition_at(
+        socket.assigns.create_automation_form_trigger_conditions,
+        index,
+        &toggle_condition_state(&1, state)
+      )
+
+    {:noreply, assign(socket, create_automation_form_trigger_conditions: conditions)}
+  end
+
+  def handle_event("add_create_automation_form_recovery_condition", %{"data" => type}, socket) do
+    conditions = socket.assigns.create_automation_form_recovery_conditions ++ [new_condition(type, :recovery)]
+    {:noreply, assign(socket, create_automation_form_recovery_conditions: conditions)}
+  end
+
+  def handle_event("delete_create_automation_form_recovery_condition", %{"index" => index}, socket) do
+    conditions = List.delete_at(socket.assigns.create_automation_form_recovery_conditions, String.to_integer(index))
+    {:noreply, assign(socket, create_automation_form_recovery_conditions: conditions)}
+  end
+
+  def handle_event("toggle_create_automation_form_recovery_condition_state", %{"data" => state, "index" => index}, socket) do
+    conditions =
+      update_condition_at(
+        socket.assigns.create_automation_form_recovery_conditions,
+        index,
+        &toggle_condition_state(&1, state)
+      )
+
+    {:noreply, assign(socket, create_automation_form_recovery_conditions: conditions)}
   end
 
   def handle_event("update_create_automation_form_threshold", %{"value" => value}, socket) do
@@ -542,7 +583,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
       assigns.create_automation_form_window,
       assigns.create_automation_form_rolling_window_size
     )
-    |> maybe_put_test_case_states(assigns.create_automation_form_trigger_states)
+    |> maybe_put_conditions(assigns.create_automation_form_trigger_conditions)
   end
 
   defp recovery_config_for("test_updated", _assigns), do: %{}
@@ -553,18 +594,37 @@ defmodule TuistWeb.ProjectAutomationsLive do
       assigns.create_automation_form_recovery_window,
       assigns.create_automation_form_recovery_rolling_window_size
     )
-    |> maybe_put_test_case_states(assigns.create_automation_form_recovery_states)
+    |> maybe_put_conditions(assigns.create_automation_form_recovery_conditions)
   end
 
-  defp maybe_put_test_case_states(config, states) when is_list(states) and states != [] do
-    Map.put(config, "test_case_states", states)
+  # Drop conditions the user left empty (e.g. a just-added state condition with
+  # no state ticked) so they neither persist nor fail validation; an absent
+  # `conditions` key means "no scoping".
+  defp maybe_put_conditions(config, conditions) do
+    case Enum.filter(conditions, &savable_condition?/1) do
+      [] -> config
+      savable -> Map.put(config, "conditions", savable)
+    end
   end
 
-  defp maybe_put_test_case_states(config, _states), do: config
+  defp savable_condition?(%{"type" => "test_case_state", "states" => states}), do: is_list(states) and states != []
+  defp savable_condition?(_), do: false
 
-  defp toggle_state(states, state) do
+  defp new_condition("test_case_state", :recovery), do: %{"type" => "test_case_state", "states" => ["muted"]}
+  defp new_condition("test_case_state", _context), do: %{"type" => "test_case_state", "states" => ["enabled"]}
+  defp new_condition(_type, context), do: new_condition("test_case_state", context)
+
+  defp update_condition_at(conditions, index, fun) do
+    List.update_at(conditions, String.to_integer(index), fun)
+  end
+
+  defp toggle_condition_state(%{"states" => states} = condition, state) do
     next = if state in states, do: List.delete(states, state), else: [state | states]
-    Enum.filter(Alert.valid_states(), &(&1 in next))
+    Map.put(condition, "states", Enum.filter(Alert.valid_states(), &(&1 in next)))
+  end
+
+  defp toggle_condition_state(condition, state) do
+    toggle_condition_state(Map.put(condition, "states", []), state)
   end
 
   defp build_trigger_config(threshold, comparison, "rolling", _window, rolling_window_size) do
@@ -679,14 +739,22 @@ defmodule TuistWeb.ProjectAutomationsLive do
   def test_case_state_label("skipped"), do: dgettext("dashboard_projects", "Skipped")
   def test_case_state_label(_), do: dgettext("dashboard_projects", "Unknown")
 
-  def test_case_state_description("enabled"), do: dgettext("dashboard_projects", "The test runs and its failures count.")
+  def condition_type_label("test_case_state"), do: dgettext("dashboard_projects", "Test state")
+  def condition_type_label(_), do: dgettext("dashboard_projects", "Unknown")
 
-  def test_case_state_description("muted"),
-    do: dgettext("dashboard_projects", "The test runs but its failures are ignored.")
+  # Condition types not yet present in the list. Each type is single-use for
+  # now (a test case has one state), so once added it drops out of the picker.
+  def available_condition_types(conditions) do
+    Enum.reject(Alert.condition_types(), &has_condition_type?(conditions, &1))
+  end
 
-  def test_case_state_description("skipped"), do: dgettext("dashboard_projects", "The test is skipped entirely.")
+  def has_condition_type?(conditions, type), do: Enum.any?(conditions, &(&1["type"] == type))
 
-  def test_case_state_description(_), do: ""
+  def condition_states_label(states) when is_list(states) and states != [] do
+    Enum.map_join(states, ", ", &test_case_state_label/1)
+  end
+
+  def condition_states_label(_), do: dgettext("dashboard_projects", "Select states")
 
   def comparison_label("gte"), do: dgettext("dashboard_projects", "Greater or equal")
   def comparison_label("gt"), do: dgettext("dashboard_projects", "Greater than")

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -309,32 +309,84 @@
                     </label>
                   </div>
                 </div>
-                <div
-                  :if={not event_driven_monitor_type?(@create_automation_form_metric)}
-                  data-part="form-row"
-                >
-                  <label data-part="label">
-                    {dgettext("dashboard_projects", "Only when test is")}
-                    <span data-part="hint">
-                      {dgettext("dashboard_projects", "(any state if none selected)")}
+              </div>
+
+              <.line_divider :if={not event_driven_monitor_type?(@create_automation_form_metric)} />
+
+              <div
+                :if={not event_driven_monitor_type?(@create_automation_form_metric)}
+                data-part="form-section"
+              >
+                <div data-part="form-section-header" data-with-action>
+                  <div data-part="form-section-header-titles">
+                    <span data-part="title">
+                      {dgettext("dashboard_projects", "Scope")}
                     </span>
-                  </label>
-                  <div id="create-automation-trigger-states" data-part="event-checkbox-list">
-                    <label
-                      :for={state <- test_case_states()}
-                      id={"create-automation-trigger-state-#{state}"}
-                      data-part="event-checkbox"
-                      phx-click="toggle_create_automation_form_trigger_state"
-                      phx-value-data={state}
-                    >
-                      <.checkbox_control checked={state in @create_automation_form_trigger_states} />
-                      <div data-part="body">
-                        <span data-part="label">{test_case_state_label(state)}</span>
-                        <span data-part="description">
-                          {test_case_state_description(state)}
+                    <span data-part="subtitle">
+                      {dgettext(
+                        "dashboard_projects",
+                        "Only act on test cases matching every condition (all tests if none added)"
+                      )}
+                    </span>
+                  </div>
+                  <.dropdown
+                    :if={
+                      available_condition_types(@create_automation_form_trigger_conditions) != []
+                    }
+                    id="create-automation-trigger-condition-add-dropdown"
+                    label={dgettext("dashboard_projects", "Add condition")}
+                  >
+                    <.dropdown_item
+                      :for={
+                        type <-
+                          available_condition_types(@create_automation_form_trigger_conditions)
+                      }
+                      value={type}
+                      label={condition_type_label(type)}
+                      on_click="add_create_automation_form_trigger_condition"
+                    />
+                  </.dropdown>
+                </div>
+                <div
+                  :if={@create_automation_form_trigger_conditions != []}
+                  data-part="form-section-body"
+                >
+                  <div
+                    :for={
+                      {condition, index} <-
+                        Enum.with_index(@create_automation_form_trigger_conditions)
+                    }
+                    data-part="action-row"
+                  >
+                    <%= case condition["type"] do %>
+                      <% "test_case_state" -> %>
+                        <span data-part="action-label">
+                          {dgettext("dashboard_projects", "Test state is any of")}
                         </span>
-                      </div>
-                    </label>
+                        <.dropdown
+                          id={"create-automation-trigger-condition-#{index}"}
+                          label={condition_states_label(condition["states"])}
+                        >
+                          <.dropdown_item
+                            :for={state <- test_case_states()}
+                            value={state}
+                            label={test_case_state_label(state)}
+                            on_click="toggle_create_automation_form_trigger_condition_state"
+                            phx-value-index={index}
+                            data-selected={state in (condition["states"] || [])}
+                          >
+                            <:right_icon><.check /></:right_icon>
+                          </.dropdown_item>
+                        </.dropdown>
+                    <% end %>
+                    <.button
+                      icon_only
+                      variant="secondary"
+                      phx-click="delete_create_automation_form_trigger_condition"
+                      phx-value-index={index}
+                    >
+                      <.icon name="trash" />
+                    </.button>
                   </div>
                 </div>
               </div>
@@ -719,30 +771,66 @@
                   </div>
                   <div data-part="form-row">
                     <label data-part="label">
-                      {dgettext("dashboard_projects", "Only when test is")}
+                      {dgettext("dashboard_projects", "Only for tests matching")}
                       <span data-part="hint">
-                        {dgettext("dashboard_projects", "(any state if none selected)")}
+                        {dgettext("dashboard_projects", "(all tests if none added)")}
                       </span>
                     </label>
-                    <div id="create-automation-recovery-states" data-part="event-checkbox-list">
-                      <label
-                        :for={state <- test_case_states()}
-                        id={"create-automation-recovery-state-#{state}"}
-                        data-part="event-checkbox"
-                        phx-click="toggle_create_automation_form_recovery_state"
-                        phx-value-data={state}
-                      >
-                        <.checkbox_control checked={
-                          state in @create_automation_form_recovery_states
-                        } />
-                        <div data-part="body">
-                          <span data-part="label">{test_case_state_label(state)}</span>
-                          <span data-part="description">
-                            {test_case_state_description(state)}
-                          </span>
-                        </div>
-                      </label>
-                    </div>
+                    <.dropdown
+                      :if={
+                        available_condition_types(@create_automation_form_recovery_conditions) !=
+                          []
+                      }
+                      id="create-automation-recovery-condition-add-dropdown"
+                      label={dgettext("dashboard_projects", "Add condition")}
+                    >
+                      <.dropdown_item
+                        :for={
+                          type <-
+                            available_condition_types(@create_automation_form_recovery_conditions)
+                        }
+                        value={type}
+                        label={condition_type_label(type)}
+                        on_click="add_create_automation_form_recovery_condition"
+                      />
+                    </.dropdown>
+                  </div>
+                  <div
+                    :for={
+                      {condition, index} <-
+                        Enum.with_index(@create_automation_form_recovery_conditions)
+                    }
+                    data-part="action-row"
+                  >
+                    <%= case condition["type"] do %>
+                      <% "test_case_state" -> %>
+                        <span data-part="action-label">
+                          {dgettext("dashboard_projects", "Test state is any of")}
+                        </span>
+                        <.dropdown
+                          id={"create-automation-recovery-condition-#{index}"}
+                          label={condition_states_label(condition["states"])}
+                        >
+                          <.dropdown_item
+                            :for={state <- test_case_states()}
+                            value={state}
+                            label={test_case_state_label(state)}
+                            on_click="toggle_create_automation_form_recovery_condition_state"
+                            phx-value-index={index}
+                            data-selected={state in (condition["states"] || [])}
+                          >
+                            <:right_icon><.check /></:right_icon>
+                          </.dropdown_item>
+                        </.dropdown>
+                    <% end %>
+                    <.button
+                      icon_only
+                      variant="secondary"
+                      phx-click="delete_create_automation_form_recovery_condition"
+                      phx-value-index={index}
+                    >
+                      <.icon name="trash" />
+                    </.button>
                   </div>
                   <div
                     :for={

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -309,6 +309,34 @@
                     </label>
                   </div>
                 </div>
+                <div
+                  :if={not event_driven_monitor_type?(@create_automation_form_metric)}
+                  data-part="form-row"
+                >
+                  <label data-part="label">
+                    {dgettext("dashboard_projects", "Only when test is")}
+                    <span data-part="hint">
+                      {dgettext("dashboard_projects", "(any state if none selected)")}
+                    </span>
+                  </label>
+                  <div id="create-automation-trigger-states" data-part="event-checkbox-list">
+                    <label
+                      :for={state <- test_case_states()}
+                      id={"create-automation-trigger-state-#{state}"}
+                      data-part="event-checkbox"
+                      phx-click="toggle_create_automation_form_trigger_state"
+                      phx-value-data={state}
+                    >
+                      <.checkbox_control checked={state in @create_automation_form_trigger_states} />
+                      <div data-part="body">
+                        <span data-part="label">{test_case_state_label(state)}</span>
+                        <span data-part="description">
+                          {test_case_state_description(state)}
+                        </span>
+                      </div>
+                    </label>
+                  </div>
+                </div>
               </div>
 
               <.line_divider />
@@ -687,6 +715,33 @@
                         phx-keyup="update_create_automation_form_recovery_rolling_window_size"
                         phx-debounce="300"
                       />
+                    </div>
+                  </div>
+                  <div data-part="form-row">
+                    <label data-part="label">
+                      {dgettext("dashboard_projects", "Only when test is")}
+                      <span data-part="hint">
+                        {dgettext("dashboard_projects", "(any state if none selected)")}
+                      </span>
+                    </label>
+                    <div id="create-automation-recovery-states" data-part="event-checkbox-list">
+                      <label
+                        :for={state <- test_case_states()}
+                        id={"create-automation-recovery-state-#{state}"}
+                        data-part="event-checkbox"
+                        phx-click="toggle_create_automation_form_recovery_state"
+                        phx-value-data={state}
+                      >
+                        <.checkbox_control checked={
+                          state in @create_automation_form_recovery_states
+                        } />
+                        <div data-part="body">
+                          <span data-part="label">{test_case_state_label(state)}</span>
+                          <span data-part="description">
+                            {test_case_state_description(state)}
+                          </span>
+                        </div>
+                      </label>
                     </div>
                   </div>
                   <div

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cache effectiveness represents the combined hit rate of both Module cache and Xcode cache, showing the percentage of cacheable items that were resolved from cache rather than being rebuilt."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:848
+#: lib/tuist_web/live/project_automations_live.html.heex:991
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
@@ -273,7 +273,7 @@ msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:87
 #: lib/tuist_web/live/project_automations_live.html.heex:74
-#: lib/tuist_web/live/project_automations_live.html.heex:889
+#: lib/tuist_web/live/project_automations_live.html.heex:1032
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:858
+#: lib/tuist_web/live/project_automations_live.html.heex:1001
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #: lib/tuist_web/live/project_settings_live.html.heex:149
@@ -624,9 +624,9 @@ msgstr ""
 msgid "Test duration"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:765
+#: lib/tuist_web/live/project_automations_live.ex:885
 #: lib/tuist_web/live/project_automations_live.html.heex:230
-#: lib/tuist_web/live/project_automations_live.html.heex:636
+#: lib/tuist_web/live/project_automations_live.html.heex:716
 #: lib/tuist_web/live/project_notifications_live.html.heex:393
 #: lib/tuist_web/live/project_notifications_live.html.heex:533
 #: lib/tuist_web/live/project_notifications_live.html.heex:717
@@ -696,8 +696,8 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:447
-#: lib/tuist_web/live/project_automations_live.html.heex:753
+#: lib/tuist_web/live/project_automations_live.html.heex:527
+#: lib/tuist_web/live/project_automations_live.html.heex:896
 #: lib/tuist_web/live/project_notifications_live.html.heex:206
 #: lib/tuist_web/live/project_notifications_live.html.heex:216
 #: lib/tuist_web/live/project_notifications_live.html.heex:473
@@ -707,8 +707,8 @@ msgstr ""
 msgid "Select channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:446
-#: lib/tuist_web/live/project_automations_live.html.heex:752
+#: lib/tuist_web/live/project_automations_live.html.heex:526
+#: lib/tuist_web/live/project_automations_live.html.heex:895
 #: lib/tuist_web/live/project_notifications_live.html.heex:215
 #: lib/tuist_web/live/project_notifications_live.html.heex:472
 #: lib/tuist_web/live/project_notifications_live.html.heex:810
@@ -753,7 +753,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:859
+#: lib/tuist_web/live/project_automations_live.html.heex:1002
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:500
 #: lib/tuist_web/live/projects_live.ex:401
@@ -1017,12 +1017,12 @@ msgstr ""
 msgid "Select organization"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:320
+#: lib/tuist_web/live/project_automations_live.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:331
+#: lib/tuist_web/live/project_automations_live.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Add action"
 msgstr ""
@@ -1032,36 +1032,36 @@ msgstr ""
 msgid "Add automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:668
+#: lib/tuist_web/live/project_automations_live.ex:788
 #, elixir-autogen, elixir-format
 msgid "Add label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:689
+#: lib/tuist_web/live/project_automations_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Add label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:560
+#: lib/tuist_web/live/project_automations_live.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Add recovery action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:501
-#: lib/tuist_web/live/project_automations_live.html.heex:807
+#: lib/tuist_web/live/project_automations_live.html.heex:581
+#: lib/tuist_web/live/project_automations_live.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "Available variables:"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:666
-#: lib/tuist_web/live/project_automations_live.html.heex:341
-#: lib/tuist_web/live/project_automations_live.html.heex:570
+#: lib/tuist_web/live/project_automations_live.ex:786
+#: lib/tuist_web/live/project_automations_live.html.heex:421
+#: lib/tuist_web/live/project_automations_live.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Change state"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:395
-#: lib/tuist_web/live/project_automations_live.html.heex:701
+#: lib/tuist_web/live/project_automations_live.html.heex:475
+#: lib/tuist_web/live/project_automations_live.html.heex:844
 #, elixir-autogen, elixir-format
 msgid "Change state to"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Create automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:915
+#: lib/tuist_web/live/project_automations_live.html.heex:1058
 #, elixir-autogen, elixir-format
 msgid "Delete this automation?"
 msgstr ""
@@ -1091,100 +1091,101 @@ msgstr ""
 msgid "Edit automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:658
+#: lib/tuist_web/live/project_automations_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Enable"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:663
-#: lib/tuist_web/live/project_automations_live.html.heex:421
-#: lib/tuist_web/live/project_automations_live.html.heex:709
+#: lib/tuist_web/live/project_automations_live.ex:737
+#: lib/tuist_web/live/project_automations_live.ex:783
+#: lib/tuist_web/live/project_automations_live.html.heex:501
+#: lib/tuist_web/live/project_automations_live.html.heex:852
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:493
-#: lib/tuist_web/live/project_automations_live.html.heex:799
+#: lib/tuist_web/live/project_automations_live.html.heex:573
+#: lib/tuist_web/live/project_automations_live.html.heex:942
 #, elixir-autogen, elixir-format
 msgid "Enter message template..."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:605
+#: lib/tuist_web/live/project_automations_live.ex:701
 #: lib/tuist_web/live/project_automations_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:606
+#: lib/tuist_web/live/project_automations_live.ex:702
 #: lib/tuist_web/live/project_automations_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:358
-#: lib/tuist_web/live/project_automations_live.html.heex:604
+#: lib/tuist_web/live/project_automations_live.html.heex:438
+#: lib/tuist_web/live/project_automations_live.html.heex:684
 #, elixir-autogen, elixir-format
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:513
-#: lib/tuist_web/live/project_automations_live.html.heex:819
+#: lib/tuist_web/live/project_automations_live.html.heex:593
+#: lib/tuist_web/live/project_automations_live.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "Mark test as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:471
-#: lib/tuist_web/live/project_automations_live.html.heex:777
+#: lib/tuist_web/live/project_automations_live.html.heex:551
+#: lib/tuist_web/live/project_automations_live.html.heex:920
 #, elixir-autogen, elixir-format
 msgid "Message template"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:877
+#: lib/tuist_web/live/project_automations_live.html.heex:1020
 #, elixir-autogen, elixir-format
 msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:548
+#: lib/tuist_web/live/project_automations_live.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "Recovery"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:669
+#: lib/tuist_web/live/project_automations_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "Remove label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:692
+#: lib/tuist_web/live/project_automations_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Remove label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:551
+#: lib/tuist_web/live/project_automations_live.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Run actions when the conditions no longer hold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:323
+#: lib/tuist_web/live/project_automations_live.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "Run these actions for each test case that meets the condition"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:667
-#: lib/tuist_web/live/project_automations_live.html.heex:380
-#: lib/tuist_web/live/project_automations_live.html.heex:434
-#: lib/tuist_web/live/project_automations_live.html.heex:609
-#: lib/tuist_web/live/project_automations_live.html.heex:740
+#: lib/tuist_web/live/project_automations_live.ex:787
+#: lib/tuist_web/live/project_automations_live.html.heex:460
+#: lib/tuist_web/live/project_automations_live.html.heex:514
+#: lib/tuist_web/live/project_automations_live.html.heex:689
+#: lib/tuist_web/live/project_automations_live.html.heex:883
 #, elixir-autogen, elixir-format
 msgid "Send Slack notification"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:686
+#: lib/tuist_web/live/project_automations_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Slack: not configured"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:474
-#: lib/tuist_web/live/project_automations_live.html.heex:780
+#: lib/tuist_web/live/project_automations_live.html.heex:554
+#: lib/tuist_web/live/project_automations_live.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "Supports Slack"
 msgstr ""
@@ -1194,7 +1195,7 @@ msgstr ""
 msgid "Test case automations"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:892
+#: lib/tuist_web/live/project_automations_live.html.heex:1035
 #, elixir-autogen, elixir-format
 msgid "Trigger"
 msgstr ""
@@ -1204,24 +1205,26 @@ msgstr ""
 msgid "Trigger the automation when this condition is met"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:609
-#: lib/tuist_web/live/project_automations_live.ex:620
-#: lib/tuist_web/live/project_automations_live.ex:643
-#: lib/tuist_web/live/project_automations_live.ex:659
-#: lib/tuist_web/live/project_automations_live.ex:664
-#: lib/tuist_web/live/project_automations_live.ex:670
+#: lib/tuist_web/live/project_automations_live.ex:705
+#: lib/tuist_web/live/project_automations_live.ex:716
+#: lib/tuist_web/live/project_automations_live.ex:740
+#: lib/tuist_web/live/project_automations_live.ex:743
+#: lib/tuist_web/live/project_automations_live.ex:763
+#: lib/tuist_web/live/project_automations_live.ex:779
+#: lib/tuist_web/live/project_automations_live.ex:784
+#: lib/tuist_web/live/project_automations_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:375
-#: lib/tuist_web/live/project_automations_live.html.heex:587
+#: lib/tuist_web/live/project_automations_live.html.heex:455
+#: lib/tuist_web/live/project_automations_live.html.heex:667
 #, elixir-autogen, elixir-format
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:517
-#: lib/tuist_web/live/project_automations_live.html.heex:823
+#: lib/tuist_web/live/project_automations_live.html.heex:597
+#: lib/tuist_web/live/project_automations_live.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Unmark test as flaky"
 msgstr ""
@@ -1231,7 +1234,7 @@ msgstr ""
 msgid "When"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:618
+#: lib/tuist_web/live/project_automations_live.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Without trigger for"
 msgstr ""
@@ -1241,32 +1244,34 @@ msgstr ""
 msgid "e.g. Auto-quarantine flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:482
-#: lib/tuist_web/live/project_automations_live.html.heex:788
+#: lib/tuist_web/live/project_automations_live.html.heex:562
+#: lib/tuist_web/live/project_automations_live.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "formatting."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:656
+#: lib/tuist_web/live/project_automations_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:661
-#: lib/tuist_web/live/project_automations_live.html.heex:403
-#: lib/tuist_web/live/project_automations_live.html.heex:718
+#: lib/tuist_web/live/project_automations_live.ex:738
+#: lib/tuist_web/live/project_automations_live.ex:781
+#: lib/tuist_web/live/project_automations_live.html.heex:483
+#: lib/tuist_web/live/project_automations_live.html.heex:861
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:657
+#: lib/tuist_web/live/project_automations_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "Skip"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:662
-#: lib/tuist_web/live/project_automations_live.html.heex:412
-#: lib/tuist_web/live/project_automations_live.html.heex:727
+#: lib/tuist_web/live/project_automations_live.ex:739
+#: lib/tuist_web/live/project_automations_live.ex:782
+#: lib/tuist_web/live/project_automations_live.html.heex:492
+#: lib/tuist_web/live/project_automations_live.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -1276,65 +1281,65 @@ msgstr ""
 msgid "Comparison"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:653
+#: lib/tuist_web/live/project_automations_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "Count"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:639
+#: lib/tuist_web/live/project_automations_live.ex:759
 #: lib/tuist_web/live/project_automations_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Greater or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:640
+#: lib/tuist_web/live/project_automations_live.ex:760
 #: lib/tuist_web/live/project_automations_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Greater than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:642
+#: lib/tuist_web/live/project_automations_live.ex:762
 #: lib/tuist_web/live/project_automations_live.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Less or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:641
+#: lib/tuist_web/live/project_automations_live.ex:761
 #: lib/tuist_web/live/project_automations_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:651
-#: lib/tuist_web/live/project_automations_live.ex:652
+#: lib/tuist_web/live/project_automations_live.ex:771
+#: lib/tuist_web/live/project_automations_live.ex:772
 #, elixir-autogen, elixir-format
 msgid "Percent"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:654
+#: lib/tuist_web/live/project_automations_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Threshold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:700
+#: lib/tuist_web/live/project_automations_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "When flakiness rate %{symbol} %{threshold}% over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:713
+#: lib/tuist_web/live/project_automations_live.ex:833
 #, elixir-autogen, elixir-format
 msgid "When flaky runs %{symbol} %{threshold} over %{window}"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:268
-#: lib/tuist_web/live/project_automations_live.html.heex:670
+#: lib/tuist_web/live/project_automations_live.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Last N runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:766
+#: lib/tuist_web/live/project_automations_live.ex:886
 #: lib/tuist_web/live/project_automations_live.html.heex:222
-#: lib/tuist_web/live/project_automations_live.html.heex:626
+#: lib/tuist_web/live/project_automations_live.html.heex:706
 #, elixir-autogen, elixir-format
 msgid "Last days"
 msgstr ""
@@ -1345,47 +1350,47 @@ msgid "Over"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:247
-#: lib/tuist_web/live/project_automations_live.html.heex:652
+#: lib/tuist_web/live/project_automations_live.html.heex:732
 #, elixir-autogen, elixir-format
 msgid "Window"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:753
+#: lib/tuist_web/live/project_automations_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:799
+#: lib/tuist_web/live/project_automations_live.ex:919
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:623
+#: lib/tuist_web/live/project_automations_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is manually flagged as flaky."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:632
+#: lib/tuist_web/live/project_automations_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is muted (still runs, failures ignored)."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:635
+#: lib/tuist_web/live/project_automations_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is skipped entirely."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:629
+#: lib/tuist_web/live/project_automations_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Fires when a test returns to the default enabled state."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:626
+#: lib/tuist_web/live/project_automations_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Fires when the flaky flag is manually removed."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:611
+#: lib/tuist_web/live/project_automations_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -1395,38 +1400,38 @@ msgstr ""
 msgid "On these events"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:614
+#: lib/tuist_web/live/project_automations_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "State changed to Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:616
+#: lib/tuist_web/live/project_automations_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "State changed to Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:618
+#: lib/tuist_web/live/project_automations_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "State changed to Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:608
+#: lib/tuist_web/live/project_automations_live.ex:704
 #: lib/tuist_web/live/project_automations_live.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Test updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:612
+#: lib/tuist_web/live/project_automations_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:740
+#: lib/tuist_web/live/project_automations_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "When a test is updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:744
+#: lib/tuist_web/live/project_automations_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "When a test is updated: %{events}"
 msgstr ""
@@ -1436,13 +1441,13 @@ msgstr ""
 msgid "New Project"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:607
+#: lib/tuist_web/live/project_automations_live.ex:703
 #: lib/tuist_web/live/project_automations_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:726
+#: lib/tuist_web/live/project_automations_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "When test reliability across branches %{symbol} %{threshold}% over %{window}"
 msgstr ""
@@ -1480,4 +1485,46 @@ msgstr ""
 #: lib/tuist_web/live/project_settings_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "can't be blank"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:776
+#, elixir-autogen, elixir-format
+msgid "(all tests if none added)"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:337
+#: lib/tuist_web/live/project_automations_live.html.heex:785
+#, elixir-autogen, elixir-format
+msgid "Add condition"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:326
+#, elixir-autogen, elixir-format
+msgid "Only act on test cases matching every condition (all tests if none added)"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:774
+#, elixir-autogen, elixir-format
+msgid "Only for tests matching"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:323
+#, elixir-autogen, elixir-format
+msgid "Scope"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:757
+#, elixir-autogen, elixir-format
+msgid "Select states"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:742
+#, elixir-autogen, elixir-format
+msgid "Test state"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:364
+#: lib/tuist_web/live/project_automations_live.html.heex:808
+#, elixir-autogen, elixir-format
+msgid "Test state is any of"
 msgstr ""

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -435,8 +435,8 @@ defmodule Tuist.Automations.Alerts.AlertTest do
     end
   end
 
-  describe "test_case_states precondition" do
-    test "accepts a trigger_config test_case_states list of valid states" do
+  describe "conditions scope" do
+    test "accepts a trigger_config with a valid test_case_state condition" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -447,7 +447,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
               "threshold" => 10,
               "window_type" => "last_days",
               "window" => "30d",
-              "test_case_states" => ["enabled"]
+              "conditions" => [%{"type" => "test_case_state", "states" => ["enabled"]}]
             }
           })
         )
@@ -455,7 +455,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert changeset.valid?
     end
 
-    test "rejects a trigger_config test_case_states with an unknown state" do
+    test "rejects a test_case_state condition with an unknown state" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -466,7 +466,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
               "threshold" => 10,
               "window_type" => "last_days",
               "window" => "30d",
-              "test_case_states" => ["enabled", "bogus"]
+              "conditions" => [%{"type" => "test_case_state", "states" => ["enabled", "bogus"]}]
             }
           })
         )
@@ -475,7 +475,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert errors_on(changeset).trigger_config
     end
 
-    test "rejects an empty trigger_config test_case_states list" do
+    test "rejects a test_case_state condition with an empty states list" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -486,7 +486,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
               "threshold" => 10,
               "window_type" => "last_days",
               "window" => "30d",
-              "test_case_states" => []
+              "conditions" => [%{"type" => "test_case_state", "states" => []}]
             }
           })
         )
@@ -495,7 +495,47 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert errors_on(changeset).trigger_config
     end
 
-    test "accepts a recovery_config test_case_states list of valid states" do
+    test "rejects a condition with an unknown type" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "conditions" => [%{"type" => "bogus", "states" => ["enabled"]}]
+            }
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).trigger_config
+    end
+
+    test "rejects conditions that are not a list" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "conditions" => %{"type" => "test_case_state", "states" => ["enabled"]}
+            }
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).trigger_config
+    end
+
+    test "accepts a recovery_config with a valid test_case_state condition" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -506,7 +546,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
             "recovery_config" => %{
               "window_type" => "rolling",
               "rolling_window_size" => 50,
-              "test_case_states" => ["muted"]
+              "conditions" => [%{"type" => "test_case_state", "states" => ["muted"]}]
             },
             "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
           })
@@ -515,7 +555,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert changeset.valid?
     end
 
-    test "rejects a recovery_config test_case_states with an unknown state" do
+    test "rejects an invalid recovery_config condition" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -526,7 +566,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
             "recovery_config" => %{
               "window_type" => "rolling",
               "rolling_window_size" => 50,
-              "test_case_states" => ["nope"]
+              "conditions" => [%{"type" => "test_case_state", "states" => ["nope"]}]
             },
             "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
           })
@@ -536,7 +576,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert errors_on(changeset).recovery_config
     end
 
-    test "ignores recovery_config test_case_states when recovery is disabled" do
+    test "ignores recovery_config conditions when recovery is disabled" do
       project = ProjectsFixtures.project_fixture()
 
       changeset =
@@ -544,7 +584,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
           %Alert{},
           valid_attrs(project, %{
             "recovery_enabled" => false,
-            "recovery_config" => %{"test_case_states" => ["nonsense"]}
+            "recovery_config" => %{"conditions" => [%{"type" => "bogus"}]}
           })
         )
 

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -435,6 +435,123 @@ defmodule Tuist.Automations.Alerts.AlertTest do
     end
   end
 
+  describe "test_case_states precondition" do
+    test "accepts a trigger_config test_case_states list of valid states" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "test_case_states" => ["enabled"]
+            }
+          })
+        )
+
+      assert changeset.valid?
+    end
+
+    test "rejects a trigger_config test_case_states with an unknown state" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "test_case_states" => ["enabled", "bogus"]
+            }
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).trigger_config
+    end
+
+    test "rejects an empty trigger_config test_case_states list" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "test_case_states" => []
+            }
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).trigger_config
+    end
+
+    test "accepts a recovery_config test_case_states list of valid states" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "recovery_enabled" => true,
+            "recovery_config" => %{
+              "window_type" => "rolling",
+              "rolling_window_size" => 50,
+              "test_case_states" => ["muted"]
+            },
+            "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
+          })
+        )
+
+      assert changeset.valid?
+    end
+
+    test "rejects a recovery_config test_case_states with an unknown state" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "recovery_enabled" => true,
+            "recovery_config" => %{
+              "window_type" => "rolling",
+              "rolling_window_size" => 50,
+              "test_case_states" => ["nope"]
+            },
+            "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).recovery_config
+    end
+
+    test "ignores recovery_config test_case_states when recovery is disabled" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "recovery_enabled" => false,
+            "recovery_config" => %{"test_case_states" => ["nonsense"]}
+          })
+        )
+
+      assert changeset.valid?
+    end
+  end
+
   describe "cadence validation" do
     test "converts cadence values to seconds" do
       assert Alert.cadence_seconds("30s") == 30

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -603,7 +603,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
-  describe "test_case_states precondition" do
+  describe "conditions scope" do
     test "trigger fires only for test cases whose current state is allowed" do
       automation =
         AutomationsFixtures.automation_alert_fixture(
@@ -611,7 +611,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
             "threshold" => 5,
             "window_type" => "rolling",
             "rolling_window_size" => 100,
-            "test_case_states" => ["enabled"]
+            "conditions" => [%{"type" => "test_case_state", "states" => ["enabled"]}]
           },
           trigger_actions: [%{"type" => "change_state", "state" => "muted"}]
         )
@@ -646,7 +646,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       automation =
         AutomationsFixtures.automation_alert_fixture(
           recovery_enabled: true,
-          recovery_config: %{"window_type" => "last_days", "window" => "1d", "test_case_states" => ["muted"]},
+          recovery_config: %{
+            "window_type" => "last_days",
+            "window" => "1d",
+            "conditions" => [%{"type" => "test_case_state", "states" => ["muted"]}]
+          },
           recovery_actions: [
             %{"type" => "change_state", "state" => "enabled"},
             %{"type" => "remove_label", "label" => "flaky"}
@@ -686,7 +690,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       automation =
         AutomationsFixtures.automation_alert_fixture(
           recovery_enabled: true,
-          recovery_config: %{"window_type" => "last_days", "window" => "1d", "test_case_states" => ["muted"]},
+          recovery_config: %{
+            "window_type" => "last_days",
+            "window" => "1d",
+            "conditions" => [%{"type" => "test_case_state", "states" => ["muted"]}]
+          },
           recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
         )
 

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -603,6 +603,132 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
+  describe "test_case_states precondition" do
+    test "trigger fires only for test cases whose current state is allowed" do
+      automation =
+        AutomationsFixtures.automation_alert_fixture(
+          trigger_config: %{
+            "threshold" => 5,
+            "window_type" => "rolling",
+            "rolling_window_size" => 100,
+            "test_case_states" => ["enabled"]
+          },
+          trigger_actions: [%{"type" => "change_state", "state" => "muted"}]
+        )
+
+      enabled_id = Ecto.UUID.generate()
+      already_muted_id = Ecto.UUID.generate()
+
+      expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+        %{triggered: [enabled_id, already_muted_id], all: [enabled_id, already_muted_id]}
+      end)
+
+      expect(Tests, :test_case_states, fn _project_id, ids ->
+        assert Enum.sort(ids) == Enum.sort([enabled_id, already_muted_id])
+        %{enabled_id => "enabled", already_muted_id => "muted"}
+      end)
+
+      expect(Automations, :list_active_alert_events, fn _id -> [] end)
+
+      # Only the currently-enabled test case is muted; the already-muted one is
+      # left alone (the automation shouldn't re-mute what it doesn't need to).
+      expected_entity = %{type: :test_case, id: enabled_id}
+      expect(ActionExecutor, :execute_actions, fn _actions, ^automation, ^expected_entity -> :ok end)
+
+      expect(Automations, :create_alert_event, fn %{test_case_id: ^enabled_id, status: "triggered"} -> :ok end)
+
+      assert :ok = run(automation.id)
+    end
+
+    test "recovery withholds its actions but still re-arms a candidate whose state is not allowed" do
+      # The reported bug: a mute automation set to recover only `muted` tests
+      # must not revert a test a human has since manually skipped.
+      automation =
+        AutomationsFixtures.automation_alert_fixture(
+          recovery_enabled: true,
+          recovery_config: %{"window_type" => "last_days", "window" => "1d", "test_case_states" => ["muted"]},
+          recovery_actions: [
+            %{"type" => "change_state", "state" => "enabled"},
+            %{"type" => "remove_label", "label" => "flaky"}
+          ]
+        )
+
+      skipped_id = Ecto.UUID.generate()
+
+      expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+        %{triggered: [], all: [skipped_id]}
+      end)
+
+      triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -3, :day)
+
+      expect(Automations, :list_active_alert_events, fn _id ->
+        [%{test_case_id: skipped_id, triggered_at: triggered_long_ago}]
+      end)
+
+      expect(Tests, :test_case_states, fn _project_id, [^skipped_id] ->
+        %{skipped_id => "skipped"}
+      end)
+
+      # State precondition fails → the recovery actions are withheld (empty list),
+      # so the manual skip / flaky mark is left untouched...
+      expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^skipped_id} ->
+        assert actions == []
+        :ok
+      end)
+
+      # ...but the candidate still re-arms so a future rising edge can fire.
+      expect(Automations, :create_alert_event, fn %{test_case_id: ^skipped_id, status: "recovered"} -> :ok end)
+
+      assert :ok = run(automation.id)
+    end
+
+    test "recovery filters its actions by state, running for allowed and re-arming the rest" do
+      automation =
+        AutomationsFixtures.automation_alert_fixture(
+          recovery_enabled: true,
+          recovery_config: %{"window_type" => "last_days", "window" => "1d", "test_case_states" => ["muted"]},
+          recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+        )
+
+      muted_id = Ecto.UUID.generate()
+      skipped_id = Ecto.UUID.generate()
+      triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -3, :day)
+
+      expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+        %{triggered: [], all: [muted_id, skipped_id]}
+      end)
+
+      expect(Automations, :list_active_alert_events, fn _id ->
+        [
+          %{test_case_id: muted_id, triggered_at: triggered_long_ago},
+          %{test_case_id: skipped_id, triggered_at: triggered_long_ago}
+        ]
+      end)
+
+      expect(Tests, :test_case_states, fn _project_id, ids ->
+        assert Enum.sort(ids) == Enum.sort([muted_id, skipped_id])
+        %{muted_id => "muted", skipped_id => "skipped"}
+      end)
+
+      expect(ActionExecutor, :execute_actions, 2, fn actions, ^automation, %{type: :test_case, id: id} ->
+        case id do
+          ^muted_id -> assert actions == automation.recovery_actions
+          ^skipped_id -> assert actions == []
+        end
+
+        :ok
+      end)
+
+      # Both re-arm regardless of whether their actions ran.
+      expect(Automations, :create_alert_event, 2, fn %{status: "recovered", test_case_id: id} ->
+        assert id in [muted_id, skipped_id]
+        :ok
+      end)
+
+      assert :ok = run(automation.id)
+    end
+  end
+
   test "test_updated alerts skip recovery bookkeeping even with stale active triggered events" do
     # A monitor-type change to test_updated can leave `triggered` events behind.
     # Event-driven monitors have no recovery semantics, so those must never get

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -7929,6 +7929,55 @@ defmodule Tuist.TestsTest do
     )
   end
 
+  describe "test_case_states/2" do
+    test "returns the current state per test case id, defaulting untouched ids to enabled" do
+      project = ProjectsFixtures.project_fixture()
+      untouched = RunsFixtures.test_case_fixture(project_id: project.id)
+      muted = RunsFixtures.test_case_fixture(project_id: project.id)
+      skipped = RunsFixtures.test_case_fixture(project_id: project.id)
+
+      IngestRepo.insert_all(
+        TestCase,
+        Enum.map([untouched, muted, skipped], &(&1 |> Map.from_struct() |> Map.delete(:__meta__)))
+      )
+
+      {:ok, _} = Tests.update_test_case(muted.id, %{state: "muted"})
+      {:ok, _} = Tests.update_test_case(skipped.id, %{state: "skipped"})
+
+      assert Tests.test_case_states(project.id, [untouched.id, muted.id, skipped.id]) == %{
+               untouched.id => "enabled",
+               muted.id => "muted",
+               skipped.id => "skipped"
+             }
+    end
+
+    test "reflects the most recent state change" do
+      project = ProjectsFixtures.project_fixture()
+      test_case = RunsFixtures.test_case_fixture(project_id: project.id)
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      {:ok, _} = Tests.update_test_case(test_case.id, %{state: "muted"})
+      {:ok, _} = Tests.update_test_case(test_case.id, %{state: "enabled"})
+
+      assert Tests.test_case_states(project.id, [test_case.id]) == %{test_case.id => "enabled"}
+    end
+
+    test "a flaky flag change alone leaves the state at enabled" do
+      project = ProjectsFixtures.project_fixture()
+      test_case = RunsFixtures.test_case_fixture(project_id: project.id)
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      {:ok, _} = Tests.update_test_case(test_case.id, %{is_flaky: true})
+
+      assert Tests.test_case_states(project.id, [test_case.id]) == %{test_case.id => "enabled"}
+    end
+
+    test "returns an empty map for no ids" do
+      project = ProjectsFixtures.project_fixture()
+      assert Tests.test_case_states(project.id, []) == %{}
+    end
+  end
+
   describe "update_test_case/3 with event creation" do
     test "creates marked_flaky event when is_flaky changes from false to true" do
       # Given

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -302,6 +302,57 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       refute Map.has_key?(automation.recovery_config, "rolling_window_size")
     end
 
+    test "persists trigger and recovery test_case_states preconditions", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "State-gated"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "enabled"})
+      render_hook(lv, "toggle_create_automation_form_recovery", %{})
+      render_hook(lv, "toggle_create_automation_form_recovery_state", %{"data" => "muted"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      assert automation.trigger_config["test_case_states"] == ["enabled"]
+      assert automation.recovery_config["test_case_states"] == ["muted"]
+    end
+
+    test "omits test_case_states from the config when no state is selected", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Any state"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      refute Map.has_key?(automation.trigger_config, "test_case_states")
+    end
+
+    test "toggling a trigger state twice removes it again", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Toggle off"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      refute Map.has_key?(automation.trigger_config, "test_case_states")
+    end
+
     test "creates a test_updated automation subscribed to the default marked_flaky event", %{
       conn: conn,
       organization: organization,
@@ -430,6 +481,38 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       assert [updated] = Automations.list_alerts(project.id)
       assert updated.id == automation.id
       assert updated.name == "Renamed"
+    end
+
+    test "edit_automation preserves existing test_case_states preconditions on save", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      automation =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          name: "Gated",
+          trigger_config: %{
+            "threshold" => 10,
+            "window_type" => "last_days",
+            "window" => "30d",
+            "test_case_states" => ["enabled"]
+          },
+          recovery_enabled: true,
+          recovery_config: %{"window_type" => "last_days", "window" => "14d", "test_case_states" => ["muted"]},
+          recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+        )
+
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "edit_automation", %{"id" => automation.id})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Gated renamed"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [updated] = Automations.list_alerts(project.id)
+      assert updated.name == "Gated renamed"
+      assert updated.trigger_config["test_case_states"] == ["enabled"]
+      assert updated.recovery_config["test_case_states"] == ["muted"]
     end
 
     test "edit_automation does nothing for an automation in another project", %{

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -302,7 +302,7 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       refute Map.has_key?(automation.recovery_config, "rolling_window_size")
     end
 
-    test "persists trigger and recovery test_case_states preconditions", %{
+    test "persists trigger and recovery test_case_state conditions", %{
       conn: conn,
       organization: organization,
       project: project
@@ -311,17 +311,19 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
 
       render_hook(lv, "open_create_automation_modal", %{})
       render_hook(lv, "update_create_automation_form_name", %{"value" => "State-gated"})
-      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "enabled"})
+      # A freshly added trigger condition defaults to ["enabled"], so no toggle
+      # is needed to land on Curtis's setup.
+      render_hook(lv, "add_create_automation_form_trigger_condition", %{"data" => "test_case_state"})
       render_hook(lv, "toggle_create_automation_form_recovery", %{})
-      render_hook(lv, "toggle_create_automation_form_recovery_state", %{"data" => "muted"})
+      render_hook(lv, "add_create_automation_form_recovery_condition", %{"data" => "test_case_state"})
       render_hook(lv, "save_automation", %{})
 
       assert [automation] = Automations.list_alerts(project.id)
-      assert automation.trigger_config["test_case_states"] == ["enabled"]
-      assert automation.recovery_config["test_case_states"] == ["muted"]
+      assert automation.trigger_config["conditions"] == [%{"type" => "test_case_state", "states" => ["enabled"]}]
+      assert automation.recovery_config["conditions"] == [%{"type" => "test_case_state", "states" => ["muted"]}]
     end
 
-    test "omits test_case_states from the config when no state is selected", %{
+    test "omits conditions from the config when none are added", %{
       conn: conn,
       organization: organization,
       project: project
@@ -329,14 +331,14 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       {:ok, lv, _html} = open(conn, organization, project)
 
       render_hook(lv, "open_create_automation_modal", %{})
-      render_hook(lv, "update_create_automation_form_name", %{"value" => "Any state"})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "No scope"})
       render_hook(lv, "save_automation", %{})
 
       assert [automation] = Automations.list_alerts(project.id)
-      refute Map.has_key?(automation.trigger_config, "test_case_states")
+      refute Map.has_key?(automation.trigger_config, "conditions")
     end
 
-    test "toggling a trigger state twice removes it again", %{
+    test "a state condition emptied of all states is dropped on save", %{
       conn: conn,
       organization: organization,
       project: project
@@ -344,13 +346,48 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       {:ok, lv, _html} = open(conn, organization, project)
 
       render_hook(lv, "open_create_automation_modal", %{})
-      render_hook(lv, "update_create_automation_form_name", %{"value" => "Toggle off"})
-      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
-      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Emptied"})
+      render_hook(lv, "add_create_automation_form_trigger_condition", %{"data" => "test_case_state"})
+      # Untick the default "enabled" so the condition has no states left.
+      render_hook(lv, "toggle_create_automation_form_trigger_condition_state", %{"data" => "enabled", "index" => "0"})
       render_hook(lv, "save_automation", %{})
 
       assert [automation] = Automations.list_alerts(project.id)
-      refute Map.has_key?(automation.trigger_config, "test_case_states")
+      refute Map.has_key?(automation.trigger_config, "conditions")
+    end
+
+    test "toggling adds a second allowed state to a condition", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Two states"})
+      render_hook(lv, "add_create_automation_form_trigger_condition", %{"data" => "test_case_state"})
+      render_hook(lv, "toggle_create_automation_form_trigger_condition_state", %{"data" => "muted", "index" => "0"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      assert automation.trigger_config["conditions"] == [%{"type" => "test_case_state", "states" => ["enabled", "muted"]}]
+    end
+
+    test "deleting a condition removes it before save", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Removed"})
+      render_hook(lv, "add_create_automation_form_trigger_condition", %{"data" => "test_case_state"})
+      render_hook(lv, "delete_create_automation_form_trigger_condition", %{"index" => "0"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      refute Map.has_key?(automation.trigger_config, "conditions")
     end
 
     test "creates a test_updated automation subscribed to the default marked_flaky event", %{
@@ -483,7 +520,7 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       assert updated.name == "Renamed"
     end
 
-    test "edit_automation preserves existing test_case_states preconditions on save", %{
+    test "edit_automation preserves existing conditions on save", %{
       conn: conn,
       organization: organization,
       project: project
@@ -496,10 +533,14 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
             "threshold" => 10,
             "window_type" => "last_days",
             "window" => "30d",
-            "test_case_states" => ["enabled"]
+            "conditions" => [%{"type" => "test_case_state", "states" => ["enabled"]}]
           },
           recovery_enabled: true,
-          recovery_config: %{"window_type" => "last_days", "window" => "14d", "test_case_states" => ["muted"]},
+          recovery_config: %{
+            "window_type" => "last_days",
+            "window" => "14d",
+            "conditions" => [%{"type" => "test_case_state", "states" => ["muted"]}]
+          },
           recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
         )
 
@@ -511,8 +552,8 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
 
       assert [updated] = Automations.list_alerts(project.id)
       assert updated.name == "Gated renamed"
-      assert updated.trigger_config["test_case_states"] == ["enabled"]
-      assert updated.recovery_config["test_case_states"] == ["muted"]
+      assert updated.trigger_config["conditions"] == [%{"type" => "test_case_state", "states" => ["enabled"]}]
+      assert updated.recovery_config["conditions"] == [%{"type" => "test_case_state", "states" => ["muted"]}]
     end
 
     test "edit_automation does nothing for an automation in another project", %{


### PR DESCRIPTION
## What changed

Automation alerts accept an optional `conditions` list in `trigger_config` and `recovery_config`, modeled like `trigger_actions`/`recovery_actions` (a list of typed maps). The only condition type today is `test_case_state`:

```json
{"type": "test_case_state", "states": ["enabled"]}
```

Conditions AND together; the `states` values within one condition OR.

- **Trigger path**: triggered candidates whose current state is outside the configured states are dropped before baseline establishment and transitions (`eligible_triggered_ids` in `AlertEvaluationWorker`), so a mute automation scoped to `["enabled"]` won't re-fire on a test that is already muted or skipped.
- **Recovery path**: candidates whose current state doesn't match the recovery conditions still re-arm (their `recovered` ledger event is appended so the next rising edge can fire again) but the recovery actions are withheld, so the automation doesn't revert a state it doesn't own (a manual skip, or another automation's change).
- New `Tuist.Tests.test_case_states/2`: a batched read of the current state per test case from the `test_case_states` projection (`argMaxIf` per column, ids bound as a single `Array(UUID)` parameter, 2000-id chunks, `multipart`), mirroring `fetch_validated_test_case_ids_chunk`. A test case with no recorded state change resolves to `enabled`.
- **Dashboard**: a generic conditions builder (a "Scope" section under Condition, and an "Only for tests matching" row in Recovery) mirroring the existing actions builder, with a test-state multi-select. A newly added trigger condition defaults to `enabled` and a recovery condition to `muted`; a condition with no states selected is dropped on save. Shown only for metric monitors.
- **API**: `trigger_config`/`recovery_config` are open `object` schemas, so only their descriptions were extended; no OpenAPI client regeneration is needed.

## Why

Recovery previously ran unconditionally on every ledger candidate whose metric condition cleared, and `ChangeStateAction` force-writes the target state regardless of the current one. A mute automation's recovery could therefore unmute or unskip a test that a human (or another automation) had quarantined in the meantime: the automation's own ledger said "triggered", the metric dipped below the threshold, and the recovery undid a state it never set. The trigger path had the sibling problem of firing on tests already in the target state.

We chose an explicit, user-configurable precondition over implicit provenance tracking (remembering who set each state). Provenance adds hidden coupling and still surprises when ownership is ambiguous, while an explicit state scope makes the behavior configurable per team: a mute automation set to trigger only on `enabled` and recover only on `muted` accounts for manual changes in between by construction. When a recovery candidate fails the precondition we still append the `recovered` event so the alert re-arms instead of latching, but withhold the undo actions.

The initial implementation used a bespoke `test_case_states` key; it was generalized into the `conditions` list (third commit) so future scoping (labels, suites, ...) extends the same shape instead of accreting parallel config keys. Adding a type means a new `apply_condition/3` clause in the worker and a `valid_condition?/1` clause in `Alert`.

The state read goes through the `test_case_states` ClickHouse projection introduced in #11977 rather than the legacy `state` column on `test_cases`, which is no longer read as of #11979.

## Impact

- Existing alerts are unchanged: an absent `conditions` key means no scoping, and no extra ClickHouse query is issued.
- With conditions configured, automations stop re-muting already-quarantined tests and stop reverting manual state changes on recovery.

## Validation

- `mix test` on the touched suites: 85 (alert schema + evaluation worker), 247 (`tests_test.exs`, including new projection-backed `test_case_states/2` tests), 63 (automations context + automations LiveView), all green.
- `mix compile --warnings-as-errors`, `mix credo`, and `mix format --check-formatted` clean.
- `mix gettext.extract` run; only `dashboard_projects.pot` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
