### PR TITLE
fix(server): bound test attachment retention reads

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -176,6 +176,11 @@ ClickHouse metadata rows, including build runs, test runs, command events,
 preview records, and shard plans, are kept so analytics and dashboards remain
 intact. The configurable policy does not change database retention rules.
 
+Test attachments created before attachment metadata included a test-run
+identifier are excluded from automated deletion. Their binary and metadata
+remain available and are included in an export. This avoids resolving account
+ownership by scanning the full test-case-run history during retention cleanup.
+
 Retention status is computed when cleanup runs. Cache artifacts use the object
 storage `last_modified` timestamp, while previews, current build archives, test
 attachments, and shard bundles use their database `inserted_at` timestamp. Run

--- a/server/lib/tuist/storage/expired_artifacts.ex
+++ b/server/lib/tuist/storage/expired_artifacts.ex
@@ -32,7 +32,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
   alias Tuist.Storage.ArtifactRetentionCursor
   alias Tuist.Storage.RetentionPolicy
   alias Tuist.Tests
-  alias Tuist.Tests.TestCaseRun
+  alias Tuist.Tests.Test
   alias Tuist.Tests.TestCaseRunAttachment
 
   def delete_previews(%Account{} = account, batch_size, opts \\ []) do
@@ -166,21 +166,22 @@ defmodule Tuist.Storage.ExpiredArtifacts do
     else
       rows =
         TestCaseRunAttachment
-        |> join(:inner, [attachment], test_case_run in TestCaseRun, on: attachment.test_case_run_id == test_case_run.id)
+        |> join(:inner, [attachment], test_run in Test, on: attachment.test_run_id == test_run.id)
         |> where(
-          [attachment, test_case_run],
-          test_case_run.project_id in ^project_ids and attachment.inserted_at < ^cutoff
+          [attachment, test_run],
+          not is_nil(attachment.test_run_id) and test_run.project_id in ^project_ids and
+            attachment.inserted_at < ^cutoff
         )
         |> apply_cursor(cursor)
         |> order_by([attachment], asc: attachment.inserted_at, asc: attachment.id)
         |> limit(^batch_size)
-        |> select([attachment, test_case_run], %{
+        |> select([attachment, test_run], %{
           id: attachment.id,
           test_case_run_id: attachment.test_case_run_id,
           test_run_id: attachment.test_run_id,
           file_name: attachment.file_name,
           inserted_at: attachment.inserted_at,
-          project_id: test_case_run.project_id
+          project_id: test_run.project_id
         })
         |> ClickHouseRepo.all()
 

--- a/server/priv/docs/en/guides/server/data-retention.md
+++ b/server/priv/docs/en/guides/server/data-retention.md
@@ -26,6 +26,8 @@ These windows define how long artifact files remain available on the hosted Tuis
 
 The active account plan determines the hosted retention window. If an account does not have an active subscription, Tuist uses the Air retention window. Some artifact types use shorter windows because they are expected to be regenerated.
 
+Test attachments created before Tuist recorded a test-run identifier are excluded from automated deletion. Their files remain available while Tuist avoids an unbounded historical ownership lookup during retention cleanup.
+
 ### Self-hosted instances {#self-hosted-artifact-files}
 
 Self-hosted artifact cleanup is opt-in, configurable separately for each artifact type, and not capped at 30 days. See the <.localized_link href="/guides/server/self-host/server#artifact-retention">self-hosted artifact retention configuration</.localized_link> for the supported artifact types and deployment options.

--- a/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
@@ -433,6 +433,41 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
           inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
         )
 
+      retained_attachment =
+        test_case_run_attachment_fixture(
+          test_case_run_id: expired_test_case_run.id,
+          test_run_id: test_run_id,
+          file_name: "recent.log",
+          inserted_at: DateTime.utc_now() |> DateTime.add(-29, :day) |> DateTime.to_naive()
+        )
+
+      legacy_attachment =
+        test_case_run_attachment_fixture(
+          test_case_run_id: expired_test_case_run.id,
+          test_run_id: nil,
+          file_name: "legacy.log",
+          inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
+        )
+
+      other_project = project_fixture()
+
+      {:ok, other_expired_test} =
+        test_fixture(
+          project_id: other_project.id,
+          account_id: other_project.account.id,
+          ran_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
+        )
+
+      other_test_case_run = List.first(other_expired_test.test_case_runs)
+
+      other_attachment =
+        test_case_run_attachment_fixture(
+          test_case_run_id: other_test_case_run.id,
+          test_run_id: other_expired_test.id,
+          file_name: "other.log",
+          inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
+        )
+
       test_fixture(
         project_id: project.id,
         account_id: account.id,
@@ -449,50 +484,34 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
           file_name: expired_attachment.file_name
         })
 
-      stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
-        assert account_id == account.id
-        send(self(), {:deleted, object_keys})
-        :ok
-      end)
-
-      assert :ok =
-               perform_job(DeleteExpiredTestAttachmentsWorker, %{
-                 "account_id" => account.id,
-                 "batch_size" => 20
-               })
-
-      assert_received {:deleted, object_keys}
-      assert expired_attachment_key in object_keys
-    end
-
-    test "the test attachment worker deletes legacy attachments without test run ids" do
-      project = project_fixture()
-      account = project.account
-      subscription_fixture(account_id: account.id, plan: :air)
-
-      expired_test_case_run =
-        test_case_run_fixture(
-          project_id: project.id,
-          account_id: account.id,
-          inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
-        )
-
-      expired_attachment =
-        test_case_run_attachment_fixture(
-          test_case_run_id: expired_test_case_run.id,
-          test_run_id: nil,
-          file_name: "failure.log",
-          inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
-        )
-
-      expired_attachment_key =
+      retained_attachment_key =
         Tests.attachment_storage_key(%{
           account_handle: account.name,
           project_handle: project.name,
-          attachment_id: expired_attachment.id,
+          attachment_id: retained_attachment.id,
+          test_case_run_id: expired_test_case_run.id,
+          test_run_id: test_run_id,
+          file_name: retained_attachment.file_name
+        })
+
+      legacy_attachment_key =
+        Tests.attachment_storage_key(%{
+          account_handle: account.name,
+          project_handle: project.name,
+          attachment_id: legacy_attachment.id,
           test_case_run_id: expired_test_case_run.id,
           test_run_id: nil,
-          file_name: expired_attachment.file_name
+          file_name: legacy_attachment.file_name
+        })
+
+      other_attachment_key =
+        Tests.attachment_storage_key(%{
+          account_handle: other_project.account.name,
+          project_handle: other_project.name,
+          attachment_id: other_attachment.id,
+          test_case_run_id: other_test_case_run.id,
+          test_run_id: other_expired_test.id,
+          file_name: other_attachment.file_name
         })
 
       stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
@@ -509,6 +528,41 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
 
       assert_received {:deleted, object_keys}
       assert expired_attachment_key in object_keys
+      refute retained_attachment_key in object_keys
+      refute legacy_attachment_key in object_keys
+      refute other_attachment_key in object_keys
+    end
+
+    test "the test attachment worker preserves legacy attachments without test run ids" do
+      project = project_fixture()
+      account = project.account
+      subscription_fixture(account_id: account.id, plan: :air)
+
+      expired_test_case_run =
+        test_case_run_fixture(
+          project_id: project.id,
+          account_id: account.id,
+          inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
+        )
+
+      test_case_run_attachment_fixture(
+        test_case_run_id: expired_test_case_run.id,
+        test_run_id: nil,
+        file_name: "failure.log",
+        inserted_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.to_naive()
+      )
+
+      stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
+        assert account_id == account.id
+        assert object_keys == []
+        :ok
+      end)
+
+      assert :ok =
+               perform_job(DeleteExpiredTestAttachmentsWorker, %{
+                 "account_id" => account.id,
+                 "batch_size" => 20
+               })
     end
 
     test "the shard bundle worker deletes expired shard bundles according to the account plan" do


### PR DESCRIPTION
Part of #12038.

## What changed

Modern test attachment retention now joins attachments to `test_runs` through `test_run_id`. The account-scoped query uses the test run's project identifier and selects only attachments whose modern relationship is present.

Historical attachments created before `test_run_id` was recorded are explicitly excluded from automated deletion. The retention and data-export documentation now records that exception.

## Why

The previous account-scoped query joined every attachment page to `test_case_runs`. Production executions read as many as 29.1 million rows and 182 mebibytes, and the same broad join was repeated for each account.

The incident path needs to remove that recurring ClickHouse pressure without introducing a large ownership backfill or making historical object deletion part of an urgent database rollout.

## Root cause

`test_case_runs` is ordered by project, test case, and run time. Resolving attachment ownership through random test-case-run identifiers cannot use that sorting-key prefix, so a small retention page can scan most of the table.

Modern attachments already carry `test_run_id`, whose parent test run contains the project identifier needed for account isolation. Historical attachments do not carry that relationship and cannot be attributed cheaply enough for safe automated deletion.

## Approach

The query handles only the modern population with a non-null `test_run_id`. It joins directly to `test_runs`, applies the account's project filter and retention cutoff before pagination, and keeps the existing storage-key format and deletion workflow.

Historical attachment cleanup is intentionally deferred. This pull request adds no lookup table, no historical backfill, no global deletion sweep, and no destructive activation switch.

## Impact

Modern expired attachments continue to follow the existing account retention policy. Recent modern attachments, attachments from other accounts, and historical attachments are preserved.

No current customer loses historical attachment data. There is no schema migration, bulk backfill, or customer communication requirement for this rollout. Historical binary and metadata records remain available for export.

## Validation

- `mix test test/tuist/storage/workers/delete_expired_artifact_workers_test.exs`
- All 11 attachment-retention worker tests passed against the repository-pinned ClickHouse 26.1.2.11 after rebasing onto current `main`.
- The tests prove that only expired modern attachments for the owning account are deleted, while recent, other-account, and historical attachments are excluded. They also cover pagination, persisted progress, and stale-worker cursor ordering.
- `mix format --check-formatted lib/tuist/storage/expired_artifacts.ex test/tuist/storage/workers/delete_expired_artifact_workers_test.exs`
- `git diff --check`