### PR TITLE
fix(infra): let the view tier read and JIT write elevation heal RunnerPool CRs

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -68,9 +68,10 @@ subjects:
 # Read-only extension to the `view` tier. The upstream `view` ClusterRole
 # omits cluster-scoped and custom resources, so a view-tier identity (every
 # member + their agents) can't observe the infra it routinely needs to:
-# nodes, CAPI machines, our Scaleway provider CRs, the Kura CRs, CRDs, and
-# RBAC objects. This aggregates into `view` via the label below (no extra
-# binding; both tuist-admins and tuist-eng inherit it), and is strictly
+# nodes, CAPI machines, our Scaleway provider CRs, the Kura CRs, the
+# RunnerPool CRs, CRDs, and RBAC objects. This aggregates into `view` via
+# the label below (no extra binding; both tuist-admins and tuist-eng
+# inherit it), and is strictly
 # `get`/`list`/`watch` with no `secrets` rule, so the view tier's deliberate
 # Secret exclusion is untouched. None of these resource kinds embed secret
 # data (CAPI/Kura reference Secrets by name, never inline).
@@ -100,6 +101,7 @@ rules:
       - cluster.x-k8s.io
       - infrastructure.cluster.x-k8s.io
       - kura.tuist.dev
+      - tuist.dev
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
@@ -130,6 +132,27 @@ metadata:
 rules:
   - apiGroups: ["kura.tuist.dev"]
     resources: ["*"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+---
+# RunnerPool analog of `tuist-edit-kura-write`. RunnerPool specs are
+# helm-rendered and autoscaler-patched, but operational corrections
+# sometimes need a direct write: healing spec drift the deploy pipeline
+# cannot see (helm's three-way merge only patches fields whose rendered
+# manifest changed between releases, so a value the apiserver rewrote
+# out-of-band persists indefinitely), or nudging a pool while its next
+# chart release is still in flight. Scoped to `runnerpools` rather than
+# the whole `tuist.dev` group so future kinds in that group don't
+# silently inherit write access from the edit tier.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-edit-runners-write
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["tuist.dev"]
+    resources: ["runnerpools"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 ---
 # Host-recovery capability for UN-WEDGING a single fleet host without the


### PR DESCRIPTION
## What changed

Two additions to the Pomerium chart's access tiers, both following existing precedent in `access-tiers.yaml`:

- `tuist-view-infra-read` (aggregated into `view`) gains read access to the `tuist.dev` API group, so the always-on view tier can observe RunnerPool specs.
- New `tuist-edit-runners-write` ClusterRole (aggregated into `edit`) grants RunnerPool writes to the JIT `tuist-<env>-write` elevation group, scoped to the `runnerpools` resource rather than the whole `tuist.dev` group so future kinds in that group do not silently inherit write access.

## Why

The access tiers never covered the `tuist.dev` API group. The view tier's infra-read extension lists CAPI, Scaleway provider, and `kura.tuist.dev` CRs but not RunnerPools, and the edit tier's only CR write extension is scoped to `kura.tuist.dev`. RunnerPools were therefore invisible and immutable to every human tier, including an active write elevation: only the runners-controller SA and the break-glass kubeconfig could touch them.

This bit today while healing the macOS warm-floor drift from #11894. That fix made an explicit `minWarmPoolFloor: 0` durable going forward, but the three already-drifted pools (`macos-26-0-1`, `macos-26-3`, `macos-26-4-1`) keep their stored `1` because helm's three-way merge only patches fields whose rendered manifest changed between releases, so an apiserver-defaulted value that drifted out-of-band is never rewritten. Healing them requires a one-time `kubectl patch` of `spec.autoscaling.minWarmPoolFloor`, and an active production write elevation could not perform it (Forbidden on `runnerpools.tuist.dev` for both reads and writes). Each of those drifted floors pins one of the 9 macOS host slots to an idle VM of a legacy Xcode pool, which is what starved the hot pools during today's queue spike.

Longer term, this drift class disappears with the GitOps adoption planned in [spec #72](https://hive.tuist.dev/specs/72): Flux continuously reconciles live state against git and corrects drift, rather than only patching fields whose rendered manifest changed between releases, so an out-of-band rewrite like this one would be reverted on the next reconcile instead of persisting. Until that reconciliation reaches the workload clusters' releases, healing drift takes an explicit write, which is what this change enables under a JIT elevation.

## Impact

- Members and their agents can read RunnerPool specs with the standard read-only kubectl access, so drift like this is diagnosable without break-glass.
- An active JIT write elevation can heal RunnerPool spec drift and perform occasional pool corrections without the break-glass kubeconfig, keeping the TTL-bounded, audited elevation path the tool for routine operational writes.
- No change to the base tiers' security posture: reads carry no secret data, and writes remain gated behind an active elevation.

## Validation

`helm template infra/helm/pomerium --set tuistEnv=production` renders the extended view rule and the new aggregated ClusterRole with the expected scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
