### PR TITLE
fix(cli): restore dynamic framework module map copying

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -83,10 +83,8 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
                 if hasModuleMap {
                     if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
-                        projectPath: project.path
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
                     ) {
-                        let escapedModuleMapPath = Self.shellEscaped(moduleMapPath.pathString)
                         switch target.product {
                         case .framework:
                             target.scripts.append(
@@ -97,17 +95,17 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                                         """
                                         set -eu
                                         mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                        cp -f '\(escapedModuleMapPath)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                                        cp -f \(Self.shellPath(from: moduleMapPath)) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
                                         """
                                     ),
-                                    inputPaths: [moduleMapPath.pathString],
+                                    inputPaths: [moduleMapPath],
                                     outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
                                     showEnvVarsInLog: false,
                                     basedOnDependencyAnalysis: true
                                 )
                             )
                         case .staticFramework:
-                            mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath.pathString)
+                            mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
                         default:
                             break
                         }
@@ -195,21 +193,44 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     } // swiftlint:enable function_body_length
 
     private static func moduleMapPath(
-        from value: SettingsDictionary.Value?,
-        projectPath: AbsolutePath
-    ) -> AbsolutePath? {
+        from value: SettingsDictionary.Value?
+    ) -> String? {
         guard case let .string(moduleMap) = value else { return nil }
 
-        return try? AbsolutePath(
-            validating: moduleMap
-                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath.pathString)
-        )
+        for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
+            let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
+            if moduleMap.hasPrefix(derivedDirectoryPrefix) {
+                let relativePath = String(moduleMap.dropFirst(derivedDirectoryPrefix.count))
+                return "$(PROJECT_DIR)/../../\(relativePath)"
+            }
+        }
+
+        if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
+            return moduleMap
+        }
+
+        guard (try? RelativePath(validating: moduleMap)) != nil else {
+            return nil
+        }
+        return "$(PROJECT_DIR)/\(moduleMap)"
     }
 
-    private static func shellEscaped(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "'\\\\''")
+    private static func shellPath(from buildSettingPath: String) -> String {
+        let variables = [
+            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
+            ("$(SRCROOT)", "$SRCROOT"),
+            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
+        ]
+        var shellPath = buildSettingPath
+        for (buildSetting, shellVariable) in variables {
+            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
+        }
+        let escapedShellPath = shellPath
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "`", with: "\\`")
+
+        return "\"\(escapedShellPath)\""
     }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -82,15 +82,35 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                 else { return (targetName, target) }
 
                 if hasModuleMap {
-                    if target.product.isFramework,
-                       case let .string(moduleMapFile) = mappedSettingsDictionary[Self.modulemapFileSetting]
-                    {
-                        // ExtractAPI consumes MODULEMAP_PATH as an explicit -fmodule-map-file input. Keeping the
-                        // source map out of the framework product avoids duplicate module-map discovery and the
-                        // static-framework copy fixed in #11588: https://github.com/tuist/tuist/pull/11588
-                        // The original $(SRCROOT)-relative value is preserved so cache hashes stay
-                        // environment-independent.
-                        mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapFile)
+                    if let moduleMapPath = Self.moduleMapPath(
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
+                        projectPath: project.path
+                    ) {
+                        let escapedModuleMapPath = Self.shellEscaped(moduleMapPath.pathString)
+                        switch target.product {
+                        case .framework:
+                            target.scripts.append(
+                                TargetScript(
+                                    name: "Copy Module Map",
+                                    order: .post,
+                                    script: .embedded(
+                                        """
+                                        set -eu
+                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                                        cp -f '\(escapedModuleMapPath)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                                        """
+                                    ),
+                                    inputPaths: [moduleMapPath.pathString],
+                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                                    showEnvVarsInLog: false,
+                                    basedOnDependencyAnalysis: true
+                                )
+                            )
+                        case .staticFramework:
+                            mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath.pathString)
+                        default:
+                            break
+                        }
                     }
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
@@ -173,6 +193,24 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         sideEffects.append(contentsOf: generatedFileSideEffects)
         return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
+
+    private static func moduleMapPath(
+        from value: SettingsDictionary.Value?,
+        projectPath: AbsolutePath
+    ) -> AbsolutePath? {
+        guard case let .string(moduleMap) = value else { return nil }
+
+        return try? AbsolutePath(
+            validating: moduleMap
+                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath.pathString)
+                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath.pathString)
+                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath.pathString)
+        )
+    }
+
+    private static func shellEscaped(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "'\\\\''")
+    }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {
         if case .external = project.type,

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -95,7 +95,10 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                                         """
                                         set -eu
                                         mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                        cp -f \(Self.shellPath(from: moduleMapPath)) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                                        cp -f \(Self
+                                            .shellPath(
+                                                from: moduleMapPath
+                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
                                         """
                                     ),
                                     inputPaths: [moduleMapPath],

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -601,6 +601,9 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+// This integration test resolves a large external package graph and runs two Xcode builds. Serializing it prevents
+// the intermittent resource contention observed when it runs alongside the rest of the acceptance-test shard.
+@Suite(.serialized)
 struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
     @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)
     func ios_app_with_modulemap_packages() async throws {

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -601,8 +601,8 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
-// This integration test resolves a large external package graph and runs two Xcode builds. Serializing it prevents
-// the intermittent resource contention observed when it runs alongside the rest of the acceptance-test shard.
+/// This integration test resolves a large external package graph and runs two Xcode builds. Serializing it prevents
+/// the intermittent resource contention observed when it runs alongside the rest of the acceptance-test shard.
 @Suite(.serialized)
 struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
     @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
+    func maps_framework_modulemap_to_modulemap_copy_script() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -419,39 +419,25 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
-        #expect(gotTarget.scripts.isEmpty)
-    }
-
-    @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_modulemap_path_for_environment_independence() throws {
-        // Given
-        let workspace = Workspace.test()
-        let projectPath = try temporaryPath().appending(component: "A")
-        let target = Target.test(
-            name: "A",
-            product: .framework,
-            settings: .test(base: [
-                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
-            ])
+        #expect(gotTarget.scripts ==
+            [
+                TargetScript(
+                    name: "Copy Module Map",
+                    order: .post,
+                    script: .embedded(
+                        """
+                        set -eu
+                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                        cp -f '\(moduleMapPath.pathString)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                        """
+                    ),
+                    inputPaths: [moduleMapPath.pathString],
+                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                    showEnvVarsInLog: false,
+                    basedOnDependencyAnalysis: true
+                ),
+            ]
         )
-        let project = Project.test(
-            path: projectPath,
-            name: "A",
-            targets: [target]
-        )
-
-        // When
-        let (gotGraph, _, _) = try subject.map(
-            graph: .test(workspace: workspace, projects: [projectPath: project]),
-            environment: MapperEnvironment()
-        )
-
-        // Then — the $(SRCROOT)-relative form is preserved so cache hashes are
-        // stable across machines with different checkout paths.
-        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
-        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"))
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -428,7 +428,7 @@ struct ModuleMapMapperTests {
                         """
                         set -eu
                         mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f '\(moduleMapPath.pathString)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
                         """
                     ),
                     inputPaths: [moduleMapPath.pathString],
@@ -475,6 +475,124 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
         #expect(gotTarget.scripts.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].script == .embedded(
+            """
+            set -eu
+            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+            """
+        ))
+        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func rewrites_srcroot_relative_derived_framework_modulemap_path_to_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let temporaryPath = try temporaryPath()
+        let projectPath = temporaryPath.appending(components: "tuist-derived", "Projects", "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/../../tuist-derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func resolves_relative_static_framework_modulemap_path_against_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("Modules/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Modules/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)

--- a/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
@@ -1,6 +1,3 @@
 import ProjectDescription
 
-let config = Config(
-    fullHandle: "tuist/ios_app_with_appclip",
-    url: "https://canary.tuist.dev"
-)
+let config = Config()


### PR DESCRIPTION
## What changed

- Restore post-build copying of module maps for dynamic frameworks.
- Keep an explicit module-map path for static frameworks.
- Update mapper tests to cover the distinct framework behaviors.

## Why

Documentation builds in the command-line tool acceptance suite regressed after module-map handling was unified for all framework products.

## Root cause

Xcode's ExtractAPI task fails for dynamic frameworks when the generated framework both receives an explicit module-map path and discovers its bundled module map. Static frameworks require the explicit path instead.

## Approach

Use the product-specific behavior expected by Xcode: package the module map in dynamic framework bundles after the build, and pass its resolved path only to static frameworks.

## Impact

Generated projects can document dependencies that use either dynamic or static frameworks without the failing module-map discovery path.

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestiOSAppWithModuleMapPackages CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestiOSAppWithAppClip CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistAutomationAcceptanceTests/BuildAcceptanceTestMultiplatformAppWithSDK CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ModuleMapMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `git diff --check`
