### PR TITLE
fix(infra): configure Grafana Helm repository

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -286,6 +286,7 @@ jobs:
             exit 1
           fi
 
+          helm repo add grafana https://grafana.github.io/helm-charts --force-update
           helm dependency build infra/helm/k8s-monitoring
           helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
             --namespace observability \


### PR DESCRIPTION
## What changed

The management-cluster workflow now registers the Grafana chart repository before building the monitoring chart dependencies.

## Why

The deployment for #12091 applied the cluster and management manifests successfully, then failed before changing the monitoring release because the fresh GitHub-hosted runner had no repository definition for `https://grafana.github.io/helm-charts`.

## Root cause

`helm dependency build` needs the chart repository to be present in the runner's local Helm configuration. Local validation had passed because the developer machine already had that repository configured, while a clean runner did not.

## Approach

Run `helm repo add grafana https://grafana.github.io/helm-charts --force-update` immediately before `helm dependency build`. The command is idempotent and keeps the dependency source aligned with `Chart.yaml`.

## Impact

This changes only workflow setup. It does not change any Kubernetes manifest or customer-facing deployment. Once merged, the management workflow can be rerun safely from the failed step sequence.

## Validation

- Reproduced the runner with an empty Helm repository configuration and cache
- Added the Grafana repository successfully
- Built the monitoring chart dependency successfully
- `helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-management.yaml`
- `mise x actionlint@1.7.7 -- actionlint .github/workflows/mgmt-cluster-apply.yml`
- `bash -n` for every workflow shell block