### PR TITLE
fix(infra): wire the cache-signing grant key in canary and production

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -23,6 +23,15 @@ server:
 
   appUrl: https://canary.tuist.dev
 
+  # Cache-signing grant private key (PEM Ed25519), synced from the
+  # TUIST_CACHE_GRANT_PRIVATE_KEY 1Password item. Without it dispatch omits the
+  # grant and the runner CLI falls back to per-machine MAC signing, so a warm
+  # cache volume's binaries never validate as local hits across VMs. Same
+  # keypair as staging (the CLI's baked public key pins it).
+  externalSecrets:
+    cacheGrant:
+      item: TUIST_CACHE_GRANT_PRIVATE_KEY
+
   # Stripe price IDs (identifiers, not secrets — the API keys live in the
   # STRIPE 1Password item). Canary's own (test-mode) IDs; the chart
   # JSON-encodes this into TUIST_STRIPE_PRICES.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -34,6 +34,15 @@ server:
 
   appUrl: https://tuist.dev
 
+  # Cache-signing grant private key (PEM Ed25519), synced from the
+  # TUIST_CACHE_GRANT_PRIVATE_KEY 1Password item. Without it dispatch omits the
+  # grant and the runner CLI falls back to per-machine MAC signing, so a warm
+  # cache volume's binaries never validate as local hits across VMs. Same
+  # keypair as staging (the CLI's baked public key pins it).
+  externalSecrets:
+    cacheGrant:
+      item: TUIST_CACHE_GRANT_PRIVATE_KEY
+
   # Stripe price IDs (identifiers, not secrets — the API keys live in the
   # STRIPE 1Password item). Live-mode prices, so they're set per env: staging
   # and canary use their own (test-mode) IDs in their overlays. The chart


### PR DESCRIPTION
The runner cache volume delivers **zero local cache hits** in production — and after a deep investigation, the cause is **not** the volume model (not contention, not convergence, not per-project keying). It is a **missing secret**.

## Root cause

Tuist EE signs local cache artifacts with a signature **bound to the machine MAC address** (`ArtifactSigner` → `\.macAddress`), so a binary cached on one VM is invalid on any other. The CLI has a purpose-built escape hatch (`ArtifactSignaturePayloadProvider.fetch`): when a runner job carries a valid **cache-signing grant**, it signs/validates against the **account scope** (`account-<id>`, stable across the account's VMs) instead of the MAC — *"so a warm cache volume's binaries validate as local hits across machines."*

That grant is minted server-side (`CacheGrant.mint`) **only when `TUIST_CACHE_GRANT_PRIVATE_KEY` is configured**. It was wired in `values-managed-staging.yaml` but **absent from canary and production**. Verified against the running prod cluster: `tuist-tuist-server` has no cache-grant env var. So `CacheGrant.mint` returned `nil`, dispatch omitted the grant, the guest never exported `TUIST_CACHE_SIGNING_GRANT`, and every job fell back to per-VM MAC signing — making the volume's entire purpose (cross-VM cache warmth) impossible. `command_events` confirms 0 local / thousands of remote hits every day, before and after the FF-LWW rollout.

## The fix

Sync the **same** `TUIST_CACHE_GRANT_PRIVATE_KEY` 1Password item staging uses into canary and production. The keypair is pinned by the CLI's baked-in public key (`CacheSigningGrantVerifier.bakedPublicKeyBase64`), so it must be the identical key — a fresh one would need a CLI baked-key update + release. The 1Password item has already been duplicated into the canary and production vaults, and the audience matches (server default `tuist-runner-cache` = the CLI's expected value).

## Impact

Once deployed and the server rolls, dispatch mints account-scoped grants → the runner CLI validates volume-carried artifacts as **local hits** across VMs → builds/tests read cache from the local warm volume instead of always fetching from remote. This is the payoff the volume was built for.

## Validation

- YAML parses; `server.externalSecrets.cacheGrant.item` resolves to `TUIST_CACHE_GRANT_PRIVATE_KEY` in staging, canary, and production; server blocks intact.
- Additive-only diff (+9 lines per file).
- The chart already renders the ESO external secret (`cache-grant-private-key`) and the server-deployment env var whenever `server.externalSecrets.cacheGrant.item` is non-empty.
- Post-deploy, confirm via `command_events`: local-cache-hit share on the macOS fleet should rise from 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)