### PR TITLE
fix(server): make command event hydration consistent

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -1141,7 +1141,9 @@ defmodule Tuist.CommandEvents do
       Event
       |> where([event], event.project_id in ^project_ids and event.id in ^ids)
       |> order_by([event], asc: event.project_id, asc: event.id, desc: event.updated_at)
-      |> ClickHouseRepo.all()
+      # The optimized view can be ahead of the replica serving this canonical table read,
+      # so hydrate with sequential consistency.
+      |> ClickHouseRepo.all(settings: [select_sequential_consistency: 1])
       |> Enum.uniq_by(&{&1.project_id, &1.id})
       |> Map.new(&{{&1.project_id, &1.id}, &1})
 

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.CommandEventsTest do
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
+  alias Tuist.ClickHouseRepo
   alias Tuist.CommandEvents
   alias Tuist.Repo
   alias Tuist.Storage
@@ -498,6 +499,34 @@ defmodule Tuist.CommandEventsTest do
       assert [%{project_id: project_id, cacheable_targets: ["SelectedApp"]}] = events
       assert project_id == project.id
       assert hd(events).id == selected_event.id
+    end
+
+    test "uses a sequentially consistent read when hydrating optimized rows" do
+      project = ProjectsFixtures.project_fixture()
+
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        name: "generate"
+      )
+
+      parent = self()
+
+      stub(ClickHouseRepo, :all, fn query, opts ->
+        send(parent, {:clickhouse_read_options, opts})
+        Mimic.call_original(ClickHouseRepo, :all, [query, opts])
+      end)
+
+      CommandEvents.list_command_events(%{
+        filters: [
+          %{field: :project_id, op: :==, value: project.id},
+          %{field: :name, op: :==, value: "generate"}
+        ],
+        order_by: [:ran_at],
+        order_directions: [:desc],
+        first: 10
+      })
+
+      assert_received {:clickhouse_read_options, [settings: [select_sequential_consistency: 1]]}
     end
   end
 


### PR DESCRIPTION
Resolves <https://tuist.sentry.io/issues/137026668/>

## What changed

The command event hydration query now requests sequential consistency when it loads the canonical rows selected by the optimized view. A regression test verifies that this database setting is applied to the hydration read.

## Why

Fresh command events could intermittently fail the generations endpoint with a missing map key instead of returning the requested page.

## Root cause

The bounded read introduced in #12083 selects a page from an optimized ClickHouse view and then hydrates the complete events from the canonical table. Those two reads can reach different replicas. In the reported incident, an event created two seconds earlier was visible to the optimized view but not yet visible to the replica serving the hydration query.

## Approach

The fix applies ClickHouse sequential consistency only to the bounded canonical hydration read. It preserves the strict `Map.fetch!` invariant and the optimized pagination path, without adding retries or silently dropping selected events.

## Impact

Recently inserted generations remain available when the optimized view and canonical table are briefly served by replicas at different replication points. There are no schema, migration, or interface changes.

## Validation

### How to test locally

- `mix format --check-formatted lib/tuist/command_events.ex test/tuist/command_events_test.exs`
- `MIX_ENV=test TUIST_SERVER_CLICKHOUSE_HTTP_PORT=18123 mix run --no-start -e 'Mix.Tasks.Test.run(["test/tuist/command_events_test.exs:504"])'`
  - Result: 1 passed, 72 excluded.
- `git diff --check`
