### PR TITLE
fix(registry): prevent metadata and archive regressions

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -92,11 +92,10 @@ server:
     # moves its origin from the cache nodes to the standalone frontend.
     - name: TUIST_REGISTRY_URL
       value: https://tuist.dev/api/registry/swift
-    # Enables the server-owned registry sync writer. Cache still writes
-    # too until it is turned off as a separate step; the two coordinate
-    # through the shared S3 sync lock, so dual-writing is safe.
+    # The legacy cache remains the sole registry writer until its schedule is
+    # disabled as a separate cutover step.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
-      value: "true"
+      value: "false"
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -419,7 +419,10 @@ processor:
   affinity: {}
 
 swiftRegistrySync:
-  enabled: true
+  # The legacy regional cache release remains the production writer until its
+  # registry schedule can be disabled. Enabling both generations violates the
+  # single-writer cutover contract.
+  enabled: false
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: prod

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -113,10 +113,6 @@ The sync side reads the same item (it needs read+write to the same
 bucket, plus a `registry_github_token` field — see
 `infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`).
 
-A published version's source archive is immutable. When metadata needs
-repair, the server-owned writer downloads and reuses the existing archive
-instead of regenerating and overwriting it.
-
 The Tigris access key must allow read on the env's `tuist-registry-<env>`
 (or `tuist-registry` for production) bucket.
 

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -22,7 +22,12 @@ managed environments that expose the registry service directly.
 - Serve the Swift Package Registry read surface under
   `/api/registry/swift/*` and `/swift/*`.
 - Read package metadata from S3 (`registry/metadata/<scope>/<name>/index.json`).
-- Emit 303 redirects to presigned S3 URLs for source archives.
+- Request strong consistency for metadata reads and revalidation so a reader
+  cannot cache a previous catalog revision after a writer has repaired it.
+- Emit 303 redirects to presigned S3 URLs for source archives without a
+  separate existence request. The object-storage download is authoritative
+  for whether an archive exists, so a temporary storage lookup failure cannot
+  be converted into a registry 404.
 - Serve manifest bodies in-process. Default `Package.swift` responses
   also include the `Link` header listing alternate manifests.
 - Emit per-ecosystem download/manifest metrics via PromEx, scraped by
@@ -107,6 +112,10 @@ Per environment vault (`tuist-k8s-{staging,canary,production}`), the
 The sync side reads the same item (it needs read+write to the same
 bucket, plus a `registry_github_token` field — see
 `infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`).
+
+A published version's source archive is immutable. When metadata needs
+repair, the server-owned writer downloads and reuses the existing archive
+instead of regenerating and overwriting it.
 
 The Tigris access key must allow read on the env's `tuist-registry-<env>`
 (or `tuist-registry` for production) bucket.

--- a/registry/lib/tuist_registry/application.ex
+++ b/registry/lib/tuist_registry/application.ex
@@ -5,8 +5,6 @@ defmodule TuistRegistry.Application do
 
   alias TuistCommon.HTTP.TransportLogger
 
-  require Logger
-
   @impl true
   def start(_type, _args) do
     TransportLogger.attach(:tuist_registry)
@@ -16,7 +14,6 @@ defmodule TuistRegistry.Application do
 
     base_children = [
       {Phoenix.PubSub, name: TuistRegistry.PubSub},
-      TuistRegistry.S3,
       TuistRegistry.Swift.Metadata,
       TuistRegistry.Swift.AlternateManifests,
       TuistRegistryWeb.Endpoint,

--- a/registry/lib/tuist_registry/s3.ex
+++ b/registry/lib/tuist_registry/s3.ex
@@ -7,24 +7,14 @@ defmodule TuistRegistry.S3 do
   Registry metadata and artifacts are stored in the configured registry bucket.
   """
 
-  import Cachex.Spec, only: [limit: 1]
-
   alias TuistRegistry.Config
 
-  require Logger
-
-  @exists_cache :s3_exists_cache
-  @exists_negative_ttl to_timeout(second: 30)
-
-  def child_spec(_) do
-    %{
-      id: __MODULE__,
-      start:
-        {Cachex, :start_link, [@exists_cache, [limit: limit(size: 500_000, policy: Cachex.Policy.LRW, reclaim: 0.1)]]}
-    }
+  @doc false
+  def request(%{headers: headers} = operation) do
+    operation
+    |> Map.put(:headers, Map.put(headers, "X-Tigris-Consistent", "true"))
+    |> ExAws.request()
   end
-
-  def exists_cache_name, do: @exists_cache
 
   @doc """
   Generates a presigned download URL for an artifact.
@@ -83,7 +73,7 @@ defmodule TuistRegistry.S3 do
         {:error, :registry_disabled}
 
       bucket ->
-        case bucket |> ExAws.S3.get_object(key) |> ExAws.request() do
+        case bucket |> ExAws.S3.get_object(key) |> request() do
           {:ok, %{status_code: 200, body: body}} ->
             {:ok, body}
 
@@ -152,59 +142,6 @@ defmodule TuistRegistry.S3 do
   end
 
   @doc """
-  Checks if an artifact exists in S3, with a short negative Cachex caching layer.
-
-  Positive results are not cached because purge runs from the server sync
-  runtime and cannot invalidate per-pod read-side caches.
-
-  ## Options
-
-    * `:type` - The storage type. Only `:registry` is supported.
-
-  Returns `false` if type is `:registry` and registry storage is not configured.
-  """
-  def exists?(key, opts \\ []) when is_binary(key) do
-    type = Keyword.get(opts, :type, :registry)
-    cache_key = {type, key}
-
-    case Cachex.get(@exists_cache, cache_key) do
-      {:ok, nil} ->
-        case do_exists?(key, opts) do
-          {:ok, true} ->
-            true
-
-          {:ok, false} ->
-            Cachex.put(@exists_cache, cache_key, false, ttl: @exists_negative_ttl)
-            false
-
-          {:error, reason} ->
-            Logger.warning("S3 exists check failed for artifact #{key}: #{inspect(reason)}")
-            false
-        end
-
-      {:ok, cached} ->
-        :telemetry.execute([:tuist_registry, :s3, :head], %{duration: 0}, %{result: :cache_hit})
-        cached
-    end
-  end
-
-  defp do_exists?(key, opts) do
-    type = Keyword.get(opts, :type, :registry)
-
-    case bucket_for_type(type) do
-      nil ->
-        {:ok, false}
-
-      bucket ->
-        case head_object_status(bucket, key, http_opts: [receive_timeout: 2_000]) do
-          :exists -> {:ok, true}
-          :not_found -> {:ok, false}
-          {:error, reason} -> {:error, reason}
-        end
-    end
-  end
-
-  @doc """
   Extracts and normalizes the ETag value from S3 response headers.
 
   Handles both `"etag"` and `"ETag"` header keys, strips surrounding quotes,
@@ -228,31 +165,4 @@ defmodule TuistRegistry.S3 do
 
   defp bucket_for_type(:registry), do: Config.registry_bucket()
   defp bucket_for_type(_type), do: Config.registry_bucket()
-
-  defp head_object_status(bucket, key, request_opts) do
-    {duration, result} =
-      :timer.tc(fn ->
-        bucket
-        |> ExAws.S3.head_object(key)
-        |> ExAws.request(request_opts)
-      end)
-
-    case result do
-      {:ok, _response} ->
-        :telemetry.execute([:tuist_registry, :s3, :head], %{duration: duration}, %{result: :found})
-        :exists
-
-      {:error, {:http_error, 404, _}} ->
-        :telemetry.execute([:tuist_registry, :s3, :head], %{duration: duration}, %{result: :not_found})
-        :not_found
-
-      {:error, {:http_error, 429, _}} ->
-        :telemetry.execute([:tuist_registry, :s3, :head], %{duration: duration}, %{result: :rate_limited})
-        {:error, :rate_limited}
-
-      {:error, reason} ->
-        :telemetry.execute([:tuist_registry, :s3, :head], %{duration: duration}, %{result: :error})
-        {:error, reason}
-    end
-  end
 end

--- a/registry/lib/tuist_registry/swift/metadata.ex
+++ b/registry/lib/tuist_registry/swift/metadata.ex
@@ -92,7 +92,7 @@ defmodule TuistRegistry.Swift.Metadata do
       :timer.tc(fn ->
         bucket
         |> ExAws.S3.get_object(key)
-        |> ExAws.request()
+        |> S3.request()
       end)
 
     case result do
@@ -166,7 +166,7 @@ defmodule TuistRegistry.Swift.Metadata do
       :timer.tc(fn ->
         bucket
         |> ExAws.S3.head_object(key)
-        |> ExAws.request()
+        |> S3.request()
       end)
 
     case result do

--- a/registry/lib/tuist_registry_web/controllers/swift/registry_controller.ex
+++ b/registry/lib/tuist_registry_web/controllers/swift/registry_controller.ex
@@ -218,26 +218,22 @@ defmodule TuistRegistryWeb.Swift.RegistryController do
         path: "source_archive.zip"
       )
 
-    if S3.exists?(key, type: :registry) do
-      if not head_request?(conn) do
-        :telemetry.execute([:tuist_registry, :swift, :download], %{count: 1}, %{
-          scope: scope,
-          name: name
-        })
-      end
+    case S3.presign_download_url(key, type: :registry, content_type: "application/zip") do
+      {:ok, url} ->
+        if not head_request?(conn) do
+          :telemetry.execute([:tuist_registry, :swift, :download], %{count: 1}, %{
+            scope: scope,
+            name: name
+          })
+        end
 
-      case S3.presign_download_url(key, type: :registry, content_type: "application/zip") do
-        {:ok, url} ->
-          conn
-          |> put_resp_header("content-version", "1")
-          |> put_status(:see_other)
-          |> redirect(external: url)
+        conn
+        |> put_resp_header("content-version", "1")
+        |> put_status(:see_other)
+        |> redirect(external: url)
 
-        {:error, _reason} ->
-          registry_not_found_response(conn)
-      end
-    else
-      registry_not_found_response(conn)
+      {:error, _reason} ->
+        service_unavailable_response(conn)
     end
   end
 

--- a/registry/test/tuist_registry/s3_test.exs
+++ b/registry/test/tuist_registry/s3_test.exs
@@ -12,6 +12,21 @@ defmodule TuistRegistry.S3Test do
     :ok
   end
 
+  test "requests strongly consistent object-storage reads" do
+    operation = %S3Operation{headers: %{"existing" => "header"}}
+
+    expect(ExAws, :request, fn requested_operation ->
+      assert requested_operation.headers == %{
+               "existing" => "header",
+               "X-Tigris-Consistent" => "true"
+             }
+
+      {:ok, :response}
+    end)
+
+    assert S3.request(operation) == {:ok, :response}
+  end
+
   describe "presign_download_url/2" do
     test "signs the requested response content type" do
       key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
@@ -29,36 +44,6 @@ defmodule TuistRegistry.S3Test do
 
       assert S3.presign_download_url(key, type: :registry, content_type: "application/zip") ==
                {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
-    end
-  end
-
-  describe "exists?/2" do
-    test "does not cache positive results" do
-      key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-      cache_key = {:registry, key}
-      {:ok, true} = Cachex.del(S3.exists_cache_name(), cache_key)
-
-      {:ok, request_count} = Agent.start_link(fn -> 0 end)
-
-      expect(ExAws.S3, :head_object, 2, fn "test-registry-bucket", ^key ->
-        %S3Operation{path: "head"}
-      end)
-
-      expect(ExAws, :request, 2, fn %S3Operation{}, _opts ->
-        Agent.get_and_update(request_count, fn count ->
-          response =
-            case count do
-              0 -> {:ok, %{status_code: 200}}
-              1 -> {:error, {:http_error, 404, ""}}
-            end
-
-          {response, count + 1}
-        end)
-      end)
-
-      assert S3.exists?(key, type: :registry)
-      refute S3.exists?(key, type: :registry)
-      assert Agent.get(request_count, & &1) == 2
     end
   end
 

--- a/registry/test/tuist_registry/swift/metadata_test.exs
+++ b/registry/test/tuist_registry/swift/metadata_test.exs
@@ -92,7 +92,8 @@ defmodule TuistRegistry.Swift.MetadataTest do
         %S3{bucket: "test-registry-bucket", path: s3_key}
       end)
 
-      expect(ExAws, :request, fn %S3{} ->
+      expect(ExAws, :request, fn %S3{headers: headers} ->
+        assert headers["X-Tigris-Consistent"] == "true"
         {:ok, %{body: json_body, headers: %{"etag" => "\"etag\""}}}
       end)
 

--- a/registry/test/tuist_registry_web/controllers/swift/registry_controller_test.exs
+++ b/registry/test/tuist_registry_web/controllers/swift/registry_controller_test.exs
@@ -169,9 +169,7 @@ defmodule TuistRegistryWeb.Swift.RegistryControllerTest do
   end
 
   describe "GET /swift/:scope/:name/:version.zip (download_archive)" do
-    test "redirects with See Other to presigned S3 URL when artifact exists", %{conn: conn} do
-      expect(S3, :exists?, fn _key, _opts -> true end)
-
+    test "redirects with See Other to the presigned object-storage URL", %{conn: conn} do
       expect(S3, :presign_download_url, fn _key, opts ->
         assert opts == [type: :registry, content_type: "application/zip"]
 
@@ -191,20 +189,7 @@ defmodule TuistRegistryWeb.Swift.RegistryControllerTest do
              ]
     end
 
-    test "returns 404 when artifact not in S3", %{conn: conn} do
-      expect(S3, :exists?, fn _key, _opts -> false end)
-
-      conn =
-        conn
-        |> registry_zip_conn()
-        |> get("/swift/apple/swift-argument-parser/1.0.0.zip")
-
-      assert conn.status == 404
-      assert get_resp_header(conn, "content-version") == ["1"]
-    end
-
-    test "returns 404 when presign fails", %{conn: conn} do
-      expect(S3, :exists?, fn _key, _opts -> true end)
+    test "returns 503 when presigning fails", %{conn: conn} do
       expect(S3, :presign_download_url, fn _key, _opts -> {:error, :unavailable} end)
 
       conn =
@@ -212,7 +197,7 @@ defmodule TuistRegistryWeb.Swift.RegistryControllerTest do
         |> registry_zip_conn()
         |> get("/swift/apple/swift-argument-parser/1.0.0.zip")
 
-      assert conn.status == 404
+      assert conn.status == 503
       assert get_resp_header(conn, "content-version") == ["1"]
     end
   end

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -22,36 +22,12 @@ defmodule Tuist.Registry.S3 do
   def get_object(key) when is_binary(key) do
     bucket = Registry.registry_bucket()
 
-    case bucket |> ExAws.S3.get_object(key) |> request() do
+    case bucket |> ExAws.S3.get_object(key) |> with_tigris_consistency() |> request() do
       {:ok, %{status_code: 200, body: body}} -> {:ok, body}
       {:ok, %{status_code: 404}} -> {:error, :not_found}
       {:ok, %{status_code: status}} -> {:error, {:s3_error, status}}
       {:error, {:http_error, 404, _}} -> {:error, :not_found}
       {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def download_file(key, local_path) when is_binary(key) and is_binary(local_path) do
-    bucket = Registry.registry_bucket()
-
-    case bucket |> ExAws.S3.head_object(key) |> request() do
-      {:ok, %{status_code: 404}} ->
-        {:error, :not_found}
-
-      {:ok, %{status_code: status}} when status >= 400 ->
-        {:error, {:s3_error, status}}
-
-      {:ok, _response} ->
-        download_existing_file(bucket, key, local_path)
-
-      {:error, {:http_error, 404, _}} ->
-        {:error, :not_found}
-
-      {:error, {:http_error, 429, _}} ->
-        {:error, :rate_limited}
-
-      {:error, reason} ->
-        {:error, reason}
     end
   end
 
@@ -151,36 +127,6 @@ defmodule Tuist.Registry.S3 do
     end)
   end
 
-  defp download_existing_file(bucket, key, local_path) do
-    {duration, result} =
-      :timer.tc(fn ->
-        bucket
-        |> ExAws.S3.download_file(key, local_path,
-          timeout: 120_000,
-          max_concurrency: 8
-        )
-        |> request()
-      end)
-
-    case result do
-      {:ok, :done} ->
-        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :ok})
-        :ok
-
-      {:error, {:http_error, 404, _}} ->
-        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :not_found})
-        {:error, :not_found}
-
-      {:error, {:http_error, 429, _}} ->
-        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :rate_limited})
-        {:error, :rate_limited}
-
-      {:error, reason} ->
-        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :error})
-        {:error, reason}
-    end
-  end
-
   def etag_from_headers(headers) when is_map(headers) do
     headers
     |> Map.get("etag", Map.get(headers, "ETag"))
@@ -195,5 +141,9 @@ defmodule Tuist.Registry.S3 do
     |> String.trim()
     |> String.trim_leading("\"")
     |> String.trim_trailing("\"")
+  end
+
+  defp with_tigris_consistency(%{headers: headers} = operation) do
+    %{operation | headers: Map.put(headers, "X-Tigris-Consistent", "true")}
   end
 end

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -31,6 +31,30 @@ defmodule Tuist.Registry.S3 do
     end
   end
 
+  def download_file(key, local_path) when is_binary(key) and is_binary(local_path) do
+    bucket = Registry.registry_bucket()
+
+    case bucket |> ExAws.S3.head_object(key) |> request() do
+      {:ok, %{status_code: 404}} ->
+        {:error, :not_found}
+
+      {:ok, %{status_code: status}} when status >= 400 ->
+        {:error, {:s3_error, status}}
+
+      {:ok, _response} ->
+        download_existing_file(bucket, key, local_path)
+
+      {:error, {:http_error, 404, _}} ->
+        {:error, :not_found}
+
+      {:error, {:http_error, 429, _}} ->
+        {:error, :rate_limited}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   def upload_file(key, local_path, opts \\ []) when is_binary(key) and is_binary(local_path) do
     bucket = Registry.registry_bucket()
     content_type_opt = Keyword.get(opts, :content_type)
@@ -125,6 +149,36 @@ defmodule Tuist.Registry.S3 do
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
+  end
+
+  defp download_existing_file(bucket, key, local_path) do
+    {duration, result} =
+      :timer.tc(fn ->
+        bucket
+        |> ExAws.S3.download_file(key, local_path,
+          timeout: 120_000,
+          max_concurrency: 8
+        )
+        |> request()
+      end)
+
+    case result do
+      {:ok, :done} ->
+        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :ok})
+        :ok
+
+      {:error, {:http_error, 404, _}} ->
+        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :not_found})
+        {:error, :not_found}
+
+      {:error, {:http_error, 429, _}} ->
+        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :rate_limited})
+        {:error, :rate_limited}
+
+      {:error, reason} ->
+        :telemetry.execute([:tuist_registry, :s3, :download], %{duration: duration}, %{result: :error})
+        {:error, reason}
+    end
   end
 
   def etag_from_headers(headers) when is_map(headers) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -91,9 +91,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     archive_path = Path.join(tmp_dir, "source_archive.zip")
 
     with {:ok, manifest_payloads} <- fetch_manifests(full_handle, tag, token),
-         :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
-         {:ok, checksum} <- checksum_for_file(archive_path),
-         :ok <- upload_source_archive(scope, name, version, archive_path),
+         {:ok, checksum} <-
+           fetch_or_reuse_source_archive(scope, name, version, full_handle, tag, token, tmp_dir, archive_path),
          {:ok, manifests} <- upload_manifests(scope, name, version, manifest_payloads) do
       update_metadata_with_release(scope, name, full_handle, version, checksum, manifests)
     else
@@ -116,6 +115,26 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
             {:error, reason}
         end
+    end
+  end
+
+  defp fetch_or_reuse_source_archive(scope, name, version, full_handle, tag, token, tmp_dir, archive_path) do
+    key = source_archive_key(scope, name, version)
+
+    case S3.download_file(key, archive_path) do
+      :ok ->
+        Logger.info("Reusing existing registry source archive for #{scope}/#{name}@#{version}")
+        checksum_for_file(archive_path)
+
+      {:error, :not_found} ->
+        with :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
+             {:ok, checksum} <- checksum_for_file(archive_path),
+             :ok <- upload_source_archive(scope, name, version, archive_path) do
+          {:ok, checksum}
+        end
+
+      {:error, reason} ->
+        {:error, {:source_archive_download_failed, reason}}
     end
   end
 
@@ -652,13 +671,14 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   end
 
   defp upload_source_archive(scope, name, version, archive_path) do
-    key =
-      KeyNormalizer.package_object_key(%{scope: scope, name: name},
-        version: version,
-        path: "source_archive.zip"
-      )
+    S3.upload_file(source_archive_key(scope, name, version), archive_path, content_type: "application/zip")
+  end
 
-    S3.upload_file(key, archive_path, content_type: "application/zip")
+  defp source_archive_key(scope, name, version) do
+    KeyNormalizer.package_object_key(%{scope: scope, name: name},
+      version: version,
+      path: "source_archive.zip"
+    )
   end
 
   defp fetch_manifests(full_handle, tag, token) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -91,8 +91,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     archive_path = Path.join(tmp_dir, "source_archive.zip")
 
     with {:ok, manifest_payloads} <- fetch_manifests(full_handle, tag, token),
-         {:ok, checksum} <-
-           fetch_or_reuse_source_archive(scope, name, version, full_handle, tag, token, tmp_dir, archive_path),
+         :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
+         {:ok, checksum} <- checksum_for_file(archive_path),
+         :ok <- upload_source_archive(scope, name, version, archive_path),
          {:ok, manifests} <- upload_manifests(scope, name, version, manifest_payloads) do
       update_metadata_with_release(scope, name, full_handle, version, checksum, manifests)
     else
@@ -115,26 +116,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
             {:error, reason}
         end
-    end
-  end
-
-  defp fetch_or_reuse_source_archive(scope, name, version, full_handle, tag, token, tmp_dir, archive_path) do
-    key = source_archive_key(scope, name, version)
-
-    case S3.download_file(key, archive_path) do
-      :ok ->
-        Logger.info("Reusing existing registry source archive for #{scope}/#{name}@#{version}")
-        checksum_for_file(archive_path)
-
-      {:error, :not_found} ->
-        with :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
-             {:ok, checksum} <- checksum_for_file(archive_path),
-             :ok <- upload_source_archive(scope, name, version, archive_path) do
-          {:ok, checksum}
-        end
-
-      {:error, reason} ->
-        {:error, {:source_archive_download_failed, reason}}
     end
   end
 

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -18,7 +18,8 @@ defmodule Tuist.Registry.S3Test do
     operation = %S3Operation{
       http_method: :get,
       bucket: "registry-bucket",
-      path: "registry/metadata/adjust/ios_sdk/index.json"
+      path: "registry/metadata/adjust/ios_sdk/index.json",
+      headers: %{"X-Tigris-Consistent" => "true"}
     }
 
     expect(Registry, :registry_bucket, fn -> "registry-bucket" end)
@@ -34,48 +35,5 @@ defmodule Tuist.Registry.S3Test do
 
     assert {:ok, ~s({"releases":{}})} =
              S3.get_object("registry/metadata/adjust/ios_sdk/index.json")
-  end
-
-  test "downloads an existing archive with the dedicated registry object-storage configuration" do
-    config = [host: "registry.example.com"]
-    key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-    local_path = "/tmp/source_archive.zip"
-    head_operation = %S3Operation{http_method: :head, bucket: "registry-bucket", path: key}
-
-    download_operation = %ExAws.S3.Download{
-      bucket: "registry-bucket",
-      path: key,
-      dest: local_path
-    }
-
-    stub(Registry, :registry_bucket, fn -> "registry-bucket" end)
-    stub(Registry, :registry_s3_config, fn -> config end)
-
-    expect(ExAws.S3, :head_object, fn "registry-bucket", ^key -> head_operation end)
-
-    expect(ExAws.S3, :download_file, fn "registry-bucket", ^key, ^local_path, opts ->
-      assert opts == [timeout: 120_000, max_concurrency: 8]
-      download_operation
-    end)
-
-    expect(ExAws, :request, 2, fn
-      ^head_operation, ^config -> {:ok, %{status_code: 200}}
-      ^download_operation, ^config -> {:ok, :done}
-    end)
-
-    assert :ok = S3.download_file(key, local_path)
-  end
-
-  test "does not start a download when the archive is missing" do
-    key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-    head_operation = %S3Operation{http_method: :head, bucket: "registry-bucket", path: key}
-
-    stub(Registry, :registry_bucket, fn -> "registry-bucket" end)
-    stub(Registry, :registry_s3_config, fn -> [host: "registry.example.com"] end)
-    expect(ExAws.S3, :head_object, fn "registry-bucket", ^key -> head_operation end)
-    expect(ExAws, :request, fn ^head_operation, _ -> {:error, {:http_error, 404, ""}} end)
-    stub(ExAws.S3, :download_file, fn _, _, _, _ -> flunk("unexpected download") end)
-
-    assert {:error, :not_found} = S3.download_file(key, "/tmp/source_archive.zip")
   end
 end

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -35,4 +35,47 @@ defmodule Tuist.Registry.S3Test do
     assert {:ok, ~s({"releases":{}})} =
              S3.get_object("registry/metadata/adjust/ios_sdk/index.json")
   end
+
+  test "downloads an existing archive with the dedicated registry object-storage configuration" do
+    config = [host: "registry.example.com"]
+    key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+    local_path = "/tmp/source_archive.zip"
+    head_operation = %S3Operation{http_method: :head, bucket: "registry-bucket", path: key}
+
+    download_operation = %ExAws.S3.Download{
+      bucket: "registry-bucket",
+      path: key,
+      dest: local_path
+    }
+
+    stub(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    stub(Registry, :registry_s3_config, fn -> config end)
+
+    expect(ExAws.S3, :head_object, fn "registry-bucket", ^key -> head_operation end)
+
+    expect(ExAws.S3, :download_file, fn "registry-bucket", ^key, ^local_path, opts ->
+      assert opts == [timeout: 120_000, max_concurrency: 8]
+      download_operation
+    end)
+
+    expect(ExAws, :request, 2, fn
+      ^head_operation, ^config -> {:ok, %{status_code: 200}}
+      ^download_operation, ^config -> {:ok, :done}
+    end)
+
+    assert :ok = S3.download_file(key, local_path)
+  end
+
+  test "does not start a download when the archive is missing" do
+    key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+    head_operation = %S3Operation{http_method: :head, bucket: "registry-bucket", path: key}
+
+    stub(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    stub(Registry, :registry_s3_config, fn -> [host: "registry.example.com"] end)
+    expect(ExAws.S3, :head_object, fn "registry-bucket", ^key -> head_operation end)
+    expect(ExAws, :request, fn ^head_operation, _ -> {:error, {:http_error, 404, ""}} end)
+    stub(ExAws.S3, :download_file, fn _, _, _, _ -> flunk("unexpected download") end)
+
+    assert {:error, :not_found} = S3.download_file(key, "/tmp/source_archive.zip")
+  end
 end

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -6,6 +6,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
   alias ExAws.Operation.S3
   alias ExAws.S3.Upload
   alias Tuist.Registry
+  alias Tuist.Registry.S3, as: RegistryS3
   alias Tuist.Registry.Swift.Lock
   alias Tuist.Registry.Swift.Metadata
   alias Tuist.Registry.Swift.ReleaseWorker
@@ -19,6 +20,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     stub(Registry, :swift_registry_github_token, fn -> "token" end)
     stub(Registry, :registry_bucket, fn -> "test-bucket" end)
     stub(Registry, :registry_s3_config, fn -> [host: "registry.example.com"] end)
+    stub(RegistryS3, :download_file, fn _, _ -> {:error, :not_found} end)
     stub(Lock, :release, fn _ -> :ok end)
 
     :ok
@@ -111,6 +113,57 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       assert is_binary(release["checksum"])
       assert [%{"swift_version" => nil, "swift_tools_version" => "5.9"}] = release["manifests"]
       refute Map.has_key?(metadata["skipped_releases"], "1.0.0")
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "reuses an existing source archive when repairing missing metadata" do
+    stub(Lock, :try_acquire, fn
+      {:release, "apple", "swift-argument-parser", "1.0.0"}, _ -> {:ok, :acquired}
+      {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, 2, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+    end)
+
+    expect(RegistryS3, :download_file, fn key, archive_path ->
+      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+      write_basic_zipball(archive_path)
+      :ok
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+    stub(RegistryS3, :upload_file, fn _, _, _ -> flunk("unexpected source archive upload") end)
+
+    expect(RegistryS3, :upload_content, fn key, content, opts ->
+      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
+      assert content == @default_manifest_content
+      assert opts == [content_type: "text/x-swift"]
+      :ok
+    end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      assert is_binary(metadata["releases"]["1.0.0"]["checksum"])
       :ok
     end)
 

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -6,7 +6,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
   alias ExAws.Operation.S3
   alias ExAws.S3.Upload
   alias Tuist.Registry
-  alias Tuist.Registry.S3, as: RegistryS3
   alias Tuist.Registry.Swift.Lock
   alias Tuist.Registry.Swift.Metadata
   alias Tuist.Registry.Swift.ReleaseWorker
@@ -20,7 +19,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     stub(Registry, :swift_registry_github_token, fn -> "token" end)
     stub(Registry, :registry_bucket, fn -> "test-bucket" end)
     stub(Registry, :registry_s3_config, fn -> [host: "registry.example.com"] end)
-    stub(RegistryS3, :download_file, fn _, _ -> {:error, :not_found} end)
     stub(Lock, :release, fn _ -> :ok end)
 
     :ok
@@ -113,57 +111,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       assert is_binary(release["checksum"])
       assert [%{"swift_version" => nil, "swift_tools_version" => "5.9"}] = release["manifests"]
       refute Map.has_key?(metadata["skipped_releases"], "1.0.0")
-      :ok
-    end)
-
-    assert :ok =
-             ReleaseWorker.perform(%Oban.Job{
-               args: %{
-                 "scope" => "apple",
-                 "name" => "swift-argument-parser",
-                 "repository_full_handle" => "apple/swift-argument-parser",
-                 "tag" => "v1.0.0"
-               }
-             })
-  end
-
-  test "reuses an existing source archive when repairing missing metadata" do
-    stub(Lock, :try_acquire, fn
-      {:release, "apple", "swift-argument-parser", "1.0.0"}, _ -> {:ok, :acquired}
-      {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired}
-    end)
-
-    expect(Metadata, :get_package, 2, fn "apple", "swift-argument-parser", [fresh: true] ->
-      {:error, :not_found}
-    end)
-
-    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
-      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
-    end)
-
-    expect(TuistCommon.GitHub, :get_file_content, fn
-      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
-        {:ok, @default_manifest_content}
-    end)
-
-    expect(RegistryS3, :download_file, fn key, archive_path ->
-      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-      write_basic_zipball(archive_path)
-      :ok
-    end)
-
-    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
-    stub(RegistryS3, :upload_file, fn _, _, _ -> flunk("unexpected source archive upload") end)
-
-    expect(RegistryS3, :upload_content, fn key, content, opts ->
-      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
-      assert content == @default_manifest_content
-      assert opts == [content_type: "text/x-swift"]
-      :ok
-    end)
-
-    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
-      assert is_binary(metadata["releases"]["1.0.0"]["checksum"])
       :ok
     end)
 


### PR DESCRIPTION
## What changed

The standalone registry now reads package metadata with strong consistency, signs archive downloads without a separate existence request, and reports signing failures as unavailable instead of not found. The server sync worker also reads catalogs with strong consistency, retries short metadata-lock contention, and refuses to publish incomplete manifest sets. Production keeps the standalone sync workload disabled while the legacy cache writers still own synchronization.

## Why

Issues #12098 and #12105 exposed missing package versions, archive download failures, and a checksum change for an already published Lottie release after the registry moved to its standalone instance. Restoring the affected objects repaired production, but the read and write paths also need to prevent the same failure mode from recurring.

## Root cause

The migration temporarily allowed the standalone sync deployment and the legacy regional cache writers to update the same package catalogs. Each writer could read an older catalog and replace a newer one, which made previously published releases disappear from metadata even though their archives still existed.

When metadata was missing, the release worker regenerated and uploaded an archive before updating the catalog. That could change the bytes and checksum associated with a published version. Separately, a transient object-storage lookup failure in the registry reader was treated as proof that an archive did not exist, producing false not-found responses.

## Approach

The fix prevents stale catalog state at its ownership boundaries: one writer generation remains active in production, server and registry metadata reads request strong consistency, and per-package metadata updates are serialized with retry and deferral. Archive redirects no longer depend on an existence preflight. The production recovery stays an explicit operational action; the steady-state server worker does not download published archives to reconstruct catalog entries.

## Impact

The sync path no longer operates from an older catalog revision or drops a release after short lock contention, and transient storage failures no longer masquerade as missing packages. The standalone production sync deployment remains off, and no archive download path is added to the server. There is no data migration or command-line client change.

## Validation

- `mix test test/tuist_registry/s3_test.exs test/tuist_registry/swift/metadata_test.exs test/tuist_registry_web/controllers/swift/registry_controller_test.exs` passed 36 tests.
- `mix test test/tuist/registry/s3_test.exs test/tuist/registry/swift/release_worker_test.exs` passed 10 tests.
- Rendered the production Helm configuration and confirmed that it contains no standalone registry writer workload.
- Revalidated all 20 reported package archives in production with no failures.
- Confirmed that Braze exposes 58 releases, including `14.0.4`, and that the restored Lottie archive matches its original checksum.
