### PR TITLE
fix(server): bound command event reads

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -16,7 +16,7 @@ defmodule Tuist.CommandEvents do
   alias Tuist.Storage
   alias Tuist.Time
 
-  @optimized_list_index_fields [:id, :ran_at, :duration, :hit_rate]
+  @optimized_list_index_fields [:id, :project_id, :ran_at, :duration, :hit_rate]
 
   def list_command_events(attrs, _opts \\ []) do
     optimized_table = sort_optimized_table(attrs)
@@ -750,7 +750,7 @@ defmodule Tuist.CommandEvents do
 
     hit_rates =
       ClickHouseRepo.all(
-        from(e in {"command_events_by_ran_at", Event},
+        from(e in Event,
           where:
             e.project_id == ^project_id and
               e.cacheable_targets_count > 0,
@@ -1134,17 +1134,18 @@ defmodule Tuist.CommandEvents do
   defp hydrate_optimized_list_results([], _optimized_table), do: []
 
   defp hydrate_optimized_list_results(results, _optimized_table) do
+    project_ids = results |> Enum.map(& &1.project_id) |> Enum.uniq()
     ids = Enum.map(results, & &1.id)
 
-    events_by_id =
+    events_by_key =
       Event
-      |> where([event], event.id in ^ids)
-      |> order_by([event], asc: event.id, desc: event.updated_at)
+      |> where([event], event.project_id in ^project_ids and event.id in ^ids)
+      |> order_by([event], asc: event.project_id, asc: event.id, desc: event.updated_at)
       |> ClickHouseRepo.all()
-      |> Enum.uniq_by(& &1.id)
-      |> Map.new(&{&1.id, &1})
+      |> Enum.uniq_by(&{&1.project_id, &1.id})
+      |> Map.new(&{{&1.project_id, &1.id}, &1})
 
-    Enum.map(ids, &Map.fetch!(events_by_id, &1))
+    Enum.map(results, &Map.fetch!(events_by_key, {&1.project_id, &1.id}))
   end
 
   defp sort_optimized_table(%{order_by: [field | _]}) when field in [:duration, "duration"],

--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -16,17 +16,22 @@ defmodule Tuist.CommandEvents do
   alias Tuist.Storage
   alias Tuist.Time
 
+  @optimized_list_index_fields [:id, :ran_at, :duration, :hit_rate]
+
   def list_command_events(attrs, _opts \\ []) do
+    optimized_table = sort_optimized_table(attrs)
+
     queryable =
-      case sort_optimized_table(attrs) do
+      case optimized_table do
         nil -> Event
-        table -> from(_ in {table, Event})
+        table -> from(event in {table, Event}, select: struct(event, @optimized_list_index_fields))
       end
 
     {results, meta} = ClickHouseFlop.validate_and_run!(queryable, attrs, for: Event)
 
     results =
       results
+      |> hydrate_optimized_list_results(optimized_table)
       |> Enum.map(&Event.normalize_enums/1)
       |> attach_user_account_names()
 
@@ -745,7 +750,7 @@ defmodule Tuist.CommandEvents do
 
     hit_rates =
       ClickHouseRepo.all(
-        from(e in Event,
+        from(e in {"command_events_by_ran_at", Event},
           where:
             e.project_id == ^project_id and
               e.cacheable_targets_count > 0,
@@ -1123,6 +1128,23 @@ defmodule Tuist.CommandEvents do
       user_name = if run.user_id, do: Map.get(user_map, run.user_id)
       {run.id, user_name}
     end)
+  end
+
+  defp hydrate_optimized_list_results(results, nil), do: results
+  defp hydrate_optimized_list_results([], _optimized_table), do: []
+
+  defp hydrate_optimized_list_results(results, _optimized_table) do
+    ids = Enum.map(results, & &1.id)
+
+    events_by_id =
+      Event
+      |> where([event], event.id in ^ids)
+      |> order_by([event], asc: event.id, desc: event.updated_at)
+      |> ClickHouseRepo.all()
+      |> Enum.uniq_by(& &1.id)
+      |> Map.new(&{&1.id, &1})
+
+    Enum.map(ids, &Map.fetch!(events_by_id, &1))
   end
 
   defp sort_optimized_table(%{order_by: [field | _]}) when field in [:duration, "duration"],

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -463,6 +463,42 @@ defmodule Tuist.CommandEventsTest do
                  {["App", "Framework"], ["App"], []}
                ]
     end
+
+    test "hydrates optimized rows within the selected project when identifiers collide" do
+      project = ProjectsFixtures.project_fixture()
+      other_project = ProjectsFixtures.project_fixture()
+      shared_id = UUIDv7.generate()
+
+      selected_event =
+        CommandEventsFixtures.command_event_fixture(
+          id: shared_id,
+          project_id: project.id,
+          name: "cache",
+          cacheable_targets: ["SelectedApp"]
+        )
+
+      CommandEventsFixtures.command_event_fixture(
+        id: shared_id,
+        project_id: other_project.id,
+        name: "cache",
+        cacheable_targets: ["OtherApp"]
+      )
+
+      {events, _meta} =
+        CommandEvents.list_command_events(%{
+          filters: [
+            %{field: :project_id, op: :==, value: project.id},
+            %{field: :name, op: :==, value: "cache"}
+          ],
+          order_by: [:ran_at],
+          order_directions: [:desc],
+          first: 10
+        })
+
+      assert [%{project_id: project_id, cacheable_targets: ["SelectedApp"]}] = events
+      assert project_id == project.id
+      assert hd(events).id == selected_event.id
+    end
   end
 
   describe "list_test_runs/1" do

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -352,7 +352,13 @@ defmodule Tuist.CommandEventsTest do
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           name: "cache",
-          ran_at: ~U[2024-03-04 01:00:00Z]
+          ran_at: ~U[2024-03-04 01:00:00Z],
+          cacheable_targets: ["App", "Framework"],
+          local_cache_target_hits: ["App"],
+          remote_cache_target_hits: ["Framework"],
+          test_targets: ["AppTests"],
+          local_test_target_hits: ["AppTests"],
+          remote_test_target_hits: ["AppTests"]
         )
 
       # A non-matching command interleaved in time must be excluded even though
@@ -384,6 +390,78 @@ defmodule Tuist.CommandEventsTest do
 
       # Then
       assert Enum.map(events, & &1.id) == [cache_event_new.id, cache_event_old.id]
+
+      hydrated_old = List.last(events)
+      assert hydrated_old.cacheable_targets == ["App", "Framework"]
+      assert hydrated_old.local_cache_target_hits == ["App"]
+      assert hydrated_old.remote_cache_target_hits == ["Framework"]
+      assert hydrated_old.test_targets == ["AppTests"]
+      assert hydrated_old.local_test_target_hits == ["AppTests"]
+      assert hydrated_old.remote_test_target_hits == ["AppTests"]
+    end
+
+    test "returns fully hydrated events ordered by duration" do
+      project = ProjectsFixtures.project_fixture()
+
+      slow_event =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          duration: 3000,
+          cacheable_targets: ["SlowApp"]
+        )
+
+      fast_event =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          duration: 1000,
+          cacheable_targets: ["FastApp"]
+        )
+
+      {events, _meta} =
+        CommandEvents.list_command_events(%{
+          filters: [%{field: :project_id, op: :==, value: project.id}],
+          order_by: [:duration],
+          order_directions: [:desc],
+          first: 10
+        })
+
+      assert Enum.map(events, & &1.id) == [slow_event.id, fast_event.id]
+      assert Enum.map(events, & &1.cacheable_targets) == [["SlowApp"], ["FastApp"]]
+    end
+
+    test "returns fully hydrated events ordered by hit rate" do
+      project = ProjectsFixtures.project_fixture()
+
+      half_hit_event =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          cacheable_targets: ["App", "Framework"],
+          local_cache_target_hits: ["App"]
+        )
+
+      full_hit_event =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          cacheable_targets: ["App", "Framework"],
+          local_cache_target_hits: ["App"],
+          remote_cache_target_hits: ["Framework"]
+        )
+
+      {events, _meta} =
+        CommandEvents.list_command_events(%{
+          filters: [%{field: :project_id, op: :==, value: project.id}],
+          order_by: [:hit_rate],
+          order_directions: [:desc],
+          first: 10
+        })
+
+      assert Enum.map(events, & &1.id) == [full_hit_event.id, half_hit_event.id]
+
+      assert Enum.map(events, &{&1.cacheable_targets, &1.local_cache_target_hits, &1.remote_cache_target_hits}) ==
+               [
+                 {["App", "Framework"], ["App"], ["Framework"]},
+                 {["App", "Framework"], ["App"], []}
+               ]
     end
   end
 


### PR DESCRIPTION
Part of #12038.

## What changed

Command-event list queries that use a sort-optimized table now read only the project identifier, event identifier, and pagination fields from that wide table. The returned page is then hydrated from `command_events` using both the project and event identifiers, and the original page order is restored.

The cache-hit metric remains on the canonical `command_events` table.

## Why

Production query telemetry showed name-filtered pages using between 850 mebibytes and one gibibyte, including 52 repeated executions. These pages selected every array column while finding only one page of identifiers.

## Root cause

The list endpoint needs the full event payload, but ClickHouse was forced to read the large target arrays for every candidate row before pagination. Event identifiers are supplied by clients and are not globally unique, so hydrating by event identifier alone could also select an event from another project when identifiers collide.

The existing run-time materialized table was created with `POPULATE`, which can miss writes that happen during population. It is therefore not safe to make that table authoritative for the cache-hit metric without a gap-free rebuild.

## Approach

The list keeps all existing filters, ordering, cursor metadata, and response fields. Only the index phase is narrow. Hydration is limited to the returned page, scoped by project and event identifier, and keyed by that same pair.

The cache-hit metric optimization is deliberately deferred. It will require a gap-free table rebuild before the run-time table can safely replace the canonical source.

## Impact

Command-event pages retain the same identifiers, order, pagination, user names, and complete array payloads. The additional project scope prevents cross-project hydration when client-supplied identifiers collide.

This adds no table, projection, materialized view, backfill, or user-visible data change. It reduces memory pressure from command-event list pages, but does not yet optimize the cache-hit metric query.

## Validation

- The full command-event test file passed against ClickHouse 26.1.2.11: 72 tests, 0 failures.
- Added a regression test with the same client-supplied event identifier in two projects and verified that hydration returns only the selected project's payload.
- Verified run-time, duration, and hit-rate ordering; complete array hydration; pagination; cache-hit averages and percentiles; empty projects; and zero-cacheable-target exclusion.
- `mix format --check-formatted lib/tuist/command_events.ex test/tuist/command_events_test.exs`
- `git diff --check`

After deployment, compare returned page identifiers and order in canary, then verify name-filtered list memory remains below 100 mebibytes before proceeding to production.