### PR TITLE
fix(infra): make Tart image uploads resilient

### DIFF
--- a/.github/actions/reliable-tart-push/action.yml
+++ b/.github/actions/reliable-tart-push/action.yml
@@ -1,0 +1,136 @@
+name: Reliable Tart push
+description: Push a large Tart image with bounded registry concurrency and jittered retries
+
+inputs:
+  local-name:
+    description: Local Tart virtual machine name
+    required: true
+  remote-names:
+    description: Newline-separated remote image names
+    required: true
+  attempts:
+    description: Maximum number of push attempts
+    required: false
+    default: "5"
+  concurrency:
+    description: Number of concurrent registry uploads within Tart
+    required: false
+    default: "1"
+  chunk-size:
+    description: Upload chunk size in megabytes
+    required: false
+    default: "3"
+
+runs:
+  using: composite
+  steps:
+    - name: Push Tart image
+      shell: bash
+      env:
+        TART_PUSH_LOCAL_NAME: ${{ inputs.local-name }}
+        TART_PUSH_REMOTE_NAMES: ${{ inputs.remote-names }}
+        TART_PUSH_ATTEMPTS: ${{ inputs.attempts }}
+        TART_PUSH_CONCURRENCY: ${{ inputs.concurrency }}
+        TART_PUSH_CHUNK_SIZE: ${{ inputs.chunk-size }}
+        # Tart can prune its local Open Container Initiative cache while
+        # staging a push. The workflow reclaims disk before reaching this
+        # action, so pruning during the upload adds risk without saving space.
+        TART_NO_AUTO_PRUNE: "1"
+      run: |
+        set -euo pipefail
+
+        require_positive_integer() {
+          local name="$1"
+          local value="$2"
+          if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::${name} must be a positive integer, got '${value}'"
+            exit 1
+          fi
+        }
+
+        probe_endpoint() {
+          local label="$1"
+          local url="$2"
+          local result
+
+          if result="$(
+            curl \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --connect-timeout 10 \
+              --max-time 20 \
+              --write-out "${label}: address=%{remote_ip} status=%{http_code} connect=%{time_connect}s secure=%{time_appconnect}s total=%{time_total}s" \
+              "$url"
+          )"; then
+            echo "$result"
+          else
+            echo "::warning::${label} probe failed: ${result}"
+          fi
+        }
+
+        probe_registry_path() {
+          probe_endpoint "registry" "https://ghcr.io/v2/"
+          probe_endpoint "blob delivery" "https://pkg-containers.githubusercontent.com/"
+        }
+
+        require_positive_integer "attempts" "$TART_PUSH_ATTEMPTS"
+        require_positive_integer "concurrency" "$TART_PUSH_CONCURRENCY"
+        require_positive_integer "chunk-size" "$TART_PUSH_CHUNK_SIZE"
+
+        remote_names=()
+        while IFS= read -r remote_name; do
+          if [ -n "$remote_name" ]; then
+            remote_names+=("$remote_name")
+          fi
+        done <<< "$TART_PUSH_REMOTE_NAMES"
+
+        if [ "${#remote_names[@]}" -eq 0 ]; then
+          echo "::error::At least one remote image name is required"
+          exit 1
+        fi
+
+        echo "Tart version: $(tart --version)"
+        echo "Host macOS version: $(sw_vers -productVersion)"
+        echo "Registry concurrency: ${TART_PUSH_CONCURRENCY}"
+        echo "Upload chunk size: ${TART_PUSH_CHUNK_SIZE} megabytes"
+        probe_registry_path
+
+        for ((attempt = 1; attempt <= TART_PUSH_ATTEMPTS; attempt++)); do
+          attempt_log="${RUNNER_TEMP:-/tmp}/tart-push-${GITHUB_RUN_ID:-local}-${attempt}.log"
+          echo "Tart push attempt ${attempt}/${TART_PUSH_ATTEMPTS} at $(date -u +%H:%M:%SZ)" >&2
+
+          if tart push \
+            --concurrency "$TART_PUSH_CONCURRENCY" \
+            --chunk-size "$TART_PUSH_CHUNK_SIZE" \
+            "$TART_PUSH_LOCAL_NAME" \
+            "${remote_names[@]}" 2>&1 | tee "$attempt_log"; then
+            echo "Pushed ${remote_names[*]} on attempt ${attempt}"
+            exit 0
+          fi
+
+          if grep -Eqi \
+            'unauthorized|authentication required|denied|invalid reference' \
+            "$attempt_log"; then
+            echo "::error::Tart push failed with a non-retryable error"
+            exit 1
+          fi
+
+          probe_registry_path
+
+          if [ "$attempt" -eq "$TART_PUSH_ATTEMPTS" ]; then
+            echo "::error::Tart push failed ${TART_PUSH_ATTEMPTS} times"
+            exit 1
+          fi
+
+          case "$attempt" in
+            1) base_delay=60 ;;
+            2) base_delay=120 ;;
+            3) base_delay=300 ;;
+            *) base_delay=600 ;;
+          esac
+          jitter=$((RANDOM % (base_delay / 2 + 1)))
+          delay=$((base_delay + jitter))
+          echo "::warning::Tart push attempt ${attempt} failed; waiting ${delay} seconds before retry"
+          sleep "$delay"
+        done

--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -1,4 +1,4 @@
-name: Reliable Tart push
+name: Tart push
 description: Push a large Tart image with bounded registry concurrency and jittered retries
 
 inputs:

--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -51,9 +51,9 @@ jobs:
     # A fresh Xcode major's `-downloadAllPlatforms` pulls brand-new
     # simulator runtimes from Apple that aren't cached yet, which can
     # push the build step alone past 50 min (26.6 took ~54 min) and
-    # leave no room to push before a 60-min cap. 90 gives headroom for
-    # the slow first build of a new major plus the multi-GB GHCR push.
-    timeout-minutes: 120
+    # leave little room for a deliberately low-concurrency image upload.
+    # Three hours covers both phases and the upload's retry budget.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 
@@ -189,42 +189,15 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
 
       - name: Push image to GHCR
+        timeout-minutes: 90
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Direct tart push. Cirrus uses the same path to publish
-        # macos-tahoe-xcode at the same size; the prior bridge through
-        # a local registry + skopeo was added after failures on a
-        # different host whose network was structurally bad. 5 attempts
-        # with growing backoff — blob uploads are content-addressed so
-        # each retry only re-uploads layers that didn't land on the
-        # previous attempt, and the backoff spreads attempts past
-        # upload-path degradation windows (see
-        # server-production-deployment.yml's
-        # release-xcresult-processor-image push step).
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.build.outputs.tag }}"
-          for attempt in 1 2 3 4 5; do
-            echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
-            if tart push macos-tahoe-xcode "ghcr.io/tuist/macos-tahoe-xcode:${TAG}"; then
-              echo "Pushed ghcr.io/tuist/macos-tahoe-xcode:${TAG} on attempt ${attempt}"
-              exit 0
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "tart push failed five times in a row" >&2
-              exit 1
-            fi
-            case "$attempt" in
-              1) delay=60 ;;
-              2) delay=120 ;;
-              3) delay=300 ;;
-              *) delay=600 ;;
-            esac
-            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-            sleep "$delay"
-          done
+        uses: ./.github/actions/reliable-tart-push
+        with:
+          local-name: macos-tahoe-xcode
+          remote-names: ghcr.io/tuist/macos-tahoe-xcode:${{ steps.build.outputs.tag }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -194,7 +194,7 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        uses: ./.github/actions/reliable-tart-push
+        uses: ./.github/actions/tart-push
         with:
           local-name: macos-tahoe-xcode
           remote-names: ghcr.io/tuist/macos-tahoe-xcode:${{ steps.build.outputs.tag }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 100
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v4
 
@@ -128,8 +128,14 @@ jobs:
             echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
           fi
 
+      - name: Resolve image tag
+        id: image-tag
+        run: |
+          set -euo pipefail
+          echo "value=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
       - name: Push image to GHCR
-        id: push
+        timeout-minutes: 90
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
@@ -143,40 +149,10 @@ jobs:
           # `reclaim-tart-disk` composite action and won't grow
           # before push completes.
           TART_NO_AUTO_PRUNE: "1"
-        # Direct tart push. Cirrus uses the same path to publish
-        # macos-tahoe-xcode at the same size; the prior bridge through
-        # a local registry was an unsuccessful workaround on a
-        # different host's structurally bad network. 5 attempts with
-        # growing backoff — blob uploads are content-addressed so each
-        # retry only re-uploads layers that didn't land on the previous
-        # attempt, and the backoff spreads attempts past upload-path
-        # degradation windows (see server-production-deployment.yml's
-        # release-xcresult-processor-image push step).
-        run: |
-          set -euo pipefail
-          GIT_SHA="${GITHUB_SHA::8}"
-          PROFILE="${{ steps.build.outputs.profile }}"
-          TAG="${PROFILE}-${GIT_SHA}"
-          for attempt in 1 2 3 4 5; do
-            echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
-            if tart push tuist-runner "ghcr.io/tuist/tuist-runner:${TAG}"; then
-              echo "Pushed ghcr.io/tuist/tuist-runner:${TAG} on attempt ${attempt}"
-              echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "tart push failed five times in a row" >&2
-              exit 1
-            fi
-            case "$attempt" in
-              1) delay=60 ;;
-              2) delay=120 ;;
-              3) delay=300 ;;
-              *) delay=600 ;;
-            esac
-            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-            sleep "$delay"
-          done
+        uses: ./.github/actions/reliable-tart-push
+        with:
+          local-name: tuist-runner
+          remote-names: ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -149,7 +149,7 @@ jobs:
           # `reclaim-tart-disk` composite action and won't grow
           # before push completes.
           TART_NO_AUTO_PRUNE: "1"
-        uses: ./.github/actions/reliable-tart-push
+        uses: ./.github/actions/tart-push
         with:
           local-name: tuist-runner
           remote-names: ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -929,7 +929,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.xcresult-processor-image-should-release == 'true'
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 100
+    timeout-minutes: 150
     env:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       MISE_GITHUB_TOKEN: ${{ github.token }}
@@ -1043,43 +1043,17 @@ jobs:
             xcresult-processor.pkr.hcl
 
       - name: Push image to GHCR
-        timeout-minutes: 55
+        timeout-minutes: 90
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Tart otherwise sends each compressed disk layer as one request.
-        # A layer can exceed 500 megabytes, while Tart's URLSession uses
-        # the default 60-second idle timeout. Use 3-megabyte chunks, below
-        # GitHub Container Registry's 4-megabyte limit, so slow uploads
-        # keep making observable request progress. Send both tags in one
-        # invocation so Tart compresses and uploads the disk only once.
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          DESTINATIONS=(
-            "ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
-            "ghcr.io/tuist/tuist-xcresult-processor:latest"
-          )
-          for attempt in 1 2 3 4 5; do
-            echo "tart push attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
-            if tart push --chunk-size 3 tuist-xcresult-processor "${DESTINATIONS[@]}"; then
-              echo "Pushed ${DESTINATIONS[*]} on attempt ${attempt}"
-              exit 0
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "tart push failed five times" >&2
-              exit 1
-            fi
-            case "$attempt" in
-              1) delay=60 ;;
-              2) delay=120 ;;
-              3) delay=300 ;;
-              *) delay=600 ;;
-            esac
-            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-            sleep "$delay"
-          done
+        uses: ./.github/actions/reliable-tart-push
+        with:
+          local-name: tuist-xcresult-processor
+          remote-names: |
+            ghcr.io/tuist/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
+            ghcr.io/tuist/tuist-xcresult-processor:latest
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4
@@ -1122,7 +1096,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.runner-image-should-release == 'true'
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 100
+    timeout-minutes: 150
     strategy:
       # If any profile build fails, abort sibling builds so the chart
       # pin doesn't move to a partially-published set.
@@ -1206,6 +1180,7 @@ jobs:
           fi
 
       - name: Push profile to GHCR
+        timeout-minutes: 90
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
@@ -1213,42 +1188,12 @@ jobs:
           # See runner-image.yml's matching step for the rationale —
           # tart's auto-prune races mid-push (cirruslabs/tart#860).
           TART_NO_AUTO_PRUNE: "1"
-        # Direct tart push; same shape as `macos-xcode-image.yml`.
-        # Push both the immutable per-version tag and the rolling
-        # `:<profile>` tag so the chart's tag template stays valid
-        # without overrides while operators can still pin to a
-        # specific version when they need to roll back. 5 attempts
-        # per tag with growing backoff — blob uploads are content-
-        # addressed so each retry only re-uploads layers that didn't
-        # land on the previous attempt, and the backoff spreads
-        # attempts past upload-path degradation windows (see the
-        # release-xcresult-processor-image push step).
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.check-releases.outputs.runner-image-next-version-number }}"
-          PROFILE="${{ steps.build.outputs.profile }}"
-          for dest_tag in "${PROFILE}-${VERSION}" "${PROFILE}"; do
-            DST="ghcr.io/tuist/tuist-runner:${dest_tag}"
-            for attempt in 1 2 3 4 5; do
-              echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
-              if tart push tuist-runner "$DST"; then
-                echo "Pushed ${DST} on attempt ${attempt}"
-                break
-              fi
-              if [ "$attempt" = 5 ]; then
-                echo "tart push failed five times for ${dest_tag}" >&2
-                exit 1
-              fi
-              case "$attempt" in
-                1) delay=60 ;;
-                2) delay=120 ;;
-                3) delay=300 ;;
-                *) delay=600 ;;
-              esac
-              echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-              sleep "$delay"
-            done
-          done
+        uses: ./.github/actions/reliable-tart-push
+        with:
+          local-name: tuist-runner
+          remote-names: |
+            ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}-${{ needs.check-releases.outputs.runner-image-next-version-number }}
+            ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1048,7 +1048,7 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        uses: ./.github/actions/reliable-tart-push
+        uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
           remote-names: |
@@ -1188,7 +1188,7 @@ jobs:
           # See runner-image.yml's matching step for the rationale —
           # tart's auto-prune races mid-push (cirruslabs/tart#860).
           TART_NO_AUTO_PRUNE: "1"
-        uses: ./.github/actions/reliable-tart-push
+        uses: ./.github/actions/tart-push
         with:
           local-name: tuist-runner
           remote-names: |

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -148,7 +148,7 @@ jobs:
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         # The production workflow owns semantic-version and latest tags.
         # This on-demand workflow publishes only its commit tag.
-        uses: ./.github/actions/reliable-tart-push
+        uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
           remote-names: ghcr.io/tuist/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
-    timeout-minutes: 100
+    timeout-minutes: 150
     env:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       MISE_VERSION: "2026.5.15"
@@ -134,40 +134,24 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
+      - name: Resolve image tag
+        id: image-tag
+        run: |
+          set -euo pipefail
+          echo "value=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
       - name: Push image to GHCR
-        timeout-minutes: 55
+        timeout-minutes: 90
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        # Match the production release workflow's chunked upload path.
-        # Tart's default monolithic uploads can exceed its 60-second
-        # URLSession idle timeout when registry throughput drops.
-        run: |
-          # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
-          # are owned by server-production-deployment.yml's release-xcresult-processor job.
-          set -euo pipefail
-          GIT_SHA="${GITHUB_SHA::8}"
-          DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
-          for attempt in 1 2 3 4 5; do
-            echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
-            if tart push --chunk-size 3 tuist-xcresult-processor "$DST"; then
-              echo "Pushed ${DST} on attempt ${attempt}"
-              exit 0
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "tart push failed five times in a row" >&2
-              exit 1
-            fi
-            case "$attempt" in
-              1) delay=60 ;;
-              2) delay=120 ;;
-              3) delay=300 ;;
-              *) delay=600 ;;
-            esac
-            echo "tart push attempt ${attempt} failed; sleeping ${delay}s before retry" >&2
-            sleep "$delay"
-          done
+        # The production workflow owns semantic-version and latest tags.
+        # This on-demand workflow publishes only its commit tag.
+        uses: ./.github/actions/reliable-tart-push
+        with:
+          local-name: tuist-xcresult-processor
+          remote-names: ghcr.io/tuist/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
 
       - name: Cleanup
         if: always()

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -218,7 +218,7 @@ managed via the same CAPI provider as the macOS Node fleets;
 scale via `buildersFleet.replicas` / `kubectl scale`.
 
 Both flows publish through the shared
-[`reliable-tart-push`](../../.github/actions/reliable-tart-push/action.yml)
+[`tart-push`](../../.github/actions/tart-push/action.yml)
 action. It bounds registry concurrency, chunks large layers, randomizes
 retry timing across builders, and captures registry-path diagnostics.
 Keep manual and production image publication on that shared action.

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -217,6 +217,12 @@ hosted runners. Builder fleet operator runbook:
 managed via the same CAPI provider as the macOS Node fleets;
 scale via `buildersFleet.replicas` / `kubectl scale`.
 
+Both flows publish through the shared
+[`reliable-tart-push`](../../.github/actions/reliable-tart-push/action.yml)
+action. It bounds registry concurrency, chunks large layers, randomizes
+retry timing across builders, and captures registry-path diagnostics.
+Keep manual and production image publication on that shared action.
+
 ## Layer 1 dependency
 
 This is **Layer 2** on top of

--- a/infra/vm-image-builder.md
+++ b/infra/vm-image-builder.md
@@ -298,6 +298,26 @@ around this by using `TART_REGISTRY_USERNAME` /
 of writing to keychain; no `tart login` is needed. If you add a
 new workflow that pushes to GHCR, follow the same pattern.
 
+## Reliable registry uploads
+
+All builder workflows use
+[`reliable-tart-push`](../.github/actions/reliable-tart-push/action.yml)
+for the final registry publication. Keep new Tart image workflows on that
+action rather than adding an inline retry loop.
+
+The action limits Tart to one concurrent registry upload and uses
+three-megabyte chunks. This trades some best-case throughput for fewer
+simultaneous long-lived requests on the Scaleway-to-GitHub path. Failed
+attempts use randomized backoff so two builders do not repeatedly retry
+in lockstep. Every failure also records connection timing and the selected
+address for the registry and blob-delivery endpoints, which gives
+operators evidence for distinguishing a GitHub-side incident from a
+provider-route problem.
+
+The upload remains content-addressed. A later attempt checks blobs that
+already landed and resumes with the missing content rather than publishing
+a different artifact.
+
 ## Workflow `runs-on:` selector
 
 Both image-build workflows pin

--- a/infra/vm-image-builder.md
+++ b/infra/vm-image-builder.md
@@ -301,7 +301,7 @@ new workflow that pushes to GHCR, follow the same pattern.
 ## Reliable registry uploads
 
 All builder workflows use
-[`reliable-tart-push`](../.github/actions/reliable-tart-push/action.yml)
+[`tart-push`](../.github/actions/tart-push/action.yml)
 for the final registry publication. Keep new Tart image workflows on that
 action rather than adding an inline retry loop.
 

--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -34,7 +34,7 @@ runners can't do this). Builder fleet operator runbook:
 [`../vm-image-builder.md`](../vm-image-builder.md).
 
 Registry publication uses the shared
-[`reliable-tart-push`](../../.github/actions/reliable-tart-push/action.yml)
+[`tart-push`](../../.github/actions/tart-push/action.yml)
 action. Its bounded concurrency, chunking, retry, and route diagnostics are
 part of the builder-fleet reliability contract; keep the on-demand and
 production release workflows on that shared path.

--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -33,6 +33,12 @@ needs a live GUI session for Virtualization.framework, so hosted
 runners can't do this). Builder fleet operator runbook:
 [`../vm-image-builder.md`](../vm-image-builder.md).
 
+Registry publication uses the shared
+[`reliable-tart-push`](../../.github/actions/reliable-tart-push/action.yml)
+action. Its bounded concurrency, chunking, retry, and route diagnostics are
+part of the builder-fleet reliability contract; keep the on-demand and
+production release workflows on that shared path.
+
 Locally:
 
 ```bash


### PR DESCRIPTION
## What changed

This adds a shared Tart upload action and moves every production and on-demand macOS virtual-machine image workflow onto it.

The action limits Tart to one concurrent registry upload, retains three-megabyte chunks, retries transient failures with randomized backoff, and records connection timing for GitHub's registry and blob-delivery endpoints. Multiple tags for the same image are now published in one Tart invocation, and workflow timeouts allow for the deliberately lower concurrency.

The builder runbook and image-specific agent guidance now treat the shared action as the publication contract for future workflows.

## Why

Recent production release workflows repeatedly failed while publishing the xcresult processor and Xcode runner images, even though the production deployment itself and ordinary container image pushes succeeded. These virtual-machine images are approximately 60 gigabytes and exercise a substantially different registry path from normal application containers.

The release needs to tolerate temporary degradation between the Scaleway Mac builders and GitHub Container Registry without turning every transport stall into a failed workflow.

## Root cause

Tart uploads up to four layers concurrently by default. A single release can therefore maintain several large upload streams per builder while another builder is doing the same. When the shared path degrades, Tart reaches its request timeout and the deterministic outer retry loops cause the builders to retry together, recreating the same pressure.

The failures were transport timeouts rather than authentication, storage, or explicit rate-limit responses. The existing three-megabyte chunk mitigation reduced individual request size but did not reduce concurrent pressure or prevent synchronized retries.

## Approach

The shared action uses one Tart upload stream and five content-addressed attempts. Randomized delays spread retries across builders and allow a new Tart process to establish fresh connections. Endpoint probes run before the first attempt and after every failure, making future logs useful for distinguishing a GitHub-side incident from a Scaleway route problem.

This intentionally trades some best-case throughput for reliability. It does not introduce an alternate egress route or a second registry, which would require a broader runtime image-distribution migration. If failures persist with one stream, the new diagnostics provide the evidence needed to justify that follow-up.

## Impact

Large Tart publications may take longer when the route is healthy, but they place less simultaneous pressure on the registry path and should recover more predictably from transient stalls. Runtime image contents, tags, credentials, and deployment behavior are unchanged. There is no migration for users or operators.

## Validation

- Parsed the composite action and four modified workflows successfully.
- Ran `actionlint` 1.7.7 against the modified workflows, excluding the repository's existing custom-runner-label and upload-action-output warnings.
- Exercised the action under Bash 3.2 with simulated successful uploads, permanent authentication failures, and transient failures through retry exhaustion.
- Ran `git diff --check` successfully.

A real 60-gigabyte upload was not run locally because it requires a prepared Tart image on the bare-metal Scaleway builder fleet.

### How to test locally

Dispatch either on-demand image workflow against this branch and confirm the upload log reports concurrency `1`, three-megabyte chunks, endpoint timing, and successful publication:

```sh
gh workflow run xcresult-processor-image.yml \
  --ref ci/production-deployment-status \
  -f xcode_version=26.6
```

