### PR TITLE
fix(infra): let the runners dashboard sync by dropping its invalid folder annotation

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -2,10 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "tuist-runners",
-    "annotations": {
-      "grafana.app/folder": "tuist"
-    }
+    "name": "tuist-runners"
   },
   "spec": {
     "title": "Tuist Runners",


### PR DESCRIPTION
The **Tuist Runners** Grafana dashboard has never been managed by Git Sync, so none of the repo edits to `runners.json` — the dispatch panels, the Allocation row, or the recently-added **Cache volumes** row — ever reached Grafana Cloud. The live dashboard was a stale hand-created copy sitting in the **General** folder (last edited by a human in June), while Git-Sync-managed dashboards live in **Tuist Dashboards** (uid `repository-2fdce57`) and are updated by the sync service.

## Root cause

Two things kept Git Sync from taking ownership:

1. **Invalid folder annotation (fixed here).** `runners.json` was the *only* dashboard carrying `grafana.app/folder: "tuist"`, and there is no folder with uid `tuist`. Every dashboard that syncs correctly omits the annotation and lets Git Sync place it in the bound folder. This PR removes it to match them.
2. **A squatting unmanaged dashboard.** A pre-existing `tuist-runners` in the General folder held the uid, so Git Sync could not create the managed copy. This has already been removed manually, so this change unblocks the sync.

## Why it matters

Once synced, the cache-volume observability panels (fast-forward reject rate, promote outcomes, warm-materialize share, resident masters, root free bytes) finally go live. That live query usage is also the reason Grafana Cloud **Adaptive Metrics** had aggregated away the `result` label on `tart_kubelet_cache_volume_promote_total` and the `outcome` label on `tart_kubelet_cache_volume_outcome_total` — no chart queried them. A keep-rule for those two metric/label pairs remains the belt-and-braces follow-up (Grafana Cloud config, out of repo).

## Validation

- JSON validates; `metadata` now reads `{"name": "tuist-runners"}`, matching the working siblings (`cache-service`, `processor-service`, …).
- Diff is a single-hunk annotation removal; all 37 panels (incl. the cache-volume row) are intact.
- After merge, Git Sync pulls on its interval (~60s) and provisions the dashboard into **Tuist Dashboards**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)