### PR TITLE
fix(server): prevent runner-cache provisioning storms

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -271,6 +271,10 @@ spec:
         {{- include "tuist.componentLabels" (dict "root" . "component" "kura-controller") | nindent 8 }}
     spec:
       serviceAccountName: {{ $name }}
+      # Kura creates one Service per cache instance. Injecting every Service
+      # as environment variables can exceed the process argument limit and
+      # prevent the controller from starting when it is most needed.
+      enableServiceLinks: false
       {{- with .Values.kuraController.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -186,6 +186,13 @@ pdcAgent:
     - tuist-tuist-pg-ro.tuist-canary.svc.cluster.local:5432
 
 kuraController:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
   sharedSecrets:
     externalSecret:
       item: kura-introspection-oauth-client

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -32,7 +32,7 @@ clusters/
 | Cluster | CP | Workers |
 |---|---|---|
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: bare-metal Robot (`pool=runners-linux`) |
-| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
+| `tuist-canary` | 3× cpx32 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
 | `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -25,7 +25,7 @@ spec:
       - name: region
         value: fsn1
       - name: hcloudControlPlaneMachineType
-        value: cpx22
+        value: cpx32
       # Roll out the kubeadm compatibility fallback in canary first. With the
       # local-mode feature enabled, new control-plane kubelets point at their
       # own not-yet-running control-plane endpoint and never start the etcd

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -2603,6 +2603,7 @@ func podTemplate(instance *kurav1alpha1.KuraInstance, otlpTracesEndpoint string,
 			Annotations: podAnnotations(instance, sharedSecretsResourceVersion),
 		},
 		Spec: corev1.PodSpec{
+			EnableServiceLinks:            ptr(false),
 			TerminationGracePeriodSeconds: ptr(terminationGracePeriodSeconds()),
 			NodeSelector:                  nodeSelector(instance),
 			Tolerations:                   instance.Spec.Tolerations,

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -353,6 +353,9 @@ func TestKuraInstanceReconcileCreatesWorkloadResources(t *testing.T) {
 	if grace := sts.Spec.Template.Spec.TerminationGracePeriodSeconds; grace == nil || *grace < drainCompletionTimeoutMs/1000+preStopDelaySeconds {
 		t.Fatalf("expected terminationGracePeriodSeconds to cover the drain budget, got %v", grace)
 	}
+	if serviceLinks := sts.Spec.Template.Spec.EnableServiceLinks; serviceLinks == nil || *serviceLinks {
+		t.Fatal("expected service-link environment injection to be disabled")
+	}
 	if len(container.EnvFrom) == 0 || container.EnvFrom[0].SecretRef == nil || container.EnvFrom[0].SecretRef.Name != sharedSecretsName {
 		t.Fatalf("expected envFrom to reference %q Secret", sharedSecretsName)
 	}

--- a/infra/kura-controller/controllers/peer_demux_controller.go
+++ b/infra/kura-controller/controllers/peer_demux_controller.go
@@ -258,10 +258,11 @@ func peerDemuxPodTemplate(region, name, configHash string, nodeSelector map[stri
 			Annotations: map[string]string{peerDemuxConfigHashAnnotation: configHash},
 		},
 		Spec: corev1.PodSpec{
-			HostNetwork:  true,
-			DNSPolicy:    corev1.DNSClusterFirstWithHostNet,
-			NodeSelector: nodeSelector,
-			Tolerations:  tolerations,
+			EnableServiceLinks: ptr(false),
+			HostNetwork:        true,
+			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+			NodeSelector:       nodeSelector,
+			Tolerations:        tolerations,
 			Containers: []corev1.Container{{
 				Name:            "demux",
 				Image:           image,

--- a/infra/kura-controller/controllers/peer_demux_controller_test.go
+++ b/infra/kura-controller/controllers/peer_demux_controller_test.go
@@ -192,6 +192,9 @@ func TestPeerDemuxReconcileCreatesAndTearsDown(t *testing.T) {
 	if !daemonSet.Spec.Template.Spec.HostNetwork {
 		t.Fatal("demux DaemonSet must be host-network")
 	}
+	if serviceLinks := daemonSet.Spec.Template.Spec.EnableServiceLinks; serviceLinks == nil || *serviceLinks {
+		t.Fatal("expected demux service-link environment injection to be disabled")
+	}
 	if daemonSet.Spec.Template.Spec.NodeSelector["node.cluster.x-k8s.io/pool"] != "kura-dedibox" {
 		t.Fatalf("demux must pin to the region pool, got %+v", daemonSet.Spec.Template.Spec.NodeSelector)
 	}

--- a/server/lib/tuist/kura/runner_cache.ex
+++ b/server/lib/tuist/kura/runner_cache.ex
@@ -20,6 +20,13 @@ defmodule Tuist.Kura.RunnerCache do
   runner rule therefore provisions caches for every eligible account, while an
   account whose runner access is removed has its cache torn down.
 
+  Each private region admits new accounts only while fewer than ten servers are
+  unsettled. Failed and destroying servers keep admission closed until they
+  recover or disappear, while active servers free slots for the next accounts.
+  Retries reuse existing server rows and at most ten may converge at once.
+  Teardown is also batched. These limits bound the backing Kubernetes work if
+  runner availability expands or contracts unexpectedly.
+
   In canary and production, an actor-only runner flag narrows the account query
   before the final availability check. Broad gates still evaluate every
   eligible account. Both steps use one flag snapshot so a concurrent flag update
@@ -30,13 +37,13 @@ defmodule Tuist.Kura.RunnerCache do
   macOS profiles, and an account that drops its last macOS profile frees that
   node even while its Linux profiles keep a node in a Linux-serving region.
 
-  This runs inside `Tuist.Kura.Reconciler`'s tick rather than on its own
-  cron, so it shares the same cadence and self-heals after a BEAM
-  restart: enabling runners for an account provisions the node on the next
-  tick; disabling them tears it down. It is a no-op unless a private region is
-  available in this runtime (via `TUIST_KURA_AVAILABLE_REGIONS`) and a Kura
-  runtime image tag is configured, so non-managed and not-yet-wired
-  environments stay inert.
+  This runs inside `Tuist.Kura.Reconciler`'s unique Oban job rather than on its
+  own cron, so production reconciliation is serialized, shares the same cadence,
+  and self-heals after a BEAM restart: enabling runners for an account provisions
+  the node on the next tick; disabling them tears it down. It is a no-op unless a
+  private region is available in this runtime (via
+  `TUIST_KURA_AVAILABLE_REGIONS`) and a Kura runtime image tag is configured, so
+  non-managed and not-yet-wired environments stay inert.
 
   Provisioning the node does not, by itself, route any traffic to it —
   `Tuist.Kura.runner_cache_endpoint_url/2` only returns a URL once the
@@ -57,6 +64,8 @@ defmodule Tuist.Kura.RunnerCache do
 
   require Logger
 
+  @max_teardowns_per_reconcile 100
+  @max_unsettled_servers_per_region 10
   @retry_backoff_seconds [60, 300, 900, 3600]
 
   @doc """
@@ -79,20 +88,25 @@ defmodule Tuist.Kura.RunnerCache do
   defp reconcile_region(%Regions{id: region_id} = region, account_ids) do
     # Tear down first so an account that flips runners off frees its node
     # even when no image tag is configured to provision new ones.
-    Enum.each(nodes_to_tear_down(region, account_ids), &tear_down/1)
+    region
+    |> nodes_to_tear_down(account_ids)
+    |> Enum.each(&tear_down/1)
 
     case image_tag() do
       nil ->
         :ok
 
       image_tag ->
-        Enum.each(accounts_needing_node(region, account_ids), &provision(&1, region_id, image_tag))
         # A node that failed before its first successful deployment
         # (transient apiserver error, missing CRD field, ...) would
         # otherwise strand its account forever: the server row exists,
         # so provisioning never re-runs, and nothing else retries
         # failed servers. Self-heal them on the same cadence.
-        Enum.each(nodes_to_retry(region_id, image_tag), &retry(&1, image_tag))
+        retry_failed_servers(region_id, account_ids, image_tag)
+
+        region
+        |> accounts_needing_node(account_ids, provisioning_slots(region_id))
+        |> Enum.each(&provision(&1, region_id, image_tag))
     end
 
     :ok
@@ -214,7 +228,7 @@ defmodule Tuist.Kura.RunnerCache do
     end)
   end
 
-  defp accounts_needing_node(%Regions{id: region_id} = region, account_ids) do
+  defp accounts_needing_node(%Regions{id: region_id} = region, account_ids, limit) do
     platforms = region_platforms(region)
 
     server_exists =
@@ -239,9 +253,36 @@ defmodule Tuist.Kura.RunnerCache do
         where: exists(profile_exists),
         where: not exists(server_exists),
         order_by: [asc: a.id],
+        limit: ^limit,
         select: a.id
       )
     )
+  end
+
+  defp provisioning_slots(region_id) do
+    unsettled_servers =
+      Repo.aggregate(
+        from(s in Server,
+          where: s.region == ^region_id,
+          where: s.status not in [:active, :destroyed]
+        ),
+        :count
+      )
+
+    max(@max_unsettled_servers_per_region - unsettled_servers, 0)
+  end
+
+  defp retry_convergence_slots(region_id) do
+    converging_servers =
+      Repo.aggregate(
+        from(s in Server,
+          where: s.region == ^region_id,
+          where: s.status in [:provisioning, :replicating]
+        ),
+        :count
+      )
+
+    max(@max_unsettled_servers_per_region - converging_servers, 0)
   end
 
   defp nodes_to_tear_down(%Regions{id: region_id} = region, account_ids) do
@@ -254,32 +295,19 @@ defmodule Tuist.Kura.RunnerCache do
         select: 1
       )
 
-    no_profiles =
-      Repo.all(
-        from(s in Server,
-          as: :server,
-          where: s.region == ^region_id,
-          where: s.status not in [:destroying, :destroyed],
-          where: not exists(profile_exists),
-          select: s
-        )
-      )
-
     cohort_ids = MapSet.to_list(account_ids)
 
-    outside_cohort =
-      Repo.all(
-        from(s in Server,
-          as: :server,
-          where: s.region == ^region_id,
-          where: s.status not in [:destroying, :destroyed],
-          where: exists(profile_exists),
-          where: s.account_id not in ^cohort_ids,
-          select: s
-        )
+    Repo.all(
+      from(s in Server,
+        as: :server,
+        where: s.region == ^region_id,
+        where: s.status not in [:destroying, :destroyed],
+        where: not exists(profile_exists) or s.account_id not in ^cohort_ids,
+        order_by: [asc: s.updated_at, asc: s.id],
+        limit: ^@max_teardowns_per_reconcile,
+        select: s
       )
-
-    Enum.uniq_by(no_profiles ++ outside_cohort, & &1.id)
+    )
   end
 
   defp provision(account_id, region_id, image_tag) do
@@ -301,19 +329,30 @@ defmodule Tuist.Kura.RunnerCache do
   # (`current_image_tag` nil) — the only state `Kura.retry_server/2`
   # accepts. Failures after a successful deploy keep their node and are
   # an operator concern, not ours.
-  defp nodes_to_retry(region_id, image_tag) do
-    servers = failed_first_deploy_servers(region_id)
+  defp retry_failed_servers(region_id, account_ids, image_tag) do
+    region_id
+    |> nodes_to_retry(account_ids, image_tag)
+    |> Enum.take(retry_convergence_slots(region_id))
+    |> Enum.each(&retry(&1, image_tag))
+  end
+
+  defp nodes_to_retry(region_id, account_ids, image_tag) do
+    servers = failed_first_deploy_servers(region_id, account_ids)
     failure_histories = retry_failure_histories(servers, image_tag)
 
     Enum.filter(servers, &retry_due?(&1, Map.get(failure_histories, &1.id, [])))
   end
 
-  defp failed_first_deploy_servers(region_id) do
+  defp failed_first_deploy_servers(region_id, account_ids) do
+    cohort_ids = MapSet.to_list(account_ids)
+
     Repo.all(
       from(s in Server,
         where: s.region == ^region_id,
+        where: s.account_id in ^cohort_ids,
         where: s.status == :failed,
         where: is_nil(s.current_image_tag),
+        order_by: [asc: s.updated_at, asc: s.id],
         select: s
       )
     )

--- a/server/test/tuist/kura/runner_cache_test.exs
+++ b/server/test/tuist/kura/runner_cache_test.exs
@@ -244,6 +244,129 @@ defmodule Tuist.Kura.RunnerCacheTest do
     assert server_regions(other) == []
   end
 
+  test "bounds unsettled servers per region and refills slots as servers become active" do
+    accounts = Enum.map(1..12, fn _index -> account_with_profiles([:macos]) end)
+    set_runner_availability(Enum.map(accounts, & &1.id))
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(Server, :count) == 10
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(Server, :count) == 10
+
+    Server
+    |> order_by([s], asc: s.id)
+    |> limit(3)
+    |> Repo.all()
+    |> Enum.each(fn server ->
+      server
+      |> Server.observation_changeset(%{
+        status: :active,
+        url: "https://#{server.id}.example.com",
+        current_image_tag: "0.5.2"
+      })
+      |> Repo.update!()
+    end)
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(Server, :count) == 12
+    assert Repo.aggregate(from(s in Server, where: s.status == :active), :count) == 3
+    assert Repo.aggregate(from(s in Server, where: s.status == :provisioning), :count) == 9
+  end
+
+  test "retries failed servers without admitting more accounts while teardown is pending" do
+    accounts = Enum.map(1..11, fn _index -> account_with_profiles([:macos]) end)
+    set_runner_availability(Enum.map(accounts, & &1.id))
+
+    assert :ok = RunnerCache.reconcile()
+
+    servers =
+      Server
+      |> order_by([s], asc: s.id)
+      |> Repo.all()
+
+    servers
+    |> Enum.take(5)
+    |> Enum.each(fn server ->
+      assert {:ok, _server} = Kura.destroy_server(server)
+    end)
+
+    servers
+    |> Enum.drop(5)
+    |> Enum.each(fn server ->
+      deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+      assert {:ok, deployment} = Kura.mark_running(deployment)
+      assert {:ok, deployment} = Kura.mark_failed(deployment, "temporary failure")
+      deployment |> Ecto.Changeset.change(finished_at: minutes_ago(2)) |> Repo.update!()
+      assert {:ok, _server} = Kura.fail_server(server)
+    end)
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(Server, :count) == 10
+    assert Repo.aggregate(from(s in Server, where: s.status == :destroying), :count) == 5
+    assert Repo.aggregate(from(s in Server, where: s.status == :provisioning), :count) == 5
+  end
+
+  test "retries at most ten failed servers in deterministic order" do
+    accounts = Enum.map(1..12, fn _index -> account_with_profiles([:macos]) end)
+
+    Enum.each(accounts, fn account ->
+      {:ok, server} = Kura.create_server(%{account_id: account.id, region: "scw-fr-par-runners", image_tag: "0.5.2"})
+      deployment = Repo.get_by!(Deployment, kura_server_id: server.id)
+      assert {:ok, deployment} = Kura.mark_running(deployment)
+      assert {:ok, deployment} = Kura.mark_failed(deployment, "temporary failure")
+      deployment |> Ecto.Changeset.change(finished_at: minutes_ago(2)) |> Repo.update!()
+      assert {:ok, _server} = Kura.fail_server(server)
+    end)
+
+    ordered_server_ids =
+      Repo.all(
+        from(s in Server,
+          order_by: [asc: s.updated_at, asc: s.id],
+          select: s.id
+        )
+      )
+
+    set_runner_availability(Enum.map(accounts, & &1.id))
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(from(s in Server, where: s.status == :provisioning), :count) == 10
+    assert Repo.aggregate(from(s in Server, where: s.status == :failed), :count) == 2
+
+    retried_server_ids =
+      Repo.all(
+        from(s in Server,
+          where: s.status == :provisioning,
+          select: s.id
+        )
+      )
+
+    assert MapSet.new(retried_server_ids) == MapSet.new(Enum.take(ordered_server_ids, 10))
+  end
+
+  test "does not retry a disabled failed server outside the teardown batch" do
+    servers =
+      Enum.map(1..101, fn _index ->
+        account = account_with_profiles([:macos])
+        {:ok, server} = Kura.create_server(%{account_id: account.id, region: "scw-fr-par-runners", image_tag: "0.5.2"})
+        server
+      end)
+
+    failed_server = List.last(servers)
+    deployment = Repo.get_by!(Deployment, kura_server_id: failed_server.id)
+    assert {:ok, deployment} = Kura.mark_running(deployment)
+    assert {:ok, deployment} = Kura.mark_failed(deployment, "temporary failure")
+    deployment |> Ecto.Changeset.change(finished_at: minutes_ago(2)) |> Repo.update!()
+    assert {:ok, _server} = Kura.fail_server(failed_server)
+
+    set_runner_availability([])
+
+    assert :ok = RunnerCache.reconcile()
+    assert Repo.aggregate(from(s in Server, where: s.status == :destroying), :count) == 100
+    assert Repo.get!(Server, failed_server.id).status == :failed
+    assert open_deployment_count(failed_server) == 0
+  end
+
   test "tears down nodes for accounts disabled by the runner flag in canary" do
     enabled = account_with_profiles([:macos])
     other = account_with_profiles([:macos])


### PR DESCRIPTION
## What changed

The runner-cache reconciler now bounds the amount of infrastructure it can ask Kubernetes to converge at once:

- It admits new accounts only while fewer than ten servers in a private region are unsettled.
- It retries only enabled accounts, in deterministic oldest-first order, and never exceeds the remaining capacity in that ten-server window.
- It tears down at most one hundred disabled runner caches per reconciliation pass.
- It disables Kubernetes Service environment injection for the Kura controller, generated Kura runtime pods, and peer-demultiplexer pods.
- It gives the canary Kura controller 2 GiB of memory for backlog recovery.
- It keeps canary on the larger `cpx32` control-plane size in the checked-in cluster definition.

## Why

Canary accumulated 4,025 `KuraInstance` resources after runner caches were enabled for a much larger cohort than intended. The Kura controller expanded 1,503 of them before failing, leaving more than 1,470 Kura pods pending on a single cache node. The resulting object, scheduling, event, list, and watch traffic overwhelmed the Kubernetes control plane.

Production remained healthy because runner eligibility there was feature-flagged, so it had only 19 Kura StatefulSets and no pending Kura pods. The canary-specific feature-flag bug was fixed separately in [#12101](https://github.com/tuist/tuist/pull/12101), but the reconciler still had no blast-radius limit if eligibility changed unexpectedly again.

## Root cause

Canary treated every eligible account as runner-enabled. Auto-created runner profiles made that cohort unexpectedly large, and the runner-cache reconciler created every missing private cache in one pass. Kubernetes then had to converge thousands of resources against capacity for roughly 31 cache pods.

The incident also exposed a recovery failure: Kubernetes injected environment variables for roughly 1,500 Services into each Kura controller pod. The container runtime rejected the resulting process environment with `argument list too long`, so the controller could not start to remove the resources.

The raw connection health check on the control-plane load balancer amplified the impact by keeping degraded control-plane backends in rotation. The name-resolution deployment failure in the linked GitHub Actions run occurred after the control plane was already unhealthy and was a downstream symptom, not the initiating failure.

## Approach

The primary containment belongs in the server reconciler because that is where desired runner-cache infrastructure is created. A ten-server admission window bounds new work while preserving eventual convergence. Failed and destroying servers keep admission closed, and retries reuse their existing rows instead of creating replacements.

Teardown is also batched so a feature-flag correction cannot replace a creation storm with a deletion storm. Disabling service links on every Kura-managed pod template removes the namespace Service count from process startup. The larger canary controller memory limit and control-plane size provide recovery headroom, but neither is treated as the root fix.

I removed the earlier monitoring-chart Python reconciler entirely. Mutating Hetzner from a monitoring workload was the wrong ownership boundary and would have placed a broad cloud token in an unrelated runtime. Declarative support for the encrypted `/readyz` load-balancer health check should be handled separately in the cluster management provider.

## Impact

Unexpectedly enabling a large runner cohort now converges gradually instead of producing thousands of infrastructure objects in a single pass. Disabling a large cohort cleans up in bounded batches. Existing small cohorts continue to converge in one pass.

Canary recovery completed with one Ready cache custom resource, one Ready StatefulSet and pod, four intended Services, one bound volume claim, zero destroying database rows, and 13 Ready nodes. Ten consecutive `/readyz` control-plane probes succeeded.

## Validation

- `mix format lib/tuist/kura/runner_cache.ex test/tuist/kura/runner_cache_test.exs`
- `mix compile --warnings-as-errors`
- `TUIST_SERVER_CLICKHOUSE_HTTP_PORT=18123 mix test test/tuist/kura/runner_cache_test.exs`: 20 tests, 0 failures
- `mise x go@1.25.0 -- go test ./...` in `infra/kura-controller`: passed
- Rendered the managed canary Helm chart and verified the controller resources and `enableServiceLinks: false`
- `git diff --check`
- Headless Claude review completed; the peer-demultiplexer service-link gap, deterministic retry ordering, and retry-cap boundary coverage were addressed
