### PR TITLE
fix(registry): enable managed registry sync

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -107,9 +107,10 @@ server:
     # advertise the canonical prefix already.
     - name: TUIST_REGISTRY_URL
       value: https://registry-canary.tuist.dev/swift
-    # Cache remains the sole registry writer until the managed cutover.
+    # The registry sync deployment owns catalog synchronization after the
+    # legacy cache writer was disabled.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
-      value: "false"
+      value: "true"
     # Single web replica shares this pool between request handling and the
     # in-node Oban queues (default: 10). Sized well above the default-queue
     # concurrency so the steady AlertEvaluationWorker load can't starve web
@@ -293,11 +294,10 @@ processor:
       cpu: "1000m"
       memory: "1Gi"
 
-# Cache remains the sole registry writer until the managed cutover. The
-# standalone registry continues exercising the read path against the
-# same bucket.
+# The registry sync deployment owns catalog synchronization after the legacy
+# cache writer was disabled. The standalone registry reads from the same bucket.
 swiftRegistrySync:
-  enabled: false
+  enabled: true
   syncAllowlist: alamofire/alamofire
   extraEnv:
     - name: TUIST_DEPLOY_ENV

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -92,10 +92,10 @@ server:
     # moves its origin from the cache nodes to the standalone frontend.
     - name: TUIST_REGISTRY_URL
       value: https://tuist.dev/api/registry/swift
-    # The legacy cache remains the sole registry writer until its schedule is
-    # disabled as a separate cutover step.
+    # The registry sync deployment owns catalog synchronization after the
+    # legacy cache writer was disabled.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
-      value: "false"
+      value: "true"
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
@@ -418,10 +418,9 @@ processor:
   affinity: {}
 
 swiftRegistrySync:
-  # The legacy regional cache release remains the production writer until its
-  # registry schedule can be disabled. Enabling both generations violates the
-  # single-writer cutover contract.
-  enabled: false
+  # The legacy cache writer is disabled, so this deployment is the sole
+  # registry synchronization writer.
+  enabled: true
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: prod

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -7,12 +7,9 @@ ingress. **The pod is a stateless read frontend.** The server-owned writer
 lives under `Tuist.Registry.Swift.*`
 and runs in a separate `TUIST_MODE=swift_registry_sync` pod (see
 `server/AGENTS.md` and
-`infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`). During
-the managed cutover, the currently deployed legacy cache release remains
-the sole scheduled writer for canary and production while staging and
-previews exercise the server-owned writer. Do not redeploy cache from the
-current main branch before cutover because its registry cron has already
-been removed.
+`infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`). The
+server-owned writer is the sole scheduled writer in managed environments;
+the legacy cache registry cron remains disabled.
 
 The service currently hosts the **Swift Package Registry** under
 `/api/registry/swift/*`. The same surface is available under `/swift/*` for
@@ -92,8 +89,7 @@ managed environments that expose the registry service directly.
 - Normal deploys run through `.github/workflows/server-deployment.yml`,
   which builds and deploys the registry read image together with the
   server image. In managed canary and production, the
-  `swift_registry_sync` writer remains disabled until cache sync is turned
-  off as a separate, deliberate cutover step.
+  `swift_registry_sync` writer runs as the sole scheduled registry writer.
 
 ### Cluster prereqs
 The chart assumes these are installed in the target cluster (they


### PR DESCRIPTION
## What changed

- Enable the server-side registry synchronization schedule in canary and production.
- Enable the managed registry synchronization deployment in canary and production.

## Why

The legacy cache nodes no longer synchronize the registry. The dedicated registry synchronization deployment must become the sole writer so package updates continue reaching the registry bucket.

## Impact

Canary retains its existing Alamofire-only synchronization allowlist. Production and canary will start the dedicated registry synchronization deployment after rollout.

## Validation

- Rendered the Helm chart for canary and production with their managed values and continuous-integration validation values.
- Verified each rendering contains the registry synchronization deployment and both synchronization flags set to `true`.

### How to test locally

```sh
for environment in canary production; do
  helm template "tuist-${environment}" infra/helm/tuist \
    -f infra/helm/tuist/values.yaml \
    -f infra/helm/tuist/values-managed-common.yaml \
    -f "infra/helm/tuist/values-managed-${environment}.yaml" \
    -f infra/helm/tuist/values-ci.yaml
done
```
