### PR TITLE
feat(infra): surface per-peer bootstrap pass progress on the Kura pod dashboard

### DIFF
--- a/infra/grafana-dashboards/kura-pod.json
+++ b/infra/grafana-dashboards/kura-pod.json
@@ -27,7 +27,6 @@
       }
     ],
     "cursorSync": "Crosshair",
-    "description": "",
     "editable": true,
     "elements": {
       "panel-1": {
@@ -404,7 +403,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "kura_bootstrap_runs_total_total{env=\"$env\", pod=\"$pod\"}",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{result}}",
                         "range": true
                       },
                       "version": "v0"
@@ -422,47 +421,14 @@
           "links": [],
           "title": "runs total",
           "vizConfig": {
-            "group": "timeseries",
+            "group": "stat",
             "kind": "VizConfig",
             "spec": {
               "fieldConfig": {
                 "defaults": {
                   "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
+                    "fixedColor": "#ad46ff",
+                    "mode": "thresholds"
                   },
                   "min": 0,
                   "thresholds": {
@@ -482,23 +448,21 @@
                 "overrides": []
               },
               "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
                 },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "enableFacetedFilter": false,
-                  "overflow": "ellipsis",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                }
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
               }
             },
             "version": "13.2.0-29854286369"
@@ -1058,6 +1022,7 @@
                       "type": "range"
                     }
                   ],
+                  "min": 0,
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1459,6 +1424,7 @@
                       "mode": "off"
                     }
                   },
+                  "min": 0,
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1715,7 +1681,32 @@
                     ]
                   }
                 },
-                "overrides": []
+                "overrides": [
+                  {
+                    "__systemRef": "hideSeriesFrom",
+                    "matcher": {
+                      "id": "byNames",
+                      "options": {
+                        "mode": "exclude",
+                        "names": [
+                          "kura-tuist-eu-central-1-1.kura-tuist-eu-central-1-headless.kura.svc.cluster.local:7443 ok"
+                        ],
+                        "prefix": "All except:",
+                        "readOnly": true
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom",
+                        "value": {
+                          "legend": false,
+                          "tooltip": true,
+                          "viz": true
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               "options": {
                 "annotations": {
@@ -1983,7 +1974,110 @@
           }
         }
       },
-      "panel-24": {
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "builder",
+                        "expr": "sum(kura_background_work_paused{env=~\"$env\", pod=~\"$pod\", worker=\"outbox\"})",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 25,
+          "links": [],
+          "title": "replication worker state",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#ad46ff",
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "Running"
+                        },
+                        "1": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "Paused"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "max": 4,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-26": {
         "kind": "Panel",
         "spec": {
           "data": {
@@ -2002,8 +2096,8 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "builder",
-                        "expr": "kura_bootstrap_digest_buckets_total_total{env=\"$env\", pod=\"$pod\"}",
-                        "legendFormat": "{{result}}",
+                        "expr": "kura_replication_bandwidth_effective_limit_bytes_per_second{env=\"$env\", pod=\"$pod\"}",
+                        "legendFormat": "__auto",
                         "range": true
                       },
                       "version": "v0"
@@ -2016,10 +2110,10 @@
               "transformations": []
             }
           },
-          "description": "Manifest digest buckets classified during bootstrap range reconciliation — matched (skipped) vs walked",
-          "id": 24,
+          "description": "Current aggregate byte/s limit for peer transfers after public-load adaptation",
+          "id": 26,
           "links": [],
-          "title": "matched / walked buckets",
+          "title": "bandwidth limit per second",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",
@@ -2063,7 +2157,335 @@
                       "mode": "off"
                     }
                   },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-27": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod, route, status) ((rate(kura_http_requests_total_total{env=~\"$env\", pod=~\"$pod\", route=~\"/_internal/bootstrap/.*\"}[$__rate_interval])) and on (pod) max by (pod) (kura_node_info{env=~\"$env\", pod=~\"$pod\"}))",
+                        "legendFormat": "{{route}} {{status}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Traffic to internal peer bootstrap routes grouped by pod, route, and status.",
+          "id": 27,
+          "links": [],
+          "title": "traffic serving bootstrap of other peers",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-28": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "kura_bootstrap_pass_buckets_divergent{env=\"$env\", pod=\"$pod\"}",
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Divergent manifest buckets identified for the peer's current pass",
+          "id": 28,
+          "links": [],
+          "title": "Divergent buckets in the current pass",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#ad46ff",
+                    "mode": "thresholds"
+                  },
+                  "fieldMinMax": false,
                   "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1366
+                      },
+                      {
+                        "color": "red",
+                        "value": 2732
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-29": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "kura_bootstrap_pass_buckets_reconciled{env=\"$env\", pod=\"$pod\"}",
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Divergent buckets fully walked so far in the current pass",
+          "id": 29,
+          "links": [],
+          "title": "Divergent buckets fully walked in the current pass",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -2224,6 +2646,297 @@
                   "mode": "single",
                   "sort": "none"
                 }
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-30": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "kura_bootstrap_current_bucket_manifests_walked{env=\"$env\", pod=\"$pod\"}",
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Manifest entries walked in the bucket currently being reconciled",
+          "id": 30,
+          "links": [],
+          "title": "Manifest entries walked in the current bucket",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "__systemRef": "hideSeriesFrom",
+                    "matcher": {
+                      "id": "byNames",
+                      "options": {
+                        "mode": "exclude",
+                        "names": [
+                          "{peer=\"https://kura-tuist-scw-fr-par-0.kura-tuist-scw-fr-par-headless.kura.svc.cluster.local:7443\"}"
+                        ],
+                        "prefix": "All except:",
+                        "readOnly": true
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom",
+                        "value": {
+                          "legend": false,
+                          "tooltip": true,
+                          "viz": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-29854286369"
+          }
+        }
+      },
+      "panel-31": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "sum by(peer) (kura_bootstrap_pass_buckets_divergent{env=\"$env\", pod=\"$pod\"})",
+                        "instant": false,
+                        "legendFormat": "{{peer}}",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "sum by(peer) (kura_bootstrap_pass_buckets_reconciled{env=\"$env\", pod=\"$pod\"})",
+                        "instant": false,
+                        "legendFormat": "{{peer}}",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expression": "$B / $A * 100",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 31,
+          "links": [],
+          "title": "Walked buckets in the current pass",
+          "vizConfig": {
+            "group": "gauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 50
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.54,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": false,
+                  "gradient": true
+                },
+                "endpointMarker": "point",
+                "minVizHeight": 75,
+                "minVizWidth": 75,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 50,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sizing": "auto",
+                "sparkline": true,
+                "textMode": "auto"
               }
             },
             "version": "13.2.0-29854286369"
@@ -2431,6 +3144,7 @@
                       "mode": "off"
                     }
                   },
+                  "min": 0,
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -2672,6 +3386,7 @@
                       "mode": "off"
                     }
                   },
+                  "min": 0,
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -2980,6 +3695,19 @@
                         "x": 6,
                         "y": 8
                       }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-25"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 12,
+                        "y": 8
+                      }
                     }
                   ]
                 }
@@ -3145,11 +3873,24 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
+                          "name": "panel-12"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
                           "name": "panel-13"
                         },
                         "height": 8,
-                        "width": 8,
-                        "x": 0,
+                        "width": 6,
+                        "x": 6,
                         "y": 0
                       }
                     },
@@ -3161,8 +3902,8 @@
                           "name": "panel-6"
                         },
                         "height": 8,
-                        "width": 8,
-                        "x": 8,
+                        "width": 6,
+                        "x": 12,
                         "y": 0
                       }
                     },
@@ -3174,8 +3915,8 @@
                           "name": "panel-4"
                         },
                         "height": 8,
-                        "width": 8,
-                        "x": 16,
+                        "width": 6,
+                        "x": 18,
                         "y": 0
                       }
                     },
@@ -3184,10 +3925,10 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-12"
+                          "name": "panel-31"
                         },
                         "height": 8,
-                        "width": 12,
+                        "width": 24,
                         "x": 0,
                         "y": 8
                       }
@@ -3197,12 +3938,64 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-24"
+                          "name": "panel-28"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 0,
+                        "y": 16
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-29"
+                        },
+                        "height": 8,
+                        "width": 9,
+                        "x": 6,
+                        "y": 16
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-30"
+                        },
+                        "height": 8,
+                        "width": 9,
+                        "x": 15,
+                        "y": 16
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-22"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 24
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-27"
                         },
                         "height": 8,
                         "width": 12,
                         "x": 12,
-                        "y": 8
+                        "y": 24
                       }
                     }
                   ]
@@ -3250,7 +4043,7 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-22"
+                          "name": "panel-23"
                         },
                         "height": 8,
                         "width": 12,
@@ -3263,7 +4056,7 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-23"
+                          "name": "panel-26"
                         },
                         "height": 8,
                         "width": 12,
@@ -3366,7 +4159,7 @@
       "timezone": "browser",
       "to": "now"
     },
-    "title": "Kura | Pod",
+    "title": "Tuist Kura / Pod",
     "variables": [
       {
         "kind": "QueryVariable",


### PR DESCRIPTION
## What changed

Reworks the `Tuist Kura / Pod` Grafana dashboard (`infra/grafana-dashboards/kura-pod.json`) around bootstrap pass progress, plus the replication-throttling signals that explain why a pass stalls.

New panels:

| Panel | Query |
| --- | --- |
| Divergent buckets in the current pass | `kura_bootstrap_pass_buckets_divergent` |
| Divergent buckets fully walked in the current pass | `kura_bootstrap_pass_buckets_reconciled` |
| Manifest entries walked in the current bucket | `kura_bootstrap_current_bucket_manifests_walked` |
| Walked buckets in the current pass | per-peer gauge, `reconciled / divergent * 100` via a `__expr__` math query |
| replication worker state | `kura_background_work_paused{worker="outbox"}` |
| bandwidth limit per second | `kura_replication_bandwidth_effective_limit_bytes_per_second` |
| traffic serving bootstrap of other peers | `rate(kura_http_requests_total_total{route=~"/_internal/bootstrap/.*"})` by pod/route/status, gated on `kura_node_info` |

Removed: `matched / walked buckets` (`kura_bootstrap_digest_buckets_total`). The counter is still registered in `kura/src/metrics.rs`; it is only dropped from this dashboard.

Also in the diff:

- Dashboard title `Kura | Pod` → `Tuist Kura / Pod`, matching the `Tuist …` prefix every other dashboard in `infra/grafana-dashboards/` already uses.
- `runs total` switches from a timeseries to a last-value stat broken out by `{{result}}` — the interesting question about bootstrap runs is "how many completed vs failed", not their shape over time.
- `min: 0` pinned on the peer/index count panels (`discovered peers`, `known peers`, `manifest index entries`) so small counts don't get an auto-scaled axis that exaggerates a delta of one.
- Row re-layout to put the pass-progress panels together at the top of the bootstrap section.

## Why

Two Kura production incidents this month came down to the same missing signal: an unready pod mid-bootstrap looks identical whether it is slowly making progress or livelocked, and unready pods are not scraped, have no `kubectl logs`/`exec` on the bare-metal nodes, and expose nothing that answers "how far along is this pass?"

- The 2026-07-21 `kura-tuist-eu-central-1` 503 turned out to be a healthy but very slow cold bootstrap (~160K manifests). Progress could only be inferred indirectly, from the *source* peer's `/_internal/bootstrap/*` request rate.
- The 2026-07-23 wedge on the same instance was the opposite — genuine non-convergence from CAS segment-eviction thrash — and separating the two took hours of round-trip querying.

#12018 added the per-peer pass-progress gauges to answer this directly. This PR is the consumer side: the numbers are now on the pod dashboard instead of requiring an ad-hoc Explore query during an incident.

The two auxiliary panels are there because they are the first things you check once you know a pass *is* moving but slowly: whether the outbox worker is paused (`kura_background_work_paused`), and what the adaptive bandwidth limiter has throttled peer transfers down to. The `/_internal/bootstrap/*` traffic panel keeps the indirect signal available on the same screen, since it is the only one that works when the bootstrapping pod itself is unscraped.

## Alternatives considered

Keeping `kura_bootstrap_digest_buckets_total` alongside the new gauges was the obvious option. It was dropped because it is a monotonic counter across all passes — it tells you buckets were classified at some point, not where the *current* pass stands, which is exactly the ambiguity the new gauges resolve. Keeping both invites reading the wrong one under pressure.

## Impact

Grafana-only; no service code, no schema, no deploy. Applies to whoever is debugging a Kura pod that will not go Ready.

## Validation

- The dashboard was authored and saved from Grafana against production data, which is what produced this commit — every panel rendered live before it was exported.
- Every metric and label referenced by the new panels was cross-checked against its registration in `kura/src/metrics.rs`: `kura_bootstrap_pass_buckets_divergent`, `kura_bootstrap_pass_buckets_reconciled`, `kura_bootstrap_current_bucket_manifests_walked`, `kura_replication_bandwidth_effective_limit_bytes_per_second`, `kura_background_work_paused`, `kura_node_info`, `kura_http_requests_total`.
- `metadata.name` (`ddfsumc1ibvuo0e`) is unchanged, so this updates the existing dashboard in place rather than creating a second one, and the file carries no folder annotation of the kind that broke the runners dashboard sync in #12049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
