### PR TITLE
feat(server): centralize effective account plan resolution

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -5501,7 +5501,7 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/Organization/name`.
             public var name: Swift.String
-            /// The plan associated with the organization
+            /// The effective plan associated with the organization. `none` is deprecated and is no longer emitted.
             ///
             /// - Remark: Generated from `#/components/schemas/Organization/plan`.
             @frozen public enum planPayload: String, Codable, Hashable, Sendable, CaseIterable {
@@ -5510,7 +5510,7 @@ public enum Components {
                 case enterprise = "enterprise"
                 case none = "none"
             }
-            /// The plan associated with the organization
+            /// The effective plan associated with the organization. `none` is deprecated and is no longer emitted.
             ///
             /// - Remark: Generated from `#/components/schemas/Organization/plan`.
             public var plan: Components.Schemas.Organization.planPayload
@@ -5540,7 +5540,7 @@ public enum Components {
             ///   - invitations: A list of organization invitations
             ///   - members: A list of organization members
             ///   - name: The organization's name
-            ///   - plan: The plan associated with the organization
+            ///   - plan: The effective plan associated with the organization. `none` is deprecated and is no longer emitted.
             ///   - sso_enforced: Whether SSO is enforced for the organization
             ///   - sso_organization_id: The organization ID associated with the SSO provider
             ///   - sso_provider: The SSO provider set up for the organization

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -2112,7 +2112,7 @@ components:
           x-struct:
           x-validate:
         plan:
-          description: The plan associated with the organization
+          description: The effective plan associated with the organization. `none` is deprecated and is no longer emitted.
           enum:
             - air
             - pro

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -249,7 +249,7 @@ struct DependenciesAcceptanceTestIosAppWithLocalSPMPackageGenerate {
     @Test(
         .withFixture("generated_ios_app_with_local_spm_package"),
         .inTemporaryDirectory,
-        .timeLimit(.minutes(1))
+        .timeLimit(.minutes(4))
     )
     func install_then_generate_does_not_deadlock() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)

--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -407,6 +407,37 @@ defmodule Tuist.Billing do
   end
 
   @doc """
+  Returns the effective plan for an account.
+
+  Accounts without an active or trialing subscription use the Air plan.
+  """
+  def effective_plan(%Account{subscriptions: subscriptions}) when is_list(subscriptions) do
+    subscriptions
+    |> Enum.filter(&(&1.status in ["active", "trialing"]))
+    |> case do
+      [] -> :air
+      active -> active |> latest_subscription() |> Map.fetch!(:plan)
+    end
+  end
+
+  def effective_plan(%Account{} = account) do
+    case get_current_active_subscription(account) do
+      %{plan: plan} when is_atom(plan) -> plan
+      _ -> :air
+    end
+  end
+
+  defp latest_subscription([subscription | subscriptions]) do
+    Enum.reduce(subscriptions, subscription, fn candidate, latest ->
+      case NaiveDateTime.compare(candidate.inserted_at, latest.inserted_at) do
+        :gt -> candidate
+        :lt -> latest
+        :eq -> if candidate.id > latest.id, do: candidate, else: latest
+      end
+    end)
+  end
+
+  @doc """
   Creates a new token usage record for billing purposes.
   """
   def create_token_usage(attrs) do

--- a/server/lib/tuist/billing/entitlements.ex
+++ b/server/lib/tuist/billing/entitlements.ex
@@ -34,7 +34,7 @@ defmodule Tuist.Billing.Entitlements do
 
   def allowed_features(account, features) when is_list(features) do
     if Environment.tuist_hosted?() do
-      plan = current_plan(account)
+      plan = resolve_plan(account)
 
       features
       |> Enum.filter(&plan_allows?(plan, &1))
@@ -61,31 +61,6 @@ defmodule Tuist.Billing.Entitlements do
 
   defp plan_allows?(_plan, _feature), do: false
 
-  defp current_plan(%Account{subscriptions: subscriptions}) when is_list(subscriptions) do
-    subscriptions
-    |> Enum.filter(&(&1.status in ["active", "trialing"]))
-    |> case do
-      [] -> :air
-      active -> active |> latest_subscription() |> Map.fetch!(:plan)
-    end
-  end
-
-  defp current_plan(%Account{} = account) do
-    case Billing.get_current_active_subscription(account) do
-      %{plan: plan} when is_atom(plan) -> plan
-      _ -> :air
-    end
-  end
-
-  defp current_plan(_), do: :air
-
-  defp latest_subscription([subscription | subscriptions]) do
-    Enum.reduce(subscriptions, subscription, fn candidate, latest ->
-      case NaiveDateTime.compare(candidate.inserted_at, latest.inserted_at) do
-        :gt -> candidate
-        :lt -> latest
-        :eq -> if candidate.id > latest.id, do: candidate, else: latest
-      end
-    end)
-  end
+  defp resolve_plan(%Account{} = account), do: Billing.effective_plan(account)
+  defp resolve_plan(_), do: :air
 end

--- a/server/lib/tuist_web/api/schemas/organization.ex
+++ b/server/lib/tuist_web/api/schemas/organization.ex
@@ -23,7 +23,7 @@ defmodule TuistWeb.API.Schemas.Organization do
       plan: %Schema{
         type: :string,
         enum: ["air", "pro", "enterprise", "none"],
-        description: "The plan associated with the organization"
+        description: "The effective plan associated with the organization. `none` is deprecated and is no longer emitted."
       },
       members: %Schema{
         type: :array,

--- a/server/lib/tuist_web/controllers/api/organizations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/organizations_controller.ex
@@ -65,7 +65,7 @@ defmodule TuistWeb.API.OrganizationsController do
         &%{
           id: &1.organization.id,
           name: &1.account.name,
-          plan: get_plan(&1.account),
+          plan: Billing.effective_plan(&1.account),
           # We don't display in the CLI members and invitations when showing a list of organizations.
           # We keep these fields for backwards compatibility but should remove in the future.
           members: [],
@@ -74,15 +74,6 @@ defmodule TuistWeb.API.OrganizationsController do
       )
 
     json(conn, %{organizations: organizations})
-  end
-
-  defp get_plan(account) do
-    account
-    |> Billing.get_current_active_subscription()
-    |> case do
-      %Billing.Subscription{} = subscription -> subscription.plan
-      nil -> :none
-    end
   end
 
   operation(:create,
@@ -142,7 +133,7 @@ defmodule TuistWeb.API.OrganizationsController do
         |> json(%{
           id: organization.id,
           name: organization_name,
-          plan: get_plan(organization.account),
+          plan: Billing.effective_plan(organization.account),
           members: [],
           invitations: []
         })
@@ -278,7 +269,7 @@ defmodule TuistWeb.API.OrganizationsController do
         json(conn, %{
           id: organization.id,
           name: organization_name,
-          plan: get_plan(organization.account),
+          plan: Billing.effective_plan(organization.account),
           members: admins ++ users,
           sso_provider: organization.sso_provider,
           sso_organization_id: organization.sso_organization_id,
@@ -423,7 +414,7 @@ defmodule TuistWeb.API.OrganizationsController do
         json(conn, %{
           id: organization.id,
           name: organization_name,
-          plan: get_plan(organization.account),
+          plan: Billing.effective_plan(organization.account),
           sso_provider: organization.sso_provider,
           sso_organization_id: organization.sso_organization_id,
           sso_enforced: organization.sso_enforced,
@@ -469,7 +460,7 @@ defmodule TuistWeb.API.OrganizationsController do
         json(conn, %{
           id: organization.id,
           name: organization.account.name,
-          plan: get_plan(organization.account),
+          plan: Billing.effective_plan(organization.account),
           sso_provider: organization.sso_provider,
           sso_organization_id: organization.sso_organization_id,
           sso_enforced: organization.sso_enforced,

--- a/server/test/tuist/billing/entitlements_test.exs
+++ b/server/test/tuist/billing/entitlements_test.exs
@@ -111,9 +111,7 @@ defmodule Tuist.Billing.EntitlementsTest do
       stub(Environment, :tuist_hosted?, fn -> true end)
       account = AccountsFixtures.organization_fixture(preload: [:account]).account
 
-      expect(Tuist.Billing, :get_current_active_subscription, 1, fn ^account ->
-        %{plan: :enterprise}
-      end)
+      expect(Tuist.Billing, :effective_plan, 1, fn ^account -> :enterprise end)
 
       assert Entitlements.allowed_features(account, [
                :self_hosted_cache,

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -682,6 +682,102 @@ defmodule Tuist.BillingTest do
     end
   end
 
+  describe "effective_plan/1" do
+    test "returns Air when an organization account has no active subscription" do
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+
+      assert Billing.effective_plan(account) == :air
+    end
+
+    test "returns the active subscription plan for a personal account" do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      BillingFixtures.subscription_fixture(account_id: user.account.id, plan: :pro)
+
+      assert Billing.effective_plan(user.account) == :pro
+    end
+
+    test "ignores inactive subscriptions" do
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise, status: "canceled")
+
+      assert Billing.effective_plan(account) == :air
+    end
+
+    test "uses the latest active or trialing preloaded subscription" do
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+
+      older =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :pro,
+          inserted_at: ~N[2026-01-31 23:59:59]
+        )
+
+      newer =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :enterprise,
+          status: "trialing",
+          inserted_at: ~N[2026-02-01 00:00:00]
+        )
+
+      canceled =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :air,
+          status: "canceled",
+          inserted_at: ~N[2026-02-02 00:00:00]
+        )
+
+      account = %{account | subscriptions: [older, newer, canceled]}
+
+      assert Billing.effective_plan(account) == :enterprise
+    end
+
+    test "returns Air when preloaded subscriptions contain no active subscription" do
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+
+      canceled =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :enterprise,
+          status: "canceled"
+        )
+
+      account = %{account | subscriptions: [canceled]}
+
+      assert Billing.effective_plan(account) == :air
+    end
+
+    test "uses the subscription identifier to break preloaded timestamp ties" do
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+      inserted_at = ~N[2026-02-01 00:00:00]
+
+      older =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :pro,
+          inserted_at: inserted_at
+        )
+
+      newer =
+        BillingFixtures.subscription_fixture(
+          account_id: account.id,
+          plan: :enterprise,
+          inserted_at: inserted_at
+        )
+
+      account = %{account | subscriptions: [older, newer]}
+
+      assert Billing.effective_plan(account) == :enterprise
+    end
+  end
+
   describe "upgrade_to_enterprise/2" do
     test "creates an invoice-billed subscription and updates the customer when no sub exists" do
       # Given

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -79,7 +79,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       end)
 
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
 
       manifest =
         KubernetesController.manifest(
@@ -109,7 +109,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       end)
 
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
 
       manifest =
         KubernetesController.manifest(
@@ -142,7 +142,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       # The self-hosting-capable account can enroll a self-hosted peer, so its
       # pods sync the dynamic peer view and arm Kura's peer-view boot gate.
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
 
       entitled =
         KubernetesController.manifest(
@@ -160,7 +160,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       # An account that cannot self-host has a fully static roster, so it must
       # not sync or arm the gate — it would otherwise block its own readiness on
       # a peer view it can never populate.
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
 
       non_entitled =
         KubernetesController.manifest(
@@ -183,7 +183,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         "00000000-0000-0000-0000-000000000001"
       end)
 
-      reject(&Tuist.Billing.get_current_active_subscription/1)
+      reject(&Tuist.Billing.effective_plan/1)
 
       manifest =
         KubernetesController.manifest(
@@ -244,7 +244,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       account = %Account{id: 1, name: "tuist"}
       external_peers = ["https://kura.acme.example:7443"]
 
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
 
       entitled =
         KubernetesController.manifest(
@@ -261,7 +261,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert entitled_env["KURA_MESH_PEERS_SYNC"] == "true"
       assert entitled["spec"]["meshExternalPeers"] == external_peers
 
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
 
       non_entitled =
         KubernetesController.manifest(
@@ -289,9 +289,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
       account = %Account{id: 1, name: "tuist"}
 
-      expect(Tuist.Billing, :get_current_active_subscription, 1, fn ^account ->
-        %{plan: :enterprise}
-      end)
+      expect(Tuist.Billing, :effective_plan, 1, fn ^account -> :enterprise end)
 
       manifest =
         KubernetesController.manifest(
@@ -320,7 +318,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       end)
 
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
 
       manifest =
         KubernetesController.manifest(
@@ -339,7 +337,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     test "emits the public peer host and external peers for a meshed region" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
 
       stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
         "00000000-0000-0000-0000-000000000001"
@@ -959,10 +957,10 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       region = eu_region(%{mesh: true})
       account = %Account{id: 1, name: "tuist"}
 
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
       non_entitled = KubernetesController.manifest_revision(account, region)
 
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
       entitled = KubernetesController.manifest_revision(account, region)
 
       # The upgrade crosses a revision boundary, so the reconciler re-applies
@@ -974,7 +972,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       # The rendered manifest stamps the same revision the reconciler computes,
       # so the two never disagree and loop.
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
 
       manifest =
         KubernetesController.manifest(
@@ -991,7 +989,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
     test "does not load self-hosted peers without the entitlement" do
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :air} end)
+      stub(Tuist.Billing, :effective_plan, fn _ -> :air end)
       reject(&Mesh.self_hosted_peer_urls/1)
 
       revision =

--- a/server/test/tuist_web/controllers/api/organizations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/organizations_controller_test.exs
@@ -40,14 +40,14 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
                  "invitations" => [],
                  "members" => [],
                  "name" => "tuist-org",
-                 "plan" => "none"
+                 "plan" => "air"
                },
                %{
                  "id" => organization_three.id,
                  "invitations" => [],
                  "members" => [],
                  "name" => "tuist-org-3",
-                 "plan" => "none"
+                 "plan" => "air"
                }
              ] == Enum.sort_by(response["organizations"], & &1["name"])
     end
@@ -90,7 +90,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
                %{
                  "id" => organization.id,
                  "name" => "tuist-org",
-                 "plan" => "none",
+                 "plan" => "air",
                  "members" => [],
                  "invitations" => []
                }
@@ -123,7 +123,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       # Then
       response = json_response(conn, :ok)
       assert response["name"] == "tuist-org"
-      assert response["plan"] == "none"
+      assert response["plan"] == "air"
     end
 
     test "returns an organization with an active pro plan", %{conn: conn, user: user} do

--- a/server/test/tuist_web/live/cache_live_test.exs
+++ b/server/test/tuist_web/live/cache_live_test.exs
@@ -252,7 +252,7 @@ defmodule TuistWeb.CacheLiveTest do
   test "hides the self-hosted section without the enterprise entitlement", %{conn: conn, account: account} do
     enable_cache(account)
     stub(Environment, :tuist_hosted?, fn -> true end)
-    stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :pro} end)
+    stub(Tuist.Billing, :effective_plan, fn _ -> :pro end)
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -265,7 +265,7 @@ defmodule TuistWeb.CacheLiveTest do
   test "shows the self-hosted section with the enterprise entitlement", %{conn: conn, account: account} do
     enable_cache(account)
     stub(Environment, :tuist_hosted?, fn -> true end)
-    stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
+    stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")


### PR DESCRIPTION
Related specification: <https://hive.tuist.dev/specs/78>

## What changed

This introduces one shared effective-plan resolver for account policy decisions. Active and trialing subscriptions retain their plan, while accounts without either now resolve to Air.

Organization responses and Kura entitlement checks use the shared resolver. The generated application programming interface and command-line client sources continue to retain the deprecated `none` value for compatibility, but the server no longer emits it.

## Why

Kura's rollout policy needs one dependable plan value for organizations and personal accounts before plan-specific storage, lifecycle, placement, and attribution work can build on it.

## Root cause

Plan resolution was duplicated across billing entitlements and organization responses. Entitlements treated an account without an active subscription as Air, while organization responses returned `none`, allowing downstream policy decisions to disagree about the same account.

## Approach

The resolver preserves the existing in-memory path when subscriptions are already loaded and the existing database lookup otherwise. Kura's lightweight manifest-rendering inputs retain their previous Air fallback without weakening the strict account resolver.

## Impact

Organizations without an active or trialing subscription now receive `air` in organization responses. Paid-plan behavior is unchanged, no database migration is required, and generated clients remain source-compatible with the deprecated `none` case.

There are no user interface changes, so screenshots are not applicable.

## Validation

- Regenerated the application programming interface and command-line client sources with `mise run generate-api-cli-code`.
- Verified formatting for every modified Elixir source and test file.
- Ran the focused billing, entitlement, organization controller, and Kura provisioner suites: 148 tests passed.
- Booted the local server successfully.

### How to test locally

From `server/`, run:

```sh
mix test test/tuist/billing_test.exs test/tuist/billing/entitlements_test.exs test/tuist_web/controllers/api/organizations_controller_test.exs test/tuist/kura/provisioner/kubernetes_controller_test.exs
```
