### PR TITLE
fix(infra): prevent server ingress connection reuse failures

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -429,6 +429,41 @@ sum by (cluster) (
 - Pending period: 5 minutes
 - Summary: `Kubernetes is rate limiting requests in {{ $labels.cluster }}`
 
+### Ingress server-error response ratio
+
+```promql
+(
+  sum by (cluster, namespace, ingress) (
+    rate(nginx_ingress_controller_requests{status=~"5.."}[5m])
+  )
+  /
+  clamp_min(
+    sum by (cluster, namespace, ingress) (
+      rate(nginx_ingress_controller_requests[5m])
+    ),
+    1
+  )
+) > 0.01
+and
+sum by (cluster, namespace, ingress) (
+  rate(nginx_ingress_controller_requests{status=~"5.."}[5m])
+) > 0.1
+```
+
+- Pending period: 2 minutes
+- Summary: `More than 1% of ingress requests are server errors for {{ $labels.ingress }} in {{ $labels.cluster }}`
+
+### Tuist server request read timeouts
+
+```promql
+sum by (cluster, namespace, method, route) (
+  increase(tuist_http_request_timeout_count[5m])
+) > 5
+```
+
+- Pending period: 2 minutes
+- Summary: `Bandit reported repeated request read timeouts for {{ $labels.route }} in {{ $labels.cluster }}`
+
 ### Tuist license expires within 30 days
 
 ```promql

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -63,17 +63,25 @@ ingress-nginx:
     # managed Tuist cluster runs. Other providers should disable these in
     # their own overlay when their LB doesn't pass through PROXY headers.
     #
-    # upstream-keepalive-timeout must stay below Bandit's
-    # thousand_island_options.read_timeout (15s in server/config/runtime.exs).
-    # Otherwise nginx reuses a connection the backend has already FIN'd,
-    # producing 502s with Bandit `reason=protocol_error`.
+    # Keep upstream connection reuse disabled for the main web ingress. Under
+    # production load, reused nginx-to-Bandit connections intermittently
+    # stalled until Bandit's read timeout or were closed before nginx received
+    # a response. Fresh connections directly to the same pods remained healthy.
+    # Keep the timeout below Bandit's 15-second read timeout as a guard if
+    # connection reuse is enabled again after the underlying behavior is fixed.
     config:
       use-forwarded-headers: "true"
       use-proxy-protocol: "true"
       compute-full-forwarded-for: "true"
+      upstream-keepalive-connections: "0"
       upstream-keepalive-timeout: "10"
     metrics:
       enabled: true
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "10254"
+          prometheus.io/path: /metrics
 
 kura-eu-central-ingress-nginx:
   enabled: false

--- a/tuist_common/lib/tuist_common/http/transport.ex
+++ b/tuist_common/lib/tuist_common/http/transport.ex
@@ -12,7 +12,7 @@ defmodule TuistCommon.HTTP.Transport do
   - Bandit request pipeline, which forwards `error.message` into `[:bandit, :request, ...]`
     telemetry metadata:
     https://github.com/mtrudel/bandit/blob/main/lib/bandit/pipeline.ex
-  - Bandit HTTP/1 socket handling, including the `"Body read timeout"` error that we classify
+  - Bandit HTTP/1 socket handling, including the request read timeout errors that we classify
     here:
     https://github.com/mtrudel/bandit/blob/main/lib/bandit/http1/socket.ex
   - Thousand Island telemetry event docs:
@@ -22,7 +22,7 @@ defmodule TuistCommon.HTTP.Transport do
     https://github.com/mtrudel/thousand_island/blob/main/lib/thousand_island/socket.ex
 
   In practice, this module uses Bandit request metadata to:
-  - classify body read timeouts
+  - classify request read timeouts
   - classify request failures
   - extract low-cardinality request tags and log fields
 
@@ -33,7 +33,7 @@ defmodule TuistCommon.HTTP.Transport do
   """
 
   def bandit_request_timeout?(metadata) do
-    metadata[:error] == "Body read timeout"
+    metadata[:error] in ["Body read timeout", "Read timeout"]
   end
 
   def bandit_request_failure_reason(metadata) do

--- a/tuist_common/lib/tuist_common/http/transport_logger.ex
+++ b/tuist_common/lib/tuist_common/http/transport_logger.ex
@@ -37,7 +37,7 @@ defmodule TuistCommon.HTTP.TransportLogger do
 
     if Transport.bandit_request_timeout?(metadata) do
       Logger.warning(
-        "Bandit request body read timed out",
+        "Bandit request read timed out",
         Map.to_list(Transport.bandit_timeout_log_metadata(measurements, metadata))
       )
     end

--- a/tuist_common/lib/tuist_common/http/transport_prom_ex_plugin.ex
+++ b/tuist_common/lib/tuist_common/http/transport_prom_ex_plugin.ex
@@ -20,7 +20,7 @@ defmodule TuistCommon.HTTP.TransportPromExPlugin do
             keep: fn metadata -> Transport.bandit_request_timeout?(metadata) end,
             tag_values: &Transport.bandit_request_metadata/1,
             tags: [:method, :route],
-            description: "Counts request body read timeouts reported by Bandit."
+            description: "Counts request read timeouts reported by Bandit."
           )
         ]
       ),

--- a/tuist_common/test/tuist_common/http/transport_logger_test.exs
+++ b/tuist_common/test/tuist_common/http/transport_logger_test.exs
@@ -16,7 +16,7 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
     %{handler_suffix: handler_suffix}
   end
 
-  test "logs Bandit body read timeouts with route and connection context", %{
+  test "logs Bandit read timeouts with route and connection context", %{
     handler_suffix: _handler_suffix
   } do
     log =
@@ -30,7 +30,7 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
             [:bandit, :request, :stop],
             %{duration: System.convert_time_unit(2, :millisecond, :native), req_body_bytes: 128},
             %{
-              error: "Body read timeout",
+              error: "Read timeout",
               telemetry_span_context: make_ref(),
               connection_telemetry_span_context: make_ref(),
               conn: %{
@@ -44,7 +44,7 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
         end
       )
 
-    assert log =~ "Bandit request body read timed out"
+    assert log =~ "Bandit request read timed out"
     assert log =~ "request_id=req_123"
     assert log =~ "method=POST"
     assert log =~ "route=/upload"

--- a/tuist_common/test/tuist_common/http/transport_prom_ex_plugin_test.exs
+++ b/tuist_common/test/tuist_common/http/transport_prom_ex_plugin_test.exs
@@ -11,6 +11,7 @@ defmodule TuistCommon.HTTP.TransportPromExPluginTest do
       assert timeout_metric.event_name == [:bandit, :request, :stop]
       assert timeout_metric.tags == [:method, :route]
       assert timeout_metric.keep.(%{error: "Body read timeout"})
+      assert timeout_metric.keep.(%{error: "Read timeout"})
       refute timeout_metric.keep.(%{})
 
       assert timeout_metric.tag_values.(%{


### PR DESCRIPTION
## What changed

- Disabled reusable upstream connections between the main NGINX ingress controller and the Tuist server pods.
- Annotated the ingress metrics Service so Grafana discovers the controller's Prometheus metrics.
- Classified both `Body read timeout` and the live `Read timeout` Bandit event as request read timeouts.
- Added Grafana alert queries for ingress server-error ratios and repeated Bandit request read timeouts.

## Why

Production was returning intermittent [Hypertext Transfer Protocol (HTTP)](https://developer.mozilla.org/en-US/docs/Web/HTTP) 502 responses while the server pods remained healthy. The failures were visible between NGINX and Bandit, not between users and the public network and not inside Phoenix request handling.

Bandit 1.12.1 and Thousand Island 1.5.0 were already deployed when the failures occurred, so the recently merged dependency update did not eliminate this behavior.

## Root cause

The initiating implementation race is not proven, but the failing boundary is well localized. NGINX reused upstream connections that intermittently stalled until Bandit's read timeout or were closed before NGINX received a response.

The evidence does not support a general internet connection drop:

- Direct requests from ingress to all server pods succeeded 80 out of 80 times.
- Server pods had no restarts and normal resource usage.
- The network data plane reported no packet drops for the affected server traffic.
- A failed safe request did not reach Phoenix on its first upstream attempt, then succeeded immediately when NGINX retried it on another connection.
- Non-idempotent requests could not be retried safely and therefore surfaced as final 502 responses.

```mermaid
sequenceDiagram
    participant Client
    participant Ingress as NGINX ingress
    participant Bandit
    participant Phoenix

    Client->>Ingress: Request
    Ingress->>Bandit: Reuse pooled upstream connection
    alt Connection closes or stalls before a response
        Bandit--xIngress: Reset or read timeout
        alt Safe request
            Ingress->>Bandit: Retry on another connection
            Bandit->>Phoenix: Dispatch request
            Phoenix-->>Client: Successful response
        else Non-idempotent request
            Ingress-->>Client: 502 response
        end
    else Healthy connection
        Bandit->>Phoenix: Dispatch request
        Phoenix-->>Client: Successful response
    end
```

## Approach

Setting [`upstream-keepalive-connections`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#upstream-keepalive-connections) to zero makes each ingress request use a fresh in-cluster upstream connection. This is the narrowest mitigation that directly targets the observed failing boundary. It trades a small amount of connection setup work for request correctness and leaves client-side connection reuse unchanged.

The telemetry change preserves the existing process-isolated tests. It does not add a new global telemetry handler or make additional test modules synchronous.

```mermaid
flowchart LR
    Request[Ingress request] --> Fresh[Fresh upstream connection]
    Fresh --> Server[Bandit and Phoenix]
    Server --> Response[Response]

    IngressMetrics[Ingress Prometheus metrics] --> Grafana[Grafana]
    BanditEvent[Bandit read-timeout event] --> Classifier[Timeout classifier]
    Classifier --> ServerMetric[Server timeout metric]
    Classifier --> StructuredLog[Structured warning]
    ServerMetric --> Grafana
    Grafana --> Alerts[Request-path alerts]
```

## Impact

The NGINX ConfigMap change triggers a dynamic configuration reload rather than a controller pod rollout. Production has not been changed manually. Canary and staging already run the proposed value, so merging makes their validated state declarative and allows the normal deployment sequence to carry it to production.

The rollback is to remove `upstream-keepalive-connections: "0"` and let the controller reload its previous upstream pool configuration.

## Validation

- Canary controlled probes before the change: 160 successful out of 160.
- Canary controlled probes after the change: 160 successful out of 160.
- Staging natural traffic before the change: 39 status 502 responses out of 119 requests.
- Staging natural traffic after the change: 0 status 502 responses out of 56 requests, with no upstream resets.
- Unchanged production in the comparison window: 572 status 502 responses out of 12,304 requests, with 900 upstream reset or premature-close log events.
- `helm lint infra/helm/platform`
- `helm lint infra/helm/platform -f infra/helm/platform/values-hetzner.yaml`
- Rendered the Hetzner and preview platform variants and confirmed the ConfigMap value and metrics Service annotations.
- `mix test test/tuist_common/http/transport_prom_ex_plugin_test.exs test/tuist_common/http/transport_logger_test.exs`
- `mix test --max-cases 1 --warnings-as-errors`: 165 tests passed.
- `mix format --check-formatted` for every changed Elixir source and test file.
