### PR TITLE
fix(server): render Open Graph images via Chromium with a writable HOME

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -205,6 +205,14 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
+# Runtime Open Graph image rendering launches Chromium as `nobody`, whose home is
+# `/nonexistent`. Route it through a wrapper that exports a writable HOME so
+# `--headless=new` can bind its DevTools port instead of timing out. See
+# server/rel/og-chromium for the full rationale.
+COPY server/rel/og-chromium /usr/local/bin/og-chromium
+RUN chmod +x /usr/local/bin/og-chromium
+ENV TUIST_OG_IMAGE_CHROME_PATH=/usr/local/bin/og-chromium
+
 WORKDIR "/app"
 RUN chown nobody /app
 

--- a/server/lib/tuist/open_graph_image_renderer.ex
+++ b/server/lib/tuist/open_graph_image_renderer.ex
@@ -25,7 +25,9 @@ defmodule Tuist.OpenGraphImageRenderer do
   end
 
   def start_pool(opts \\ []) do
-    case BrowseChrome.BrowserPool.start_link(name: @pool, pool_size: pool_size(opts)) do
+    pool_opts = maybe_put_chrome_path([name: @pool, pool_size: pool_size(opts)], chrome_path(opts))
+
+    case BrowseChrome.BrowserPool.start_link(pool_opts) do
       {:ok, pid} ->
         {:ok, pid}
 
@@ -67,6 +69,27 @@ defmodule Tuist.OpenGraphImageRenderer do
     case OpenGraph.generate_og_image_binary(title) do
       {:ok, image} -> {:fallback, image}
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_put_chrome_path(pool_opts, nil), do: pool_opts
+  defp maybe_put_chrome_path(pool_opts, path), do: Keyword.put(pool_opts, :chrome_path, path)
+
+  # In the release image this points at the `og-chromium` wrapper, which gives
+  # Chromium a writable HOME so `--headless=new` can bind its DevTools port.
+  # Unset in dev, where BrowseChrome auto-detects the local Chrome.
+  defp chrome_path(opts) do
+    case Keyword.get(opts, :chrome_path) do
+      nil -> chrome_path_from_environment()
+      path -> path
+    end
+  end
+
+  defp chrome_path_from_environment do
+    case System.get_env("TUIST_OG_IMAGE_CHROME_PATH") do
+      nil -> nil
+      "" -> nil
+      path -> path
     end
   end
 

--- a/server/rel/og-chromium
+++ b/server/rel/og-chromium
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Wrapper around Chromium for runtime Open Graph image rendering.
+#
+# The release runs as `nobody`, whose home directory is `/nonexistent`. Chromium
+# needs a writable HOME (and XDG cache/config dirs) for its font cache and, under
+# `--headless=new`, for the crashpad handler's database. Without one it floods
+# stderr with "Fontconfig error: No writable cache directories" and
+# "chrome_crashpad_handler: --database is required", and on the production nodes
+# that broken environment left Chromium never binding its DevTools port, so every
+# render timed out (`:devtools_timeout`) and the renderer fell back to the
+# low-fidelity image. Pointing HOME at a writable tmp directory clears it.
+#
+# `exec` keeps Chromium as the direct child of the caller (MuonTrap), so process
+# supervision and cleanup are unchanged. Extra arguments from the caller are
+# forwarded verbatim.
+set -e
+
+export HOME="${TUIST_OG_IMAGE_CHROME_HOME:-/tmp/tuist-og-chrome}"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_DATA_HOME="$HOME/.local/share"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME"
+
+exec /usr/bin/chromium "$@"


### PR DESCRIPTION
> Fix runtime Open Graph image generation, which was silently degrading to the low-fidelity fallback image on every request in production.

## What changed

- Added `server/rel/og-chromium`, a wrapper that exports a writable `HOME` (and the matching `XDG_*` cache/config directories) before exec'ing Chromium.
- Wired the wrapper into the release image via a new `TUIST_OG_IMAGE_CHROME_PATH` env var (`server/Dockerfile`), and taught `Tuist.OpenGraphImageRenderer.start_pool/1` to pass it as the pool's `chrome_path` when set. The var is unset in dev and on-premise images, so nothing changes there.

## Why

After we moved Open Graph images to runtime generation, every docs and marketing card was being served as the libvips fallback: the title only, no subtitle, wrong template. It also loaded slowly every single time and was never cached.

I reproduced it against production. The image URL responded with `cache-control: public, max-age=60` and `cf-cache-status: DYNAMIC`, taking around 31 seconds on every request including repeats. That is the transient fallback path: nothing is persisted to object storage, so the CDN never caches it and each request re-renders.

## Root cause

The server logs showed every pod, every ten seconds, failing to initialize a browser pool worker:

```
** (RuntimeError) failed to initialize browser: :devtools_timeout (browse 0.5.0)
... Headless browser Open Graph image rendering failed, using the fallback renderer:
    {:timeout, {NimblePool, :checkout, [Tuist.OpenGraphImagePool]}}
```

Chromium was spawning but never binding its DevTools remote-debugging port within the ten second window, so no pool worker ever came up and every render fell through to the fallback.

The release runs as `nobody`, whose home directory is `/nonexistent`. Running Chromium in the exact production image (`ghcr.io/tuist/tuist:sha-1c4fa55ae161`) as `nobody` showed the broken environment directly:

```
chrome_crashpad_handler: --database is required
[...util/file/filesystem_posix.cc] mkdir : No such file or directory (2)
Fontconfig error: No writable cache directories   (repeated hundreds of times)
```

Under `--headless=new` Chromium starts a separate crashpad handler that needs a writable database directory, and fontconfig needs a writable cache. With `HOME=/nonexistent` both fail, and on the production nodes that broken startup left the DevTools port unbound.

## Approach

The Chromium launch arguments are hardcoded inside the `browse_chrome` dependency, so the only launch knob we control is the executable path (`chrome_path`). Pointing it at a wrapper that first exports a writable `HOME` is the least invasive fix and needs no dependency fork. I scoped it to the Open Graph Chromium via the wrapper rather than setting a process-wide `HOME`, so the rest of the release is untouched. `exec` keeps Chromium as the direct child of MuonTrap, so process supervision and cleanup are unchanged.

The runtime browser pool is already started only when `Environment.tuist_hosted?() or Environment.dev?()` (see `open_graph_image_children/0`), and on-premise the Open Graph routes are forwarded away by the router pipeline, so this only ever runs on Tuist-hosted instances.

## Impact

Once deployed, docs and marketing cards render through the real templates again (title plus subtitle plus category), get persisted to object storage under their content-addressed key, and are served with `cache-control: public, max-age=31536000, immutable` so both object storage and the CDN cache them. On-premise deployments are unaffected.

## Validation

- Reproduced the failure in the exact production image and confirmed Chromium as `nobody` with `HOME=/nonexistent` floods stderr with the crashpad and fontconfig errors above.
- With the wrapper (writable `HOME`), running the exact `browse_chrome` arguments as `nobody` through the `muontrap` binary, Chromium binds DevTools in about one second with zero crashpad and zero fontconfig errors:
  ```
  FINAL: devtools=OK polls=13 crashpad=0 fontconfig=0
  DevTools listening on ws://127.0.0.1:9392/devtools/browser/...
  ```
- `mix compile --warnings-as-errors` passes.

I could not reproduce the DevTools timeout itself locally (Chromium binds fine under OrbStack regardless of `HOME`), so final confirmation that the timeout is gone should happen on canary: curl a docs Open Graph image and check for the `immutable` cache header and a fast second response.

### How to test locally

Open Graph image generation needs the headless browser pool, which runs in dev. Load a docs page (for example `/en/docs/guides/install-gradle-plugin`), read its `og:image` URL, and request it twice: the second response should be fast and carry `cache-control: public, max-age=31536000, immutable`.
