### PR TITLE
fix(kura): recover bootstrap-blocked rollouts

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -74,7 +74,10 @@ rules:
     verbs: [get, list, watch, create, update, patch, delete]
   - apiGroups: [""]
     resources: [pods]
-    verbs: [get, list, watch]
+    # delete lets a new Kura image replace pods that cannot pass readiness on
+    # the previous image. Ready pods remain under the StatefulSet's ordinary
+    # ordered rollout.
+    verbs: [get, list, watch, delete]
   - apiGroups: ["discovery.k8s.io"]
     resources: [endpointslices]
     verbs: [get, list, watch]

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -88,6 +88,7 @@ const (
 	legacyPeerRetireAfterAnnotation             = "kura.tuist.dev/legacy-peer-retire-after"
 	legacyPeerFallbackRepublishAnnotation       = "kura.tuist.dev/legacy-peer-fallback-republish-requested-at"
 	legacyPeerFallbackObservedAnnotation        = "kura.tuist.dev/legacy-peer-fallback-observed-at"
+	unreadyPodsReplacedForImageAnnotation       = "kura.tuist.dev/unready-pods-replaced-for-image"
 	legacyPeerPhaseRepairing                    = "repairing-fallback"
 	legacyPeerPhaseCutoverRequested             = "cutover-requested"
 	legacyPeerPhaseDraining                     = "draining"
@@ -242,7 +243,7 @@ func terminationGracePeriodSeconds() int64 {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch;delete
@@ -365,6 +366,9 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 	if err := r.reconcileStatefulSet(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.replaceUnreadyPodsForImageChange(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -2263,6 +2267,63 @@ func (r *KuraInstanceReconciler) reconcileStatefulSet(ctx context.Context, insta
 		return err
 	}
 	return r.reconcileDataPersistentVolumeClaims(ctx, instance)
+}
+
+// replaceUnreadyPodsForImageChange lets a new Kura image escape a rollout that
+// the ordinary StatefulSet readiness gate cannot advance. Ready pods keep
+// serving and roll through the normal ordered path. Pods that are not ready and
+// still run the previous image are deleted in parallel so the StatefulSet
+// recreates them directly on the desired image.
+//
+// The handled image is recorded on the KuraInstance only after every deletion
+// succeeds. If the controller stops midway, the next pass retries only the
+// remaining old-image pods and ignores pods already recreated on the desired
+// image. This makes the operation safe across retries without repeatedly
+// restarting a new pod that is still bootstrapping.
+func (r *KuraInstanceReconciler) replaceUnreadyPodsForImageChange(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {
+	if instance.Annotations[unreadyPodsReplacedForImageAnnotation] == instance.Spec.Image {
+		return nil
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, client.InNamespace(instance.Namespace), client.MatchingLabels(selectorLabels(instance))); err != nil {
+		return err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.DeletionTimestamp != nil || podReady(pod) || podKuraImage(pod) == instance.Spec.Image {
+			continue
+		}
+		if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.FromContext(ctx).Info(
+			"replacing unready Kura pod on image change",
+			"pod",
+			pod.Name,
+			"previousImage",
+			podKuraImage(pod),
+			"desiredImage",
+			instance.Spec.Image,
+		)
+	}
+
+	before := instance.DeepCopy()
+	if instance.Annotations == nil {
+		instance.Annotations = map[string]string{}
+	}
+	instance.Annotations[unreadyPodsReplacedForImageAnnotation] = instance.Spec.Image
+	return r.Patch(ctx, instance, client.MergeFrom(before))
+}
+
+func podKuraImage(pod *corev1.Pod) string {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "kura" {
+			return container.Image
+		}
+	}
+	return ""
 }
 
 func (r *KuraInstanceReconciler) reconcileDataPersistentVolumeClaims(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -52,6 +52,90 @@ func TestKuraInstanceDesiredStateChangedPredicate(t *testing.T) {
 	}
 }
 
+func TestReplaceUnreadyPodsForImageChange(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &kurav1alpha1.KuraInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kura-tuist-eu-1",
+			Namespace: "kura",
+			Annotations: map[string]string{
+				unreadyPodsReplacedForImageAnnotation: "ghcr.io/tuist/kura:0.5.2",
+			},
+		},
+		Spec: kurav1alpha1.KuraInstanceSpec{
+			AccountHandle: "tuist",
+			Region:        "eu",
+			Image:         "ghcr.io/tuist/kura:0.5.3",
+		},
+	}
+	podLabels := selectorLabels(instance)
+	oldUnready := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: instance.Name + "-0", Namespace: instance.Namespace, Labels: podLabels},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "kura",
+			Image: "ghcr.io/tuist/kura:0.5.2",
+		}}},
+	}
+	oldReady := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: instance.Name + "-1", Namespace: instance.Namespace, Labels: podLabels},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "kura",
+			Image: "ghcr.io/tuist/kura:0.5.2",
+		}}},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	newUnready := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: instance.Name + "-2", Namespace: instance.Namespace, Labels: podLabels},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "kura",
+			Image: "ghcr.io/tuist/kura:0.5.3",
+		}}},
+	}
+
+	reconciler := &KuraInstanceReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(instance, oldUnready, oldReady, newUnready).
+			Build(),
+		Scheme: scheme,
+	}
+
+	if err := reconciler.replaceUnreadyPodsForImageChange(ctx, instance); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted := &corev1.Pod{}
+	err := reconciler.Get(ctx, types.NamespacedName{Name: oldUnready.Name, Namespace: oldUnready.Namespace}, deleted)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected unready pod on the previous image to be deleted, got %v", err)
+	}
+	for _, pod := range []*corev1.Pod{oldReady, newUnready} {
+		got := &corev1.Pod{}
+		if err := reconciler.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, got); err != nil {
+			t.Fatalf("expected pod %s to remain: %v", pod.Name, err)
+		}
+	}
+
+	gotInstance := &kurav1alpha1.KuraInstance{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, gotInstance); err != nil {
+		t.Fatal(err)
+	}
+	if got := gotInstance.Annotations[unreadyPodsReplacedForImageAnnotation]; got != instance.Spec.Image {
+		t.Fatalf("expected handled image annotation %q, got %q", instance.Spec.Image, got)
+	}
+}
+
 func TestKuraInstanceReconcileCreatesWorkloadResources(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()

--- a/kura/Dockerfile
+++ b/kura/Dockerfile
@@ -31,6 +31,7 @@ COPY src src
 RUN --mount=type=cache,id=kura-target-${TARGETARCH},target=/app/target,sharing=locked \
     --mount=type=cache,id=kura-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=kura-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    touch src/lib.rs src/main.rs && \
     cargo build --release --locked && \
     cp /app/target/release/kura /usr/local/bin/kura
 

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -108,7 +108,7 @@ Two observability surfaces support capacity and sharding decisions: `kura_public
 
 Newly joined nodes catch up by **bootstrapping from a peer**: paginated manifest and tombstone fetches followed by lazy artifact body fetches. Bootstrap re-uses the same apply paths as live replication, so the same conflict rules apply. A fresh node bootstraps from every known peer concurrently (so it captures artifacts that exist on only one peer), which means the same artifact is offered by several peers at once. Three layers keep that overlap bounded: a per-artifact **fetch gate** single-flights the body download so only the first peer-task to claim a key transfers it while the rest re-check presence and skip the network; a live-memory reservation admits only the transfer windows that fit below the soft watermark; and the per-key **apply lock** is the last-line guarantee that even a body that does get fetched twice is written to a segment only once. Large transfers do not reserve their full object size because a valid object may approach the container limit. Instead, once pressure rises, completed temporary-file and append-only segment ranges are synchronized and released from Linux file cache in bounded intervals before the stream waits for recovery. The cache advice is an optional optimization and never changes storage correctness.
 
-Before walking a peer's manifests, bootstrap runs **range-digest anti-entropy** so the walk costs O(delta) rather than O(peer dataset). The manifests column family is a sorted keyspace over `artifact_id` (a content/storage hash, identical across nodes for identical content); both nodes summarize it as per-prefix-bucket digests (`GET /_internal/bootstrap/digest?prefix_len=3` → 4096 buckets of `(prefix, count, hash)`, where the hash folds the sorted `(artifact_id, version_ms)` pairs so adds, removes, and version bumps all flip a bucket). The joining node diffs the peer's digest against its own and enumerates only the mismatching buckets — scoping the existing paginated walk to each divergent prefix range (`&prefix=`). For a mostly-in-sync pair this collapses a full-keyspace page walk into one digest exchange plus a handful of small range walks. The endpoint is additive and negotiated: a peer that 404s it (one version behind during a rollout) falls back to the full walk, so a mixed-version mesh stays correct. The digest only decides *which ranges to enumerate*; apply semantics are unchanged, so a digest bug can at worst cause an unnecessary walk, never a wrong apply.
+Before walking a peer's manifests, bootstrap runs **range-digest anti-entropy** so the walk costs O(delta) rather than O(peer dataset). The manifests column family is a sorted keyspace over `artifact_id` (a content/storage hash, identical across nodes for identical content); both nodes summarize it as per-prefix-bucket digests (`GET /_internal/bootstrap/digest?prefix_len=3` → 4096 buckets of `(prefix, count, hash)`, where the hash folds the sorted `(artifact_id, version_ms)` pairs so adds, removes, and version bumps all flip a bucket). The joining node diffs the peer's digest against its own and enumerates only the mismatching buckets — scoping the existing paginated walk to each divergent prefix range (`&prefix=`). For a mostly-in-sync pair this collapses a full-keyspace page walk into one digest exchange plus a handful of small range walks. The digest endpoint is additive and negotiated: a peer that returns `404 Not Found` because it is one version behind falls back to the full walk. Manifest pages also negotiate across adjacent versions: a new node prefers 2048 manifests per request and retries once with the legacy 256-manifest limit when an older peer returns `400 Bad Request`. Namespace tombstones stay at the legacy limit. These fallbacks keep mixed-version rollouts and rollbacks correct. The digest only decides *which ranges to enumerate*; apply semantics are unchanged, so a digest bug can at worst cause an unnecessary walk, never a wrong apply.
 
 A per-peer bootstrap runs under a **no-progress watchdog** rather than a fixed total-runtime cap. `KURA_BOOTSTRAP_TIMEOUT_MS` is the maximum time the bootstrap may go *without* forward progress (a fetched page or applied artifact); a bootstrap that keeps advancing runs to completion however long that takes, and only a genuinely stalled one is abandoned and retried. A single wall-clock cap could never let a large cold pull finish — it would be killed and restarted from scratch every window — so a node whose backlog exceeds one window's worth of transfer would stay `NotReady` indefinitely.
 
@@ -124,7 +124,7 @@ A node finds peers in three ways:
 
 A `spawn_membership_task` loop polls each candidate's `GET /_internal/status` every two seconds. Only peers that respond with the same `tenant_id` and a different `node_url` are admitted as members. The local node never lists itself.
 
-Mesh **membership itself** is control-plane state for enrolled nodes: a node that stops sending mesh heartbeats is deactivated (withheld from every peer's view) and its row is purged once its peer certificate can no longer be valid. Heartbeats never create or restore membership — a withheld node is answered `mesh_member: false` and recovers with a **recovery re-enrollment** (backoff-limited), which reactivates or recreates its membership server-side, clears local bootstrap progress, and takes the node out of serving until it has re-pulled the full dataset: the writes it missed while out of the mesh were never enqueued for it (replication targets are computed at write time), so only a full re-bootstrap can reconcile the gap.
+Mesh **membership itself** is control-plane state for enrolled nodes: a node that stops sending mesh heartbeats is deactivated (withheld from every peer's view) and its row is purged once its peer certificate can no longer be valid. Heartbeats never create or restore membership — a withheld node is answered `mesh_member: false` and recovers with a **recovery re-enrollment** (backoff-limited), which reactivates or recreates its membership server-side, clears local bootstrap progress, and briefly takes the node out of serving. A node with usable local data can serve again after discovery settles while reconciliation continues; an empty node stays joining until the bootstrap completes. The writes missed while the node was out of the mesh were never enqueued for it (replication targets are computed at write time), so a full re-bootstrap still runs to reconcile the gap.
 
 Each tick produces a `MembershipUpdate` and feeds it into `ReadinessState` (`src/state.rs`). The state tracks:
 
@@ -138,24 +138,24 @@ Each tick produces a `MembershipUpdate` and feeds it into `ReadinessState` (`src
 
 ## Traffic Lifecycle
 
-A node moves through three explicit traffic states (`src/runtime.rs`):
+A node moves through three explicit traffic states (`src/runtime.rs`). Ordinary membership changes do not demote a serving node; newly discovered or returning peers reconcile in the background:
 
 ```
-        ┌──────────┐  membership generation     ┌──────────┐
-        │          │   advances or restart      │          │
+        ┌──────────┐  restart or recovery       ┌──────────┐
+        │          │      re-enrollment         │          │
         │ joining  │ ◄──────────────────────────│ serving  │
         │          │                            │          │
         └────┬─────┘                            └─────┬────┘
-             │ all known peers bootstrapped,          │
-             │ discovery observed, settle window      │
-             │ elapsed                                │
+             │ discovery settled and either           │
+             │ local data exists or an empty node     │
+             │ completed every peer bootstrap         │
              ▼                                        ▼
         ┌──────────┐         drain request      ┌──────────┐
         │ serving  │ ─────────────────────────► │ draining │
         └──────────┘                            └──────────┘
 ```
 
-- **`joining`** — public reads/writes are accepted but `/ready` returns `503` until bootstrap completes for every known peer. This keeps load balancers from routing traffic to a half-warm pod.
+- **`joining`** — public reads/writes are accepted but `/ready` returns `503`. A node that entered the joining cycle with usable persistent data becomes ready after discovery settles and continues reconciliation in the background. A truly empty node waits until bootstrap completes for every known peer.
 - **`serving`** — `/ready` returns `200`. Public APIs handle traffic normally.
 - **`draining`** — public HTTP rejects new requests and stops reusing HTTP/1.1 connections; established HTTP/2 connections (gRPC included) receive a GOAWAY so channels finish in-flight streams and reconnect elsewhere. Inflight work continues until a shared **drain deadline** (`KURA_DRAIN_COMPLETION_TIMEOUT_MS`) elapses.
 

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -141,6 +141,7 @@ async fn run_with_config(
         config.snapshot_cache_max_bytes,
     ));
     let store = Store::open(&config, io.clone(), memory.clone())?;
+    let local_data_available_at_join = store.has_artifacts()?;
     let tmp_staging_budget = store.tmp_staging_budget();
     match store.sweep_orphaned_segments().await {
         Ok(0) => {}
@@ -189,6 +190,9 @@ async fn run_with_config(
         replication_bandwidth_limiter,
         notify,
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
+        local_data_available_at_join: std::sync::atomic::AtomicBool::new(
+            local_data_available_at_join,
+        ),
         bootstrap_semaphore,
         tmp_staging_budget,
         bootstrap_staging_budget,

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -82,6 +82,7 @@ pub const DEFAULT_USAGE_MAX_BUCKETS: usize = 10_000;
 pub const DEFAULT_USAGE_OUTBOX_MAX_DEPTH: usize = 100_000;
 
 pub const MAX_BOOTSTRAP_PAGE_BYTES: u64 = 32 * 1024 * 1024;
+pub const MAX_BOOTSTRAP_PAGE_ITEMS: usize = 2048;
 // Range-digest anti-entropy: partition the sorted `artifact_id` keyspace by its
 // leading hex characters. 3 nibbles = 4096 buckets (~340 artifacts/bucket at
 // 1.4M), enough to make a mostly-in-sync bootstrap O(delta) while keeping the

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -27,9 +27,10 @@ use crate::{
     artifact::{manifest::ArtifactManifest, producer::ArtifactProducer},
     bandwidth::BandwidthLimiter,
     constants::{
-        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, MAX_GRADLE_BYTES, MAX_INLINE_REPLICATION_BODY_BYTES,
-        MAX_MODULE_PART_BYTES, MAX_MODULE_TOTAL_BYTES, MAX_REPLICATION_BODY_BYTES, MAX_XCODE_BYTES,
-        RESPONSE_STREAM_MIN_CHUNK_BYTES, response_stream_chunk_bytes,
+        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, MAX_BOOTSTRAP_PAGE_ITEMS, MAX_GRADLE_BYTES,
+        MAX_INLINE_REPLICATION_BODY_BYTES, MAX_MODULE_PART_BYTES, MAX_MODULE_TOTAL_BYTES,
+        MAX_REPLICATION_BODY_BYTES, MAX_XCODE_BYTES, RESPONSE_STREAM_MIN_CHUNK_BYTES,
+        response_stream_chunk_bytes,
     },
     extension::{AccessDecision, ExtensionContext},
     io::is_fd_pool_exhausted_error,
@@ -475,8 +476,10 @@ impl PageQuery {
         if limit == 0 {
             return Err("Invalid limit: must be greater than 0".to_string());
         }
-        if limit > 256 {
-            return Err("Invalid limit: must not exceed 256".to_string());
+        if limit > MAX_BOOTSTRAP_PAGE_ITEMS {
+            return Err(format!(
+                "Invalid limit: must not exceed {MAX_BOOTSTRAP_PAGE_ITEMS}"
+            ));
         }
 
         Ok(Self {
@@ -2812,17 +2815,17 @@ mod tests {
 
     #[test]
     fn bootstrap_page_query_rejects_unbounded_limits() {
-        let maximum = HashMap::from([("limit".to_owned(), "256".to_owned())]);
+        let maximum = HashMap::from([("limit".to_owned(), MAX_BOOTSTRAP_PAGE_ITEMS.to_string())]);
         assert_eq!(
             PageQuery::from_params(&maximum)
                 .expect("maximum bootstrap page should be accepted")
                 .limit,
-            256
+            MAX_BOOTSTRAP_PAGE_ITEMS
         );
         let oversized = HashMap::from([("limit".to_owned(), usize::MAX.to_string())]);
         assert_eq!(
             PageQuery::from_params(&oversized).expect_err("oversized page must be rejected"),
-            "Invalid limit: must not exceed 256"
+            format!("Invalid limit: must not exceed {MAX_BOOTSTRAP_PAGE_ITEMS}")
         );
     }
 

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     artifact::manifest::ArtifactManifest,
     config::Config,
     constants::{
-        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, MAX_BOOTSTRAP_PAGE_BYTES,
+        BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN, MAX_BOOTSTRAP_PAGE_BYTES, MAX_BOOTSTRAP_PAGE_ITEMS,
         MAX_INLINE_REPLICATION_BODY_BYTES, MAX_REPLICATION_BODY_BYTES, REPLICATION_RETRY_SECS,
     },
     failpoints::FailpointName,
@@ -40,14 +40,18 @@ use crate::{
 
 use self::{operation::ReplicationOperation, outbox_message::OutboxMessage};
 
-// Manifests per page of the bootstrap keyspace walk. Sized to hold a whole
+// Preferred manifests per page of the bootstrap keyspace walk. Sized to hold a whole
 // digest bucket in one request: at BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN the
 // keyspace splits into 4096 buckets, so a 3M-artifact account averages ~750
 // manifests per bucket and every divergent bucket used to cost three
 // round-trips instead of one. A page is bounded by count, not bytes — a REAPI
 // manifest serializes to ~420 B, so 2048 is ~850 KiB, well inside the
 // MAX_BOOTSTRAP_PAGE_BYTES ceiling the puller reads under.
-const BOOTSTRAP_PAGE_LIMIT: usize = 2048;
+const BOOTSTRAP_MANIFEST_PAGE_LIMIT: usize = MAX_BOOTSTRAP_PAGE_ITEMS;
+// Peers before the larger manifest-page rollout reject limits above 256. Keep
+// tombstones on the legacy size and negotiate manifest pages down once per
+// peer pass so adjacent versions can bootstrap each other during a rollout.
+const BOOTSTRAP_LEGACY_PAGE_LIMIT: usize = 256;
 
 // Artifact bodies fetched from a peer concurrently within a bootstrap page. Caps
 // open peer connections; staged bytes stay bounded by bootstrap_staging_budget.
@@ -430,6 +434,7 @@ async fn bootstrap_manifests_from_peer(
     let prefix_len = BOOTSTRAP_DIGEST_DEFAULT_PREFIX_LEN;
     let mut applied = 0_u64;
     let mut failed = 0_u64;
+    let mut page_limit = BOOTSTRAP_MANIFEST_PAGE_LIMIT;
 
     // Range-based anti-entropy: exchange per-bucket digests and walk only the
     // buckets whose contents differ. For a mostly-in-sync pair this collapses a
@@ -460,14 +465,16 @@ async fn bootstrap_manifests_from_peer(
                 .set_bootstrap_pass_buckets_reconciled(peer, "digest", 0);
             let mut reconciled = 0;
             for prefix in divergent {
-                let (range_applied, range_failed) = bootstrap_manifest_range_from_peer(
-                    state,
-                    peer,
-                    Some(&prefix),
-                    "digest",
-                    progress,
-                )
-                .await?;
+                let (range_applied, range_failed) =
+                    bootstrap_manifest_range_from_peer_with_page_limit(
+                        state,
+                        peer,
+                        Some(&prefix),
+                        "digest",
+                        progress,
+                        &mut page_limit,
+                    )
+                    .await?;
                 applied += range_applied;
                 failed += range_failed;
                 reconciled += 1;
@@ -489,9 +496,15 @@ async fn bootstrap_manifests_from_peer(
             state
                 .metrics
                 .set_bootstrap_pass_buckets_reconciled(peer, "full_walk", 0);
-            let (range_applied, range_failed) =
-                bootstrap_manifest_range_from_peer(state, peer, None, "full_walk", progress)
-                    .await?;
+            let (range_applied, range_failed) = bootstrap_manifest_range_from_peer_with_page_limit(
+                state,
+                peer,
+                None,
+                "full_walk",
+                progress,
+                &mut page_limit,
+            )
+            .await?;
             applied += range_applied;
             failed += range_failed;
             state
@@ -540,6 +553,7 @@ fn divergent_prefixes(
 /// Walk the peer's manifest keyspace (optionally scoped to a single digest
 /// bucket prefix), pre-checking and fetching each artifact. Returns
 /// `(applied, failed)` for the caller to aggregate across ranges.
+#[cfg(test)]
 async fn bootstrap_manifest_range_from_peer(
     state: &SharedState,
     peer: &str,
@@ -550,6 +564,26 @@ async fn bootstrap_manifest_range_from_peer(
     mode: &'static str,
     progress: &AtomicU64,
 ) -> Result<(u64, u64), String> {
+    let mut page_limit = BOOTSTRAP_MANIFEST_PAGE_LIMIT;
+    bootstrap_manifest_range_from_peer_with_page_limit(
+        state,
+        peer,
+        prefix,
+        mode,
+        progress,
+        &mut page_limit,
+    )
+    .await
+}
+
+async fn bootstrap_manifest_range_from_peer_with_page_limit(
+    state: &SharedState,
+    peer: &str,
+    prefix: Option<&str>,
+    mode: &'static str,
+    progress: &AtomicU64,
+    page_limit: &mut usize,
+) -> Result<(u64, u64), String> {
     let mut after = None;
     let mut applied = 0_u64;
     let mut failed = 0_u64;
@@ -559,7 +593,10 @@ async fn bootstrap_manifest_range_from_peer(
         .set_bootstrap_current_bucket_manifests_walked(peer, mode, 0);
 
     loop {
-        let page = fetch_bootstrap_manifests_page(state, peer, after.as_deref(), prefix).await?;
+        let (page, accepted_page_limit) =
+            fetch_bootstrap_manifests_page(state, peer, after.as_deref(), prefix, *page_limit)
+                .await?;
+        *page_limit = accepted_page_limit;
         // Fetching a page is forward progress even when it applies nothing (a
         // warm re-walk or an already-present range), so the no-progress watchdog
         // never abandons a bootstrap that is still advancing through the walk.
@@ -929,8 +966,38 @@ async fn fetch_bootstrap_manifests_page(
     peer: &str,
     after: Option<&str>,
     prefix: Option<&str>,
-) -> Result<ManifestPage, String> {
-    let mut url = format!("{peer}/_internal/bootstrap/manifests?limit={BOOTSTRAP_PAGE_LIMIT}");
+    requested_limit: usize,
+) -> Result<(ManifestPage, usize), String> {
+    let mut accepted_limit = requested_limit;
+    let mut response =
+        request_bootstrap_manifests_page(state, peer, after, prefix, accepted_limit).await?;
+    if response.status() == reqwest::StatusCode::BAD_REQUEST
+        && accepted_limit > BOOTSTRAP_LEGACY_PAGE_LIMIT
+    {
+        accepted_limit = BOOTSTRAP_LEGACY_PAGE_LIMIT;
+        info!(
+            "bootstrap peer {peer} rejected {requested_limit}-manifest pages; falling back to {accepted_limit}"
+        );
+        response =
+            request_bootstrap_manifests_page(state, peer, after, prefix, accepted_limit).await?;
+    }
+    let response = response
+        .error_for_status()
+        .map_err(|error| format!("bootstrap manifest response failed: {error}"))?;
+    let bytes = read_bounded_body(response, MAX_BOOTSTRAP_PAGE_BYTES, "bootstrap manifest").await?;
+    serde_json::from_slice(&bytes)
+        .map(|page| (page, accepted_limit))
+        .map_err(|error| format!("failed to decode bootstrap manifest page: {error}"))
+}
+
+async fn request_bootstrap_manifests_page(
+    state: &SharedState,
+    peer: &str,
+    after: Option<&str>,
+    prefix: Option<&str>,
+    limit: usize,
+) -> Result<reqwest::Response, String> {
+    let mut url = format!("{peer}/_internal/bootstrap/manifests?limit={limit}");
     if let Some(after) = after {
         url.push_str("&after=");
         url.push_str(&url_encode(after));
@@ -940,17 +1007,12 @@ async fn fetch_bootstrap_manifests_page(
         url.push_str(&url_encode(prefix));
     }
 
-    let response = state
+    state
         .client()
         .get(&url)
         .send()
         .await
-        .map_err(|error| format!("bootstrap manifest request failed: {error}"))?
-        .error_for_status()
-        .map_err(|error| format!("bootstrap manifest response failed: {error}"))?;
-    let bytes = read_bounded_body(response, MAX_BOOTSTRAP_PAGE_BYTES, "bootstrap manifest").await?;
-    serde_json::from_slice(&bytes)
-        .map_err(|error| format!("failed to decode bootstrap manifest page: {error}"))
+        .map_err(|error| format!("bootstrap manifest request failed: {error}"))
 }
 
 /// Fetch the peer's per-bucket manifest digest for range-based anti-entropy.
@@ -993,8 +1055,9 @@ async fn fetch_bootstrap_tombstones_page(
     peer: &str,
     after: Option<&str>,
 ) -> Result<NamespaceTombstonePage, String> {
-    let mut url =
-        format!("{peer}/_internal/bootstrap/namespace_tombstones?limit={BOOTSTRAP_PAGE_LIMIT}");
+    let mut url = format!(
+        "{peer}/_internal/bootstrap/namespace_tombstones?limit={BOOTSTRAP_LEGACY_PAGE_LIMIT}"
+    );
     if let Some(after) = after {
         url.push_str("&after=");
         url.push_str(&url_encode(after));
@@ -2960,6 +3023,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_negotiates_manifest_pages_down_once_for_an_older_peer() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use axum::{
+            extract::Request,
+            middleware::{self, Next},
+            response::IntoResponse,
+        };
+
+        let remote = test_context(|_| {}).await;
+        for index in 0..16 {
+            remote
+                .state
+                .store
+                .persist_artifact_from_bytes(
+                    ArtifactProducer::Xcode,
+                    "ios",
+                    &format!("artifact-{index}"),
+                    "application/octet-stream",
+                    b"payload",
+                )
+                .await
+                .expect("remote artifact should persist");
+        }
+
+        let preferred_requests = Arc::new(AtomicUsize::new(0));
+        let legacy_requests = Arc::new(AtomicUsize::new(0));
+        let preferred = preferred_requests.clone();
+        let legacy = legacy_requests.clone();
+        let peer_router = router(remote.state.clone()).layer(middleware::from_fn(
+            move |request: Request, next: Next| {
+                let preferred = preferred.clone();
+                let legacy = legacy.clone();
+                async move {
+                    if request.uri().path() == "/_internal/bootstrap/manifests" {
+                        let query = request.uri().query().unwrap_or_default();
+                        if query.contains(&format!("limit={BOOTSTRAP_MANIFEST_PAGE_LIMIT}")) {
+                            preferred.fetch_add(1, Ordering::SeqCst);
+                            return StatusCode::BAD_REQUEST.into_response();
+                        }
+                        if query.contains(&format!("limit={BOOTSTRAP_LEGACY_PAGE_LIMIT}")) {
+                            legacy.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                    next.run(request).await
+                }
+            },
+        ));
+        let (remote_url, _server) = spawn_server(peer_router).await;
+
+        let local = test_context(|_| {}).await;
+        let applied = bootstrap_manifests_from_peer(&local.state, &remote_url, &AtomicU64::new(0))
+            .await
+            .expect("bootstrap should negotiate the older page limit");
+
+        assert_eq!(applied, 16);
+        assert_eq!(
+            preferred_requests.load(Ordering::SeqCst),
+            1,
+            "the preferred size should only be probed once per peer pass"
+        );
+        assert!(
+            legacy_requests.load(Ordering::SeqCst) > 1,
+            "all remaining divergent ranges should retain the negotiated legacy size"
+        );
+    }
+
+    #[tokio::test]
     async fn range_digest_reconciles_a_mostly_in_sync_pair_by_walking_only_the_delta() {
         use std::sync::{
             Arc,
@@ -2976,9 +3110,9 @@ mod tests {
         // node already holds almost all of. Prod is ~1.4M artifacts / 4096
         // buckets, ~99% in sync; this spans many buckets and forces the legacy
         // full walk into several pages while staying fast. Keep it a multiple of
-        // BOOTSTRAP_PAGE_LIMIT above 1 so the full walk stays multi-page — the
+        // BOOTSTRAP_MANIFEST_PAGE_LIMIT above 1 so the full walk stays multi-page — the
         // A/B assertion below is only meaningful while it is.
-        const TOTAL: usize = 4 * BOOTSTRAP_PAGE_LIMIT;
+        const TOTAL: usize = 4 * BOOTSTRAP_MANIFEST_PAGE_LIMIT;
         const MISSING: usize = 2;
 
         let remote = test_context(|_| {}).await;
@@ -3164,7 +3298,7 @@ mod tests {
         }
 
         let full_page_count = full_pages.load(Ordering::SeqCst);
-        let expected_full_walk = TOTAL.div_ceil(BOOTSTRAP_PAGE_LIMIT);
+        let expected_full_walk = TOTAL.div_ceil(BOOTSTRAP_MANIFEST_PAGE_LIMIT);
         assert_eq!(
             full_page_count, expected_full_walk,
             "legacy walk pages the entire keyspace"
@@ -3373,7 +3507,7 @@ mod tests {
             response::IntoResponse,
         };
 
-        // Fewer artifacts than BOOTSTRAP_PAGE_LIMIT, so the walk is a single
+        // Fewer artifacts than BOOTSTRAP_MANIFEST_PAGE_LIMIT, so the walk is a single
         // page, each body fetch delayed. At concurrency 16 that page takes
         // ~16*40ms to drain — many watchdog windows — with no page boundary in
         // between.

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use arc_swap::ArcSwap;
@@ -60,6 +63,11 @@ pub struct AppState {
     pub replication_bandwidth_limiter: Option<Arc<BandwidthLimiter>>,
     pub notify: Notify,
     pub readiness: Mutex<ReadinessState>,
+    /// Whether the node entered its current joining cycle with usable local
+    /// cache data. Warm nodes can serve that data while anti-entropy catches
+    /// up; a node that starts its initial joining cycle empty waits for a clean
+    /// bootstrap pass.
+    pub local_data_available_at_join: AtomicBool,
     pub bootstrap_semaphore: Arc<Semaphore>,
     /// Process-wide byte budget shared by every transient disk writer.
     pub tmp_staging_budget: Arc<TmpBudget>,
@@ -369,16 +377,7 @@ impl AppState {
 
         let membership_update = {
             let mut readiness = self.readiness.lock().await;
-            let membership_update = readiness.apply_membership(
-                members,
-                known_peers,
-                discovery_observed,
-                Instant::now(),
-            );
-            if membership_update.generation_changed {
-                self.runtime.clear_serving();
-            }
-            membership_update
+            readiness.apply_membership(members, known_peers, discovery_observed, Instant::now())
         };
         // A lost peer silently drops its bootstrapped mark and re-enters the
         // bootstrap gate when it returns; a flapping peer set is the difference
@@ -413,19 +412,20 @@ impl AppState {
     }
 
     /// Forgets all bootstrap progress so the membership loop re-pulls the full
-    /// dataset from every known peer, and takes the node out of serving until
-    /// the gate re-passes. Called on a *recovery* re-enrollment — the node was
-    /// out of the mesh for an unknown window, and the writes it missed were
-    /// never enqueued for it (replication targets are computed at write time),
-    /// so only a full re-bootstrap can reconcile the gap, including namespace
-    /// delete tombstones. Readiness implies complete data, so the node must
-    /// not keep advertising ready while it knows its data is incomplete —
-    /// every *other* node already re-enters the gate when this node rejoins
-    /// (their membership generation changes); this keeps the one node whose
-    /// data actually is incomplete from being the only one that skips it.
-    /// Bumps the bootstrap epoch so passes already in flight cannot re-mark
-    /// their peer bootstrapped.
+    /// dataset from every known peer, and re-evaluates whether the node can
+    /// keep serving from local data. Called on a *recovery* re-enrollment — the
+    /// node was out of the mesh for an unknown window, and the writes it missed
+    /// were never enqueued for it (replication targets are computed at write
+    /// time), so a full re-bootstrap reconciles the gap, including namespace
+    /// delete tombstones. A node with local artifacts can return to serving
+    /// after the settle window while that reconciliation continues; an empty
+    /// node stays out until it has usable data. Bumps the bootstrap epoch so
+    /// passes already in flight cannot re-mark their peer bootstrapped.
     pub async fn reset_bootstrap_progress(&self) {
+        self.local_data_available_at_join.store(
+            self.store.has_artifacts().unwrap_or(false),
+            Ordering::Release,
+        );
         self.readiness
             .lock()
             .await
@@ -518,6 +518,15 @@ impl AppState {
         }
         let snapshot = self.readiness_snapshot().await;
         if !snapshot.initial_discovery_completed || !snapshot.readiness_settled {
+            return;
+        }
+
+        // Availability takes precedence over a fully reconciled warm replica.
+        // A restarted node with persistent cache data can already answer useful
+        // requests while anti-entropy continues in the background. A node that
+        // entered this joining cycle empty still waits for a clean pass.
+        if self.local_data_available_at_join.load(Ordering::Acquire) {
+            self.runtime.mark_serving();
             return;
         }
 
@@ -666,7 +675,7 @@ impl AppState {
 mod tests {
     use tokio::sync::Barrier;
 
-    use crate::test_support::test_context;
+    use crate::{artifact::producer::ArtifactProducer, test_support::test_context};
 
     use super::*;
 
@@ -871,7 +880,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn app_state_returns_to_joining_when_membership_generation_advances() {
+    async fn app_state_keeps_serving_when_membership_generation_advances() {
         let context = test_context(|_| {}).await;
         let peer_a = "http://peer-a.kura.internal:7443".to_string();
         let peer_b = "http://peer-b.kura.internal:7443".to_string();
@@ -906,15 +915,51 @@ mod tests {
             )
             .await;
 
-        let joining = context.state.readiness_report().await;
-        assert!(!joining.ready);
-        assert_eq!(joining.state, TrafficState::Joining);
-        assert!(
-            joining
-                .reasons
-                .iter()
-                .any(|reason| reason.contains("discovery settling"))
+        let still_serving = context.state.readiness_report().await;
+        assert!(still_serving.ready);
+        assert_eq!(still_serving.state, TrafficState::Serving);
+        assert_eq!(
+            still_serving.bootstrapped_peers,
+            vec![peer_a],
+            "the newly discovered peer still reconciles in the background"
         );
+    }
+
+    #[tokio::test]
+    async fn app_state_serves_warm_data_while_bootstrap_continues() {
+        let context = test_context(|_| {}).await;
+        context
+            .state
+            .store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("local artifact should persist");
+        context.state.reset_bootstrap_progress().await;
+
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote".to_string()]),
+                BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
+            )
+            .await;
+        assert!(context.state.note_bootstrap_started(&peer).await.is_some());
+        context.state.expire_readiness_settle_window().await;
+        context.state.maybe_mark_serving().await;
+
+        let serving = context.state.readiness_report().await;
+        assert!(serving.ready);
+        assert_eq!(serving.state, TrafficState::Serving);
+        assert_eq!(serving.bootstrap_inflight_peers, vec![peer]);
+        assert!(serving.bootstrapped_peers.is_empty());
     }
 
     fn rendered_metric_value(rendered: &str, selector: &str) -> Option<u64> {

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -3717,6 +3717,16 @@ impl Store {
         Ok(())
     }
 
+    /// Whether this store has any locally usable cache data.
+    pub fn has_artifacts(&self) -> Result<bool, String> {
+        self.db
+            .iterator_cf(self.cf(ROCKSDB_CF_MANIFESTS), IteratorMode::Start)
+            .next()
+            .transpose()
+            .map(|item| item.is_some())
+            .map_err(|error| format!("failed to inspect manifests: {error}"))
+    }
+
     /// Walk the manifest keyspace, optionally restricted to an `artifact_id`
     /// prefix. When `prefix` is set the walk starts at the prefix's lower bound
     /// (unless a later `after` cursor is supplied) and stops as soon as it
@@ -6738,6 +6748,25 @@ mod tests {
             read_manifest_bytes(&reopened, &rebuilt).await,
             b"module-bytes"
         );
+    }
+
+    #[tokio::test]
+    async fn has_artifacts_tracks_local_manifest_availability() {
+        let (_temp_dir, _config, store) = temp_store();
+        assert!(!store.has_artifacts().expect("empty store should inspect"));
+
+        store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Gradle,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("artifact should persist");
+
+        assert!(store.has_artifacts().expect("warm store should inspect"));
     }
 
     #[tokio::test]

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -132,6 +132,9 @@ where
     ));
     let store =
         Store::open(&config, io.clone(), memory.clone()).expect("failed to open test store");
+    let local_data_available_at_join = store
+        .has_artifacts()
+        .expect("failed to inspect local test artifacts");
     let tmp_staging_budget = store.tmp_staging_budget();
     let analytics =
         Analytics::from_config(config.analytics.as_ref(), &config.node_url, metrics.clone())
@@ -175,6 +178,9 @@ where
         replication_bandwidth_limiter,
         notify: Notify::new(),
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
+        local_data_available_at_join: std::sync::atomic::AtomicBool::new(
+            local_data_available_at_join,
+        ),
         bootstrap_semaphore,
         tmp_staging_budget,
         bootstrap_staging_budget,

--- a/kura/test/e2e/kura_compatibility_rollout.sh
+++ b/kura/test/e2e/kura_compatibility_rollout.sh
@@ -10,6 +10,9 @@ KURA_US_PORT="${KURA_US_PORT:-4701}"
 KURA_EU_PORT="${KURA_EU_PORT:-4702}"
 PREVIOUS_IMAGE="${PREVIOUS_IMAGE:-kura-compat-previous:latest}"
 CURRENT_IMAGE="${CURRENT_IMAGE:-kura-compat-current:latest}"
+PREVIOUS_WORKTREE_CANONICAL=""
+
+export KURA_US_PORT KURA_EU_PORT
 
 if [[ -z "${PREVIOUS_REF}" ]]; then
   echo "Set PREVIOUS_REF to the adjacent version ref to validate, for example PREVIOUS_REF=origin/main" >&2
@@ -22,12 +25,13 @@ PREVIOUS_OVERRIDE="${TMP_DIR}/compose.previous.yml"
 MIXED_OVERRIDE="${TMP_DIR}/compose.mixed.yml"
 
 cleanup() {
+  local registered_worktree="${PREVIOUS_WORKTREE_CANONICAL:-${PREVIOUS_WORKTREE}}"
   docker compose -p "${COMPOSE_PROJECT_NAME}" \
     -f "${PROJECT_ROOT}/docker-compose.yml" \
     -f "${PREVIOUS_OVERRIDE}" \
     down -v --remove-orphans >/dev/null 2>&1 || true
-  if git -C "${PROJECT_ROOT}" worktree list --porcelain 2>/dev/null | grep -q "^worktree ${PREVIOUS_WORKTREE}\$"; then
-    git -C "${PROJECT_ROOT}" worktree remove --force "${PREVIOUS_WORKTREE}" >/dev/null 2>&1 || true
+  if git -C "${PROJECT_ROOT}" worktree list --porcelain 2>/dev/null | grep -q "^worktree ${registered_worktree}\$"; then
+    git -C "${PROJECT_ROOT}" worktree remove --force "${registered_worktree}" >/dev/null 2>&1 || true
   fi
   rm -rf "${TMP_DIR}"
 }
@@ -52,7 +56,8 @@ build_image_from_ref() {
   fi
 
   git -C "${PROJECT_ROOT}" worktree add --detach "${context_dir}" "${ref}" >/dev/null
-  docker build -t "${image}" "${context_dir}"
+  PREVIOUS_WORKTREE_CANONICAL="$(cd "${context_dir}" && pwd -P)"
+  docker build -t "${image}" "${context_dir}/kura"
 }
 
 write_override() {

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -88,10 +88,12 @@ defmodule Tuist.Kura do
   Creates deployments for active Kura servers that are behind the
   latest released Kura runtime image tag.
 
-  Each `(server, image_tag)` pair is scheduled at most once. A failed
-  deployment for the configured image is intentionally not retried here;
-  operators can inspect and re-trigger it manually, while the next Tuist
-  released Kura version will be scheduled normally.
+  Each `(server, image_tag)` pair is scheduled at most once. A newer image
+  supersedes an open deployment for an older image so a rollout that cannot
+  become ready never blocks delivery of its fix. A failed deployment for the
+  configured image is intentionally not retried here; operators can inspect
+  and re-trigger it manually, while the next Tuist released Kura version will
+  be scheduled normally.
   """
   def schedule_runtime_image_deployments do
     case runtime_image_tag() do
@@ -162,9 +164,11 @@ defmodule Tuist.Kura do
         select: 1
       )
 
-    open_deployment_exists_query =
+    open_older_deployment_exists_query =
       from(d in Deployment,
-        where: parent_as(:server).id == d.kura_server_id and d.status in [:pending, :running],
+        where:
+          parent_as(:server).id == d.kura_server_id and d.status in [:pending, :running] and
+            d.image_tag != ^image_tag,
         select: 1
       )
 
@@ -177,9 +181,8 @@ defmodule Tuist.Kura do
       # row picks the runtime bump up normally once the move completes.
       where: s.move_phase == :none,
       where: s.status in @version_rollout_statuses,
-      where: s.current_image_tag != ^image_tag,
+      where: s.current_image_tag != ^image_tag or exists(open_older_deployment_exists_query),
       where: not exists(deployment_for_image_exists_query),
-      where: not exists(open_deployment_exists_query),
       order_by: [asc: s.updated_at, asc: s.id],
       limit: ^@version_rollout_batch_size
     )
@@ -1173,20 +1176,44 @@ defmodule Tuist.Kura do
   end
 
   defp insert_scheduled_deployment(server, region, image_tag) do
-    case insert_deployment(server, region, image_tag) do
-      {:ok, deployment} ->
+    if deployment_for_image_exists?(server.id, image_tag) do
+      nil
+    else
+      with :ok <- supersede_open_deployments(server.id, image_tag),
+           {:ok, deployment} <- insert_deployment(server, region, image_tag) do
         deployment
+      else
+        {:error, %Ecto.Changeset{} = changeset} ->
+          rollback_unless_open_deployment_conflict(changeset)
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        if open_deployment_conflict?(changeset) do
-          nil
-        else
-          Repo.rollback(changeset)
-        end
-
-      {:error, reason} ->
-        Repo.rollback(reason)
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
     end
+  end
+
+  defp rollback_unless_open_deployment_conflict(changeset) do
+    if open_deployment_conflict?(changeset), do: nil, else: Repo.rollback(changeset)
+  end
+
+  defp deployment_for_image_exists?(server_id, image_tag) do
+    Repo.exists?(
+      from(d in Deployment,
+        where: d.kura_server_id == ^server_id and d.image_tag == ^image_tag
+      )
+    )
+  end
+
+  defp supersede_open_deployments(server_id, image_tag) do
+    Deployment
+    |> where([d], d.kura_server_id == ^server_id and d.status in [:pending, :running])
+    |> Repo.all()
+    |> Enum.reduce_while(:ok, fn deployment, :ok ->
+      case mark_superseded(deployment, "superseded by Kura image #{image_tag}") do
+        {:ok, _deployment} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   defp open_deployment_conflict?(changeset) do
@@ -1277,6 +1304,15 @@ defmodule Tuist.Kura do
   def mark_cancelled(%Deployment{} = deployment, message) when is_binary(message) do
     update_deployment_status(deployment, %{
       status: :cancelled,
+      error_message: message,
+      finished_at: now_truncated()
+    })
+  end
+
+  @doc "Marks an open deployment as superseded by a newer runtime image."
+  def mark_superseded(%Deployment{} = deployment, message) when is_binary(message) do
+    update_deployment_status(deployment, %{
+      status: :superseded,
       error_message: message,
       finished_at: now_truncated()
     })

--- a/server/lib/tuist/kura/deployment.ex
+++ b/server/lib/tuist/kura/deployment.ex
@@ -26,14 +26,15 @@ defmodule Tuist.Kura.Deployment do
 
   alias Tuist.Kura.Server
 
-  @status_mappings [pending: 0, running: 1, succeeded: 2, failed: 3, cancelled: 4]
+  @status_mappings [pending: 0, running: 1, succeeded: 2, failed: 3, cancelled: 4, superseded: 5]
   @statuses Keyword.keys(@status_mappings)
   @allowed_status_transitions %{
-    pending: [:pending, :running, :failed, :cancelled],
-    running: [:running, :succeeded, :failed, :cancelled],
+    pending: [:pending, :running, :failed, :cancelled, :superseded],
+    running: [:running, :succeeded, :failed, :cancelled, :superseded],
     succeeded: [:succeeded],
     failed: [:failed],
-    cancelled: [:cancelled]
+    cancelled: [:cancelled],
+    superseded: [:superseded]
   }
   @image_tag_format ~r/\A[A-Za-z0-9_][A-Za-z0-9_.-]*\z/
   @image_tag_message "must be a valid OCI image tag like sha-abcdef123456, latest, or 0.5.2"

--- a/server/lib/tuist_web/live/ops_account_kura_deployment_live.ex
+++ b/server/lib/tuist_web/live/ops_account_kura_deployment_live.ex
@@ -75,12 +75,14 @@ defmodule TuistWeb.OpsAccountKuraDeploymentLive do
   def deployment_status_label(:succeeded), do: dgettext("dashboard", "Succeeded")
   def deployment_status_label(:failed), do: dgettext("dashboard", "Failed")
   def deployment_status_label(:cancelled), do: dgettext("dashboard", "Cancelled")
+  def deployment_status_label(:superseded), do: dgettext("dashboard", "Superseded")
 
   def deployment_status_color(:pending), do: "neutral"
   def deployment_status_color(:running), do: "information"
   def deployment_status_color(:succeeded), do: "success"
   def deployment_status_color(:failed), do: "destructive"
   def deployment_status_color(:cancelled), do: "warning"
+  def deployment_status_color(:superseded), do: "warning"
 
   def format_time(nil), do: dgettext("dashboard", "None")
   def format_time(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -1015,7 +1015,7 @@ msgstr ""
 
 #: lib/tuist/utilities/date_formatter.ex:5
 #: lib/tuist/utilities/date_formatter.ex:76
-#: lib/tuist_web/live/ops_account_kura_deployment_live.ex:85
+#: lib/tuist_web/live/ops_account_kura_deployment_live.ex:87
 #: lib/tuist_web/live/ops_account_live.html.heex:23
 #: lib/tuist_web/live/ops_account_live.html.heex:27
 #: lib/tuist_web/live/ops_account_live.html.heex:33
@@ -1883,4 +1883,9 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_live.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "vCPU limit"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_kura_deployment_live.ex:78
+#, elixir-autogen, elixir-format
+msgid "Superseded"
 msgstr ""

--- a/server/priv/repo/migrations/20260727120000_allow_superseded_kura_deployment_status.exs
+++ b/server/priv/repo/migrations/20260727120000_allow_superseded_kura_deployment_status.exs
@@ -1,0 +1,31 @@
+defmodule Tuist.Repo.Migrations.AllowSupersededKuraDeploymentStatus do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:kura_deployments, :kura_deployments_status_valid)
+
+    # excellent_migrations:safety-assured-for-next-line check_constraint_added
+    create constraint(:kura_deployments, :kura_deployments_status_valid,
+             check: "status IN (0, 1, 2, 3, 4, 5)"
+           )
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute("""
+    UPDATE kura_deployments
+    SET status = 4,
+        error_message = COALESCE(error_message, 'cancelled while rolling back superseded deployment support'),
+        finished_at = COALESCE(finished_at, NOW()),
+        updated_at = NOW()
+    WHERE status = 5
+    """)
+
+    drop constraint(:kura_deployments, :kura_deployments_status_valid)
+
+    # excellent_migrations:safety-assured-for-next-line check_constraint_added
+    create constraint(:kura_deployments, :kura_deployments_status_valid,
+             check: "status IN (0, 1, 2, 3, 4)"
+           )
+  end
+end

--- a/server/test/tuist/kura/deployment_test.exs
+++ b/server/test/tuist/kura/deployment_test.exs
@@ -13,7 +13,8 @@ defmodule Tuist.Kura.DeploymentTest do
                running: 1,
                succeeded: 2,
                failed: 3,
-               cancelled: 4
+               cancelled: 4,
+               superseded: 5
              ]
     end
   end
@@ -93,7 +94,7 @@ defmodule Tuist.Kura.DeploymentTest do
 
       assert definition =~ "status"
 
-      for status <- 0..4 do
+      for status <- 0..5 do
         assert definition =~ Integer.to_string(status)
       end
     end
@@ -188,13 +189,16 @@ defmodule Tuist.Kura.DeploymentTest do
         {:pending, :running},
         {:pending, :failed},
         {:pending, :cancelled},
+        {:pending, :superseded},
         {:running, :running},
         {:running, :succeeded},
         {:running, :failed},
         {:running, :cancelled},
+        {:running, :superseded},
         {:succeeded, :succeeded},
         {:failed, :failed},
-        {:cancelled, :cancelled}
+        {:cancelled, :cancelled},
+        {:superseded, :superseded}
       ]
 
       for {from, to} <- transitions do
@@ -207,7 +211,8 @@ defmodule Tuist.Kura.DeploymentTest do
         {:pending, :succeeded},
         {:succeeded, :running},
         {:failed, :running},
-        {:cancelled, :running}
+        {:cancelled, :running},
+        {:superseded, :running}
       ]
 
       for {from, to} <- transitions do

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -166,6 +166,81 @@ defmodule Tuist.KuraTest do
       assert {:ok, %{scheduled: [], failures: []}} = Kura.schedule_runtime_image_deployments()
     end
 
+    test "supersedes an open deployment when a newer runtime image is configured" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      [open_deployment] = server.deployments
+      {:ok, _open_deployment} = Kura.mark_running(open_deployment)
+
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
+
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "0.5.3"} = deployment], failures: []}} =
+               Kura.schedule_runtime_image_deployments()
+
+      superseded = Repo.get!(Deployment, open_deployment.id)
+      assert superseded.status == :superseded
+      assert superseded.error_message == "superseded by Kura image 0.5.3"
+      assert superseded.finished_at
+      assert deployment.kura_server_id == server.id
+
+      assert Repo.aggregate(
+               from(d in Deployment,
+                 where: d.kura_server_id == ^server.id and d.status in [:pending, :running]
+               ),
+               :count
+             ) == 1
+    end
+
+    test "supersedes an older open deployment even when the server already observes the new image" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      [open_deployment] = server.deployments
+      {:ok, _server} = Kura.activate_server(server, "0.5.3")
+
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.3" end)
+
+      assert {:ok, %{scheduled: [%Deployment{image_tag: "0.5.3"}], failures: []}} =
+               Kura.schedule_runtime_image_deployments()
+
+      assert Repo.get!(Deployment, open_deployment.id).status == :superseded
+    end
+
+    test "keeps the open deployment when the replacement image tag is invalid" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      [open_deployment] = server.deployments
+      {:ok, _open_deployment} = Kura.mark_running(open_deployment)
+
+      assert {:ok, %{scheduled: [], failures: [%{reason: %Ecto.Changeset{}}]}} =
+               Kura.schedule_version_deployments("bad tag")
+
+      assert Repo.get!(Deployment, open_deployment.id).status == :running
+    end
+
     test "does not create deployments when no runtime image tag is configured" do
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> nil end)
 

--- a/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
@@ -38,4 +38,22 @@ defmodule TuistWeb.OpsAccountKuraDeploymentLiveTest do
     assert html =~ "Grafana"
     assert html =~ "tuist.grafana.net/explore"
   end
+
+  test "renders a superseded deployment", %{conn: conn, user: user} do
+    {:ok, server} =
+      Kura.create_server(%{
+        account_id: user.account.id,
+        region: "local-controller",
+        image_tag: "0.5.2"
+      })
+
+    deployment = List.first(server.deployments)
+    {:ok, deployment} = Kura.mark_superseded(deployment, "superseded by Kura image 0.5.3")
+
+    {:ok, _live_view, html} =
+      live(conn, ~p"/ops/accounts/#{user.account.id}/kura/deployments/#{deployment.id}")
+
+    assert html =~ "Superseded"
+    assert html =~ "superseded by Kura image 0.5.3"
+  end
 end


### PR DESCRIPTION
## What changed

- Keeps namespace tombstone bootstrap pages at the compatible 256-item limit and lets manifest bootstrap negotiate from 2,048 down to 256 when an older peer rejects the preferred size.
- Allows warm Kura nodes to become ready after discovery settles while reconciliation continues in the background. Empty nodes still wait for a complete bootstrap.
- Lets the Kura controller replace unready pods on the previous image once per target image, while retaining ready pods, persistent storage, and pods already running the target image.
- Allows a newer Kura deployment to supersede an older pending or running deployment atomically.
- Adds the `Superseded` deployment state to storage and the operator page.
- Hardens the local adjacent-version rollout harness and prevents a stale cached Kura binary during Docker builds.

## Why

Production currently has 12 of 18 Kura instances Pending, including every Tuist Kura pod. A new release must be able to reach those instances even though the current rollout cannot pass readiness.

The recovery path follows availability over convergence: warm nodes can serve the cache they already hold while they reconcile missed writes, and already-unready pods do not block delivery of the image that fixes them.

## Root cause

Kura `0.21.3` changed the shared bootstrap client page size from 256 to 2,048, but the server still rejected page limits above 256. The enlarged value was also used for namespace tombstones. Nodes therefore rejected each other's bootstrap requests with `400 Bad Request`, remained in the joining state, and never passed readiness.

The deployment control plane then compounded the failure: an open deployment prevented scheduling the next image, and the StatefulSet rollout could not advance past pods that were unready on the old image.

## Approach

The protocol change remains compatible in both directions. A new node talking to `0.21.3` retries manifest pages at 256 and requests tombstones at 256. A `0.21.3` node talking to a new node can continue requesting 2,048 because the new server accepts that limit.

The controller records each handled target image only after issuing every required deletion. A retry ignores pods already recreated on the target image, so it cannot repeatedly restart a legitimately bootstrapping pod. Pod deletion preserves the StatefulSet's persistent storage.

Deployment supersession and insertion happen in one database transaction under the server row lock. This ensures there is always one authoritative open intent.

Marek's fast cold-join proposal and the presence-based anti-entropy design remain valuable follow-up work, but they are not prerequisites for recovering the current fleet.

## Impact

A newly released Kura image can recover the currently Pending instances without manual pod deletion. Warm replicas may briefly serve cache entries from a namespace deleted while the node was away, until tombstone reconciliation catches up. This is an availability tradeoff for a content-addressed cache and does not corrupt or delete artifacts.

Already-unready old-image pods update in parallel. Ready old-image pods retain the ordinary rollout path.

## Validation

- `mise run format -- --check` in `kura/`
- `mise run test-unit` in `kura/`: 456 passed, 1 ignored
- `mise run clippy` in `kura/`
- Adjacent-version persistent-volume rollout: `kura@0.21.0` to this change and back to `kura@0.21.0`, with artifacts readable throughout
- Focused server deployment, scheduler, reconciler, migration, and operator-page tests: 118 passed
- `mix credo` and targeted server formatting
- `mise x go@1.25.0 -- go test ./...` in `infra/kura-controller/`
- `mise exec -- helm lint infra/helm/tuist`: 1 chart, 0 failures
- Independent Claude review: no blocking findings, recommendation to ship

The operator-page state is covered by a rendered LiveView test. A connected Chrome session was unavailable in this environment, so no browser screenshot is attached.