### PR TITLE
fix(server): remove unsupported changelog link syntax

### DIFF
--- a/server/priv/marketing/changelog/2026.07.27-noora-web-components.md
+++ b/server/priv/marketing/changelog/2026.07.27-noora-web-components.md
@@ -4,16 +4,16 @@ description: "Use Noora’s design system from any standards-based web applicati
 category: "OSS"
 ---
 
-Noora is now available as standards-based [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components){:target="_blank"}. They share the design tokens, visual language, and component behavior used by Noora’s Phoenix LiveView components, while remaining usable from plain Hypertext Markup Language or any browser framework.
+Noora is now available as standards-based [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). They share the design tokens, visual language, and component behavior used by Noora’s Phoenix LiveView components, while remaining usable from plain Hypertext Markup Language or any browser framework.
 
-Install `@tuist/noora` from the [Node Package Manager package registry](https://www.npmjs.com/package/@tuist/noora){:target="_blank"}, then import the design tokens and component registration bundle once in your browser entry point:
+Install `@tuist/noora` from the [Node Package Manager package registry](https://www.npmjs.com/package/@tuist/noora), then import the design tokens and component registration bundle once in your browser entry point:
 
 ```javascript
 import "@tuist/noora/tokens.css";
 import "@tuist/noora/web-components";
 ```
 
-For a quick browser-only prototype, a content delivery network such as [jsDelivr](https://www.jsdelivr.com/){:target="_blank"} can serve the same published files directly from the Node Package Manager package:
+For a quick browser-only prototype, a content delivery network such as [jsDelivr](https://www.jsdelivr.com/) can serve the same published files directly from the Node Package Manager package:
 
 ```html
 <link


### PR DESCRIPTION
## What changed

Removed the unsupported `{:target="_blank"}` suffix from the three external links in the Noora web components changelog entry.

## Why

The suffix was displayed as visible text beside each link, which made the published changelog entry look broken.

## Root cause

The changelog Markdown renderer does not interpret Kramdown-style inline link attributes.

## Approach

Use plain Markdown links, matching the convention used by recent changelog entries.

## Impact

The links continue to work, and the unsupported attribute text is no longer shown to readers.

### How to test locally

- Run `mix test test/tuist/marketing/changelog_entry_parser_test.exs` from `server`. All three tests pass.
- Start the local server and load `/changelog/2026.07.27-noora-web-components`. The page returns status 200 and the rendered response does not contain the unsupported suffix.
