### PR TITLE
fix(swifterpm): preserve URL path casing for git operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c85b672a56e1ce80bd2c8e8909e48cd41a9b0426e7384ed2d88e9795ed461ab9",
+  "originHash" : "1465ec8d5fa9379820cc52eec4970022e9c1667d85b39a67b96d47241f7a076c",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -95,7 +95,7 @@
       "identity" : "apple.swift-http-types",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-http-types.git",
+      "originalLocation" : "https://github.com/apple/swift-http-types",
       "state" : {
         "version" : "1.5.1"
       }
@@ -274,15 +274,6 @@
       }
     },
     {
-      "identity" : "fluid-menu-bar-extra",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lfroms/fluid-menu-bar-extra",
-      "state" : {
-        "revision" : "e152a3a1a25aca24906217f8d4d63afbb08d7f97",
-        "version" : "1.1.0"
-      }
-    },
-    {
       "identity" : "frazer-rbsn.OrderedSet",
       "kind" : "registry",
       "location" : "",
@@ -439,6 +430,15 @@
       }
     },
     {
+      "identity" : "lfroms.fluid-menu-bar-extra",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/lfroms/fluid-menu-bar-extra",
+      "state" : {
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "MobileNativeFoundation.XCLogParser",
       "kind" : "registry",
       "location" : "",
@@ -507,6 +507,15 @@
       "originalLocation" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "version" : "1.18.7"
+      }
+    },
+    {
+      "identity" : "pointfreeco.xctest-dynamic-overlay",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "version" : "1.7.0"
       }
     },
     {
@@ -684,7 +693,7 @@
       "identity" : "tuist.Path",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tuist/Path.git",
+      "originalLocation" : "https://github.com/tuist/path",
       "state" : {
         "version" : "0.3.8"
       }
@@ -720,15 +729,6 @@
       "originalLocation" : "https://github.com/tuist/ZIPFoundation",
       "state" : {
         "version" : "0.9.21"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
       }
     }
   ],

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -115,8 +115,7 @@ enum SourceControlLocations {
         let withoutGit =
             trimmed.lowercased().hasSuffix(".git")
                 ? String(trimmed.dropLast(4)) : trimmed
-        let path = withoutGit.lowercased()
-        return path.isEmpty ? "" : "/\(path)"
+        return withoutGit.isEmpty ? "" : "/\(withoutGit)"
     }
 
     fileprivate static func canonicalizesProviderPath(host: String) -> Bool {

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -109,19 +109,19 @@ struct GitHubTests {
             SourceControlLocations.canonicalResolvedFileLocation(
                 "https://github.com/CombineCommunity/CombineExt.git"
             )
-                == "https://github.com/combinecommunity/combineext"
+                == "https://github.com/CombineCommunity/CombineExt"
         )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
                 "git@github.com:DataDog/dd-sdk-ios.git"
             )
-                == "git@github.com:datadog/dd-sdk-ios"
+                == "git@github.com:DataDog/dd-sdk-ios"
         )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
                 "https://gitlab.com/Tuist/SwifterPM.git"
             )
-                == "https://gitlab.com/tuist/swifterpm"
+                == "https://gitlab.com/Tuist/SwifterPM"
         )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
@@ -134,6 +134,25 @@ struct GitHubTests {
                 "git@Source.Example.com:Tuist/SwifterPM.git"
             )
                 == "git@source.example.com:Tuist/SwifterPM.git"
+        )
+    }
+
+    @Test
+    func canonicalResolvedFileLocationsPreserveMixedCaseGitHubOrg() {
+        // Git's url.*.insteadOf rules match case-sensitively, so lowercasing
+        // the path breaks CI setups that inject credentials per-org. Only the
+        // scheme and host are lowercased; the path keeps its declared casing.
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "https://github.com/Fourthline-com/FourthlineSDK-iOS.git"
+            )
+                == "https://github.com/Fourthline-com/FourthlineSDK-iOS"
+        )
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "https://github.com/Fourthline-com/FourthlineSDK-iOS"
+            )
+                == "https://github.com/Fourthline-com/FourthlineSDK-iOS"
         )
     }
 }

--- a/swifterpm/Tests/swifterpmTests/ModelsTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ModelsTests.swift
@@ -137,7 +137,7 @@ struct ModelsTests {
             let readBackByIdentity = Dictionary(uniqueKeysWithValues: readBack.pins.map {
                 ($0.identity, $0)
             })
-            #expect(readBackByIdentity["apple.swift-log"]?.originalLocation == "https://github.com/apple/swift-log")
+            #expect(readBackByIdentity["apple.swift-log"]?.originalLocation == "https://github.com/Apple/swift-log")
             #expect(readBackByIdentity["example.package"]?.originalLocation == "https://source.example.com/Tuist/SwifterPM.git")
 
             let resolvedFilePath = root.appendingPathComponent("Package.resolved")
@@ -152,7 +152,7 @@ struct ModelsTests {
                     return (identity, pin)
                 }
             )
-            #expect(rawPinsByIdentity["apple.swift-log"]?["originalLocation"] as? String == "https://github.com/apple/swift-log")
+            #expect(rawPinsByIdentity["apple.swift-log"]?["originalLocation"] as? String == "https://github.com/Apple/swift-log")
             #expect(rawPinsByIdentity["example.package"]?["originalLocation"] as? String ==
                 "https://source.example.com/Tuist/SwifterPM.git")
         }
@@ -234,9 +234,9 @@ struct ModelsTests {
                 "generic",
                 "swifterpm",
             ]))
-            #expect(rawPinsByIdentity["combineext"]?["location"] as? String == "https://github.com/combinecommunity/combineext")
-            #expect(rawPinsByIdentity["dd-sdk-ios"]?["location"] as? String == "git@github.com:datadog/dd-sdk-ios")
-            #expect(rawPinsByIdentity["swifterpm"]?["location"] as? String == "https://gitlab.com/tuist/swifterpm")
+            #expect(rawPinsByIdentity["combineext"]?["location"] as? String == "https://github.com/CombineCommunity/CombineExt")
+            #expect(rawPinsByIdentity["dd-sdk-ios"]?["location"] as? String == "git@github.com:DataDog/dd-sdk-ios")
+            #expect(rawPinsByIdentity["swifterpm"]?["location"] as? String == "https://gitlab.com/Tuist/SwifterPM")
             #expect(rawPinsByIdentity["generic"]?["location"] as? String == "https://source.example.com/Tuist/SwifterPM.git")
             #expect(rawPinsByIdentity["LocalPackage"]?["location"] as? String == "file:///tmp/LocalPackage.git")
             #expect(!rawLocations.contains("https://github.com/CombineCommunity/CombineExt.git"))


### PR DESCRIPTION
Upgrading from Tuist 4.200.5 to 4.201.0 caused `tuist install` to fail in CI when resolving private GitHub dependencies whose org or repo names contain uppercase characters. The failure only appeared on cold-cache runs, which made it look like a Tuist upgrade regression rather than an authentication problem.

A user reported this with a private dependency declared as:

```swift
.package(url: "https://github.com/Fourthline-com/FourthlineSDK-iOS", exact: "3.4.28")
```

Their CI injects a GitHub token via a `git config url.*.insteadOf` rewrite rule scoped per org. After the upgrade, the fetch failed with `git@github.com: Permission denied (publickey)` because Git fell back to SSH without the token.

### How to test locally

```bash
cd swifterpm && swift test
```

All 126 tests pass, including the new `canonicalResolvedFileLocationsPreserveMixedCaseGitHubOrg` test that covers the regression scenario directly.

## Root cause

PR #11400 (commit `951793abe8`, shipped in 4.201.0) introduced `canonicalProviderPath` in `swifterpm/Sources/swifterpm/GitHub.swift` to stabilize `Package.resolved` by canonicalizing remote source-control locations. For GitHub and GitLab URLs, the function lowercased the entire path (org + repo).

The normalized URL then flowed through the restore path:

1. `Resolve.swift` calls `normalizedForResolvedFile()` during resolution, which lowercases `pin.location` and writes it to `Package.resolved`.
2. `Restore.swift` reads `pin.location` from `Package.resolved` and passes it to `SourceControlLocations.fetchCandidates(pin.location)`, which feeds it into `git fetch`.
3. Git's `url.*.insteadOf` rules match **case-sensitively** as prefix comparisons. A rule scoped to `https://github.com/Fourthline-com/` does not fire when the URL has been rewritten to `https://github.com/fourthline-com/`, so no credential is injected and Git falls back to SSH.

This only affected dependencies with uppercase characters in their org or repo name. Dependencies with all-lowercase names (e.g. `qonto-private`, `flowyourmoney`) were unaffected, which is why only some private dependencies broke.

## Approach

The fix removes the `.lowercased()` call on the path component in `canonicalProviderPath` while keeping every other normalization that PR #11400 introduced:

- Scheme is still lowercased (`HTTPS://` becomes `https://`).
- Host is still lowercased (`GitHub.com` becomes `github.com`).
- Trailing `.git` suffix is still stripped (the most common source of `Package.resolved` churn).

What changed: the path (`Fourthline-com/FourthlineSDK-iOS`) now retains its declared casing through the resolve, write, read, and restore cycle.

This means `insteadOf` rules matching on the original casing work correctly, while the remaining normalizations still provide meaningful `Package.resolved` stability against the most common sources of churn.

The alternative considered was to preserve the original URL spelling entirely and use lowercased forms only for cache lookup and deduplication. That would have required a schema change to `Package.resolved` to store both spellings, which is a larger change for a narrower benefit. The chosen approach is simpler and addresses the root cause directly.

## Impact

Users who experienced `Permission denied (publickey)` errors on cold-cache CI runs after upgrading to 4.201.0 with mixed-case private GitHub dependencies will no longer hit this issue. No migration is needed; the next `tuist install` will write a `Package.resolved` with correct casing, and the dirty-tree diff caused by the lowercased rewrite will also disappear.

For users who added duplicate lowercase `insteadOf` rules as a workaround, those rules are no longer necessary but are harmless to keep.

## Validation

- `swift test` in `swifterpm/` (126 tests, all passing)
- New test `canonicalResolvedFileLocationsPreserveMixedCaseGitHubOrg` verifies that `https://github.com/Fourthline-com/FourthlineSDK-iOS.git` canonicalizes to `https://github.com/Fourthline-com/FourthlineSDK-iOS` (scheme and host lowercased, path casing preserved, `.git` stripped)
- Existing test `writeNormalizesRemoteLocationsAndSkipsIdenticalRewrites` updated to verify path casing is preserved for GitHub, GitLab, and generic hosts
