### PR TITLE
fix(infra): restore control-plane bootstrap and monitoring

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -6,7 +6,7 @@ name: Mgmt Cluster Apply
 # paths change.
 #
 # Why a workflow instead of Argo CD / Flux: the mgmt cluster has a tiny
-# manifest surface (one ClusterClass, four Cluster CRs, two mgmt-side
+# manifest surface (one ClusterClass, four Cluster CRs, and a few mgmt-side
 # workloads) — drift detection / continuous reconciliation provided by
 # a long-running GitOps controller is overkill at this scale. A
 # push-driven CI apply gets us GitOps-style "the repo is the source of
@@ -44,6 +44,7 @@ on:
       - 'infra/k8s/mgmt/etcd-snapshot.yaml'
       - 'infra/k8s/mgmt/tailscale.yaml'
       - 'infra/k8s/mgmt/hetzner-robot-controller.yaml'
+      - 'infra/k8s/mgmt/observability-namespace.yaml'
       - 'infra/helm/k8s-monitoring/**'
       - '.github/workflows/mgmt-cluster-apply.yml'
   # Manual re-runs of the apply path, e.g. to force a re-deploy
@@ -70,7 +71,7 @@ jobs:
       name: mgmt-cluster-apply
     # `kubectl diff` can be slow against the Cluster API CRDs when many
     # Machines are changing, so leave enough room for the visibility step.
-    timeout-minutes: 15
+    timeout-minutes: 35
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
@@ -87,6 +88,71 @@ jobs:
           mkdir -p "$(dirname "$KUBECONFIG")"
           op document get "kubeconfig: tuist-mgmt" --vault tuist-k8s-mgmt --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
+      - name: Validate management monitoring credential
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing_monitoring_credential_is_complete() {
+            local actual_username
+            local expected_username
+            expected_username="$(printf '%s' '1774467' | base64 | tr -d '\n')"
+            actual_username="$(
+              kubectl -n observability get secret k8s-monitoring-grafana-cloud \
+                -o jsonpath='{.data.prometheus-username}' 2>/dev/null
+            )"
+            [ "$actual_username" = "$expected_username" ] &&
+              kubectl -n observability get secret k8s-monitoring-grafana-cloud \
+                -o jsonpath='{.data.prometheus-password}' 2>/dev/null | grep -q .
+          }
+
+          monitoring_credential_source=""
+          monitoring_password=""
+          if monitoring_token="$(op read 'op://tuist-k8s-mgmt/PROMETHEUS_TOKEN/password' 2>/dev/null)" &&
+            [ -n "$monitoring_token" ]; then
+            monitoring_credential_source="1Password"
+            monitoring_password="$monitoring_token"
+            unset monitoring_token
+          elif existing_monitoring_credential_is_complete; then
+            monitoring_credential_source="existing in-cluster Secret"
+            monitoring_password="$(
+              kubectl -n observability get secret k8s-monitoring-grafana-cloud \
+                -o jsonpath='{.data.prometheus-password}' | base64 --decode
+            )"
+            unset monitoring_token
+          else
+            unset monitoring_token
+            echo "::error::PROMETHEUS_TOKEN is unavailable and the management cluster has no existing monitoring credential"
+            exit 1
+          fi
+
+          echo "::add-mask::$monitoring_password"
+          remote_write_status="$(
+            curl -sS -o /dev/null -w '%{http_code}' \
+              --connect-timeout 5 \
+              --max-time 15 \
+              --user "1774467:$monitoring_password" \
+              --request POST \
+              --header 'Content-Encoding: snappy' \
+              --header 'Content-Type: application/x-protobuf' \
+              --header 'X-Prometheus-Remote-Write-Version: 0.1.0' \
+              --data-binary '' \
+              'https://prometheus-prod-24-prod-eu-west-2.grafana.net/api/prom/push'
+          )"
+          unset monitoring_password
+
+          # An authenticated request reaches payload validation and returns
+          # 400 for the deliberately empty protobuf. Invalid credentials
+          # return 401 before payload validation.
+          if [ "$remote_write_status" != "400" ] &&
+            [ "$remote_write_status" != "204" ]; then
+            echo "::error::The $monitoring_credential_source monitoring credential failed the Grafana remote-write authentication probe (HTTP $remote_write_status)"
+            exit 1
+          fi
+
+          if [ "$monitoring_credential_source" = "existing in-cluster Secret" ]; then
+            echo "::warning::PROMETHEUS_TOKEN is unavailable in the management vault; a live Grafana check passed, so the existing in-cluster monitoring credential will be preserved"
+          fi
       - name: Diff (visibility into what's about to change)
         # `kubectl diff` exits non-zero when there's a diff, which is
         # the expected case here, so don't fail the step on that.
@@ -119,6 +185,9 @@ jobs:
           echo "::endgroup::"
           echo "::group::cluster-autoscaler.yaml diff"
           kubectl diff -f infra/k8s/mgmt/cluster-autoscaler.yaml || true
+          echo "::endgroup::"
+          echo "::group::observability-namespace.yaml diff"
+          kubectl diff -f infra/k8s/mgmt/observability-namespace.yaml || true
           echo "::endgroup::"
       - name: Apply ClusterClass first (Cluster CRs reference it)
         run: |
@@ -169,26 +238,160 @@ jobs:
         # These are mgmt-cluster Deployments / CronJobs, not Cluster
         # CRs. Independent of the CAPI manifests above.
         run: |
+          kubectl apply -f infra/k8s/mgmt/observability-namespace.yaml
           kubectl apply -f infra/k8s/mgmt/hetzner-robot-controller.yaml
           kubectl apply -f infra/k8s/mgmt/cluster-autoscaler.yaml
           kubectl apply -f infra/k8s/mgmt/etcd-snapshot.yaml
           kubectl apply -f infra/k8s/mgmt/tailscale.yaml
+
+          # These regional clusters were retired, but kubectl apply does not
+          # remove resources that disappear from a manifest.
+          kubectl -n org-tuist delete deployment \
+            cluster-autoscaler-tuist-kura-us-east \
+            cluster-autoscaler-tuist-kura-us-west \
+            --ignore-not-found
       - name: Install management-cluster monitoring
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           set -euo pipefail
-          kubectl create namespace observability --dry-run=client -o yaml | kubectl apply -f -
+          existing_monitoring_credential_is_complete() {
+            local actual_username
+            local expected_username
+            expected_username="$(printf '%s' '1774467' | base64 | tr -d '\n')"
+            actual_username="$(
+              kubectl -n observability get secret k8s-monitoring-grafana-cloud \
+                -o jsonpath='{.data.prometheus-username}' 2>/dev/null
+            )"
+            [ "$actual_username" = "$expected_username" ] &&
+              kubectl -n observability get secret k8s-monitoring-grafana-cloud \
+                -o jsonpath='{.data.prometheus-password}' 2>/dev/null | grep -q .
+          }
 
-          PROMETHEUS_TOKEN="$(op read 'op://tuist-k8s-mgmt/PROMETHEUS_TOKEN/password')"
-          kubectl -n observability create secret generic k8s-monitoring-grafana-cloud \
-            --from-literal=prometheus-username=1774467 \
-            --from-literal=prometheus-password="$PROMETHEUS_TOKEN" \
-            --dry-run=client -o yaml | kubectl apply -f -
-          unset PROMETHEUS_TOKEN
+          monitoring_token=""
+          if monitoring_token="$(op read 'op://tuist-k8s-mgmt/PROMETHEUS_TOKEN/password' 2>/dev/null)" &&
+            [ -n "$monitoring_token" ]; then
+            echo "::add-mask::$monitoring_token"
+            kubectl -n observability create secret generic k8s-monitoring-grafana-cloud \
+              --from-literal=prometheus-username=1774467 \
+              --from-literal=prometheus-password="$monitoring_token" \
+              --dry-run=client -o yaml | kubectl apply -f -
+            unset monitoring_token
+          elif existing_monitoring_credential_is_complete; then
+            unset monitoring_token
+            echo "::warning::PROMETHEUS_TOKEN is unavailable in the management vault; preserving the existing in-cluster monitoring credential"
+          else
+            unset monitoring_token
+            echo "::error::PROMETHEUS_TOKEN is unavailable and the management cluster has no existing monitoring credential"
+            exit 1
+          fi
 
           helm dependency build infra/helm/k8s-monitoring
           helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
             --namespace observability \
             -f infra/helm/k8s-monitoring/values-management.yaml \
-            --wait --timeout 10m
+            --atomic --cleanup-on-fail --wait --timeout 10m
+      - name: Verify converged management state
+        run: |
+          set -euo pipefail
+
+          release_status="$(helm -n observability status k8s-monitoring -o json | jq -r '.info.status')"
+          if [ "$release_status" != "deployed" ]; then
+            echo "::error::The management monitoring release is $release_status"
+            exit 1
+          fi
+
+          kubectl -n observability rollout status deployment/k8s-monitoring-alloy-operator --timeout=2m
+          kubectl -n observability rollout status deployment/k8s-monitoring-kube-state-metrics --timeout=2m
+          kubectl -n observability wait --for=create daemonset/k8s-monitoring-alloy-control-plane --timeout=2m
+          kubectl -n observability wait --for=create daemonset/k8s-monitoring-alloy-metrics --timeout=2m
+          kubectl -n observability rollout status daemonset/k8s-monitoring-alloy-control-plane --timeout=2m
+          kubectl -n observability rollout status daemonset/k8s-monitoring-alloy-metrics --timeout=2m
+          kubectl -n observability rollout status daemonset/k8s-monitoring-node-exporter --timeout=2m
+
+          port_forward_log="$(mktemp)"
+          kubectl -n observability port-forward \
+            daemonset/k8s-monitoring-alloy-metrics 12345:12345 \
+            >"$port_forward_log" 2>&1 &
+          port_forward_pid=$!
+          cleanup_port_forward() {
+            kill "$port_forward_pid" >/dev/null 2>&1 || true
+            wait "$port_forward_pid" 2>/dev/null || true
+            rm -f "$port_forward_log"
+          }
+          trap cleanup_port_forward EXIT
+
+          remote_write_ready=false
+          for _ in $(seq 1 30); do
+            latest_sent_timestamp="$(
+              curl -fsS http://127.0.0.1:12345/metrics 2>/dev/null |
+                awk '/^prometheus_remote_storage_queue_highest_sent_timestamp_seconds/ {print $2; exit}' ||
+                true
+            )"
+            if [ -n "$latest_sent_timestamp" ] &&
+              awk -v sent="$latest_sent_timestamp" -v now="$(date +%s)" \
+                'BEGIN { exit !(sent >= now - 120) }'; then
+              remote_write_ready=true
+              break
+            fi
+            sleep 5
+          done
+
+          if [ "$remote_write_ready" != "true" ]; then
+            echo "::error::Management metrics have not been delivered to Grafana Cloud in the last two minutes"
+            cat "$port_forward_log"
+            exit 1
+          fi
+          cleanup_port_forward
+          trap - EXIT
+
+          for deployment in \
+            cluster-autoscaler-tuist-kura-us-east \
+            cluster-autoscaler-tuist-kura-us-west; do
+            if kubectl -n org-tuist get deployment "$deployment" >/dev/null 2>&1; then
+              echo "::error::Retired regional cluster autoscaler $deployment still exists"
+              exit 1
+            fi
+          done
+
+          assert_no_drift() {
+            local diff_output
+            local diff_status
+            local manifest="$1"
+
+            set +e
+            diff_output="$(kubectl diff -f "$manifest" 2>&1)"
+            diff_status=$?
+            set -e
+
+            case "$diff_status" in
+              0)
+                return 0
+                ;;
+              1)
+                printf '%s\n' "$diff_output"
+                echo "::error::Declarative drift remains for $manifest"
+                return 1
+                ;;
+              *)
+                printf '%s\n' "$diff_output"
+                echo "::error::Unable to compare live state with $manifest (kubectl exit $diff_status)"
+                return "$diff_status"
+                ;;
+            esac
+          }
+
+          assert_no_drift infra/k8s/clusters/clusterclass-tuist.yaml
+          for f in infra/k8s/clusters/bare-metal*.yaml; do
+            [ -e "$f" ] || continue
+            assert_no_drift "$f"
+          done
+          for f in infra/k8s/clusters/cluster-*.yaml; do
+            [ -e "$f" ] || continue
+            assert_no_drift "$f"
+          done
+          assert_no_drift infra/k8s/mgmt/hetzner-robot-controller.yaml
+          assert_no_drift infra/k8s/mgmt/cluster-autoscaler.yaml
+          assert_no_drift infra/k8s/mgmt/etcd-snapshot.yaml
+          assert_no_drift infra/k8s/mgmt/tailscale.yaml
+          assert_no_drift infra/k8s/mgmt/observability-namespace.yaml

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -25,6 +25,15 @@ on:
       - .github/workflows/gradle-release.yml
       - .github/workflows/skills-release.yml
       - .github/workflows/hetzner-robot-controller-release.yml
+      # Management-cluster state has its own apply workflow and must not
+      # redeploy the customer-facing server.
+      - infra/k8s/clusters/**
+      - infra/k8s/mgmt/**
+      - .github/workflows/mgmt-cluster-apply.yml
+      # Documentation and release-workflow-only edits do not change a
+      # deployable server artifact.
+      - infra/helm/k8s-monitoring/**/*.md
+      - .github/workflows/server-production-deployment.yml
 
 permissions:
   contents: write

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -44,6 +44,26 @@ are intentionally disabled on that small cluster. The Hetzner load-balancer
 exporter reuses the existing `org-tuist/hetzner` Secret and its `hcloud` key
 that the Cluster API provider already requires.
 
+During credential-access recovery, the workflow can preserve an existing
+`observability/k8s-monitoring-grafana-cloud` Secret when the service account
+cannot read `PROMETHEUS_TOKEN`. This does not make the credential optional for
+new clusters: the workflow fails before applying infrastructure when neither
+the 1Password item nor the exact existing Secret with the expected username is
+available. Once the management vault item is readable, the next run refreshes
+the Secret from 1Password automatically. Before applying anything, the workflow
+probes Grafana's remote-write endpoint and rejects a revoked credential. The
+post-apply check also requires a fresh successful remote write, so an
+incorrectly configured collector fails the workflow even when every collector
+Pod is running.
+
+The management cluster enforces the baseline
+[Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+by default. `infra/k8s/mgmt/observability-namespace.yaml` grants only the
+`observability` namespace the host access required by the node and
+control-plane collectors. Restricted-mode audit events and warnings remain
+enabled there and are pinned to the management cluster's Kubernetes minor
+version. Do not deploy unrelated workloads into this privileged namespace.
+
 Prerequisites:
 
 1. **ClusterSecretStore `onepassword` exists.** Installed once per workload cluster as part of the bootstrap — see [`k8s/onboarding.md`](../../k8s/onboarding.md) §4.

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -26,6 +26,12 @@ spec:
         value: fsn1
       - name: hcloudControlPlaneMachineType
         value: cpx22
+      # Roll out the kubeadm compatibility fallback in canary first. With the
+      # local-mode feature enabled, new control-plane kubelets point at their
+      # own not-yet-running control-plane endpoint and never start the etcd
+      # learner.
+      - name: disableControlPlaneKubeletLocalMode
+        value: true
       - name: hcloudWorkerMachineType
         value: cpx32
       - name: hcloudSSHKeyName

--- a/infra/k8s/clusters/clusterclass-tuist.yaml
+++ b/infra/k8s/clusters/clusterclass-tuist.yaml
@@ -255,6 +255,14 @@ spec:
         openAPIV3Schema:
           type: string
           default: ExternalIP,Hostname,InternalDNS,ExternalDNS
+    # Rollout switch for a kubeadm control-plane join failure observed with
+    # ControlPlaneKubeletLocalMode on the Hetzner nodes. Keep this opt-in so
+    # each environment can validate the compatibility fallback separately.
+    - name: disableControlPlaneKubeletLocalMode
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
   patches:
     - name: HetznerClusterTemplateGeneral
       definitions:
@@ -436,6 +444,25 @@ spec:
               path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs"
               valueFrom:
                 template: '[{"name": "kubelet-preferred-address-types", "value": {{ .kubeletPreferredAddressTypes | quote }} }]'
+    # kubeadm's local-mode join points the bootstrap kubelet at the new node's
+    # control-plane endpoint before that endpoint exists. On the affected
+    # Hetzner nodes, the kubelet cannot finish its certificate bootstrap, so
+    # the local etcd learner never starts and kubeadm aborts the join. This
+    # opt-in patch restores the established load-balancer bootstrap path per
+    # environment.
+    - name: DisableControlPlaneKubeletLocalMode
+      enabledIf: "{{ if .disableControlPlaneKubeletLocalMode }}true{{end}}"
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/featureGates"
+              valueFrom:
+                template: '{"ControlPlaneKubeletLocalMode": false}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerClusterTemplate

--- a/infra/k8s/mgmt/observability-namespace.yaml
+++ b/infra/k8s/mgmt/observability-namespace.yaml
@@ -1,0 +1,16 @@
+# The management cluster enforces the baseline Pod Security standard by
+# default. The monitoring collectors need host networking, host ports, and
+# read-only host filesystem mounts to scrape the control plane and node.
+# Keep the exception scoped to this namespace while retaining restricted-mode
+# audit events and warnings.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.36
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.36
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.36


### PR DESCRIPTION
## What changed

This follows [#12081](https://github.com/tuist/tuist/pull/12081) with the control-plane repair and management-observability work discovered during the incident investigation.

- Added a canary-only Kubernetes [Cluster API](https://cluster-api.sigs.k8s.io/) switch that disables `ControlPlaneKubeletLocalMode` and restores load-balancer-based kubelet bootstrap.
- Made the switch opt-in so staging and production render exactly as before until each environment is validated separately.
- Added a declarative `observability` namespace with the narrowly scoped host-access policy required by the management collectors.
- Made the management monitoring workflow validate either the 1Password credential or the exact existing in-cluster credential against Grafana before applying anything.
- Made the monitoring installation atomic, verified fresh remote-write delivery afterward, and failed when declarative drift remains.
- Removed the two retired regional autoscalers and verified that they stay absent.
- Prevented management-only changes from triggering the customer-facing server deployment workflow.

## Why

The original outage exposed two separate weaknesses. The server outage path was hardened in #12081, but production also had only one functioning control-plane member because replacement machines could not finish joining. That made a brief readiness interruption capable of taking the Kubernetes endpoint down.

The management cluster was also missing the metrics needed to detect the degraded control plane and distinguish a bootstrap failure from a general connectivity failure. This change makes those metrics durable and turns missing delivery or remaining drift into a failed workflow.

## Root cause

The joining machine had enough connectivity to download packages and images, reach the load-balanced Kubernetes endpoint, fetch certificates, and add an etcd learner. The failure happened afterward:

1. `ControlPlaneKubeletLocalMode` rewrote the joining kubelet to use the new node's own control-plane endpoint.
2. That endpoint was not running yet.
3. The kubelet could not finish its certificate bootstrap.
4. The local etcd learner never started, so kubeadm aborted the join.
5. Replacements repeated the same loop, leaving production with one Ready control-plane member.

This rules out a general Internet connection drop as the cause of the machine bootstrap failure.

```mermaid
flowchart TD
  A[Desired control plane: three members] --> B[Replacement machine starts joining]
  B --> C[Local mode points kubelet at its own endpoint]
  C --> D[Local endpoint is not running]
  D --> E[Certificate bootstrap cannot finish]
  E --> F[etcd learner never starts]
  F --> G[kubeadm join aborts]
  G --> H[Only one control-plane member remains Ready]
  I[Brief readiness interruption] --> J[Kubernetes application programming interface unavailable]
  H --> J
  J --> K[Stable outbound gateway moves to standby]
  K --> L[Cilium sees gateway label before outbound address attachment]
  L --> M[Cilium does not retry after address attachment]
  M --> N[Server outbound requests fail]
  N --> O[Keygen startup validation times out]
  O --> P[Server exits]
  P --> Q[503 responses]
```

## Approach

The etcd learner behavior remains enabled because learners protect membership changes. The compatibility fallback changes only the kubelet bootstrap endpoint and is gated per environment. Canary was repaired first from a validated snapshot, then allowed to complete a normal rolling replacement.

Monitoring follows a fail-closed sequence. The workflow resolves a credential, proves it can authenticate to Grafana, applies the manifests, waits for every collector, requires a fresh remote-write timestamp, and finally requires zero declarative drift.

```mermaid
flowchart LR
  subgraph Bootstrap_recovery[Control-plane bootstrap recovery]
    A[Canary opts into compatibility fallback] --> B[Disable local-mode kubelet bootstrap]
    B --> C[Joining kubelet uses load balancer]
    C --> D[Certificate bootstrap completes]
    D --> E[etcd learner starts and becomes a voter]
    E --> F[Canary reaches three Ready members]
  end

  subgraph Monitoring_recovery[Management monitoring recovery]
    G[Read 1Password token or exact existing Secret] --> H[Probe Grafana authentication]
    H --> I[Atomic Helm reconciliation]
    I --> J[Verify collector readiness]
    J --> K[Verify fresh remote-write delivery]
    K --> L[Verify zero declarative drift]
  end

  M[Management-only path filters] --> N[No customer server deployment]
```

## Impact

Canary is currently converged at three Ready and updated control-plane nodes with three started etcd voters and no rollout in progress. All canary Tuist deployments are Ready.

Production and staging do not enable the compatibility switch in this pull request, and their rendered control-plane specifications were unchanged during the canary rollout. The pull request remains a draft while the remaining environments are handled through separate, explicitly authorized maintenance steps.

## Validation

- `mise x actionlint@1.7.7 -- actionlint .github/workflows/mgmt-cluster-apply.yml`
- `mise x actionlint@1.7.7 -- actionlint` on the production deployment workflow, ignoring its pre-existing custom-runner and reusable-output warnings
- `bash -n` for every changed GitHub Actions shell block
- `helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-management.yaml`
- Server-side Kubernetes dry runs for the ClusterClass and canary Cluster
- Zero live drift for the ClusterClass and canary Cluster
- Live missing-vault fallback using the preserved credential, including successful Grafana authentication
- Validated 215 megabyte etcd snapshot before repair
- Canary: three of three control-plane nodes Ready and updated, three started voters, no rollout in progress
- tuist.dev health checks throughout the canary repair
- Final headless Claude review: no blocking findings