### PR TITLE
perf(infra): skip cache-volume uploads that cannot win the promote

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -68,13 +68,22 @@ runtime — no service, sudo entry, or auto-login targets it.
   captures the HTTP status EXPLICITLY (no `curl -f`, which would collapse a 409
   and a transport error into one failure) and relays the outcome into the
   `status` share as `cache-promote-result`: `accepted <generation>`, `conflict`,
-  or `error`. The host's `Finalize` installs the branch as the account's local
-  master (a whole-image replace) ONLY on `accepted` — so the local master and the
-  HEAD advance together. A `conflict` (a stale base another host advanced past) or
-  an `error` (upload/network/control-plane failure — kept distinct so an outage
-  is not mistaken for cross-host contention) discards the branch and lets
-  convergence re-warm it. A rejected promote still uploaded its object, so the
-  server records it as an orphan and reclaims it after the URL-TTL grace. The
+  or `error`. Most promotes lose that race, and the upload blocks the VM halt and
+  the host's slot, so the guest sends `base_generation` when MINTING the upload
+  URL too and the server 409s there — pre-empting the transfer for a promote that
+  cannot win. That pre-check may only ever skip doomed work: it is racy by
+  construction (another host can win during the upload), so the bump's
+  compare-and-swap stays the authority, an absent `base_generation` disables it
+  for older runner images, and any other failure falls back to
+  upload-then-arbitrate. The host's `Finalize` installs the branch as the
+  account's local master (a whole-image replace) ONLY on `accepted` — so the local
+  master and the HEAD advance together. A `conflict` (a stale base another host
+  advanced past) or an `error` (upload/network/control-plane failure — kept
+  distinct so an outage is not mistaken for cross-host contention) discards the
+  branch and lets convergence re-warm it. A rejected promote that got as far as
+  uploading leaves an object no HEAD points at, so the server records it as an
+  orphan and reclaims it after the URL-TTL grace; a pre-empted one never wrote
+  anything to reclaim. The
   host clones the promoted image and cannot tell a torn snapshot from a good one,
   so a mount torn down by the VM halting would poison the account's master; if the
   detach fails even with `-force`, the guest withdraws the image from both

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -614,7 +614,8 @@ VOLUME_HEAD_UPLOAD_TIMEOUT=600
 
 # report_volume_head publishes this job's warm set as the account's new HEAD on a
 # successful, cache-changing job, in three steps:
-#   1. mint a presigned PUT URL keyed by THIS job's inventory digest,
+#   1. mint a presigned PUT URL keyed by THIS job's inventory digest, sending the
+#      base generation so the server can pre-empt a promote that cannot win,
 #   2. PUT the settled image to it,
 #   3. bump the account's HEAD to that digest.
 #
@@ -638,17 +639,41 @@ report_volume_head() {
   [ -n "${CACHE_INVENTORY_AFTER}" ] || return 0
   [ "${CACHE_INVENTORY_AFTER}" != "${CACHE_INVENTORY_BEFORE}" ] || return 0
 
+  local base_generation
+  base_generation=$(read_base_generation)
+
   # Mint the content-addressed upload URL for this digest. The server binds it to
   # the account this Pod ran (server-stamped label) and rejects a non-hex digest,
   # so the guest cannot target another account or escape its prefix.
-  local upload_url
-  upload_url=$(curl -fsS --connect-timeout 10 --max-time 30 -X POST \
+  #
+  # The base generation rides along so the server can PRE-EMPT the upload: most
+  # promotes lose the fast-forward under cross-host contention, and paying for a
+  # multi-GB PUT first meant that loss still held the VM (and the host's slot)
+  # open for the whole transfer. A 409 here means the base has already been
+  # advanced past, so this promote is certain to be rejected and there is nothing
+  # to gain by uploading. It is only an optimization — the bump below stays the
+  # authority, and another host can still win in the window between the two — so
+  # every other outcome falls through to the upload-then-arbitrate path.
+  #
+  # Status captured explicitly instead of `curl -f` so the 409 is distinguishable
+  # from a transport failure, which must NOT be recorded as contention.
+  local mint_body mint_http upload_url
+  mint_body=$(mktemp 2>/dev/null || echo "/tmp/volhead-mint.$$")
+  mint_http=$(curl -sS --connect-timeout 10 --max-time 30 -X POST \
     -H "Authorization: Bearer ${SA_TOKEN}" -H "Content-Type: application/json" \
-    --data "{\"tree_digest\":\"${CACHE_INVENTORY_AFTER}\"}" \
-    "${VOLUME_HEAD_UPLOAD_URL_MINT_ENDPOINT}" 2>/dev/null \
-    | sed -n 's/.*"upload_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    --data "{\"tree_digest\":\"${CACHE_INVENTORY_AFTER}\",\"base_generation\":${base_generation}}" \
+    -o "${mint_body}" -w '%{http_code}' \
+    "${VOLUME_HEAD_UPLOAD_URL_MINT_ENDPOINT}" 2>/dev/null)
+  if [ "${mint_http}" = "409" ]; then
+    rm -f "${mint_body}" 2>/dev/null || true
+    write_promote_result "conflict"
+    echo "$(date -u +%FT%TZ) dispatch-poll: volume HEAD already advanced past base=${base_generation}; image not uploaded"
+    return 0
+  fi
+  upload_url=$(sed -n 's/.*"upload_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${mint_body}" 2>/dev/null)
+  rm -f "${mint_body}" 2>/dev/null || true
   if [ -z "${upload_url}" ]; then
-    echo "$(date -u +%FT%TZ) dispatch-poll: no master upload URL; HEAD not advanced"
+    echo "$(date -u +%FT%TZ) dispatch-poll: no master upload URL (http=${mint_http:-000}); HEAD not advanced"
     write_promote_result "error"
     return 0
   fi
@@ -690,9 +715,10 @@ report_volume_head() {
   # same failure — so the host can distinguish a genuine fast-forward rejection
   # (cross-host contention) from an upload/network/control-plane failure. On 200
   # the host installs the branch as its local master at the accepted generation;
-  # on 409 or error it discards and re-converges.
-  local base_generation body http_code promoted_generation
-  base_generation=$(read_base_generation)
+  # on 409 or error it discards and re-converges. The mint above pre-empts the
+  # common stale-base case, but this is still where the outcome is decided: the
+  # HEAD can have moved during the upload that just ran.
+  local body http_code promoted_generation
   body=$(mktemp 2>/dev/null || echo "/tmp/volhead-report.$$")
   http_code=$(curl -sS --connect-timeout 10 --max-time 15 -X POST \
     -H "Authorization: Bearer ${SA_TOKEN}" -H "Content-Type: application/json" \

--- a/infra/tart-kubelet/go.mod
+++ b/infra/tart-kubelet/go.mod
@@ -6,6 +6,7 @@ toolchain go1.25.10
 
 require (
 	github.com/prometheus/client_golang v1.19.1
+	github.com/prometheus/client_model v0.6.1
 	golang.org/x/sys v0.43.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
@@ -40,7 +41,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -262,12 +262,19 @@ var cacheVolumeAdmissionDeclinedTotal = prometheus.NewCounter(
 // how long a promoting job holds the host slot before it can be reclaimed — the
 // signal for keeping the volume sized so uploads stay fast (the CAS is folded in,
 // so this now includes CAS bytes). Reported by the guest via the volume-upload-ms
-// status marker and recorded here at finalize.
+// status marker and recorded here at finalize, from the marker ALONE — outside
+// the switch on the promote result, so an accepted promote observes a sample
+// just as a rejected one does.
 //
-// A promote the server pre-empts at mint time (its base was already advanced
-// past) uploads nothing and so contributes NO sample, only a "rejected" promote.
-// The count of this histogram against promote_total{result="rejected"} is
-// therefore how much doomed transfer the pre-flight is still not avoiding.
+// That is what makes _count minus promote_total{result="accepted"} the reading
+// for the mint-time pre-flight: uploads that happened and did NOT become HEAD.
+// A promote the server pre-empts (its base was already advanced past) transfers
+// nothing, so it counts as "rejected" with no sample here, and the difference
+// trends toward zero. It does not reach zero — an upload followed by a failed
+// bump lands in the "error" bucket, and a job excluded from the promote ratio
+// (unclean halt, account mismatch) can leave a marker with no promote counted at
+// all. Reading _count against result="rejected" instead would move with the
+// accept rate rather than with the pre-flight.
 var cacheVolumeUploadSeconds = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Name:    "tart_kubelet_cache_volume_upload_seconds",

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -263,6 +263,11 @@ var cacheVolumeAdmissionDeclinedTotal = prometheus.NewCounter(
 // signal for keeping the volume sized so uploads stay fast (the CAS is folded in,
 // so this now includes CAS bytes). Reported by the guest via the volume-upload-ms
 // status marker and recorded here at finalize.
+//
+// A promote the server pre-empts at mint time (its base was already advanced
+// past) uploads nothing and so contributes NO sample, only a "rejected" promote.
+// The count of this histogram against promote_total{result="rejected"} is
+// therefore how much doomed transfer the pre-flight is still not avoiding.
 var cacheVolumeUploadSeconds = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Name:    "tart_kubelet_cache_volume_upload_seconds",

--- a/infra/tart-kubelet/internal/podagent/volume_test.go
+++ b/infra/tart-kubelet/internal/podagent/volume_test.go
@@ -1127,6 +1127,47 @@ func TestReadPromoteResult(t *testing.T) {
 	}
 }
 
+// A promote the server pre-empted at mint time reports a conflict WITHOUT ever
+// uploading, so it must be counted as a rejection while contributing no sample to
+// the upload histogram — the whole point of the pre-flight is that a doomed
+// promote stops holding the slot open for a transfer. That distinction is exactly
+// what the deploy is measured by (upload count falling relative to rejected
+// promotes), so pin it: a conflict with no volume-upload-ms marker leaves the
+// histogram untouched, while an uploaded conflict still records one.
+func TestPreEmptedPromoteRecordsNoUpload(t *testing.T) {
+	statusDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(statusDir, promoteResultFile), []byte("conflict"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readPromoteResult(statusDir); got.Result != "conflict" {
+		t.Fatalf("pre-empted promote = %+v; want conflict (cross-host contention, not an error)", got)
+	}
+	if got := readUploadMillis(statusDir); got != -1 {
+		t.Fatalf("upload millis after a pre-empted promote = %d; want -1 (nothing was uploaded)", got)
+	}
+
+	// finalizeVolume's own branches over those two reads: counted as contention,
+	// but gated out of the upload histogram by the negative duration.
+	rejectedBefore := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected"))
+	RecordVolumePromote("rejected")
+	if readUploadMillis(statusDir) >= 0 {
+		t.Fatal("a pre-empted promote must not reach RecordVolumeUpload")
+	}
+	if got := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected")); got != rejectedBefore+1 {
+		t.Fatalf("rejected promotes = %v; want %v", got, rejectedBefore+1)
+	}
+
+	// The upload-then-arbitrate path (a promote that lost the race after paying
+	// for the transfer) still reports its duration.
+	if err := os.WriteFile(filepath.Join(statusDir, uploadMillisFile), []byte("4200"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readUploadMillis(statusDir); got != 4200 {
+		t.Fatalf("upload millis = %d; want 4200", got)
+	}
+}
+
 func TestCacheImageSplit(t *testing.T) {
 	const gib = uint64(1024 * 1024 * 1024)
 

--- a/infra/tart-kubelet/internal/podagent/volume_test.go
+++ b/infra/tart-kubelet/internal/podagent/volume_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -1127,45 +1128,136 @@ func TestReadPromoteResult(t *testing.T) {
 	}
 }
 
-// A promote the server pre-empted at mint time reports a conflict WITHOUT ever
-// uploading, so it must be counted as a rejection while contributing no sample to
-// the upload histogram — the whole point of the pre-flight is that a doomed
-// promote stops holding the slot open for a transfer. That distinction is exactly
-// what the deploy is measured by (upload count falling relative to rejected
-// promotes), so pin it: a conflict with no volume-upload-ms marker leaves the
-// histogram untouched, while an uploaded conflict still records one.
-func TestPreEmptedPromoteRecordsNoUpload(t *testing.T) {
-	statusDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(statusDir, promoteResultFile), []byte("conflict"), 0o644); err != nil {
+func TestReadUploadMillis(t *testing.T) {
+	if got := readUploadMillis(""); got != -1 {
+		t.Fatalf("empty status dir = %d; want -1", got)
+	}
+	dir := t.TempDir()
+	// Absent marker: no promote, or a promote the server pre-empted before the
+	// transfer. Either way there is no duration to observe.
+	if got := readUploadMillis(dir); got != -1 {
+		t.Fatalf("missing file = %d; want -1 (nothing was uploaded)", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, uploadMillisFile), []byte("4200\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	if got := readPromoteResult(statusDir); got.Result != "conflict" {
-		t.Fatalf("pre-empted promote = %+v; want conflict (cross-host contention, not an error)", got)
-	}
-	if got := readUploadMillis(statusDir); got != -1 {
-		t.Fatalf("upload millis after a pre-empted promote = %d; want -1 (nothing was uploaded)", got)
-	}
-
-	// finalizeVolume's own branches over those two reads: counted as contention,
-	// but gated out of the upload histogram by the negative duration.
-	rejectedBefore := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected"))
-	RecordVolumePromote("rejected")
-	if readUploadMillis(statusDir) >= 0 {
-		t.Fatal("a pre-empted promote must not reach RecordVolumeUpload")
-	}
-	if got := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected")); got != rejectedBefore+1 {
-		t.Fatalf("rejected promotes = %v; want %v", got, rejectedBefore+1)
-	}
-
-	// The upload-then-arbitrate path (a promote that lost the race after paying
-	// for the transfer) still reports its duration.
-	if err := os.WriteFile(filepath.Join(statusDir, uploadMillisFile), []byte("4200"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if got := readUploadMillis(statusDir); got != 4200 {
+	if got := readUploadMillis(dir); got != 4200 {
 		t.Fatalf("upload millis = %d; want 4200", got)
 	}
+
+	// Unparseable reads as absent rather than as a zero-second upload, which
+	// would understate the tail this histogram exists to watch.
+	if err := os.WriteFile(filepath.Join(dir, uploadMillisFile), []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readUploadMillis(dir); got != -1 {
+		t.Fatalf("garbage = %d; want -1", got)
+	}
+}
+
+// uploadSampleCount is the number of observations in the upload histogram — what
+// tart_kubelet_cache_volume_upload_seconds_count exposes. Sample count, not
+// series count, so a test can assert that a given finalize did or did not
+// observe an upload.
+func uploadSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	var m dto.Metric
+	if err := cacheVolumeUploadSeconds.Write(&m); err != nil {
+		t.Fatalf("collect upload histogram: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+// finalizeVolume's promote accounting, driven through the real function rather
+// than by re-asserting the calls a test made itself.
+//
+// A promote the server pre-empts at mint time reports a conflict WITHOUT ever
+// uploading: it must still count as contention, and must contribute no sample to
+// the upload histogram — the whole point of the pre-flight is that a doomed
+// promote stops holding the slot open for a transfer. The same conflict WITH an
+// upload marker (it lost the race after paying for the transfer, which is what
+// happens whenever another host wins during the upload) must still be counted
+// and still observe its duration, so the gate is pinned in both directions.
+func TestFinalizeVolumePromoteAccounting(t *testing.T) {
+	// finalize takes a job that did cache-changing work for its own account —
+	// the only shape that is promote-eligible — and runs it to completion with
+	// the guest-relayed status the given promote produced.
+	finalize := func(t *testing.T, vm, promoteResult string, uploadMillis string) {
+		t.Helper()
+		m, _ := newTestManager(t, 100)
+		seedMasterGen(t, m, "42", "existing-master", 5)
+
+		att := mustAllocate(t, m, vm)
+		if _, _, err := m.Materialize(att, "42"); err != nil {
+			t.Fatalf("Materialize: %v", err)
+		}
+		att.SourceAccount = "42"
+		writeBranchCache(t, m, att, "branch")
+
+		statusDir := t.TempDir()
+		// "1": the runner exited 0 AND the cache changed, so the job is eligible.
+		if err := os.WriteFile(filepath.Join(statusDir, dirtyMarkerFile), []byte("1"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(statusDir, promoteResultFile), []byte(promoteResult), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if uploadMillis != "" {
+			if err := os.WriteFile(filepath.Join(statusDir, uploadMillisFile), []byte(uploadMillis), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		r := &Reconciler{Volumes: m}
+		r.finalizeVolume(&Entry{VMName: vm, Volume: att, VolumeStatusDir: statusDir}, "42", true)
+	}
+
+	t.Run("pre-empted at mint: rejected, no upload observed", func(t *testing.T) {
+		rejectedBefore := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected"))
+		uploadsBefore := uploadSampleCount(t)
+
+		finalize(t, "vm-preempted", "conflict", "")
+
+		if got := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected")); got != rejectedBefore+1 {
+			t.Fatalf("rejected promotes = %v; want %v (a conflict is contention, not an error)", got, rejectedBefore+1)
+		}
+		if got := uploadSampleCount(t); got != uploadsBefore {
+			t.Fatalf("upload samples = %d; want %d (a pre-empted promote uploads nothing)", got, uploadsBefore)
+		}
+	})
+
+	t.Run("lost the race after uploading: rejected, upload observed", func(t *testing.T) {
+		rejectedBefore := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected"))
+		uploadsBefore := uploadSampleCount(t)
+
+		finalize(t, "vm-uploaded", "conflict", "4200")
+
+		if got := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("rejected")); got != rejectedBefore+1 {
+			t.Fatalf("rejected promotes = %v; want %v", got, rejectedBefore+1)
+		}
+		if got := uploadSampleCount(t); got != uploadsBefore+1 {
+			t.Fatalf("upload samples = %d; want %d (the transfer still happened)", got, uploadsBefore+1)
+		}
+	})
+
+	t.Run("accepted promotes also observe their upload", func(t *testing.T) {
+		acceptedBefore := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("accepted"))
+		uploadsBefore := uploadSampleCount(t)
+
+		finalize(t, "vm-accepted", "accepted 6", "5100")
+
+		if got := testutil.ToFloat64(cacheVolumePromoteTotal.WithLabelValues("accepted")); got != acceptedBefore+1 {
+			t.Fatalf("accepted promotes = %v; want %v", got, acceptedBefore+1)
+		}
+		// The upload sample is recorded outside the switch on the promote result,
+		// so accepts contribute to this histogram too — which is why the
+		// pre-flight's effect reads as upload_count MINUS accepted promotes, not
+		// against rejected ones.
+		if got := uploadSampleCount(t); got != uploadsBefore+1 {
+			t.Fatalf("upload samples = %d; want %d (an accept uploaded too)", got, uploadsBefore+1)
+		}
+	})
 }
 
 func TestCacheImageSplit(t *testing.T) {

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -243,6 +243,21 @@ defmodule Tuist.Runners do
 
   def volume_master_upload_url(_account_id, _tree_digest), do: :error
 
+  @doc """
+  Whether a promote built on `base_generation` could still win `account_id`'s
+  cache-volume fast-forward — the pre-flight a runner makes before uploading.
+
+  The runner's image upload runs at teardown and blocks the VM halt (and so the
+  host slot's reclaim) for its whole duration, yet under cross-host contention
+  most promotes lose the fast-forward that follows it. Asking this first lets a
+  runner whose base another host has already advanced past skip the transfer
+  entirely instead of paying for it and being rejected.
+
+  Advisory only: see `Tuist.Runners.VolumeHeads.fast_forward_viable?/3` — the
+  compare-and-swap in `report_volume_head/4` remains what decides the HEAD.
+  """
+  defdelegate fast_forward_viable?(account_id, base_generation), to: VolumeHeads
+
   defp valid_inventory_digest?(digest), do: Regex.match?(~r/^[a-f0-9]{40}$/, digest)
 
   @doc """

--- a/server/lib/tuist/runners/volume_heads.ex
+++ b/server/lib/tuist/runners/volume_heads.ex
@@ -120,4 +120,30 @@ defmodule Tuist.Runners.VolumeHeads do
   end
 
   def get_head(_account_id, _volume_name), do: nil
+
+  @doc """
+  Whether a promote built on `base_generation` could still win the fast-forward —
+  the pre-flight the runner makes BEFORE uploading its image.
+
+  Mirrors `bump_head/5`'s acceptance rule: base 0 is viable only while the account
+  has no HEAD, base N > 0 only while the HEAD is exactly at N.
+
+  This is an OPTIMIZATION, not a decision. It is racy by construction (another
+  host can advance the HEAD between this read and the bump), so it may only ever
+  let a caller skip work that `bump_head/5` would reject anyway — the
+  compare-and-swap there stays the sole authority on what becomes HEAD. Anything
+  it cannot evaluate reads as viable, so an odd input never suppresses a promote
+  that would have been accepted.
+  """
+  def fast_forward_viable?(account_id, base_generation, volume_name \\ @reserved_tuist_cache)
+
+  def fast_forward_viable?(account_id, base_generation, volume_name)
+      when is_integer(account_id) and is_integer(base_generation) and base_generation >= 0 do
+    case get_head(account_id, volume_name) do
+      nil -> base_generation == 0
+      %{generation: generation} -> generation == base_generation
+    end
+  end
+
+  def fast_forward_viable?(_account_id, _base_generation, _volume_name), do: true
 end

--- a/server/lib/tuist_web/controllers/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/runners_controller.ex
@@ -158,18 +158,28 @@ defmodule TuistWeb.RunnersController do
   # current HEAD points at. Same SA-token + server-stamped account-label binding
   # as report_volume_head, so a runner can only mint an upload URL under the
   # account it actually ran.
+  #
+  # Minting also PRE-FLIGHTS the fast-forward the upload leads to: a runner that
+  # sends the base generation it built on gets a 409 here, before transferring
+  # the image, when that base has already been advanced past. The upload blocks
+  # the VM halt and the host slot's reclaim, so a promote that is certain to lose
+  # is worth not paying for.
   def volume_head_upload_url(conn, params) do
     digest = Map.get(params, "tree_digest", "")
 
     with {:ok, token} <- bearer_token(conn),
          {:ok, %{namespace: ns, name: sa_name}} <- K8sClient.create_token_review(token),
          {:ok, account_id} <- Runners.account_id_for_sa(ns, sa_name) do
-      case Runners.volume_master_upload_url(account_id, digest) do
-        {:ok, upload_url} ->
-          json(conn, %{upload_url: upload_url})
+      if doomed_fast_forward?(account_id, params) do
+        conn |> put_status(:conflict) |> json(%{error: "stale base generation"})
+      else
+        case Runners.volume_master_upload_url(account_id, digest) do
+          {:ok, upload_url} ->
+            json(conn, %{upload_url: upload_url})
 
-        :error ->
-          conn |> put_status(:unprocessable_entity) |> json(%{error: "invalid digest"})
+          :error ->
+            conn |> put_status(:unprocessable_entity) |> json(%{error: "invalid digest"})
+        end
       end
     else
       {:error, :missing_bearer} ->
@@ -177,6 +187,23 @@ defmodule TuistWeb.RunnersController do
 
       _ ->
         conn |> put_status(:unauthorized) |> json(%{error: "unauthorized"})
+    end
+  end
+
+  # True when the promote this mint would serve is already certain to be rejected
+  # because its base generation has been advanced past. Advisory: it may only
+  # skip doomed uploads, never authorize a promote — report_volume_head's
+  # compare-and-swap is what decides the HEAD, and another host can still win
+  # between this check and that bump.
+  #
+  # An absent base_generation disables the pre-check rather than defaulting to 0
+  # the way the bump does: a runner image predating this pre-flight sends no base
+  # here, and must keep its upload-then-arbitrate path instead of being told its
+  # cold-job promote is stale.
+  defp doomed_fast_forward?(account_id, params) do
+    case Map.fetch(params, "base_generation") do
+      {:ok, value} -> not Runners.fast_forward_viable?(account_id, parse_base_generation(value))
+      :error -> false
     end
   end
 

--- a/server/test/tuist/runners/volume_heads_test.exs
+++ b/server/test/tuist/runners/volume_heads_test.exs
@@ -73,4 +73,36 @@ defmodule Tuist.Runners.VolumeHeadsTest do
       assert VolumeHeads.get_head(account.id) == nil
     end
   end
+
+  describe "fast_forward_viable?/3" do
+    test "agrees with bump_head on every base, so it only ever skips doomed work" do
+      account = account_fixture()
+
+      # No HEAD yet: only a cold base can win, exactly as establish_first_head.
+      assert VolumeHeads.fast_forward_viable?(account.id, 0)
+      refute VolumeHeads.fast_forward_viable?(account.id, 1)
+
+      VolumeHeads.bump_head(account.id, "mac-01", "digest-a", 0)
+
+      # HEAD at generation 1: a cold job and a job built on anything else are both
+      # already lost; only the current generation can still fast-forward.
+      refute VolumeHeads.fast_forward_viable?(account.id, 0)
+      assert VolumeHeads.fast_forward_viable?(account.id, 1)
+      refute VolumeHeads.fast_forward_viable?(account.id, 2)
+
+      # And what it calls viable, bump_head accepts.
+      assert {:ok, 2} = VolumeHeads.bump_head(account.id, "mac-02", "digest-b", 1)
+      refute VolumeHeads.fast_forward_viable?(account.id, 1)
+    end
+
+    test "reads as viable for anything it cannot evaluate" do
+      account = account_fixture()
+
+      # Fail-safe: a malformed base must never suppress a promote the
+      # compare-and-swap would have accepted.
+      assert VolumeHeads.fast_forward_viable?(account.id, "1")
+      assert VolumeHeads.fast_forward_viable?(account.id, -1)
+      assert VolumeHeads.fast_forward_viable?(nil, 0)
+    end
+  end
 end

--- a/server/test/tuist_web/controllers/runners_controller_test.exs
+++ b/server/test/tuist_web/controllers/runners_controller_test.exs
@@ -291,6 +291,80 @@ defmodule TuistWeb.RunnersControllerTest do
       conn = post(conn, "/api/internal/runners/volume-head/upload-url", %{"tree_digest" => "x"})
       assert json_response(conn, 401)
     end
+
+    test "409 before minting when the base generation has been advanced past", %{conn: conn} do
+      digest = String.duplicate("a", 40)
+
+      stub(K8sClient, :create_token_review, fn "valid-token" ->
+        {:ok, %{namespace: "tuist-runners", name: "pod-1"}}
+      end)
+
+      stub(Runners, :account_id_for_sa, fn _ns, _sa -> {:ok, 77} end)
+      stub(Runners, :fast_forward_viable?, fn 77, 4 -> false end)
+      # The whole point: no URL is minted, so the runner never uploads an image
+      # for a promote that is certain to be rejected.
+      stub(Runners, :volume_master_upload_url, fn _account_id, _digest ->
+        flunk("minted an upload URL for a promote that cannot win")
+      end)
+
+      body =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> post("/api/internal/runners/volume-head/upload-url", %{
+          "tree_digest" => digest,
+          "base_generation" => 4
+        })
+        |> json_response(409)
+
+      assert body["error"] == "stale base generation"
+    end
+
+    test "mints when the base generation can still win", %{conn: conn} do
+      digest = String.duplicate("a", 40)
+
+      stub(K8sClient, :create_token_review, fn "valid-token" ->
+        {:ok, %{namespace: "tuist-runners", name: "pod-1"}}
+      end)
+
+      stub(Runners, :account_id_for_sa, fn _ns, _sa -> {:ok, 77} end)
+      stub(Runners, :fast_forward_viable?, fn 77, 4 -> true end)
+      stub(Runners, :volume_master_upload_url, fn 77, ^digest -> {:ok, "https://bucket.example.com/put"} end)
+
+      body =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> post("/api/internal/runners/volume-head/upload-url", %{
+          "tree_digest" => digest,
+          "base_generation" => "4"
+        })
+        |> json_response(200)
+
+      assert body["upload_url"] == "https://bucket.example.com/put"
+    end
+
+    test "skips the pre-check entirely for a runner that sends no base generation", %{conn: conn} do
+      digest = String.duplicate("a", 40)
+
+      stub(K8sClient, :create_token_review, fn "valid-token" ->
+        {:ok, %{namespace: "tuist-runners", name: "pod-1"}}
+      end)
+
+      stub(Runners, :account_id_for_sa, fn _ns, _sa -> {:ok, 77} end)
+
+      # A runner image predating the pre-flight must keep its upload-then-arbitrate
+      # path rather than have a missing base read as the cold base 0 and 409.
+      stub(Runners, :fast_forward_viable?, fn _account_id, _base ->
+        flunk("pre-checked a runner that sent no base generation")
+      end)
+
+      stub(Runners, :volume_master_upload_url, fn 77, ^digest -> {:ok, "https://bucket.example.com/put"} end)
+
+      assert %{"upload_url" => "https://bucket.example.com/put"} =
+               conn
+               |> put_req_header("authorization", "Bearer valid-token")
+               |> post("/api/internal/runners/volume-head/upload-url", %{"tree_digest" => digest})
+               |> json_response(200)
+    end
   end
 
   describe "POST /api/internal/runners/volume-head" do


### PR DESCRIPTION
Runner cache-volume promotes upload the entire image **before** the server arbitrates the fast-forward, so most uploads are wasted work that blocks VM teardown. This adds a pre-flight generation check so a promote that cannot win never transfers anything.

### The problem

`report_volume_head` in `infra/runner-image/dispatch-poll.sh` did:

1. POST to mint a content-addressed presigned upload URL (keyed by the new inventory digest)
2. `curl -X PUT --upload-file "${CACHE_IMAGE}"` — the WHOLE image, timed into `volume-upload-ms`
3. Only then the server's compare-and-swap (`bump_head`) returns accepted / conflict / error

So a promote that loses the fast-forward race still paid the full upload cost. That upload blocks guest teardown, which blocks VM halt and runner slot reclaim.

Measured across three converged production hosts (`tart_kubelet_cache_volume_*`):

| host | upload mean | promote accepted / rejected |
|---|---|---|
| `2t7nk` | 89.8s (538.8s / 6) | 11 / 16 |
| `8n9bz` | 52.9s (317.6s / 6) | 2 / 13 |
| `c22td` | 44.0s (176.1s / 4) | 6 / 16 |

Fleet-wide: **19 accepted vs 45 rejected, so ~66% of promotes lose**, at a mean upload of ~65s (up to 90s). Roughly two thirds of all that blocked-halt time was spent on work the server was going to reject.

### What changed

The guest now sends the base generation it built on when **minting** the upload URL, and the server 409s there when that base has already been advanced past. The guest records the outcome as a conflict and skips the PUT entirely.

**Server**

- `VolumeHeads.fast_forward_viable?/3` mirrors `bump_head/5`'s acceptance rule exactly: base 0 viable only while the account has no HEAD, base N only while the HEAD is exactly at N.
- `Runners.fast_forward_viable?/2` delegates it, so the controller keeps talking only to the context.
- `volume_head_upload_url` pre-flights before minting and returns the same `stale base generation` 409 shape as the bump.

**Guest** (`dispatch-poll.sh`)

- Reads `base_generation` before the mint and sends it in the mint body.
- Captures the mint's HTTP status explicitly. It was `curl -fsS`, which would have collapsed a 409 into "no upload URL" and mislabeled genuine contention as `error`, the exact conflation the bump call already avoids.
- On 409: writes `conflict`, logs, returns without the PUT.

**Host** — no behavior change needed. `readUploadMillis` already returns -1 when the marker is absent, so a pre-empted promote counts as `rejected` with no upload observation.

### Why this shape

**No new surface.** The mint POST already existed, already carried the digest, and already had the SA-token + server-stamped account-label binding. A separate GET-current-HEAD endpoint would have added a route and a second round trip for the same answer, and the mint is exactly the moment the guest is about to commit to the transfer.

**Optimization, never a decision.** The pre-check is racy by construction: another host can win between the check and the PUT. So it may only ever *skip* doomed work, never grant a promote. Three things enforce that:

- `bump_head`'s compare-and-swap stays the sole authority on what becomes HEAD, and still runs on every upload that happens.
- `fast_forward_viable?` reads as viable for anything it cannot evaluate, so an odd input never suppresses a promote that would have been accepted.
- Every non-409 mint outcome, including transport failure and a 000 status, falls through to the existing upload-then-arbitrate path.

**A missing `base_generation` disables the pre-check** rather than defaulting to 0 the way the bump does. Runner images predating this change send no base, and defaulting would 409 their cold-job promotes for the entire duration of the fleet roll.

### Impact

Rejected promotes should mostly stop transferring anything, which returns the corresponding ~65s of blocked teardown per losing promote to the warm pool. Accepted promotes are unaffected. The pre-check adds no round trip: it rides the mint request that already happened.

The guest half only takes effect once a new runner image ships; until then those runners send no base and keep the old path.

### How to test locally

Server:

```
mix test test/tuist/runners/ test/tuist_web/controllers/runners_controller_test.exs test/tuist/runners_test.exs
```

530 passed. New coverage: `fast_forward_viable?` agreeing with `bump_head` at every base and its fail-safe fallbacks; the 409-before-mint path (the test `flunk`s if an upload URL is minted); the viable path; and the no-base-sent backward-compat path (`flunk`s if the pre-check runs at all).

Host agent:

```
go test ./internal/podagent/ -count=1
```

Full package passes. `TestFinalizeVolumePromoteAccounting` builds an `Entry` and drives the real `finalizeVolume` across three cases: pre-empted (rejected, no upload sample), lost after uploading (rejected, sample), and accepted (accepted, sample). Verified non-vacuous by folding `conflict` into the `default` arm, which fails two of the three subtests. `readUploadMillis` gets its own test including the unparseable case, since it had no coverage before this branch. `go vet` and `gofmt` clean.

`client_model` moves from indirect to direct in `go.mod` — the histogram assertion needs a sample count, which `testutil` cannot express.

Guest script:

```
shellcheck -S error infra/runner-image/dispatch-poll.sh
```

Clean, along with `bash -n`.

### Deploy signal

`tart_kubelet_cache_volume_upload_seconds_count` minus `tart_kubelet_cache_volume_promote_total{result="accepted"}` — the count of uploads that happened and did **not** become HEAD. It should trend toward zero as the image rolls.

Corrected after review: an earlier version of this section read `_count` against `result="rejected"`, which is wrong. `finalizeVolume` records the upload sample from the `volume-upload-ms` marker alone, outside the switch on the promote result, so accepted promotes observe samples too and that ratio would move with the accept rate as much as with the pre-flight.

The difference does not reach zero, and the metric comment says why: an upload followed by a failed bump lands in the `error` bucket, and a job excluded from the promote ratio (unclean halt, account mismatch) can leave a marker with no promote counted at all. Both are small and worth seeing.

### Context

Came out of watching the folded-CAS rollout (#11857 shipped the machinery, #12066 turned it on in staging/canary/production). The CAS itself is healthy: 87% warm materialization, `fill_percent` averaging ~24% with no sample above 50%, so image sizing (`masterCapGib: 28`, `casGib: 16`) is comfortable and is not the issue. The issue was purely the upload-then-arbitrate ordering.

