### PR TITLE
fix(registry): preserve code-signed bundle symlinks in source archives

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -26,6 +26,17 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   @metadata_lock_max_attempts 5
   @metadata_lock_backoff_ms 200
   @metadata_lock_snooze_seconds 30
+  # Symlinks nested inside these code-signed bundles are part of the bundle's
+  # sealed layout (e.g. a Mac Catalyst framework's `Versions/Current -> A` and
+  # the `Binary`/`Resources` links). Code signing records them as symlinks in
+  # `_CodeSignature/CodeResources`, so flattening them into real copies
+  # invalidates the signature ("a sealed resource is missing or invalid"). They
+  # always live well below the package root, so the SwiftPM root-level symlink
+  # extraction bug that `resolve_symlinks/1` works around
+  # (https://github.com/swiftlang/swift-package-manager/pull/9411) does not
+  # apply to them, and they are safe to keep as symlinks in the archive.
+  @signed_bundle_extensions ~w(.xcframework .framework .app .appex .bundle .dSYM .plugin .systemextension .xpc)
+
   @skippable_submodule_failure_markers [
     "no url found for submodule path",
     "transport 'file' not allowed",
@@ -413,7 +424,10 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
     with :ok <- remove_symlinks_outside_root(directory),
          :ok <- resolve_symlinks(directory) do
-      case System.cmd("zip", ["-r", archive_path, base_name], cd: parent_dir) do
+      # `-y` stores the symlinks that `resolve_symlinks/1` deliberately preserved
+      # (those inside code-signed bundles) as symlinks instead of following them
+      # and inlining their target, which would otherwise break the signature.
+      case System.cmd("zip", ["-r", "-y", archive_path, base_name], cd: parent_dir) do
         {_, 0} -> :ok
         {output, status} -> {:error, {:zip_failed, status, output}}
       end
@@ -423,7 +437,11 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp resolve_symlinks(directory) do
     case System.cmd("find", [directory, "-type", "l"], stderr_to_stdout: true) do
       {output, 0} ->
-        symlink_paths = String.split(output, "\n", trim: true)
+        symlink_paths =
+          output
+          |> String.split("\n", trim: true)
+          |> Enum.reject(&within_signed_bundle?/1)
+
         {directory_symlinks, non_directory_symlinks} = classify_symlinks(symlink_paths)
 
         with :ok <- resolve_non_directory_symlinks(non_directory_symlinks) do
@@ -433,6 +451,14 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
       {output, status} ->
         {:error, {:find_symlinks_failed, status, output}}
     end
+  end
+
+  defp within_signed_bundle?(path) do
+    path
+    |> Path.split()
+    |> Enum.any?(fn component ->
+      Enum.any?(@signed_bundle_extensions, &String.ends_with?(component, &1))
+    end)
   end
 
   defp classify_symlinks(symlink_paths) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -454,8 +454,14 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   end
 
   defp within_signed_bundle?(path) do
+    # Inspect only the ancestor directories, not the symlink's own basename: the
+    # bundle whose sealed layout we protect is always a real directory above the
+    # symlink. A root-level symlink that happens to be named like a bundle (e.g.
+    # `Foo.framework -> ...`) must still be flattened, so it does not reintroduce
+    # the SwiftPM root-level extraction failure on un-patched clients.
     path
     |> Path.split()
+    |> Enum.drop(-1)
     |> Enum.any?(fn component ->
       Enum.any?(@signed_bundle_extensions, &String.ends_with?(component, &1))
     end)

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -484,6 +484,28 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join(extracted_framework, "Resources"))
       assert {:ok, "A"} = File.read_link(Path.join([extracted_framework, "Versions", "Current"]))
     end
+
+    test "flattens a root-level symlink even when it is named like a code-signed bundle" do
+      tmp = Path.join(System.tmp_dir!(), "zip_directory_bundle_named_link_#{System.unique_integer([:positive])}")
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      source = Path.join(tmp, "repo-v1.0.0")
+      File.mkdir_p!(source)
+      File.write!(Path.join(source, "README.md"), "readme")
+      # A package-root symlink whose own basename matches a bundle extension must
+      # still be flattened, since it is a root-level symlink SwiftPM mishandles.
+      File.ln_s!("README.md", Path.join(source, "Widget.framework"))
+
+      archive_path = Path.join(tmp, "source_archive.zip")
+      assert :ok = ReleaseWorker.zip_directory(source, archive_path)
+
+      extract_dir = Path.join(tmp, "extract")
+      File.mkdir_p!(extract_dir)
+      {_, 0} = System.cmd("unzip", ["-q", archive_path, "-d", extract_dir])
+
+      assert {:ok, %File.Stat{type: :regular}} =
+               File.lstat(Path.join([extract_dir, "repo-v1.0.0", "Widget.framework"]))
+    end
   end
 
   defp write_basic_zipball(archive_path) do

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -440,6 +440,52 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     assert ReleaseWorker.skippable_submodule_failure?(output)
   end
 
+  describe "zip_directory/2" do
+    test "preserves symlinks inside code-signed bundles while flattening other symlinks" do
+      tmp = Path.join(System.tmp_dir!(), "zip_directory_test_#{System.unique_integer([:positive])}")
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      source = Path.join(tmp, "repo-v1.0.0")
+      framework = Path.join([source, "Vendor", "Adyen3DS2.xcframework", "ios-maccatalyst", "Adyen3DS2.framework"])
+      version_a = Path.join([framework, "Versions", "A"])
+      File.mkdir_p!(Path.join(version_a, "Resources"))
+
+      File.write!(Path.join(source, "README.md"), "readme")
+      # Non-bundle symlink: should be flattened into a regular file.
+      File.ln_s!("README.md", Path.join(source, "CLAUDE.md"))
+
+      File.write!(Path.join(version_a, "Adyen3DS2"), "binary")
+      File.write!(Path.join([version_a, "Resources", "Info.plist"]), "plist")
+      # Sealed bundle symlinks: must survive as symlinks.
+      File.ln_s!("A", Path.join([framework, "Versions", "Current"]))
+      File.ln_s!("Versions/Current/Adyen3DS2", Path.join(framework, "Adyen3DS2"))
+      File.ln_s!("Versions/Current/Resources", Path.join(framework, "Resources"))
+
+      archive_path = Path.join(tmp, "source_archive.zip")
+      assert :ok = ReleaseWorker.zip_directory(source, archive_path)
+
+      extract_dir = Path.join(tmp, "extract")
+      File.mkdir_p!(extract_dir)
+      {_, 0} = System.cmd("unzip", ["-q", archive_path, "-d", extract_dir])
+
+      extracted_framework =
+        Path.join([
+          extract_dir,
+          "repo-v1.0.0",
+          "Vendor",
+          "Adyen3DS2.xcframework",
+          "ios-maccatalyst",
+          "Adyen3DS2.framework"
+        ])
+
+      assert {:ok, %File.Stat{type: :regular}} = File.lstat(Path.join([extract_dir, "repo-v1.0.0", "CLAUDE.md"]))
+      assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join([extracted_framework, "Versions", "Current"]))
+      assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join(extracted_framework, "Adyen3DS2"))
+      assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join(extracted_framework, "Resources"))
+      assert {:ok, "A"} = File.read_link(Path.join([extracted_framework, "Versions", "Current"]))
+    end
+  end
+
   defp write_basic_zipball(archive_path) do
     tmp = Path.join(Path.dirname(archive_path), "zipball_content")
     top_dir = Path.join(tmp, "repo-v1.0.0")


### PR DESCRIPTION
## What

The Swift registry writer flattened every symlink when building a package's source archive. This invalidated the code signature of any signed `.xcframework` (or other signed bundle) committed into a package. This PR keeps the symlinks that live inside code-signed bundles intact, and stores them as symlinks in the archive.

## Why

A customer reported that `Adyen3DS2.xcframework` failed `codesign --verify --deep --strict` with `a sealed resource is missing or invalid` when the package was installed from the registry, while the exact same package installed from its GitHub URL verified fine. The asymmetry pointed at the archive our writer produces rather than at the framework itself.

The framework is committed into the package repo and, because it ships a Mac Catalyst slice, it uses the versioned-bundle layout: `Versions/Current -> A`, plus `Binary -> Versions/Current/Binary` and `Resources -> Versions/Current/Resources`. Code signing seals those entries as symlinks in `_CodeSignature/CodeResources`. When the writer replaced them with real copies, the seal no longer matched.

## Root cause

`Tuist.Registry.Swift.ReleaseWorker.zip_directory/2` ran `resolve_symlinks/1` before zipping, which rewrites every symlink into a real copy of its target, and it invoked `zip -r` without `-y`, so `zip` also followed any remaining symlink and inlined its target. Either path destroys a signed bundle's internal symlinks.

That flattening was added on purpose as a workaround for a SwiftPM extraction bug (swiftlang/swift-package-manager#9411). That bug is specific to root-level symlinks moved one-by-one during `stripFirstLevel` (the `CLAUDE.md -> AGENTS.md` case). Symlinks nested inside a bundle directory move together with their parent directory, so the bug never touches them. The workaround was broader than the bug it fixed.

## Approach and alternatives

SwiftPM's own `ZipArchiver.compress` (the code behind `swift package archive-source`, the canonical way registry source archives are produced) runs `zip -ry`, which preserves symlinks. So a registry archive is expected to contain symlinks, and we were the outlier by stripping them.

Options considered:
- Preserve all symlinks (drop the workaround entirely). Rejected because un-patched SwiftPM clients in the field would still hit #9411 on packages with root-level symlinks.
- Only inline symlinks whose target is a regular text file. Narrower, but still risks the framework binary symlink and directory symlinks inside bundles.
- Chosen: skip symlink resolution for anything inside a code-signed bundle, and add `-y` so those preserved symlinks are stored as symlinks. Root-level and text symlinks are still flattened, so un-patched clients keep working, and signed bundles keep their signature. This is also the smallest divergence from SwiftPM's own behavior.

Bundle detection is by extension: `.xcframework`, `.framework`, `.app`, `.appex`, `.bundle`, `.dSYM`, `.plugin`, `.systemextension`, `.xpc`.

## Impact

Signed xcframeworks committed into registry packages verify again after their archive is regenerated. No change for packages without bundle symlinks. Existing broken archives are not rewritten automatically; affected releases need a resync (see below).

## Validation

- Added a test that builds a Mac Catalyst framework layout with `Versions/Current -> A`, a framework binary symlink, and a `Resources` symlink alongside a non-bundle `CLAUDE.md -> README.md` symlink, zips it through `zip_directory/2`, extracts it, and asserts the bundle symlinks survive as symlinks while the non-bundle symlink is flattened to a regular file.
- `mix test test/tuist/registry/swift/release_worker_test.exs`: 10 passed.
- Cross-checked SwiftPM's `Sources/Basics/Archiver/ZipArchiver.swift` to confirm `zip -ry` is the reference behavior.

## Follow-up (resync)

The fix only produces correct archives once it runs in the `swift_registry_sync` pod. After deploy, the affected package needs a forced resync of all its versions via `Tuist.Registry.force_resync_swift_package_version/2` (or the ops registry page), which enqueues a `SyncWorker` with `force: true` to bypass the already-synced skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)