### PR TITLE
fix(cli): infer test platform from selected scheme

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -195,7 +195,7 @@ jobs:
   cli-unit-tests:
     name: Unit Tests
     runs-on: tuist-macos
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write
@@ -234,7 +234,7 @@ jobs:
   cli-acceptance-tests-build:
     name: Build Acceptance Tests
     runs-on: tuist-macos
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1897,6 +1897,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
+        let explicitPlatform = try platform.map {
+            try XcodeGraph.Platform.from(commandLineValue: $0)
+        }
         let destination: XcodeBuildDestination?
 
         if passthroughXcodeBuildArguments.contains("-destination") {
@@ -1904,8 +1907,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         } else {
             let buildPlatform: XcodeGraph.Platform
 
-            if let platform {
-                buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
+            if let explicitPlatform {
+                buildPlatform = explicitPlatform
             } else if let resolvedPlatform = Self.resolvePlatform(
                 for: buildableTarget,
                 scheme: scheme,
@@ -2254,7 +2257,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return targetPlatforms.first
         }
 
-        let compatibleSchemePlatformSets = scheme.nonCodeCoverageTargetDependencies()
+        let platformConstrainingTargets =
+            (scheme.buildAction?.targets ?? [])
+                + (scheme.testAction?.targets.map(\.target) ?? [])
+        let compatibleSchemePlatformSets = platformConstrainingTargets
             .compactMap {
                 graphTraverser.target(path: $0.projectPath, name: $0.name)?
                     .target

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -77,7 +77,7 @@ public enum TestServiceError: FatalError, Equatable {
             return "Could not find .xctestproducts bundle. Pass -derivedDataPath explicitly."
         case let .unspecifiedPlatform(target, platforms):
             return
-                "Only single platform targets supported. The target \(target) specifies multiple supported platforms (\(platforms.joined(separator: ", ")))."
+                "Could not infer which platform to use for the multi-platform target \(target) (\(platforms.joined(separator: ", "))). Pass --platform or forward a destination to xcodebuild after --."
         case .shardPlanningRequiresBuildOnly:
             return
                 "Shard planning flags (--shard-min/--shard-max/--shard-total) only apply when building tests for sharding. Pass --build-only to create a shard plan, or remove the shard flag(s) to run tests normally."
@@ -1897,26 +1897,28 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
-        let buildPlatform: XcodeGraph.Platform
-
-        if let platform {
-            buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
-        } else if let resolvedPlatform = buildableTarget.target.destinations.first?.platform,
-                  buildableTarget.target.destinations.platforms.count == 1
-        {
-            buildPlatform = resolvedPlatform
-        } else {
-            throw TestServiceError.unspecifiedPlatform(
-                target: buildableTarget.target.name,
-                platforms: buildableTarget.target.supportedPlatforms.map(\.rawValue)
-            )
-        }
-
         let destination: XcodeBuildDestination?
 
         if passthroughXcodeBuildArguments.contains("-destination") {
             destination = nil
         } else {
+            let buildPlatform: XcodeGraph.Platform
+
+            if let platform {
+                buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
+            } else if let resolvedPlatform = Self.resolvePlatform(
+                for: buildableTarget,
+                scheme: scheme,
+                graphTraverser: graphTraverser
+            ) {
+                buildPlatform = resolvedPlatform
+            } else {
+                throw TestServiceError.unspecifiedPlatform(
+                    target: buildableTarget.target.name,
+                    platforms: buildableTarget.target.supportedPlatforms.map(\.rawValue).sorted()
+                )
+            }
+
             destination = try await XcodeBuildDestination.find(
                 for: buildableTarget.target,
                 on: buildPlatform,
@@ -2231,13 +2233,41 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 action: .build
             ) else { continue }
 
-            guard let resolvedPlatform = target.target.destinations.first?.platform,
-                  target.target.destinations.platforms.count == 1
-            else { continue }
+            guard let resolvedPlatform = Self.resolvePlatform(
+                for: target,
+                scheme: scheme,
+                graphTraverser: graphTraverser
+            ) else { continue }
 
             return resolvedPlatform.xcodebuildPlatformDestination
         }
         return nil
+    }
+
+    static func resolvePlatform(
+        for target: GraphTarget,
+        scheme: Scheme,
+        graphTraverser: GraphTraversing
+    ) -> XcodeGraph.Platform? {
+        let targetPlatforms = target.target.supportedPlatforms
+        if targetPlatforms.count == 1 {
+            return targetPlatforms.first
+        }
+
+        let compatibleSchemePlatformSets = scheme.nonCodeCoverageTargetDependencies()
+            .compactMap {
+                graphTraverser.target(path: $0.projectPath, name: $0.name)?
+                    .target
+                    .supportedPlatforms
+                    .intersection(targetPlatforms)
+            }
+            .filter { !$0.isEmpty }
+
+        let sharedPlatforms = compatibleSchemePlatformSets.reduce(targetPlatforms) {
+            $0.intersection($1)
+        }
+        guard sharedPlatforms.count == 1 else { return nil }
+        return sharedPlatforms.first
     }
 
     private func xcodebuildDestination(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1912,6 +1912,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
             } else if let resolvedPlatform = Self.resolvePlatform(
                 for: buildableTarget,
                 scheme: scheme,
+                testActionTargets: testActionTargetReferences(
+                    scheme: scheme,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
+                ),
                 graphTraverser: graphTraverser
             ) {
                 buildPlatform = resolvedPlatform
@@ -2226,6 +2231,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlan: String? = nil,
         graphTraverser: GraphTraversing
     ) -> String? {
+        let testPlanConfiguration = testPlan.map { TestPlanConfiguration(testPlan: $0) }
         for scheme in schemes {
             guard let target = buildGraphInspector.testableTarget(
                 scheme: scheme,
@@ -2239,6 +2245,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
             guard let resolvedPlatform = Self.resolvePlatform(
                 for: target,
                 scheme: scheme,
+                testActionTargets: testActionTargetReferences(
+                    scheme: scheme,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: .build
+                ),
                 graphTraverser: graphTraverser
             ) else { continue }
 
@@ -2250,6 +2261,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
     static func resolvePlatform(
         for target: GraphTarget,
         scheme: Scheme,
+        testActionTargets: [TargetReference],
         graphTraverser: GraphTraversing
     ) -> XcodeGraph.Platform? {
         let targetPlatforms = target.target.supportedPlatforms
@@ -2259,7 +2271,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         let platformConstrainingTargets =
             (scheme.buildAction?.targets ?? [])
-                + (scheme.testAction?.targets.map(\.target) ?? [])
+                + testActionTargets
         let compatibleSchemePlatformSets = platformConstrainingTargets
             .compactMap {
                 graphTraverser.target(path: $0.projectPath, name: $0.name)?

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -614,49 +614,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_run_tests_with_passthrough_destination_validates_explicit_platform() async throws {
-        // Given
-        givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.test(project: .testGeneratedProject()))
-        given(generator)
-            .generateWithGraph(path: .any, options: .any)
-            .willProduce { path, _ in
-                (
-                    path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])),
-                    MapperEnvironment()
-                )
-            }
-        given(buildGraphInspector)
-            .testableTarget(
-                scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any,
-                graphTraverser: .any,
-                action: .any
-            )
-            .willReturn(
-                .test(target: .test(destinations: [.iPhone, .mac]))
-            )
-        given(simulatorController)
-            .findAvailableDevice(udid: .any)
-            .willReturn(.test(device: .test(name: "Test iPhone")))
-        let path = try temporaryPath()
-
-        // When
-        do {
-            try await testRun(
-                schemeName: "TestScheme",
-                path: path,
-                platform: "unsupported",
-                passthroughXcodeBuildArguments: ["-destination", "id=device-id"]
-            )
-            XCTFail("Expected an unsupported platform error")
-        } catch {
-            // Then
-            XCTAssertTrue(error is UnsupportedPlatformError)
-        }
-    }
-
     func test_run_tests_for_only_specified_scheme() async throws {
         // Given
         givenGenerator()
@@ -6130,8 +6087,28 @@ final class TestServiceTests: TuistUnitTestCase {
         let graphTraverser = MockGraphTraversing()
         XCTAssertNil(subject.inferPlatformDestination(schemes: [], graphTraverser: graphTraverser))
     }
+}
 
-    func test_resolvePlatform_ignores_pre_action_targets() throws {
+@Suite
+struct TestServiceSchemePlanningTests {
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_with_passthrough_destination_validates_explicit_platform() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fixture = TestServiceSchemePlanningFixture(
+            scenario: SchemePlanningScenario(rootDirectory: temporaryDirectory)
+        )
+
+        await #expect(throws: UnsupportedPlatformError.self) {
+            try await fixture.run(
+                path: temporaryDirectory,
+                platform: "unsupported",
+                passthroughXcodeBuildArguments: ["-destination", "id=device-id"]
+            )
+        }
+    }
+
+    @Test
+    func resolvePlatform_ignores_pre_action_targets() throws {
         let projectPath = try AbsolutePath(validating: "/Project")
         let app = Target.test(name: "App", destinations: .iOS)
         let tests = Target.test(
@@ -6173,20 +6150,84 @@ final class TestServiceTests: TuistUnitTestCase {
                 ]
             )
         )
-        let graphTarget = try XCTUnwrap(
+        let graphTarget = try #require(
             graphTraverser.target(path: projectPath, name: tests.name)
         )
 
         let platform = TestService.resolvePlatform(
             for: graphTarget,
             scheme: scheme,
+            testActionTargets: [testsReference],
             graphTraverser: graphTraverser
         )
 
-        XCTAssertEqual(platform, .iOS)
+        #expect(platform == .iOS)
     }
 
-    func test_resolvePlatform_leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint() throws {
+    @Test
+    func resolvePlatform_uses_selected_test_plan_targets() throws {
+        let projectPath = try AbsolutePath(validating: "/Project")
+        let tests = Target.test(
+            name: "BaseTests",
+            destinations: [.iPhone, .mac],
+            product: .unitTests
+        )
+        let iosTests = Target.test(
+            name: "iOSTests",
+            destinations: .iOS,
+            product: .unitTests
+        )
+        let testsReference = TargetReference(projectPath: projectPath, name: tests.name)
+        let iosTestsReference = TargetReference(projectPath: projectPath, name: iosTests.name)
+        let scheme = Scheme.test(
+            name: "SelectedPlan",
+            buildAction: .test(targets: [testsReference]),
+            testAction: .test(
+                targets: [],
+                testPlans: [
+                    TestPlan(
+                        path: projectPath.appending(component: "SelectedPlan.xctestplan"),
+                        testTargets: [
+                            .test(target: testsReference),
+                            .test(target: iosTestsReference),
+                        ],
+                        isDefault: false
+                    ),
+                ]
+            ),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let graphTraverser = GraphTraverser(
+            graph: .test(
+                path: projectPath,
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [tests, iosTests],
+                        schemes: [scheme]
+                    ),
+                ]
+            )
+        )
+        let graphTarget = try #require(
+            graphTraverser.target(path: projectPath, name: tests.name)
+        )
+        let selectedPlan = try #require(scheme.testAction?.testPlans?.first)
+
+        let platform = TestService.resolvePlatform(
+            for: graphTarget,
+            scheme: scheme,
+            testActionTargets: selectedPlan.testTargets.map(\.target),
+            graphTraverser: graphTraverser
+        )
+
+        #expect(platform == .iOS)
+    }
+
+    @Test
+    func resolvePlatform_leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint() throws {
         let projectPath = try AbsolutePath(validating: "/Project")
         let tests = Target.test(
             name: "BaseTests",
@@ -6214,22 +6255,20 @@ final class TestServiceTests: TuistUnitTestCase {
                 ]
             )
         )
-        let graphTarget = try XCTUnwrap(
+        let graphTarget = try #require(
             graphTraverser.target(path: projectPath, name: tests.name)
         )
 
         let platform = TestService.resolvePlatform(
             for: graphTarget,
             scheme: scheme,
+            testActionTargets: [testsReference],
             graphTraverser: graphTraverser
         )
 
-        XCTAssertNil(platform)
+        #expect(platform == nil)
     }
-}
 
-@Suite
-struct TestServiceSchemePlanningTests {
     @Test(.inTemporaryDirectory, .withMockedDependencies())
     func run_uses_non_overlapping_single_target_schemes_for_mixed_tests() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
@@ -6691,6 +6730,7 @@ private struct TestServiceSchemePlanningFixture {
     func run(
         path: AbsolutePath,
         action: XcodeBuildTestAction = .test,
+        platform: String? = nil,
         resultBundlePath: AbsolutePath? = nil,
         derivedDataPath: AbsolutePath? = nil,
         testTargets: [TestIdentifier] = [],
@@ -6705,7 +6745,7 @@ private struct TestServiceSchemePlanningFixture {
                 configuration: nil,
                 path: path,
                 deviceName: nil,
-                platform: nil,
+                platform: platform,
                 osVersion: nil,
                 action: action,
                 rosetta: false,

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -614,6 +614,49 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_tests_with_passthrough_destination_validates_explicit_platform() async throws {
+        // Given
+        givenGenerator()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])),
+                    MapperEnvironment()
+                )
+            }
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(
+                .test(target: .test(destinations: [.iPhone, .mac]))
+            )
+        given(simulatorController)
+            .findAvailableDevice(udid: .any)
+            .willReturn(.test(device: .test(name: "Test iPhone")))
+        let path = try temporaryPath()
+
+        // When
+        do {
+            try await testRun(
+                schemeName: "TestScheme",
+                path: path,
+                platform: "unsupported",
+                passthroughXcodeBuildArguments: ["-destination", "id=device-id"]
+            )
+            XCTFail("Expected an unsupported platform error")
+        } catch {
+            // Then
+            XCTAssertTrue(error is UnsupportedPlatformError)
+        }
+    }
+
     func test_run_tests_for_only_specified_scheme() async throws {
         // Given
         givenGenerator()
@@ -6087,12 +6130,8 @@ final class TestServiceTests: TuistUnitTestCase {
         let graphTraverser = MockGraphTraversing()
         XCTAssertNil(subject.inferPlatformDestination(schemes: [], graphTraverser: graphTraverser))
     }
-}
 
-@Suite
-struct TestServicePlatformResolutionTests {
-    @Test
-    func resolves_multi_platform_test_target_from_scheme_targets() throws {
+    func test_resolvePlatform_ignores_pre_action_targets() throws {
         let projectPath = try AbsolutePath(validating: "/Project")
         let app = Target.test(name: "App", destinations: .iOS)
         let tests = Target.test(
@@ -6100,11 +6139,23 @@ struct TestServicePlatformResolutionTests {
             destinations: [.iPhone, .mac],
             product: .unitTests
         )
+        let codegenTool = Target.test(name: "CodegenTool", destinations: .macOS)
         let appReference = TargetReference(projectPath: projectPath, name: app.name)
         let testsReference = TargetReference(projectPath: projectPath, name: tests.name)
+        let codegenToolReference = TargetReference(projectPath: projectPath, name: codegenTool.name)
         let scheme = Scheme.test(
             name: "iOS",
-            buildAction: .test(targets: [appReference, testsReference]),
+            buildAction: .test(
+                targets: [appReference, testsReference],
+                preActions: [
+                    ExecutionAction(
+                        title: "Generate code",
+                        scriptText: "generate-code",
+                        target: codegenToolReference,
+                        shellPath: "/bin/sh"
+                    ),
+                ]
+            ),
             testAction: .test(targets: [.test(target: testsReference)]),
             runAction: nil,
             archiveAction: nil,
@@ -6116,13 +6167,13 @@ struct TestServicePlatformResolutionTests {
                 projects: [
                     projectPath: .test(
                         path: projectPath,
-                        targets: [app, tests],
+                        targets: [app, tests, codegenTool],
                         schemes: [scheme]
                     ),
                 ]
             )
         )
-        let graphTarget = try #require(
+        let graphTarget = try XCTUnwrap(
             graphTraverser.target(path: projectPath, name: tests.name)
         )
 
@@ -6132,11 +6183,10 @@ struct TestServicePlatformResolutionTests {
             graphTraverser: graphTraverser
         )
 
-        #expect(platform == .iOS)
+        XCTAssertEqual(platform, .iOS)
     }
 
-    @Test
-    func leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint() throws {
+    func test_resolvePlatform_leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint() throws {
         let projectPath = try AbsolutePath(validating: "/Project")
         let tests = Target.test(
             name: "BaseTests",
@@ -6164,7 +6214,7 @@ struct TestServicePlatformResolutionTests {
                 ]
             )
         )
-        let graphTarget = try #require(
+        let graphTarget = try XCTUnwrap(
             graphTraverser.target(path: projectPath, name: tests.name)
         )
 
@@ -6174,7 +6224,7 @@ struct TestServicePlatformResolutionTests {
             graphTraverser: graphTraverser
         )
 
-        #expect(platform == nil)
+        XCTAssertNil(platform)
     }
 }
 

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -549,6 +549,15 @@ final class TestServiceTests: TuistUnitTestCase {
                     MapperEnvironment()
                 )
             }
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(
+                .test(target: .test(destinations: [.iPhone, .mac]))
+            )
         given(simulatorController)
             .findAvailableDevice(udid: .any)
             .willReturn(.test(device: .test(name: "Test iPhone")))
@@ -6077,6 +6086,95 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_inferPlatformDestination_returns_nil_for_empty_schemes() {
         let graphTraverser = MockGraphTraversing()
         XCTAssertNil(subject.inferPlatformDestination(schemes: [], graphTraverser: graphTraverser))
+    }
+}
+
+@Suite
+struct TestServicePlatformResolutionTests {
+    @Test
+    func resolves_multi_platform_test_target_from_scheme_targets() throws {
+        let projectPath = try AbsolutePath(validating: "/Project")
+        let app = Target.test(name: "App", destinations: .iOS)
+        let tests = Target.test(
+            name: "BaseTests",
+            destinations: [.iPhone, .mac],
+            product: .unitTests
+        )
+        let appReference = TargetReference(projectPath: projectPath, name: app.name)
+        let testsReference = TargetReference(projectPath: projectPath, name: tests.name)
+        let scheme = Scheme.test(
+            name: "iOS",
+            buildAction: .test(targets: [appReference, testsReference]),
+            testAction: .test(targets: [.test(target: testsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let graphTraverser = GraphTraverser(
+            graph: .test(
+                path: projectPath,
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [app, tests],
+                        schemes: [scheme]
+                    ),
+                ]
+            )
+        )
+        let graphTarget = try #require(
+            graphTraverser.target(path: projectPath, name: tests.name)
+        )
+
+        let platform = TestService.resolvePlatform(
+            for: graphTarget,
+            scheme: scheme,
+            graphTraverser: graphTraverser
+        )
+
+        #expect(platform == .iOS)
+    }
+
+    @Test
+    func leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint() throws {
+        let projectPath = try AbsolutePath(validating: "/Project")
+        let tests = Target.test(
+            name: "BaseTests",
+            destinations: [.iPhone, .mac],
+            product: .unitTests
+        )
+        let testsReference = TargetReference(projectPath: projectPath, name: tests.name)
+        let scheme = Scheme.test(
+            name: "AllPlatforms",
+            buildAction: .test(targets: [testsReference]),
+            testAction: .test(targets: [.test(target: testsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let graphTraverser = GraphTraverser(
+            graph: .test(
+                path: projectPath,
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [tests],
+                        schemes: [scheme]
+                    ),
+                ]
+            )
+        )
+        let graphTarget = try #require(
+            graphTraverser.target(path: projectPath, name: tests.name)
+        )
+
+        let platform = TestService.resolvePlatform(
+            for: graphTarget,
+            scheme: scheme,
+            graphTraverser: graphTraverser
+        )
+
+        #expect(platform == nil)
     }
 }
 


### PR DESCRIPTION
## What changed

`tuist test` now resolves a multi-platform test target against the targets that the selected scheme actually builds or tests. Script hosts and targets from unrelated scheme actions do not influence the result. A forwarded Xcode destination bypasses Tuist's platform inference, while an explicit `--platform` value is still validated.

## Why

Projects can share a test target across iOS and macOS while exposing platform-specific schemes. Running `tuist test iOS` should use the iOS constraints already present in the selected scheme instead of rejecting the shared test target.

## Root cause

The test service inferred the destination from the first testable target in isolation. When that target supported more than one platform, it failed before considering the relevant build and test targets in the selected scheme or a destination already forwarded to Xcode.

## Approach

Platform resolution intersects the test target's supported platforms with compatible build and test targets from the scheme. It selects a platform only when the result is unambiguous, ignores pre-action and post-action script hosts, and keeps the explicit `--platform` override as the highest-priority Tuist input.

## Impact

Platform-specific schemes can test shared multi-platform targets without repeating `--platform`. Genuinely ambiguous schemes still require an explicit platform or Xcode destination and now receive clearer guidance.

## Validation

### How to test locally

- `mise run cli:lint --fix`
- `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TestServiceTests/test_resolvePlatform_ignores_pre_action_targets -only-testing TuistKitTests/TestServiceTests/test_resolvePlatform_leaves_multi_platform_test_target_ambiguous_without_a_scheme_constraint -only-testing TuistKitTests/TestServiceTests/test_run_tests_with_passthrough_destination -only-testing TuistKitTests/TestServiceTests/test_run_tests_with_passthrough_destination_validates_explicit_platform CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `git diff --check`
- Claude headless regression review of the final diff: no findings
