### PR TITLE
fix(server): bound stale test run resolution

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -3458,7 +3458,9 @@ defmodule Tuist.Tests do
     # `idx_status` skip index, which is the only thing that makes finding
     # `in_progress` rows cheap. Find candidate ids without FINAL (the skip
     # index then prunes granules), then re-resolve their latest version via
-    # the `proj_by_id` projection — FINAL over a small id set stays cheap.
+    # the `proj_by_id` projection. Status and age must be checked only after
+    # resolving the latest version, or an older in-progress version could
+    # overwrite a completed run.
     candidate_ids =
       ClickHouseRepo.all(
         from(t in Test,
@@ -3469,19 +3471,23 @@ defmodule Tuist.Tests do
         )
       )
 
-    stale_runs =
+    latest_candidate_runs =
       if candidate_ids == [] do
         []
       else
-        ClickHouseRepo.all(
-          from(t in Test,
-            hints: ["FINAL"],
-            where: t.id in ^candidate_ids,
-            where: t.status == "in_progress",
-            where: t.inserted_at < ^six_hours_ago
-          )
+        from(t in Test,
+          where: t.id in ^candidate_ids,
+          order_by: [asc: t.id, desc: t.inserted_at]
         )
+        |> ClickHouseRepo.all()
+        |> Enum.uniq_by(& &1.id)
       end
+
+    stale_runs =
+      Enum.filter(
+        latest_candidate_runs,
+        &(&1.status == "in_progress" and NaiveDateTime.before?(&1.inserted_at, six_hours_ago))
+      )
 
     updated_runs =
       Enum.map(stale_runs, fn run ->

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -9381,6 +9381,46 @@ defmodule Tuist.TestsTest do
 
       assert run.status == "success"
     end
+
+    test "does not expire a run whose latest version completed" do
+      project = ProjectsFixtures.project_fixture()
+      seven_hours_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -7, :hour)
+      one_hour_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -1, :hour)
+      completed_id = UUIDv7.generate()
+
+      common_attrs = %{
+        id: completed_id,
+        project_id: project.id,
+        account_id: project.account.id,
+        duration: 0,
+        model_identifier: "",
+        macos_version: "",
+        xcode_version: "",
+        git_branch: "main",
+        git_commit_sha: "",
+        git_ref: "",
+        ran_at: seven_hours_ago,
+        is_ci: true,
+        is_flaky: false
+      }
+
+      IngestRepo.insert_all(Tests.Test, [
+        Map.merge(common_attrs, %{status: "in_progress", inserted_at: seven_hours_ago}),
+        Map.merge(common_attrs, %{status: "success", duration: 5000, inserted_at: one_hour_ago})
+      ])
+
+      :ok = Tests.expire_stale_in_progress_test_runs()
+
+      latest =
+        Tests.Test
+        |> where([test], test.id == ^completed_id)
+        |> order_by([test], desc: test.inserted_at)
+        |> limit(1)
+        |> ClickHouseRepo.one()
+
+      assert latest.status == "success"
+      assert latest.inserted_at == one_hour_ago
+    end
   end
 
   defp test_report(project, test_cases) do


### PR DESCRIPTION
Part of #12038.

## What changed

The stale test-run reaper now uses a two-step lookup:

- Find old `in_progress` candidate identifiers through the existing status data-skipping index.
- Resolve only those identifiers through the existing identifier projection, choose the newest stored version, and then decide whether it is still stale.

The second lookup no longer uses `FINAL`, which previously expanded the read to most of `test_runs` and reached 2.09 gibibytes of memory.

## Why

The reaper runs every six hours. Its current query has read about 2.02 million rows for fewer than one hundred candidate runs and has become one of the largest ClickHouse memory consumers involved in the recent production failures.

## Root cause

`test_runs` uses a replacing table engine and stores every status transition as a new row. Applying `FINAL` while resolving candidates prevents the identifier projection from bounding the read.

Dropping `FINAL` alone would be incorrect. An older `in_progress` version remains stored after a run completes, so status and age predicates must be applied only after selecting the newest version for each identifier.

## Approach

The first query remains a cheap superset lookup. The second query reads all stored versions only for that small identifier set, orders them newest first, deduplicates them in application memory, and evaluates staleness on the resolved version.

This preserves the replacing-table semantics without forcing ClickHouse to finalize the full table.

## Impact

Completed and recently active runs remain untouched. Genuinely stale runs are still marked as failures, and missing shard results are still synthesized through the existing path.

This is an application-only query change. It adds no table, projection, materialized view, or backfill.

## Validation

- `MIX_ENV=test mix test test/tuist/tests_test.exs:9280` on the repository-pinned ClickHouse 26.1.2.11
- All four stale-run regression cases passed, including a stored old `in_progress` version followed by a newer `success` version.
- `mix format --check-formatted lib/tuist/tests.ex test/tuist/tests_test.exs`
- `git diff --check`

After deployment, verify that the reaper query remains below 50 mebibytes of peak memory and that two consecutive worker executions do not write another failure version for an already-resolved run.