### PR TITLE
fix(server): pass rolling query limits through ClickHouse requests

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -30,7 +30,13 @@ config :tuist, Tuist.ClickHouseRepo,
   default_dynamic_repo: Tuist.IngestRepo,
   # Workaround for ClickHouse lazy materialization bug with projections
   # https://github.com/ClickHouse/ClickHouse/issues/80201
-  settings: [readonly: 1, query_plan_optimize_lazy_materialization: 0, session_timezone: "UTC"]
+  settings: [
+    readonly: 1,
+    max_threads: 4,
+    max_memory_usage: 6 * 1024 * 1024 * 1024,
+    query_plan_optimize_lazy_materialization: 0,
+    session_timezone: "UTC"
+  ]
 
 config :tuist, Tuist.CommandEvents, metadata_queries_bypass_dynamic_repo: true
 

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -62,8 +62,10 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # Merging the rolling aggregate states is memory-heavy and memory grows with
   # parallelism. Keep this limit local to these queries so concurrent alert
   # evaluations leave headroom for runner lifecycle writes and other reads.
-  @rolling_query_max_threads 2
-  @rolling_query_max_memory_bytes 1024 * 1024 * 1024
+  @rolling_query_settings [
+    max_threads: 2,
+    max_memory_usage: 1024 * 1024 * 1024
+  ]
 
   def evaluate(alert, test_case_ids \\ nil) do
     trigger_config = alert.trigger_config
@@ -402,15 +404,17 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       )
     )
     WHERE length(recent_runs) > 0
-    SETTINGS max_threads = #{@rolling_query_max_threads},
-             max_memory_usage = #{@rolling_query_max_memory_bytes}
     """
 
     %{rows: rows} =
-      ClickHouseRepo.query!(sql, %{
-        project_id: project_id,
-        test_case_ids: test_case_ids
-      })
+      ClickHouseRepo.query!(
+        sql,
+        %{
+          project_id: project_id,
+          test_case_ids: test_case_ids
+        },
+        settings: @rolling_query_settings
+      )
 
     Enum.map(rows, fn [binary, matching_run_count, run_count] ->
       {Ecto.UUID.load!(binary), matching_run_count, run_count}
@@ -533,8 +537,6 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
     )
     WHERE length(recent_runs) > 0
       AND #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
-    SETTINGS max_threads = #{@rolling_query_max_threads},
-             max_memory_usage = #{@rolling_query_max_memory_bytes}
     """
 
     params = maybe_put_test_case_ids(%{project_id: project_id, threshold: threshold * 1.0}, test_case_ids)
@@ -545,7 +547,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
     # active event. Letting the error propagate matches the
     # `ClickHouseRepo.all` path in the `last_days` branch and gives Oban a
     # chance to retry.
-    %{rows: rows} = ClickHouseRepo.query!(sql, params)
+    %{rows: rows} = ClickHouseRepo.query!(sql, params, settings: @rolling_query_settings)
 
     # ClickHouse returns identifier columns as 16-byte binaries here; the rest
     # of the worker compares against string-encoded identifiers from the Ecto

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
   use TuistTestSupport.Cases.DataCase, async: false
 
   alias Tuist.Automations.Monitors.FlakyTestsMonitor
+  alias Tuist.ClickHouseRepo
   alias Tuist.IngestRepo
   alias Tuist.Tests
   alias Tuist.Tests.TestCaseRun
@@ -478,6 +479,41 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
   end
 
   describe "evaluate_rolling_alerts/2" do
+    test "executes rolling queries through the read repository" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = Ecto.UUID.generate()
+      ran_at = NaiveDateTime.utc_now()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        is_flaky: true,
+        ran_at: ran_at,
+        inserted_at: ran_at
+      )
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{
+            "threshold" => 1,
+            "comparison" => "gte",
+            "window_type" => "rolling",
+            "rolling_window_size" => 5
+          }
+        )
+
+      with_read_repo(fn ->
+        assert FlakyTestsMonitor.evaluate(alert, [test_case_id]).triggered == [test_case_id]
+
+        triggered_by_alert_id =
+          FlakyTestsMonitor.evaluate_rolling_alerts([alert], [test_case_id])
+
+        assert triggered_by_alert_id[alert.id] == [test_case_id]
+      end)
+    end
+
     test "shares measurements between flakiness rate and flaky run count alerts" do
       project = ProjectsFixtures.project_fixture()
       one_flaky_run_id = Ecto.UUID.generate()
@@ -1094,6 +1130,19 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
 
   defp insert_test_case_runs(rows) do
     IngestRepo.insert_all(TestCaseRun, rows)
+  end
+
+  defp with_read_repo(fun) do
+    previous_dynamic_repo = ClickHouseRepo.get_dynamic_repo()
+
+    try do
+      # ClickHouse exposes parts inserted by the sandboxed write connection to
+      # the separate read connection before the surrounding transaction ends.
+      ClickHouseRepo.put_dynamic_repo(ClickHouseRepo)
+      fun.()
+    after
+      ClickHouseRepo.put_dynamic_repo(previous_dynamic_repo)
+    end
   end
 
   defp test_case_run_attrs(project_id, test_case_id, attrs) do

--- a/server/test/tuist/clickhouse_repo_test.exs
+++ b/server/test/tuist/clickhouse_repo_test.exs
@@ -1,0 +1,50 @@
+defmodule Tuist.ClickHouseRepoTest do
+  use ExUnit.Case, async: false
+
+  alias Tuist.ClickHouseRepo
+
+  test "query settings override the connection defaults" do
+    with_read_repo(fn ->
+      assert resource_settings() == %{
+               "max_memory_usage" => "6442450944",
+               "max_threads" => "4"
+             }
+
+      assert resource_settings(
+               settings: [
+                 max_threads: 2,
+                 max_memory_usage: 1024 * 1024 * 1024
+               ]
+             ) == %{
+               "max_memory_usage" => "1073741824",
+               "max_threads" => "2"
+             }
+    end)
+  end
+
+  defp resource_settings(options \\ []) do
+    %{rows: rows} =
+      ClickHouseRepo.query!(
+        """
+        SELECT name, value
+        FROM system.settings
+        WHERE name IN ('max_threads', 'max_memory_usage')
+        """,
+        %{},
+        options
+      )
+
+    Map.new(rows, fn [name, value] -> {name, value} end)
+  end
+
+  defp with_read_repo(fun) do
+    previous_dynamic_repo = ClickHouseRepo.get_dynamic_repo()
+
+    try do
+      ClickHouseRepo.put_dynamic_repo(ClickHouseRepo)
+      fun.()
+    after
+      ClickHouseRepo.put_dynamic_repo(previous_dynamic_repo)
+    end
+  end
+end

--- a/server/test/tuist/clickhouse_repo_test.exs
+++ b/server/test/tuist/clickhouse_repo_test.exs
@@ -6,8 +6,8 @@ defmodule Tuist.ClickHouseRepoTest do
   test "query settings override the connection defaults" do
     with_read_repo(fn ->
       assert resource_settings() == %{
-               "max_memory_usage" => "6442450944",
-               "max_threads" => "4"
+               max_memory_usage: 6 * 1024 * 1024 * 1024,
+               max_threads: 4
              }
 
       assert resource_settings(
@@ -16,25 +16,25 @@ defmodule Tuist.ClickHouseRepoTest do
                  max_memory_usage: 1024 * 1024 * 1024
                ]
              ) == %{
-               "max_memory_usage" => "1073741824",
-               "max_threads" => "2"
+               max_memory_usage: 1024 * 1024 * 1024,
+               max_threads: 2
              }
     end)
   end
 
   defp resource_settings(options \\ []) do
-    %{rows: rows} =
+    %{rows: [[max_threads, max_memory_usage]]} =
       ClickHouseRepo.query!(
         """
-        SELECT name, value
-        FROM system.settings
-        WHERE name IN ('max_threads', 'max_memory_usage')
+        SELECT
+          getSetting('max_threads'),
+          getSetting('max_memory_usage')
         """,
         %{},
         options
       )
 
-    Map.new(rows, fn [name, value] -> {name, value} end)
+    %{max_threads: max_threads, max_memory_usage: max_memory_usage}
   end
 
   defp with_read_repo(fun) do


### PR DESCRIPTION
## What changed

The rolling flaky-test monitor now passes its thread and memory limits as ClickHouse request settings instead of embedding them in the query text.

Regression coverage now:

- Executes both rolling query paths through the actual read repository.
- Confirms per-query thread and memory settings override the connection defaults.

## Why

Rolling automation evaluations need lower local resource ceilings so their aggregate merges leave capacity for runner lifecycle writes and other reads. The limits must work without weakening the read repository's existing protection or allowing unrelated queries to raise the global connection ceilings.

## Root cause

The rolling queries applied `max_threads` and `max_memory_usage` through query-local `SETTINGS` clauses. ClickHouse treats those clauses as setting modifications and rejects them when the connection uses read-only mode 1, even when the requested values are lower than the connection defaults.

The query therefore failed before the automation could calculate its measurement or run actions. Existing tests used the write-backed dynamic repository and did not exercise the production read connection.

## Approach

Pass the two limits through the ClickHouse driver's request settings. The driver merges these values over the connection defaults while retaining read-only mode 1.

This is narrower than changing the connection to read-only mode 2. Mode 2 would let any future read query replace global resource settings, while request-level settings keep the existing read-only posture and scope the lower limits to the two rolling queries that need them.

## Impact

Rolling flakiness and reliability automations can evaluate again while retaining their per-query thread and memory ceilings. The read repository configuration and write protection remain unchanged.

The two affected Pinterest automations will require a separate production reconciliation after deployment because their baselines were not established while evaluations were failing.

## Validation

- Confirmed against local ClickHouse 26.1 that request-level limits work with `readonly=1`.
- Confirmed the equivalent in-query `SETTINGS` clause fails with ClickHouse error code 164.
- `mix test test/tuist/clickhouse_repo_test.exs test/tuist/automations/monitors/flaky_tests_monitor_test.exs` (27 tests passed)
- `mix format config/test.exs lib/tuist/automations/monitors/flaky_tests_monitor.ex test/tuist/automations/monitors/flaky_tests_monitor_test.exs test/tuist/clickhouse_repo_test.exs`
- `git diff --cached --check`