### PR TITLE
fix(server): bound automation evaluation windows

### DIFF
--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -27,7 +27,7 @@ defmodule Tuist.Automations do
   # project-wide identifier set as one scan.
   @max_scoped_evaluation_range_size 2000
   @minimum_scoped_evaluation_ranges 4
-  @max_scoped_evaluation_window_seconds [hour: 1] |> to_timeout() |> div(1000)
+  @max_scoped_evaluation_window_seconds [minute: 15] |> to_timeout() |> div(1000)
 
   def list_alerts(project_id) do
     Alert

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -27,6 +27,7 @@ defmodule Tuist.Automations do
   # project-wide identifier set as one scan.
   @max_scoped_evaluation_range_size 2000
   @minimum_scoped_evaluation_ranges 4
+  @max_scoped_evaluation_window_seconds [hour: 1] |> to_timeout() |> div(1000)
 
   def list_alerts(project_id) do
     Alert
@@ -200,37 +201,44 @@ defmodule Tuist.Automations do
   end
 
   def recent_test_case_run_changes_for_alert(%Alert{} = alert) do
-    recent_test_case_run_changes(alert.project_id, scoped_evaluation_query_since(alert))
+    now = DateTime.utc_now(:second)
+    cursor = scoped_evaluation_cursor(alert, now)
+    recent_test_case_run_changes(alert.project_id, cursor, now)
   end
 
   def recent_test_case_run_changes_for_alerts([%Alert{} = alert | _alerts] = alerts) do
-    since =
+    now = DateTime.utc_now(:second)
+
+    cursor =
       alerts
-      |> Enum.map(&scoped_evaluation_query_since/1)
+      |> Enum.map(&scoped_evaluation_cursor(&1, now))
       |> Enum.min(DateTime)
 
-    recent_test_case_run_changes(alert.project_id, since)
+    recent_test_case_run_changes(alert.project_id, cursor, now)
   end
 
-  defp recent_test_case_run_changes(project_id, since) do
-    rows =
+  defp recent_test_case_run_changes(project_id, cursor, now) do
+    query_start = DateTime.add(cursor, -scoped_evaluation_cursor_lookback_seconds(), :second)
+
+    window_end = Enum.min([DateTime.add(cursor, @max_scoped_evaluation_window_seconds, :second), now], DateTime)
+
+    test_case_ids =
       ClickHouseRepo.all(
         from(r in {"test_case_runs_by_inserted_at", TestCaseRun},
           where: r.project_id == ^project_id,
           where: not is_nil(r.test_case_id),
-          where: r.inserted_at >= ^DateTime.to_naive(since),
+          where: r.inserted_at >= ^DateTime.to_naive(query_start),
+          where: r.inserted_at < ^DateTime.to_naive(window_end),
           group_by: r.test_case_id,
           order_by: [asc: r.test_case_id],
-          select: %{
-            test_case_id: r.test_case_id,
-            last_inserted_at: max(r.inserted_at)
-          }
+          select: r.test_case_id
         )
       )
 
     %{
-      test_case_ids: Enum.map(rows, & &1.test_case_id),
-      cursor: latest_inserted_at_cursor(rows) || DateTime.utc_now(:second)
+      test_case_ids: test_case_ids,
+      cursor: window_end,
+      more?: DateTime.before?(window_end, now)
     }
   end
 
@@ -295,13 +303,8 @@ defmodule Tuist.Automations do
     div(Environment.clickhouse_flush_interval_ms(), 1000) + 1
   end
 
-  defp scoped_evaluation_query_since(%Alert{last_scoped_evaluation_inserted_at: nil}) do
-    DateTime.add(DateTime.utc_now(:second), -scoped_evaluation_cursor_lookback_seconds(), :second)
-  end
-
-  defp scoped_evaluation_query_since(%Alert{last_scoped_evaluation_inserted_at: cursor}) do
-    DateTime.add(cursor, -scoped_evaluation_cursor_lookback_seconds(), :second)
-  end
+  defp scoped_evaluation_cursor(%Alert{last_scoped_evaluation_inserted_at: nil}, now), do: now
+  defp scoped_evaluation_cursor(%Alert{last_scoped_evaluation_inserted_at: cursor}, _now), do: cursor
 
   defp scoped_evaluation_cursor_lookback_seconds do
     max(alert_evaluation_schedule_in(), 10)
@@ -311,27 +314,6 @@ defmodule Tuist.Automations do
 
   defp later_cursor(current_cursor, cursor) do
     Enum.max([current_cursor, cursor], DateTime)
-  end
-
-  defp latest_inserted_at_cursor([]), do: nil
-
-  defp latest_inserted_at_cursor(rows) do
-    rows
-    |> Enum.map(&clickhouse_datetime_to_utc_datetime(&1.last_inserted_at))
-    |> Enum.max_by(&DateTime.to_unix(&1, :microsecond))
-    |> DateTime.truncate(:second)
-  end
-
-  defp clickhouse_datetime_to_utc_datetime(%DateTime{} = datetime) do
-    datetime
-    |> DateTime.shift_zone!("Etc/UTC")
-    |> DateTime.truncate(:second)
-  end
-
-  defp clickhouse_datetime_to_utc_datetime(%NaiveDateTime{} = datetime) do
-    datetime
-    |> NaiveDateTime.truncate(:second)
-    |> DateTime.from_naive!("Etc/UTC")
   end
 
   @doc """

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -192,7 +192,7 @@ defmodule Tuist.Automations do
         unique: [
           keys: [:project_id, :cadence_seconds, :evaluate_recent_test_case_runs],
           period: :infinity,
-          states: [:available, :scheduled]
+          states: [:available, :scheduled, :executing, :retryable]
         ]
       )
       |> Oban.insert()

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -19,15 +19,18 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   # `Array(UUID)` parameter and the run scan stay within the engine's request
   # limits no matter how many tests an alert has quarantined.
   @recovery_candidate_batch_size 500
+  @attempts_per_window 3
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{
-          "project_id" => project_id,
-          "cadence_seconds" => cadence_seconds,
-          "evaluate_recent_test_case_runs" => true
-        }
-      }) do
+  def perform(
+        %Oban.Job{
+          args: %{
+            "project_id" => project_id,
+            "cadence_seconds" => cadence_seconds,
+            "evaluate_recent_test_case_runs" => true
+          }
+        } = job
+      ) do
     alerts =
       project_id
       |> Automations.list_alerts()
@@ -37,10 +40,10 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
           trigger_window_supported?(alert)
       end)
 
-    evaluate_recent_test_case_runs_and_execute(alerts)
+    evaluate_recent_test_case_runs_and_execute(alerts, job)
   end
 
-  def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args}) do
+  def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args} = job) do
     case Automations.get_alert(alert_id) do
       {:ok, alert} ->
         cond do
@@ -51,7 +54,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
             :ok
 
           evaluate_recent_test_case_runs?(args) ->
-            evaluate_recent_test_case_runs_and_execute(alert)
+            evaluate_recent_test_case_runs_and_execute(alert, job)
 
           true ->
             evaluate_and_execute(alert, scoped_test_case_ids(args))
@@ -74,7 +77,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     end
   end
 
-  defp evaluate_recent_test_case_runs_and_execute(%Alert{} = alert) do
+  defp evaluate_recent_test_case_runs_and_execute(%Alert{} = alert, job) do
     if alert.baseline_established_at == nil do
       evaluate_and_execute(alert, nil)
     else
@@ -86,21 +89,21 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       |> Enum.each(&evaluate_and_execute(alert, &1))
 
       {:ok, updated_alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
-      enqueue_next_scoped_evaluation(updated_alert, more?)
+      continue_scoped_evaluation(updated_alert, job, more?)
     end
-
-    :ok
   end
 
-  defp evaluate_recent_test_case_runs_and_execute([]), do: :ok
+  defp evaluate_recent_test_case_runs_and_execute([], _job), do: :ok
 
-  defp evaluate_recent_test_case_runs_and_execute(alerts) when is_list(alerts) do
+  defp evaluate_recent_test_case_runs_and_execute(alerts, job) when is_list(alerts) do
     {established_alerts, pending_baseline_alerts} =
       Enum.split_with(alerts, &(&1.baseline_established_at != nil))
 
     Enum.each(pending_baseline_alerts, &evaluate_and_execute(&1, nil))
 
-    if established_alerts != [] do
+    if established_alerts == [] do
+      :ok
+    else
       %{test_case_ids: test_case_ids, cursor: cursor, more?: more?} =
         Automations.recent_test_case_run_changes_for_alerts(established_alerts)
 
@@ -109,17 +112,22 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       |> Enum.each(&evaluate_alert_group(established_alerts, &1))
 
       {:ok, _updated_count} = Automations.advance_alert_scoped_evaluation_cursors(established_alerts, cursor)
-      enqueue_next_scoped_evaluation(hd(established_alerts), more?)
+      continue_scoped_evaluation(hd(established_alerts), job, more?)
     end
-
-    :ok
   end
 
-  defp enqueue_next_scoped_evaluation(alert, true) do
-    Automations.enqueue_scoped_alert_evaluation(alert, schedule_in: 0)
-  end
+  defp continue_scoped_evaluation(_alert, _job, false), do: :ok
 
-  defp enqueue_next_scoped_evaluation(_alert, false), do: :ok
+  defp continue_scoped_evaluation(_alert, %Oban.Job{id: nil}, true), do: {:snooze, 0}
+
+  defp continue_scoped_evaluation(_alert, %Oban.Job{} = job, true) do
+    max_attempts = job.attempt + @attempts_per_window - 1
+
+    case Oban.update_job(job, %{max_attempts: max_attempts}) do
+      {:ok, _job} -> {:snooze, 0}
+      error -> error
+    end
+  end
 
   defp evaluate_recent_test_case_runs?(%{"evaluate_recent_test_case_runs" => true}), do: true
   defp evaluate_recent_test_case_runs?(_args), do: false

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -78,13 +78,15 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     if alert.baseline_established_at == nil do
       evaluate_and_execute(alert, nil)
     else
-      %{test_case_ids: test_case_ids, cursor: cursor} = Automations.recent_test_case_run_changes_for_alert(alert)
+      %{test_case_ids: test_case_ids, cursor: cursor, more?: more?} =
+        Automations.recent_test_case_run_changes_for_alert(alert)
 
       test_case_ids
       |> Automations.scoped_evaluation_ranges()
       |> Enum.each(&evaluate_and_execute(alert, &1))
 
-      {:ok, _alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
+      {:ok, updated_alert} = Automations.update_alert_scoped_evaluation_cursor(alert, cursor)
+      enqueue_next_scoped_evaluation(updated_alert, more?)
     end
 
     :ok
@@ -99,7 +101,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     Enum.each(pending_baseline_alerts, &evaluate_and_execute(&1, nil))
 
     if established_alerts != [] do
-      %{test_case_ids: test_case_ids, cursor: cursor} =
+      %{test_case_ids: test_case_ids, cursor: cursor, more?: more?} =
         Automations.recent_test_case_run_changes_for_alerts(established_alerts)
 
       test_case_ids
@@ -107,10 +109,17 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       |> Enum.each(&evaluate_alert_group(established_alerts, &1))
 
       {:ok, _updated_count} = Automations.advance_alert_scoped_evaluation_cursors(established_alerts, cursor)
+      enqueue_next_scoped_evaluation(hd(established_alerts), more?)
     end
 
     :ok
   end
+
+  defp enqueue_next_scoped_evaluation(alert, true) do
+    Automations.enqueue_scoped_alert_evaluation(alert, schedule_in: 0)
+  end
+
+  defp enqueue_next_scoped_evaluation(_alert, false), do: :ok
 
   defp evaluate_recent_test_case_runs?(%{"evaluate_recent_test_case_runs" => true}), do: true
   defp evaluate_recent_test_case_runs?(_args), do: false

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -89,7 +89,7 @@ defmodule Tuist.MixProject do
       {:mimic, "~> 2.0", only: :test},
       {:ymlr, "~> 5.0"},
       {:open_api_spex, "~> 3.22"},
-      {:oban, "~> 2.19"},
+      {:oban, "~> 2.20"},
       {:oban_web, "~> 2.11"},
       {:bcrypt_elixir, "~> 3.0"},
       {:stripity_stripe, "~> 3.1"},

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -386,7 +386,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     test_case_id = Ecto.UUID.generate()
 
     expect(ClickHouseRepo, :all, fn _query ->
-      [%{test_case_id: test_case_id, last_inserted_at: ~N[2026-06-09 10:00:02]}]
+      [test_case_id]
     end)
 
     reject(&FlakyTestsMonitor.evaluate/2)
@@ -414,8 +414,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert {:ok, updated_valid_alert} = Automations.get_alert(valid_alert.id)
     assert {:ok, updated_second_valid_alert} = Automations.get_alert(second_valid_alert.id)
     assert {:ok, updated_unsupported_alert} = Automations.get_alert(unsupported_alert.id)
-    assert updated_valid_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
-    assert updated_second_valid_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+    assert updated_valid_alert.last_scoped_evaluation_inserted_at
+
+    assert updated_second_valid_alert.last_scoped_evaluation_inserted_at ==
+             updated_valid_alert.last_scoped_evaluation_inserted_at
+
     assert updated_unsupported_alert.last_scoped_evaluation_inserted_at == nil
   end
 

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -151,14 +151,14 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     automation =
       AutomationsFixtures.automation_alert_fixture(trigger_actions: [%{"type" => "change_state", "state" => "muted"}])
 
+    {:ok, automation} =
+      Automations.update_alert_scoped_evaluation_cursor(automation, ~U[2026-06-09 09:00:02Z])
+
     [first_id, second_id] = Enum.map(1..2, fn _ -> Ecto.UUID.generate() end)
     test_pid = self()
 
     expect(ClickHouseRepo, :all, fn _query ->
-      [
-        %{test_case_id: first_id, last_inserted_at: ~N[2026-06-09 10:00:01]},
-        %{test_case_id: second_id, last_inserted_at: ~N[2026-06-09 10:00:02]}
-      ]
+      [first_id, second_id]
     end)
 
     reject(&FlakyTestsMonitor.evaluate/1)
@@ -186,6 +186,54 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     assert {:ok, updated} = Automations.get_alert(automation.id)
     assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+  end
+
+  test "ingestion-driven job keeps the cursor when evaluation fails" do
+    automation = AutomationsFixtures.automation_alert_fixture()
+
+    {:ok, automation} =
+      Automations.update_alert_scoped_evaluation_cursor(automation, ~U[2026-06-09 09:00:00Z])
+
+    test_case_id = Ecto.UUID.generate()
+
+    expect(ClickHouseRepo, :all, fn _query -> [test_case_id] end)
+
+    expect(FlakyTestsMonitor, :evaluate, fn ^automation, [^test_case_id] ->
+      raise "evaluation failed"
+    end)
+
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert_raise RuntimeError, "evaluation failed", fn ->
+      run_recent_test_case_runs(automation.id)
+    end
+
+    assert {:ok, unchanged} = Automations.get_alert(automation.id)
+    assert unchanged.last_scoped_evaluation_inserted_at == ~U[2026-06-09 09:00:00Z]
+    assert all_enqueued(worker: AlertEvaluationWorker) == []
+  end
+
+  test "ingestion-driven job advances and continues across an empty backlog window" do
+    automation = AutomationsFixtures.automation_alert_fixture()
+
+    {:ok, automation} =
+      Automations.update_alert_scoped_evaluation_cursor(automation, ~U[2026-06-09 09:00:00Z])
+
+    expect(ClickHouseRepo, :all, fn _query -> [] end)
+    reject(&FlakyTestsMonitor.evaluate/2)
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert :ok = run_recent_test_case_runs(automation.id)
+
+    assert {:ok, updated} = Automations.get_alert(automation.id)
+    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:00Z]
+
+    assert [%{args: %{"project_id" => project_id, "evaluate_recent_test_case_runs" => true}}] =
+             all_enqueued(worker: AlertEvaluationWorker)
+
+    assert project_id == automation.project_id
   end
 
   test "project-scoped job shares rolling measurements across compatible alerts" do
@@ -224,7 +272,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     test_case_id = Ecto.UUID.generate()
 
     expect(ClickHouseRepo, :all, fn _query ->
-      [%{test_case_id: test_case_id, last_inserted_at: ~N[2026-06-09 10:00:02]}]
+      [test_case_id]
     end)
 
     reject(&FlakyTestsMonitor.evaluate/1)
@@ -243,8 +291,8 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     assert {:ok, updated_first_alert} = Automations.get_alert(first_alert.id)
     assert {:ok, updated_second_alert} = Automations.get_alert(second_alert.id)
-    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:10Z]
-    assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 11:00:00Z]
+    assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 11:00:00Z]
   end
 
   test "project-scoped job isolates an unsupported alert from valid alerts" do
@@ -335,13 +383,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
   test "ingestion-driven job chunks large affected sets" do
     automation = AutomationsFixtures.automation_alert_fixture()
+    {:ok, automation} = Automations.update_alert_scoped_evaluation_cursor(automation, ~U[2026-06-09 09:00:00Z])
     test_case_ids = Enum.map(1..4001, fn _ -> Ecto.UUID.generate() end)
     test_pid = self()
 
     expect(ClickHouseRepo, :all, fn _query ->
-      Enum.map(test_case_ids, fn test_case_id ->
-        %{test_case_id: test_case_id, last_inserted_at: ~N[2026-06-09 10:00:00]}
-      end)
+      test_case_ids
     end)
 
     expect(FlakyTestsMonitor, :evaluate, 5, fn ^automation, chunk ->

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -177,7 +177,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
 
-    assert :ok = run_recent_test_case_runs(automation.id)
+    assert {:snooze, 0} = run_recent_test_case_runs(automation.id)
 
     assert_receive {:evaluated_test_case_id, ^first_id}
     assert_receive {:evaluated_test_case_id, ^second_id}
@@ -185,7 +185,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert_receive {:checked_active_test_case_id, ^second_id}
 
     assert {:ok, updated} = Automations.get_alert(automation.id)
-    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:02Z]
+    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 09:15:02Z]
   end
 
   test "ingestion-driven job keeps the cursor when evaluation fails" do
@@ -225,15 +225,53 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
 
-    assert :ok = run_recent_test_case_runs(automation.id)
+    assert {:snooze, 0} = run_recent_test_case_runs(automation.id)
 
     assert {:ok, updated} = Automations.get_alert(automation.id)
-    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:00Z]
+    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 09:15:00Z]
 
-    assert [%{args: %{"project_id" => project_id, "evaluate_recent_test_case_runs" => true}}] =
-             all_enqueued(worker: AlertEvaluationWorker)
+    assert all_enqueued(worker: AlertEvaluationWorker) == []
+  end
 
-    assert project_id == automation.project_id
+  test "project-scoped backlog continuation snoozes the current job" do
+    project = ProjectsFixtures.project_fixture()
+
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        project: project,
+        trigger_config: %{
+          "threshold" => 10,
+          "window_type" => "rolling",
+          "rolling_window_size" => 75
+        }
+      )
+
+    {:ok, automation} =
+      Automations.update_alert_scoped_evaluation_cursor(automation, ~U[2026-06-09 09:00:00Z])
+
+    args = %{
+      project_id: project.id,
+      cadence_seconds: 300,
+      evaluate_recent_test_case_runs: true
+    }
+
+    assert {:ok, current_job} = args |> AlertEvaluationWorker.new() |> Oban.insert()
+    current_job = Repo.get!(Oban.Job, current_job.id)
+
+    expect(ClickHouseRepo, :all, fn _query -> [] end)
+    reject(&FlakyTestsMonitor.evaluate/2)
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert {:snooze, 0} =
+             AlertEvaluationWorker.perform(%{current_job | state: "executing", attempt: 3})
+
+    assert [continued_job] = all_enqueued(worker: AlertEvaluationWorker)
+    assert continued_job.id == current_job.id
+    assert continued_job.max_attempts == 5
+
+    assert {:ok, updated} = Automations.get_alert(automation.id)
+    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 09:15:00Z]
   end
 
   test "project-scoped job shares rolling measurements across compatible alerts" do
@@ -287,12 +325,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
 
-    assert :ok = run_recent_test_case_runs_for_project(project.id)
+    assert {:snooze, 0} = run_recent_test_case_runs_for_project(project.id)
 
     assert {:ok, updated_first_alert} = Automations.get_alert(first_alert.id)
     assert {:ok, updated_second_alert} = Automations.get_alert(second_alert.id)
-    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 11:00:00Z]
-    assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 11:00:00Z]
+    assert updated_first_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:15:00Z]
+    assert updated_second_alert.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:15:00Z]
   end
 
   test "project-scoped job isolates an unsupported alert from valid alerts" do
@@ -405,7 +443,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
 
-    assert :ok = run_recent_test_case_runs(automation.id)
+    assert {:snooze, 0} = run_recent_test_case_runs(automation.id)
 
     assert_receive {:monitor_chunk_size, 1000}
     assert_receive {:monitor_chunk_size, 1000}
@@ -419,7 +457,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert_receive {:active_events_chunk_size, 1}
 
     assert {:ok, updated} = Automations.get_alert(automation.id)
-    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 10:00:00Z]
+    assert updated.last_scoped_evaluation_inserted_at == ~U[2026-06-09 09:15:00Z]
   end
 
   test "ingestion-driven job no-ops when the alert is disabled" do

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -345,13 +345,13 @@ defmodule Tuist.AutomationsTest do
         project_id: project.id,
         test_case_id: corrected_id,
         ran_at: ~N[2025-01-01 00:00:00.000000],
-        inserted_at: ~N[2026-06-09 10:30:00.000000]
+        inserted_at: ~N[2026-06-09 10:10:00.000000]
       )
 
       RunsFixtures.test_case_run_fixture(
         project_id: project.id,
         test_case_id: outside_window_id,
-        inserted_at: ~N[2026-06-09 11:00:50.000000]
+        inserted_at: ~N[2026-06-09 10:15:50.000000]
       )
 
       RunsFixtures.test_case_run_fixture(
@@ -370,7 +370,7 @@ defmodule Tuist.AutomationsTest do
                Automations.recent_test_case_run_changes_for_alert(alert)
 
       assert MapSet.new(test_case_ids) == MapSet.new([first_id, second_id, corrected_id])
-      assert cursor == ~U[2026-06-09 11:00:50Z]
+      assert cursor == ~U[2026-06-09 10:15:50Z]
     end
   end
 

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -314,6 +314,8 @@ defmodule Tuist.AutomationsTest do
 
       first_id = Ecto.UUID.generate()
       second_id = Ecto.UUID.generate()
+      corrected_id = Ecto.UUID.generate()
+      outside_window_id = Ecto.UUID.generate()
 
       RunsFixtures.test_case_run_fixture(
         project_id: project.id,
@@ -341,6 +343,19 @@ defmodule Tuist.AutomationsTest do
 
       RunsFixtures.test_case_run_fixture(
         project_id: project.id,
+        test_case_id: corrected_id,
+        ran_at: ~N[2025-01-01 00:00:00.000000],
+        inserted_at: ~N[2026-06-09 10:30:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: outside_window_id,
+        inserted_at: ~N[2026-06-09 11:00:50.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
         test_case_id: nil,
         inserted_at: ~N[2026-06-09 10:00:49.000000]
       )
@@ -351,11 +366,11 @@ defmodule Tuist.AutomationsTest do
         inserted_at: ~N[2026-06-09 10:00:49.000000]
       )
 
-      assert %{test_case_ids: test_case_ids, cursor: cursor} =
+      assert %{test_case_ids: test_case_ids, cursor: cursor, more?: true} =
                Automations.recent_test_case_run_changes_for_alert(alert)
 
-      assert MapSet.new(test_case_ids) == MapSet.new([first_id, second_id])
-      assert cursor == ~U[2026-06-09 10:00:48Z]
+      assert MapSet.new(test_case_ids) == MapSet.new([first_id, second_id, corrected_id])
+      assert cursor == ~U[2026-06-09 11:00:50Z]
     end
   end
 

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -2,10 +2,13 @@ defmodule Tuist.AutomationsTest do
   use TuistTestSupport.Cases.DataCase, async: false
   use Mimic
 
+  import Ecto.Query
+
   alias Tuist.Automations
   alias Tuist.Automations.ActionExecutor
   alias Tuist.Automations.Alerts.Alert
   alias Tuist.Automations.Workers.AlertEvaluationWorker
+  alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AutomationsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
@@ -302,6 +305,39 @@ defmodule Tuist.AutomationsTest do
 
       assert [%{scheduled_at: scheduled_at}] = all_enqueued(worker: AlertEvaluationWorker)
       assert DateTime.diff(scheduled_at, enqueued_at, :second) in 30..31
+    end
+
+    test "does not enqueue a second scoped evaluation while the existing job is active" do
+      project = ProjectsFixtures.project_fixture()
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          cadence: "5m",
+          trigger_config: %{
+            "threshold" => 10,
+            "window_type" => "rolling",
+            "rolling_window_size" => 75
+          }
+        )
+
+      assert :ok = Automations.enqueue_scoped_alert_evaluation(alert)
+
+      job_query =
+        from(job in Oban.Job,
+          where: job.worker == ^inspect(AlertEvaluationWorker)
+        )
+
+      job = Repo.one!(job_query)
+
+      for state <- ["executing", "retryable"] do
+        Repo.update!(Ecto.Changeset.change(job, state: state))
+
+        assert :ok = Automations.enqueue_scoped_alert_evaluation(alert)
+        assert [%{id: job_id, state: ^state}] = Repo.all(job_query)
+        assert job_id == job.id
+      end
     end
   end
 


### PR DESCRIPTION
Part of #12038.

## What changed

Automation alert evaluation now reads test-case changes in fixed, 15-minute `inserted_at` windows through the existing ClickHouse insertion-time index. A project or alert with a backlog advances through those windows by snoozing the same Oban job, while each completed window renews a three-attempt retry budget.

Scoped evaluation jobs are now unique across queued, executing, and retrying states. This prevents ingestion from starting another cursor window while the existing evaluation is still active.

The declared Oban dependency now requires version 2.20 because the continuation path uses `Oban.update_job/2`, which was introduced in that release.

## Why

Production traces showed alert evaluation reading as many as 34.1 million rows per execution, with byte-identical scans repeated dozens of times. A failed evaluation could also leave the cursor behind and cause the same unbounded range to be read again.

## Root cause

The query read from the last successful cursor through the current time as one range. The cost therefore grew with backlog age and ingestion volume. The first continuation design inserted another unique job, which could collide with the scheduled job that was already queued and silently stop backlog progress. Ingestion could also enqueue a second job after the first entered the executing or retrying state, allowing cursor windows to overlap.

## Approach

Each query uses a half-open insertion-time window. Evaluation completes before the cursor advances, so failures retry the same window and do not skip changes. Corrections with an old run time remain visible because the window is based on insertion time.

Backlogs continue by updating and snoozing the current persisted job. Active-state uniqueness covers available, scheduled, executing, and retryable jobs. This preserves at-least-once evaluation while preventing concurrent cursor advancement. Cursor updates remain monotonic for grouped project evaluation.

## Impact

The maximum amount of ClickHouse data read by one alert-evaluation query is bounded by 15 minutes of ingestion. Alert transitions, recovery, grouped rolling evaluation, and late corrections retain their existing semantics. A backlogged project may need multiple short executions to catch up, but it no longer submits one memory-heavy query.

## Validation

- `mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs test/tuist/automations_test.exs`
- 65 focused tests passed against ClickHouse 26.3.9.8 with transaction isolation.
- Coverage includes exact half-open boundaries, old-run-time corrections, cursor persistence, retry without cursor advancement, empty windows, grouped project evaluation, large test-case sets, persisted-job snoozing, and ingestion coalescing while a job is executing or retrying.
- `mix format --check-formatted lib/tuist/automations.ex lib/tuist/automations/workers/alert_evaluation_worker.ex test/tuist/automations_test.exs test/tuist/automations/workers/alert_evaluation_worker_test.exs`
- `git diff --check`
- An independent Claude review of the continuation behavior returned `SHIP` and verified snooze semantics, the retry budget, monotonic cursor updates, valid worker return values, and removal of the queued-job collision.