### PR TITLE
chore(infra): reduce Grafana metrics scrape frequency

### DIFF
--- a/cache/platform/alloy.nix
+++ b/cache/platform/alloy.nix
@@ -6,8 +6,8 @@
 }: let
   hostName = config.networking.hostName;
   isNonProduction = lib.hasSuffix "-staging" hostName || lib.hasSuffix "-canary" hostName;
-  cachePromexScrapeInterval = if isNonProduction then "120s" else "30s";
-  internalExporterScrapeInterval = if isNonProduction then "60s" else "30s";
+  cachePromexScrapeInterval = if isNonProduction then "120s" else "60s";
+  internalExporterScrapeInterval = "60s";
 
   grafanaCloudUrl = config.services.onepassword-secrets.secrets.grafanaCloudPromRemoteWriteUrl.path;
   grafanaCloudUsername = config.services.onepassword-secrets.secrets.grafanaCloudPromUsername.path;

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -76,6 +76,15 @@ Plus the telemetry services themselves:
 - `kube-state-metrics` Deployment
 - `node-exporter` DaemonSet
 
+## Metrics scrape cadence
+
+All cluster and custom metrics jobs use a 60-second scrape interval. This
+matches Grafana Cloud's included rate of one data point per minute for each
+active series, while keeping enough resolution for the infrastructure
+dashboards and alerts. Keep job-specific overrides at 60 seconds unless a
+documented operational requirement justifies the additional ingestion cost.
+See [Grafana's scrape interval guidance](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/).
+
 ## Local validation
 
 ```bash

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -48,7 +48,7 @@ k8s-monitoring:
     name: ""
 
   global:
-    scrapeInterval: 30s
+    scrapeInterval: 60s
 
   # v4 schema: destinations is a map keyed by destination name. Per-env
   # overlays merge into these entries (e.g. adding `extraLabels.env`) so
@@ -725,16 +725,17 @@ k8s-monitoring:
           targets = discovery.relabel.tuist_macos_node_exporter.output
           forward_to = [prometheus.relabel.tuist_macos_node_exporter.receiver]
           job_name = "tuist-macos-node-exporter"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           // Without this block, every alloy-metrics replica scrapes the
           // same target independently. The chart-default scrape blocks
           // (cadvisor, kubelet, kube-state-metrics, …) all opt in; the
           // five Tuist extraConfig blocks below did not, which manifested
-          // as 36 DPM (~18× the 2 DPM expected at 30s) on the `node_*` /
-          // `tart_kubelet_*` / `cnpg_*` series — a perfect match against
-          // the 18 alloy-metrics replicas the chart runs in production.
+          // as 36 data points per minute at the previous 30-second interval
+          // on the `node_*` / `tart_kubelet_*` / `cnpg_*` series — a perfect
+          // match against the 18 alloy-metrics replicas the chart runs in
+          // production.
           clustering {
             enabled = true
           }
@@ -780,7 +781,7 @@ k8s-monitoring:
           // values.yaml — dashes → underscores per Alloy syntax).
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
           job_name = "tuist-macos-tart-kubelet"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           clustering {
@@ -832,7 +833,7 @@ k8s-monitoring:
           // values.yaml — dashes → underscores per Alloy syntax).
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
           job_name = "tuist-macos-pod-metrics"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           // Same reason as the node-exporter job above: without this,
@@ -902,7 +903,7 @@ k8s-monitoring:
           targets = discovery.relabel.tuist_cnpg_instances.output
           forward_to = [prometheus.relabel.tuist_cnpg_instances.receiver]
           job_name = "tuist-cnpg-instances"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           clustering {
@@ -984,7 +985,7 @@ k8s-monitoring:
           targets = discovery.relabel.tuist_cnpg_pooler.output
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
           job_name = "tuist-cnpg-pooler"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           clustering {
@@ -1034,7 +1035,7 @@ k8s-monitoring:
           targets = discovery.relabel.tuist_cnpg_operator.output
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
           job_name = "tuist-cnpg-operator"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           clustering {
@@ -1103,7 +1104,7 @@ k8s-monitoring:
           targets = discovery.relabel.tuist_kura_unready.output
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
           job_name = "kura"
-          scrape_interval = "30s"
+          scrape_interval = "60s"
           scrape_timeout = "10s"
 
           clustering {


### PR DESCRIPTION
## What changed

The Grafana Alloy scrape cadence is now 60 seconds for the shared Kubernetes
monitoring configuration and every custom macOS, Kura, and CloudNativePG job.
Production cache hosts use the same cadence for application and internal
exporters, while the existing 120-second non-production application interval
is preserved. The monitoring documentation now records this cost boundary.

## Why

Grafana Cloud metrics usage has increased alongside the monitored macOS and
Kura fleets. A 30-second cadence sends two data points per minute for every
active series, while the paid plan includes one. Moving general infrastructure
telemetry to 60 seconds reduces ingestion without materially changing the
dashboards or operational alerts.

## Root cause

The monitored target count grew substantially, but its scrape cadence remained
at 30 seconds. That made each new active series contribute twice the included
data-point rate and amplified the cost of otherwise expected fleet growth.

## Approach

The change standardizes all cluster-level and explicit custom jobs on 60
seconds instead of changing only the global default. The independent cache-host
configuration is updated in the same commit so production does not retain a
second 30-second ingestion path.

## Impact

Affected jobs should emit approximately half as many metric data points.
Active-series cardinality is unchanged. Dashboard refreshes and alert
observations can be delayed by up to an additional 30 seconds.

## Validation

Helm lint and full template rendering succeeded for staging, canary, and
production. The cache-host Nix configuration also parsed successfully, and a
repository search confirmed that no 30-second scrape configuration remains.

### How to test locally

```bash
helm dependency update infra/helm/k8s-monitoring
helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-staging.yaml
helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-canary.yaml
helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-production.yaml
helm template k8s-monitoring infra/helm/k8s-monitoring -n observability -f infra/helm/k8s-monitoring/values-production.yaml
nix-instantiate --parse cache/platform/alloy.nix
```
