### PR TITLE
fix(cli): link file system testing in Linux tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1063,6 +1063,8 @@ var targets: [Target] = [
             "TuistServer",
             "TuistEnvironmentTesting",
             "TuistNooraTesting",
+            fileSystemDependency,
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             mockableDependency,
         ],
         path: "cli/Tests/TuistProjectCommandTests"


### PR DESCRIPTION
## What changed

The [command-line interface](https://en.wikipedia.org/wiki/Command-line_interface) package manifest now links `FileSystem` and `FileSystemTesting` directly into `TuistProjectCommandTests`.

## Why

The Linux unit-test job could compile the test module but failed while linking its test runner, blocking pull requests that include the latest `main` branch.

## Root cause

`ProjectShowServiceTests` imports `FileSystemTesting` and uses its temporary-directory trait, but `TuistProjectCommandTests` did not declare the corresponding products as direct package dependencies. The Linux linker therefore omitted the symbols required by the test runner.

## Approach

Add the missing dependency edges to the existing test target. This keeps the fix limited to the package graph and does not change test or production behavior.

## Impact

Linux project-command tests can link and run again. Production targets and users are unaffected.

### How to test locally

Run the package resolution and tests in the pinned Linux Swift container used by the GitHub Actions workflow:

```sh
swift package resolve --replace-scm-with-registry
swift test --replace-scm-with-registry
```

## Validation

- The full Linux package build and test run passed in `swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0` on `aarch64-unknown-linux-gnu`.
- `TuistProjectCommandTests-test-runner` linked successfully, and the project-command test suites passed.
- `swift package --replace-scm-with-registry dump-package` confirmed both direct product dependencies.
- `git diff --check` passed.
- SwiftFormat reported that zero of 1,891 files require formatting.
