### PR TITLE
fix(infra): keep terminal Failed phase so the stuck-machine alert can fire

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -902,7 +902,9 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// as bootstrap returns; whether the Node has reported Ready yet is
 	// a separate concern observable via `kubectl get nodes`.
 	machine.Status.Ready = true
-	machine.Status.Phase = "Ready"
+	if !terminalPhasePinned(machine.Status.FailureReason) {
+		machine.Status.Phase = "Ready"
+	}
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
@@ -1142,6 +1144,24 @@ func (r *ScalewayAppleSiliconMachineReconciler) dashboardVNCRelayPort() int {
 // migration case for machines provisioned before the hash existed.
 func hostConfigDrift(operatorHash, machineHash string) bool {
 	return operatorHash != "" && machineHash != operatorHash
+}
+
+// terminalPhasePinned reports whether the reconcile tail must leave
+// Status.Phase alone because the machine holds a terminal failure.
+//
+// The drift gate SKIPS a terminal machine rather than returning early, so
+// every reconcile after the one that recorded the failure still falls
+// through to the tail. Writing "Ready" there overwrote the "Failed" that
+// recordUpdateFailure had just set — within a single reconcile interval —
+// leaving machines that carried FailureReason while reporting phase Ready.
+//
+// That combination is invisible to alerting: the "stuck Failed" rule keys
+// on phase="Failed" persisting for 30m, and the phase flapped back to Ready
+// in ~5m, so the rule could never fire. Three production hosts sat wedged on
+// a stale tart-kubelet for weeks with the alert green. Pinning the phase is
+// what makes the terminal state observable; clearUpdateFailure lifts it.
+func terminalPhasePinned(failureReason *string) bool {
+	return failureReason != nil
 }
 
 // shouldClearTerminalFailure reports whether a terminal tart-kubelet-update

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -105,6 +105,60 @@ func TestRecordUpdateFailure_TransitionsToFailedAtCap(t *testing.T) {
 	}
 }
 
+// Regression for the silent-wedge: the reconcile tail is reached on every
+// pass for a terminal machine (the drift gate skips, it does not return), so
+// an unconditional Phase="Ready" there reset the "Failed" recordUpdateFailure
+// had set. Machines then carried FailureReason while reporting Ready, and the
+// "stuck Failed" alert — which needs phase="Failed" held for 30m — stayed
+// green while hosts sat wedged on a stale tart-kubelet.
+func TestTerminalPhasePinned(t *testing.T) {
+	reason := "TartKubeletUpdateExceededRetries"
+	cases := []struct {
+		name          string
+		failureReason *string
+		want          bool
+	}{
+		{"terminal failure pins the phase", &reason, true},
+		{"healthy machine keeps advancing to Ready", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := terminalPhasePinned(tc.failureReason); got != tc.want {
+				t.Fatalf("terminalPhasePinned() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A machine that exhausts its retry budget must still read as Failed after
+// later reconciles fall through the tail — the exact sequence that hid three
+// production hosts. Phase only returns to Ready once the terminal state is
+// lifted.
+func TestTerminalPhaseSurvivesSubsequentReconciles(t *testing.T) {
+	machine := &infrav1.ScalewayAppleSiliconMachine{}
+	for i := 0; i < 5; i++ {
+		recordUpdateFailure(machine, errors.New("dial :22 i/o timeout"), 5, "desired-hash", logr.Discard(), fakeRecorder())
+	}
+	if machine.Status.Phase != "Failed" {
+		t.Fatalf("Phase after cap: got %q, want Failed", machine.Status.Phase)
+	}
+
+	// Stand in for the reconcile tail running again on a terminal machine.
+	for i := 0; i < 3; i++ {
+		if !terminalPhasePinned(machine.Status.FailureReason) {
+			machine.Status.Phase = "Ready"
+		}
+	}
+	if machine.Status.Phase != "Failed" {
+		t.Fatalf("terminal phase must survive later reconciles; got %q", machine.Status.Phase)
+	}
+
+	clearUpdateFailure(machine, logr.Discard(), fakeRecorder())
+	if terminalPhasePinned(machine.Status.FailureReason) {
+		t.Fatal("clearing the terminal failure must unpin the phase")
+	}
+}
+
 // Regression for the retry-cap defeat: a broken config never updates
 // Status.HostConfigHash, so the self-heal must key on the FAILED hash — else
 // every reconcile sees drift-vs-applied and clears the cap forever.


### PR DESCRIPTION
## What changed

A `ScalewayAppleSiliconMachine` whose tart-kubelet config roll exhausts its retry budget now keeps `status.phase: Failed` for as long as it holds a terminal `status.failureReason`. Previously the phase was overwritten back to `Ready` on the next reconcile.

The guard is extracted as `terminalPhasePinned()` to match the existing tested-predicate idiom in this file (`hostConfigDrift`, `shouldClearTerminalFailure`) rather than an inline nil check buried in the reconcile tail.

## Why

Three production Mac minis were found stuck on a pre-#11857 tart-kubelet binary and host config. They had been terminal `TartKubeletUpdateExceededRetries` for weeks. Nobody was paged.

The "Runner Machine Stuck Failed" Grafana alert exists and is wired to Slack, but it could not fire, by construction:

- `recordUpdateFailure` sets `Phase = "Failed"` when attempts hit the cap.
- The drift gate is `if configDrift && !terminalFailure`. For a terminal machine that condition is false, so the reconcile **skips the update and keeps going** rather than returning early.
- It therefore reaches the reconcile tail on every pass, which set `machine.Status.Phase = "Ready"` unconditionally.

Net effect: the machines carried `failureReason: TartKubeletUpdateExceededRetries` **and** `phase: Ready` simultaneously. The alert keys on `phase="Failed"` persisting `for: 30m`, and the phase flapped back to `Ready` within one 5 minute reconcile interval, so it sat green while hosts drifted. The condition surfaced only indirectly, as a cross-host cache convergence digest mismatch and an elevated promote error rate on one host.

Verified live before the fix: all 13 production machines reported `phase: Ready`, while 3 of them had a terminal `failureReason` set.

## Why this fix over the alternatives

- **Not "set Ready = false" as well.** The Node genuinely still serves workloads, and CAPI `Ready` describes infrastructure provisioning. Flipping it would misreport a serving host and risk CAPI-side remediation on a machine that only needs a config roll. Only the phase should reflect that the operator has stopped pushing config.
- **Not "fix the alert query to key on failure_reason instead".** The phase is the field the operator publishes as the machine's lifecycle state through `capt_scaleway_applesilicon_machine_phase`; a phase that contradicts `failureReason` is wrong on its own terms and would keep misleading anyone reading `kubectl get scalewayapplesiliconmachine`.
- **Not a new health metric.** Adding a signal on top of a silently broken one leaves the broken one in place.

## Impact

Terminal machines become visible to both the existing alert and `kubectl get scalewayapplesiliconmachine`. No behavior change for healthy machines: with no `failureReason` set, the tail advances to `Ready` exactly as before. `clearUpdateFailure` unpins the phase, so a recovered machine returns to `Ready` on the next reconcile and stops matching the alert.

## Validation

- `go build ./...` clean.
- `go test ./controllers/...` green across the `linux`, `macos`, and `shared` packages.
- Two new tests: `TestTerminalPhasePinned` for the predicate, and `TestTerminalPhaseSurvivesSubsequentReconciles`, which drives `recordUpdateFailure` to the cap, replays the reconcile-tail assignment three times, and asserts the phase stays `Failed` until `clearUpdateFailure` lifts it. That second test fails against the previous behavior.

## Follow-ups not in this PR

Both live in the Grafana rule (uid `bfss9votttr7kb`), not in this repo, so they are not fixed here:

1. Its PromQL is scoped `fleet="tuist-tuist-runners-fleet"`, so the builders and macos fleets cannot alert at all. Two of the three stuck hosts are in those fleets and would stay invisible even with this fix.
2. `no_data_state: OK` means a machine whose series disappears resolves silently.

The rule's runbook annotation also states that clearing this state needs break-glass because "CAPI writes are not in the JIT edit tier". That is incorrect: the JIT `edit` tier patches `scalewayapplesiliconmachines/status` fine, verified under an active elevation. As written it sends whoever gets paged to break-glass for routine ops.

### How to test locally

```
cd infra/cluster-api-provider-tuist
go test ./controllers/macos/ -run 'TestTerminalPhase' -v
```

To see the original failure mode, revert the `terminalPhasePinned` guard in the reconcile tail back to an unconditional `machine.Status.Phase = "Ready"`; `TestTerminalPhaseSurvivesSubsequentReconciles` then fails with the phase reset to `Ready`.
