### PR TITLE
fix(server): restore development live reload

### DIFF
--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -8,6 +8,8 @@ import Config
 # to bundle .js and .css sources.
 
 noora_source_path = Path.expand("../../noora", __DIR__)
+server_source_path = Path.expand("..", __DIR__)
+escaped_noora_source_path = Regex.escape(noora_source_path)
 deps_path = Path.expand("../deps", __DIR__)
 node_modules_path = Path.expand("../node_modules", __DIR__)
 code_reloader_enabled = System.get_env("TUIST_DEV_DISABLE_CODE_RELOADER") not in ["1", "true"]
@@ -51,10 +53,10 @@ base_live_reload_patterns = [
   ~r"lib/tuist_web/marketing/(controllers|live|components)/.*(ex|heex)$",
   ~r"lib/tuist_web/docs/.*(ex|heex)$",
   ~r"priv/marketing/blog/*/.*(md)$",
-  ~r"../../noora/lib/noora/.*(ex|heex)$",
-  ~r"../../noora/js/.*(js)$",
-  ~r"../../noora/css/.*(css)$",
-  ~r"../../noora/priv/static/.*(js|css)$"
+  ~r"#{escaped_noora_source_path}/lib/noora/.*(ex|heex)$",
+  ~r"#{escaped_noora_source_path}/js/.*(js)$",
+  ~r"#{escaped_noora_source_path}/css/.*(css)$",
+  ~r"#{escaped_noora_source_path}/priv/static/.*(js|css)$"
 ]
 
 config :esbuild,
@@ -130,9 +132,11 @@ config :phoenix, :stacktrace_depth, 20
 
 config :phoenix_live_reload,
   dirs: [
-    "../../noora/lib",
-    "../../noora/js",
-    "../../noora/css"
+    server_source_path,
+    Path.join(noora_source_path, "lib"),
+    Path.join(noora_source_path, "js"),
+    Path.join(noora_source_path, "css"),
+    Path.join(noora_source_path, "priv/static")
   ]
 
 # Include HEEx debug annotations as HTML comments in rendered markup


### PR DESCRIPTION
## What changed

The development live reloader now watches the server root alongside the Noora source directories. Noora file patterns are built from the escaped absolute source path, and Noora's generated static assets are monitored as well.

## Why

Small stylesheet changes were rebuilding successfully, but an already-open browser did not receive the updated bundle. This forced developers to refresh manually and could make changes appear delayed.

## Root cause

Configuring explicit live-reload directories replaced the default server working directory, so generated assets under `server/priv/static` were no longer observed. Noora events were emitted as absolute paths, while the configured patterns expected relative paths beginning with `../../noora`, so those events did not match either.

## Approach

The live reloader monitors the server root plus the relevant Noora directories. Server patterns continue matching generated assets, while Noora patterns use the normalized absolute source path emitted by the file watcher.

## Impact

Development-only stylesheet and JavaScript changes now propagate to an open browser automatically. Production behavior is unchanged.

## Validation

- Ran `mise x -- mix compile --warnings-as-errors` successfully.
- Validated that every monitored server and Noora path matches the configured live-reload patterns.
- Started the server with `mise run dev` and loaded it in headless Chrome.
- Saved a temporary Noora stylesheet probe and confirmed that the browser applied it without a manual refresh in under 1.7 seconds.
- Removed the probe and confirmed that the browser automatically applied the restored stylesheet.
- Ran `git diff --check` successfully.

### How to test locally

1. Run `mise run dev` from `server`.
2. Open the local server in a browser.
3. Change and save a style in `noora/css`.
4. Confirm that the open page applies the rebuilt stylesheet without a manual refresh.
