### PR TITLE
fix(server): bound test case state filtering

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -65,6 +65,10 @@ defmodule Tuist.Tests do
   @active_window_days 14
   @short_cache_ttl to_timeout(second: 10)
   @unscoped_test_suite_runs_lookback_days 7
+  # ClickHouse query parameters are encoded in the request address. Ten thousand
+  # identifiers stay comfortably below its default one-mebibyte limit while
+  # still covering the small explicit-state sets this path is designed for.
+  @max_preloaded_test_case_states 10_000
 
   @doc """
   Number of trailing days used across the product to decide whether a test case
@@ -1083,6 +1087,27 @@ defmodule Tuist.Tests do
         is_flaky: fragment("argMaxIf(?, ?, isNotNull(?))", s.is_flaky, s.inserted_at, s.is_flaky)
       }
     )
+  end
+
+  defp resolve_test_case_states(project_id, test_case_ids \\ nil)
+
+  defp resolve_test_case_states(_project_id, []), do: %{}
+
+  defp resolve_test_case_states(project_id, test_case_ids) do
+    query = test_case_states_subquery(project_id)
+
+    query =
+      if is_nil(test_case_ids) do
+        query
+      else
+        where(query, [state], state.test_case_id in ^test_case_ids)
+      end
+
+    query
+    |> ClickHouseRepo.all()
+    |> Map.new(fn state ->
+      {state.test_case_id, normalize_test_case_state(state)}
+    end)
   end
 
   @doc """
@@ -2231,22 +2256,45 @@ defmodule Tuist.Tests do
     quarantine_filter? = quarantine_filter?(filters)
     is_ci = Keyword.get(opts, :is_ci)
 
-    # `state` / `is_flaky` are resolved from the joined `test_case_states`
-    # subquery, not from the columns Flop would reach on `test_cases`, so they
-    # are pulled out of the Flop filter set and applied by hand below.
+    # `state` / `is_flaky` are resolved from `test_case_states`, not from the
+    # legacy columns on `test_cases`, so they are pulled out of the Flop filter
+    # set and applied by hand below.
     {control_plane_filters, flop_filters} = Enum.split_with(filters, &control_plane_filter?/1)
     attrs = Map.put(attrs, :filters, flop_filters)
 
-    base_query =
-      from(test_case in TestCase,
-        hints: ["FINAL"],
-        left_join: test_case_state in subquery(test_case_states_subquery(project_id)),
-        as: :test_case_state,
-        on: test_case.id == test_case_state.test_case_id,
-        where: test_case.project_id == ^project_id
-      )
+    {state_filter_mode, resolved_states} =
+      state_filter_mode(project_id, control_plane_filters)
 
-    base_query = Enum.reduce(control_plane_filters, base_query, &apply_control_plane_filter/2)
+    base_query =
+      case state_filter_mode do
+        :joined ->
+          from(test_case in TestCase,
+            hints: ["FINAL"],
+            left_join: test_case_state in subquery(test_case_states_subquery(project_id)),
+            as: :test_case_state,
+            on: test_case.id == test_case_state.test_case_id,
+            where: test_case.project_id == ^project_id
+          )
+
+        :preloaded ->
+          from(test_case in TestCase,
+            hints: ["FINAL"],
+            where: test_case.project_id == ^project_id
+          )
+      end
+
+    base_query =
+      case state_filter_mode do
+        :joined ->
+          Enum.reduce(control_plane_filters, base_query, &apply_joined_control_plane_filter/2)
+
+        :preloaded ->
+          apply_preloaded_control_plane_filters(
+            control_plane_filters,
+            base_query,
+            resolved_states
+          )
+      end
 
     base_query =
       cond do
@@ -2268,9 +2316,39 @@ defmodule Tuist.Tests do
     flop = Tuist.ClickHouseFlop.validate!(attrs, for: TestCase)
     total_count = test_cases_count(base_query, flop)
 
-    base_query
-    |> select_resolved_test_case_state()
-    |> Tuist.ClickHouseFlop.run(flop, for: TestCase, count: total_count)
+    case state_filter_mode do
+      :joined ->
+        base_query
+        |> select_resolved_test_case_state()
+        |> Tuist.ClickHouseFlop.run(flop, for: TestCase, count: total_count)
+
+      :preloaded ->
+        {test_cases, meta} =
+          Tuist.ClickHouseFlop.run(base_query, flop, for: TestCase, count: total_count)
+
+        resolved_page_states =
+          resolve_test_case_states(project_id, Enum.map(test_cases, & &1.id))
+
+        test_cases =
+          Enum.map(test_cases, fn test_case ->
+            resolved = Map.get(resolved_page_states, test_case.id, @default_test_case_state)
+            apply_test_case_state(test_case, resolved)
+          end)
+
+        {test_cases, meta}
+    end
+  end
+
+  defp state_filter_mode(_project_id, []), do: {:preloaded, %{}}
+
+  defp state_filter_mode(project_id, _control_plane_filters) do
+    resolved_states = resolve_test_case_states(project_id)
+
+    if map_size(resolved_states) <= @max_preloaded_test_case_states do
+      {:preloaded, resolved_states}
+    else
+      {:joined, %{}}
+    end
   end
 
   # Two different nulls collapse to the same answer here. A test case with no
@@ -2298,9 +2376,84 @@ defmodule Tuist.Tests do
 
   # Only the operators the callers actually build: `:==` / `:!=` from the
   # dashboard's option filter, `:==` / `:in` from the API's `state` and
-  # `quarantined` params. Anything else raises rather than silently degrading to
-  # equality, which would invert the meaning of a negated filter.
-  defp apply_control_plane_filter(filter, query) do
+  # `quarantined` params. Anything else matches nothing rather than silently
+  # degrading to equality, which would invert the meaning of a negated filter.
+  defp apply_preloaded_control_plane_filters(filters, query, resolved_states) do
+    case control_plane_filter_matchers(filters) do
+      {:ok, matchers} ->
+        matcher = fn state -> Enum.all?(matchers, & &1.(state)) end
+        default_matches? = matcher.(@default_test_case_state)
+
+        {matching_ids, non_matching_ids} =
+          Enum.reduce(resolved_states, {[], []}, fn {test_case_id, state}, {matching, non_matching} ->
+            if matcher.(state) do
+              {[test_case_id | matching], non_matching}
+            else
+              {matching, [test_case_id | non_matching]}
+            end
+          end)
+
+        apply_resolved_state_ids(query, default_matches?, matching_ids, non_matching_ids)
+
+      :error ->
+        where(query, false)
+    end
+  end
+
+  defp control_plane_filter_matchers(filters) do
+    Enum.reduce_while(filters, {:ok, []}, fn filter, {:ok, matchers} ->
+      case control_plane_filter_matcher(filter) do
+        {:ok, matcher} ->
+          {:cont, {:ok, [matcher | matchers]}}
+
+        :error ->
+          log_unsupported_control_plane_filter(filter)
+          {:halt, :error}
+      end
+    end)
+  end
+
+  defp control_plane_filter_matcher(filter) do
+    op = Map.get(filter, :op, :==)
+    value = Map.get(filter, :value)
+
+    case {control_plane_filter_field(filter), op} do
+      {:state, :in} ->
+        values = List.wrap(value)
+        {:ok, &Enum.member?(values, &1.state)}
+
+      {:state, :not_in} ->
+        values = List.wrap(value)
+        {:ok, &(not Enum.member?(values, &1.state))}
+
+      {:state, :==} ->
+        {:ok, &(&1.state == value)}
+
+      {:state, :!=} ->
+        {:ok, &(&1.state != value)}
+
+      {:is_flaky, :==} ->
+        {:ok, &(&1.is_flaky == value)}
+
+      {:is_flaky, :!=} ->
+        {:ok, &(&1.is_flaky != value)}
+
+      {_field, _op} ->
+        :error
+    end
+  end
+
+  defp apply_resolved_state_ids(query, true, _matching_ids, []), do: query
+
+  defp apply_resolved_state_ids(query, true, _matching_ids, non_matching_ids),
+    do: where(query, [test_case], test_case.id not in ^non_matching_ids)
+
+  defp apply_resolved_state_ids(query, false, [], _non_matching_ids), do: where(query, false)
+
+  defp apply_resolved_state_ids(query, false, matching_ids, _non_matching_ids),
+    do: where(query, [test_case], test_case.id in ^matching_ids)
+
+  defp apply_joined_control_plane_filter(filter, query) do
     op = Map.get(filter, :op, :==)
     value = Map.get(filter, :value)
 
@@ -2348,18 +2501,24 @@ defmodule Tuist.Tests do
         where(query, [test_case_state: state], fragment("ifNull(?, false) != ?", state.is_flaky, ^value))
 
       {field, op} ->
-        # Neither the dashboard nor the public API builds anything else: the
-        # trait filter's dropdown only offers `:==` and `:!=`, and the API
-        # hard-codes `:==` and `:in`. A hand-edited query string can still
-        # smuggle one of the other Noora operators through, because the
-        # operator whitelist there isn't narrowed to the filter's type. Match
-        # nothing rather than raising: this runs inside the listing's
-        # `assign_async`, where an exception surfaces as an empty table anyway,
-        # only with a crashed task and the error noise that comes with it.
-        Logger.warning("Ignoring test case #{field} filter with unsupported operator #{inspect(op)}")
-
+        log_unsupported_control_plane_filter(%{field: field, op: op})
         where(query, false)
     end
+  end
+
+  defp log_unsupported_control_plane_filter(filter) do
+    field = control_plane_filter_field(filter)
+    op = Map.get(filter, :op, :==)
+
+    # Neither the dashboard nor the public API builds anything else: the
+    # trait filter's dropdown only offers `:==` and `:!=`, and the API
+    # hard-codes `:==` and `:in`. A hand-edited query string can still
+    # smuggle one of the other Noora operators through, because the
+    # operator whitelist there isn't narrowed to the filter's type. Match
+    # nothing rather than raising: this runs inside the listing's
+    # `assign_async`, where an exception surfaces as an empty table anyway,
+    # only with a crashed task and the error noise that comes with it.
+    Logger.warning("Ignoring test case #{field} filter with unsupported operator #{inspect(op)}")
   end
 
   defp test_cases_count(query, flop) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -3387,6 +3387,58 @@ defmodule Tuist.TestsTest do
       assert not_flaky |> Enum.map(& &1.name) |> Enum.sort() == ["mutedTest", "plainTest"]
     end
 
+    test "preserves default state semantics for every supported control-plane filter" do
+      project = ProjectsFixtures.project_fixture()
+
+      plain = RunsFixtures.test_case_fixture(project_id: project.id, name: "plain")
+      enabled = RunsFixtures.test_case_fixture(project_id: project.id, name: "enabled", state: "enabled")
+      muted = RunsFixtures.test_case_fixture(project_id: project.id, name: "muted", state: "muted")
+      skipped = RunsFixtures.test_case_fixture(project_id: project.id, name: "skipped", state: "skipped")
+      flaky = RunsFixtures.test_case_fixture(project_id: project.id, name: "flaky", is_flaky: true)
+
+      muted_flaky =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "muted_flaky",
+          state: "muted",
+          is_flaky: true
+        )
+
+      IngestRepo.insert_all(
+        TestCase,
+        Enum.map(
+          [plain, enabled, muted, skipped, flaky, muted_flaky],
+          &(&1 |> Map.from_struct() |> Map.delete(:__meta__))
+        )
+      )
+
+      assert listed_test_case_names(project.id, [%{field: :state, op: :==, value: "enabled"}]) ==
+               ~w(enabled flaky plain)
+
+      assert listed_test_case_names(project.id, [%{field: :state, op: :!=, value: "enabled"}]) ==
+               ~w(muted muted_flaky skipped)
+
+      assert listed_test_case_names(project.id, [
+               %{field: :state, op: :in, value: ["enabled", "muted"]}
+             ]) ==
+               ~w(enabled flaky muted muted_flaky plain)
+
+      assert listed_test_case_names(project.id, [
+               %{field: :state, op: :not_in, value: ["enabled", "muted"]}
+             ]) == ["skipped"]
+
+      assert listed_test_case_names(project.id, [%{field: :is_flaky, op: :==, value: true}]) ==
+               ~w(flaky muted_flaky)
+
+      assert listed_test_case_names(project.id, [%{field: :is_flaky, op: :==, value: false}]) ==
+               ~w(enabled muted plain skipped)
+
+      assert listed_test_case_names(project.id, [
+               %{field: :state, op: :==, value: "muted"},
+               %{field: :is_flaky, op: :==, value: true}
+             ]) == ["muted_flaky"]
+    end
+
     test "preserves state when an in-flight ingestion read the row before the mute" do
       # Ingestion snapshots the existing test case rows once per report and only
       # stamps `inserted_at` later, per module. A mute landing inside that window
@@ -9421,6 +9473,14 @@ defmodule Tuist.TestsTest do
       assert latest.status == "success"
       assert latest.inserted_at == one_hour_ago
     end
+  end
+
+  defp listed_test_case_names(project_id, filters) do
+    {test_cases, _meta} = Tests.list_test_cases(project_id, %{filters: filters})
+
+    test_cases
+    |> Enum.map(& &1.name)
+    |> Enum.sort()
   end
 
   defp test_report(project, test_cases) do


### PR DESCRIPTION
Part of #12038.

## What changed

Test-case listing no longer joins every project test case to `test_case_states` before applying state and flaky filters.

For projects with at most 10,000 explicit state rows, the listing resolves the small state table first and translates all control-plane filters into one identifier inclusion or exclusion predicate on `test_cases`. It then resolves state only for the returned page. Projects above that guard retain the existing join path.

## Why

The muted-test listing reached 647 mebibytes across 294 executions. The state table is small, but the post-join predicate forced ClickHouse to materialize and sort roughly 303,000 test cases for the affected project before returning a page of 500 rows.

## Root cause

Missing state rows mean `enabled` and not flaky. That default was previously expressed through `ifNull` after a left join, so ClickHouse could not use the filtered test-case identifiers to bound the large side of the query.

## Approach

Each supported filter is evaluated against both the explicit state map and the default state:

- If the default matches, the query excludes only explicit identifiers that do not match.
- If the default does not match, the query includes only explicit identifiers that do match.

All state and flaky filters are combined before producing the predicate. This preserves conjunction semantics while sending only one identifier parameter to ClickHouse.

The 10,000-row guard keeps that parameter at roughly 450 kilobytes, comfortably below ClickHouse's default one-mebibyte request-address limit. Projects above the guard use the existing join as a correctness-preserving fallback.

This preserves equality, negation, `in`, `not_in`, missing-row defaults, combined state and flaky filters, and the legacy quarantined filter. `FINAL` remains on `test_cases`, so replacing-table deduplication and pagination counts are unchanged.

## Impact

Muted, skipped, enabled, flaky, and non-flaky listings retain their existing semantics. Quarantined tests still bypass the 14-day active window, including skipped tests that have not run recently. Returned test-case structs still contain resolved state and flaky values.

This adds no table, projection, materialized view, backfill, or customer migration.

## Validation

- Rebasing onto the current `main` completed without conflicts.
- `MIX_ENV=test TUIST_SERVER_CLICKHOUSE_HTTP_PORT=18124 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_pr12084_test TUIST_SERVER_TEST_POSTGRES_DB=tuist_pr12084_test mix test test/tuist/tests_test.exs:3125`
- All 12 focused test-case listing tests passed against ClickHouse 26.3.9.8 with transaction isolation enabled.
- Coverage includes pagination and total counts, deterministic tied-row pagination, state preservation during ingestion, unsupported operators, equality and negation, `in` and `not_in` with `enabled`, missing-row defaults, combined state and flaky filters, and the quarantine active-window bypass.
- `mix format --check-formatted lib/tuist/tests.ex test/tuist/tests_test.exs`
- `git diff --check`
- A 10,000-identifier parameter encodes to approximately 450 kilobytes, below ClickHouse's default 1,048,576-byte request-address limit.

After deployment, compare every supported filter shape against the existing query on the canary environment, then verify muted and skipped listings remain below 50 mebibytes of peak memory.
