### PR TITLE
fix(cli): keep tuist cache's compilation cache out of the throwaway build dir

### DIFF
--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -2269,9 +2269,21 @@ impl Proxy {
             let last = Duration::from_millis(state.last_used.load(Ordering::Relaxed));
             let idle = now.saturating_sub(last);
             let cas_dir_gone = std::fs::symlink_metadata(&cas_path).is_err();
-            if should_reclaim(idle, cas_dir_gone) {
-                state.invalidate();
-                state.publish_cache.lock().unwrap().clear();
+            if !should_reclaim(idle, cas_dir_gone) {
+                continue;
+            }
+            state.invalidate();
+            state.publish_cache.lock().unwrap().clear();
+            // A CAS whose on-disk directory is gone never comes back: the path is a one-shot
+            // throwaway (e.g. `tuist cache`'s temp derived-data, a deleted worktree). Forget it
+            // entirely rather than retain the shell, so we stop sweeping a vanished spool and
+            // stop persisting a registry entry per run, which would otherwise grow without bound.
+            if cas_dir_gone {
+                self.paths.lock().unwrap().remove(&cas_path);
+                let mut map = self.path_instance.lock().unwrap();
+                if map.remove(&cas_path).is_some() {
+                    self.persist_registry(&map);
+                }
             }
         }
     }
@@ -2319,6 +2331,12 @@ impl Proxy {
     pub fn sweep(&self) {
         let paths: Vec<String> = self.paths.lock().unwrap().keys().cloned().collect();
         for cas_path in paths {
+            // A path whose on-disk CAS is gone (its build's throwaway dir was removed) has no
+            // spool to drain, and claiming records back into a directory mid-teardown is what
+            // races the remover into an ENOTEMPTY failure. Skip it; reclaim_idle forgets it.
+            if std::fs::symlink_metadata(&cas_path).is_err() {
+                continue;
+            }
             let Some(instance) = self.path_instance.lock().unwrap().get(&cas_path).cloned() else {
                 continue;
             };

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -2269,21 +2269,9 @@ impl Proxy {
             let last = Duration::from_millis(state.last_used.load(Ordering::Relaxed));
             let idle = now.saturating_sub(last);
             let cas_dir_gone = std::fs::symlink_metadata(&cas_path).is_err();
-            if !should_reclaim(idle, cas_dir_gone) {
-                continue;
-            }
-            state.invalidate();
-            state.publish_cache.lock().unwrap().clear();
-            // A CAS whose on-disk directory is gone never comes back: the path is a one-shot
-            // throwaway (e.g. `tuist cache`'s temp derived-data, a deleted worktree). Forget it
-            // entirely rather than retain the shell, so we stop sweeping a vanished spool and
-            // stop persisting a registry entry per run, which would otherwise grow without bound.
-            if cas_dir_gone {
-                self.paths.lock().unwrap().remove(&cas_path);
-                let mut map = self.path_instance.lock().unwrap();
-                if map.remove(&cas_path).is_some() {
-                    self.persist_registry(&map);
-                }
+            if should_reclaim(idle, cas_dir_gone) {
+                state.invalidate();
+                state.publish_cache.lock().unwrap().clear();
             }
         }
     }
@@ -2331,12 +2319,6 @@ impl Proxy {
     pub fn sweep(&self) {
         let paths: Vec<String> = self.paths.lock().unwrap().keys().cloned().collect();
         for cas_path in paths {
-            // A path whose on-disk CAS is gone (its build's throwaway dir was removed) has no
-            // spool to drain, and claiming records back into a directory mid-teardown is what
-            // races the remover into an ENOTEMPTY failure. Skip it; reclaim_idle forgets it.
-            if std::fs::symlink_metadata(&cas_path).is_err() {
-                continue;
-            }
             let Some(instance) = self.path_instance.lock().unwrap().get(&cas_path).cloned() else {
                 continue;
             };

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -343,43 +343,43 @@ import XcodeGraph
                     Logger.current.info("\(successfullyStoredTargets.count) targets stored: \(targetsStored)")
                 }
             } catch {
-                await cleanUpCacheWarmDirectory(temporaryDirectory)
+                await removeCacheWarmDirectory(temporaryDirectory)
                 throw error
             }
 
-            await cleanUpCacheWarmDirectory(temporaryDirectory)
+            await removeCacheWarmDirectory(temporaryDirectory)
         }
 
-        /// Removes the throwaway cache-warm directory, tolerating a cleanup failure so it can never fail an
-        /// otherwise-successful run.
-        ///
-        /// The build writes Xcode's compilation cache into `derived-data/CompilationCache.noindex`, whose
-        /// spool the machine-wide CAS proxy drains asynchronously; it can create spool entries there
-        /// concurrently with this teardown. Removing that subtree first, with a short retry, keeps a lost
-        /// race (the directory repopulated between enumeration and `rmdir`, surfaced as "Directory not
-        /// empty") from aborting the command after the cache has already been stored.
-        private func cleanUpCacheWarmDirectory(_ temporaryDirectory: AbsolutePath) async {
-            let compilationCachePath = temporaryDirectory
-                .appending(components: ["derived-data", "CompilationCache.noindex"])
-            await bestEffortRemove(compilationCachePath)
-            await bestEffortRemove(temporaryDirectory)
-        }
-
-        private func bestEffortRemove(_ path: AbsolutePath, attempts: Int = 3) async {
+        /// Removes the throwaway cache-warm directory, tolerating a failure so cleanup can never fail an
+        /// otherwise-successful run. Only the build products live here; Xcode's compilation cache is kept
+        /// out of this directory (see `compilationCacheCASArgument`), so nothing writes to it concurrently
+        /// and the retry is a safety net for an unexpected straggler, not the fix for a known race.
+        private func removeCacheWarmDirectory(_ temporaryDirectory: AbsolutePath, attempts: Int = 3) async {
             for attempt in 1 ... attempts {
                 do {
-                    try await fileSystem.remove(path)
+                    try await fileSystem.remove(temporaryDirectory)
                     return
                 } catch {
                     if attempt == attempts {
                         Logger.current.debug(
-                            "Best-effort cleanup of \(path.pathString) failed after \(attempts) attempts: \(error)"
+                            "Best-effort cleanup of \(temporaryDirectory.pathString) failed after \(attempts) attempts: \(error)"
                         )
                     } else {
                         try? await Task.sleep(for: .milliseconds(200))
                     }
                 }
             }
+        }
+
+        /// Pins Xcode's compilation cache (CAS) to the machine's shared DerivedData instead of letting it
+        /// follow `-derivedDataPath` into this command's throwaway build directory. The plugin's spool
+        /// there is drained asynchronously by the machine-wide CAS proxy and must outlive the build, so
+        /// keeping it at the default location avoids racing the directory's teardown and warms the same
+        /// store regular Xcode builds read.
+        private func compilationCacheCASArgument() async throws -> XcodeBuildArgument {
+            let casPath = try await Environment.current.derivedDataDirectory()
+                .appending(component: "CompilationCache.noindex")
+            return .xcarg("COMPILATION_CACHE_CAS_PATH", casPath.pathString)
         }
 
         private func productsDirectory(
@@ -420,6 +420,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_ALLOWED", "NO"),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
+                try await compilationCacheCASArgument(),
             ]
             try await xcodeBuildController.build(
                 xcodebuildTarget,
@@ -482,6 +483,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .configuration(configuration),
                 .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
+                try await compilationCacheCASArgument(),
             ]
             // We currently skip building for maccatalyst as we prefer to generate a bundle for iOS instead.
             // iOS bundles should be compatible with maccatalyst ones
@@ -738,6 +740,7 @@ import XcodeGraph
                         .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                         .configuration(configuration),
                         .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
+                        try await compilationCacheCASArgument(),
                         // To prevent the rejection when publishing on the App Store
                         // https://developer.apple.com/library/archive/qa/qa1964/_index.html
                     ] + (isReleaseConfiguration ? [
@@ -784,6 +787,7 @@ import XcodeGraph
                 .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                 .configuration(configuration),
                 .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
+                try await compilationCacheCASArgument(),
                 // To prevent the rejection when publishing on the App Store
                 // https://developer.apple.com/library/archive/qa/qa1964/_index.html
             ] + (isReleaseConfiguration ? [
@@ -866,6 +870,7 @@ import XcodeGraph
                     .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                     .configuration(configuration),
                     .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
+                    try await compilationCacheCASArgument(),
                 ] + (isReleaseConfiguration ? [
                     .xcarg("GCC_INSTRUMENT_PROGRAM_FLOW_ARCS", "NO"),
                     .xcarg("CLANG_ENABLE_CODE_COVERAGE", "NO"),

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -257,8 +257,7 @@ import XcodeGraph
                 .filter { !($0.buildAction?.targets ?? []).isEmpty }
                 .map { (scheme: $0, cacheOutputType: CacheOutputType.xcframework) }
 
-            let temporaryDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "CacheWarm")
-            do {
+            try await fileSystem.runInTemporaryDirectory(prefix: "CacheWarm") { temporaryDirectory in
                 var artifactsToStore: [CacheGraphTargetBuiltArtifact] = []
 
                 let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
@@ -341,32 +340,6 @@ import XcodeGraph
                     Logger.current.info("\(successfullyStoredTargets.count) target stored: \(targetsStored)")
                 } else {
                     Logger.current.info("\(successfullyStoredTargets.count) targets stored: \(targetsStored)")
-                }
-            } catch {
-                await removeCacheWarmDirectory(temporaryDirectory)
-                throw error
-            }
-
-            await removeCacheWarmDirectory(temporaryDirectory)
-        }
-
-        /// Removes the throwaway cache-warm directory, tolerating a failure so cleanup can never fail an
-        /// otherwise-successful run. Only the build products live here; Xcode's compilation cache is kept
-        /// out of this directory (see `compilationCacheCASArgument`), so nothing writes to it concurrently
-        /// and the retry is a safety net for an unexpected straggler, not the fix for a known race.
-        private func removeCacheWarmDirectory(_ temporaryDirectory: AbsolutePath, attempts: Int = 3) async {
-            for attempt in 1 ... attempts {
-                do {
-                    try await fileSystem.remove(temporaryDirectory)
-                    return
-                } catch {
-                    if attempt == attempts {
-                        Logger.current.debug(
-                            "Best-effort cleanup of \(temporaryDirectory.pathString) failed after \(attempts) attempts: \(error)"
-                        )
-                    } else {
-                        try? await Task.sleep(for: .milliseconds(200))
-                    }
                 }
             }
         }

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -257,7 +257,8 @@ import XcodeGraph
                 .filter { !($0.buildAction?.targets ?? []).isEmpty }
                 .map { (scheme: $0, cacheOutputType: CacheOutputType.xcframework) }
 
-            try await fileSystem.runInTemporaryDirectory(prefix: "CacheWarm") { temporaryDirectory in
+            let temporaryDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "CacheWarm")
+            do {
                 var artifactsToStore: [CacheGraphTargetBuiltArtifact] = []
 
                 let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
@@ -340,6 +341,43 @@ import XcodeGraph
                     Logger.current.info("\(successfullyStoredTargets.count) target stored: \(targetsStored)")
                 } else {
                     Logger.current.info("\(successfullyStoredTargets.count) targets stored: \(targetsStored)")
+                }
+            } catch {
+                await cleanUpCacheWarmDirectory(temporaryDirectory)
+                throw error
+            }
+
+            await cleanUpCacheWarmDirectory(temporaryDirectory)
+        }
+
+        /// Removes the throwaway cache-warm directory, tolerating a cleanup failure so it can never fail an
+        /// otherwise-successful run.
+        ///
+        /// The build writes Xcode's compilation cache into `derived-data/CompilationCache.noindex`, whose
+        /// spool the machine-wide CAS proxy drains asynchronously; it can create spool entries there
+        /// concurrently with this teardown. Removing that subtree first, with a short retry, keeps a lost
+        /// race (the directory repopulated between enumeration and `rmdir`, surfaced as "Directory not
+        /// empty") from aborting the command after the cache has already been stored.
+        private func cleanUpCacheWarmDirectory(_ temporaryDirectory: AbsolutePath) async {
+            let compilationCachePath = temporaryDirectory
+                .appending(components: ["derived-data", "CompilationCache.noindex"])
+            await bestEffortRemove(compilationCachePath)
+            await bestEffortRemove(temporaryDirectory)
+        }
+
+        private func bestEffortRemove(_ path: AbsolutePath, attempts: Int = 3) async {
+            for attempt in 1 ... attempts {
+                do {
+                    try await fileSystem.remove(path)
+                    return
+                } catch {
+                    if attempt == attempts {
+                        Logger.current.debug(
+                            "Best-effort cleanup of \(path.pathString) failed after \(attempts) attempts: \(error)"
+                        )
+                    } else {
+                        try? await Task.sleep(for: .milliseconds(200))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What

`tuist cache` was intermittently exiting 1 at the very end of an otherwise-successful run:

```
✖ Error
  Directory not empty (use recursive option):
  .../CacheWarm-*/derived-data/CompilationCache.noindex/plugin/tuist-spool
```

All real work (building every XCFramework, storing remote binaries, uploading run metadata) had already completed. The command failed only while removing its throwaway temporary directory (the failing Cache job in run 30026345103).

## Root cause

`tuist cache` builds into a throwaway temp `-derivedDataPath`. With Xcode compilation caching on, the Tuist CAS plugin's on-disk store, and its `tuist-spool` write-ahead records, land under `<derivedData>/CompilationCache.noindex`, i.e. inside that temp tree. The spool is drained asynchronously by `tuist-cas-proxy`, a persistent machine-wide daemon that keeps sweeping records into `.claim-<pid>` sidecar files. When the recursive teardown enumerates the spool, deletes its entries, and rmdir's it, a concurrent sweep can recreate a file in the gap, so the rmdir hits ENOTEMPTY (surfaced as "Directory not empty") even though the removal was already recursive.

## Fix

The compilation cache should never have been inside the throwaway build directory; only the build products belong there. This PR points the cache-warm builds' `COMPILATION_CACHE_CAS_PATH` at the machine's shared DerivedData (`~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex`), so:

- the CAS and its spool live at the stable, default location the machine-wide proxy already drains, and that regular Xcode builds read (so `tuist cache` warms the same store), and
- only the build products stay under the temp `-derivedDataPath`, which the command deletes on exit.

With the spool out of the temp tree, nothing writes there concurrently, so `runInTemporaryDirectory`'s recursive teardown no longer races the drain. The race is structurally impossible in every configuration, and the fix is a single build-setting override rather than any change to how the temp directory is cleaned up.

## Relationship to #11857

#11857 (folded per-account CAS image) already relocates the CAS to a stable mount via `COMPILATION_CACHE_CAS_PATH`, but only on `cas-enabled` runners (`casGib > 0`, off by default) and via a runner-side xcconfig. This change fixes the same problem at the command level, for every environment (developer machines, non-folded accounts, any runner), and composes with #11857: where the folded CAS is enabled, its xcconfig `COMPILATION_CACHE_CAS_PATH` (via `XCODE_XCCONFIG_FILE`) takes precedence over this command-line setting, as intended.

## Behavior change

`tuist cache` now writes the compilation cache into the machine's real DerivedData instead of an isolated temp store. On CI runners this is the ephemeral per-VM DerivedData (discarded with the VM); on a developer machine it warms and grows the same CompilationCache their normal Xcode builds use. This is intentional and beneficial (a warm, shared store), but it is a change from the previous cold, isolated temp CAS.

## Validation

- CLI: `tuist generate tuist` plus `xcodebuild build -scheme tuist` compiles. SwiftFormat clean on the changed file. (Compilation caching was disabled for the local build because the remote CAS is unreachable from the dev host.)
- The relocation itself (spool no longer under the temp dir) needs a live daemon and a real cache run to observe, so it is exercised in CI. The change is a build-setting override that #11857 already relies on via xcconfig, which confirms Xcode honors it.

### How to test locally

- Build the CLI and run `tuist cache` on a project with Xcode remote caching enabled and a running `tuist-cas-proxy`. Confirm `CompilationCache.noindex` is created under `~/Library/Developer/Xcode/DerivedData` (not under the `CacheWarm-*` temp dir), and that a run which stores its binaries no longer exits 1 with a "Directory not empty ... tuist-spool" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
