### PR TITLE
fix(server): defer throttled registry sync jobs

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -106,6 +106,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             Logger.info("Deferring release #{scope}/#{name}@#{tag}: package metadata lock is contended")
             {:snooze, seconds}
 
+          {:discard, discard_reason} ->
+            {:discard, discard_reason}
+
           :not_skipped ->
             Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
             {:error, reason}
@@ -816,7 +819,28 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     update_metadata_with_skipped_release(scope, name, full_handle, version, "missing_default_manifest")
   end
 
-  defp maybe_skip_release(_scope, _name, _full_handle, _version, _reason), do: :not_skipped
+  defp maybe_skip_release(_scope, _name, _full_handle, _version, reason) do
+    case rate_limit_status(reason) do
+      nil ->
+        :not_skipped
+
+      status ->
+        Logger.warning("Deferring registry release after GitHub rate limit (HTTP #{status})")
+        {:discard, reason}
+    end
+  end
+
+  defp rate_limit_status({:rate_limited, status}), do: status
+
+  defp rate_limit_status(tuple) when is_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> Enum.find_value(&rate_limit_status/1)
+  end
+
+  defp rate_limit_status(list) when is_list(list), do: Enum.find_value(list, &rate_limit_status/1)
+  defp rate_limit_status(map) when is_map(map), do: map |> Map.values() |> Enum.find_value(&rate_limit_status/1)
+  defp rate_limit_status(_reason), do: nil
 
   defp update_metadata_with_skipped_release(scope, name, full_handle, version, reason) do
     lock_key = {:package, scope, name}

--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -140,19 +140,20 @@ defmodule Tuist.Registry.Swift.SyncWorker do
       Logger.warning("Skipping Swift Package Index list fetch after transient error: #{inspect(reason)}")
       {:discard, reason}
     else
-      # Response-status failures (403 rate or abuse limit, 5xx, an authentication or
-      # scope problem) can be persistent and are worth surfacing, so
-      # they stay a hard error that retries and reports.
+      # Non-throttling response-status failures (5xx, authentication, or scope
+      # problems) can be persistent and are worth surfacing, so they stay a hard
+      # error that retries and reports.
       Logger.error("Failed to fetch Swift Package Index list: #{inspect(reason)}")
       {:error, reason}
     end
   end
 
-  # Transport and protocol errors arrive as Req exception structs; a real
-  # response maps to a `{:http_error, status}` tuple upstream and is
-  # deliberately excluded here so 403s and 5xx keep surfacing.
+  # GitHub rate limits are returned separately from other HTTP status errors, so
+  # the cron job can resume at its next scheduled run without replaying an
+  # exhausted job in the meantime.
   defp transient_fetch_error?(%Req.TransportError{}), do: true
   defp transient_fetch_error?(%Req.HTTPError{}), do: true
+  defp transient_fetch_error?({:rate_limited, _status}), do: true
   defp transient_fetch_error?(_reason), do: false
 
   defp sync_package(%{scope: scope, name: name, repository_full_handle: full_handle}, token) do

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -215,7 +215,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
-  test "retries when a listed manifest cannot be fetched" do
+  test "discards the job when GitHub rate limits a manifest request" do
     expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
       {:ok, :acquired}
     end)
@@ -230,18 +230,19 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
 
     expect(TuistCommon.GitHub, :get_file_content, fn
       "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
-        {:error, {:http_error, 403}}
+        {:error, {:rate_limited, 403}}
     end)
 
     stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+
     stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected skipped-release write") end)
 
-    assert {:error,
+    assert {:discard,
             {:manifest_fetch_failed,
              [
                %{
                  path: "Package.swift",
-                 reason: {:http_error, 403}
+                 reason: {:rate_limited, 403}
                }
              ]}} =
              ReleaseWorker.perform(%Oban.Job{

--- a/server/test/tuist/registry/swift/sync_worker_test.exs
+++ b/server/test/tuist/registry/swift/sync_worker_test.exs
@@ -218,10 +218,10 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
     assert {:discard, ^reason} = SyncWorker.perform(%Oban.Job{args: %{}})
   end
 
-  test "surfaces an HTTP status error as a hard failure" do
-    expect(SwiftPackageIndex, :list_packages, fn "token" -> {:error, {:http_error, 403}} end)
+  test "discards the job when GitHub rate limits the catalog request" do
+    expect(SwiftPackageIndex, :list_packages, fn "token" -> {:error, {:rate_limited, 403}} end)
 
-    assert {:error, {:http_error, 403}} = SyncWorker.perform(%Oban.Job{args: %{}})
+    assert {:discard, {:rate_limited, 403}} = SyncWorker.perform(%Oban.Job{args: %{}})
   end
 
   test "force resyncs only the requested package version without taking the catalog lock" do

--- a/tuist_common/lib/tuist_common/github.ex
+++ b/tuist_common/lib/tuist_common/github.ex
@@ -59,8 +59,8 @@ defmodule TuistCommon.GitHub do
       {:ok, %{status: 404}} ->
         {:error, :not_found}
 
-      {:ok, %{status: status}} ->
-        {:error, {:http_error, status}}
+      {:ok, response} ->
+        http_error(response)
 
       {:error, reason} ->
         {:error, reason}
@@ -83,7 +83,7 @@ defmodule TuistCommon.GitHub do
     |> case do
       {:ok, %{status: 200, body: body}} when is_list(body) -> {:ok, body}
       {:ok, %{status: 404}} -> {:error, :not_found}
-      {:ok, %{status: status}} -> {:error, {:http_error, status}}
+      {:ok, response} -> http_error(response)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -114,8 +114,8 @@ defmodule TuistCommon.GitHub do
       {:ok, %{status: 404}} ->
         {:error, :not_found}
 
-      {:ok, %{status: status}} ->
-        {:error, {:http_error, status}}
+      {:ok, response} ->
+        http_error(response)
 
       {:error, reason} ->
         {:error, reason}
@@ -142,7 +142,7 @@ defmodule TuistCommon.GitHub do
     |> request(url, token, request_opts)
     |> case do
       {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status}} -> {:error, {:http_error, status}}
+      {:ok, response} -> http_error(response)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -199,6 +199,26 @@ defmodule TuistCommon.GitHub do
       [_, next_url] -> next_url
       _ -> nil
     end
+  end
+
+  defp http_error(%{status: 429}), do: {:error, {:rate_limited, 429}}
+
+  defp http_error(%{status: 403, headers: headers}) do
+    if rate_limited?(headers) do
+      {:error, {:rate_limited, 403}}
+    else
+      {:error, {:http_error, 403}}
+    end
+  end
+
+  defp http_error(%{status: status}), do: {:error, {:http_error, status}}
+
+  defp rate_limited?(headers) do
+    Enum.any?(headers, fn
+      {"retry-after", _value} -> true
+      {"x-ratelimit-remaining", "0"} -> true
+      _header -> false
+    end)
   end
 
   defp request(method, url, token, opts) do

--- a/tuist_common/lib/tuist_common/github.ex
+++ b/tuist_common/lib/tuist_common/github.ex
@@ -216,7 +216,7 @@ defmodule TuistCommon.GitHub do
   defp rate_limited?(headers) do
     Enum.any?(headers, fn
       {"retry-after", _value} -> true
-      {"x-ratelimit-remaining", "0"} -> true
+      {"x-ratelimit-remaining", value} when value in ["0", ["0"]] -> true
       _header -> false
     end)
   end

--- a/tuist_common/test/tuist_common/github_test.exs
+++ b/tuist_common/test/tuist_common/github_test.exs
@@ -150,6 +150,20 @@ defmodule TuistCommon.GitHubTest do
                GitHub.get_file_content("tuist/tuist", "test-token", "nonexistent.swift", "main")
     end
 
+    test "identifies GitHub throttling responses" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 403,
+           body: %{},
+           headers: %{"x-ratelimit-remaining" => "0"}
+         }}
+      end)
+
+      assert {:error, {:rate_limited, 403}} =
+               GitHub.get_file_content("tuist/tuist", "test-token", "Package.swift", "main")
+    end
+
     test "returns error for invalid base64 content" do
       stub(Req, :request, fn _opts ->
         {:ok,
@@ -193,6 +207,15 @@ defmodule TuistCommon.GitHubTest do
 
       assert {:error, :not_found} =
                GitHub.list_repository_contents("tuist/nonexistent", "test-token", "main")
+    end
+
+    test "identifies GitHub throttling responses" do
+      stub(Req, :request, fn _opts ->
+        {:ok, %Req.Response{status: 429, body: %{}}}
+      end)
+
+      assert {:error, {:rate_limited, 429}} =
+               GitHub.list_repository_contents("tuist/tuist", "test-token", "main")
     end
   end
 

--- a/tuist_common/test/tuist_common/github_test.exs
+++ b/tuist_common/test/tuist_common/github_test.exs
@@ -150,13 +150,13 @@ defmodule TuistCommon.GitHubTest do
                GitHub.get_file_content("tuist/tuist", "test-token", "nonexistent.swift", "main")
     end
 
-    test "identifies GitHub throttling responses" do
+    test "identifies GitHub throttling responses with list-valued headers" do
       stub(Req, :request, fn _opts ->
         {:ok,
          %Req.Response{
            status: 403,
            body: %{},
-           headers: %{"x-ratelimit-remaining" => "0"}
+           headers: %{"x-ratelimit-remaining" => ["0"]}
          }}
       end)
 


### PR DESCRIPTION
> Prevent registry synchronization jobs from repeatedly failing while GitHub is throttling requests.

## What changed

- Classify GitHub throttling responses separately from other failed requests.
- Discard catalog and release synchronization jobs that were throttled so the next scheduled catalog pass can retry them.
- Keep access-denied and other non-throttling failures visible.

## Why

The registry synchronizer was producing repeated Sentry errors for requests that GitHub was throttling. Retrying the same job immediately consumed attempts without making progress.

## Root cause

The shared GitHub client represented all status 403 responses as generic failures. The workers could not distinguish a rate limit from an access failure.

## Approach

Recognize status 429 and status 403 responses that include GitHub's rate-limit headers. The release worker recursively detects that classification in wrapped manifest failures and discards the job without recording the release as permanently skipped.

## Impact

Throttled work is retried by a later catalog pass. Authentication and authorization failures continue to be reported for investigation.

### How to test locally

- `MIX_ENV=test mise exec -- mix test test/tuist_common/github_test.exs`
- `MIX_ENV=test mise exec -- mix test test/tuist/registry/swift/sync_worker_test.exs test/tuist/registry/swift/release_worker_test.exs`
