### PR TITLE
perf(kura): widen the bootstrap manifest page to 2048

### DIFF
--- a/kura/src/reapi/service.rs
+++ b/kura/src/reapi/service.rs
@@ -2238,8 +2238,17 @@ fn digest_key(digest: &reapi::Digest) -> Result<String, Status> {
     if digest.size_bytes < 0 {
         return Err(Status::invalid_argument("digest size must be non-negative"));
     }
-    if digest.hash.is_empty() {
-        return Err(Status::invalid_argument("digest hash must be present"));
+    // The hash becomes the manifest key, and a SHA-256 digest is always 32 bytes
+    // = 64 hex chars. The CAS write paths bound it implicitly by verifying the
+    // uploaded bytes against it, but update_action_result stores the digest as a
+    // key with no body to check against — so without this an authenticated client
+    // could persist an arbitrarily long "hash", inflating the manifest key until a
+    // bootstrap page overflows the receiver's MAX_BOOTSTRAP_PAGE_BYTES ceiling and
+    // wedges a joining node. Pin it to the fixed width a conforming client sends.
+    if digest.hash.len() != 64 || !digest.hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(Status::invalid_argument(
+            "digest hash must be a 64-character hex SHA-256",
+        ));
     }
     Ok(format!("{}/{}", digest.hash, digest.size_bytes))
 }
@@ -2962,6 +2971,37 @@ mod tests {
         cache.trim_to(3 * 1024, "test", &metrics);
 
         assert!(cache.stats().bytes <= 3 * 1024);
+    }
+
+    #[test]
+    fn digest_key_requires_a_fixed_width_sha256_hash() {
+        let valid = reapi::Digest {
+            hash: hex::encode([0xabu8; 32]),
+            size_bytes: 10,
+        };
+        assert_eq!(
+            digest_key(&valid).expect("a 64-hex hash must be accepted"),
+            format!("{}/10", hex::encode([0xabu8; 32]))
+        );
+
+        // An unbounded hash is what inflates the manifest key past the bootstrap
+        // page ceiling; update_action_result has no body to verify it against, so
+        // the width check is the only thing keeping the key fixed-size.
+        for bad in [
+            String::new(),
+            "abc".to_string(),
+            "z".repeat(64),
+            "a".repeat(63),
+            "a".repeat(65),
+            "a".repeat(16 * 1024),
+        ] {
+            let digest = reapi::Digest {
+                hash: bad,
+                size_bytes: 10,
+            };
+            let status = digest_key(&digest).expect_err("a non-64-hex hash must be rejected");
+            assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        }
     }
 
     #[test]

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -40,7 +40,14 @@ use crate::{
 
 use self::{operation::ReplicationOperation, outbox_message::OutboxMessage};
 
-const BOOTSTRAP_PAGE_LIMIT: usize = 256;
+// Manifests per page of the bootstrap keyspace walk. Sized to hold a whole
+// digest bucket in one request: at BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN the
+// keyspace splits into 4096 buckets, so a 3M-artifact account averages ~750
+// manifests per bucket and every divergent bucket used to cost three
+// round-trips instead of one. A page is bounded by count, not bytes — a REAPI
+// manifest serializes to ~420 B, so 2048 is ~850 KiB, well inside the
+// MAX_BOOTSTRAP_PAGE_BYTES ceiling the puller reads under.
+const BOOTSTRAP_PAGE_LIMIT: usize = 2048;
 
 // Artifact bodies fetched from a peer concurrently within a bootstrap page. Caps
 // open peer connections; staged bytes stay bounded by bootstrap_staging_budget.
@@ -631,7 +638,7 @@ async fn bootstrap_manifest_range_from_peer(
                         let applied = outcome.applied();
                         if applied {
                             // Tick progress as each artifact lands, not once per
-                            // page: draining a single 256-manifest page can take
+                            // page: draining a single full page can take
                             // longer than the no-progress window on a slow/cold
                             // link, and batching the bump to page end would let the
                             // watchdog cancel a bootstrap that is in fact applying.
@@ -2967,9 +2974,11 @@ mod tests {
 
         // Reproduces the production wedge: a large peer dataset that the joining
         // node already holds almost all of. Prod is ~1.4M artifacts / 4096
-        // buckets, ~99% in sync; a thousand here spans many buckets and forces
-        // the legacy full walk into several pages while staying fast.
-        const TOTAL: usize = 1024;
+        // buckets, ~99% in sync; this spans many buckets and forces the legacy
+        // full walk into several pages while staying fast. Keep it a multiple of
+        // BOOTSTRAP_PAGE_LIMIT above 1 so the full walk stays multi-page — the
+        // A/B assertion below is only meaningful while it is.
+        const TOTAL: usize = 4 * BOOTSTRAP_PAGE_LIMIT;
         const MISSING: usize = 2;
 
         let remote = test_context(|_| {}).await;
@@ -3364,9 +3373,10 @@ mod tests {
             response::IntoResponse,
         };
 
-        // Exactly one page (limit=256) of segment-backed artifacts, each body
-        // fetch delayed. At concurrency 16 the single page takes ~16*40ms to
-        // drain — many watchdog windows — with no page boundary in between.
+        // Fewer artifacts than BOOTSTRAP_PAGE_LIMIT, so the walk is a single
+        // page, each body fetch delayed. At concurrency 16 that page takes
+        // ~16*40ms to drain — many watchdog windows — with no page boundary in
+        // between.
         let remote = test_context(|_| {}).await;
         for i in 0..256 {
             let key = format!("artifact-{i:05}");


### PR DESCRIPTION
## What changed

Two commits:

1. **`BOOTSTRAP_PAGE_LIMIT`: 256 → 2048** manifests per page of the bootstrap keyspace walk (`kura/src/replication/mod.rs`).
2. **Bound the REAPI digest hash to a fixed-width SHA-256** in `digest_key` (`kura/src/reapi/mod.rs`), which is what makes the wider page safe in the worst case.

## Why widen the page

Bootstrap reconciles against a peer in two steps. First it exchanges per-bucket digests: `manifests_digest` partitions the sorted `artifact_id` keyspace by its leading `BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN` = 3 hex characters into 4096 buckets, folding each bucket's ordered `(artifact_id, version_ms)` pairs into one hash. `divergent_prefixes` diffs local against peer, and only the mismatching buckets get walked.

That second step — `bootstrap_manifest_range_from_peer` → `GET /_internal/bootstrap/manifests?limit=…&prefix=<bucket>` — is what this changes. It is **not** an `(id, version_ms)` probe; it returns the full `ArtifactManifest` for every entry (`artifact_id`, `producer`, `namespace_id`, `key`, `content_type`, `inline`, `size`, `version_ms`, …). A conforming REAPI manifest serializes to ~420 B.

At 4096 buckets, the eu-central account from the recent bootstrap investigation (~3.06M artifacts) averages ~750 manifests per divergent bucket, so a 256-entry page split every one of them across **three** sequential round-trips where one would do — and the pages are sequential, each gated on `next_after` from the last. A page was ~106 KiB against a `MAX_BOOTSTRAP_PAGE_BYTES` ceiling of 32 MiB; the count limit was binding ~300× before the byte limit was anywhere close. 2048 covers a whole average bucket in one request and still sits at ~2.6% of the byte ceiling.

### Why 2048 and not larger

The byte ceiling would permit far more, but the useful stopping point is "one average bucket, one request." Past that, extra width buys nothing on the common bucket and only grows the per-page working set the responder materializes and the puller clones. 2048 keeps a comfortable margin even for accounts with longer handles.

## The page-size safety fix (`digest_key`)

Raising the count would make correctness depend on the manifest staying small, and the manifest `key` is only as bounded as the metadata it is built from. Tracing ingestion by producer:

- **HTTP producers (Xcode, Gradle, Nx, Metro):** the key arrives as a URL **path segment** (`AxumPath<String>`), so it is bounded by the request-line/header length limit (single-digit KiB in practice). Even a full 2048-entry page of these stays well under 32 MiB.
- **REAPI CAS writes (ByteStream + BatchUpdateBlobs):** the claimed hash is **verified against the uploaded bytes** (`reapi/service.rs:421`, `:2219`), so it can only ever be a real 64-hex SHA-256.
- **REAPI `update_action_result`:** the action digest is stored **as a key with no body to verify it against** — the action itself is never uploaded. `digest_key` checked only that the hash was non-empty, and the gRPC decode limit is 64 MiB (`REAPI_MAX_DECODING_MESSAGE_SIZE`). So an authenticated client could persist an arbitrarily long "hash", inflating the manifest key.

That last path is the only way a manifest key can exceed a page. The failure mode is specifically a **liveness wedge**: an oversized page trips the puller's `read_bounded_body` (32 MiB) in `fetch_bootstrap_manifests_page`, which returns an error **before** the walk cursor advances, so every retry re-requests the same failing page and the joining node never becomes ready — and bootstrap is node-global, so one namespace's poisoned entries would wedge the whole node during a mixed-version rollout.

Rather than cap the page by bytes or reshape the walk protocol, the fix removes the source: pin the hash to the width every conforming client already sends.

```rust
if digest.hash.len() != 64 || !digest.hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
    return Err(Status::invalid_argument("digest hash must be a 64-character hex SHA-256"));
}
```

This is protocol-correct — Kura only supports SHA-256 (`require_sha256`), and a SHA-256 digest is always 32 bytes = 64 hex — so it has **no effect on real traffic**; it only rejects the malformed-hash write that could poison bootstrap. It is scoped to REAPI on purpose: `digest_key` is REAPI-only, and REAPI is the sole producer whose key is a digest hash. The HTTP producers keep their URL-length bound; the CAS write paths keep their content-hash verification. With every stored key pinned to the fixed ~90-byte size, a 2048-entry page is provably under the ceiling.

## Why not the alternatives

- **Byte-bounded pagination on the responder** doesn't cover the exact case flagged — the digest-less fallback is triggered by an *old* peer serving the page, which has no byte budget; the joining (new) node is the puller. Bounding the source at ingestion does cover it.
- **Puller-side adaptive page shrink** would defend against a size variability that conforming REAPI traffic doesn't exhibit — the key is fixed-width by protocol. It was complexity for a non-case once the hash is bounded at ingestion.
- **A generic key-length cap across all producers** was rejected as wrong-shaped: the non-REAPI producers have legitimately variable, non-hex keys and are already URL-bounded.

## Rollout safety

- Safe under one version skew. The puller drives page size and the serving side has no upper clamp on `limit` (`PageQuery::from_params` validates only `limit != 0`), so a new node asking an old peer for 2048 gets 2048, and an old node asking a new peer for 256 is unchanged. No wire-format, on-disk, or config surface changes.
- The `digest_key` bound is a stricter ingestion validation of an invariant conforming clients already satisfy, `invalid_argument` (non-retriable) so a malformed client gets a clean rejection instead of a poison entry. No existing entry is affected; no Helm values move.

## Follow-ups not taken here

- **~26% of each manifest is fields the puller never reads** (`segment_id`, `segment_offset`, `created_at_ms`, and `blob_path` when set — the serving peer's local storage layout, which the receiver re-derives on apply). Trimming the walk projection would cut ~340 MB off a 3.06M-artifact full walk. Left out to keep this a focused change; it's a response-shape change deserving its own skew analysis.
- **An `(id, version_ms)` probe page with metadata-on-fetch** would make any page size safe by construction and shrink the common skip path, but it's a protocol reshape — tracked separately.

## Validation

- `cargo test --lib` — **374 passed, 0 failed** (1 pre-existing ignored), including the new `digest_key_requires_a_fixed_width_sha256_hash` and the existing bootstrap page/watchdog tests.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Two tests encoded the old page constant and were updated:

- `range_digest_reconciles_a_mostly_in_sync_pair_by_walking_only_the_delta` asserts the digest path walks strictly fewer pages than the legacy full walk. Its `TOTAL = 1024` dataset became a **single**-page full walk under a 2048 limit, degenerating the A/B comparison (it failed with `2 < 1`). Now `TOTAL = 4 * BOOTSTRAP_PAGE_LIMIT`, keeping the full walk multi-page and tying the dataset to the constant so it can't silently rot again.
- `bootstrap_ticks_progress_per_artifact_within_a_slow_page` seeds 256 artifacts; still a single page under the wider limit, and the assertion is about a single page's drain outlasting the watchdog. Comment corrected; no behavior change. (The watchdog is unaffected regardless — progress ticks per applied artifact, not per page.)

Not validated here: the Bazel path (`mise run test-unit`) and the shellspec e2e suite, which CI covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
