### PR TITLE
fix(registry): recover releases after transient manifest failures

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -127,6 +127,12 @@ spec:
                 secretKeyRef:
                   name: {{ $registryRuntimeSecretName }}
                   key: S3_REGISTRY_BUCKET
+            - name: TUIST_REGISTRY_S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_ENDPOINT
+                  optional: true
             - name: TUIST_REGISTRY_S3_HOST
               valueFrom:
                 secretKeyRef:

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $secretName := include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
 {{- $objectStorageAccessKey := include "tuist.objectStorageAccessKey" . -}}
 {{- $objectStorageSecretKey := include "tuist.objectStorageSecretKey" . -}}
+{{- $registryRuntimeSecretName := .Values.registry.runtimeSecretName | default (include "tuist.componentName" (dict "root" . "component" "registry-runtime")) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -120,6 +121,33 @@ spec:
               value: {{ .Values.server.logLevel | quote }}
             - name: TUIST_HOSTED
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
+            {{- if .Values.registry.enabled }}
+            - name: TUIST_REGISTRY_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_REGISTRY_BUCKET
+            - name: TUIST_REGISTRY_S3_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_HOST
+            - name: TUIST_REGISTRY_S3_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_REGION
+            - name: TUIST_REGISTRY_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_ACCESS_KEY_ID
+            - name: TUIST_REGISTRY_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $registryRuntimeSecretName }}
+                  key: S3_SECRET_ACCESS_KEY
+            {{- end }}
             {{- if .Values.codebaseSearch.enabled }}
             - name: TUIST_CODEBASE_SEARCH_URL
               value: {{ printf "http://%s:%v" (include "tuist.componentName" (dict "root" . "component" "codebase-search")) .Values.codebaseSearch.service.port | quote }}

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -654,14 +654,15 @@ end
 
 # Registry config.
 #
-# The bucket name is shared across ecosystems (one Tigris bucket).
+# The bucket name is shared across ecosystems (one Tigris bucket). The web
+# runtime receives a dedicated registry object-storage configuration so its
+# operations pages do not reuse the account-artifact credentials.
 # `swift_*` keys are scoped to the Swift Package Registry sync workers.
 # `Tuist.Registry.Swift.SyncWorker` is cron-fired by the :web leader
 # and inserts jobs into the `:swift_registry_sync` queue. The
 # swift-registry-sync pod (`TUIST_MODE=swift_registry_sync`) consumes
 # them plus the `:swift_registry_release` jobs each SyncWorker enqueues
-# per missing tag. Reads from the bucket happen on the standalone
-# `registry` Phoenix app, not here.
+# per missing tag.
 swift_registry_sync_allowlist =
   case System.get_env("SWIFT_REGISTRY_SYNC_ALLOWLIST") do
     nil -> nil
@@ -675,77 +676,109 @@ swift_registry_sync_limit =
     value -> String.to_integer(value)
   end
 
+first_registry_env = fn names ->
+  Enum.find_value(names, fn name ->
+    case System.get_env(name) do
+      value when value not in [nil, ""] -> value
+      _ -> nil
+    end
+  end)
+end
+
+legacy_registry_s3_names =
+  if Tuist.Environment.swift_registry_sync_mode?() do
+    %{
+      endpoint: ["S3_ENDPOINT"],
+      host: ["S3_HOST"],
+      region: ["S3_REGION"],
+      access_key_id: ["S3_ACCESS_KEY_ID"],
+      secret_access_key: ["S3_SECRET_ACCESS_KEY"]
+    }
+  else
+    %{endpoint: [], host: [], region: [], access_key_id: [], secret_access_key: []}
+  end
+
+registry_bucket = first_registry_env.(["TUIST_REGISTRY_S3_BUCKET", "S3_REGISTRY_BUCKET"])
+
+registry_s3_endpoint =
+  first_registry_env.(["TUIST_REGISTRY_S3_ENDPOINT"] ++ legacy_registry_s3_names.endpoint)
+
+registry_s3_host =
+  first_registry_env.(["TUIST_REGISTRY_S3_HOST"] ++ legacy_registry_s3_names.host)
+
+registry_s3_region =
+  first_registry_env.(["TUIST_REGISTRY_S3_REGION"] ++ legacy_registry_s3_names.region) || "auto"
+
+registry_s3_access_key_id =
+  first_registry_env.(["TUIST_REGISTRY_S3_ACCESS_KEY_ID"] ++ legacy_registry_s3_names.access_key_id)
+
+registry_s3_secret_access_key =
+  first_registry_env.(["TUIST_REGISTRY_S3_SECRET_ACCESS_KEY"] ++ legacy_registry_s3_names.secret_access_key)
+
+{registry_s3_scheme, registry_s3_host, registry_s3_port} =
+  case registry_s3_endpoint do
+    nil ->
+      {"https://", registry_s3_host, nil}
+
+    endpoint ->
+      uri = URI.parse(endpoint)
+      {"#{uri.scheme || "https"}://", uri.host || registry_s3_host, uri.port}
+  end
+
+registry_s3_values = [
+  {"registry bucket", registry_bucket},
+  {"registry object-storage endpoint or host", registry_s3_host},
+  {"registry object-storage access key", registry_s3_access_key_id},
+  {"registry object-storage secret key", registry_s3_secret_access_key}
+]
+
+missing_registry_s3_values =
+  Enum.filter(registry_s3_values, fn {_name, value} -> value in [nil, ""] end)
+
+if registry_bucket not in [nil, ""] and missing_registry_s3_values != [] do
+  names = Enum.map_join(missing_registry_s3_values, ", ", fn {name, _value} -> name end)
+  raise "Registry object storage requires #{names} to be set; refusing to boot"
+end
+
+registry_s3_config =
+  if missing_registry_s3_values == [] do
+    then(
+      [
+        scheme: registry_s3_scheme,
+        host: registry_s3_host,
+        region: registry_s3_region,
+        virtual_host: false,
+        access_key_id: registry_s3_access_key_id,
+        secret_access_key: registry_s3_secret_access_key
+      ],
+      fn config ->
+        if is_nil(registry_s3_port), do: config, else: Keyword.put(config, :port, registry_s3_port)
+      end
+    )
+  else
+    []
+  end
+
 config :tuist, :registry,
-  bucket: System.get_env("S3_REGISTRY_BUCKET"),
+  bucket: registry_bucket,
+  s3_config: registry_s3_config,
   url: System.get_env("TUIST_REGISTRY_URL"),
   swift_github_token: System.get_env("SWIFT_REGISTRY_GITHUB_TOKEN"),
   swift_sync_enabled: swift_registry_sync_enabled,
   swift_sync_allowlist: swift_registry_sync_allowlist,
   swift_sync_limit: swift_registry_sync_limit
 
-# In swift-registry-sync mode the BEAM only talks to the registry S3
-# bucket, so override ex_aws to the registry's Tigris key set. No other
-# queue runs in this pod, so the override never reaches a Storage call.
-# We fail fast if any required env is blank: silently falling back to the
-# account-storage credentials would write to the registry bucket with the
-# wrong principal and 403 every upload while the cursor still advances.
+# In swift-registry-sync mode the BEAM only talks to the registry object-storage
+# bucket, so the dedicated configuration can also be the global ExAws
+# configuration. No other queue runs in this pod, so the override never reaches
+# an account-artifact Storage call.
 if Tuist.Environment.swift_registry_sync_mode?() do
-  registry_s3_endpoint = System.get_env("S3_ENDPOINT")
-
-  {registry_s3_scheme, registry_s3_host, registry_s3_port} =
-    case registry_s3_endpoint do
-      endpoint when endpoint in [nil, ""] ->
-        {"https://", System.get_env("S3_HOST"), nil}
-
-      endpoint ->
-        uri = URI.parse(endpoint)
-
-        {host, port} =
-          case {uri.host, uri.port} do
-            {nil, _} -> {System.get_env("S3_HOST"), nil}
-            {host, nil} -> {host, nil}
-            {host, port} -> {host, port}
-          end
-
-        scheme = (uri.scheme || "https") <> "://"
-        {scheme, host, port}
-    end
-
-  registry_s3_region = System.get_env("S3_REGION") || "auto"
-  registry_s3_access_key_id = System.get_env("S3_ACCESS_KEY_ID")
-  registry_s3_secret_access_key = System.get_env("S3_SECRET_ACCESS_KEY")
-  registry_bucket = System.get_env("S3_REGISTRY_BUCKET")
-
-  missing =
-    Enum.filter(
-      [
-        {"S3_REGISTRY_BUCKET", registry_bucket},
-        {"S3_ENDPOINT or S3_HOST", registry_s3_host},
-        {"S3_ACCESS_KEY_ID", registry_s3_access_key_id},
-        {"S3_SECRET_ACCESS_KEY", registry_s3_secret_access_key}
-      ],
-      fn {_name, value} -> value in [nil, ""] end
-    )
-
-  if missing != [] do
-    names = Enum.map_join(missing, ", ", fn {name, _} -> name end)
+  if missing_registry_s3_values != [] do
+    names = Enum.map_join(missing_registry_s3_values, ", ", fn {name, _value} -> name end)
     raise "TUIST_MODE=swift_registry_sync requires #{names} to be set; refusing to boot"
   end
 
-  registry_s3_config =
-    then(
-      [
-        scheme: registry_s3_scheme,
-        host: registry_s3_host,
-        region: registry_s3_region,
-        virtual_host: false
-      ],
-      fn config ->
-        if is_nil(registry_s3_port), do: config, else: Keyword.put(config, :port, registry_s3_port)
-      end
-    )
-
-  config :ex_aws, :s3, registry_s3_config
+  config :ex_aws, :s3, Keyword.drop(registry_s3_config, [:access_key_id, :secret_access_key])
 
   config :ex_aws,
     access_key_id: registry_s3_access_key_id,

--- a/server/lib/tuist/registry.ex
+++ b/server/lib/tuist/registry.ex
@@ -26,6 +26,7 @@ defmodule Tuist.Registry do
   alias Tuist.Registry.Swift.SyncWorker
 
   def registry_bucket, do: Application.get_env(:tuist, :registry)[:bucket]
+  def registry_s3_config, do: Application.get_env(:tuist, :registry)[:s3_config] || []
 
   @doc """
   The full public base URL, including the API path prefix, that clients use

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -1,11 +1,12 @@
 defmodule Tuist.Registry.S3 do
   @moduledoc """
-  S3 helpers for sync workers writing into the registry bucket.
+  S3 helpers for reading and writing the registry bucket.
 
   Server uses `Tuist.Storage` for account-scoped artifact buckets; this
-  module is the parallel surface for the registry bucket and is only
-  touched by `Tuist.Registry.Swift.*` workers. The standalone registry
-  pod has its own equivalent (`TuistRegistry.S3`) for reads.
+  module is the parallel surface for the registry bucket. It always passes
+  the registry's dedicated connection and credentials so operations-page
+  reads cannot accidentally use the account-artifact storage configuration.
+  The standalone registry pod has its own equivalent (`TuistRegistry.S3`).
   """
 
   alias ExAws.S3.Upload
@@ -15,8 +16,9 @@ defmodule Tuist.Registry.S3 do
 
   def get_object(key) when is_binary(key) do
     bucket = Registry.registry_bucket()
+    config = Registry.registry_s3_config()
 
-    case bucket |> ExAws.S3.get_object(key) |> ExAws.request() do
+    case bucket |> ExAws.S3.get_object(key) |> ExAws.request(config) do
       {:ok, %{status_code: 200, body: body}} -> {:ok, body}
       {:ok, %{status_code: 404}} -> {:error, :not_found}
       {:ok, %{status_code: status}} -> {:error, {:s3_error, status}}
@@ -27,6 +29,7 @@ defmodule Tuist.Registry.S3 do
 
   def upload_file(key, local_path, opts \\ []) when is_binary(key) and is_binary(local_path) do
     bucket = Registry.registry_bucket()
+    config = Registry.registry_s3_config()
     content_type_opt = Keyword.get(opts, :content_type)
 
     upload_opts =
@@ -39,7 +42,7 @@ defmodule Tuist.Registry.S3 do
         local_path
         |> Upload.stream_file()
         |> ExAws.S3.upload(bucket, key, upload_opts)
-        |> ExAws.request()
+        |> ExAws.request(config)
       end)
 
     case result do
@@ -59,6 +62,7 @@ defmodule Tuist.Registry.S3 do
 
   def upload_content(key, content, opts \\ []) when is_binary(key) do
     bucket = Registry.registry_bucket()
+    config = Registry.registry_s3_config()
     content_type_opt = Keyword.get(opts, :content_type)
     put_opts = if content_type_opt, do: [content_type: content_type_opt], else: []
 
@@ -66,7 +70,7 @@ defmodule Tuist.Registry.S3 do
       :timer.tc(fn ->
         bucket
         |> ExAws.S3.put_object(key, content, put_opts)
-        |> ExAws.request()
+        |> ExAws.request(config)
       end)
 
     case result do
@@ -90,9 +94,10 @@ defmodule Tuist.Registry.S3 do
   """
   def delete_all_with_prefix(prefix) when is_binary(prefix) do
     bucket = Registry.registry_bucket()
+    config = Registry.registry_s3_config()
 
     Logger.info("Deleting all S3 objects with prefix: #{prefix}")
-    {duration, result} = :timer.tc(fn -> list_and_delete_objects(bucket, prefix, 0) end)
+    {duration, result} = :timer.tc(fn -> list_and_delete_objects(bucket, prefix, config, 0) end)
 
     case result do
       {:ok, count} ->
@@ -107,14 +112,14 @@ defmodule Tuist.Registry.S3 do
     end
   end
 
-  defp list_and_delete_objects(bucket, prefix, acc) do
+  defp list_and_delete_objects(bucket, prefix, config, acc) do
     bucket
     |> ExAws.S3.list_objects(prefix: prefix)
-    |> ExAws.stream!()
+    |> ExAws.stream!(config)
     |> Stream.map(& &1.key)
     |> Stream.chunk_every(1000)
     |> Enum.reduce_while({:ok, acc}, fn keys, {:ok, count} ->
-      case bucket |> ExAws.S3.delete_multiple_objects(keys) |> ExAws.request() do
+      case bucket |> ExAws.S3.delete_multiple_objects(keys) |> ExAws.request(config) do
         {:ok, _} -> {:cont, {:ok, count + length(keys)}}
         {:error, reason} -> {:halt, {:error, reason}}
       end

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -14,11 +14,15 @@ defmodule Tuist.Registry.S3 do
 
   require Logger
 
+  @doc false
+  def request(operation) do
+    ExAws.request(operation, Registry.registry_s3_config())
+  end
+
   def get_object(key) when is_binary(key) do
     bucket = Registry.registry_bucket()
-    config = Registry.registry_s3_config()
 
-    case bucket |> ExAws.S3.get_object(key) |> ExAws.request(config) do
+    case bucket |> ExAws.S3.get_object(key) |> request() do
       {:ok, %{status_code: 200, body: body}} -> {:ok, body}
       {:ok, %{status_code: 404}} -> {:error, :not_found}
       {:ok, %{status_code: status}} -> {:error, {:s3_error, status}}
@@ -29,7 +33,6 @@ defmodule Tuist.Registry.S3 do
 
   def upload_file(key, local_path, opts \\ []) when is_binary(key) and is_binary(local_path) do
     bucket = Registry.registry_bucket()
-    config = Registry.registry_s3_config()
     content_type_opt = Keyword.get(opts, :content_type)
 
     upload_opts =
@@ -42,7 +45,7 @@ defmodule Tuist.Registry.S3 do
         local_path
         |> Upload.stream_file()
         |> ExAws.S3.upload(bucket, key, upload_opts)
-        |> ExAws.request(config)
+        |> request()
       end)
 
     case result do
@@ -62,7 +65,6 @@ defmodule Tuist.Registry.S3 do
 
   def upload_content(key, content, opts \\ []) when is_binary(key) do
     bucket = Registry.registry_bucket()
-    config = Registry.registry_s3_config()
     content_type_opt = Keyword.get(opts, :content_type)
     put_opts = if content_type_opt, do: [content_type: content_type_opt], else: []
 
@@ -70,7 +72,7 @@ defmodule Tuist.Registry.S3 do
       :timer.tc(fn ->
         bucket
         |> ExAws.S3.put_object(key, content, put_opts)
-        |> ExAws.request(config)
+        |> request()
       end)
 
     case result do
@@ -94,10 +96,9 @@ defmodule Tuist.Registry.S3 do
   """
   def delete_all_with_prefix(prefix) when is_binary(prefix) do
     bucket = Registry.registry_bucket()
-    config = Registry.registry_s3_config()
 
     Logger.info("Deleting all S3 objects with prefix: #{prefix}")
-    {duration, result} = :timer.tc(fn -> list_and_delete_objects(bucket, prefix, config, 0) end)
+    {duration, result} = :timer.tc(fn -> list_and_delete_objects(bucket, prefix, 0) end)
 
     case result do
       {:ok, count} ->
@@ -112,14 +113,14 @@ defmodule Tuist.Registry.S3 do
     end
   end
 
-  defp list_and_delete_objects(bucket, prefix, config, acc) do
+  defp list_and_delete_objects(bucket, prefix, acc) do
     bucket
     |> ExAws.S3.list_objects(prefix: prefix)
-    |> ExAws.stream!(config)
+    |> ExAws.stream!(Registry.registry_s3_config())
     |> Stream.map(& &1.key)
     |> Stream.chunk_every(1000)
     |> Enum.reduce_while({:ok, acc}, fn keys, {:ok, count} ->
-      case bucket |> ExAws.S3.delete_multiple_objects(keys) |> ExAws.request(config) do
+      case bucket |> ExAws.S3.delete_multiple_objects(keys) |> request() do
         {:ok, _} -> {:cont, {:ok, count + length(keys)}}
         {:error, reason} -> {:halt, {:error, reason}}
       end

--- a/server/lib/tuist/registry/swift/lock.ex
+++ b/server/lib/tuist/registry/swift/lock.ex
@@ -34,7 +34,7 @@ defmodule Tuist.Registry.Swift.Lock do
     lock_key = lock_key(key)
     bucket = bucket()
 
-    case bucket |> ExAws.S3.delete_object(lock_key) |> ExAws.request() do
+    case bucket |> ExAws.S3.delete_object(lock_key) |> S3.request() do
       {:ok, _} ->
         :ok
 
@@ -81,7 +81,7 @@ defmodule Tuist.Registry.Swift.Lock do
     case bucket
          |> ExAws.S3.get_object(lock_key)
          |> with_tigris_consistency()
-         |> ExAws.request() do
+         |> S3.request() do
       {:ok, %{body: body, headers: headers}} ->
         with {:ok, lock} <- JSON.decode(body) do
           {:ok, lock, S3.etag_from_headers(headers)}
@@ -101,7 +101,7 @@ defmodule Tuist.Registry.Swift.Lock do
     bucket
     |> ExAws.S3.put_object(lock_key, body, Keyword.merge([content_type: "application/json"], opts))
     |> with_tigris_consistency()
-    |> ExAws.request()
+    |> S3.request()
   end
 
   defp with_tigris_consistency(%{headers: headers} = op) do

--- a/server/lib/tuist/registry/swift/metadata.ex
+++ b/server/lib/tuist/registry/swift/metadata.ex
@@ -9,6 +9,18 @@ defmodule Tuist.Registry.Swift.Metadata do
   alias Tuist.Registry.S3
   alias TuistCommon.Registry.Swift.Metadata, as: MetadataContract
 
+  @skip_classification_version 2
+
+  def verified_skip?(%{"classification_version" => @skip_classification_version}), do: true
+  def verified_skip?(_skip), do: false
+
+  def verified_skip(reason) when is_binary(reason) do
+    %{
+      "classification_version" => @skip_classification_version,
+      "reason" => reason
+    }
+  end
+
   def get_package(scope, name, _opts \\ []) do
     key = MetadataContract.s3_key(scope, name)
 

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -26,6 +26,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   @metadata_lock_max_attempts 5
   @metadata_lock_backoff_ms 200
   @metadata_lock_snooze_seconds 30
+  @skip_classification_version 2
   @skippable_submodule_failure_markers [
     "no url found for submodule path",
     "transport 'file' not allowed",
@@ -74,7 +75,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             skipped_releases = Map.get(metadata, "skipped_releases", %{})
 
             if Map.has_key?(releases, normalized_version) or
-                 Map.has_key?(skipped_releases, normalized_version) do
+                 verified_skipped_release?(skipped_releases, normalized_version) do
               :ok
             else
               sync_release(scope, name, full_handle, tag, normalized_version, token)
@@ -664,31 +665,35 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp fetch_manifests(full_handle, tag, token) do
     with {:ok, contents} <-
            TuistCommon.GitHub.list_repository_contents(full_handle, token, tag, @github_opts) do
-      manifest_payloads =
+      {manifest_payloads, failures} =
         contents
         |> Enum.map(&Map.get(&1, "path"))
         |> Enum.filter(&manifest_path?/1)
-        |> Enum.map(fn path ->
+        |> Enum.reduce({[], []}, fn path, {manifest_payloads, failures} ->
           filename = Path.basename(path)
 
           case TuistCommon.GitHub.get_file_content(full_handle, token, path, tag, @github_opts) do
             {:ok, content} ->
-              %{
+              manifest_payload = %{
                 content: content,
                 filename: filename,
                 path: path,
                 swift_version: AlternateManifest.swift_version_from_filename(filename)
               }
 
+              {[manifest_payload | manifest_payloads], failures}
+
             {:error, reason} ->
               Logger.warning("Failed to fetch manifest #{path} for #{full_handle}@#{tag}: #{inspect(reason)}")
 
-              nil
+              {manifest_payloads, [%{path: path, reason: reason} | failures]}
           end
         end)
-        |> Enum.reject(&is_nil/1)
 
       cond do
+        failures != [] ->
+          {:error, {:manifest_fetch_failed, Enum.reverse(failures)}}
+
         manifest_payloads == [] ->
           {:error, {:missing_manifests, full_handle, tag}}
 
@@ -696,7 +701,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
           {:error, {:missing_default_manifest, full_handle, tag}}
 
         true ->
-          {:ok, manifest_payloads}
+          {:ok, Enum.reverse(manifest_payloads)}
       end
     end
   end
@@ -886,9 +891,15 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
         })
       end
     )
+    |> Map.update("skipped_releases", %{}, &Map.delete(&1 || %{}, version))
   end
 
   defp build_updated_metadata_with_skipped_release(metadata, scope, name, full_handle, version, reason) do
+    skipped_release = %{
+      "classification_version" => @skip_classification_version,
+      "reason" => reason
+    }
+
     metadata
     |> Map.put_new("scope", scope)
     |> Map.put_new("name", name)
@@ -899,11 +910,18 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     )
     |> Map.update(
       "skipped_releases",
-      %{version => %{"reason" => reason}},
+      %{version => skipped_release},
       fn skipped_releases ->
-        Map.put(skipped_releases || %{}, version, %{"reason" => reason})
+        Map.put(skipped_releases || %{}, version, skipped_release)
       end
     )
+  end
+
+  defp verified_skipped_release?(skipped_releases, version) do
+    case Map.get(skipped_releases, version) do
+      %{"classification_version" => @skip_classification_version} -> true
+      _ -> false
+    end
   end
 
   defp upload_manifest(scope, name, version, filename, content) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -26,7 +26,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   @metadata_lock_max_attempts 5
   @metadata_lock_backoff_ms 200
   @metadata_lock_snooze_seconds 30
-  @skip_classification_version 2
   @skippable_submodule_failure_markers [
     "no url found for submodule path",
     "transport 'file' not allowed",
@@ -75,7 +74,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             skipped_releases = Map.get(metadata, "skipped_releases", %{})
 
             if Map.has_key?(releases, normalized_version) or
-                 verified_skipped_release?(skipped_releases, normalized_version) do
+                 Metadata.verified_skip?(Map.get(skipped_releases, normalized_version)) do
               :ok
             else
               sync_release(scope, name, full_handle, tag, normalized_version, token)
@@ -895,10 +894,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   end
 
   defp build_updated_metadata_with_skipped_release(metadata, scope, name, full_handle, version, reason) do
-    skipped_release = %{
-      "classification_version" => @skip_classification_version,
-      "reason" => reason
-    }
+    skipped_release = Metadata.verified_skip(reason)
 
     metadata
     |> Map.put_new("scope", scope)
@@ -915,13 +911,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
         Map.put(skipped_releases || %{}, version, skipped_release)
       end
     )
-  end
-
-  defp verified_skipped_release?(skipped_releases, version) do
-    case Map.get(skipped_releases, version) do
-      %{"classification_version" => @skip_classification_version} -> true
-      _ -> false
-    end
   end
 
   defp upload_manifest(scope, name, version, filename, content) do

--- a/server/lib/tuist/registry/swift/sync_cursor.ex
+++ b/server/lib/tuist/registry/swift/sync_cursor.ex
@@ -2,6 +2,7 @@ defmodule Tuist.Registry.Swift.SyncCursor do
   @moduledoc false
 
   alias Tuist.Registry
+  alias Tuist.Registry.S3
 
   require Logger
 
@@ -10,7 +11,7 @@ defmodule Tuist.Registry.Swift.SyncCursor do
   def get do
     bucket = Registry.registry_bucket()
 
-    case bucket |> ExAws.S3.get_object(@key) |> ExAws.request() do
+    case bucket |> ExAws.S3.get_object(@key) |> S3.request() do
       {:ok, %{body: body}} ->
         case JSON.decode(body) do
           {:ok, %{"cursor" => cursor}} when is_integer(cursor) and cursor >= 0 -> cursor
@@ -35,7 +36,7 @@ defmodule Tuist.Registry.Swift.SyncCursor do
 
     case Registry.registry_bucket()
          |> ExAws.S3.put_object(@key, body, content_type: "application/json")
-         |> ExAws.request() do
+         |> S3.request() do
       {:ok, _response} ->
         :ok
 

--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -26,6 +26,7 @@ defmodule Tuist.Registry.Swift.SyncWorker do
   @sync_lock_ttl_seconds 3_000
   @package_lock_ttl_seconds 900
   @release_lock_ttl_seconds 1_800
+  @skip_classification_version 2
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -265,7 +266,15 @@ defmodule Tuist.Registry.Swift.SyncWorker do
   defp missing_versions(tags, metadata) do
     releases = Map.get(metadata, "releases", %{})
     skipped_releases = Map.get(metadata, "skipped_releases", %{})
-    known_versions = Map.keys(releases) ++ Map.keys(skipped_releases)
+
+    verified_skipped_versions =
+      skipped_releases
+      |> Enum.filter(fn {_version, release} ->
+        match?(%{"classification_version" => @skip_classification_version}, release)
+      end)
+      |> Enum.map(&elem(&1, 0))
+
+    known_versions = Map.keys(releases) ++ verified_skipped_versions
 
     tags
     |> Enum.filter(&KeyNormalizer.valid_source_tag?/1)

--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -26,7 +26,6 @@ defmodule Tuist.Registry.Swift.SyncWorker do
   @sync_lock_ttl_seconds 3_000
   @package_lock_ttl_seconds 900
   @release_lock_ttl_seconds 1_800
-  @skip_classification_version 2
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -269,9 +268,7 @@ defmodule Tuist.Registry.Swift.SyncWorker do
 
     verified_skipped_versions =
       skipped_releases
-      |> Enum.filter(fn {_version, release} ->
-        match?(%{"classification_version" => @skip_classification_version}, release)
-      end)
+      |> Enum.filter(fn {_version, release} -> Metadata.verified_skip?(release) end)
       |> Enum.map(&elem(&1, 0))
 
     known_versions = Map.keys(releases) ++ verified_skipped_versions

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -1,0 +1,38 @@
+defmodule Tuist.Registry.S3Test do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias ExAws.Operation.S3, as: S3Operation
+  alias Tuist.Registry
+  alias Tuist.Registry.S3
+
+  setup :set_mimic_from_context
+
+  test "reads with the dedicated registry object-storage configuration" do
+    config = [
+      host: "registry.example.com",
+      access_key_id: "registry-access-key",
+      secret_access_key: "registry-secret-key"
+    ]
+
+    operation = %S3Operation{
+      http_method: :get,
+      bucket: "registry-bucket",
+      path: "registry/metadata/adjust/ios_sdk/index.json"
+    }
+
+    expect(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    expect(Registry, :registry_s3_config, fn -> config end)
+
+    expect(ExAws.S3, :get_object, fn "registry-bucket", "registry/metadata/adjust/ios_sdk/index.json" ->
+      operation
+    end)
+
+    expect(ExAws, :request, fn ^operation, ^config ->
+      {:ok, %{status_code: 200, body: ~s({"releases":{}})}}
+    end)
+
+    assert {:ok, ~s({"releases":{}})} =
+             S3.get_object("registry/metadata/adjust/ios_sdk/index.json")
+  end
+end

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -18,6 +18,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     Sandbox.checkout(Tuist.Repo)
     stub(Registry, :swift_registry_github_token, fn -> "token" end)
     stub(Registry, :registry_bucket, fn -> "test-bucket" end)
+    stub(Registry, :registry_s3_config, fn -> [host: "registry.example.com"] end)
     stub(Lock, :release, fn _ -> :ok end)
 
     :ok
@@ -47,13 +48,18 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
-  test "downloads, uploads, and updates metadata for a new release" do
+  test "repairs a release that was skipped before skip classifications were versioned" do
+    legacy_metadata = %{
+      "releases" => %{},
+      "skipped_releases" => %{"1.0.0" => %{"reason" => "missing_manifests"}}
+    }
+
     expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
       {:ok, :acquired}
     end)
 
     expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
-      {:error, :not_found}
+      {:ok, legacy_metadata}
     end)
 
     expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
@@ -83,7 +89,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       %S3{http_method: :put, bucket: "test-bucket", path: key}
     end)
 
-    expect(ExAws, :request, 2, fn _op ->
+    expect(ExAws, :request, 2, fn _op, config ->
+      assert config == [host: "registry.example.com"]
       {:ok, %{status_code: 200, body: ""}}
     end)
 
@@ -92,7 +99,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     end)
 
     expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
-      {:error, :not_found}
+      {:ok, legacy_metadata}
     end)
 
     expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
@@ -103,6 +110,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       release = metadata["releases"]["1.0.0"]
       assert is_binary(release["checksum"])
       assert [%{"swift_version" => nil, "swift_tools_version" => "5.9"}] = release["manifests"]
+      refute Map.has_key?(metadata["skipped_releases"], "1.0.0")
       :ok
     end)
 
@@ -153,7 +161,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       %S3{http_method: :put, bucket: "test-bucket", path: key}
     end)
 
-    expect(ExAws, :request, 2, fn _operation ->
+    expect(ExAws, :request, 2, fn _operation, _config ->
       {:ok, %{status_code: 200, body: ""}}
     end)
 
@@ -188,11 +196,54 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ -> flunk("unexpected file request") end)
 
     expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
-      assert metadata["skipped_releases"]["1.0.0"] == %{"reason" => "missing_manifests"}
+      assert metadata["skipped_releases"]["1.0.0"] == %{
+               "classification_version" => 2,
+               "reason" => "missing_manifests"
+             }
+
       :ok
     end)
 
     assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "retries when a listed manifest cannot be fetched" do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:error, {:http_error, 403}}
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected skipped-release write") end)
+
+    assert {:error,
+            {:manifest_fetch_failed,
+             [
+               %{
+                 path: "Package.swift",
+                 reason: {:http_error, 403}
+               }
+             ]}} =
              ReleaseWorker.perform(%Oban.Job{
                args: %{
                  "scope" => "apple",
@@ -277,7 +328,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       %S3{http_method: :put, bucket: "test-bucket", path: key}
     end)
 
-    expect(ExAws, :request, 2, fn _operation ->
+    expect(ExAws, :request, 2, fn _operation, _config ->
       {:ok, %{status_code: 200, body: ""}}
     end)
 
@@ -346,7 +397,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       %S3{http_method: :put, bucket: "test-bucket", path: key}
     end)
 
-    expect(ExAws, :request, 4, fn _op ->
+    expect(ExAws, :request, 4, fn _op, _config ->
       {:ok, %{status_code: 200, body: ""}}
     end)
 

--- a/server/test/tuist/registry/swift/sync_worker_test.exs
+++ b/server/test/tuist/registry/swift/sync_worker_test.exs
@@ -69,7 +69,7 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
     )
   end
 
-  test "does not enqueue skipped versions" do
+  test "does not enqueue versions with a verified skip classification" do
     expect(Lock, :try_acquire, 2, fn
       :sync, _ -> {:ok, :acquired}
       {:package, "newrelic", "newrelic-ios-agent-spm"}, _ -> {:ok, :acquired}
@@ -90,11 +90,20 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
     expect(SyncCursor, :put, fn 0 -> :ok end)
 
     expect(Metadata, :get_package, fn "newrelic", "newrelic-ios-agent-spm" ->
-      {:ok, %{"releases" => %{}, "skipped_releases" => %{"7.0.0" => %{"reason" => "missing_manifests"}}}}
+      {:ok,
+       %{
+         "releases" => %{},
+         "skipped_releases" => %{
+           "7.0.0" => %{"classification_version" => 2, "reason" => "missing_manifests"}
+         }
+       }}
     end)
 
     expect(Metadata, :put_package, fn "newrelic", "newrelic-ios-agent-spm", metadata ->
-      assert metadata["skipped_releases"] == %{"7.0.0" => %{"reason" => "missing_manifests"}}
+      assert metadata["skipped_releases"] == %{
+               "7.0.0" => %{"classification_version" => 2, "reason" => "missing_manifests"}
+             }
+
       :ok
     end)
 
@@ -104,6 +113,53 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
 
     assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
     refute_enqueued(worker: ReleaseWorker)
+  end
+
+  test "rechecks versions skipped before skip classifications were versioned" do
+    expect(Lock, :try_acquire, 2, fn
+      :sync, _ -> {:ok, :acquired}
+      {:package, "adjust", "ios_sdk"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(SwiftPackageIndex, :list_packages, fn "token" ->
+      {:ok,
+       [
+         %{
+           scope: "adjust",
+           name: "ios_sdk",
+           repository_full_handle: "adjust/ios_sdk"
+         }
+       ]}
+    end)
+
+    expect(SyncCursor, :get, fn -> 0 end)
+    expect(SyncCursor, :put, fn 0 -> :ok end)
+
+    expect(Metadata, :get_package, fn "adjust", "ios_sdk" ->
+      {:ok,
+       %{
+         "releases" => %{},
+         "skipped_releases" => %{"5.6.2" => %{"reason" => "missing_manifests"}}
+       }}
+    end)
+
+    expect(Metadata, :put_package, fn "adjust", "ios_sdk", _metadata -> :ok end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "adjust/ios_sdk", "token", _ ->
+      {:ok, ["v5.6.2"]}
+    end)
+
+    assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
+
+    assert_enqueued(
+      worker: ReleaseWorker,
+      args: %{
+        "scope" => "adjust",
+        "name" => "ios_sdk",
+        "repository_full_handle" => "adjust/ios_sdk",
+        "tag" => "v5.6.2"
+      }
+    )
   end
 
   test "ignores tags that do not match the accepted source format" do


### PR DESCRIPTION
## What changed

- Treat failures while fetching a listed package manifest as retryable release failures.
- Version permanent skip classifications so releases skipped by the previous behavior are reconsidered automatically.
- Remove stale skip metadata after a release is synchronized successfully.
- Centralize permanent-skip classification in the registry metadata module.
- Give every registry object-storage request a dedicated configuration, including package metadata, sync locks, and the sync cursor.
- Inject both host-based and endpoint-based registry storage settings into the server deployment when the registry is enabled.

## Why

A customer reported that valid package versions disappeared from registry package listings even though their manifests and source archives were already present. The same incident exposed that the internal registry operations page could not read package metadata.

## Root cause

The release worker first listed repository contents and then fetched each manifest separately. A permission-denied response from GitHub during the second step was converted to `nil`. When every manifest fetch failed, the release was classified as permanently missing manifests, and the normal catalog sync treated that skip as final.

The operations page read registry metadata from the server application, but the server deployment only had account-artifact storage credentials. Registry metadata reads therefore used the wrong object-storage configuration. The first implementation also omitted endpoint-based self-hosted storage from the server deployment, which would have prevented those server pods from starting.

## Approach

Manifest fetch errors now remain errors so the job retries. Only a complete, successful repository listing with no supported manifest is stored as a permanent skip. New permanent skips carry a classification version, while historical unversioned skips are reconsidered and migrated naturally during catalog traversal.

Registry storage is configured separately from account artifact storage. All registry object-storage requests pass that configuration directly. The server deployment accepts either a storage host or endpoint, preserving managed and self-hosted configurations without broadening secret access.

## Impact

Previously affected releases recover automatically as the catalog sync reaches them. New transient upstream failures no longer create permanent omissions. Operators can load registry package details without granting the web runtime ambiguous global storage credentials.

As an immediate production mitigation, Adjust `5.6.2` and BRYXBanner `0.8.5` were restored from their existing, validated archives and manifests. Both public package listings and release endpoints now return the repaired versions with matching checksums.

The customer also reported Lottie. The linked failing run resolved Lottie `4.6.0` successfully and then failed on BRYXBanner `0.8.5`. Lottie `4.6.0` currently has a healthy listing, manifest, and archive with a matching published checksum, so no production rewrite was needed for it.

## Validation

- Focused registry tests passed: 26 before cleanup and 23 after the final refactor.
- Operations-page tests passed: 8.
- Elixir formatting validation passed.
- Strict Credo analysis completed successfully.
- Sobelow security analysis completed successfully with only existing baseline findings.
- Production and self-hosted Helm templates rendered successfully, including an endpoint-only self-hosted configuration.
- A local object-storage write succeeded using the dedicated registry configuration.
- Both restored production archives passed integrity checks, and their published checksums match the archive bytes.
- Lottie `4.6.0` returned a valid release document and manifest; its downloaded archive passed integrity validation and matched checksum `42cf1056d799be440d935dc98b97a98c501580f108ed2b289d3ed4141b24a637`.
- `git diff --check` passed.
- An independent Claude review found no regression or security blockers after the endpoint and credential-isolation changes.

## Screenshots

The incident report contains the before screenshots. An after screenshot could not be captured because no headless Chrome browser was connected to this session. The repaired public endpoints and operations-page data path were verified directly.
