### PR TITLE
feat(cli): add bundle support to AppClip

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -558,6 +558,7 @@ public struct GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .framework),
             LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .appExtension),
+            LintableTarget(platform: .iOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .macro),
         ],
         LintableTarget(platform: .iOS, product: .extensionKitExtension): [

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1087,6 +1087,11 @@ struct GenerateAcceptanceTestiOSAppWithAppClip {
             destination: "Debug-iphonesimulator",
             extension: "AppClip1Widgets"
         )
+        try await XCTAssertProductWithDestinationContainsResource(
+            "AppClip1.app",
+            destination: "Debug-iphonesimulator",
+            resource: "Bundle.bundle/dummy.jpg"
+        )
     }
 }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1064,17 +1064,10 @@ struct GenerateAcceptanceTestiOSAppWithCoreData {
 }
 
 struct GenerateAcceptanceTestiOSAppWithAppClip {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_appclip"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_appclip"), .inTemporaryDirectory)
     func ios_app_with_appclip() async throws {
         try await run(GenerateCommand.self)
-        try await run(BuildCommand.self)
-        try await XCTAssertProductWithDestinationContainsAppClipWithArchitecture(
-            "App.app",
-            destination: "Debug-iphonesimulator",
-            appClip: "AppClip1",
-            architecture: "arm64"
-        )
-        try await XCTAssertFrameworkEmbedded("Framework", by: "AppClip1")
+        try await run(BuildCommand.self, "App")
         try await XCTAssertProductWithDestinationContainsAppClipWithArchitecture(
             "App.app",
             destination: "Debug-iphonesimulator",

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -607,6 +607,32 @@ struct GraphLinterTests {
         #expect(result.isEmpty == true)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_appClip_canDependOnBundle() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let appClip = Target.empty(name: "app_clip", product: .appClip)
+        let bundle = Target.empty(name: "bundle", product: .bundle)
+        let project = Project.empty(path: path)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: appClip.name, path: path): Set([.target(name: bundle.name, path: path)]),
+            .target(name: bundle.name, path: path): Set([]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(result.isEmpty == true)
+    }
+
     @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_frameworkDependsOnBundle() async throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/examples/xcode/generated_ios_app_with_appclip/Project.swift
+++ b/examples/xcode/generated_ios_app_with_appclip/Project.swift
@@ -45,6 +45,7 @@ let project = Project(
                 .target(name: "Framework"),
                 .target(name: "StaticFramework"),
                 .target(name: "AppClip1Widgets"),
+                .target(name: "Bundle"),
             ]
         ),
         .target(
@@ -86,6 +87,13 @@ let project = Project(
             dependencies: [
                 .target(name: "StaticFramework"),
             ]
+        ),
+        .target(
+            name: "Bundle",
+            destinations: .iOS,
+            product: .bundle,
+            bundleId: "dev.tuist.App.Bundle",
+            resources: "Bundle/**"
         ),
     ]
 )


### PR DESCRIPTION
Supersedes #11597 (same changes, re-enabled acceptance test, pushed from a non-fork branch so CI runs fully).

## What changed

When declaring a `.bundle` target and making an `.appClip` depend on it, Tuist rejected the graph with a lint error even though App Clips fully support resources and can embed bundles. The root cause was a one-line omission in `GraphLinter.validLinks`: PR #6415 added `.bundle` as a valid dependency for `.appExtension` but the same entry was never added for `.appClip`. The rest of the pipeline (`resourceBundleDependencies`, `supportsResources`, `generateResourceBundle`) already handles AppClips correctly — only the linter was blocking it.

This PR:
- Adds `LintableTarget(platform: .iOS, product: .bundle)` to the `.appClip` entry in `GraphLinter.validLinks`.
- Adds a unit test `lint_appClip_canDependOnBundle` next to the existing `lint_appExtension_canDependOnBundle`.
- Adds a Bundle target to the `generated_ios_app_with_appclip` fixture (identical to the one in `generated_ios_app_with_extensions`).
- Re-enables the `ios_app_with_appclip` acceptance test (disabled in #10128 alongside many others during CI consolidation). The analogous `ios_app_with_extensions` test was kept enabled, so this one should be too. While re-enabling, cleaned up duplicate assertions (AppClip and Framework embedding were each checked twice) and narrowed the build to `BuildCommand "App"` to match the extensions test pattern.

## How to verify

The unit test `GraphLinterTests/lint_appClip_canDependOnBundle` covers the linting rule. The acceptance test `GenerateAcceptanceTestiOSAppWithAppClip/ios_app_with_appclip` covers the end-to-end generation + build + resource embedding.