### PR TITLE
fix(cli): strip registry package root directories

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,6 +13,9 @@ on:
       # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
       # inside the CLI, so its changes must run CLI build/test/acceptance.
       - "cas-plugin/**"
+      # SwifterPMCore is compiled into the command-line binary through
+      # TuistSupport, so its changes must run the command-line test suite.
+      - "swifterpm/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"
@@ -36,6 +39,9 @@ on:
       # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
       # inside the CLI, so its changes must run CLI build/test/acceptance.
       - "cas-plugin/**"
+      # SwifterPMCore is compiled into the command-line binary through
+      # TuistSupport, so its changes must run the command-line test suite.
+      - "swifterpm/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"

--- a/.github/workflows/swifterpm.yml
+++ b/.github/workflows/swifterpm.yml
@@ -1,0 +1,42 @@
+name: SwifterPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "swifterpm/**"
+      - ".github/workflows/swifterpm.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "swifterpm/**"
+      - ".github/workflows/swifterpm.yml"
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERSION: "2026.5.15"
+
+concurrency:
+  group: swifterpm-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: tuist-macos
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "bazel"
+          working_directory: swifterpm
+          cache: "false"
+          github_token: ${{ github.token }}
+      - name: Test
+        working-directory: swifterpm
+        run: mise run test:unit

--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -115,12 +115,11 @@ extension FileSystem {
         return url
     }
 
-    /// If `directory` contains exactly one subdirectory, replace `directory` with that subdirectory's contents.
+    /// If `directory` contains exactly one subdirectory, move that subdirectory's contents up one level.
     func flattenSingleDirectory(_ url: URL) async throws {
-        let entries = try await contentsOfDirectory(url.absolutePath)
-        guard entries.count == 1 else { return }
-        let nested = entries[0].fileURL
-        guard isDirectoryAndNotSymlink(nested) else { return }
+        let subdirectories = try await contentsOfDirectory(at: url)
+            .filter { isDirectoryAndNotSymlink($0) }
+        guard subdirectories.count == 1, let nested = subdirectories.first else { return }
 
         let temp = url.deletingLastPathComponent().appendingPathComponent(
             "\(url.lastPathComponent).flattening")
@@ -128,8 +127,14 @@ extension FileSystem {
             try await remove(temp.absolutePath)
         }
         try await move(from: nested.absolutePath, to: temp.absolutePath, options: [])
-        try await remove(url.absolutePath)
-        try await move(from: temp.absolutePath, to: url.absolutePath, options: [])
+        for entry in try await contentsOfDirectory(at: temp) {
+            try await move(
+                from: entry.absolutePath,
+                to: url.appendingPathComponent(entry.lastPathComponent).absolutePath,
+                options: []
+            )
+        }
+        try await remove(temp.absolutePath)
     }
 
     /// Materialise `source` at `destination`, removing any existing item first. By default,

--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -120,6 +120,11 @@ extension FileSystem {
         let subdirectories = try await contentsOfDirectory(at: url)
             .filter { isDirectoryAndNotSymlink($0) }
         guard subdirectories.count == 1, let nested = subdirectories.first else { return }
+        if try await exists(url.appendingPathComponent("Package.swift").absolutePath),
+           ["Plugins", "Sources", "Tests"].contains(nested.lastPathComponent)
+        {
+            return
+        }
 
         let temp = url.deletingLastPathComponent().appendingPathComponent(
             "\(url.lastPathComponent).flattening")

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -87,4 +87,28 @@ struct FileSystemSupportTests {
             #expect(!fileSystem.existsIncludingSymlinks(link))
         }
     }
+
+    @Test
+    func flattenSingleDirectoryPreservesTopLevelFiles() async throws {
+        try await withTemporaryDirectory { root in
+            let packageManifest = root.appendingPathComponent("Package.swift")
+            let nestedSource = root.appendingPathComponent("discarded/Sources/Package/Package.swift")
+            try await fileSystem.atomicWrite("// package manifest", to: packageManifest)
+            try await fileSystem.atomicWrite("// package source", to: nestedSource)
+
+            try await fileSystem.flattenSingleDirectory(root)
+
+            #expect(try await fileSystem.exists(packageManifest.absolutePath))
+            #expect(
+                try await fileSystem.exists(
+                    root.appendingPathComponent("Sources/Package/Package.swift").absolutePath
+                )
+            )
+            #expect(
+                !(try await fileSystem.exists(
+                    root.appendingPathComponent("discarded").absolutePath
+                ))
+            )
+        }
+    }
 }

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -111,4 +111,24 @@ struct FileSystemSupportTests {
             )
         }
     }
+
+    @Test
+    func flattenSingleDirectoryPreservesPackageSourcesAtRoot() async throws {
+        try await withTemporaryDirectory { root in
+            let packageManifest = root.appendingPathComponent("Package.swift")
+            let packageSource = root.appendingPathComponent("Sources/Package/Package.swift")
+            try await fileSystem.atomicWrite("// package manifest", to: packageManifest)
+            try await fileSystem.atomicWrite("// package source", to: packageSource)
+
+            try await fileSystem.flattenSingleDirectory(root)
+
+            #expect(try await fileSystem.exists(packageManifest.absolutePath))
+            #expect(try await fileSystem.exists(packageSource.absolutePath))
+            #expect(
+                !(try await fileSystem.exists(
+                    root.appendingPathComponent("Package").absolutePath
+                ))
+            )
+        }
+    }
 }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11463>

SwifterPM now identifies the single real directory in a registry package archive and moves its contents into the package root while preserving sibling files such as `Package.swift`. This matches Swift Package Manager's archive layout handling and prevents valid source paths from remaining nested under a discarded wrapper directory.

A regression test covers an archive containing a top-level `Package.swift` alongside `discarded/Sources`.

### How to test locally

```sh
cd swifterpm
mise run test:unit
```

All 124 tests pass.
