### PR TITLE
fix(registry): request consistent archive reads

### DIFF
--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -24,10 +24,12 @@ managed environments that expose the registry service directly.
 - Read package metadata from S3 (`registry/metadata/<scope>/<name>/index.json`).
 - Request strong consistency for metadata reads and revalidation so a reader
   cannot cache a previous catalog revision after a writer has repaired it.
-- Emit 303 redirects to presigned S3 URLs for source archives without a
-  separate existence request. The object-storage download is authoritative
-  for whether an archive exists, so a temporary storage lookup failure cannot
-  be converted into a registry 404.
+- Emit 303 redirects to strongly consistent presigned S3 URLs for source
+  archives without a separate existence request. The consistency query keeps
+  a repaired archive from being shadowed by an older regional object copy.
+  The object-storage download is authoritative for whether an archive exists,
+  so a temporary storage lookup failure cannot be converted into a registry
+  404.
 - Serve manifest bodies in-process. Default `Package.swift` responses
   also include the `Link` header listing alternate manifests.
 - Emit per-ecosystem download/manifest metrics via PromEx, scraped by
@@ -43,9 +45,10 @@ managed environments that expose the registry service directly.
 
 ## Serving model
 - **Source archives** are served as `303` redirects to presigned Tigris
-  URLs. The signed request overrides the object response content type with
-  `application/zip`, including for existing objects with generic metadata.
-  SE-0292 §4.4 explicitly permits this shape for signed archive URLs.
+  URLs. The signed request requests strong consistency and overrides the
+  object response content type with `application/zip`, including for existing
+  objects with generic metadata. SE-0292 §4.4 explicitly permits this shape
+  for signed archive URLs.
 - **Default `Package.swift`** is loaded from Tigris into memory and
   served in-process with an alternate-manifest `Link` header attached.
 - **Version-specific manifests** are also loaded from Tigris and served

--- a/registry/lib/tuist_registry/s3.ex
+++ b/registry/lib/tuist_registry/s3.ex
@@ -40,10 +40,16 @@ defmodule TuistRegistry.S3 do
         presign_opts =
           case Keyword.fetch(opts, :content_type) do
             {:ok, content_type} ->
-              [expires_in: 600, query_params: [{"response-content-type", content_type}]]
+              [
+                expires_in: 600,
+                query_params: [
+                  {"response-content-type", content_type},
+                  {"x-tigris-consistent", "true"}
+                ]
+              ]
 
             :error ->
-              [expires_in: 600]
+              [expires_in: 600, query_params: [{"x-tigris-consistent", "true"}]]
           end
 
         ExAws.S3.presigned_url(config, :get, bucket, key, presign_opts)

--- a/registry/test/tuist_registry/s3_test.exs
+++ b/registry/test/tuist_registry/s3_test.exs
@@ -36,13 +36,34 @@ defmodule TuistRegistry.S3Test do
       expect(ExAws.S3, :presigned_url, fn :config, :get, "test-registry-bucket", ^key, opts ->
         assert opts == [
                  expires_in: 600,
-                 query_params: [{"response-content-type", "application/zip"}]
+                 query_params: [
+                   {"response-content-type", "application/zip"},
+                   {"x-tigris-consistent", "true"}
+                 ]
                ]
 
         {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
       end)
 
       assert S3.presign_download_url(key, type: :registry, content_type: "application/zip") ==
+               {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
+    end
+
+    test "requests consistent object-storage reads without a content type override" do
+      key = "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+
+      expect(ExAws.Config, :new, fn :s3 -> :config end)
+
+      expect(ExAws.S3, :presigned_url, fn :config, :get, "test-registry-bucket", ^key, opts ->
+        assert opts == [
+                 expires_in: 600,
+                 query_params: [{"x-tigris-consistent", "true"}]
+               ]
+
+        {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
+      end)
+
+      assert S3.presign_download_url(key, type: :registry) ==
                {:ok, "https://s3.example.com/source_archive.zip?signed=true"}
     end
   end


### PR DESCRIPTION
## What changed

Registry archive redirects now sign `x-tigris-consistent=true` into object-storage download URLs. Focused tests cover downloads with and without a content-type override.

## Why

During registry recovery, metadata could reference the repaired archive while a regional object-storage replica still returned older bytes. Swift Package Manager then rejected the download because its checksum did not match the registry metadata.

## Root cause

Archive redirects used ordinary presigned reads. Following an object repair, those reads could temporarily reach a stale regional copy instead of the authoritative object.

## Approach

Request a strongly consistent read in the existing presigned URL. This keeps the current redirect architecture and archive bytes unchanged while ensuring clients receive the authoritative object.

## Impact

Repaired packages no longer fluctuate between old and current archive bytes. This prevents checksum mismatches without changing package metadata or introducing new archive hashes.

## Validation

- `mise run format --check`
- `mise run test`
- 43 tests passed with no failures
- Repeated production downloads returned the authoritative SwiftEntryKit archive checksum