### PR TITLE
fix(server): size the runner-cache CAS ring to match the mesh

### DIFF
--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -19,7 +19,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   alias Tuist.Kura.Server
 
   @namespace "kura"
-  @manifest_revision "2026-07-19-peer-publication-v1"
+  @manifest_revision "2026-07-24-align-runner-cas-capacity-v1"
   @manifest_revision_annotation "tuist.dev/kura-manifest-revision"
   @warm_handoffs_enabled Application.compile_env(:tuist, :kura_warm_handoffs_enabled, false)
   # Mirrors Kura's DEFAULT_TMP_DIR_MAX_BYTES (kura/src/constants.rs): 4 x

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -200,24 +200,15 @@ defmodule Tuist.Kura.Regions do
       # installed on the pool out-of-band).
       storage_class: "scw-local-nvme",
       storage_size: "50Gi",
-      # A local-path volume is a directory on the node's shared NVMe, so the claim
-      # above bounds nothing and this pool has been running near 137Gi per account
-      # off Kura's statvfs default. This is the whole per-account disk envelope
-      # (ring + index + upload staging) rather than the ring itself — the ring is
-      # what is left after the reserves, ~137GiB here — so it lands the ring back
-      # on roughly what the pool already holds rather than shrinking a healthy
-      # cache to a claim that never applied. Three accounts leave the ~900G node
-      # about half free;
-      # the box tops out near five, so raising this or adding accounts past that
-      # needs a second box, not a bigger number.
-      #
-      # Kept separate from storage_size because raising the claim is not a no-op:
-      # the controller patches existing PVCs up to spec.storageSize on every
-      # reconcile, and scw-local-nvme sets allowVolumeExpansion: false, so the API
-      # would reject each resize and wedge the instances that already exist. Only
-      # meaningful where the claim is a fiction — leave it unset on a class that
-      # enforces the claim, so the ring stays inside the volume.
-      disk_envelope_size: "150Gi",
+      # No disk_envelope_size override: this region derives the mesh-standard
+      # ~40GiB ring (storage_size after reserves), the same budget every managed
+      # region uses. A per-account node here peers with the account's other
+      # regions under one mesh, and a peer only reaches "caught up" (Ready) if its
+      # ring can hold the set its peers serve — so every region must size its ring
+      # the same, or a larger ring here leaves a smaller-ringed peer (e.g.
+      # eu-central) evicting-and-refetching forever, never Ready, serving an
+      # incomplete CAS that fails clang builds. Uniform 40GiB per account also
+      # keeps this shared ~900G node well clear of the box's disk envelope.
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -200,15 +200,6 @@ defmodule Tuist.Kura.Regions do
       # installed on the pool out-of-band).
       storage_class: "scw-local-nvme",
       storage_size: "50Gi",
-      # No disk_envelope_size override: this region derives the mesh-standard
-      # ~40GiB ring (storage_size after reserves), the same budget every managed
-      # region uses. A per-account node here peers with the account's other
-      # regions under one mesh, and a peer only reaches "caught up" (Ready) if its
-      # ring can hold the set its peers serve — so every region must size its ring
-      # the same, or a larger ring here leaves a smaller-ringed peer (e.g.
-      # eu-central) evicting-and-refetching forever, never Ready, serving an
-      # incomplete CAS that fails clang builds. Uniform 40GiB per account also
-      # keeps this shared ~900G node well clear of the box's disk envelope.
       runner_platforms: [:macos],
       # The macOS Tart VMs reach this pool over a Scaleway Private
       # Network, not the cluster's pod network, so cluster Service DNS

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -255,12 +255,11 @@ defmodule Tuist.Kura.RegionsTest do
       assert scw_config.storage_class == "scw-local-nvme"
       assert scw_config.replicas == 1
 
-      # The cache budget rides disk_envelope_size, and the claim stays put:
-      # scw-local-nvme is not expandable, and the controller patches live PVCs up
-      # to spec.storageSize on every reconcile, so raising the claim would wedge
-      # every runner-cache instance that already exists.
+      # No disk_envelope_size override: the ring derives from storage_size like
+      # every managed region, so a per-account node here sizes its CAS ring the
+      # same as its cross-region mesh peers and can stay caught up.
       assert scw_config.storage_size == "50Gi"
-      assert scw_config.disk_envelope_size == "150Gi"
+      assert scw_config.disk_envelope_size == nil
       assert scw_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura-scw-fr-par"}
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)


### PR DESCRIPTION
## What changed

- Drop the `disk_envelope_size: "150Gi"` override on the `scw-fr-par-runners` region so its CAS ring derives from `storage_size` (~40 GiB) like every managed region.
- Bump `@manifest_revision` so existing runner-cache instances re-apply and pick up the lower `KURA_CAS_CAPACITY_BYTES`.

## Why (root cause)

`tuist cache` on the tuist-macos runner fleet was failing with repeated `error: CAS operation failed: missing object '0~...'` and `** BUILD FAILED **` (36 failures, rc 65). Every failing command was a `ClangCachingMaterializeKey`: the clang lane hard-fails on a genuinely missing compilation-CAS object, whereas the Swift lane downgrades to a recompile, which is why the test job passed in the same run and only the cache job (which builds all cacheable targets, including the C/ObjC ones) tripped.

The account's compilation CAS is served by a per-account kura mesh spanning two regions. Live prod diagnosis showed both eu-central replicas stuck NotReady (readiness `/ready` returning 503 for many hours), serving an incomplete CAS. It was not memory pressure (ruled out, pods well under limit) and not disk eviction (DiskPressure was false across all nodes the whole window; PVCs were 15 days old and never recreated).

The real cause is a cross-region CAS ring size mismatch. `KURA_CAS_CAPACITY_BYTES` was ~40 GiB on the managed region but ~137 GiB on `scw-fr-par-runners`. The account's dataset served from the larger ring exceeds ~40 GiB, so the smaller-ringed peer could never hold the full set. Its bootstrap perpetually evicted and re-fetched (metrics showed millions of artifacts applied over 20+ hours across restarts, with segment evictions climbing the whole time) and never reached the `is_serving` state that readiness requires. A NotReady, incompletely-bootstrapped replica still answers resolve requests but returns not-found for blobs it has not managed to hold, which is exactly the missing-object the clang lane fails on.

A mesh peer only reaches "caught up" once its ring can hold the set its peers serve, so every region in an account's mesh has to size its ring the same. Only the runner-cache region carried the larger envelope; aligning it to the mesh default is what lets the peers converge.

## Why this approach over the alternatives

- Grow the managed region to ~150 GiB instead: rejected. That region's node is shared by several other single-replica instances and is already committing a large fraction of its disk; growing one instance to 137 GiB per replica risks over-committing the node (the same class of failure a prior incident hit). Matching the rings down keeps every co-located instance within the node envelope.
- Route the account's CI to the healthy region and leave the mismatch in place: viable as an immediate unblock, but it does not fix the underlying non-convergence and leaves the mesh permanently split.

Matching the ring sizes is the smallest change that makes the mesh convergent and simultaneously relieves node-disk pressure on the shared runner-cache box.

## Impact

- Every per-account node in `scw-fr-par-runners` sizes its CAS ring at ~40 GiB instead of ~137 GiB. These are single-replica runner caches; each rolls once to pick up the new env. Other instances only re-annotate (no pod roll), since their STS env is unchanged.
- The retained cache on that region shrinks accordingly, so those accounts get more cache misses (slower restores and more recompiles), not failures. The runner hot path stays node-local.
- The account whose mesh was split can now converge: with both regions on the same ring size, the previously-NotReady replicas can reach "caught up" and serve a complete CAS again.

## Operational note

The wedged image rollout on the affected managed instance was un-stuck out of band (it is now on the current fleet image), but it keeps thrashing the undersized ring until this lands. This PR is the durable fix.

## Validation

- `mix compile` clean.
- `mix test test/tuist/kura/regions_test.exs` (36 passed) and `test/tuist/kura/provisioner/kubernetes_controller_test.exs` (58 passed).
- Confirmed the capacity math: with the override removed, `cas_capacity_bytes/1` on `storage_size: 50Gi` yields `43223477125`, byte-identical to the managed regions.

## Follow-ups (separate)

- Rollout stranding: a failed version deployment permanently excludes an instance from auto-retry, so a wedged instance is stranded on the version it broke on until manual intervention.
- Graceful degradation: a not-yet-serving replica still advertises resolves it cannot back, so the clang lane hard-fails instead of degrading to a cache miss. Gating resolve serving on `is_serving` would turn this into a recompile rather than a build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)