### PR TITLE
fix(server): stop spurious rollout error alerts from Oban ordering and OG pool timeouts

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -297,6 +297,12 @@ defmodule Tuist.Application do
   end
 
   defp get_children do
+    # Oban starts after the endpoint (and, because a :one_for_one supervisor
+    # stops children in reverse order, drains before it). Workers building
+    # Phoenix.VerifiedRoutes URLs read the endpoint's persistent term, which
+    # only exists while the endpoint runs; starting Oban first raised
+    # "could not find persistent term for endpoint" on boot/shutdown during
+    # rollouts (Sentry TUIST-3R9).
     children =
       [
         {DBConnection.TelemetryListener, name: TelemetryListener},
@@ -329,9 +335,10 @@ defmodule Tuist.Application do
         Supervisor.child_spec(CASEvent.Buffer, id: CASEvent.Buffer),
         Supervisor.child_spec(DeliveryAttempt.Buffer, id: DeliveryAttempt.Buffer),
         Tuist.Vault,
-        # Queued jobs can run as soon as Oban starts, so their connection pool must already be available.
+        # Oban starts last (after the endpoint, see below), so every dependency
+        # queued jobs rely on — Repo, Finch, Cachex, PubSub — is already
+        # available by the time the first job runs.
         {Finch, name: Tuist.Finch, pools: finch_pools()},
-        {Oban, Application.fetch_env!(:tuist, Oban)},
         {Cachex, [:tuist, []]},
         Cache,
         {Phoenix.PubSub, name: Tuist.PubSub},
@@ -342,7 +349,8 @@ defmodule Tuist.Application do
         ops_clickhouse_children() ++
         open_graph_image_children() ++
         RuntimeChildren.guardian_db_sweeper(Environment.mode()) ++
-        dev_content_children() ++ [TuistWeb.Endpoint]
+        dev_content_children() ++
+        [TuistWeb.Endpoint, {Oban, Application.fetch_env!(:tuist, Oban)}]
 
     children
     |> Kernel.++(

--- a/server/lib/tuist/open_graph_image_renderer.ex
+++ b/server/lib/tuist/open_graph_image_renderer.ex
@@ -42,13 +42,29 @@ defmodule Tuist.OpenGraphImageRenderer do
   end
 
   def render(html, fallback_title) do
-    # async_nolink (not Task.async) so a crashing render only surfaces as a
-    # {:exit, reason} we can fall back on, instead of the link killing the
-    # calling HTTP request process before render_fallback/2 runs. A pool that
-    # failed to start arrives here as an exit too, and degrades the same way.
+    run_render(fallback_title, fn ->
+      Carta.render(@pool, html, width: 1920, height: 1080, quality: 95)
+    end)
+  end
+
+  @doc false
+  # Runs `render_fun` in a supervised task and degrades to the fallback renderer
+  # on any failure. `async_nolink` keeps a crashing render from killing the
+  # calling HTTP request; it surfaces here as a `{:exit, reason}` we fall back on.
+  #
+  # We trap the exit inside the task because a saturated pool makes
+  # `NimblePool.checkout!` exit, and `Task.Supervised` logs a "Task ...
+  # terminating" report for every such exit, flooding Sentry (TUIST-3R8) even
+  # though the fallback already handles it. Returning `{:error, reason}` lets
+  # the task exit cleanly while still logging one warning with the reason.
+  def run_render(fallback_title, render_fun) do
     task =
       Task.Supervisor.async_nolink(@task_supervisor, fn ->
-        Carta.render(@pool, html, width: 1920, height: 1080, quality: 95)
+        try do
+          render_fun.()
+        catch
+          :exit, reason -> {:error, reason}
+        end
       end)
 
     case Task.yield(task, @render_timeout) || Task.shutdown(task, :brutal_kill) do

--- a/server/test/tuist/open_graph_image_renderer_test.exs
+++ b/server/test/tuist/open_graph_image_renderer_test.exs
@@ -1,0 +1,36 @@
+defmodule Tuist.OpenGraphImageRendererTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Tuist.OpenGraphImageRenderer
+
+  setup do
+    if !Process.whereis(OpenGraphImageRenderer.TaskSupervisor) do
+      start_supervised!({Task.Supervisor, name: OpenGraphImageRenderer.TaskSupervisor})
+    end
+
+    :ok
+  end
+
+  describe "run_render/2 when the browser pool checkout times out (Sentry TUIST-3R8)" do
+    test "degrades to the fallback renderer without logging a task crash report" do
+      # This is exactly the exit NimblePool.checkout! raises when every browser
+      # in the pool stays busy past the checkout timeout.
+      checkout_timeout = fn ->
+        exit({:timeout, {NimblePool, :checkout, [OpenGraphImageRenderer]}})
+      end
+
+      log =
+        capture_log(fn ->
+          assert {:fallback, image} = OpenGraphImageRenderer.run_render("Tuist", checkout_timeout)
+          assert is_binary(image)
+        end)
+
+      # The single, intended warning still surfaces the reason.
+      assert log =~ "Headless browser Open Graph image rendering failed"
+      # The noisy per-request crash report that floods Sentry must be gone.
+      refute log =~ "terminating"
+    end
+  end
+end


### PR DESCRIPTION
Two production error alerts that fire on every rollout (`environment=prod`), even though nothing goes down. Both traced back to supervision/task-lifecycle wiring rather than genuine outages. Sentry issues: [TUIST-3R9](https://tuist.sentry.io/issues/137364743/) and [TUIST-3R8](https://tuist.sentry.io/issues/137364544/).

## What changed

- **Start Oban after `TuistWeb.Endpoint`.** Moved the Oban child spec to the end of the supervision child list so it starts after the endpoint and, because a `:one_for_one` supervisor stops children in reverse order, drains before the endpoint is torn down.
- **Stop Open Graph pool checkout timeouts from crashing the render task.** Trapped the `NimblePool` checkout `:exit` inside the `async_nolink` render task so it returns `{:error, reason}` instead of terminating, and added a test that reproduces the exact crash report and asserts it no longer appears.

## Why

Both alerts are noise, not incidents (0 users impacted on TUIST-3R9; TUIST-3R8 still serves a valid card via the fallback renderer), but they page on every deploy and bury real signals.

## Root cause

**TUIST-3R9 (`could not find persistent term for endpoint TuistWeb.Endpoint`).** Oban started before `TuistWeb.Endpoint` in the `:one_for_one` tree, which stops children in reverse start order, so the endpoint also stopped *before* Oban drained. Workers that build URLs with `Phoenix.VerifiedRoutes` (for example `Tuist.VCS.Workers.CommentWorker`) read the endpoint's persistent term at runtime. On a rollout both windows are hit: on boot a queued job can run before the term is registered, and on shutdown an in-flight job drains into a teardown where the term is already erased. The job retries (`max_attempts: 20`), which is why it never surfaced to users. This ordering has never been changed since the monorepo import; the one prior ordering fix ([#11823](https://github.com/tuist/tuist/pull/11823), "start Finch before background jobs") addressed the same class of dependency-before-Oban bug and is preserved here (Finch still starts before Oban).

**TUIST-3R8 (`NimblePool.checkout ... time out`).** Runtime Open Graph image rendering runs inside a `Task.Supervisor.async_nolink` task. When every browser in the pool stays busy past the checkout timeout, `NimblePool.checkout!` *exits* the task, and `Task.Supervised` logs a `Task ... terminating` crash report for each occurrence. The caller already falls back to the [libvips](https://www.libvips.org/) renderer, so the crash report is pure noise, but under crawler bursts (the sample event is Amazonbot) against slow renders it floods Sentry.

## Approach

For the endpoint ordering, moving Oban last was chosen over moving the endpoint earlier because it fixes both the boot and shutdown windows at once and keeps every job dependency (Repo, Finch, Cachex, PubSub) started first. The endpoint's readiness probe (`GET /ready`) is a bare `200` with no Oban dependency, so serving Oban last introduces no readiness regression. The reasoning is captured in a comment next to the reordered child spec.

For the render task, the exit was trapped at the task boundary (rather than widening pool size or checkout timeouts) so the behavior is unchanged for the caller: same fallback image, same single `Logger.warning` with the reason, just no duplicate crash report. The underlying render hang that let the pool saturate was fixed separately in [#12132](https://github.com/tuist/tuist/pull/12132) (give Chromium a writable HOME), which this branch is rebased on top of; trapping the exit remains as defense so a future slow-render spike degrades quietly instead of paging.

## Impact

- No behavior change for users. Rollouts stop emitting the two spurious error alerts.
- Draining Oban jobs that build verified-route URLs now always have a live endpoint.
- Open Graph rendering keeps degrading gracefully to the fallback without paging.

## Validation

```
cd server
mix test test/tuist/open_graph_image_renderer_test.exs   # 1 passed
mix format <changed files>
mix credo lib/tuist/open_graph_image_renderer.ex lib/tuist/application.ex               # no issues
```

The Open Graph test was also run with the fix reverted to confirm it reproduces the exact `Task ... terminating ** (stop) exited in: NimblePool.checkout(...) ** (EXIT) time out` report from TUIST-3R8, then passes once the exit is trapped.

### How to test locally

- `cd server && mix test test/tuist/open_graph_image_renderer_test.exs`
- To see the reproduction for the Open Graph fix, remove the `try/catch :exit` block in `OpenGraphImageRenderer.run_render/2` and re-run the renderer test: the `Task ... terminating` crash report reappears in the captured log and the test fails.
