### PR TITLE
fix(infra): harden control-plane outage recovery

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -83,7 +83,7 @@ jobs:
             "infra/helm/typesense|values-ci.yaml"
             "infra/helm/slack|values-ci.yaml"
             "infra/helm/noora-storybook|values-ci.yaml"
-            "infra/helm/tuist|values-ci.yaml"
+            "infra/helm/tuist|values-self-hosted-ci.yaml values-ci.yaml"
             "infra/helm/tuist|values-preview.yaml values-preview-kura.yaml values-preview-ci.yaml values-ci.yaml"
             "infra/helm/tuist|values-k3s-smoke.yaml"
             "infra/helm/k8s-monitoring|"

--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -30,7 +30,8 @@ name: Mgmt Cluster Apply
 # Required secrets (on the mgmt-cluster-apply GitHub Environment):
 #   OP_SERVICE_ACCOUNT_TOKEN - 1Password SA scoped read-only to the
 #     tuist-k8s-mgmt vault, where the mgmt cluster's kubeconfig is
-#     stored as `kubeconfig: tuist-mgmt`.
+#     stored as `kubeconfig: tuist-mgmt` and the Grafana Cloud metrics
+#     token is stored as `PROMETHEUS_TOKEN`.
 
 on:
   push:
@@ -43,6 +44,7 @@ on:
       - 'infra/k8s/mgmt/etcd-snapshot.yaml'
       - 'infra/k8s/mgmt/tailscale.yaml'
       - 'infra/k8s/mgmt/hetzner-robot-controller.yaml'
+      - 'infra/helm/k8s-monitoring/**'
       - '.github/workflows/mgmt-cluster-apply.yml'
   # Manual re-runs of the apply path, e.g. to force a re-deploy
   # without a code change. No inputs — incident-recovery actions
@@ -75,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
-          install_args: "--locked kubectl"
+          install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2
       - name: Load mgmt kubeconfig from 1Password
@@ -171,3 +173,22 @@ jobs:
           kubectl apply -f infra/k8s/mgmt/cluster-autoscaler.yaml
           kubectl apply -f infra/k8s/mgmt/etcd-snapshot.yaml
           kubectl apply -f infra/k8s/mgmt/tailscale.yaml
+      - name: Install management-cluster monitoring
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          kubectl create namespace observability --dry-run=client -o yaml | kubectl apply -f -
+
+          PROMETHEUS_TOKEN="$(op read 'op://tuist-k8s-mgmt/PROMETHEUS_TOKEN/password')"
+          kubectl -n observability create secret generic k8s-monitoring-grafana-cloud \
+            --from-literal=prometheus-username=1774467 \
+            --from-literal=prometheus-password="$PROMETHEUS_TOKEN" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          unset PROMETHEUS_TOKEN
+
+          helm dependency update infra/helm/k8s-monitoring
+          helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
+            --namespace observability \
+            -f infra/helm/k8s-monitoring/values-management.yaml \
+            --wait --timeout 10m

--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -187,7 +187,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
           unset PROMETHEUS_TOKEN
 
-          helm dependency update infra/helm/k8s-monitoring
+          helm dependency build infra/helm/k8s-monitoring
           helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
             --namespace observability \
             -f infra/helm/k8s-monitoring/values-management.yaml \

--- a/infra/helm/k8s-monitoring/Chart.yaml
+++ b/infra/helm/k8s-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tuist-k8s-monitoring
 description: >
-  Grafana Kubernetes Monitoring for the Tuist-managed cluster. Wraps the
+  Grafana Kubernetes Monitoring for Tuist-managed clusters. Wraps the
   upstream grafana/k8s-monitoring chart and adds an ExternalSecret that
   syncs the Grafana Cloud Prometheus / Loki / Tempo tokens from 1Password
   via external-secrets-operator. Ships cluster-level metrics

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -12,8 +12,16 @@ Wraps [`grafana/k8s-monitoring`](https://github.com/grafana/k8s-monitoring-helm)
 | node-exporter | Deployed as DaemonSet (node CPU / mem / disk / net) |
 | kubelet + cAdvisor | Scraped (container resource usage) |
 | Kubernetes Events | Streamed to Loki as structured logs |
+| Kubernetes control endpoint | Request latency, requests in flight, rejected requests, and scrape availability |
+| etcd | Leader state, commit latency, write-ahead-log synchronization latency, and peer round-trip time |
+| Stable outbound gateway | Controller reconciliation plus active and prepared gateway state |
+| Management cluster | Desired, current, ready, available, and up-to-date control-plane replicas |
+| Hetzner load balancers | Target health, connections, requests, and inbound/outbound bandwidth |
 
 With these in place the Grafana Cloud **Observability → Kubernetes** app populates automatically (Cluster / Namespace / Workload / Pod / Node views) without importing dashboards by hand.
+
+The recommended incident alerts and Grafana setup steps are in
+[`alerts.md`](alerts.md).
 
 ## Install
 
@@ -27,6 +35,14 @@ helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
   -n observability --create-namespace \
   -f infra/helm/k8s-monitoring/values-staging.yaml
 ```
+
+The Cluster API management cluster is installed by
+`.github/workflows/mgmt-cluster-apply.yml` with `values-management.yaml`. Its
+`tuist-k8s-mgmt` 1Password vault must contain a `PROMETHEUS_TOKEN` password
+item. The workflow creates only the metrics destination Secret; logs and traces
+are intentionally disabled on that small cluster. The Hetzner load-balancer
+exporter reuses the existing `org-tuist/hetzner` Secret and its `hcloud` key
+that the Cluster API provider already requires.
 
 Prerequisites:
 
@@ -70,6 +86,13 @@ Four Alloy instances, split by role (managed by the upstream `alloy-operator`):
 - `alloy-logs` — DaemonSet tailing pod logs from `/var/log/pods`, plus host journald from `/var/log/journal` (node logs feature, scoped to `containerd` / `kubelet` / kernel)
 - `alloy-singleton` — cluster events (singleton so events aren't duplicated)
 - `alloy-receiver` — OTLP gRPC and HTTP receiver for managed workload traces
+- `alloy-control-plane` — one host-networked Pod per control-plane node,
+  scraping the local Kubernetes and etcd endpoints without exposing etcd
+  outside the machine
+
+The management cluster runs only `alloy-metrics` and `alloy-control-plane`.
+It also runs a Hetzner load-balancer exporter and configures kube-state-metrics
+to expose `KubeadmControlPlane` replica state.
 
 Plus the telemetry services themselves:
 
@@ -93,6 +116,12 @@ helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-staging.
 helm template k8s-monitoring infra/helm/k8s-monitoring \
   -n observability \
   -f infra/helm/k8s-monitoring/values-staging.yaml \
+  | kubectl apply --dry-run=client -f -
+
+helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-management.yaml
+helm template k8s-monitoring infra/helm/k8s-monitoring \
+  -n observability \
+  -f infra/helm/k8s-monitoring/values-management.yaml \
   | kubectl apply --dry-run=client -f -
 ```
 

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -30,7 +30,7 @@ Installed automatically by the `observability-install` job in [`.github/workflow
 Manual install (only needed when bootstrapping a fresh cluster ahead of the first CI deploy, or iterating locally):
 
 ```bash
-helm dependency update infra/helm/k8s-monitoring
+helm dependency build infra/helm/k8s-monitoring
 helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
   -n observability --create-namespace \
   -f infra/helm/k8s-monitoring/values-staging.yaml
@@ -56,7 +56,7 @@ Prerequisites:
    | `TEMPO_TOKEN` | Password | `password` |
 
 3. **Grafana Cloud endpoints / usernames** — baked into `values.yaml`. Sanity-check they match the stack before installing a fresh cluster.
-4. **Worker nodes sized for the footprint.** Four Alloy DaemonSets × 2 workers + kube-state-metrics + node-exporter want ~1.5 GB per node on top of the app. Staging/canary clusters run on `cpx31` (8 GB/node), production on `ccx23` (16 GB/node). `cpx22` (4 GB) is too small — a rolling server update can't fit a fresh pod alongside the old one while the Alloy DaemonSets are pinned to the node.
+4. **Worker nodes sized for the footprint.** The Alloy collectors, kube-state-metrics, and node-exporter want ~1.5 GB per node on top of the app. Staging/canary clusters run on `cpx31` (8 GB/node), production on `ccx23` (16 GB/node). `cpx22` (4 GB) is too small — a rolling server update can't fit a fresh pod alongside the old one while the node-local collectors are pinned to the node.
 
 ## Workload-side wiring
 
@@ -80,7 +80,7 @@ Server pod metrics are discovered automatically: the server Deployment carries `
 
 ## What gets deployed
 
-Four Alloy instances, split by role (managed by the upstream `alloy-operator`):
+Five Alloy instances, split by role (managed by the upstream `alloy-operator`):
 
 - `alloy-metrics` — scrapes metrics (cluster / node / app) ; runs clustered so replicas hash-partition targets
 - `alloy-logs` — DaemonSet tailing pod logs from `/var/log/pods`, plus host journald from `/var/log/journal` (node logs feature, scoped to `containerd` / `kubelet` / kernel)
@@ -101,17 +101,20 @@ Plus the telemetry services themselves:
 
 ## Metrics scrape cadence
 
-All cluster and custom metrics jobs use a 60-second scrape interval. This
+Cluster and custom metrics jobs normally use a 60-second scrape interval. The
+local control-plane jobs use 30 seconds so a short control-plane interruption
+still produces enough samples to distinguish process, storage, and network
+pressure. The one-minute default
 matches Grafana Cloud's included rate of one data point per minute for each
 active series, while keeping enough resolution for the infrastructure
-dashboards and alerts. Keep job-specific overrides at 60 seconds unless a
+dashboards and alerts. Keep other job-specific overrides at 60 seconds unless a
 documented operational requirement justifies the additional ingestion cost.
 See [Grafana's scrape interval guidance](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/).
 
 ## Local validation
 
 ```bash
-helm dependency update infra/helm/k8s-monitoring
+helm dependency build infra/helm/k8s-monitoring
 helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-staging.yaml
 helm template k8s-monitoring infra/helm/k8s-monitoring \
   -n observability \
@@ -128,7 +131,7 @@ helm template k8s-monitoring infra/helm/k8s-monitoring \
 ## Verify it's working after install
 
 ```bash
-# All four Alloy StatefulSets / DaemonSets ready
+# All Alloy workloads ready
 kubectl -n observability get alloy,statefulset,daemonset
 
 # Grafana Cloud token secret materialized
@@ -157,6 +160,7 @@ Server-level labels (`namespace`, `pod`, `container`, deployment/statefulset nam
 ## RBAC — what access does this chart get?
 
 - `alloy-metrics` — cluster-wide `get/list/watch` on nodes/pods/services/endpoints for target discovery, plus `/metrics/cadvisor` on kubelets.
+- `alloy-control-plane` — one host-networked pod on each control-plane node, with read-only access to the Kubernetes `/metrics` endpoint. etcd metrics remain on the host loopback interface.
 - `alloy-logs` — node-local hostPath to `/var/log/pods` (pod logs) and `/var/log/journal` (host journald: `containerd` / `kubelet` / kernel). No extra Kubernetes API access; a compromised pod can still only read logs from the single node it runs on.
 - `alloy-singleton` — cluster-wide `get/list/watch` on events.
 - `alloy-receiver` — none beyond standard pod execution.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -7,17 +7,23 @@ failure, or a stable outbound-gateway failure.
 All queries below are suitable for Grafana-managed alert rules. Use the
 Grafana Cloud metrics data source and evaluate them every minute.
 
+The metrics `cluster` label uses `tuist-production`, `tuist-staging`,
+`tuist-canary`, and `tuist-management`. The Cluster API
+`workload_cluster` label uses the Kubernetes Cluster object names `tuist`,
+`tuist-staging`, and `tuist-canary`, so production deliberately differs
+between these two labels.
+
 ## Critical alerts
 
 ### Kubernetes control endpoint unavailable
 
 ```promql
 min by (cluster, instance) (
-  up{job="tuist-kube-apiserver"}
+  min_over_time(up{job="tuist-kube-apiserver"}[2m])
 ) == 0
 ```
 
-- Pending period: 2 minutes
+- Pending period: 0 minutes
 - Summary: `Kubernetes control endpoint unavailable on {{ $labels.instance }} ({{ $labels.cluster }})`
 
 ### Kubernetes control-plane collector unavailable
@@ -31,6 +37,40 @@ kube_daemonset_status_number_unavailable{
 
 - Pending period: 2 minutes
 - Summary: `Control-plane metrics collector unavailable in {{ $labels.cluster }}`
+
+### Kubernetes control-plane scrape telemetry missing
+
+```promql
+absent_over_time(up{cluster="tuist-production", job="tuist-kube-apiserver"}[5m])
+or
+absent_over_time(up{cluster="tuist-production", job="tuist-etcd"}[5m])
+or
+absent_over_time(up{cluster="tuist-staging", job="tuist-kube-apiserver"}[5m])
+or
+absent_over_time(up{cluster="tuist-staging", job="tuist-etcd"}[5m])
+or
+absent_over_time(up{cluster="tuist-canary", job="tuist-kube-apiserver"}[5m])
+or
+absent_over_time(up{cluster="tuist-canary", job="tuist-etcd"}[5m])
+or
+absent_over_time(up{cluster="tuist-management", job="tuist-kube-apiserver"}[5m])
+or
+absent_over_time(up{cluster="tuist-management", job="tuist-etcd"}[5m])
+```
+
+- Pending period: 0 minutes
+- Summary: `Kubernetes control-plane scrape telemetry is missing for {{ $labels.job }} in {{ $labels.cluster }}`
+
+### Kubernetes requests terminated
+
+```promql
+sum by (cluster) (
+  increase(apiserver_request_terminations_total[2m])
+) > 0
+```
+
+- Pending period: 0 minutes
+- Summary: `Kubernetes control endpoint terminated requests in {{ $labels.cluster }}`
 
 ### Kubernetes requests rejected
 
@@ -58,17 +98,18 @@ min by (cluster, instance) (
 
 ```promql
 min by (cluster, instance) (
-  up{job="tuist-etcd"}
+  min_over_time(up{job="tuist-etcd"}[2m])
 ) == 0
 ```
 
-- Pending period: 2 minutes
+- Pending period: 0 minutes
 - Summary: `etcd metrics unavailable on {{ $labels.instance }} ({{ $labels.cluster }})`
 
 ### Hetzner control-plane load-balancer target unhealthy
 
 ```promql
 min by (
+  cluster,
   hetzner_load_balancer_name,
   hetzner_target_name,
   hetzner_target_port
@@ -81,7 +122,7 @@ min by (
 ```
 
 - Pending period: 2 minutes
-- Summary: `Hetzner load balancer {{ $labels.hetzner_load_balancer_name }} has an unhealthy control-plane target`
+- Summary: `Hetzner load balancer {{ $labels.hetzner_load_balancer_name }} has an unhealthy control-plane target ({{ $labels.cluster }})`
 
 ### Hetzner load-balancer exporter unavailable
 
@@ -133,6 +174,60 @@ kube_customresource_kubeadmcontrolplane_spec_replicas{
 - Pending period: 10 minutes
 - Summary: `Control plane for {{ $labels.workload_cluster }} has fewer ready replicas than desired`
 
+### Control-plane replica telemetry missing
+
+```promql
+absent_over_time(
+  kube_customresource_kubeadmcontrolplane_spec_replicas{
+    cluster="tuist-management"
+  }[10m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Control-plane desired and ready replica telemetry is missing`
+
+### Node exporter coverage incomplete
+
+```promql
+count by (cluster) (
+  up{job="integrations/node_exporter"} == 1
+)
+<
+max by (cluster) (
+  kube_daemonset_status_desired_number_scheduled{
+    namespace="observability",
+    daemonset="k8s-monitoring-node-exporter"
+  }
+)
+```
+
+- Pending period: 5 minutes
+- Summary: `Node-level host metrics are missing for one or more nodes in {{ $labels.cluster }}`
+
+### Node exporter telemetry missing
+
+```promql
+absent_over_time(
+  up{cluster="tuist-production", job="integrations/node_exporter"}[10m]
+)
+or
+absent_over_time(
+  up{cluster="tuist-staging", job="integrations/node_exporter"}[10m]
+)
+or
+absent_over_time(
+  up{cluster="tuist-canary", job="integrations/node_exporter"}[10m]
+)
+or
+absent_over_time(
+  up{cluster="tuist-management", job="integrations/node_exporter"}[10m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Node exporter telemetry is missing in {{ $labels.cluster }}`
+
 ### Stable outbound gateway unavailable
 
 ```promql
@@ -144,11 +239,33 @@ max by (cluster) (
 - Pending period: 2 minutes
 - Summary: `No healthy prepared stable outbound gateway in {{ $labels.cluster }}`
 
+### Stable outbound gateway telemetry missing
+
+```promql
+absent_over_time(
+  tuist_stable_egress_gateway_available{cluster="tuist-production"}[10m]
+)
+or
+absent_over_time(
+  tuist_stable_egress_gateway_available{cluster="tuist-staging"}[10m]
+)
+or
+absent_over_time(
+  tuist_stable_egress_gateway_available{cluster="tuist-canary"}[10m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Stable outbound gateway telemetry is missing in {{ $labels.cluster }}`
+
 ### Stable outbound traffic dropped
 
 ```promql
 sum by (cluster) (
-  rate(cilium_drop_count_total{reason="No Egress IP configured"}[5m])
+  rate(cilium_drop_count_total{
+    direction="INGRESS",
+    reason="No Egress IP configured"
+  }[5m])
 ) > 0
 ```
 
@@ -172,6 +289,75 @@ kube_deployment_spec_replicas{
 - Pending period: 2 minutes
 - Summary: `Tuist server has unavailable replicas in {{ $labels.namespace }}`
 
+### Tuist license invalid or near expiration
+
+```promql
+min by (cluster, namespace) (
+  tuist_license_valid
+) == 0
+or
+(
+  min by (cluster, namespace) (
+    tuist_license_expiration_timestamp_seconds
+  )
+  - time()
+) < 604800
+```
+
+- Pending period: 0 minutes
+- Summary: `Tuist license is invalid or expires within seven days in {{ $labels.cluster }}`
+
+### Tuist license telemetry missing
+
+```promql
+absent_over_time(
+  tuist_license_valid{cluster="tuist-production"}[15m]
+)
+or
+absent_over_time(
+  tuist_license_valid{cluster="tuist-staging"}[15m]
+)
+or
+absent_over_time(
+  tuist_license_valid{cluster="tuist-canary"}[15m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Tuist license telemetry is missing in {{ $labels.cluster }}`
+
+### Public endpoint unavailable from multiple locations
+
+Create a Grafana Synthetic Monitoring Hypertext Transfer Protocol check named
+`tuist-public-readiness` for `https://tuist.dev`, run it every minute from at
+least three public probes, and set its **Job** field to
+`tuist-public-readiness`. Alert when fewer than two probes have succeeded in
+the last three minutes:
+
+```promql
+sum(
+  max by (probe) (
+    max_over_time(
+      probe_success{job="tuist-public-readiness"}[3m]
+    )
+  )
+) < 2
+```
+
+- Pending period: 0 minutes
+- Summary: `Tuist is unavailable from multiple external probe locations`
+
+### Public endpoint telemetry missing
+
+```promql
+absent_over_time(
+  probe_success{job="tuist-public-readiness"}[3m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `The public endpoint check stopped producing telemetry`
+
 ## Warning alerts
 
 ### Kubernetes request latency
@@ -189,6 +375,95 @@ histogram_quantile(
 
 - Pending period: 5 minutes
 - Summary: `Kubernetes request latency above one second in {{ $labels.cluster }}`
+
+### Kubernetes priority level concurrency saturated
+
+```promql
+sum by (cluster, instance, priority_level) (
+  apiserver_flowcontrol_current_executing_seats
+)
+/
+clamp_min(
+  max by (cluster, instance, priority_level) (
+    apiserver_flowcontrol_current_limit_seats
+  ),
+  1
+) > 0.8
+```
+
+- Pending period: 5 minutes
+- Summary: `Kubernetes priority level {{ $labels.priority_level }} uses more than 80% of its request capacity in {{ $labels.cluster }}`
+
+### Kubernetes server errors
+
+```promql
+(
+  sum by (cluster) (
+    rate(apiserver_request_total{code=~"5.."}[5m])
+  )
+  /
+  clamp_min(
+    sum by (cluster) (
+      rate(apiserver_request_total[5m])
+    ),
+    1
+  )
+) > 0.01
+and
+sum by (cluster) (
+  rate(apiserver_request_total{code=~"5.."}[5m])
+) > 0.1
+```
+
+- Pending period: 5 minutes
+- Summary: `More than 1% of Kubernetes requests are server errors in {{ $labels.cluster }}`
+
+### Kubernetes rate limiting responses
+
+```promql
+sum by (cluster) (
+  rate(apiserver_request_total{code="429"}[5m])
+) > 0.1
+```
+
+- Pending period: 5 minutes
+- Summary: `Kubernetes is rate limiting requests in {{ $labels.cluster }}`
+
+### Tuist license expires within 30 days
+
+```promql
+(
+  min by (cluster, namespace) (
+    tuist_license_expiration_timestamp_seconds
+  )
+  - time()
+) < 2592000
+and
+min by (cluster, namespace) (
+  tuist_license_valid
+) == 1
+```
+
+- Pending period: 1 hour
+- Summary: `Tuist license expires within 30 days in {{ $labels.cluster }}`
+
+### Database connection pool starved
+
+```promql
+sum by (cluster, namespace, repo, database) (
+  increase(tuist_repo_pool_checkout_queue_starved_samples_sum[5m])
+)
+/
+clamp_min(
+  sum by (cluster, namespace, repo, database) (
+    increase(tuist_repo_pool_checkout_queue_total_samples_sum[5m])
+  ),
+  1
+) > 0.1
+```
+
+- Pending period: 2 minutes
+- Summary: `More than 10% of database pool samples had queued work and no ready connection for {{ $labels.repo }} in {{ $labels.cluster }}`
 
 ### etcd write-ahead-log synchronization latency
 
@@ -218,6 +493,228 @@ histogram_quantile(
 - Pending period: 5 minutes
 - Summary: `etcd backend commits are slow on {{ $labels.instance }}`
 
+### etcd peer round-trip latency
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (cluster, instance, le) (
+    rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])
+  )
+) > 0.1
+```
+
+- Pending period: 5 minutes
+- Summary: `etcd peer round-trip latency is above 100 milliseconds on {{ $labels.instance }}`
+
+### etcd leader changed
+
+```promql
+sum by (cluster) (
+  increase(etcd_server_leader_changes_seen_total[10m])
+) > 0
+```
+
+- Pending period: 0 minutes
+- Summary: `etcd leadership changed in {{ $labels.cluster }}`
+
+### etcd proposals stalled or failed
+
+```promql
+max by (cluster, instance) (
+  etcd_server_proposals_pending
+) > 100
+or
+sum by (cluster, instance) (
+  increase(etcd_server_proposals_failed_total[5m])
+) > 0
+```
+
+- Pending period: 2 minutes
+- Summary: `etcd proposals are stalled or failing on {{ $labels.instance }}`
+
+### etcd slow applies
+
+```promql
+sum by (cluster, instance) (
+  increase(etcd_server_slow_apply_total[5m])
+) > 0
+```
+
+- Pending period: 0 minutes
+- Summary: `etcd reported slow request application on {{ $labels.instance }}`
+
+### Control-plane process file descriptors nearly exhausted
+
+```promql
+max by (cluster, job, instance) (
+  process_open_fds{
+    job=~"tuist-kube-apiserver|tuist-etcd"
+  }
+  /
+  clamp_min(
+    process_max_fds{
+      job=~"tuist-kube-apiserver|tuist-etcd"
+    },
+    1
+  )
+) > 0.8
+```
+
+- Pending period: 5 minutes
+- Summary: `{{ $labels.job }} uses more than 80% of its file descriptor limit on {{ $labels.instance }}`
+
+### Host processor saturation
+
+```promql
+1 - avg by (cluster, instance) (
+  rate(node_cpu_seconds_total{mode="idle"}[5m])
+) > 0.9
+```
+
+- Pending period: 10 minutes
+- Summary: `Host processor utilization is above 90% on {{ $labels.instance }}`
+
+### Host processor steal time
+
+```promql
+avg by (cluster, instance) (
+  rate(node_cpu_seconds_total{mode="steal"}[5m])
+) > 0.1
+```
+
+- Pending period: 5 minutes
+- Summary: `Virtual machine host contention is stealing processor time from {{ $labels.instance }}`
+
+### Host disk input/output saturation
+
+```promql
+max by (cluster, instance) (
+  rate(node_disk_io_time_seconds_total{
+    device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+  }[5m])
+) > 0.8
+```
+
+- Pending period: 10 minutes
+- Summary: `Host disk is busy more than 80% of the time on {{ $labels.instance }}`
+
+### Host disk operation latency
+
+```promql
+max by (cluster, instance) (
+  (
+    rate(node_disk_read_time_seconds_total{
+      device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+    }[5m])
+    +
+    rate(node_disk_write_time_seconds_total{
+      device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+    }[5m])
+  )
+  /
+  clamp_min(
+    rate(node_disk_reads_completed_total{
+      device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+    }[5m])
+    +
+    rate(node_disk_writes_completed_total{
+      device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+    }[5m]),
+    0.001
+  )
+) > 0.05
+and
+max by (cluster, instance) (
+  rate(node_disk_reads_completed_total{
+    device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+  }[5m])
+  +
+  rate(node_disk_writes_completed_total{
+    device=~"(sd|vd|xvd)[a-z]+|nvme[0-9]+n[0-9]+"
+  }[5m])
+) > 1
+```
+
+- Pending period: 5 minutes
+- Summary: `Host disk operations average more than 50 milliseconds on {{ $labels.instance }}`
+
+### Host network errors
+
+```promql
+sum by (cluster, instance) (
+  rate({
+    __name__=~"node_network_(receive|transmit)_errs_total",
+    device=~"e(n|th).*"
+  }[5m])
+) > 0
+```
+
+- Pending period: 5 minutes
+- Summary: `Host network interface reports errors on {{ $labels.instance }}`
+
+### Host network packet drops
+
+```promql
+(
+  sum by (cluster, instance) (
+    rate({
+      __name__=~"node_network_(receive|transmit)_drop_total",
+      device=~"e(n|th).*"
+    }[5m])
+  )
+  /
+  clamp_min(
+    sum by (cluster, instance) (
+      rate({
+        __name__=~"node_network_(receive|transmit)_packets_total",
+        device=~"e(n|th).*"
+      }[5m])
+    ),
+    1
+  )
+) > 0.001
+and
+sum by (cluster, instance) (
+  rate({
+    __name__=~"node_network_(receive|transmit)_packets_total",
+    device=~"e(n|th).*"
+  }[5m])
+) > 100
+```
+
+- Pending period: 5 minutes
+- Summary: `Host network packet drops exceed 0.1% on {{ $labels.instance }}`
+
+### Host clock offset
+
+```promql
+max by (cluster, instance) (
+  abs(node_timex_offset_seconds)
+) > 0.1
+```
+
+- Pending period: 5 minutes
+- Summary: `Host clock differs from its time source by more than 100 milliseconds on {{ $labels.instance }}`
+
+### Transmission Control Protocol retransmissions
+
+```promql
+sum by (cluster, instance) (
+  rate(node_netstat_Tcp_RetransSegs[5m])
+)
+/
+clamp_min(
+  sum by (cluster, instance) (
+    rate(node_netstat_Tcp_OutSegs[5m])
+  ),
+  1
+) > 0.01
+```
+
+- Pending period: 5 minutes
+- Summary: `Transmission Control Protocol retransmissions exceed 1% on {{ $labels.instance }}`
+
 ### Stable outbound gateway not prepared
 
 ```promql
@@ -228,6 +725,41 @@ min by (cluster, node) (
 
 - Pending period: 5 minutes
 - Summary: `Stable outbound gateway candidate {{ $labels.node }} is not prepared`
+
+### Stable outbound gateway redundancy lost
+
+```promql
+sum by (cluster) (
+  max by (cluster, node) (
+    tuist_stable_egress_gateway_prepared
+  )
+) < 2
+```
+
+- Pending period: 5 minutes
+- Summary: `Fewer than two stable outbound gateway candidates are prepared in {{ $labels.cluster }}`
+
+### Stable outbound gateway direct health check failing
+
+```promql
+min by (cluster, node) (
+  tuist_stable_egress_gateway_node_healthy
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Cilium is not directly reachable on stable outbound gateway {{ $labels.node }}`
+
+### Stable outbound gateway failed over
+
+```promql
+sum by (cluster) (
+  increase(tuist_stable_egress_failovers_total[10m])
+) > 0
+```
+
+- Pending period: 0 minutes
+- Summary: `The stable outbound address moved to another gateway in {{ $labels.cluster }}`
 
 ### Stable outbound controller reconciliation errors
 
@@ -272,6 +804,50 @@ Stable outbound gateway assignments:
 tuist_stable_egress_gateway_active
 ```
 
+Kubernetes API server and etcd process pressure:
+
+```promql
+rate(process_cpu_seconds_total{job=~"tuist-kube-apiserver|tuist-etcd"}[5m])
+```
+
+```promql
+process_resident_memory_bytes{job=~"tuist-kube-apiserver|tuist-etcd"}
+```
+
+```promql
+process_open_fds{job=~"tuist-kube-apiserver|tuist-etcd"}
+/
+clamp_min(
+  process_max_fds{job=~"tuist-kube-apiserver|tuist-etcd"},
+  1
+)
+```
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (cluster, job, instance, le) (
+    rate(go_sched_latencies_seconds_bucket{
+      job="tuist-kube-apiserver"
+    }[5m])
+  )
+)
+```
+
+Server database pool pressure:
+
+```promql
+max by (cluster, namespace, repo, database) (
+  tuist_repo_pool_checkout_queue_length
+)
+```
+
+```promql
+min by (cluster, namespace, repo, database) (
+  tuist_repo_pool_ready_conn_count
+)
+```
+
 ## Create the rules in Grafana
 
 1. Open **Alerts & incident response → Alerting → Alert rules**.
@@ -280,19 +856,34 @@ tuist_stable_egress_gateway_active
 4. Paste one query from this document and set it as the alert condition.
 5. Set the evaluation interval to one minute and use the pending period shown
    with the query.
-6. For availability rules, set the **No Data** state to **Alerting** so a
-   missing collector or exporter cannot turn an outage into a silent query.
-7. Add the suggested summary, a `severity` label, and the notification contact
+6. Set **No Data** to **Normal** for threshold rules. Healthy comparison
+   expressions commonly return an empty result, and treating that as alerting
+   creates false positives.
+7. Use the explicit telemetry-missing rules in this document to detect absent
+   series. They use `absent_over_time` and fire even though threshold rules use
+   **No Data: Normal**.
+8. Set **Error** to **Alerting** for the critical availability and
+   telemetry-missing rules. Use **Keep Last State** for capacity and latency
+   warnings so a data-source evaluation error does not fan out into unrelated
+   warnings.
+9. Add the suggested summary, a `severity` label, and the notification contact
    point used by the infrastructure team.
-8. Preview the rule against recent data before saving it.
+10. Preview the raw metric selector and the final comparison separately against
+    recent data before saving it.
 
 The same rules can be created with Grafana Assistant. Give it this prompt:
 
-> Create Grafana-managed alert rules from
-> `infra/helm/k8s-monitoring/alerts.md`. Use the Grafana Cloud metrics data
-> source, preserve every query and pending period exactly, put the rules in a
-> folder named `Tuist infrastructure`, add the suggested summary as the
-> annotation, and route critical and warning severities through our existing
-> infrastructure notification policy. Configure No Data as Alerting for every
-> availability rule. Preview each query and show me the resulting rules before
-> saving.
+```text
+Create Grafana-managed alert rules from
+infra/helm/k8s-monitoring/alerts.md. Use the Grafana Cloud metrics data source,
+preserve every query and pending period exactly, put the rules in a folder
+named Tuist infrastructure, add the suggested summary as the annotation, and
+route critical and warning severities through our existing infrastructure
+notification policy. Configure No Data and Error as Alerting for every
+explicit telemetry-missing rule. Configure No Data as Normal for every
+threshold rule. Configure Error as Alerting for critical availability and
+telemetry-missing rules, and Keep Last State for warning rules. Group
+notifications by cluster and alert name. Preview each raw metric selector and
+final comparison against the last seven days, report any selector with no
+matching series, and show me the resulting rules before saving.
+```

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1,0 +1,298 @@
+# Control plane and stable egress alerts
+
+The monitoring chart sends the signals needed to distinguish a Kubernetes
+control-endpoint interruption from an etcd stall, a Hetzner load-balancer
+failure, or a stable outbound-gateway failure.
+
+All queries below are suitable for Grafana-managed alert rules. Use the
+Grafana Cloud metrics data source and evaluate them every minute.
+
+## Critical alerts
+
+### Kubernetes control endpoint unavailable
+
+```promql
+min by (cluster, instance) (
+  up{job="tuist-kube-apiserver"}
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Kubernetes control endpoint unavailable on {{ $labels.instance }} ({{ $labels.cluster }})`
+
+### Kubernetes control-plane collector unavailable
+
+```promql
+kube_daemonset_status_number_unavailable{
+  namespace="observability",
+  daemonset="k8s-monitoring-alloy-control-plane"
+} > 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Control-plane metrics collector unavailable in {{ $labels.cluster }}`
+
+### Kubernetes requests rejected
+
+```promql
+sum by (cluster) (
+  increase(apiserver_flowcontrol_rejected_requests_total[5m])
+) > 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Kubernetes control endpoint is rejecting requests in {{ $labels.cluster }}`
+
+### etcd has no leader
+
+```promql
+min by (cluster, instance) (
+  etcd_server_has_leader
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `etcd has no leader on {{ $labels.instance }} ({{ $labels.cluster }})`
+
+### etcd scrape unavailable
+
+```promql
+min by (cluster, instance) (
+  up{job="tuist-etcd"}
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `etcd metrics unavailable on {{ $labels.instance }} ({{ $labels.cluster }})`
+
+### Hetzner control-plane load-balancer target unhealthy
+
+```promql
+min by (
+  hetzner_load_balancer_name,
+  hetzner_target_name,
+  hetzner_target_port
+) (
+  hetzner_load_balancer_service_state{
+    cluster="tuist-management",
+    hetzner_load_balancer_name=~"tuist(|-staging|-canary)-.*-kube-apiserver-.*"
+  }
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Hetzner load balancer {{ $labels.hetzner_load_balancer_name }} has an unhealthy control-plane target`
+
+### Hetzner load-balancer exporter unavailable
+
+```promql
+kube_deployment_status_replicas_available{
+  cluster="tuist-management",
+  namespace="org-tuist",
+  deployment="hcloud-load-balancer-exporter"
+}
+<
+kube_deployment_spec_replicas{
+  cluster="tuist-management",
+  namespace="org-tuist",
+  deployment="hcloud-load-balancer-exporter"
+}
+```
+
+- Pending period: 2 minutes
+- Summary: `Hetzner load-balancer telemetry exporter is unavailable`
+
+### Hetzner load-balancer telemetry missing
+
+```promql
+absent_over_time(
+  hetzner_load_balancer_service_state{
+    cluster="tuist-management",
+    hetzner_load_balancer_name=~"tuist(|-staging|-canary)-.*-kube-apiserver-.*"
+  }[5m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Hetzner control-plane load-balancer health telemetry is missing`
+
+### Control-plane replicas below desired state
+
+```promql
+kube_customresource_kubeadmcontrolplane_ready_replicas{
+  cluster="tuist-management",
+  workload_cluster=~"tuist|tuist-staging|tuist-canary"
+}
+<
+kube_customresource_kubeadmcontrolplane_spec_replicas{
+  cluster="tuist-management",
+  workload_cluster=~"tuist|tuist-staging|tuist-canary"
+}
+```
+
+- Pending period: 10 minutes
+- Summary: `Control plane for {{ $labels.workload_cluster }} has fewer ready replicas than desired`
+
+### Stable outbound gateway unavailable
+
+```promql
+max by (cluster) (
+  tuist_stable_egress_gateway_available
+) == 0
+```
+
+- Pending period: 2 minutes
+- Summary: `No healthy prepared stable outbound gateway in {{ $labels.cluster }}`
+
+### Stable outbound traffic dropped
+
+```promql
+sum by (cluster) (
+  rate(cilium_drop_count_total{reason="No Egress IP configured"}[5m])
+) > 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Cilium is dropping stable outbound traffic in {{ $labels.cluster }}`
+
+### Tuist server replicas unavailable
+
+```promql
+kube_deployment_status_replicas_available{
+  namespace=~"tuist|tuist-staging|tuist-canary",
+  deployment="tuist-tuist-server"
+}
+<
+kube_deployment_spec_replicas{
+  namespace=~"tuist|tuist-staging|tuist-canary",
+  deployment="tuist-tuist-server"
+}
+```
+
+- Pending period: 2 minutes
+- Summary: `Tuist server has unavailable replicas in {{ $labels.namespace }}`
+
+## Warning alerts
+
+### Kubernetes request latency
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (cluster, le) (
+    rate(apiserver_request_duration_seconds_bucket{
+      verb!~"WATCH|CONNECT"
+    }[5m])
+  )
+) > 1
+```
+
+- Pending period: 5 minutes
+- Summary: `Kubernetes request latency above one second in {{ $labels.cluster }}`
+
+### etcd write-ahead-log synchronization latency
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (cluster, instance, le) (
+    rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])
+  )
+) > 0.5
+```
+
+- Pending period: 5 minutes
+- Summary: `etcd write-ahead-log synchronization is slow on {{ $labels.instance }}`
+
+### etcd backend commit latency
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (cluster, instance, le) (
+    rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])
+  )
+) > 0.25
+```
+
+- Pending period: 5 minutes
+- Summary: `etcd backend commits are slow on {{ $labels.instance }}`
+
+### Stable outbound gateway not prepared
+
+```promql
+min by (cluster, node) (
+  tuist_stable_egress_gateway_prepared
+) == 0
+```
+
+- Pending period: 5 minutes
+- Summary: `Stable outbound gateway candidate {{ $labels.node }} is not prepared`
+
+### Stable outbound controller reconciliation errors
+
+```promql
+sum by (cluster) (
+  increase(controller_runtime_reconcile_errors_total{
+    controller="stable-egress-failover"
+  }[5m])
+) > 0
+```
+
+- Pending period: 2 minutes
+- Summary: `Stable outbound controller reconciliation is failing in {{ $labels.cluster }}`
+
+## Useful investigation queries
+
+Current Kubernetes requests in flight:
+
+```promql
+sum by (cluster, request_kind) (
+  apiserver_current_inflight_requests
+)
+```
+
+Hetzner load-balancer connections and traffic:
+
+```promql
+hetzner_load_balancer_open_connections{cluster="tuist-management"}
+```
+
+```promql
+hetzner_load_balancer_bandwidth_in{cluster="tuist-management"}
+```
+
+```promql
+hetzner_load_balancer_bandwidth_out{cluster="tuist-management"}
+```
+
+Stable outbound gateway assignments:
+
+```promql
+tuist_stable_egress_gateway_active
+```
+
+## Create the rules in Grafana
+
+1. Open **Alerts & incident response → Alerting → Alert rules**.
+2. Select **New alert rule**.
+3. Choose the Grafana Cloud metrics data source.
+4. Paste one query from this document and set it as the alert condition.
+5. Set the evaluation interval to one minute and use the pending period shown
+   with the query.
+6. For availability rules, set the **No Data** state to **Alerting** so a
+   missing collector or exporter cannot turn an outage into a silent query.
+7. Add the suggested summary, a `severity` label, and the notification contact
+   point used by the infrastructure team.
+8. Preview the rule against recent data before saving it.
+
+The same rules can be created with Grafana Assistant. Give it this prompt:
+
+> Create Grafana-managed alert rules from
+> `infra/helm/k8s-monitoring/alerts.md`. Use the Grafana Cloud metrics data
+> source, preserve every query and pending period exactly, put the rules in a
+> folder named `Tuist infrastructure`, add the suggested summary as the
+> annotation, and route critical and warning severities through our existing
+> infrastructure notification policy. Configure No Data as Alerting for every
+> availability rule. Preview each query and show me the resulting rules before
+> saving.

--- a/infra/helm/k8s-monitoring/templates/hcloud-load-balancer-exporter.yaml
+++ b/infra/helm/k8s-monitoring/templates/hcloud-load-balancer-exporter.yaml
@@ -1,0 +1,73 @@
+{{- with .Values.hcloudLoadBalancerExporter }}
+{{- if .enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hcloud-load-balancer-exporter
+  namespace: {{ .namespace }}
+  labels:
+    app.kubernetes.io/name: hcloud-load-balancer-exporter
+    app.kubernetes.io/component: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hcloud-load-balancer-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hcloud-load-balancer-exporter
+        app.kubernetes.io/component: observability
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: /metrics
+    spec:
+      containers:
+        - name: exporter
+          image: {{ printf "%s:%s" .image.repository .image.tag | quote }}
+          imagePullPolicy: {{ .image.pullPolicy }}
+          env:
+            - name: LOAD_BALANCER_IDS
+              value: {{ .loadBalancerIds | quote }}
+            - name: ACCESS_TOKEN_PATH
+              value: /etc/hcloud/token
+            - name: SCRAPE_INTERVAL
+              value: {{ .scrapeIntervalSeconds | quote }}
+          ports:
+            - name: metrics
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            periodSeconds: 30
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 11001
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: hcloud-token
+              mountPath: /etc/hcloud
+              readOnly: true
+      volumes:
+        - name: hcloud-token
+          secret:
+            secretName: {{ .tokenSecretRef.name }}
+            items:
+              - key: {{ .tokenSecretRef.key }}
+                path: token
+{{- end }}
+{{- end }}

--- a/infra/helm/k8s-monitoring/values-management.yaml
+++ b/infra/helm/k8s-monitoring/values-management.yaml
@@ -1,0 +1,111 @@
+# Metrics-only monitoring for the Cluster API management cluster. The
+# management cluster must remain observable when a workload cluster is
+# unreachable, so it reports under its own cluster label and exports
+# KubeadmControlPlane desired/current/ready state.
+
+externalSecrets:
+  enabled: false
+
+hcloudLoadBalancerExporter:
+  enabled: true
+
+k8s-monitoring:
+  cluster:
+    name: tuist-management
+
+  destinations:
+    grafana-cloud-metrics:
+      extraLabels:
+        env: management
+
+  clusterEvents:
+    enabled: false
+  podLogsViaLoki:
+    enabled: false
+  nodeLogs:
+    enabled: false
+  applicationObservability:
+    enabled: false
+
+  clusterMetrics:
+    kube-state-metrics:
+      metricsTuning:
+        includeMetrics:
+          - kube_customresource_kubeadmcontrolplane_.*
+
+  integrations:
+    alloy:
+      instances:
+        - name: alloy-metrics
+          labelSelectors:
+            app.kubernetes.io/name: alloy-metrics
+          metrics:
+            tuning:
+              useDefaultAllowList: false
+              includeMetrics:
+                - alloy_config_last_load_successful
+                - alloy_config_last_load_success_timestamp_seconds
+
+  collectors:
+    alloy-logs:
+      enabled: false
+    alloy-singleton:
+      enabled: false
+    alloy-receiver:
+      enabled: false
+
+  telemetryServices:
+    kube-state-metrics:
+      rbac:
+        extraRules:
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["controlplane.cluster.x-k8s.io"]
+            resources: ["kubeadmcontrolplanes"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: controlplane.cluster.x-k8s.io
+                  version: v1beta2
+                  kind: KubeadmControlPlane
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  kubeadmcontrolplane: [metadata, name]
+                  workload_cluster: [metadata, labels, "cluster.x-k8s.io/cluster-name"]
+                metrics:
+                  - name: kubeadmcontrolplane_spec_replicas
+                    help: Desired control-plane replicas.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, replicas]
+                  - name: kubeadmcontrolplane_status_replicas
+                    help: Current control-plane replicas.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, replicas]
+                  - name: kubeadmcontrolplane_ready_replicas
+                    help: Ready control-plane replicas.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, readyReplicas]
+                  - name: kubeadmcontrolplane_available_replicas
+                    help: Available control-plane replicas.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, availableReplicas]
+                  - name: kubeadmcontrolplane_up_to_date_replicas
+                    help: Up-to-date control-plane replicas.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, upToDateReplicas]

--- a/infra/helm/k8s-monitoring/values-management.yaml
+++ b/infra/helm/k8s-monitoring/values-management.yaml
@@ -47,6 +47,9 @@ k8s-monitoring:
                 - alloy_config_last_load_success_timestamp_seconds
 
   collectors:
+    alloy-metrics:
+      includeDestinations:
+        - grafana-cloud-metrics
     alloy-logs:
       enabled: false
     alloy-singleton:

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -37,6 +37,29 @@ grafanaCloud:
       item: TEMPO_TOKEN
       field: password
 
+# Optional management-cluster exporter for Hetzner load-balancer health and
+# traffic. It runs beside Cluster API so the signal remains available when a
+# workload cluster's own control endpoint is unreachable.
+hcloudLoadBalancerExporter:
+  enabled: false
+  namespace: org-tuist
+  image:
+    repository: wacken/hetzner-load-balancer-prometheus-exporter
+    tag: 1.7.0
+    pullPolicy: IfNotPresent
+  loadBalancerIds: all
+  scrapeIntervalSeconds: 30
+  tokenSecretRef:
+    name: hetzner
+    key: hcloud
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 192Mi
+
 # Upstream grafana/k8s-monitoring chart values. Everything under this key
 # is passed verbatim to the subchart — see
 # https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring
@@ -627,6 +650,80 @@ k8s-monitoring:
   # upstream presets — without them the Alloy subchart defaults to a
   # DaemonSet, which is wrong for the singleton + receiver roles.
   collectors:
+    # One Pod per control-plane node, using the host network so etcd's
+    # loopback-only metrics endpoint stays private. This captures the control
+    # endpoint and etcd signals that distinguish a network interruption from
+    # request saturation, storage latency, or lost etcd leadership.
+    alloy-control-plane:
+      includeDestinations:
+        - grafana-cloud-metrics
+      controller:
+        type: daemonset
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: ""
+        tolerations:
+          - operator: Exists
+        priorityClassName: system-node-critical
+      alloy:
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 192Mi
+      extraConfig: |
+        prometheus.scrape "tuist_kube_apiserver" {
+          targets = [{
+            "__address__" = "127.0.0.1:6443",
+            "instance" = sys.env("HOSTNAME"),
+          }]
+          forward_to = [prometheus.relabel.tuist_kube_apiserver.receiver]
+          job_name = "tuist-kube-apiserver"
+          scheme = "https"
+          scrape_interval = "30s"
+          scrape_timeout = "10s"
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+          tls_config {
+            ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            server_name = "kubernetes"
+          }
+        }
+
+        prometheus.relabel "tuist_kube_apiserver" {
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|apiserver_current_inflight_requests|apiserver_flowcontrol_rejected_requests_total|apiserver_request_duration_seconds_(bucket|count|sum)|apiserver_request_total"
+            action = "keep"
+          }
+
+          forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+        }
+
+        prometheus.scrape "tuist_etcd" {
+          targets = [{
+            "__address__" = "127.0.0.1:2381",
+            "instance" = sys.env("HOSTNAME"),
+          }]
+          forward_to = [prometheus.relabel.tuist_etcd.receiver]
+          job_name = "tuist-etcd"
+          scrape_interval = "30s"
+          scrape_timeout = "10s"
+        }
+
+        prometheus.relabel "tuist_etcd" {
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|etcd_server_has_leader|etcd_server_is_leader|etcd_server_leader_changes_seen_total|etcd_server_proposals_failed_total|etcd_disk_wal_fsync_duration_seconds_(bucket|count|sum)|etcd_disk_backend_commit_duration_seconds_(bucket|count|sum)|etcd_network_peer_round_trip_time_seconds_(bucket|count|sum)|etcd_mvcc_db_total_size_in_bytes|etcd_mvcc_db_total_size_in_use_in_bytes"
+            action = "keep"
+          }
+
+          forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+        }
+
     # Clustering lets multiple alloy-metrics replicas hash-partition the
     # scrape targets, so adding replicas linearly scales capacity. Required
     # by the clusterMetrics / hostMetrics / annotationAutodiscovery features.

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -101,7 +101,7 @@ k8s-monitoring:
         }
         write_relabel_config {
           source_labels = ["__name__"]
-          regex = "node_network_(receive|transmit)_drop_total|traces_service_graph_request_.*"
+          regex = "traces_service_graph_request_.*"
           action = "drop"
         }
         write_relabel_config {
@@ -338,6 +338,10 @@ k8s-monitoring:
           # throughput against the Hetzner kura nodes.
           - node_network_receive_bytes_total
           - node_network_transmit_bytes_total
+          - node_network_receive_packets_total
+          - node_network_transmit_packets_total
+          - node_network_receive_drop_total
+          - node_network_transmit_drop_total
           # NIC link-state + error signals so a host NIC/datapath flap is
           # directly visible per-node. 2026-07-20 incident: the Postgres
           # primary's node eth0 flapped for ~7s (isolating it from its
@@ -351,6 +355,18 @@ k8s-monitoring:
           - node_network_carrier_changes_total
           - node_network_receive_errs_total
           - node_network_transmit_errs_total
+          # Disk service time and saturation identify a host storage stall
+          # even when etcd itself has not emitted an error.
+          - node_disk_io_time_seconds_total
+          - node_disk_read_time_seconds_total
+          - node_disk_write_time_seconds_total
+          - node_disk_reads_completed_total
+          - node_disk_writes_completed_total
+          # Retransmissions distinguish a network path interruption from
+          # application or storage latency.
+          - node_netstat_Tcp_OutSegs
+          - node_netstat_Tcp_RetransSegs
+          - node_timex_offset_seconds
       # The allow-list above keeps node_cpu_seconds_total for all CPU modes
       # and every node_network_* series for every interface, but the
       # dashboards/alerts only read mode="idle" and physical devices
@@ -365,7 +381,7 @@ k8s-monitoring:
         rule {
           source_labels = ["__name__", "mode"]
           separator = ";"
-          regex = "node_cpu_seconds_total;(guest|guest_nice|steal|irq|softirq)"
+          regex = "node_cpu_seconds_total;(guest|guest_nice|irq|softirq)"
           action = "drop"
         }
         rule {
@@ -696,8 +712,12 @@ k8s-monitoring:
         prometheus.relabel "tuist_kube_apiserver" {
           rule {
             source_labels = ["__name__"]
-            regex = "up|scrape_samples_scraped|apiserver_current_inflight_requests|apiserver_flowcontrol_rejected_requests_total|apiserver_request_duration_seconds_(bucket|count|sum)|apiserver_request_total"
+            regex = "up|scrape_samples_scraped|process_cpu_seconds_total|process_resident_memory_bytes|process_open_fds|process_max_fds|go_goroutines|go_gc_duration_seconds(_sum|_count)?|go_sched_latencies_seconds_(bucket|count|sum)|apiserver_current_inflight_requests|apiserver_flowcontrol_current_executing_requests|apiserver_flowcontrol_current_executing_seats|apiserver_flowcontrol_current_limit_seats|apiserver_flowcontrol_nominal_limit_seats|apiserver_flowcontrol_rejected_requests_total|apiserver_request_duration_seconds_(bucket|count|sum)|apiserver_request_terminations_total|apiserver_request_total"
             action = "keep"
+          }
+          rule {
+            regex = "component|dry_run|group|resource|scope|subresource|version"
+            action = "labeldrop"
           }
 
           forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
@@ -717,7 +737,7 @@ k8s-monitoring:
         prometheus.relabel "tuist_etcd" {
           rule {
             source_labels = ["__name__"]
-            regex = "up|scrape_samples_scraped|etcd_server_has_leader|etcd_server_is_leader|etcd_server_leader_changes_seen_total|etcd_server_proposals_failed_total|etcd_disk_wal_fsync_duration_seconds_(bucket|count|sum)|etcd_disk_backend_commit_duration_seconds_(bucket|count|sum)|etcd_network_peer_round_trip_time_seconds_(bucket|count|sum)|etcd_mvcc_db_total_size_in_bytes|etcd_mvcc_db_total_size_in_use_in_bytes"
+            regex = "up|scrape_samples_scraped|process_cpu_seconds_total|process_resident_memory_bytes|process_open_fds|process_max_fds|go_goroutines|go_gc_duration_seconds(_sum|_count)?|etcd_server_has_leader|etcd_server_is_leader|etcd_server_leader_changes_seen_total|etcd_server_proposals_failed_total|etcd_server_proposals_pending|etcd_server_slow_apply_total|etcd_disk_wal_fsync_duration_seconds_(bucket|count|sum)|etcd_disk_backend_commit_duration_seconds_(bucket|count|sum)|etcd_network_peer_round_trip_time_seconds_(bucket|count|sum)|etcd_mvcc_db_total_size_in_bytes|etcd_mvcc_db_total_size_in_use_in_bytes"
             action = "keep"
           }
 

--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -92,8 +92,8 @@ When enabled, a `values-<cluster-name>.yaml` overlay renders:
   configured egress IP via the node carrying the **active** label
   `tuist.dev/stable-egress-gateway=server`.
 - `DaemonSet/kube-system/tuist-server-stable-egress-host-configurer`, which runs
-  on the active node and keeps the Floating IP + source route present on its
-  `eth0`.
+  on every candidate node and keeps the Floating IP + source route prepared on
+  its `eth0`. Hetzner routes the address only to the active cloud server.
 - When `failoverController.enabled`, the
   `Deployment/kube-system/stable-egress-controller` (see
   [`infra/stable-egress-controller/`](../../stable-egress-controller/)).
@@ -117,8 +117,11 @@ automatic failover — no manual steps and no SPOF:
   is no healthy active node does it fail over to a Ready `md-egress` candidate,
   moving the IP + label together (~30–60s: node-NotReady detection + reassign;
   faster on deletion).
-- **Datapath:** Cilium re-selects the gateway (1s reconcile) and the
-  host-configurer reschedules onto the new active node automatically.
+- **Preparation:** the host-configurer runs on every candidate and reports
+  Ready only after the outbound address is attached. The controller excludes
+  unprepared candidates from election.
+- **Datapath:** once the Floating IP is assigned, the controller applies the
+  active label and Cilium re-selects the already-prepared gateway.
 
 Why Cilium alone isn't enough: our Cilium 1.18 OSS egress gateway selects a
 gateway node by lexical order with no health-based failover (cilium/cilium#30157

--- a/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
+++ b/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
@@ -1,6 +1,7 @@
 {{- with .Values.ciliumEgressGateway.server }}
 {{- if and .enabled .hostConfigurator.enabled }}
 {{- $egressIP := required "ciliumEgressGateway.server.egressIP is required when ciliumEgressGateway.server.hostConfigurator.enabled=true" .egressIP }}
+{{- $nodeSelector := required "ciliumEgressGateway.server.hostConfigurator.nodeSelector is required when the host-configurer is enabled" .hostConfigurator.nodeSelector }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -19,10 +20,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ printf "%s-host-configurer" .name | quote }}
         app.kubernetes.io/component: stable-egress
+        tuist.dev/stable-egress-host-configurer: "true"
     spec:
       hostNetwork: true
       nodeSelector:
-        {{- toYaml .gatewayNodeSelector | nindent 8 }}
+        {{- toYaml $nodeSelector | nindent 8 }}
       tolerations:
         - operator: Exists
       containers:
@@ -60,5 +62,13 @@ spec:
 
                 sleep "${RECONCILE_INTERVAL_SECONDS}"
               done
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - ip -4 address show dev "${INTERFACE}" | grep -Fq "${EGRESS_IP}/32"
+            periodSeconds: 2
+            failureThreshold: 3
 {{- end }}
 {{- end }}

--- a/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
+++ b/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
@@ -1,7 +1,10 @@
 {{- with .Values.ciliumEgressGateway.server }}
 {{- if and .enabled .hostConfigurator.enabled }}
 {{- $egressIP := required "ciliumEgressGateway.server.egressIP is required when ciliumEgressGateway.server.hostConfigurator.enabled=true" .egressIP }}
-{{- $nodeSelector := required "ciliumEgressGateway.server.hostConfigurator.nodeSelector is required when the host-configurer is enabled" .hostConfigurator.nodeSelector }}
+{{- if empty .hostConfigurator.nodeSelector }}
+{{- fail "ciliumEgressGateway.server.hostConfigurator.nodeSelector must select the candidate pool when the host-configurer is enabled" }}
+{{- end }}
+{{- $nodeSelector := .hostConfigurator.nodeSelector }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -66,8 +69,12 @@ spec:
             exec:
               command:
                 - /bin/sh
-                - -ec
-                - ip -4 address show dev "${INTERFACE}" | grep -Fq "${EGRESS_IP}/32"
+                - -euc
+                - |
+                  ip -4 address show dev "${INTERFACE}" | grep -Fq "${EGRESS_IP}/32"
+                  ip rule show priority "${RULE_PRIORITY}" | grep -Fq "from ${EGRESS_IP}"
+                  ip route show table "${ROUTE_TABLE}" | grep -Fq "${GATEWAY} dev ${INTERFACE} scope link"
+                  ip route show table "${ROUTE_TABLE}" | grep -F "default via ${GATEWAY} dev ${INTERFACE}" | grep -Fq "src ${EGRESS_IP}"
             periodSeconds: 2
             failureThreshold: 3
 {{- end }}

--- a/infra/helm/platform/templates/stable-egress-controller.yaml
+++ b/infra/helm/platform/templates/stable-egress-controller.yaml
@@ -25,6 +25,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -71,6 +74,11 @@ spec:
       labels:
         app.kubernetes.io/name: stable-egress-controller
         app.kubernetes.io/component: stable-egress
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port-name: metrics
+        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
     spec:
       serviceAccountName: stable-egress-controller
       # Spread the replicas so the controller's own availability does not

--- a/infra/helm/platform/templates/stable-egress-controller.yaml
+++ b/infra/helm/platform/templates/stable-egress-controller.yaml
@@ -2,8 +2,8 @@
 {{- if and .enabled .failoverController.enabled }}
 {{- $fipName := required "ciliumEgressGateway.server.failoverController.floatingIpName is required when the failover controller is enabled" .failoverController.floatingIpName }}
 # Stable-egress failover controller. Keeps the Hetzner Floating IP + the active
-# gateway label (`gatewayNodeSelector`) on a single Ready node from the egress
-# candidate pool, and fails over to another candidate on node loss — so a node
+# gateway label (`gatewayNodeSelector`) on a directly reachable node from the
+# egress candidate pool, and fails over to another candidate on node loss, so a node
 # replacement self-heals without the manual `hcloud floating-ip assign` runbook.
 apiVersion: v1
 kind: ServiceAccount
@@ -25,9 +25,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch", "patch", "update"]
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -46,6 +43,36 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: stable-egress-controller
+subjects:
+  - kind: ServiceAccount
+    name: stable-egress-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: stable-egress-controller-pods
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: stable-egress-controller
+    app.kubernetes.io/component: stable-egress
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: stable-egress-controller-pods
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: stable-egress-controller
+    app.kubernetes.io/component: stable-egress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stable-egress-controller-pods
 subjects:
   - kind: ServiceAccount
     name: stable-egress-controller
@@ -109,6 +136,10 @@ spec:
             - --health-probe-bind-address=:8081
             - --floating-ip-name={{ $fipName }}
             - --hcloud-token-path=/etc/hcloud/token
+            - --node-health-port={{ .failoverController.nodeHealthPort }}
+            - --node-health-timeout={{ .failoverController.nodeHealthTimeout }}
+            - --node-unhealthy-grace-period={{ .failoverController.nodeUnhealthyGracePeriod }}
+            - --node-unprepared-grace-period={{ .failoverController.nodeUnpreparedGracePeriod }}
             {{- with .failoverController.egressIpAllowlist }}
             - --egress-ip-allowlist={{ join "," . }}
             {{- end }}

--- a/infra/helm/platform/values-tuist-canary.yaml
+++ b/infra/helm/platform/values-tuist-canary.yaml
@@ -13,6 +13,8 @@ ciliumEgressGateway:
     egressIP: 78.47.174.50
     hostConfigurator:
       enabled: true
+      nodeSelector:
+        tuist.dev/stable-egress-candidate: server
     failoverController:
       enabled: true
       # Image tag resolved at deploy time by k8s:install-platform.

--- a/infra/helm/platform/values-tuist-staging.yaml
+++ b/infra/helm/platform/values-tuist-staging.yaml
@@ -13,6 +13,8 @@ ciliumEgressGateway:
     egressIP: 78.47.186.71
     hostConfigurator:
       enabled: true
+      nodeSelector:
+        tuist.dev/stable-egress-candidate: server
     failoverController:
       enabled: true
       # Image tag is resolved at deploy time by k8s:install-platform (the

--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -18,6 +18,8 @@ ciliumEgressGateway:
     egressIP: 116.202.0.10
     hostConfigurator:
       enabled: true
+      nodeSelector:
+        tuist.dev/stable-egress-candidate: server
     failoverController:
       # Enabled. The controller ADOPTS the node that currently holds the active
       # label (today the hand-labelled general worker) on first reconcile — no

--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -8,7 +8,7 @@
 # cluster-production.yaml), whose nodes self-apply the
 # `tuist.dev/stable-egress-candidate=server` label at kubelet registration. The
 # failover controller keeps the Floating IP + the active gateway label on one
-# Ready candidate and fails over on node loss — so a node replacement
+# prepared, directly healthy candidate and fails over on node loss, so a node replacement
 # self-heals in seconds, instead of the manual failover that caused the
 # 2026-06-14 outage.
 ciliumEgressGateway:
@@ -21,12 +21,9 @@ ciliumEgressGateway:
       nodeSelector:
         tuist.dev/stable-egress-candidate: server
     failoverController:
-      # Enabled. The controller ADOPTS the node that currently holds the active
-      # label (today the hand-labelled general worker) on first reconcile — no
-      # Floating IP move, no Cilium reconvergence, no egress blip — and only
-      # fails over to an md-egress candidate when that node stops being Ready.
-      # So enabling is a no-op for the live datapath. The image tag is resolved
-      # at deploy time by k8s:install-platform (no pinned tag here).
+      # The controller keeps the active candidate unless its direct health or
+      # prepared host state remains unhealthy past the configured grace period.
+      # The image tag is resolved at deploy time by k8s:install-platform.
       enabled: true
       floatingIpName: tuist-production-server-egress
       # Reserved egress set customers allowlist: Hetzner Floating IPs

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -335,6 +335,18 @@ ciliumEgressGateway:
       # an un-allowlisted egress IP. Keep this in lockstep with the customer
       # network guide (server/priv/docs/en/guides/server/network.md).
       egressIpAllowlist: []
+      # Port 9962 requires Cilium's Prometheus listener, which the managed
+      # workload bootstrap enables on every Linux node.
+      # Probe Cilium directly on the node instead of treating Kubernetes
+      # NodeReady as the active-gateway failover signal. The wall-clock grace
+      # period cannot be consumed early by bursts of Kubernetes events.
+      nodeHealthPort: 9962
+      nodeHealthTimeout: 2s
+      nodeUnhealthyGracePeriod: 90s
+      # Host preparation is a promotion requirement. A longer demotion grace
+      # avoids moving the address during a host-configurer rolling update while
+      # still recovering when the address or source-routing state stays absent.
+      nodeUnpreparedGracePeriod: 5m
       resources:
         requests:
           cpu: 25m

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -299,6 +299,9 @@ ciliumEgressGateway:
     egressIP: ""
     hostConfigurator:
       enabled: false
+      # Required when enabled. Select the full candidate pool so every standby
+      # is prepared before the failover controller can activate it.
+      nodeSelector: {}
       image: quay.io/cilium/cilium:v1.18.7
       imagePullPolicy: IfNotPresent
       interface: eth0

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -456,31 +456,44 @@ one of:
 {{- end }}
 
 {{/*
-License env vars. Resolves to (in order):
-  1. ESO-managed Secret (server.externalSecrets.license.item set) — preview /
-     managed envs that sync the license from 1Password via
-     templates/external-secrets.yaml.
-  2. Chart-managed app-secrets Secret — when server.license.key is inlined.
+License env vars. Resolves to one mutually exclusive source:
+  1. ESO-managed Secret (server.externalSecrets.license.item or
+     server.externalSecrets.license.certificateItem set) for managed
+     environments that sync the license from 1Password.
+  2. Chart-managed app-secrets Secret when server.license.key or
+     server.license.certificateBase64 is inlined.
 */}}
 {{- define "tuist.licenseEnv" -}}
 {{- $appSecret := include "tuist.componentName" (dict "root" . "component" "app-secrets") -}}
 {{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
-{{- $useEso := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
-{{- if and $useEso .Values.server.license.key -}}
-{{- fail "server.externalSecrets.license.item and server.license.key are mutually exclusive — pick one license source." -}}
+{{- $useEsoKey := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
+{{- $useEsoCertificate := ne (.Values.server.externalSecrets.license.certificateItem | default "") "" -}}
+{{- $useInlineKey := ne (.Values.server.license.key | default "") "" -}}
+{{- $useInlineCertificate := ne (.Values.server.license.certificateBase64 | default "") "" -}}
+{{- if and $useEsoKey $useEsoCertificate -}}
+{{- fail "server.externalSecrets.license.item and server.externalSecrets.license.certificateItem are mutually exclusive; pick one license source." -}}
 {{- end -}}
-{{- if or $useEso .Values.server.license.key }}
+{{- if and (or $useEsoKey $useEsoCertificate) (or $useInlineKey $useInlineCertificate) -}}
+{{- fail "external and inline license settings are mutually exclusive; pick one license source." -}}
+{{- end -}}
+{{- if and $useInlineKey $useInlineCertificate -}}
+{{- fail "server.license.key and server.license.certificateBase64 are mutually exclusive; pick one license source." -}}
+{{- end -}}
+{{- if not (or $useEsoKey $useEsoCertificate $useInlineKey $useInlineCertificate) -}}
+{{- fail "no Tuist license source is configured; set exactly one online key or air-gapped certificate source." -}}
+{{- end -}}
+{{- if or $useEsoKey $useInlineKey }}
 - name: TUIST_LICENSE_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ ternary $esoSecret $appSecret $useEso | quote }}
+      name: {{ ternary $esoSecret $appSecret $useEsoKey | quote }}
       key: server-license-key
 {{- end }}
-{{- if .Values.server.license.certificateBase64 }}
+{{- if or $useEsoCertificate $useInlineCertificate }}
 - name: TUIST_LICENSE_CERTIFICATE_BASE64
   valueFrom:
     secretKeyRef:
-      name: {{ $appSecret | quote }}
+      name: {{ ternary $esoSecret $appSecret $useEsoCertificate | quote }}
       key: server-license-certificate-base64
 {{- end }}
 {{- end -}}

--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -1,4 +1,6 @@
-{{- $syncLicense := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
+{{- $syncLicenseKey := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
+{{- $syncLicenseCertificate := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.certificateItem | default "") "") -}}
+{{- $syncLicense := or $syncLicenseKey $syncLicenseCertificate -}}
 {{- $syncCacheGrant := and .Values.server.enabled (ne (.Values.server.externalSecrets.cacheGrant.item | default "") "") -}}
 {{- $serverKuraIntrospection := .Values.server.externalSecrets.kuraIntrospection -}}
 {{- $kuraSharedSecrets := .Values.kuraController.sharedSecrets -}}
@@ -51,8 +53,11 @@ spec:
     template:
       engineVersion: v2
       data:
-        {{- if $syncLicense }}
+        {{- if $syncLicenseKey }}
         server-license-key: "{{ `{{ .server_license_key | trim }}` }}"
+        {{- end }}
+        {{- if $syncLicenseCertificate }}
+        server-license-certificate-base64: "{{ `{{ .server_license_certificate_base64 | trim }}` }}"
         {{- end }}
         {{- if $syncCacheGrant }}
         cache-grant-private-key: "{{ `{{ .cache_grant_private_key | trim }}` }}"
@@ -69,10 +74,15 @@ spec:
         TUIST_KURA_INTROSPECTION_CLIENT_SECRET: "{{ `{{ .kura_introspection_client_secret | trim }}` }}"
         {{- end }}
   data:
-    {{- if $syncLicense }}
+    {{- if $syncLicenseKey }}
     - secretKey: server_license_key
       remoteRef:
         key: "{{ .Values.server.externalSecrets.license.item }}/{{ .Values.server.externalSecrets.license.field | default "password" }}"
+    {{- end }}
+    {{- if $syncLicenseCertificate }}
+    - secretKey: server_license_certificate_base64
+      remoteRef:
+        key: "{{ .Values.server.externalSecrets.license.certificateItem }}/{{ .Values.server.externalSecrets.license.certificateField | default "password" }}"
     {{- end }}
     {{- if $syncCacheGrant }}
     - secretKey: cache_grant_private_key

--- a/infra/helm/tuist/values-k3s-smoke.yaml
+++ b/infra/helm/tuist/values-k3s-smoke.yaml
@@ -10,6 +10,10 @@ server:
   migrationJob:
     enabled: false
   license:
+    # The Deployment is scaled to zero, so the value is never validated or
+    # sent anywhere. It satisfies the chart's mandatory-source guard while
+    # preserving the rendered server workload in this Kubernetes smoke test.
+    key: k3s-smoke-not-a-valid-license
     selfHostingDevelopmentMode: true
   resources:
     requests:

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -114,10 +114,13 @@ server:
       kind: ClusterSecretStore
       name: onepassword
     # Source the Tuist license from 1Password instead of the blob, so the blob
-    # can be removed. Per-env vault holds the TUIST_LICENSE_KEY item.
+    # can be removed. Environments can override this with certificateItem to
+    # use a locally verified air-gapped license.
     license:
       item: TUIST_LICENSE_KEY
       field: password
+      certificateItem: ""
+      certificateField: password
 
   # ESO-synced GitHub App + bot PATs. The PEM file attachment name
   # differs per env (production.pem / staging.pem / canary.pem) and is

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -40,6 +40,9 @@ server:
   # cache volume's binaries never validate as local hits across VMs. Same
   # keypair as staging (the CLI's baked public key pins it).
   externalSecrets:
+    license:
+      item: ""
+      certificateItem: TUIST_LICENSE_CERTIFICATE_BASE64
     cacheGrant:
       item: TUIST_CACHE_GRANT_PRIVATE_KEY
 

--- a/infra/helm/tuist/values-self-hosted-ci.yaml
+++ b/infra/helm/tuist/values-self-hosted-ci.yaml
@@ -1,0 +1,7 @@
+# Placeholder for static Helm validation of the self-hosted configuration.
+# The server is never started by this profile, and the deliberately invalid
+# value proves the chart requires an explicit license source without placing
+# a real license in source control.
+server:
+  license:
+    key: self-hosted-validation-not-a-valid-license

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -271,12 +271,14 @@ server:
     storeRef:
       kind: ClusterSecretStore
       name: onepassword
-    # Sync the Tuist license key from the external store. Independent of
-    # managedSecrets — preview environments use this without the encrypted
-    # priv/secrets blob. Leave `item` empty to skip license sync.
+    # Sync either the online Tuist license key or the air-gapped license
+    # certificate from the external store. These sources are mutually
+    # exclusive. Leave both item names empty to skip license sync.
     license:
       item: ""
       field: password
+      certificateItem: ""
+      certificateField: password
     # Cache-signing grant private key: a PEM Ed25519 key the
     # server signs runner cache grants with. Leave item empty to disable
     # grant minting (dispatch omits the grant; CLI falls back to the MAC

--- a/infra/k8s/clusters/clusterclass-tuist.yaml
+++ b/infra/k8s/clusters/clusterclass-tuist.yaml
@@ -16,7 +16,10 @@ spec:
         name: tuist-hcloud-hcloud-machinetemplate
     healthCheck:
       checks:
-        nodeStartupTimeoutSeconds: 900
+        # New members currently reach the infrastructure-ready state but do
+        # not register a Node. Do not delete and recreate them indefinitely
+        # until that bootstrap defect has been diagnosed from the host.
+        nodeStartupTimeoutSeconds: 0
         unhealthyNodeConditions:
           - type: Ready
             status: Unknown
@@ -26,7 +29,10 @@ spec:
             timeoutSeconds: 300
       remediation:
         triggerIf:
-          unhealthyLessThanOrEqualTo: 33%
+          # Allow only one registered unhealthy member to be replaced at a
+          # time. An absolute limit does not change as the control plane
+          # moves between two and three Machines.
+          unhealthyLessThanOrEqualTo: 1
   infrastructure:
     templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -77,7 +77,7 @@ Every engineer's Google Workspace identity already carries `view`-tier read acce
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
 - A Cloudflare account with an API token stored as `cloudflare-tuist-dns`. Local bootstrap reads it from the `Founders` vault.
 - The `cloudflare-tuist-dns` token must be able to edit DNS for `tuist.dev`, read `tuist.dev` zone metadata, manage zone Load Balancers, and manage account-level Load Balancing pools/monitors.
-- Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, Grafana Cloud tokens) and a Service Account token scoped to the vault.
+- Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, `TUIST_LICENSE_CERTIFICATE_BASE64` for production, Grafana Cloud tokens) and a Service Account token scoped to the vault.
 - CLI tools installed via mise:
   ```bash
   mise use -g kubectl helm clusterctl talosctl
@@ -265,6 +265,92 @@ The platform chart issues the wildcard certificate through cert-manager's Cloudf
 ### 8.2 Preview-specific 1Password items
 
 In the `tuist-k8s-preview` vault: `TUIST_LICENSE_KEY` (Login or Password category, `password` field). The `Service Account Auth Token: tuist-preview-k8s` 1P item authorizes ESO to read it.
+
+### Production air-gapped license
+
+Production uses the signed air-gapped license so server startup does not depend
+on Keygen availability or outbound connectivity. Store the Base64-encoded
+license value in the `password` field of the
+`TUIST_LICENSE_CERTIFICATE_BASE64` Password item in the
+`tuist-k8s-production` vault. Do not also configure `TUIST_LICENSE_KEY`.
+
+Before updating 1Password, validate the encoded certificate locally without
+printing it:
+
+```bash
+chmod 600 /path/to/license.key
+cd server
+mix run --no-start -e '
+encoded = IO.binread(:stdio, :eof) |> String.trim()
+
+with {:ok, certificate} <- Base.decode64(encoded, ignore: :whitespace),
+     {:ok, %Tuist.License{valid: true, expiration_date: expiration_date}} <-
+       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_key(), certificate) do
+  IO.puts("valid through #{expiration_date}")
+else
+  :error -> raise "air-gapped license is not valid Base64"
+  {:ok, %Tuist.License{valid: false}} -> raise "air-gapped license is expired or invalid"
+  {:error, reason} -> raise "air-gapped license validation failed: #{reason}"
+end
+' < /path/to/license.key
+```
+
+Then create the 1Password item from a JavaScript Object Notation template passed through standard
+input, so the certificate is not placed in shell history or process arguments:
+
+```bash
+op item template get Password --format json \
+  | jq --rawfile certificate /path/to/license.key '
+      .title = "TUIST_LICENSE_CERTIFICATE_BASE64"
+      | (.fields[] | select(.id == "password") | .value) =
+          ($certificate | gsub("[[:space:]]"; ""))
+    ' \
+  | op item create --account tuist.1password.com \
+      --vault tuist-k8s-production -
+```
+
+If the item already exists, update its concealed `password` field through the
+1Password application rather than creating a duplicate. The External Secrets
+Operator refreshes it into the cluster as
+`TUIST_LICENSE_CERTIFICATE_BASE64`.
+
+Validate the stored value through the same parser without printing or writing
+it back to disk:
+
+```bash
+op item get TUIST_LICENSE_CERTIFICATE_BASE64 \
+  --account tuist.1password.com \
+  --vault tuist-k8s-production \
+  --fields label=password \
+  --reveal \
+  | mix run --no-start -e '
+encoded = IO.binread(:stdio, :eof)
+
+with {:ok, certificate} <- Base.decode64(encoded, ignore: :whitespace),
+     {:ok, %Tuist.License{valid: true, expiration_date: expiration_date}} <-
+       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_key(), certificate) do
+  IO.puts("stored license valid through #{expiration_date}")
+else
+  :error -> raise "stored air-gapped license is not valid Base64"
+  {:ok, %Tuist.License{valid: false}} -> raise "stored air-gapped license is expired or invalid"
+  {:error, reason} -> raise "stored air-gapped license validation failed: #{reason}"
+end
+'
+```
+
+After the stored value validates, remove the local source file and confirm it
+is gone:
+
+```bash
+rm /path/to/license.key
+test ! -e /path/to/license.key
+```
+
+The server publishes `tuist_license_valid` and
+`tuist_license_expiration_timestamp_seconds`. Configure the seven-day critical
+and 30-day warning rules from
+[`infra/helm/k8s-monitoring/alerts.md`](../helm/k8s-monitoring/alerts.md) before
+the first production deployment.
 
 ### 8.3 First preview
 

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -71,6 +71,9 @@ Every engineer's Google Workspace identity already carries `view`-tier read acce
 
 - Tailscale on the `tuist.dev` tailnet, with `talosctl` reachable on the mgmt VM at `100.92.208.109:50000` (see [`mgmt/tailscale.yaml`](mgmt/tailscale.yaml) for tailnet onboarding).
 - Mgmt cluster kubeconfig in 1Password as `kubeconfig: tuist-mgmt` in the `tuist-k8s-mgmt` vault.
+- Grafana Cloud `PROMETHEUS_TOKEN` password item in the `tuist-k8s-mgmt`
+  vault. `mgmt-cluster-apply.yml` uses it to install the metrics-only
+  management monitoring overlay.
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
 - A Cloudflare account with an API token stored as `cloudflare-tuist-dns`. Local bootstrap reads it from the `Founders` vault.
 - The `cloudflare-tuist-dns` token must be able to edit DNS for `tuist.dev`, read `tuist.dev` zone metadata, manage zone Load Balancers, and manage account-level Load Balancing pools/monitors.
@@ -226,6 +229,14 @@ gh workflow run server-deployment.yml -f environment=<env>
 ## 7. Observability
 
 The [`infra/helm/k8s-monitoring/`](../helm/k8s-monitoring/) chart forwards Kubernetes telemetry to Grafana Cloud. The bootstrap task in §4 installs it; the `observability-install` job in `server-deployment.yml` keeps it in sync on every deploy. After it lights up, look for the cluster name in **Observability → Kubernetes** in Grafana Cloud. Verification steps live in [`infra/helm/k8s-monitoring/README.md`](../helm/k8s-monitoring/README.md).
+
+`mgmt-cluster-apply.yml` installs the same chart with
+`values-management.yaml` into the management cluster. That metrics-only
+instance exports Cluster API control-plane replica state and Hetzner
+load-balancer telemetry under `cluster="tuist-management"`, so it remains
+available when a workload cluster is unreachable. Alert queries and setup
+instructions live in
+[`infra/helm/k8s-monitoring/alerts.md`](../helm/k8s-monitoring/alerts.md).
 
 ## 8. Preview environments (ephemeral pull request / commit deploys)
 

--- a/infra/stable-egress-controller/AGENTS.md
+++ b/infra/stable-egress-controller/AGENTS.md
@@ -10,23 +10,28 @@ policy routes through one gateway node, and the Floating IP can only be assigned
 to one server at a time — so the gateway is inherently active/standby. This
 controller makes the failover automatic.
 
-It keeps one Ready node designated **active** — holding the Floating IP (Hetzner
-Cloud API) and the active gateway label. It **adopts** whatever node already
-holds the active label as long as that node is Ready (even one outside the
-candidate pool), so it never disturbs a working gateway — enabling it over an
-existing hand-configured gateway moves nothing (no Floating IP churn, no Cilium
-reconvergence, no egress blip). Only when there is no healthy active node does it
-fail over to a Ready candidate whose host-configurer Pod has reported Ready,
-moving the IP + label together. This replaces the manual `hcloud floating-ip
+It keeps one directly healthy, host-prepared node designated **active** —
+holding the Floating IP (Hetzner Cloud API) and the active gateway label.
+Kubernetes NodeReady does not demote a working active gateway, but readiness and
+schedulability are required before promoting a standby. The controller adopts
+an already-active prepared node without disturbing it. Only after 90 seconds of
+continuous direct health-check failure does it fail over to another prepared
+candidate. It removes the old selector before moving the address, then selects
+the new gateway after the provider assignment succeeds. This replaces the
+manual `hcloud floating-ip
 assign` + relabel runbook
 that caused a multi-hour egress outage on 2026-06-14 when a hand-labelled gateway
 node was replaced.
+
+The grace timestamps are deliberately leader-local. A controller restart or
+leadership handover restarts the grace period, preferring a delayed failover
+over moving the outbound address on stale health evidence.
 
 ## Architecture
 
 ```
  md-egress pool (≥2 nodes)            this controller (2 replicas, leader-elected)
- each self-labels at kubelet:          watches Nodes ──► elects 1 Ready candidate
+ each self-labels at kubelet:          watches Nodes ──► checks Cilium directly
    tuist.dev/stable-egress-                              │
      candidate=server       host-configurer prepares IP ──┤
                                 and reports Pod Ready      ├─► Hetzner API: assign Floating IP → active node
@@ -65,6 +70,10 @@ The Deployment + RBAC are rendered by the platform Helm chart
 | `--active-label` | `tuist.dev/stable-egress-gateway=server` | label placed on the single active node selected by Cilium |
 | `--prepared-pod-label` | `tuist.dev/stable-egress-host-configurer=true` | Ready Pod label proving a candidate has the outbound address configured |
 | `--prepared-pod-namespace` | `kube-system` | namespace containing the host-configurer Pods |
+| `--node-health-port` | `9962` | Cilium host-network listener used to check node reachability independently from NodeReady |
+| `--node-health-timeout` | `2s` | timeout for each direct node health check |
+| `--node-unhealthy-grace-period` | `90s` | continuous failed-health duration required before failover |
+| `--node-unprepared-grace-period` | `5m` | continuous missing host-preparation duration required before failover |
 | `--hcloud-token-path` | `/etc/hcloud/token` | token file, mounted from `kube-system/hcloud` |
 | `--resync-interval` | `30s` | periodic reconcile floor; Node eligibility changes and host-configurer Pod changes trigger reconciles in between. Kubelet status heartbeats are filtered out so the per-reconcile Hetzner read stays well under the API rate limit. |
 | `--leader-elect` | `true` | required when `replicas > 1` |
@@ -105,5 +114,8 @@ Keep `failoverController.enabled: false` in prod until the image is released
 The controller exposes `tuist_stable_egress_gateway_available`,
 `tuist_stable_egress_gateway_prepared`,
 `tuist_stable_egress_gateway_active`, and
-`tuist_stable_egress_failovers_total` alongside controller-runtime reconcile
-metrics. The platform chart annotates the metrics port for Alloy discovery.
+`tuist_stable_egress_failovers_total`,
+`tuist_stable_egress_gateway_node_healthy`, and
+`tuist_stable_egress_health_check_failures_total` alongside controller-runtime
+reconcile metrics. The platform chart annotates the metrics port for Alloy
+discovery.

--- a/infra/stable-egress-controller/AGENTS.md
+++ b/infra/stable-egress-controller/AGENTS.md
@@ -16,8 +16,9 @@ holds the active label as long as that node is Ready (even one outside the
 candidate pool), so it never disturbs a working gateway — enabling it over an
 existing hand-configured gateway moves nothing (no Floating IP churn, no Cilium
 reconvergence, no egress blip). Only when there is no healthy active node does it
-fail over to a Ready candidate from the egress pool, moving the IP + label
-together. This replaces the manual `hcloud floating-ip assign` + relabel runbook
+fail over to a Ready candidate whose host-configurer Pod has reported Ready,
+moving the IP + label together. This replaces the manual `hcloud floating-ip
+assign` + relabel runbook
 that caused a multi-hour egress outage on 2026-06-14 when a hand-labelled gateway
 node was replaced.
 
@@ -27,18 +28,20 @@ node was replaced.
  md-egress pool (≥2 nodes)            this controller (2 replicas, leader-elected)
  each self-labels at kubelet:          watches Nodes ──► elects 1 Ready candidate
    tuist.dev/stable-egress-                              │
-     candidate=server                                    ├─► Hetzner API: assign Floating IP → active node
-                                                          └─► label active node tuist.dev/stable-egress-gateway=server
+     candidate=server       host-configurer prepares IP ──┤
+                                and reports Pod Ready      ├─► Hetzner API: assign Floating IP → active node
+                                                          └─► label prepared node tuist.dev/stable-egress-gateway=server
                                                                          │
  CiliumEgressGatewayPolicy ──selects active label──────────────────────┘
- host-configurer DaemonSet ──selects active label──► configures eth0 on active node
+ host-configurer DaemonSet ──selects candidate label──► preconfigures every standby
 ```
 
 Why not lean on Cilium: OSS Cilium egress gateway picks a gateway node by
 lexical order with no health-based failover (cilium/cilium#30157; HA is an
 Isovalent Enterprise feature) and has no concept of the Hetzner Floating IP,
 which only moves via the Cloud API. The controller owns election + the IP + the
-label; Cilium and the host-configurer just follow the label.
+label; Cilium follows the active label after the host-configurer has prepared
+the candidate.
 
 ## Module layout
 
@@ -59,9 +62,11 @@ The Deployment + RBAC are rendered by the platform Helm chart
 | `--floating-ip-name` | (required) | Hetzner Cloud Floating IP to keep on the active node |
 | `--egress-ip-allowlist` | (empty) | Comma-separated CIDRs of the documented egress set customers allowlist. When set, the controller **fails closed** if the Floating IP's address is outside it — so an un-allowlisted egress IP is never activated. Keep in lockstep with the customer network guide. |
 | `--candidate-label` | `tuist.dev/stable-egress-candidate=server` | egress candidate pool selector |
-| `--active-label` | `tuist.dev/stable-egress-gateway=server` | label placed on the single active node (Cilium + host-configurer select on it) |
+| `--active-label` | `tuist.dev/stable-egress-gateway=server` | label placed on the single active node selected by Cilium |
+| `--prepared-pod-label` | `tuist.dev/stable-egress-host-configurer=true` | Ready Pod label proving a candidate has the outbound address configured |
+| `--prepared-pod-namespace` | `kube-system` | namespace containing the host-configurer Pods |
 | `--hcloud-token-path` | `/etc/hcloud/token` | token file, mounted from `kube-system/hcloud` |
-| `--resync-interval` | `30s` | periodic reconcile floor; only Node events that change gateway eligibility (Ready transition, candidate/active label, termination) trigger reconciles in between — kubelet status heartbeats are filtered out so the per-reconcile Hetzner read stays well under the API rate limit |
+| `--resync-interval` | `30s` | periodic reconcile floor; Node eligibility changes and host-configurer Pod changes trigger reconciles in between. Kubelet status heartbeats are filtered out so the per-reconcile Hetzner read stays well under the API rate limit. |
 | `--leader-elect` | `true` | required when `replicas > 1` |
 
 ## Tests
@@ -71,10 +76,11 @@ cd infra/stable-egress-controller
 go test ./...
 ```
 
-Covers `selectActive` (sticky / failover / lexical / none), `providerID`
-parsing, the egress-IP allowlist guard, the Node event predicate (heartbeats
-dropped, eligibility changes let through), and full reconcile (failover moves IP
-+ label, stale cluster-wide labels are stripped, steady state is no-op) against
+Covers `selectGateway` (sticky / failover / lexical / none), prepared-candidate
+gating, `providerID` parsing, the egress-IP allowlist guard, the Node event
+predicate (heartbeats dropped, eligibility changes let through), the
+host-configurer Pod event predicate, and full reconcile (failover moves IP +
+label, stale cluster-wide labels are stripped, steady state is no-op) against
 controller-runtime's fake client + a fake Floating IP manager.
 
 ## Releasing
@@ -94,8 +100,10 @@ for pre-release iteration.
 Keep `failoverController.enabled: false` in prod until the image is released
 (the first `stable-egress-controller@0.1.0` release publishes it).
 
-## Future work
+## Metrics
 
-- Emit a metric / Kubernetes Event when no Ready candidate exists, and alert on
-  it (the silent gap that hid the original outage).
-- Consider faster NotReady detection than the kubelet node-monitor grace period.
+The controller exposes `tuist_stable_egress_gateway_available`,
+`tuist_stable_egress_gateway_prepared`,
+`tuist_stable_egress_gateway_active`, and
+`tuist_stable_egress_failovers_total` alongside controller-runtime reconcile
+metrics. The platform chart annotates the metrics port for Alloy discovery.

--- a/infra/stable-egress-controller/cmd/manager/main.go
+++ b/infra/stable-egress-controller/cmd/manager/main.go
@@ -44,6 +44,8 @@ func main() {
 
 		candidateLabel    string
 		activeLabel       string
+		preparedPodLabel  string
+		preparedPodNS     string
 		floatingIPName    string
 		tokenPath         string
 		egressIPAllowlist string
@@ -57,7 +59,12 @@ func main() {
 		"key=value label identifying the egress candidate node pool (set by kubelet node-labels)")
 	flag.StringVar(&activeLabel, "active-label", "tuist.dev/stable-egress-gateway=server",
 		"key=value label this controller places on the single active gateway node; "+
-			"the CiliumEgressGatewayPolicy and host-configurer select on it")
+			"the CiliumEgressGatewayPolicy selects on it")
+	flag.StringVar(&preparedPodLabel, "prepared-pod-label",
+		"tuist.dev/stable-egress-host-configurer=true",
+		"key=value label identifying host-configurer Pods whose readiness proves a gateway is prepared")
+	flag.StringVar(&preparedPodNS, "prepared-pod-namespace", "kube-system",
+		"Namespace containing the host-configurer Pods")
 	flag.StringVar(&floatingIPName, "floating-ip-name", "",
 		"Name of the Hetzner Cloud Floating IP to keep on the active node (required)")
 	flag.StringVar(&tokenPath, "hcloud-token-path", "/etc/hcloud/token",
@@ -88,6 +95,15 @@ func main() {
 		setupLog.Error(nil, "invalid --active-label, want key=value", "value", activeLabel)
 		os.Exit(1)
 	}
+	preparedKey, preparedVal, ok := splitLabel(preparedPodLabel)
+	if !ok {
+		setupLog.Error(nil, "invalid --prepared-pod-label, want key=value", "value", preparedPodLabel)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(preparedPodNS) == "" {
+		setupLog.Error(nil, "--prepared-pod-namespace must not be empty")
+		os.Exit(1)
+	}
 
 	allowlist, err := parsePrefixes(egressIPAllowlist)
 	if err != nil {
@@ -114,15 +130,18 @@ func main() {
 	}
 
 	if err := (&controllers.FailoverReconciler{
-		Client:              mgr.GetClient(),
-		FIP:                 hcloud.New(strings.TrimSpace(string(token))),
-		FloatingIPName:      floatingIPName,
-		CandidateLabelKey:   candKey,
-		CandidateLabelValue: candVal,
-		ActiveLabelKey:      actKey,
-		ActiveLabelValue:    actVal,
-		EgressIPAllowlist:   allowlist,
-		ResyncInterval:      resyncInterval,
+		Client:                mgr.GetClient(),
+		FIP:                   hcloud.New(strings.TrimSpace(string(token))),
+		FloatingIPName:        floatingIPName,
+		CandidateLabelKey:     candKey,
+		CandidateLabelValue:   candVal,
+		ActiveLabelKey:        actKey,
+		ActiveLabelValue:      actVal,
+		PreparedPodNamespace:  preparedPodNS,
+		PreparedPodLabelKey:   preparedKey,
+		PreparedPodLabelValue: preparedVal,
+		EgressIPAllowlist:     allowlist,
+		ResyncInterval:        resyncInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup FailoverReconciler")
 		os.Exit(1)
@@ -138,7 +157,8 @@ func main() {
 	}
 
 	setupLog.Info("starting manager", "floatingIP", floatingIPName,
-		"candidateLabel", candidateLabel, "activeLabel", activeLabel)
+		"candidateLabel", candidateLabel, "activeLabel", activeLabel,
+		"preparedPodLabel", preparedPodLabel, "preparedPodNamespace", preparedPodNS)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "manager exited")
 		os.Exit(1)

--- a/infra/stable-egress-controller/cmd/manager/main.go
+++ b/infra/stable-egress-controller/cmd/manager/main.go
@@ -1,10 +1,10 @@
 // Command manager is the controller-manager binary for
 // stable-egress-controller. It runs in a workload cluster and keeps the
-// hosted server's stable-egress gateway highly available: exactly one Ready
-// node from the egress candidate pool holds the Hetzner Floating IP and the
-// active gateway label (which the CiliumEgressGatewayPolicy + host-configurer
-// select on). On loss of that node it re-elects another Ready candidate and
-// moves the Floating IP + label together — replacing the manual
+// hosted server's stable-egress gateway highly available: exactly one
+// host-prepared node from the egress candidate pool holds the Hetzner Floating
+// IP and the active gateway label (which the CiliumEgressGatewayPolicy
+// selects on). On loss of that node it elects another prepared, directly
+// reachable candidate and moves the Floating IP + label together, replacing the manual
 // `hcloud floating-ip assign` failover runbook.
 package main
 
@@ -15,10 +15,14 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -50,6 +54,10 @@ func main() {
 		tokenPath         string
 		egressIPAllowlist string
 		resyncInterval    time.Duration
+		nodeHealthPort    int
+		nodeHealthTimeout time.Duration
+		unhealthyGrace    time.Duration
+		unpreparedGrace   time.Duration
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint")
@@ -74,6 +82,14 @@ func main() {
 			"controller refuses (fails closed) to operate a Floating IP whose address is outside it")
 	flag.DurationVar(&resyncInterval, "resync-interval", 30*time.Second,
 		"Periodic reconcile interval; node events trigger reconciles in between")
+	flag.IntVar(&nodeHealthPort, "node-health-port", 9962,
+		"Host-network Cilium listener port used for direct gateway health checks")
+	flag.DurationVar(&nodeHealthTimeout, "node-health-timeout", 2*time.Second,
+		"Timeout for each direct gateway node health check")
+	flag.DurationVar(&unhealthyGrace, "node-unhealthy-grace-period", 90*time.Second,
+		"Continuous direct health check failure duration required before failover")
+	flag.DurationVar(&unpreparedGrace, "node-unprepared-grace-period", 5*time.Minute,
+		"Continuous host preparation failure duration required before failover")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -104,6 +120,26 @@ func main() {
 		setupLog.Error(nil, "--prepared-pod-namespace must not be empty")
 		os.Exit(1)
 	}
+	if nodeHealthPort < 1 || nodeHealthPort > 65535 {
+		setupLog.Error(nil, "--node-health-port must be between 1 and 65535")
+		os.Exit(1)
+	}
+	if nodeHealthTimeout <= 0 {
+		setupLog.Error(nil, "--node-health-timeout must be positive")
+		os.Exit(1)
+	}
+	if unhealthyGrace <= 0 {
+		setupLog.Error(nil, "--node-unhealthy-grace-period must be positive")
+		os.Exit(1)
+	}
+	if unpreparedGrace <= 0 {
+		setupLog.Error(nil, "--node-unprepared-grace-period must be positive")
+		os.Exit(1)
+	}
+	if resyncInterval <= 0 {
+		setupLog.Error(nil, "--resync-interval must be positive")
+		os.Exit(1)
+	}
 
 	allowlist, err := parsePrefixes(egressIPAllowlist)
 	if err != nil {
@@ -123,6 +159,14 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "stable-egress-controller.tuist.dev",
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {
+					Namespaces: map[string]cache.Config{preparedPodNS: {}},
+					Label:      labels.SelectorFromSet(labels.Set{preparedKey: preparedVal}),
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "create manager")
@@ -141,6 +185,12 @@ func main() {
 		PreparedPodLabelKey:   preparedKey,
 		PreparedPodLabelValue: preparedVal,
 		EgressIPAllowlist:     allowlist,
+		NodeHealthChecker: controllers.DirectNodeHealthChecker{
+			Port:    nodeHealthPort,
+			Timeout: nodeHealthTimeout,
+		},
+		UnhealthyGracePeriod:  unhealthyGrace,
+		UnpreparedGracePeriod: unpreparedGrace,
 		ResyncInterval:        resyncInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup FailoverReconciler")

--- a/infra/stable-egress-controller/controllers/failover.go
+++ b/infra/stable-egress-controller/controllers/failover.go
@@ -54,6 +54,13 @@ type FailoverReconciler struct {
 	ActiveLabelKey      string
 	ActiveLabelValue    string
 
+	// PreparedPodNamespace and PreparedPod labels identify the host-configurer
+	// Pods whose Ready condition proves a candidate has the outbound address
+	// before Cilium is allowed to select it.
+	PreparedPodNamespace  string
+	PreparedPodLabelKey   string
+	PreparedPodLabelValue string
+
 	// EgressIPAllowlist, when non-empty, is the documented set of CIDRs
 	// customers allowlist. The controller refuses to operate a Floating IP
 	// whose address falls outside it — failing closed so we never activate an
@@ -79,16 +86,34 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 		return ctrl.Result{}, fmt.Errorf("listing active-labelled nodes: %w", err)
 	}
 
-	desiredNode := selectGateway(candidates.Items, labeled.Items)
+	prepared, err := r.preparedCandidates(ctx, candidates.Items)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	gatewayPrepared.Reset()
+	preparedCandidates := make([]corev1.Node, 0, len(candidates.Items))
+	for i := range candidates.Items {
+		node := &candidates.Items[i]
+		isPrepared := prepared[node.Name]
+		gatewayPrepared.WithLabelValues(node.Name).Set(boolFloat(isPrepared))
+		if isPrepared {
+			preparedCandidates = append(preparedCandidates, *node)
+		}
+	}
+
+	desiredNode := selectGateway(preparedCandidates, labeled.Items)
 	if desiredNode == nil {
 		// No healthy active node and no Ready candidate — leave any stale
 		// label/IP as-is so an active node recovering in place needs no action,
 		// and surface the gap (a monitoring alert on "no active gateway" belongs
 		// here).
-		logger.Error(nil, "no healthy stable-egress gateway: no healthy active node and no Ready candidate",
+		gatewayAvailable.Set(0)
+		gatewayActive.Reset()
+		logger.Error(nil, "no healthy stable-egress gateway: no healthy active node and no Ready prepared candidate",
 			"candidateLabel", r.CandidateLabelKey+"="+r.CandidateLabelValue)
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 	}
+	gatewayAvailable.Set(1)
 
 	serverID, err := parseHCloudServerID(desiredNode.Spec.ProviderID)
 	if err != nil {
@@ -126,6 +151,7 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 		if err := r.FIP.Assign(ctx, r.FloatingIPName, serverID); err != nil {
 			return ctrl.Result{}, fmt.Errorf("assigning Floating IP to server %d: %w", serverID, err)
 		}
+		gatewayFailovers.Inc()
 	}
 
 	// 2) Make the active label track the elected node: add to it, strip from any
@@ -134,8 +160,50 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 	if err := r.reconcileActiveLabel(ctx, desiredNode); err != nil {
 		return ctrl.Result{}, err
 	}
+	gatewayActive.Reset()
+	gatewayActive.WithLabelValues(desiredNode.Name, addr).Set(1)
 
 	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
+}
+
+func (r *FailoverReconciler) preparedCandidates(ctx context.Context, candidates []corev1.Node) (map[string]bool, error) {
+	prepared := make(map[string]bool, len(candidates))
+	if r.PreparedPodNamespace == "" || r.PreparedPodLabelKey == "" {
+		for i := range candidates {
+			prepared[candidates[i].Name] = true
+		}
+		return prepared, nil
+	}
+
+	var pods corev1.PodList
+	if err := r.List(
+		ctx,
+		&pods,
+		client.InNamespace(r.PreparedPodNamespace),
+		client.MatchingLabels{r.PreparedPodLabelKey: r.PreparedPodLabelValue},
+	); err != nil {
+		return nil, fmt.Errorf("listing host-configurer pods: %w", err)
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName == "" || pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				prepared[pod.Spec.NodeName] = true
+				break
+			}
+		}
+	}
+	return prepared, nil
+}
+
+func boolFloat(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 // reconcileActiveLabel ensures the active label is present on exactly the
@@ -175,6 +243,9 @@ func (r *FailoverReconciler) reconcileActiveLabel(ctx context.Context, desired *
 }
 
 func (r *FailoverReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.PreparedPodNamespace == "" || r.PreparedPodLabelKey == "" {
+		return fmt.Errorf("prepared Pod namespace and label are required")
+	}
 	mapToSingleton := func(context.Context, client.Object) []reconcile.Request {
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: reconcileName}}}
 	}
@@ -183,6 +254,9 @@ func (r *FailoverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Node{},
 			handler.EnqueueRequestsFromMapFunc(mapToSingleton),
 			builder.WithPredicates(r.nodeEventPredicate())).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(mapToSingleton),
+			builder.WithPredicates(r.preparedPodEventPredicate())).
 		Complete(r)
 }
 
@@ -204,6 +278,27 @@ func (r *FailoverReconciler) nodeEventPredicate() predicate.Predicate {
 				oldNode.Labels[r.CandidateLabelKey] != newNode.Labels[r.CandidateLabelKey] ||
 				oldNode.Labels[r.ActiveLabelKey] != newNode.Labels[r.ActiveLabelKey] ||
 				(oldNode.DeletionTimestamp == nil) != (newNode.DeletionTimestamp == nil)
+		},
+	}
+}
+
+// preparedPodEventPredicate wakes the controller as soon as a host-configurer
+// Pod becomes Ready, rather than waiting for the periodic resync. Updates that
+// add or remove the identifying label are included so preparedness cannot get
+// stuck if a Pod is relabelled.
+func (r *FailoverReconciler) preparedPodEventPredicate() predicate.Predicate {
+	matches := func(object client.Object) bool {
+		if object == nil || object.GetNamespace() != r.PreparedPodNamespace {
+			return false
+		}
+		return object.GetLabels()[r.PreparedPodLabelKey] == r.PreparedPodLabelValue
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return matches(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return matches(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return matches(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return matches(e.ObjectOld) || matches(e.ObjectNew)
 		},
 	}
 }

--- a/infra/stable-egress-controller/controllers/failover.go
+++ b/infra/stable-egress-controller/controllers/failover.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -37,12 +38,11 @@ type FloatingIPManager interface {
 
 // FailoverReconciler keeps a single healthy node designated as the stable-egress
 // gateway: it carries the active label (which the CiliumEgressGatewayPolicy +
-// host-configurer select on) and holds the Hetzner Floating IP. It ADOPTS a
-// healthy node that already holds the active label — even one outside the
-// candidate pool — so enabling the controller over an existing gateway, or any
-// steady state, never moves the Floating IP needlessly (no Cilium
-// reconvergence, no egress blip). Only when there is no healthy active node
-// does it fail over to a Ready candidate, moving the IP + label together.
+// host-configurer coordinate around) and holds the Hetzner Floating IP. It
+// adopts a prepared, directly healthy node that already holds the active label,
+// so steady state never moves the Floating IP needlessly. Only when there is no
+// healthy active node does it fail over to a prepared, directly reachable
+// candidate.
 type FailoverReconciler struct {
 	client.Client
 	FIP FloatingIPManager
@@ -67,7 +67,14 @@ type FailoverReconciler struct {
 	// egress IP customers have not allowlisted.
 	EgressIPAllowlist []netip.Prefix
 
-	ResyncInterval time.Duration
+	NodeHealthChecker     NodeHealthChecker
+	UnhealthyGracePeriod  time.Duration
+	UnpreparedGracePeriod time.Duration
+	ResyncInterval        time.Duration
+	Now                   func() time.Time
+
+	unhealthySince  map[string]time.Time
+	unpreparedSince map[string]time.Time
 }
 
 // reconcileKey funnels every Node event to one serialized reconcile of the
@@ -86,34 +93,48 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 		return ctrl.Result{}, fmt.Errorf("listing active-labelled nodes: %w", err)
 	}
 
-	prepared, err := r.preparedCandidates(ctx, candidates.Items)
+	prepared, err := r.preparedCandidates(ctx, candidates.Items, labeled.Items)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	nodeHealth := r.probeNodeHealth(ctx, candidates.Items, labeled.Items)
 	gatewayPrepared.Reset()
 	preparedCandidates := make([]corev1.Node, 0, len(candidates.Items))
 	for i := range candidates.Items {
 		node := &candidates.Items[i]
 		isPrepared := prepared[node.Name]
 		gatewayPrepared.WithLabelValues(node.Name).Set(boolFloat(isPrepared))
-		if isPrepared {
+		if isPrepared && nodeHealth[node.Name] && isPromotionReady(node) {
 			preparedCandidates = append(preparedCandidates, *node)
 		}
 	}
 
-	desiredNode := selectGateway(preparedCandidates, labeled.Items)
+	now := time.Now()
+	if r.Now != nil {
+		now = r.Now()
+	}
+	healthyActive, holdFor := r.eligibleActiveNodes(labeled.Items, prepared, nodeHealth, now)
+	if len(healthyActive) == 0 && holdFor > 0 {
+		gatewayAvailable.Set(0)
+		// Keep gatewayActive unchanged so responders retain the identity of the
+		// selected gateway while its health is being evaluated.
+		logger.Info("holding stable-egress gateway during direct health grace period",
+			"remaining", holdFor)
+		return ctrl.Result{RequeueAfter: min(holdFor, r.ResyncInterval)}, nil
+	}
+	desiredNode := selectGateway(preparedCandidates, healthyActive)
 	if desiredNode == nil {
-		// No healthy active node and no Ready candidate — leave any stale
+		// No healthy active node and no prepared candidate: leave any stale
 		// label/IP as-is so an active node recovering in place needs no action,
 		// and surface the gap (a monitoring alert on "no active gateway" belongs
 		// here).
 		gatewayAvailable.Set(0)
 		gatewayActive.Reset()
-		logger.Error(nil, "no healthy stable-egress gateway: no healthy active node and no Ready prepared candidate",
+		logger.Error(nil, "no healthy stable-egress gateway: no directly reachable active node and no prepared candidate",
 			"candidateLabel", r.CandidateLabelKey+"="+r.CandidateLabelValue)
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 	}
-	gatewayAvailable.Set(1)
+	gatewayAvailable.Set(boolFloat(nodeHealth[desiredNode.Name]))
 
 	serverID, err := parseHCloudServerID(desiredNode.Spec.ProviderID)
 	if err != nil {
@@ -144,19 +165,37 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 		logger.Info("active egress IP", "address", addr, "node", desiredNode.Name)
 	}
 
-	// 1) Make the Floating IP follow the elected node (idempotent).
+	// 1) When moving the Floating IP, first remove every active selector so
+	// Cilium never selects a gateway after the provider has routed the address
+	// away from it. A temporary absence is safer than two selected gateways.
 	if currentServer != serverID {
+		if err := r.stripActiveLabels(ctx, ""); err != nil {
+			return ctrl.Result{}, err
+		}
 		logger.Info("reassigning Floating IP", "floatingIP", r.FloatingIPName,
 			"fromServer", currentServer, "toServer", serverID, "node", desiredNode.Name)
 		if err := r.FIP.Assign(ctx, r.FloatingIPName, serverID); err != nil {
+			recoveryErr := r.recoverActiveLabelAfterAssignError(
+				ctx,
+				desiredNode,
+				candidates.Items,
+				labeled.Items,
+			)
+			if recoveryErr != nil {
+				return ctrl.Result{}, fmt.Errorf(
+					"assigning Floating IP to server %d: %w; recovering active label: %v",
+					serverID,
+					err,
+					recoveryErr,
+				)
+			}
 			return ctrl.Result{}, fmt.Errorf("assigning Floating IP to server %d: %w", serverID, err)
 		}
 		gatewayFailovers.Inc()
 	}
 
-	// 2) Make the active label track the elected node: add to it, strip from any
-	// other node still carrying it. Cilium re-selects the gateway on the next
-	// reconciliation (datapath trigger interval is 1s).
+	// 2) Normalize any externally introduced duplicate labels, then select the
+	// elected node. Cilium re-selects the gateway on its next reconciliation.
 	if err := r.reconcileActiveLabel(ctx, desiredNode); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -166,11 +205,122 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 }
 
-func (r *FailoverReconciler) preparedCandidates(ctx context.Context, candidates []corev1.Node) (map[string]bool, error) {
-	prepared := make(map[string]bool, len(candidates))
+func (r *FailoverReconciler) probeNodeHealth(
+	ctx context.Context,
+	nodeSets ...[]corev1.Node,
+) map[string]bool {
+	health := map[string]bool{}
+	gatewayNodeHealthy.Reset()
+	for _, nodes := range nodeSets {
+		for i := range nodes {
+			node := &nodes[i]
+			if _, checked := health[node.Name]; checked {
+				continue
+			}
+			if node.DeletionTimestamp != nil {
+				health[node.Name] = false
+				gatewayNodeHealthy.WithLabelValues(node.Name).Set(0)
+				continue
+			}
+
+			healthy, err := r.NodeHealthChecker.Healthy(ctx, node)
+			health[node.Name] = healthy
+			gatewayNodeHealthy.WithLabelValues(node.Name).Set(boolFloat(healthy))
+			if !healthy {
+				gatewayHealthCheckFailures.WithLabelValues(node.Name).Inc()
+				log.FromContext(ctx).Info("direct gateway node health check failed",
+					"node", node.Name, "error", err)
+			}
+		}
+	}
+	return health
+}
+
+func (r *FailoverReconciler) eligibleActiveNodes(
+	labeled []corev1.Node,
+	prepared map[string]bool,
+	nodeHealth map[string]bool,
+	now time.Time,
+) ([]corev1.Node, time.Duration) {
+	if r.unhealthySince == nil {
+		r.unhealthySince = map[string]time.Time{}
+	}
+	if r.unpreparedSince == nil {
+		r.unpreparedSince = map[string]time.Time{}
+	}
+
+	activeNames := make(map[string]struct{}, len(labeled))
+	eligible := make([]corev1.Node, 0, len(labeled))
+	holdFor := time.Duration(0)
+	for i := range labeled {
+		node := &labeled[i]
+		activeNames[node.Name] = struct{}{}
+		if node.DeletionTimestamp != nil || node.Spec.Unschedulable {
+			delete(r.unhealthySince, node.Name)
+			delete(r.unpreparedSince, node.Name)
+			continue
+		}
+
+		if nodeHealth[node.Name] && prepared[node.Name] {
+			delete(r.unhealthySince, node.Name)
+			delete(r.unpreparedSince, node.Name)
+			eligible = append(eligible, *node)
+			continue
+		}
+
+		var remaining time.Duration
+		if !nodeHealth[node.Name] {
+			delete(r.unpreparedSince, node.Name)
+			remaining = remainingGrace(r.unhealthySince, node.Name, now, r.UnhealthyGracePeriod)
+		} else {
+			delete(r.unhealthySince, node.Name)
+			remaining = remainingGrace(r.unpreparedSince, node.Name, now, r.UnpreparedGracePeriod)
+		}
+		if remaining > holdFor {
+			holdFor = remaining
+		}
+	}
+
+	for nodeName := range r.unhealthySince {
+		if _, active := activeNames[nodeName]; !active {
+			delete(r.unhealthySince, nodeName)
+		}
+	}
+	for nodeName := range r.unpreparedSince {
+		if _, active := activeNames[nodeName]; !active {
+			delete(r.unpreparedSince, nodeName)
+		}
+	}
+	if len(eligible) > 0 {
+		holdFor = 0
+	}
+	return eligible, holdFor
+}
+
+func remainingGrace(
+	failures map[string]time.Time,
+	nodeName string,
+	now time.Time,
+	gracePeriod time.Duration,
+) time.Duration {
+	since, exists := failures[nodeName]
+	if !exists {
+		since = now
+		failures[nodeName] = since
+	}
+	return gracePeriod - now.Sub(since)
+}
+
+func (r *FailoverReconciler) preparedCandidates(
+	ctx context.Context,
+	nodeSets ...[]corev1.Node,
+) (map[string]bool, error) {
+	prepared := map[string]bool{}
 	if r.PreparedPodNamespace == "" || r.PreparedPodLabelKey == "" {
-		for i := range candidates {
-			prepared[candidates[i].Name] = true
+		for _, nodes := range nodeSets {
+			for i := range nodes {
+				prepared[nodes[i].Name] = true
+			}
 		}
 		return prepared, nil
 	}
@@ -207,20 +357,38 @@ func boolFloat(value bool) float64 {
 }
 
 // reconcileActiveLabel ensures the active label is present on exactly the
-// desired node, cluster-wide. It strips the label from ANY other node that
-// carries it — not just candidates — so a stale label (e.g. a manual failover
-// on a non-candidate node, or a previous gateway) can't shadow the elected
-// node in Cilium's selector and black-hole egress.
+// desired node, cluster-wide. It removes every other selector before adding
+// the desired one so Cilium never observes two eligible gateways.
 func (r *FailoverReconciler) reconcileActiveLabel(ctx context.Context, desired *corev1.Node) error {
+	if err := r.stripActiveLabels(ctx, desired.Name); err != nil {
+		return err
+	}
+	var current corev1.Node
+	if err := r.Get(ctx, client.ObjectKey{Name: desired.Name}, &current); err != nil {
+		return fmt.Errorf("reading desired active node %q: %w", desired.Name, err)
+	}
+	if current.Labels[r.ActiveLabelKey] == r.ActiveLabelValue {
+		return nil
+	}
+	patch := client.MergeFrom(current.DeepCopy())
+	if current.Labels == nil {
+		current.Labels = map[string]string{}
+	}
+	current.Labels[r.ActiveLabelKey] = r.ActiveLabelValue
+	if err := r.Patch(ctx, &current, patch); err != nil {
+		return fmt.Errorf("setting active label on node %q: %w", desired.Name, err)
+	}
+	return nil
+}
+
+func (r *FailoverReconciler) stripActiveLabels(ctx context.Context, keepNodeName string) error {
 	var labeled corev1.NodeList
 	if err := r.List(ctx, &labeled, client.MatchingLabels{r.ActiveLabelKey: r.ActiveLabelValue}); err != nil {
 		return fmt.Errorf("listing active-labelled nodes: %w", err)
 	}
-	desiredHasLabel := false
 	for i := range labeled.Items {
 		n := &labeled.Items[i]
-		if n.Name == desired.Name {
-			desiredHasLabel = true
+		if n.Name == keepNodeName {
 			continue
 		}
 		patch := client.MergeFrom(n.DeepCopy())
@@ -229,22 +397,41 @@ func (r *FailoverReconciler) reconcileActiveLabel(ctx context.Context, desired *
 			return fmt.Errorf("stripping active label from node %q: %w", n.Name, err)
 		}
 	}
-	if !desiredHasLabel {
-		patch := client.MergeFrom(desired.DeepCopy())
-		if desired.Labels == nil {
-			desired.Labels = map[string]string{}
-		}
-		desired.Labels[r.ActiveLabelKey] = r.ActiveLabelValue
-		if err := r.Patch(ctx, desired, patch); err != nil {
-			return fmt.Errorf("setting active label on node %q: %w", desired.Name, err)
+	return nil
+}
+
+func (r *FailoverReconciler) recoverActiveLabelAfterAssignError(
+	ctx context.Context,
+	desired *corev1.Node,
+	candidates []corev1.Node,
+	previouslyLabeled []corev1.Node,
+) error {
+	_, observedServer, err := r.FIP.Get(ctx, r.FloatingIPName)
+	if err != nil {
+		return fmt.Errorf("reading Floating IP after failed assignment: %w", err)
+	}
+	if observedServer == 0 {
+		return nil
+	}
+
+	nodes := append([]corev1.Node{*desired}, candidates...)
+	nodes = append(nodes, previouslyLabeled...)
+	for i := range nodes {
+		node := &nodes[i]
+		serverID, err := parseHCloudServerID(node.Spec.ProviderID)
+		if err == nil && serverID == observedServer {
+			return r.reconcileActiveLabel(ctx, node)
 		}
 	}
-	return nil
+	return fmt.Errorf("no Kubernetes node matches observed Hetzner server %d", observedServer)
 }
 
 func (r *FailoverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.PreparedPodNamespace == "" || r.PreparedPodLabelKey == "" {
 		return fmt.Errorf("prepared Pod namespace and label are required")
+	}
+	if r.NodeHealthChecker == nil {
+		return fmt.Errorf("node health checker is required")
 	}
 	mapToSingleton := func(context.Context, client.Object) []reconcile.Request {
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: reconcileName}}}
@@ -264,8 +451,9 @@ func (r *FailoverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // chiefly the kubelet status heartbeats and lease renewals that fire every few
 // seconds per node — so a reconcile (and its Hetzner API read against a shared,
 // rate-limited token) only runs when gateway eligibility can actually change: a
-// Ready transition, a candidate/active label change, or the node entering
-// termination. Create, Delete, and Generic events always reconcile.
+// Ready transition, a candidate/active label change, an address change, or the
+// node entering termination. NodeReady only triggers an immediate direct health
+// check; it never determines gateway eligibility.
 func (r *FailoverReconciler) nodeEventPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -277,6 +465,7 @@ func (r *FailoverReconciler) nodeEventPredicate() predicate.Predicate {
 			return isNodeReady(oldNode) != isNodeReady(newNode) ||
 				oldNode.Labels[r.CandidateLabelKey] != newNode.Labels[r.CandidateLabelKey] ||
 				oldNode.Labels[r.ActiveLabelKey] != newNode.Labels[r.ActiveLabelKey] ||
+				nodeAddressKey(oldNode) != nodeAddressKey(newNode) ||
 				(oldNode.DeletionTimestamp == nil) != (newNode.DeletionTimestamp == nil)
 		},
 	}
@@ -303,25 +492,25 @@ func (r *FailoverReconciler) preparedPodEventPredicate() predicate.Predicate {
 	}
 }
 
-// selectGateway picks the node that should hold the egress gateway. It adopts a
-// healthy node that already carries the active label — even one outside the
+// selectGateway picks the node that should hold the egress gateway. It adopts an
+// eligible node that already carries the active label — even one outside the
 // candidate pool — so a working gateway is never disturbed (no Floating IP
 // churn, no Cilium reconvergence, no egress blip). Only when there is no healthy
-// active node does it fail over to the lexically-lowest Ready candidate.
+// active node does it fail over to the lexically-lowest prepared candidate.
 // Returns nil when nothing is eligible.
 func selectGateway(candidates, labeled []corev1.Node) *corev1.Node {
-	if n := lowestReady(labeled); n != nil {
+	if n := lowestEligible(labeled); n != nil {
 		return n
 	}
-	return lowestReady(candidates)
+	return lowestEligible(candidates)
 }
 
-// lowestReady returns the lexically-lowest Ready, non-terminating node, or nil.
-func lowestReady(nodes []corev1.Node) *corev1.Node {
+// lowestEligible returns the lexically-lowest non-terminating node, or nil.
+func lowestEligible(nodes []corev1.Node) *corev1.Node {
 	var best *corev1.Node
 	for i := range nodes {
 		n := &nodes[i]
-		if n.DeletionTimestamp != nil || !isNodeReady(n) {
+		if n.DeletionTimestamp != nil {
 			continue
 		}
 		if best == nil || n.Name < best.Name {
@@ -338,6 +527,16 @@ func isNodeReady(n *corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+func nodeAddressKey(node *corev1.Node) string {
+	addresses := nodeAddresses(node)
+	sort.Strings(addresses)
+	return strings.Join(addresses, ",")
+}
+
+func isPromotionReady(node *corev1.Node) bool {
+	return node.DeletionTimestamp == nil && !node.Spec.Unschedulable && isNodeReady(node)
 }
 
 // ipInAllowlist reports whether addr falls within any of the allowed prefixes.

--- a/infra/stable-egress-controller/controllers/failover_test.go
+++ b/infra/stable-egress-controller/controllers/failover_test.go
@@ -42,10 +42,10 @@ func TestSelectGateway(t *testing.T) {
 	}{
 		{"adopt healthy active even if non-candidate", []corev1.Node{tnode("c1", true), tnode("c2", true)}, []corev1.Node{tnode("general-1", true)}, "general-1"},
 		{"sticky to active candidate", []corev1.Node{tnode("a", true), tnode("b", true)}, []corev1.Node{tnode("a", true)}, "a"},
-		{"failover to candidate when active NotReady", []corev1.Node{tnode("b", true), tnode("c", true)}, []corev1.Node{tnode("a", false)}, "b"},
+		{"use candidate when unhealthy active was filtered out", []corev1.Node{tnode("b", true), tnode("c", true)}, nil, "b"},
+		{"NodeReady does not affect an already checked active node", []corev1.Node{tnode("b", true)}, []corev1.Node{tnode("a", false)}, "a"},
 		{"elect lexically-lowest candidate when no active", []corev1.Node{tnode("c", true), tnode("a", true), tnode("b", true)}, nil, "a"},
 		{"nothing eligible", nil, nil, ""},
-		{"active NotReady and no Ready candidate", []corev1.Node{tnode("b", false)}, []corev1.Node{tnode("a", false)}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,12 +76,27 @@ type fakeFIP struct {
 	addr      string
 	assignErr error
 	assigns   []int64
+	onAssign  func()
+}
+
+type fakeNodeHealth struct {
+	healthy map[string]bool
+}
+
+func (f fakeNodeHealth) Healthy(_ context.Context, node *corev1.Node) (bool, error) {
+	if healthy, ok := f.healthy[node.Name]; ok {
+		return healthy, nil
+	}
+	return true, nil
 }
 
 func (f *fakeFIP) Get(context.Context, string) (string, int64, error) { return f.addr, f.server, nil }
 func (f *fakeFIP) Assign(_ context.Context, _ string, serverID int64) error {
 	if f.assignErr != nil {
 		return f.assignErr
+	}
+	if f.onAssign != nil {
+		f.onAssign()
 	}
 	f.assigns = append(f.assigns, serverID)
 	f.server = serverID
@@ -127,14 +142,16 @@ func preparedPod(name, node string, ready bool) *corev1.Pod {
 func newReconciler(fip FloatingIPManager, objs ...client.Object) *FailoverReconciler {
 	c := fake.NewClientBuilder().WithObjects(objs...).Build()
 	return &FailoverReconciler{
-		Client:              c,
-		FIP:                 fip,
-		FloatingIPName:      "tuist-production-server-egress",
-		CandidateLabelKey:   candKey,
-		CandidateLabelValue: candVal,
-		ActiveLabelKey:      actKey,
-		ActiveLabelValue:    actVal,
-		ResyncInterval:      30 * time.Second,
+		Client:               c,
+		FIP:                  fip,
+		FloatingIPName:       "tuist-production-server-egress",
+		CandidateLabelKey:    candKey,
+		CandidateLabelValue:  candVal,
+		ActiveLabelKey:       actKey,
+		ActiveLabelValue:     actVal,
+		NodeHealthChecker:    fakeNodeHealth{},
+		ResyncInterval:       30 * time.Second,
+		UnhealthyGracePeriod: 0,
 	}
 }
 
@@ -159,6 +176,7 @@ func TestReconcileFailover(t *testing.T) {
 	alive := candidateNode("egress-b", "hcloud://222", true, false)
 	fip := &fakeFIP{server: 111} // IP still on the dead node
 	r := newReconciler(fip, dead, alive)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
 
 	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: reconcileName}}); err != nil {
 		t.Fatal(err)
@@ -189,6 +207,7 @@ func TestReconcileWaitsForPreparedCandidate(t *testing.T) {
 	r.PreparedPodNamespace = "kube-system"
 	r.PreparedPodLabelKey = "app.kubernetes.io/name"
 	r.PreparedPodLabelValue = "host-configurer"
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
 
 	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: reconcileName}}); err != nil {
 		t.Fatal(err)
@@ -199,6 +218,37 @@ func TestReconcileWaitsForPreparedCandidate(t *testing.T) {
 	}
 	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-c" {
 		t.Fatalf("active nodes = %v, want [egress-c]", got)
+	}
+}
+
+func TestReconcileLeavesCurrentAssignmentWhenNoCandidateIsPrepared(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", false, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(
+		fip,
+		active,
+		standby,
+		preparedPod("host-configurer-a", "egress-a", false),
+		preparedPod("host-configurer-b", "egress-b", false),
+	)
+	r.PreparedPodNamespace = "kube-system"
+	r.PreparedPodLabelKey = "app.kubernetes.io/name"
+	r.PreparedPodLabelValue = "host-configurer"
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if fip.server != 111 {
+		t.Fatalf("Floating IP moved to unprepared server %d", fip.server)
+	}
+	if len(fip.assigns) != 0 {
+		t.Fatalf("unexpected Floating IP assignments: %v", fip.assigns)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
+		t.Fatalf("active selectors = %v, want stale provider holder [egress-a]", got)
 	}
 }
 
@@ -277,6 +327,7 @@ func TestReconcileStripsDeadNonCandidateLabelOnFailover(t *testing.T) {
 	}
 	fip := &fakeFIP{server: 111}
 	r := newReconciler(fip, candidate, dead)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"general-1": false}}
 
 	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: reconcileName}}); err != nil {
 		t.Fatal(err)
@@ -394,6 +445,16 @@ func TestSetupRequiresPreparedPodSelector(t *testing.T) {
 	}
 }
 
+func TestSetupRequiresNodeHealthChecker(t *testing.T) {
+	r := newReconciler(&fakeFIP{})
+	r.PreparedPodNamespace = "kube-system"
+	r.PreparedPodLabelKey = "app.kubernetes.io/name"
+	r.NodeHealthChecker = nil
+	if err := r.SetupWithManager(nil); err == nil {
+		t.Fatal("expected setup to reject a nil node health checker")
+	}
+}
+
 // Steady state: active node healthy — no IP churn, label unchanged.
 func TestReconcileStickyNoChurn(t *testing.T) {
 	a := candidateNode("egress-a", "hcloud://111", true, true)
@@ -409,5 +470,258 @@ func TestReconcileStickyNoChurn(t *testing.T) {
 	}
 	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
 		t.Fatalf("active nodes = %v, want [egress-a]", got)
+	}
+}
+
+func TestReconcileIgnoresNodeReadyWhenDirectHealthSucceeds(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", false, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fip.assigns) != 0 {
+		t.Fatalf("NodeReady alone must not move the Floating IP, got %v", fip.assigns)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
+		t.Fatalf("active nodes = %v, want [egress-a]", got)
+	}
+}
+
+func TestReconcileRequiresContinuousDirectHealthFailure(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", true, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+	r.UnhealthyGracePeriod = 90 * time.Second
+	now := time.Unix(1_000, 0)
+	r.Now = func() time.Time { return now }
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+			t.Fatal(err)
+		}
+		if fip.server != 111 {
+			t.Fatalf("attempt %d moved the Floating IP before the grace period", attempt)
+		}
+	}
+
+	now = now.Add(89 * time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 111 {
+		t.Fatal("moved the Floating IP before 90 seconds of continuous failure")
+	}
+
+	now = now.Add(time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 222 {
+		t.Fatalf("Floating IP on server %d after the grace period, want 222", fip.server)
+	}
+}
+
+func TestReconcileDoesNotUndoExternalAssignmentDuringGracePeriod(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", true, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+	r.UnhealthyGracePeriod = 90 * time.Second
+	now := time.Unix(1_000, 0)
+	r.Now = func() time.Time { return now }
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	fip.server = 222
+	now = now.Add(30 * time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if fip.server != 222 {
+		t.Fatalf("controller pulled the Floating IP back to unhealthy server %d during grace", fip.server)
+	}
+	if len(fip.assigns) != 0 {
+		t.Fatalf("grace period must not write provider state, got assignments %v", fip.assigns)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
+		t.Fatalf("grace period changed active selectors to %v", got)
+	}
+}
+
+func TestReconcileOnlyPromotesReadySchedulableCandidate(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", false, true)
+	notReady := candidateNode("egress-b", "hcloud://222", false, false)
+	unschedulable := candidateNode("egress-c", "hcloud://333", true, false)
+	unschedulable.Spec.Unschedulable = true
+	deleting := candidateNode("egress-d", "hcloud://444", true, false)
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	deleting.Finalizers = []string{"test.tuist.dev"}
+	ready := candidateNode("egress-e", "hcloud://555", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, notReady, unschedulable, deleting, ready)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 555 {
+		t.Fatalf("Floating IP on server %d, want ready, schedulable, non-deleting server 555", fip.server)
+	}
+}
+
+func TestReconcileImmediatelyDemotesDeletingActiveNode(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", true, true)
+	now := metav1.Now()
+	active.DeletionTimestamp = &now
+	active.Finalizers = []string{"test.tuist.dev"}
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+	r.UnhealthyGracePeriod = 90 * time.Second
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 222 {
+		t.Fatalf("Floating IP on server %d, want standby server 222", fip.server)
+	}
+}
+
+func TestReconcileRemovesOldSelectorBeforeProviderAssignment(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", false, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+	fip.onAssign = func() {
+		if got := activeNames(t, r); len(got) != 0 {
+			t.Fatalf("active selectors during provider assignment = %v, want none", got)
+		}
+	}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-b" {
+		t.Fatalf("active selectors after failover = %v, want [egress-b]", got)
+	}
+}
+
+func TestReconcileRecoversSelectorAfterProviderAssignmentFailure(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", false, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111, assignErr: context.DeadlineExceeded}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: map[string]bool{"egress-a": false}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err == nil {
+		t.Fatal("expected provider assignment error")
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
+		t.Fatalf("active selectors after failed assignment = %v, want provider-observed egress-a", got)
+	}
+}
+
+func TestReconcileResetsGraceAfterHealthRecovers(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", true, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	health := map[string]bool{"egress-a": false}
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, active, standby)
+	r.NodeHealthChecker = fakeNodeHealth{healthy: health}
+	r.UnhealthyGracePeriod = 90 * time.Second
+	now := time.Unix(1_000, 0)
+	r.Now = func() time.Time { return now }
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(60 * time.Second)
+	health["egress-a"] = true
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	health["egress-a"] = false
+	now = now.Add(time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(89 * time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 111 {
+		t.Fatal("moved the Floating IP before the reset grace period elapsed")
+	}
+	now = now.Add(time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 222 {
+		t.Fatalf("Floating IP on server %d after a fresh grace period, want 222", fip.server)
+	}
+}
+
+func TestReconcileUsesLongerGraceForPreparationLoss(t *testing.T) {
+	active := candidateNode("egress-a", "hcloud://111", true, true)
+	standby := candidateNode("egress-b", "hcloud://222", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(
+		fip,
+		active,
+		standby,
+		preparedPod("host-configurer-a", "egress-a", false),
+		preparedPod("host-configurer-b", "egress-b", true),
+	)
+	r.PreparedPodNamespace = "kube-system"
+	r.PreparedPodLabelKey = "app.kubernetes.io/name"
+	r.PreparedPodLabelValue = "host-configurer"
+	r.UnpreparedGracePeriod = 5 * time.Minute
+	now := time.Unix(1_000, 0)
+	r.Now = func() time.Time { return now }
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(4*time.Minute + 59*time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 111 {
+		t.Fatal("moved the Floating IP during the host-preparation grace period")
+	}
+	now = now.Add(time.Second)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if fip.server != 222 {
+		t.Fatalf("Floating IP on server %d after preparation stayed absent, want 222", fip.server)
+	}
+}
+
+func TestReconcileNormalizesDuplicateSelectorsWithoutProviderMove(t *testing.T) {
+	first := candidateNode("egress-a", "hcloud://111", true, true)
+	second := candidateNode("egress-b", "hcloud://222", true, true)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(fip, first, second)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fip.assigns) != 0 {
+		t.Fatalf("normalizing selectors moved the Floating IP: %v", fip.assigns)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-a" {
+		t.Fatalf("active selectors after normalization = %v, want [egress-a]", got)
 	}
 }

--- a/infra/stable-egress-controller/controllers/failover_test.go
+++ b/infra/stable-egress-controller/controllers/failover_test.go
@@ -106,6 +106,24 @@ func candidateNode(name, providerID string, ready bool, active bool) *corev1.Nod
 	}
 }
 
+func preparedPod(name, node string, ready bool) *corev1.Pod {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+			Labels:    map[string]string{"app.kubernetes.io/name": "host-configurer"},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: status}},
+		},
+	}
+}
+
 func newReconciler(fip FloatingIPManager, objs ...client.Object) *FailoverReconciler {
 	c := fake.NewClientBuilder().WithObjects(objs...).Build()
 	return &FailoverReconciler{
@@ -152,6 +170,35 @@ func TestReconcileFailover(t *testing.T) {
 	got := activeNames(t, r)
 	if len(got) != 1 || got[0] != "egress-b" {
 		t.Fatalf("active nodes = %v, want [egress-b]", got)
+	}
+}
+
+func TestReconcileWaitsForPreparedCandidate(t *testing.T) {
+	dead := candidateNode("egress-a", "hcloud://111", false, true)
+	unprepared := candidateNode("egress-b", "hcloud://222", true, false)
+	prepared := candidateNode("egress-c", "hcloud://333", true, false)
+	fip := &fakeFIP{server: 111}
+	r := newReconciler(
+		fip,
+		dead,
+		unprepared,
+		prepared,
+		preparedPod("host-configurer-b", "egress-b", false),
+		preparedPod("host-configurer-c", "egress-c", true),
+	)
+	r.PreparedPodNamespace = "kube-system"
+	r.PreparedPodLabelKey = "app.kubernetes.io/name"
+	r.PreparedPodLabelValue = "host-configurer"
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: reconcileName}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if fip.server != 333 {
+		t.Fatalf("Floating IP on server %d, want prepared server 333", fip.server)
+	}
+	if got := activeNames(t, r); len(got) != 1 || got[0] != "egress-c" {
+		t.Fatalf("active nodes = %v, want [egress-c]", got)
 	}
 }
 
@@ -310,6 +357,40 @@ func TestNodeEventPredicate(t *testing.T) {
 	}
 	if !pred.Delete(event.DeleteEvent{Object: base}) {
 		t.Fatal("Delete events must reconcile")
+	}
+}
+
+func TestPreparedPodEventPredicate(t *testing.T) {
+	r := newReconciler(&fakeFIP{})
+	r.PreparedPodNamespace = "kube-system"
+	r.PreparedPodLabelKey = "app.kubernetes.io/name"
+	r.PreparedPodLabelValue = "host-configurer"
+	pred := r.preparedPodEventPredicate()
+
+	matching := preparedPod("host-configurer-a", "egress-a", true)
+	unrelated := preparedPod("other", "egress-a", true)
+	unrelated.Labels[r.PreparedPodLabelKey] = "other"
+	wrongNamespace := preparedPod("host-configurer-b", "egress-b", true)
+	wrongNamespace.Namespace = "default"
+
+	if !pred.Create(event.CreateEvent{Object: matching}) {
+		t.Fatal("matching Pod create must reconcile")
+	}
+	if pred.Create(event.CreateEvent{Object: unrelated}) {
+		t.Fatal("unrelated Pod create must not reconcile")
+	}
+	if pred.Create(event.CreateEvent{Object: wrongNamespace}) {
+		t.Fatal("matching Pod in another namespace must not reconcile")
+	}
+	if !pred.Update(event.UpdateEvent{ObjectOld: matching, ObjectNew: unrelated}) {
+		t.Fatal("removing the identifying label must reconcile")
+	}
+}
+
+func TestSetupRequiresPreparedPodSelector(t *testing.T) {
+	r := newReconciler(&fakeFIP{})
+	if err := r.SetupWithManager(nil); err == nil {
+		t.Fatal("expected setup to reject an empty prepared Pod selector")
 	}
 }
 

--- a/infra/stable-egress-controller/controllers/metrics.go
+++ b/infra/stable-egress-controller/controllers/metrics.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	gatewayAvailable = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "gateway_available",
+		Help:      "Whether a healthy active or prepared standby gateway is available.",
+	})
+	gatewayPrepared = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "gateway_prepared",
+		Help:      "Whether the outbound address is configured and ready on a candidate gateway node.",
+	}, []string{"node"})
+	gatewayActive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "gateway_active",
+		Help:      "The gateway node currently selected for stable outbound traffic.",
+	}, []string{"node", "egress_ip"})
+	gatewayFailovers = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "failovers_total",
+		Help:      "Total number of stable outbound address assignments performed during failover.",
+	})
+)
+
+func init() {
+	metrics.Registry.MustRegister(gatewayAvailable, gatewayPrepared, gatewayActive, gatewayFailovers)
+}

--- a/infra/stable-egress-controller/controllers/metrics.go
+++ b/infra/stable-egress-controller/controllers/metrics.go
@@ -30,8 +30,27 @@ var (
 		Name:      "failovers_total",
 		Help:      "Total number of stable outbound address assignments performed during failover.",
 	})
+	gatewayNodeHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "gateway_node_healthy",
+		Help:      "Whether the controller can directly reach the Cilium listener on a gateway node.",
+	}, []string{"node"})
+	gatewayHealthCheckFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tuist",
+		Subsystem: "stable_egress",
+		Name:      "health_check_failures_total",
+		Help:      "Total number of failed direct gateway node health checks.",
+	}, []string{"node"})
 )
 
 func init() {
-	metrics.Registry.MustRegister(gatewayAvailable, gatewayPrepared, gatewayActive, gatewayFailovers)
+	metrics.Registry.MustRegister(
+		gatewayAvailable,
+		gatewayPrepared,
+		gatewayActive,
+		gatewayFailovers,
+		gatewayNodeHealthy,
+		gatewayHealthCheckFailures,
+	)
 }

--- a/infra/stable-egress-controller/controllers/node_health.go
+++ b/infra/stable-egress-controller/controllers/node_health.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeHealthChecker tests the data-plane path independently from the
+// Kubernetes NodeReady condition.
+type NodeHealthChecker interface {
+	Healthy(ctx context.Context, node *corev1.Node) (bool, error)
+}
+
+// DirectNodeHealthChecker connects directly to a host-network listener on the
+// node. Production points this at Cilium's Prometheus listener, which proves
+// both node reachability and that the Cilium agent process is accepting
+// connections without coupling failover to kubelet heartbeats.
+type DirectNodeHealthChecker struct {
+	Port    int
+	Timeout time.Duration
+}
+
+func (c DirectNodeHealthChecker) Healthy(ctx context.Context, node *corev1.Node) (bool, error) {
+	addresses := nodeAddresses(node)
+	if len(addresses) == 0 {
+		return false, fmt.Errorf("node %q has no internal or external IP address", node.Name)
+	}
+
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	port := c.Port
+	if port == 0 {
+		port = 9962
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	results := make(chan error, len(addresses))
+	for _, address := range addresses {
+		go func(address string) {
+			conn, err := (&net.Dialer{}).DialContext(
+				probeCtx,
+				"tcp",
+				net.JoinHostPort(address, strconv.Itoa(port)),
+			)
+			if err == nil {
+				_ = conn.Close()
+			}
+			results <- err
+		}(address)
+	}
+
+	var lastErr error
+	for range addresses {
+		select {
+		case err := <-results:
+			if err == nil {
+				return true, nil
+			}
+			lastErr = err
+		case <-probeCtx.Done():
+			return false, fmt.Errorf(
+				"checking node %q on port %d: %w",
+				node.Name,
+				port,
+				probeCtx.Err(),
+			)
+		}
+	}
+	return false, fmt.Errorf("checking node %q on port %d: %w", node.Name, port, lastErr)
+}
+
+func nodeAddresses(node *corev1.Node) []string {
+	addresses := make([]string, 0, 2)
+	for _, addressType := range []corev1.NodeAddressType{corev1.NodeInternalIP, corev1.NodeExternalIP} {
+		for _, address := range node.Status.Addresses {
+			if address.Type == addressType && address.Address != "" {
+				addresses = append(addresses, address.Address)
+			}
+		}
+	}
+	return addresses
+}

--- a/infra/stable-egress-controller/controllers/node_health_test.go
+++ b/infra/stable-egress-controller/controllers/node_health_test.go
@@ -1,0 +1,111 @@
+package controllers
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDirectNodeHealthChecker(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	checker := DirectNodeHealthChecker{Port: port, Timeout: time.Second}
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "127.0.0.1"},
+			},
+		},
+	}
+
+	healthy, err := checker.Healthy(context.Background(), node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !healthy {
+		t.Fatal("expected the listening node to be healthy")
+	}
+}
+
+func TestDirectNodeHealthCheckerReportsClosedPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := DirectNodeHealthChecker{Port: port, Timeout: 100 * time.Millisecond}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress-a"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "127.0.0.1"},
+			},
+		},
+	}
+
+	healthy, err := checker.Healthy(context.Background(), node)
+	if err == nil {
+		t.Fatal("expected a closed port error")
+	}
+	if healthy {
+		t.Fatal("expected the node with closed port " + strconv.Itoa(port) + " to be unhealthy")
+	}
+}
+
+func TestDirectNodeHealthCheckerFallsBackToExternalAddress(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	checker := DirectNodeHealthChecker{Port: port, Timeout: time.Second}
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "127.0.0.2"},
+				{Type: corev1.NodeExternalIP, Address: "127.0.0.1"},
+			},
+		},
+	}
+
+	healthy, err := checker.Healthy(context.Background(), node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !healthy {
+		t.Fatal("expected the external-address fallback to succeed")
+	}
+}
+
+func TestDirectNodeHealthCheckerRequiresAddress(t *testing.T) {
+	checker := DirectNodeHealthChecker{Port: 9962, Timeout: time.Second}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "egress-a"}}
+
+	healthy, err := checker.Healthy(context.Background(), node)
+	if err == nil {
+		t.Fatal("expected a missing-address error")
+	}
+	if healthy {
+		t.Fatal("expected a node without an address to be unhealthy")
+	}
+}

--- a/infra/stable-egress-controller/go.mod
+++ b/infra/stable-egress-controller/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/hetznercloud/hcloud-go/v2 v2.17.0
+	github.com/prometheus/client_golang v1.20.5
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -38,7 +39,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -37,13 +37,17 @@ defmodule Tuist.License do
     )
   end
 
+  def get_cached_license do
+    KeyValueStore.get([__MODULE__, "license"])
+  end
+
   defp fetch_license do
     cond do
-      key = Tuist.Environment.license_key() ->
-        resolve_license(key)
-
       Tuist.Environment.license_certificate_base64() ->
         resolve_certificate()
+
+      key = Tuist.Environment.license_key() ->
+        resolve_license(key)
 
       true ->
         {:error, :license_not_found}
@@ -55,8 +59,8 @@ defmodule Tuist.License do
     "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
   end
 
-  def certificate do
-    Base.decode64!(Tuist.Environment.license_certificate_base64())
+  def certificate(encoded \\ Tuist.Environment.license_certificate_base64()) do
+    Base.decode64!(encoded, ignore: :whitespace)
   end
 
   @doc """

--- a/server/lib/tuist/license/prom_ex_plugin.ex
+++ b/server/lib/tuist/license/prom_ex_plugin.ex
@@ -1,0 +1,60 @@
+defmodule Tuist.License.PromExPlugin do
+  @moduledoc """
+  Publishes the cached license status and expiration time.
+  """
+
+  use PromEx.Plugin
+
+  alias Tuist.Environment
+  alias Tuist.License
+  alias Tuist.Telemetry
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, to_timeout(minute: 10))
+
+    [
+      Polling.build(
+        :tuist_license_status_metrics,
+        poll_rate,
+        {__MODULE__, :execute_license_status_telemetry_event, []},
+        [
+          last_value(
+            [:tuist, :license, :expiration, :timestamp, :seconds],
+            event_name: Telemetry.event_name_license_status(),
+            description: "Unix timestamp at which the configured Tuist license expires.",
+            measurement: :expiration_timestamp_seconds
+          ),
+          last_value(
+            [:tuist, :license, :valid],
+            event_name: Telemetry.event_name_license_status(),
+            description: "Whether the configured Tuist license is currently valid.",
+            measurement: :valid
+          )
+        ]
+      )
+    ]
+  end
+
+  def execute_license_status_telemetry_event do
+    license =
+      if Environment.license_certificate_base64() do
+        License.resolve_certificate()
+      else
+        License.get_cached_license() || {:error, :license_not_cached}
+      end
+
+    measurements = license_status_measurements(license)
+
+    :telemetry.execute(Telemetry.event_name_license_status(), measurements, %{})
+  end
+
+  def license_status_measurements({:ok, %License{expiration_date: %DateTime{} = expiration_date, valid: valid}}) do
+    %{
+      expiration_timestamp_seconds: DateTime.to_unix(expiration_date),
+      valid: if(valid, do: 1, else: 0)
+    }
+  end
+
+  def license_status_measurements(_result), do: %{expiration_timestamp_seconds: 0, valid: 0}
+end

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -76,6 +76,7 @@ defmodule Tuist.PromEx do
         Tuist.KeyValueStore.PromExPlugin,
         Tuist.Authentication.PromExPlugin,
         Tuist.HTTP.PromExPlugin,
+        Tuist.License.PromExPlugin,
         Tuist.Runners.PromExPlugin,
         TuistCommon.HTTP.TransportPromExPlugin
       ]

--- a/server/lib/tuist/telemetry.ex
+++ b/server/lib/tuist/telemetry.ex
@@ -16,6 +16,10 @@ defmodule Tuist.Telemetry do
     [:tuist, :accounts, :organizations, :count]
   end
 
+  def event_name_license_status do
+    [:tuist, :license, :status]
+  end
+
   def event_name_storage_get_object_as_string_size do
     [:tuist, :storage, :get_object_size]
   end

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
       "defu": "6.1.5",
       "follow-redirects": "1.16.0",
       "protobufjs": "7.6.5",
-      "postcss": "8.5.12",
+      "postcss": "8.5.18",
       "shell-quote": "1.9.0",
       "form-data": "4.0.6",
       "@opentelemetry/core": "2.8.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   follow-redirects: 1.16.0
   form-data: 4.0.6
   mdast-util-to-hast: 13.2.1
-  postcss: 8.5.12
+  postcss: 8.5.18
   protobufjs: 7.6.5
   shell-quote: 1.9.0
   ts-deepmerge: 8.0.0
@@ -36,7 +36,7 @@ time:
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
-  postcss@8.5.12: 2026-04-26T14:23:03.643Z
+  postcss@8.5.18: 2026-07-12T20:38:40.936Z
   protobufjs@7.6.5: 2026-07-04T01:13:19.092Z
   shell-quote@1.9.0: 2026-06-25T04:47:19.588Z
   ts-deepmerge@8.0.0: 2026-05-22T00:15:00.073Z
@@ -1210,8 +1210,8 @@ packages:
     peerDependencies:
       postcss: 8.5.10
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.363.2:
@@ -2281,7 +2281,7 @@ snapshots:
       '@vue/shared': 3.5.30
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.12
+      postcss: 8.5.18
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.30':
@@ -2434,9 +2434,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-declaration-sorter@7.3.1(postcss@8.5.12):
+  css-declaration-sorter@7.3.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   csstype@3.2.3: {}
 
@@ -3169,15 +3169,15 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  postcss-less@6.0.0(postcss@8.5.12):
+  postcss-less@6.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
-  postcss-scss@4.0.9(postcss@8.5.12):
+  postcss-scss@4.0.9(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
-  postcss@8.5.12:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3203,9 +3203,9 @@ snapshots:
 
   prettier-plugin-css-order@2.2.0(prettier@3.5.3):
     dependencies:
-      css-declaration-sorter: 7.3.1(postcss@8.5.12)
-      postcss-less: 6.0.0(postcss@8.5.12)
-      postcss-scss: 4.0.9(postcss@8.5.12)
+      css-declaration-sorter: 7.3.1(postcss@8.5.18)
+      postcss-less: 6.0.0(postcss@8.5.18)
+      postcss-scss: 4.0.9(postcss@8.5.18)
       prettier: 3.5.3
     transitivePeerDependencies:
     - postcss

--- a/server/test/tuist/license/prom_ex_plugin_test.exs
+++ b/server/test/tuist/license/prom_ex_plugin_test.exs
@@ -1,0 +1,30 @@
+defmodule Tuist.License.PromExPluginTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.License
+  alias Tuist.License.PromExPlugin
+
+  test "reports a valid license and its expiration timestamp" do
+    expiration_date = ~U[2029-01-31 00:00:00Z]
+
+    assert PromExPlugin.license_status_measurements(
+             {:ok,
+              %License{
+                id: "license",
+                features: [],
+                expiration_date: expiration_date,
+                valid: true
+              }}
+           ) == %{
+             expiration_timestamp_seconds: 1_864_512_000,
+             valid: 1
+           }
+  end
+
+  test "reports an invalid state when license resolution fails" do
+    assert PromExPlugin.license_status_measurements({:error, :license_not_found}) == %{
+             expiration_timestamp_seconds: 0,
+             valid: 0
+           }
+  end
+end

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -114,6 +114,13 @@ defmodule Tuist.LicenseTest do
   end
 
   describe "resolve_certificate/2" do
+    test "decodes an environment certificate containing whitespace" do
+      encoded = Base.encode64("certificate")
+      wrapped = String.slice(encoded, 0, 4) <> "\n  " <> String.slice(encoded, 4..-1//1)
+
+      assert License.certificate(wrapped) == "certificate"
+    end
+
     test "returns valid license when certificate is valid with real signed data" do
       {public_key, private_key} = :crypto.generate_key(:eddsa, :ed25519)
       verify_key = Base.encode16(public_key, case: :lower)


### PR DESCRIPTION
## What changed

Production now uses the signed air-gapped license stored in 1Password and synchronized through External Secrets. The chart requires exactly one license source for every server workload, rejects missing or conflicting sources, and injects the offline certificate into the server, processor, result processor, registry synchronization worker, and migration job. The server validates the signature and expiry locally, and publishes validity and expiration metrics without making a new network request.

Stable outbound recovery now checks the data path directly instead of treating Kubernetes node readiness as the active-gateway health signal. Every candidate is preconfigured and must prove that its outbound address, routing rule, and routes exist before promotion. A failover removes old Cilium selectors, waits for the Hetzner assignment, then applies exactly one new selector. Direct-health and preparation failures use elapsed-time grace periods, and a failed provider move restores the selector only when the observed provider state identifies the holder.

The monitoring chart now collects the missing control-plane, etcd, Hetzner load-balancer, host, stable outbound, license, and [Kubernetes Cluster API](https://cluster-api.sigs.k8s.io/) signals. [`infra/helm/k8s-monitoring/alerts.md`](https://github.com/tuist/tuist/blob/chore/cluster-sentry-investigation/infra/helm/k8s-monitoring/alerts.md) contains 59 parser-validated Grafana alert and investigation queries, pending periods, missing-telemetry rules, and setup instructions.

Control-plane machines that never register a Kubernetes Node are no longer deleted and recreated indefinitely while the current bootstrap defect is unresolved. Replacement of a registered unhealthy member remains limited to one at a time.

A refreshed vulnerability scan also identified a fixed PostCSS path-traversal issue in the existing lockfile. The override and lockfile now pin PostCSS 8.5.18 without re-resolving unrelated frontend dependencies.

## Why

A brief control-endpoint interruption cascaded into a complete server outage through a readiness-driven stable outbound failover and synchronous online license validation. The service recovered, but the previous design could reproduce the same sequence and the available telemetry could not identify the initiating control-plane failure.

The license must remain mandatory so self-hosted users cannot bypass the feature-complete license. A signed offline certificate preserves that enforcement without making production startup depend on Keygen or outbound connectivity.

## Root cause

High availability had already eroded before the incident: production desired three control-plane members but had only one registered member for about 82 days.

Around 03:31:07 Coordinated Universal Time, the sole [Kubernetes application programming interface server](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) stopped completing requests for roughly 31 seconds. Server logs show request-handler timeouts, terminated requests, and lost [Hypertext Transfer Protocol version 2](https://httpwg.org/specs/rfc9113.html) connections. This proves a connection interruption at the control endpoint, but it does not prove a general Internet outage. The initiating host, process, storage, or network cause remains unknown because historical host and runtime metrics were missing.

At 03:31:28 Coordinated Universal Time, the resulting readiness interruption triggered stable outbound failover. Cilium observed the new gateway label before the host configurer had attached `116.202.0.10` and its source routes, and logged `no interface with 116.202.0.10 IPv4 assigned to`. No later event forced a fresh gateway calculation after the host finished configuring the address, so hosted server outbound traffic remained unusable.

Every server startup then synchronously validated its license with Keygen. That outbound request timed out, `server/lib/tuist/license.ex:175` raised, and `server/lib/tuist/application.ex:58` terminated each server replica. nginx consequently returned 503 responses.

A sole-host uplink or network-path interruption could have initiated the control-endpoint failure, but the evidence does not establish it. The Keygen timeout is evidence of the downstream stable outbound failure, not evidence that a general Internet outage started the incident.

The currently unresolved Sentry groups do not change this conclusion. The visible registry 403 errors are authorization failures, the ClickHouse read-only and memory-limit errors are database capacity failures, the Bandit read timeouts follow successful responses at the configured idle keepalive boundary, and the sampled PostgreSQL connection message was a client process exit rather than a shared transport outage. The ClickHouse failures deserve a separate follow-up.

```mermaid
flowchart TD
    A["High availability already degraded: 1 of 3 control-plane members registered"] --> B["Sole control endpoint stopped completing requests"]
    U["Initiating host, process, storage, or network cause is unknown"] -.-> B
    J["General Internet outage is possible but not demonstrated"] -.-> B
    B --> C["Kubernetes readiness interruption"]
    C --> D["Stable outbound address moved to standby"]
    D --> E["Cilium observed the gateway label before the address and routes existed"]
    E --> F["Hosted server outbound traffic became unusable"]
    F --> G["Online Keygen validation timed out during startup"]
    G --> H["Every server replica exited"]
    H --> I["nginx returned 503"]
```

## Approach

The solution removes both amplification points while retaining fail-closed licensing and conservative gateway behavior.

```mermaid
flowchart LR
    subgraph License["Mandatory offline licensing"]
        O["1Password signed certificate"] --> E["External Secrets"]
        E --> S["Every server workload"]
        S --> V["Local signature and expiry validation"]
    end

    subgraph Gateway["Stable outbound recovery"]
        C["Preconfigure every candidate"] --> P["Verify address, rule, and routes"]
        P --> D["Check Cilium directly with elapsed-time grace"]
        D --> R["Remove old selector"]
        R --> A["Wait for provider assignment"]
        A --> N["Apply exactly one new selector"]
    end

    subgraph Observe["Diagnosis and alerting"]
        M["Control plane, etcd, load balancer, host, gateway, license, and public probes"] --> G["Grafana rules with separate missing-telemetry alerts"]
    end
```

The active gateway ignores a brief node-readiness change while the Cilium listener remains reachable. A standby still must be ready, schedulable, non-deleting, directly reachable, and host-prepared before promotion. Controller leadership changes restart the grace period deliberately, preferring delayed recovery over a move based on stale health evidence.

The existing control-plane template is immutable. Versioning it now would trigger a rollout through a bootstrap path that is already failing. This change therefore disables automatic recycling only for machines that never register. The follow-up is to capture cloud-init, kubelet, container runtime, and kubeadm logs from the current replacement host, fix joining, verify a new member registers, then introduce a versioned template with bounded remediation retries.

## Impact

After deployment, production startup no longer calls Keygen. The required signed license remains enforced, and expiry is alertable before it becomes an outage.

A short Kubernetes readiness interruption no longer moves a healthy outbound gateway. A real data-path failure waits for 90 seconds of continuous direct-health failure before moving to an already prepared standby. Loss of host preparation uses a five-minute grace period to tolerate rollouts.

The change improves diagnosis but does not claim that control-plane high availability is restored. The current replacement reaches infrastructure-ready state but has not registered a Kubernetes Node. Automated deletion loops are paused until that bootstrap defect is diagnosed.

The Grafana rules are documented but are not created by this pull request. Threshold rules use normal handling for no data, while explicit missing-telemetry rules detect collectors or series that disappear.

## Validation

- `mise x go@1.25.10 -- go test -race ./...`
- `mise x go@1.25.10 -- go vet ./...`
- Focused Elixir formatting and license tests: 14 passed
- `mise run security`: zero vulnerable lockfile packages
- Frozen Aube install, dependency-tree check, and vulnerability audit passed
- Helm 4.1.4 lint for self-hosted, preview, K3s, platform, and management-monitoring profiles
- Strict Kubernetes schema validation with Kubeconform 0.7.0: zero invalid resources and zero errors
- Prometheus 3.5 `promtool check rules`: 59 rules parsed successfully
- Negative Helm checks proving missing, conflicting, and empty-selector configuration fails rendering
- Production rendering contains five offline-certificate references and zero online-key references
- Management-cluster server-side dry run accepts the control-plane health-check change
- Live production verification confirms four of four server replicas are ready with zero restarts, both stable outbound candidates are ready, and both controller replicas are healthy
- The production server rollout uses one surge replica and zero unavailable replicas; the pre-upgrade migration Job gates Deployment updates on the synchronized license certificate
- Live Cilium metrics confirm the retained `No Egress IP configured` drop reason and direction
- The signed license was validated without printing it, stored in the production 1Password vault, verified by streaming it back into the parser, and removed from the local filesystem
- Three focused headless Claude reviews covered stable outbound recovery, mandatory licensing, and monitoring semantics. Concrete findings were fixed and revalidated
