### PR TITLE
ci(cli): drop redundant runtime Metal toolchain download

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -273,8 +273,6 @@ jobs:
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
-      - name: Download Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
       - name: Build tests
         id: shard
         run: tuist test --build-only --shard-total 2 --shard-granularity suite --shard-reference "$TUIST_ACCEPTANCE_SHARD_REFERENCE" TuistAcceptanceTests
@@ -366,8 +364,6 @@ jobs:
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
-      - name: Download Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
       - name: Set up new keychain
         run: |
           TMP_DIRECTORY=$(mktemp -d)


### PR DESCRIPTION
## What changed

Removed the two `xcodebuild -downloadComponent MetalToolchain` steps from the CLI acceptance-test jobs (`Build Acceptance Tests` and `Acceptance Tests (Fork)`) in `.github/workflows/cli.yml`.

## Why

These runtime downloads are the source of an intermittent CI failure. Example: [run 30093469399](https://github.com/tuist/tuist/actions/runs/30093469399/job/89481848958) failed with:

```
xcodebuild: error: Failed fetching catalog for assetType (com.apple.MobileAsset.MetalToolchain), serverParameters ({ RequestedBuild = 17F113; })
Process completed with exit code 70.
```

### Root cause

Xcode 26 unbundled the Metal compiler toolchain into a ~700MB downloadable MobileAsset that each job fetched at runtime. The intermittent failure is `mobileassetd` failing to cryptographically verify Apple's signed MobileAsset catalog on some Tart VM clones — not a network, throttle, or clock problem. It surfaces as an exit-70 `Failed fetching catalog` roughly seconds into the step, before any tests run.

### Why removal is the right fix

The Metal toolchain is now baked into the base runner image via `sudo xcodebuild -downloadComponent MetalToolchain` in the macOS + Xcode Packer template ([#11992](https://github.com/tuist/tuist/pull/11992), merged to `main` 2026-07-22). The `tuist-macos` runner image is Layer 2a on top of that base, so every VM already ships the toolchain. The runtime download steps were therefore pure redundancy — and the only thing standing between the runner and the tests was a flaky, unnecessary network fetch. Removing them lets the jobs use the preinstalled toolchain directly.

## Impact

- Removes a recurring, non-deterministic failure mode from CLI acceptance test runs.
- No functional loss: the toolchain is present in the image, so Metal-dependent test compilation still works.

## Validation

- Confirmed via `git log`/`git branch --contains` that the image bake-in ([#11992](https://github.com/tuist/tuist/pull/11992)) is in `main` and predates the failing run.
- Confirmed `cli.yml` has no remaining `MetalToolchain` references after the change.

> [!NOTE]
> This assumes the deployed `tuist-macos` runner image has been rebuilt against the post-#11992 base. Given #11992 merged two days before the failing run and is titled a fix for exactly this, that should be the current fleet state — worth a sanity check against the chart's `runnersFleet.runnerImage` digest pin before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)