### PR TITLE
fix(noora): isolate mise GitHub token

### DIFF
--- a/.github/workflows/noora-release.yml
+++ b/.github/workflows/noora-release.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   MISE_VERSION: "2026.5.15"
-  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
 jobs:


### PR DESCRIPTION
## What changed

The Noora release workflow now uses the short-lived token created for each GitHub Actions job when `mise` downloads tools and verifies their attestations. The existing release token remains available for creating the GitHub release.

## Why

Noora `0.85.0` did not publish after pull request #12079 merged. The workflow stopped during tool installation before release calculation or registry access.

## Root cause

The workflow supplied the shared release token to `mise`. While installing `jq`, GitHub rejected artifact attestation verification because that credential had exceeded its request limit.

## Approach

`MISE_GITHUB_TOKEN` now receives `github.token`, which is short-lived and scoped to the current job. `GITHUB_TOKEN` continues to use `TUIST_RELEASE_GITHUB_TOKEN` for the release operation that requires it.

## Impact

Merging this workflow change triggers a fresh Noora release run. The release check still resolves to `0.85.0`, and no package registry or 1Password credentials change.

## Validation

- Workflow configuration parsed successfully.
- `actionlint` passed, excluding the expected custom `tuist-linux` runner-label warning.
- `git diff --check`
- `mise run --skip-tools release:check noora`: resolved `noora@0.85.0` with `release? true`

### How to test locally

```sh
mise x actionlint@1.7.7 -- actionlint -ignore 'label "tuist-linux" is unknown' .github/workflows/noora-release.yml
mise run --skip-tools release:check noora
```
