### PR TITLE
fix(server): filter automation actions by test state

### DIFF
--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -12,6 +12,7 @@ defmodule Tuist.Automations do
   alias Tuist.Environment
   alias Tuist.IngestRepo
   alias Tuist.Repo
+  alias Tuist.Tests
   alias Tuist.Tests.TestCase
   alias Tuist.Tests.TestCaseRun
 
@@ -789,10 +790,35 @@ defmodule Tuist.Automations do
   defp event_to_subscription_key(:unskipped), do: "state_changed_to_enabled"
   defp event_to_subscription_key(_), do: nil
 
-  defp subscribed_alerts(%{project_id: project_id}, subscription_key) do
-    project_id
-    |> test_updated_alerts()
-    |> Enum.filter(&subscribed?(&1, subscription_key))
+  defp subscribed_alerts(%{project_id: project_id, id: test_case_id}, subscription_key) do
+    alerts =
+      project_id
+      |> test_updated_alerts()
+      |> Enum.filter(&subscribed?(&1, subscription_key))
+
+    filter_by_trigger_state(alerts, project_id, test_case_id)
+  end
+
+  defp filter_by_trigger_state([], _project_id, _test_case_id), do: []
+
+  defp filter_by_trigger_state(alerts, project_id, test_case_id) do
+    if Enum.any?(alerts, &has_trigger_state_filter?/1) do
+      states = Tests.get_test_case_states(project_id, [test_case_id])
+      current_state = Map.get(states, test_case_id, %{state: "enabled"}).state
+
+      Enum.filter(alerts, fn alert ->
+        case Map.get(alert.trigger_config || %{}, "state") do
+          state when state in ["enabled", "muted", "skipped"] -> current_state == state
+          _ -> true
+        end
+      end)
+    else
+      alerts
+    end
+  end
+
+  defp has_trigger_state_filter?(alert) do
+    Map.get(alert.trigger_config || %{}, "state") in ["enabled", "muted", "skipped"]
   end
 
   defp test_updated_alerts(project_id) do

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -807,8 +807,8 @@ defmodule Tuist.Automations do
       current_state = Map.get(states, test_case_id, %{state: "enabled"}).state
 
       Enum.filter(alerts, fn alert ->
-        case Map.get(alert.trigger_config || %{}, "state") do
-          state when state in ["enabled", "muted", "skipped"] -> current_state == state
+        case Map.get(alert.trigger_config || %{}, "states") do
+          s when is_list(s) and s != [] -> current_state in s
           _ -> true
         end
       end)
@@ -818,7 +818,10 @@ defmodule Tuist.Automations do
   end
 
   defp has_trigger_state_filter?(alert) do
-    Map.get(alert.trigger_config || %{}, "state") in ["enabled", "muted", "skipped"]
+    case Map.get(alert.trigger_config || %{}, "states") do
+      s when is_list(s) and s != [] -> true
+      _ -> false
+    end
   end
 
   defp test_updated_alerts(project_id) do

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -259,6 +259,7 @@ defmodule Tuist.Automations.Alerts.Alert do
 
     changeset
     |> validate_comparison(trigger_config)
+    |> validate_state_filter(trigger_config, :trigger_config)
     |> validate_recovery_config()
   end
 
@@ -287,6 +288,14 @@ defmodule Tuist.Automations.Alerts.Alert do
       nil -> changeset
       value when value in @comparisons -> changeset
       _ -> add_error(changeset, :trigger_config, "comparison must be one of: #{Enum.join(@comparisons, ", ")}")
+    end
+  end
+
+  defp validate_state_filter(changeset, config, field) do
+    case Map.get(config, "state") do
+      nil -> changeset
+      state when state in @valid_states -> changeset
+      _ -> add_error(changeset, field, "state must be one of: #{Enum.join(@valid_states, ", ")}")
     end
   end
 
@@ -334,7 +343,7 @@ defmodule Tuist.Automations.Alerts.Alert do
       recovery_config = get_field(changeset, :recovery_config) || %{}
 
       case validate_window_shape(recovery_config, @max_rolling_window_size) do
-        :ok -> changeset
+        :ok -> validate_state_filter(changeset, recovery_config, :recovery_config)
         {:error, message} -> add_error(changeset, :recovery_config, message)
       end
     else

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -292,10 +292,21 @@ defmodule Tuist.Automations.Alerts.Alert do
   end
 
   defp validate_state_filter(changeset, config, field) do
-    case Map.get(config, "state") do
-      nil -> changeset
-      state when state in @valid_states -> changeset
-      _ -> add_error(changeset, field, "state must be one of: #{Enum.join(@valid_states, ", ")}")
+    case Map.get(config, "states") do
+      nil ->
+        changeset
+
+      states when is_list(states) ->
+        invalid = Enum.reject(states, &(&1 in @valid_states))
+
+        if invalid == [] do
+          changeset
+        else
+          add_error(changeset, field, "states must be one of: #{Enum.join(@valid_states, ", ")}")
+        end
+
+      _ ->
+        add_error(changeset, field, "states must be a list of: #{Enum.join(@valid_states, ", ")}")
     end
   end
 

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -256,7 +256,6 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       active_events
       |> Enum.reject(&MapSet.member?(currently_triggered_set, &1.test_case_id))
       |> reject_unevaluated_this_tick(scoped_test_case_ids)
-      |> filter_by_current_state(alert, alert.recovery_config)
 
     # Re-arming (appending the "recovered" event so the next rising edge can
     # fire again) happens for every alert once its condition clears — without
@@ -268,7 +267,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     # because `Alert.changeset` only validates it when recovery is on.
     {recovered, recovery_actions} =
       if alert.recovery_enabled do
-        {filter_recovered_candidates(alert, candidates, alert.recovery_config || %{}), alert.recovery_actions}
+        recovered =
+          candidates
+          |> filter_by_current_state(alert, alert.recovery_config)
+          |> then(&filter_recovered_candidates(alert, &1, alert.recovery_config || %{}))
+
+        {recovered, alert.recovery_actions}
       else
         {candidates, []}
       end

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -199,7 +199,10 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   defp establish_baseline(alert) do
     Automations.establish_alert_baseline(alert, fn test_case_ids ->
       %{triggered: triggered_ids} = evaluate_monitor(alert, test_case_ids)
-      reject_unvalidated_test_cases(alert, triggered_ids)
+
+      triggered_ids
+      |> then(&reject_unvalidated_test_cases(alert, &1))
+      |> filter_by_current_state(alert, alert.trigger_config)
     end)
   end
 
@@ -207,7 +210,10 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     active_events = active_alert_events(alert, scoped_test_case_ids)
     already_triggered_ids = MapSet.new(active_events, & &1.test_case_id)
 
-    newly_triggered = Enum.reject(triggered_ids, &MapSet.member?(already_triggered_ids, &1))
+    newly_triggered =
+      triggered_ids
+      |> Enum.reject(&MapSet.member?(already_triggered_ids, &1))
+      |> filter_by_current_state(alert, alert.trigger_config)
 
     Enum.each(newly_triggered, fn test_case_id ->
       entity = %{type: :test_case, id: test_case_id}
@@ -250,6 +256,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       active_events
       |> Enum.reject(&MapSet.member?(currently_triggered_set, &1.test_case_id))
       |> reject_unevaluated_this_tick(scoped_test_case_ids)
+      |> filter_by_current_state(alert, alert.recovery_config)
 
     # Re-arming (appending the "recovered" event so the next rising edge can
     # fire again) happens for every alert once its condition clears — without
@@ -305,6 +312,29 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     evaluated = MapSet.new(scoped_test_case_ids)
     Enum.filter(candidates, &MapSet.member?(evaluated, &1.test_case_id))
   end
+
+  # A state filter makes an action conditional on the test case's current
+  # control-plane state. It lets a skipped-test recovery leave a test alone
+  # after someone manually changes it to muted. Omitting the filter preserves
+  # the behavior of automations created before this option existed.
+  defp filter_by_current_state(items, _alert, config) when not is_map(config), do: items
+
+  defp filter_by_current_state(items, alert, config) do
+    case Map.get(config, "state") do
+      state when state in ["enabled", "muted", "skipped"] ->
+        states = Tests.get_test_case_states(alert.project_id, Enum.map(items, &test_case_id/1))
+
+        Enum.filter(items, fn item ->
+          Map.get(states, test_case_id(item), %{state: "enabled"}).state == state
+        end)
+
+      _ ->
+        items
+    end
+  end
+
+  defp test_case_id(%{test_case_id: test_case_id}), do: test_case_id
+  defp test_case_id(test_case_id), do: test_case_id
 
   # In `last_days` mode the recovery cooldown is "wait this long without a
   # re-trigger." In `rolling` mode it's "wait for at least this many new runs

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -258,33 +258,44 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       |> reject_unevaluated_this_tick(scoped_test_case_ids)
 
     # Re-arming (appending the "recovered" event so the next rising edge can
-    # fire again) happens for every alert once its condition clears — without
-    # it, an alert latches in `triggered` forever and silently stops acting.
-    # When recovery is enabled the user's dwell and undo actions apply; when
-    # it's disabled we re-arm the moment the condition clears (no dwell, no
-    # undo) and leave any effect in place until a human clears it. The
-    # persisted recovery_config is intentionally ignored on the disabled path
-    # because `Alert.changeset` only validates it when recovery is on.
-    {recovered, recovery_actions} =
+    # fire again) happens for every alert once its condition clears past the
+    # dwell window — without it, an alert latches in `triggered` forever and
+    # silently stops acting. When recovery is enabled the user's dwell gates
+    # re-arming and the undo actions run on top; when it's disabled we re-arm
+    # the moment the condition clears (no dwell, no undo) and leave any effect
+    # in place until a human clears it. The persisted recovery_config is
+    # intentionally ignored on the disabled path because `Alert.changeset`
+    # only validates it when recovery is on.
+    #
+    # The recovery STATE filter only gates whether the undo actions run — it
+    # must not gate re-arming. A test whose state was manually changed away
+    # from the recovery filter (e.g. someone muted a test the automation had
+    # skipped) should be left untouched by recovery, but the alert still has
+    # to re-arm once the dwell elapses, or it latches and can never trigger
+    # again for that test. So we re-arm every dwell-elapsed candidate and run
+    # the actions only on the subset that still matches the filter.
+    {to_rearm, actionable_ids} =
       if alert.recovery_enabled do
-        recovered =
-          candidates
-          |> filter_by_current_state(alert, alert.recovery_config)
-          |> then(&filter_recovered_candidates(alert, &1, alert.recovery_config || %{}))
-
-        {recovered, alert.recovery_actions}
+        elapsed = filter_recovered_candidates(alert, candidates, alert.recovery_config || %{})
+        actionable = filter_by_current_state(elapsed, alert, alert.recovery_config)
+        {elapsed, MapSet.new(actionable, & &1.test_case_id)}
       else
-        {candidates, []}
+        {candidates, MapSet.new([])}
       end
 
-    Enum.each(recovered, fn event ->
+    Enum.each(to_rearm, fn event ->
       entity = %{type: :test_case, id: event.test_case_id}
+
+      actions =
+        if MapSet.member?(actionable_ids, event.test_case_id),
+          do: alert.recovery_actions,
+          else: []
 
       # Run recovery actions BEFORE appending the "recovered" event. If we
       # flipped the order, a failure in the Slack ping / label removal /
       # state reset would leave the rule visually resolved while the user's
       # intended side effects never happened.
-      case ActionExecutor.execute_actions(recovery_actions, alert, entity) do
+      case ActionExecutor.execute_actions(actions, alert, entity) do
         :ok ->
           now = NaiveDateTime.utc_now()
 
@@ -321,15 +332,18 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   # control-plane state. It lets a skipped-test recovery leave a test alone
   # after someone manually changes it to muted. Omitting the filter preserves
   # the behavior of automations created before this option existed.
+  defp filter_by_current_state([], _alert, _config), do: []
+
   defp filter_by_current_state(items, _alert, config) when not is_map(config), do: items
 
   defp filter_by_current_state(items, alert, config) do
-    case Map.get(config, "state") do
-      state when state in ["enabled", "muted", "skipped"] ->
-        states = Tests.get_test_case_states(alert.project_id, Enum.map(items, &test_case_id/1))
+    case Map.get(config, "states") do
+      states when is_list(states) and states != [] ->
+        allowed = MapSet.new(states)
+        resolved = Tests.get_test_case_states(alert.project_id, Enum.map(items, &test_case_id/1))
 
         Enum.filter(items, fn item ->
-          Map.get(states, test_case_id(item), %{state: "enabled"}).state == state
+          Map.get(resolved, test_case_id(item), %{state: "enabled"}).state in allowed
         end)
 
       _ ->

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1097,6 +1097,21 @@ defmodule Tuist.Tests do
   # or flagged, so it resolves to the defaults.
   @default_test_case_state %{state: "enabled", is_flaky: false}
 
+  @doc """
+  Returns the current control-plane state for each requested test case.
+
+  Test cases without a state event are included as enabled so callers can
+  apply state-based policies without treating an absent projection row as an
+  unknown state.
+  """
+  def get_test_case_states(project_id, test_case_ids) do
+    resolved_states = resolve_test_case_states(project_id, test_case_ids)
+
+    Map.new(test_case_ids, fn test_case_id ->
+      {test_case_id, Map.get(resolved_states, test_case_id, @default_test_case_state)}
+    end)
+  end
+
   # Scoped by `project_id` (which the caller already read off the test case) so
   # this rides the `(project_id, test_case_id)` sort prefix instead of leaning
   # on the bloom-filter index across every tenant's rows.

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -66,11 +66,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     |> assign(create_automation_form_window: "30d")
     |> assign(create_automation_form_rolling_window_size: "75")
     |> assign(create_automation_form_events: ["marked_flaky"])
+    |> assign(create_automation_form_trigger_state: nil)
     |> assign(create_automation_form_trigger_actions: [default_add_label_action()])
     |> assign(create_automation_form_recovery_enabled: false)
     |> assign(create_automation_form_recovery_window_type: "last_days")
     |> assign(create_automation_form_recovery_window: "14d")
     |> assign(create_automation_form_recovery_rolling_window_size: "100")
+    |> assign(create_automation_form_recovery_state: nil)
     |> assign(create_automation_form_recovery_actions: [default_remove_label_action()])
   end
 
@@ -122,11 +124,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
       window: automation.trigger_config["window"] || "30d",
       rolling_window_size: to_string(automation.trigger_config["rolling_window_size"] || 75),
       events: parse_events(automation.trigger_config["events"]),
+      trigger_state: parse_state(automation.trigger_config["state"]),
       trigger_actions: automation.trigger_actions,
       recovery_enabled: automation.recovery_enabled,
       recovery_window_type: parse_window_type(automation.recovery_config["window_type"]),
       recovery_window: automation.recovery_config["window"] || "14d",
       recovery_rolling_window_size: to_string(automation.recovery_config["rolling_window_size"] || 100),
+      recovery_state: parse_state(automation.recovery_config["state"]),
       recovery_actions: automation.recovery_actions,
       enabled: automation.enabled
     }
@@ -143,6 +147,9 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   defp parse_window_type(window_type) when window_type in @window_types, do: window_type
   defp parse_window_type(_), do: "last_days"
+
+  defp parse_state(state) when state in ["enabled", "muted", "skipped"], do: state
+  defp parse_state(_), do: nil
 
   @impl true
   def handle_params(_params, _uri, socket) do
@@ -173,11 +180,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
         |> assign(create_automation_form_window: form.window)
         |> assign(create_automation_form_rolling_window_size: form.rolling_window_size)
         |> assign(create_automation_form_events: form.events)
+        |> assign(create_automation_form_trigger_state: form.trigger_state)
         |> assign(create_automation_form_trigger_actions: form.trigger_actions)
         |> assign(create_automation_form_recovery_enabled: form.recovery_enabled)
         |> assign(create_automation_form_recovery_window_type: form.recovery_window_type)
         |> assign(create_automation_form_recovery_window: form.recovery_window)
         |> assign(create_automation_form_recovery_rolling_window_size: form.recovery_rolling_window_size)
+        |> assign(create_automation_form_recovery_state: form.recovery_state)
         |> assign(create_automation_form_recovery_actions: form.recovery_actions)
         |> push_event("open-modal", %{id: "create-automation-modal"})
 
@@ -238,6 +247,10 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event("update_create_automation_form_threshold", %{"value" => value}, socket) do
     {:noreply, assign(socket, create_automation_form_threshold: value)}
+  end
+
+  def handle_event("update_create_automation_form_trigger_state", %{"data" => state}, socket) do
+    {:noreply, assign(socket, create_automation_form_trigger_state: parse_state(state))}
   end
 
   def handle_event("update_create_automation_form_window", %{"value" => value}, socket) do
@@ -324,6 +337,10 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event("update_create_automation_form_recovery_window", %{"value" => value}, socket) do
     {:noreply, assign(socket, create_automation_form_recovery_window: value)}
+  end
+
+  def handle_event("update_create_automation_form_recovery_state", %{"data" => state}, socket) do
+    {:noreply, assign(socket, create_automation_form_recovery_state: parse_state(state))}
   end
 
   def handle_event("update_create_automation_form_recovery_window_type", %{"data" => window_type}, socket) do
@@ -522,27 +539,30 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   defp trigger_config_for("test_updated", assigns) do
-    %{"events" => assigns.create_automation_form_events}
+    maybe_put_state(%{"events" => assigns.create_automation_form_events}, assigns.create_automation_form_trigger_state)
   end
 
   defp trigger_config_for(metric, assigns) do
-    build_trigger_config(
-      parse_threshold(metric, assigns.create_automation_form_threshold),
+    metric
+    |> parse_threshold(assigns.create_automation_form_threshold)
+    |> build_trigger_config(
       assigns.create_automation_form_comparison,
       assigns.create_automation_form_window_type,
       assigns.create_automation_form_window,
       assigns.create_automation_form_rolling_window_size
     )
+    |> maybe_put_state(assigns.create_automation_form_trigger_state)
   end
 
   defp recovery_config_for("test_updated", _assigns), do: %{}
 
   defp recovery_config_for(_metric, assigns) do
-    build_recovery_config(
-      assigns.create_automation_form_recovery_window_type,
+    assigns.create_automation_form_recovery_window_type
+    |> build_recovery_config(
       assigns.create_automation_form_recovery_window,
       assigns.create_automation_form_recovery_rolling_window_size
     )
+    |> maybe_put_state(assigns.create_automation_form_recovery_state)
   end
 
   defp build_trigger_config(threshold, comparison, "rolling", _window, rolling_window_size) do
@@ -576,6 +596,9 @@ defmodule TuistWeb.ProjectAutomationsLive do
       "window" => window
     }
   end
+
+  defp maybe_put_state(config, nil), do: config
+  defp maybe_put_state(config, state), do: Map.put(config, "state", state)
 
   # The default `add_label flaky` / `remove_label flaky` trigger actions
   # presume the threshold-monitor mental model. For the event-driven

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -66,13 +66,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     |> assign(create_automation_form_window: "30d")
     |> assign(create_automation_form_rolling_window_size: "75")
     |> assign(create_automation_form_events: ["marked_flaky"])
-    |> assign(create_automation_form_trigger_state: nil)
+    |> assign(create_automation_form_trigger_states: [])
     |> assign(create_automation_form_trigger_actions: [default_add_label_action()])
     |> assign(create_automation_form_recovery_enabled: false)
     |> assign(create_automation_form_recovery_window_type: "last_days")
     |> assign(create_automation_form_recovery_window: "14d")
     |> assign(create_automation_form_recovery_rolling_window_size: "100")
-    |> assign(create_automation_form_recovery_state: nil)
+    |> assign(create_automation_form_recovery_states: [])
     |> assign(create_automation_form_recovery_actions: [default_remove_label_action()])
   end
 
@@ -124,13 +124,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
       window: automation.trigger_config["window"] || "30d",
       rolling_window_size: to_string(automation.trigger_config["rolling_window_size"] || 75),
       events: parse_events(automation.trigger_config["events"]),
-      trigger_state: parse_state(automation.trigger_config["state"]),
+      trigger_states: parse_states(automation.trigger_config["states"]),
       trigger_actions: automation.trigger_actions,
       recovery_enabled: automation.recovery_enabled,
       recovery_window_type: parse_window_type(automation.recovery_config["window_type"]),
       recovery_window: automation.recovery_config["window"] || "14d",
       recovery_rolling_window_size: to_string(automation.recovery_config["rolling_window_size"] || 100),
-      recovery_state: parse_state(automation.recovery_config["state"]),
+      recovery_states: parse_states(automation.recovery_config["states"]),
       recovery_actions: automation.recovery_actions,
       enabled: automation.enabled
     }
@@ -148,8 +148,11 @@ defmodule TuistWeb.ProjectAutomationsLive do
   defp parse_window_type(window_type) when window_type in @window_types, do: window_type
   defp parse_window_type(_), do: "last_days"
 
-  defp parse_state(state) when state in ["enabled", "muted", "skipped"], do: state
-  defp parse_state(_), do: nil
+  defp parse_states(states) when is_list(states) do
+    Enum.filter(states, &(&1 in ["enabled", "muted", "skipped"]))
+  end
+
+  defp parse_states(_), do: []
 
   @impl true
   def handle_params(_params, _uri, socket) do
@@ -180,13 +183,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
         |> assign(create_automation_form_window: form.window)
         |> assign(create_automation_form_rolling_window_size: form.rolling_window_size)
         |> assign(create_automation_form_events: form.events)
-        |> assign(create_automation_form_trigger_state: form.trigger_state)
+        |> assign(create_automation_form_trigger_states: form.trigger_states)
         |> assign(create_automation_form_trigger_actions: form.trigger_actions)
         |> assign(create_automation_form_recovery_enabled: form.recovery_enabled)
         |> assign(create_automation_form_recovery_window_type: form.recovery_window_type)
         |> assign(create_automation_form_recovery_window: form.recovery_window)
         |> assign(create_automation_form_recovery_rolling_window_size: form.recovery_rolling_window_size)
-        |> assign(create_automation_form_recovery_state: form.recovery_state)
+        |> assign(create_automation_form_recovery_states: form.recovery_states)
         |> assign(create_automation_form_recovery_actions: form.recovery_actions)
         |> push_event("open-modal", %{id: "create-automation-modal"})
 
@@ -249,8 +252,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, assign(socket, create_automation_form_threshold: value)}
   end
 
-  def handle_event("update_create_automation_form_trigger_state", %{"data" => state}, socket) do
-    {:noreply, assign(socket, create_automation_form_trigger_state: parse_state(state))}
+  def handle_event("toggle_create_automation_form_trigger_state", %{"data" => state}, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :create_automation_form_trigger_states,
+       toggle_state(socket.assigns.create_automation_form_trigger_states, state)
+     )}
   end
 
   def handle_event("update_create_automation_form_window", %{"value" => value}, socket) do
@@ -339,8 +347,13 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, assign(socket, create_automation_form_recovery_window: value)}
   end
 
-  def handle_event("update_create_automation_form_recovery_state", %{"data" => state}, socket) do
-    {:noreply, assign(socket, create_automation_form_recovery_state: parse_state(state))}
+  def handle_event("toggle_create_automation_form_recovery_state", %{"data" => state}, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :create_automation_form_recovery_states,
+       toggle_state(socket.assigns.create_automation_form_recovery_states, state)
+     )}
   end
 
   def handle_event("update_create_automation_form_recovery_window_type", %{"data" => window_type}, socket) do
@@ -539,7 +552,10 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   defp trigger_config_for("test_updated", assigns) do
-    maybe_put_state(%{"events" => assigns.create_automation_form_events}, assigns.create_automation_form_trigger_state)
+    maybe_put_states(
+      %{"events" => assigns.create_automation_form_events},
+      assigns.create_automation_form_trigger_states
+    )
   end
 
   defp trigger_config_for(metric, assigns) do
@@ -551,7 +567,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
       assigns.create_automation_form_window,
       assigns.create_automation_form_rolling_window_size
     )
-    |> maybe_put_state(assigns.create_automation_form_trigger_state)
+    |> maybe_put_states(assigns.create_automation_form_trigger_states)
   end
 
   defp recovery_config_for("test_updated", _assigns), do: %{}
@@ -562,7 +578,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
       assigns.create_automation_form_recovery_window,
       assigns.create_automation_form_recovery_rolling_window_size
     )
-    |> maybe_put_state(assigns.create_automation_form_recovery_state)
+    |> maybe_put_states(assigns.create_automation_form_recovery_states)
   end
 
   defp build_trigger_config(threshold, comparison, "rolling", _window, rolling_window_size) do
@@ -597,8 +613,12 @@ defmodule TuistWeb.ProjectAutomationsLive do
     }
   end
 
-  defp maybe_put_state(config, nil), do: config
-  defp maybe_put_state(config, state), do: Map.put(config, "state", state)
+  defp maybe_put_states(config, []), do: config
+  defp maybe_put_states(config, states), do: Map.put(config, "states", states)
+
+  defp toggle_state(states, state) do
+    if state in states, do: List.delete(states, state), else: states ++ [state]
+  end
 
   # The default `add_label flaky` / `remove_label flaky` trigger actions
   # presume the threshold-monitor mental model. For the event-driven

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -318,36 +318,24 @@
                     </label>
                   </div>
                 </div>
-                <div data-part="form-row" data-size="dropdown">
+                <div data-part="form-row">
                   <label data-part="label">
-                    {dgettext("dashboard_projects", "Only apply when the test is")}
+                    {dgettext("dashboard_projects", "Only apply to tests in these states")}
                   </label>
-                  <.dropdown
-                    id="create-automation-trigger-state-dropdown"
-                    label={
-                      (@create_automation_form_trigger_state &&
-                         trigger_action_label(@create_automation_form_trigger_state)) ||
-                        dgettext("dashboard_projects", "In any state")
-                    }
-                  >
-                    <.dropdown_item
-                      value=""
-                      label={dgettext("dashboard_projects", "In any state")}
-                      on_click="update_create_automation_form_trigger_state"
-                      data-selected={is_nil(@create_automation_form_trigger_state)}
-                    >
-                      <:right_icon><.check /></:right_icon>
-                    </.dropdown_item>
-                    <.dropdown_item
+                  <div id="create-automation-trigger-states" data-part="event-checkbox-list">
+                    <label
                       :for={state <- ["enabled", "muted", "skipped"]}
-                      value={state}
-                      label={trigger_action_label(state)}
-                      on_click="update_create_automation_form_trigger_state"
-                      data-selected={@create_automation_form_trigger_state == state}
+                      id={"create-automation-trigger-state-#{state}"}
+                      data-part="event-checkbox"
+                      phx-click="toggle_create_automation_form_trigger_state"
+                      phx-value-data={state}
                     >
-                      <:right_icon><.check /></:right_icon>
-                    </.dropdown_item>
-                  </.dropdown>
+                      <.checkbox_control checked={state in @create_automation_form_trigger_states} />
+                      <div data-part="body">
+                        <span data-part="label">{trigger_action_label(state)}</span>
+                      </div>
+                    </label>
+                  </div>
                 </div>
               </div>
 
@@ -730,36 +718,26 @@
                       />
                     </div>
                   </div>
-                  <div data-part="form-row" data-size="dropdown">
+                  <div data-part="form-row">
                     <label data-part="label">
-                      {dgettext("dashboard_projects", "Only apply when the test is")}
+                      {dgettext("dashboard_projects", "Only apply to tests in these states")}
                     </label>
-                    <.dropdown
-                      id="create-automation-recovery-state-dropdown"
-                      label={
-                        (@create_automation_form_recovery_state &&
-                           trigger_action_label(@create_automation_form_recovery_state)) ||
-                          dgettext("dashboard_projects", "In any state")
-                      }
-                    >
-                      <.dropdown_item
-                        value=""
-                        label={dgettext("dashboard_projects", "In any state")}
-                        on_click="update_create_automation_form_recovery_state"
-                        data-selected={is_nil(@create_automation_form_recovery_state)}
-                      >
-                        <:right_icon><.check /></:right_icon>
-                      </.dropdown_item>
-                      <.dropdown_item
+                    <div id="create-automation-recovery-states" data-part="event-checkbox-list">
+                      <label
                         :for={state <- ["enabled", "muted", "skipped"]}
-                        value={state}
-                        label={trigger_action_label(state)}
-                        on_click="update_create_automation_form_recovery_state"
-                        data-selected={@create_automation_form_recovery_state == state}
+                        id={"create-automation-recovery-state-#{state}"}
+                        data-part="event-checkbox"
+                        phx-click="toggle_create_automation_form_recovery_state"
+                        phx-value-data={state}
                       >
-                        <:right_icon><.check /></:right_icon>
-                      </.dropdown_item>
-                    </.dropdown>
+                        <.checkbox_control checked={
+                          state in @create_automation_form_recovery_states
+                        } />
+                        <div data-part="body">
+                          <span data-part="label">{trigger_action_label(state)}</span>
+                        </div>
+                      </label>
+                    </div>
                   </div>
                   <div
                     :for={

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -325,8 +325,8 @@
                   <.dropdown
                     id="create-automation-trigger-state-dropdown"
                     label={
-                      @create_automation_form_trigger_state &&
-                        trigger_action_label(@create_automation_form_trigger_state) ||
+                      (@create_automation_form_trigger_state &&
+                         trigger_action_label(@create_automation_form_trigger_state)) ||
                         dgettext("dashboard_projects", "In any state")
                     }
                   >
@@ -737,8 +737,8 @@
                     <.dropdown
                       id="create-automation-recovery-state-dropdown"
                       label={
-                        @create_automation_form_recovery_state &&
-                          trigger_action_label(@create_automation_form_recovery_state) ||
+                        (@create_automation_form_recovery_state &&
+                           trigger_action_label(@create_automation_form_recovery_state)) ||
                           dgettext("dashboard_projects", "In any state")
                       }
                     >

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -318,6 +318,37 @@
                     </label>
                   </div>
                 </div>
+                <div data-part="form-row" data-size="dropdown">
+                  <label data-part="label">
+                    {dgettext("dashboard_projects", "Only apply when the test is")}
+                  </label>
+                  <.dropdown
+                    id="create-automation-trigger-state-dropdown"
+                    label={
+                      @create_automation_form_trigger_state &&
+                        trigger_action_label(@create_automation_form_trigger_state) ||
+                        dgettext("dashboard_projects", "In any state")
+                    }
+                  >
+                    <.dropdown_item
+                      value=""
+                      label={dgettext("dashboard_projects", "In any state")}
+                      on_click="update_create_automation_form_trigger_state"
+                      data-selected={is_nil(@create_automation_form_trigger_state)}
+                    >
+                      <:right_icon><.check /></:right_icon>
+                    </.dropdown_item>
+                    <.dropdown_item
+                      :for={state <- ["enabled", "muted", "skipped"]}
+                      value={state}
+                      label={trigger_action_label(state)}
+                      on_click="update_create_automation_form_trigger_state"
+                      data-selected={@create_automation_form_trigger_state == state}
+                    >
+                      <:right_icon><.check /></:right_icon>
+                    </.dropdown_item>
+                  </.dropdown>
+                </div>
               </div>
 
               <.line_divider />
@@ -698,6 +729,37 @@
                         phx-debounce="300"
                       />
                     </div>
+                  </div>
+                  <div data-part="form-row" data-size="dropdown">
+                    <label data-part="label">
+                      {dgettext("dashboard_projects", "Only apply when the test is")}
+                    </label>
+                    <.dropdown
+                      id="create-automation-recovery-state-dropdown"
+                      label={
+                        @create_automation_form_recovery_state &&
+                          trigger_action_label(@create_automation_form_recovery_state) ||
+                          dgettext("dashboard_projects", "In any state")
+                      }
+                    >
+                      <.dropdown_item
+                        value=""
+                        label={dgettext("dashboard_projects", "In any state")}
+                        on_click="update_create_automation_form_recovery_state"
+                        data-selected={is_nil(@create_automation_form_recovery_state)}
+                      >
+                        <:right_icon><.check /></:right_icon>
+                      </.dropdown_item>
+                      <.dropdown_item
+                        :for={state <- ["enabled", "muted", "skipped"]}
+                        value={state}
+                        label={trigger_action_label(state)}
+                        on_click="update_create_automation_form_recovery_state"
+                        data-selected={@create_automation_form_recovery_state == state}
+                      >
+                        <:right_icon><.check /></:right_icon>
+                      </.dropdown_item>
+                    </.dropdown>
                   </div>
                   <div
                     :for={

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cache effectiveness represents the combined hit rate of both Module cache and Xcode cache, showing the percentage of cacheable items that were resolved from cache rather than being rebuilt."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:858
+#: lib/tuist_web/live/project_automations_live.html.heex:920
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
@@ -273,7 +273,7 @@ msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:87
 #: lib/tuist_web/live/project_automations_live.html.heex:82
-#: lib/tuist_web/live/project_automations_live.html.heex:899
+#: lib/tuist_web/live/project_automations_live.html.heex:961
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:868
+#: lib/tuist_web/live/project_automations_live.html.heex:930
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #: lib/tuist_web/live/project_settings_live.html.heex:149
@@ -624,9 +624,9 @@ msgstr ""
 msgid "Test duration"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:779
+#: lib/tuist_web/live/project_automations_live.ex:802
 #: lib/tuist_web/live/project_automations_live.html.heex:238
-#: lib/tuist_web/live/project_automations_live.html.heex:645
+#: lib/tuist_web/live/project_automations_live.html.heex:676
 #: lib/tuist_web/live/project_notifications_live.html.heex:393
 #: lib/tuist_web/live/project_notifications_live.html.heex:533
 #: lib/tuist_web/live/project_notifications_live.html.heex:717
@@ -696,8 +696,8 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:456
-#: lib/tuist_web/live/project_automations_live.html.heex:763
+#: lib/tuist_web/live/project_automations_live.html.heex:487
+#: lib/tuist_web/live/project_automations_live.html.heex:825
 #: lib/tuist_web/live/project_notifications_live.html.heex:206
 #: lib/tuist_web/live/project_notifications_live.html.heex:216
 #: lib/tuist_web/live/project_notifications_live.html.heex:473
@@ -707,8 +707,8 @@ msgstr ""
 msgid "Select channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:455
-#: lib/tuist_web/live/project_automations_live.html.heex:762
+#: lib/tuist_web/live/project_automations_live.html.heex:486
+#: lib/tuist_web/live/project_automations_live.html.heex:824
 #: lib/tuist_web/live/project_notifications_live.html.heex:215
 #: lib/tuist_web/live/project_notifications_live.html.heex:472
 #: lib/tuist_web/live/project_notifications_live.html.heex:810
@@ -753,7 +753,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:869
+#: lib/tuist_web/live/project_automations_live.html.heex:931
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:500
 #: lib/tuist_web/live/projects_live.ex:400
@@ -1017,12 +1017,12 @@ msgstr ""
 msgid "Select organization"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:329
+#: lib/tuist_web/live/project_automations_live.html.heex:360
 #, elixir-autogen, elixir-format
 msgid "Action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:340
+#: lib/tuist_web/live/project_automations_live.html.heex:371
 #, elixir-autogen, elixir-format
 msgid "Add action"
 msgstr ""
@@ -1032,36 +1032,36 @@ msgstr ""
 msgid "Add automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:682
+#: lib/tuist_web/live/project_automations_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Add label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:703
+#: lib/tuist_web/live/project_automations_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Add label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:569
+#: lib/tuist_web/live/project_automations_live.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "Add recovery action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:510
-#: lib/tuist_web/live/project_automations_live.html.heex:817
+#: lib/tuist_web/live/project_automations_live.html.heex:541
+#: lib/tuist_web/live/project_automations_live.html.heex:879
 #, elixir-autogen, elixir-format
 msgid "Available variables:"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:680
-#: lib/tuist_web/live/project_automations_live.html.heex:350
-#: lib/tuist_web/live/project_automations_live.html.heex:579
+#: lib/tuist_web/live/project_automations_live.ex:703
+#: lib/tuist_web/live/project_automations_live.html.heex:381
+#: lib/tuist_web/live/project_automations_live.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "Change state"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:404
-#: lib/tuist_web/live/project_automations_live.html.heex:711
+#: lib/tuist_web/live/project_automations_live.html.heex:435
+#: lib/tuist_web/live/project_automations_live.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "Change state to"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Create automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:925
+#: lib/tuist_web/live/project_automations_live.html.heex:987
 #, elixir-autogen, elixir-format
 msgid "Delete this automation?"
 msgstr ""
@@ -1091,100 +1091,100 @@ msgstr ""
 msgid "Edit automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:672
+#: lib/tuist_web/live/project_automations_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Enable"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:677
-#: lib/tuist_web/live/project_automations_live.html.heex:430
-#: lib/tuist_web/live/project_automations_live.html.heex:719
+#: lib/tuist_web/live/project_automations_live.ex:700
+#: lib/tuist_web/live/project_automations_live.html.heex:461
+#: lib/tuist_web/live/project_automations_live.html.heex:781
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:502
-#: lib/tuist_web/live/project_automations_live.html.heex:809
+#: lib/tuist_web/live/project_automations_live.html.heex:533
+#: lib/tuist_web/live/project_automations_live.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Enter message template..."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:619
+#: lib/tuist_web/live/project_automations_live.ex:642
 #: lib/tuist_web/live/project_automations_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:620
+#: lib/tuist_web/live/project_automations_live.ex:643
 #: lib/tuist_web/live/project_automations_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:367
-#: lib/tuist_web/live/project_automations_live.html.heex:613
+#: lib/tuist_web/live/project_automations_live.html.heex:398
+#: lib/tuist_web/live/project_automations_live.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:522
-#: lib/tuist_web/live/project_automations_live.html.heex:829
+#: lib/tuist_web/live/project_automations_live.html.heex:553
+#: lib/tuist_web/live/project_automations_live.html.heex:891
 #, elixir-autogen, elixir-format
 msgid "Mark test as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:480
-#: lib/tuist_web/live/project_automations_live.html.heex:787
+#: lib/tuist_web/live/project_automations_live.html.heex:511
+#: lib/tuist_web/live/project_automations_live.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Message template"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:887
+#: lib/tuist_web/live/project_automations_live.html.heex:949
 #, elixir-autogen, elixir-format
 msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:557
+#: lib/tuist_web/live/project_automations_live.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Recovery"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:683
+#: lib/tuist_web/live/project_automations_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Remove label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:706
+#: lib/tuist_web/live/project_automations_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "Remove label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:560
+#: lib/tuist_web/live/project_automations_live.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Run actions when the conditions no longer hold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:332
+#: lib/tuist_web/live/project_automations_live.html.heex:363
 #, elixir-autogen, elixir-format
 msgid "Run these actions for each test case that meets the condition"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:681
-#: lib/tuist_web/live/project_automations_live.html.heex:389
-#: lib/tuist_web/live/project_automations_live.html.heex:443
-#: lib/tuist_web/live/project_automations_live.html.heex:618
-#: lib/tuist_web/live/project_automations_live.html.heex:750
+#: lib/tuist_web/live/project_automations_live.ex:704
+#: lib/tuist_web/live/project_automations_live.html.heex:420
+#: lib/tuist_web/live/project_automations_live.html.heex:474
+#: lib/tuist_web/live/project_automations_live.html.heex:649
+#: lib/tuist_web/live/project_automations_live.html.heex:812
 #, elixir-autogen, elixir-format
 msgid "Send Slack notification"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:700
+#: lib/tuist_web/live/project_automations_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Slack: not configured"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:483
-#: lib/tuist_web/live/project_automations_live.html.heex:790
+#: lib/tuist_web/live/project_automations_live.html.heex:514
+#: lib/tuist_web/live/project_automations_live.html.heex:852
 #, elixir-autogen, elixir-format
 msgid "Supports Slack"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Test case automations"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:902
+#: lib/tuist_web/live/project_automations_live.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "Trigger"
 msgstr ""
@@ -1204,24 +1204,24 @@ msgstr ""
 msgid "Trigger the automation when this condition is met"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:623
-#: lib/tuist_web/live/project_automations_live.ex:634
+#: lib/tuist_web/live/project_automations_live.ex:646
 #: lib/tuist_web/live/project_automations_live.ex:657
-#: lib/tuist_web/live/project_automations_live.ex:673
-#: lib/tuist_web/live/project_automations_live.ex:678
-#: lib/tuist_web/live/project_automations_live.ex:684
+#: lib/tuist_web/live/project_automations_live.ex:680
+#: lib/tuist_web/live/project_automations_live.ex:696
+#: lib/tuist_web/live/project_automations_live.ex:701
+#: lib/tuist_web/live/project_automations_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:384
-#: lib/tuist_web/live/project_automations_live.html.heex:596
+#: lib/tuist_web/live/project_automations_live.html.heex:415
+#: lib/tuist_web/live/project_automations_live.html.heex:627
 #, elixir-autogen, elixir-format
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:526
-#: lib/tuist_web/live/project_automations_live.html.heex:833
+#: lib/tuist_web/live/project_automations_live.html.heex:557
+#: lib/tuist_web/live/project_automations_live.html.heex:895
 #, elixir-autogen, elixir-format
 msgid "Unmark test as flaky"
 msgstr ""
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "When"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:627
+#: lib/tuist_web/live/project_automations_live.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "Without trigger for"
 msgstr ""
@@ -1241,32 +1241,32 @@ msgstr ""
 msgid "e.g. Auto-quarantine flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:491
-#: lib/tuist_web/live/project_automations_live.html.heex:798
+#: lib/tuist_web/live/project_automations_live.html.heex:522
+#: lib/tuist_web/live/project_automations_live.html.heex:860
 #, elixir-autogen, elixir-format
 msgid "formatting."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:670
+#: lib/tuist_web/live/project_automations_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:675
-#: lib/tuist_web/live/project_automations_live.html.heex:412
-#: lib/tuist_web/live/project_automations_live.html.heex:728
+#: lib/tuist_web/live/project_automations_live.ex:698
+#: lib/tuist_web/live/project_automations_live.html.heex:443
+#: lib/tuist_web/live/project_automations_live.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:671
+#: lib/tuist_web/live/project_automations_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "Skip"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:676
-#: lib/tuist_web/live/project_automations_live.html.heex:421
-#: lib/tuist_web/live/project_automations_live.html.heex:737
+#: lib/tuist_web/live/project_automations_live.ex:699
+#: lib/tuist_web/live/project_automations_live.html.heex:452
+#: lib/tuist_web/live/project_automations_live.html.heex:799
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -1276,65 +1276,65 @@ msgstr ""
 msgid "Comparison"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:667
+#: lib/tuist_web/live/project_automations_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Count"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:653
+#: lib/tuist_web/live/project_automations_live.ex:676
 #: lib/tuist_web/live/project_automations_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Greater or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:654
+#: lib/tuist_web/live/project_automations_live.ex:677
 #: lib/tuist_web/live/project_automations_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Greater than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:656
+#: lib/tuist_web/live/project_automations_live.ex:679
 #: lib/tuist_web/live/project_automations_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Less or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:655
+#: lib/tuist_web/live/project_automations_live.ex:678
 #: lib/tuist_web/live/project_automations_live.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:665
-#: lib/tuist_web/live/project_automations_live.ex:666
+#: lib/tuist_web/live/project_automations_live.ex:688
+#: lib/tuist_web/live/project_automations_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Percent"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:668
+#: lib/tuist_web/live/project_automations_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Threshold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:714
+#: lib/tuist_web/live/project_automations_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "When flakiness rate %{symbol} %{threshold}% over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:727
+#: lib/tuist_web/live/project_automations_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "When flaky runs %{symbol} %{threshold} over %{window}"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:276
-#: lib/tuist_web/live/project_automations_live.html.heex:679
+#: lib/tuist_web/live/project_automations_live.html.heex:710
 #, elixir-autogen, elixir-format
 msgid "Last N runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:780
+#: lib/tuist_web/live/project_automations_live.ex:803
 #: lib/tuist_web/live/project_automations_live.html.heex:230
-#: lib/tuist_web/live/project_automations_live.html.heex:635
+#: lib/tuist_web/live/project_automations_live.html.heex:666
 #, elixir-autogen, elixir-format
 msgid "Last days"
 msgstr ""
@@ -1345,47 +1345,47 @@ msgid "Over"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:255
-#: lib/tuist_web/live/project_automations_live.html.heex:661
+#: lib/tuist_web/live/project_automations_live.html.heex:692
 #, elixir-autogen, elixir-format
 msgid "Window"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:767
+#: lib/tuist_web/live/project_automations_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:816
+#: lib/tuist_web/live/project_automations_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:637
+#: lib/tuist_web/live/project_automations_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is manually flagged as flaky."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:646
+#: lib/tuist_web/live/project_automations_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is muted (still runs, failures ignored)."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:649
+#: lib/tuist_web/live/project_automations_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is skipped entirely."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:643
+#: lib/tuist_web/live/project_automations_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Fires when a test returns to the default enabled state."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:640
+#: lib/tuist_web/live/project_automations_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Fires when the flaky flag is manually removed."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:625
+#: lib/tuist_web/live/project_automations_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -1395,38 +1395,38 @@ msgstr ""
 msgid "On these events"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:628
+#: lib/tuist_web/live/project_automations_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "State changed to Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:630
+#: lib/tuist_web/live/project_automations_live.ex:653
 #, elixir-autogen, elixir-format
 msgid "State changed to Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:632
+#: lib/tuist_web/live/project_automations_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "State changed to Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:622
+#: lib/tuist_web/live/project_automations_live.ex:645
 #: lib/tuist_web/live/project_automations_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Test updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:626
+#: lib/tuist_web/live/project_automations_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:754
+#: lib/tuist_web/live/project_automations_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "When a test is updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:758
+#: lib/tuist_web/live/project_automations_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "When a test is updated: %{events}"
 msgstr ""
@@ -1436,13 +1436,13 @@ msgstr ""
 msgid "New Project"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:621
+#: lib/tuist_web/live/project_automations_live.ex:644
 #: lib/tuist_web/live/project_automations_live.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:740
+#: lib/tuist_web/live/project_automations_live.ex:763
 #, elixir-autogen, elixir-format
 msgid "When test reliability across branches %{symbol} %{threshold}% over %{window}"
 msgstr ""
@@ -1482,7 +1482,21 @@ msgstr ""
 msgid "can't be blank"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:462
+#: lib/tuist_web/live/project_automations_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "This automation uses an unsupported trigger configuration. Edit it before enabling it."
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:330
+#: lib/tuist_web/live/project_automations_live.html.heex:335
+#: lib/tuist_web/live/project_automations_live.html.heex:742
+#: lib/tuist_web/live/project_automations_live.html.heex:747
+#, elixir-autogen, elixir-format
+msgid "In any state"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:323
+#: lib/tuist_web/live/project_automations_live.html.heex:735
+#, elixir-autogen, elixir-format
+msgid "Only apply when the test is"
 msgstr ""

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cache effectiveness represents the combined hit rate of both Module cache and Xcode cache, showing the percentage of cacheable items that were resolved from cache rather than being rebuilt."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:896
+#: lib/tuist_web/live/project_automations_live.html.heex:898
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
@@ -273,7 +273,7 @@ msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:87
 #: lib/tuist_web/live/project_automations_live.html.heex:82
-#: lib/tuist_web/live/project_automations_live.html.heex:937
+#: lib/tuist_web/live/project_automations_live.html.heex:939
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:906
+#: lib/tuist_web/live/project_automations_live.html.heex:908
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #: lib/tuist_web/live/project_settings_live.html.heex:149
@@ -697,7 +697,7 @@ msgid "Slack"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:475
-#: lib/tuist_web/live/project_automations_live.html.heex:801
+#: lib/tuist_web/live/project_automations_live.html.heex:803
 #: lib/tuist_web/live/project_notifications_live.html.heex:206
 #: lib/tuist_web/live/project_notifications_live.html.heex:216
 #: lib/tuist_web/live/project_notifications_live.html.heex:473
@@ -708,7 +708,7 @@ msgid "Select channel"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:474
-#: lib/tuist_web/live/project_automations_live.html.heex:800
+#: lib/tuist_web/live/project_automations_live.html.heex:802
 #: lib/tuist_web/live/project_notifications_live.html.heex:215
 #: lib/tuist_web/live/project_notifications_live.html.heex:472
 #: lib/tuist_web/live/project_notifications_live.html.heex:810
@@ -753,7 +753,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:907
+#: lib/tuist_web/live/project_automations_live.html.heex:909
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:500
 #: lib/tuist_web/live/projects_live.ex:400
@@ -1048,7 +1048,7 @@ msgid "Add recovery action"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:529
-#: lib/tuist_web/live/project_automations_live.html.heex:855
+#: lib/tuist_web/live/project_automations_live.html.heex:857
 #, elixir-autogen, elixir-format
 msgid "Available variables:"
 msgstr ""
@@ -1061,7 +1061,7 @@ msgid "Change state"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:423
-#: lib/tuist_web/live/project_automations_live.html.heex:749
+#: lib/tuist_web/live/project_automations_live.html.heex:751
 #, elixir-autogen, elixir-format
 msgid "Change state to"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Create automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:963
+#: lib/tuist_web/live/project_automations_live.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Delete this automation?"
 msgstr ""
@@ -1098,13 +1098,13 @@ msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.ex:720
 #: lib/tuist_web/live/project_automations_live.html.heex:449
-#: lib/tuist_web/live/project_automations_live.html.heex:757
+#: lib/tuist_web/live/project_automations_live.html.heex:759
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:521
-#: lib/tuist_web/live/project_automations_live.html.heex:847
+#: lib/tuist_web/live/project_automations_live.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Enter message template..."
 msgstr ""
@@ -1128,18 +1128,18 @@ msgid "Mark as flaky"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:541
-#: lib/tuist_web/live/project_automations_live.html.heex:867
+#: lib/tuist_web/live/project_automations_live.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Mark test as flaky"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:499
-#: lib/tuist_web/live/project_automations_live.html.heex:825
+#: lib/tuist_web/live/project_automations_live.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "Message template"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:925
+#: lib/tuist_web/live/project_automations_live.html.heex:927
 #, elixir-autogen, elixir-format
 msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 #: lib/tuist_web/live/project_automations_live.html.heex:408
 #: lib/tuist_web/live/project_automations_live.html.heex:462
 #: lib/tuist_web/live/project_automations_live.html.heex:637
-#: lib/tuist_web/live/project_automations_live.html.heex:788
+#: lib/tuist_web/live/project_automations_live.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "Send Slack notification"
 msgstr ""
@@ -1184,7 +1184,7 @@ msgid "Slack: not configured"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:502
-#: lib/tuist_web/live/project_automations_live.html.heex:828
+#: lib/tuist_web/live/project_automations_live.html.heex:830
 #, elixir-autogen, elixir-format
 msgid "Supports Slack"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Test case automations"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:940
+#: lib/tuist_web/live/project_automations_live.html.heex:942
 #, elixir-autogen, elixir-format
 msgid "Trigger"
 msgstr ""
@@ -1221,7 +1221,7 @@ msgid "Unmark as flaky"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:545
-#: lib/tuist_web/live/project_automations_live.html.heex:871
+#: lib/tuist_web/live/project_automations_live.html.heex:873
 #, elixir-autogen, elixir-format
 msgid "Unmark test as flaky"
 msgstr ""
@@ -1242,7 +1242,7 @@ msgid "e.g. Auto-quarantine flaky tests"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:510
-#: lib/tuist_web/live/project_automations_live.html.heex:836
+#: lib/tuist_web/live/project_automations_live.html.heex:838
 #, elixir-autogen, elixir-format
 msgid "formatting."
 msgstr ""
@@ -1254,7 +1254,7 @@ msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.ex:718
 #: lib/tuist_web/live/project_automations_live.html.heex:431
-#: lib/tuist_web/live/project_automations_live.html.heex:766
+#: lib/tuist_web/live/project_automations_live.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.ex:719
 #: lib/tuist_web/live/project_automations_live.html.heex:440
-#: lib/tuist_web/live/project_automations_live.html.heex:775
+#: lib/tuist_web/live/project_automations_live.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cache effectiveness represents the combined hit rate of both Module cache and Xcode cache, showing the percentage of cacheable items that were resolved from cache rather than being rebuilt."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:920
+#: lib/tuist_web/live/project_automations_live.html.heex:896
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
@@ -273,7 +273,7 @@ msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:87
 #: lib/tuist_web/live/project_automations_live.html.heex:82
-#: lib/tuist_web/live/project_automations_live.html.heex:961
+#: lib/tuist_web/live/project_automations_live.html.heex:937
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:930
+#: lib/tuist_web/live/project_automations_live.html.heex:906
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #: lib/tuist_web/live/project_settings_live.html.heex:149
@@ -624,9 +624,9 @@ msgstr ""
 msgid "Test duration"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:802
+#: lib/tuist_web/live/project_automations_live.ex:822
 #: lib/tuist_web/live/project_automations_live.html.heex:238
-#: lib/tuist_web/live/project_automations_live.html.heex:676
+#: lib/tuist_web/live/project_automations_live.html.heex:664
 #: lib/tuist_web/live/project_notifications_live.html.heex:393
 #: lib/tuist_web/live/project_notifications_live.html.heex:533
 #: lib/tuist_web/live/project_notifications_live.html.heex:717
@@ -696,8 +696,8 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:487
-#: lib/tuist_web/live/project_automations_live.html.heex:825
+#: lib/tuist_web/live/project_automations_live.html.heex:475
+#: lib/tuist_web/live/project_automations_live.html.heex:801
 #: lib/tuist_web/live/project_notifications_live.html.heex:206
 #: lib/tuist_web/live/project_notifications_live.html.heex:216
 #: lib/tuist_web/live/project_notifications_live.html.heex:473
@@ -707,8 +707,8 @@ msgstr ""
 msgid "Select channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:486
-#: lib/tuist_web/live/project_automations_live.html.heex:824
+#: lib/tuist_web/live/project_automations_live.html.heex:474
+#: lib/tuist_web/live/project_automations_live.html.heex:800
 #: lib/tuist_web/live/project_notifications_live.html.heex:215
 #: lib/tuist_web/live/project_notifications_live.html.heex:472
 #: lib/tuist_web/live/project_notifications_live.html.heex:810
@@ -753,7 +753,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:931
+#: lib/tuist_web/live/project_automations_live.html.heex:907
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:500
 #: lib/tuist_web/live/projects_live.ex:400
@@ -1017,12 +1017,12 @@ msgstr ""
 msgid "Select organization"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:360
+#: lib/tuist_web/live/project_automations_live.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:371
+#: lib/tuist_web/live/project_automations_live.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Add action"
 msgstr ""
@@ -1032,36 +1032,36 @@ msgstr ""
 msgid "Add automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:705
+#: lib/tuist_web/live/project_automations_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Add label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:726
+#: lib/tuist_web/live/project_automations_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Add label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:600
+#: lib/tuist_web/live/project_automations_live.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Add recovery action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:541
-#: lib/tuist_web/live/project_automations_live.html.heex:879
+#: lib/tuist_web/live/project_automations_live.html.heex:529
+#: lib/tuist_web/live/project_automations_live.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "Available variables:"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:703
-#: lib/tuist_web/live/project_automations_live.html.heex:381
-#: lib/tuist_web/live/project_automations_live.html.heex:610
+#: lib/tuist_web/live/project_automations_live.ex:723
+#: lib/tuist_web/live/project_automations_live.html.heex:369
+#: lib/tuist_web/live/project_automations_live.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Change state"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:435
-#: lib/tuist_web/live/project_automations_live.html.heex:773
+#: lib/tuist_web/live/project_automations_live.html.heex:423
+#: lib/tuist_web/live/project_automations_live.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "Change state to"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Create automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:987
+#: lib/tuist_web/live/project_automations_live.html.heex:963
 #, elixir-autogen, elixir-format
 msgid "Delete this automation?"
 msgstr ""
@@ -1091,100 +1091,100 @@ msgstr ""
 msgid "Edit automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:695
+#: lib/tuist_web/live/project_automations_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Enable"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:700
-#: lib/tuist_web/live/project_automations_live.html.heex:461
-#: lib/tuist_web/live/project_automations_live.html.heex:781
+#: lib/tuist_web/live/project_automations_live.ex:720
+#: lib/tuist_web/live/project_automations_live.html.heex:449
+#: lib/tuist_web/live/project_automations_live.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:533
-#: lib/tuist_web/live/project_automations_live.html.heex:871
+#: lib/tuist_web/live/project_automations_live.html.heex:521
+#: lib/tuist_web/live/project_automations_live.html.heex:847
 #, elixir-autogen, elixir-format
 msgid "Enter message template..."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:642
+#: lib/tuist_web/live/project_automations_live.ex:662
 #: lib/tuist_web/live/project_automations_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:643
+#: lib/tuist_web/live/project_automations_live.ex:663
 #: lib/tuist_web/live/project_automations_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:398
-#: lib/tuist_web/live/project_automations_live.html.heex:644
+#: lib/tuist_web/live/project_automations_live.html.heex:386
+#: lib/tuist_web/live/project_automations_live.html.heex:632
 #, elixir-autogen, elixir-format
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:553
-#: lib/tuist_web/live/project_automations_live.html.heex:891
+#: lib/tuist_web/live/project_automations_live.html.heex:541
+#: lib/tuist_web/live/project_automations_live.html.heex:867
 #, elixir-autogen, elixir-format
 msgid "Mark test as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:511
-#: lib/tuist_web/live/project_automations_live.html.heex:849
+#: lib/tuist_web/live/project_automations_live.html.heex:499
+#: lib/tuist_web/live/project_automations_live.html.heex:825
 #, elixir-autogen, elixir-format
 msgid "Message template"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:949
+#: lib/tuist_web/live/project_automations_live.html.heex:925
 #, elixir-autogen, elixir-format
 msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:588
+#: lib/tuist_web/live/project_automations_live.html.heex:576
 #, elixir-autogen, elixir-format
 msgid "Recovery"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:706
+#: lib/tuist_web/live/project_automations_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Remove label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:729
+#: lib/tuist_web/live/project_automations_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "Remove label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:591
+#: lib/tuist_web/live/project_automations_live.html.heex:579
 #, elixir-autogen, elixir-format
 msgid "Run actions when the conditions no longer hold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:363
+#: lib/tuist_web/live/project_automations_live.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "Run these actions for each test case that meets the condition"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:704
-#: lib/tuist_web/live/project_automations_live.html.heex:420
-#: lib/tuist_web/live/project_automations_live.html.heex:474
-#: lib/tuist_web/live/project_automations_live.html.heex:649
-#: lib/tuist_web/live/project_automations_live.html.heex:812
+#: lib/tuist_web/live/project_automations_live.ex:724
+#: lib/tuist_web/live/project_automations_live.html.heex:408
+#: lib/tuist_web/live/project_automations_live.html.heex:462
+#: lib/tuist_web/live/project_automations_live.html.heex:637
+#: lib/tuist_web/live/project_automations_live.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "Send Slack notification"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:723
+#: lib/tuist_web/live/project_automations_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "Slack: not configured"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:514
-#: lib/tuist_web/live/project_automations_live.html.heex:852
+#: lib/tuist_web/live/project_automations_live.html.heex:502
+#: lib/tuist_web/live/project_automations_live.html.heex:828
 #, elixir-autogen, elixir-format
 msgid "Supports Slack"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Test case automations"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:964
+#: lib/tuist_web/live/project_automations_live.html.heex:940
 #, elixir-autogen, elixir-format
 msgid "Trigger"
 msgstr ""
@@ -1204,24 +1204,24 @@ msgstr ""
 msgid "Trigger the automation when this condition is met"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:646
-#: lib/tuist_web/live/project_automations_live.ex:657
-#: lib/tuist_web/live/project_automations_live.ex:680
-#: lib/tuist_web/live/project_automations_live.ex:696
-#: lib/tuist_web/live/project_automations_live.ex:701
-#: lib/tuist_web/live/project_automations_live.ex:707
+#: lib/tuist_web/live/project_automations_live.ex:666
+#: lib/tuist_web/live/project_automations_live.ex:677
+#: lib/tuist_web/live/project_automations_live.ex:700
+#: lib/tuist_web/live/project_automations_live.ex:716
+#: lib/tuist_web/live/project_automations_live.ex:721
+#: lib/tuist_web/live/project_automations_live.ex:727
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:415
-#: lib/tuist_web/live/project_automations_live.html.heex:627
+#: lib/tuist_web/live/project_automations_live.html.heex:403
+#: lib/tuist_web/live/project_automations_live.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:557
-#: lib/tuist_web/live/project_automations_live.html.heex:895
+#: lib/tuist_web/live/project_automations_live.html.heex:545
+#: lib/tuist_web/live/project_automations_live.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Unmark test as flaky"
 msgstr ""
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "When"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:658
+#: lib/tuist_web/live/project_automations_live.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Without trigger for"
 msgstr ""
@@ -1241,32 +1241,32 @@ msgstr ""
 msgid "e.g. Auto-quarantine flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:522
-#: lib/tuist_web/live/project_automations_live.html.heex:860
+#: lib/tuist_web/live/project_automations_live.html.heex:510
+#: lib/tuist_web/live/project_automations_live.html.heex:836
 #, elixir-autogen, elixir-format
 msgid "formatting."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:693
+#: lib/tuist_web/live/project_automations_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:698
-#: lib/tuist_web/live/project_automations_live.html.heex:443
-#: lib/tuist_web/live/project_automations_live.html.heex:790
+#: lib/tuist_web/live/project_automations_live.ex:718
+#: lib/tuist_web/live/project_automations_live.html.heex:431
+#: lib/tuist_web/live/project_automations_live.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:694
+#: lib/tuist_web/live/project_automations_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Skip"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:699
-#: lib/tuist_web/live/project_automations_live.html.heex:452
-#: lib/tuist_web/live/project_automations_live.html.heex:799
+#: lib/tuist_web/live/project_automations_live.ex:719
+#: lib/tuist_web/live/project_automations_live.html.heex:440
+#: lib/tuist_web/live/project_automations_live.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -1276,65 +1276,65 @@ msgstr ""
 msgid "Comparison"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:690
+#: lib/tuist_web/live/project_automations_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "Count"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:676
+#: lib/tuist_web/live/project_automations_live.ex:696
 #: lib/tuist_web/live/project_automations_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Greater or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:677
+#: lib/tuist_web/live/project_automations_live.ex:697
 #: lib/tuist_web/live/project_automations_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Greater than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:679
+#: lib/tuist_web/live/project_automations_live.ex:699
 #: lib/tuist_web/live/project_automations_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Less or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:678
+#: lib/tuist_web/live/project_automations_live.ex:698
 #: lib/tuist_web/live/project_automations_live.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:688
-#: lib/tuist_web/live/project_automations_live.ex:689
+#: lib/tuist_web/live/project_automations_live.ex:708
+#: lib/tuist_web/live/project_automations_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Percent"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:691
+#: lib/tuist_web/live/project_automations_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Threshold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:737
+#: lib/tuist_web/live/project_automations_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "When flakiness rate %{symbol} %{threshold}% over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:750
+#: lib/tuist_web/live/project_automations_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "When flaky runs %{symbol} %{threshold} over %{window}"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:276
-#: lib/tuist_web/live/project_automations_live.html.heex:710
+#: lib/tuist_web/live/project_automations_live.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Last N runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:803
+#: lib/tuist_web/live/project_automations_live.ex:823
 #: lib/tuist_web/live/project_automations_live.html.heex:230
-#: lib/tuist_web/live/project_automations_live.html.heex:666
+#: lib/tuist_web/live/project_automations_live.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "Last days"
 msgstr ""
@@ -1345,47 +1345,47 @@ msgid "Over"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:255
-#: lib/tuist_web/live/project_automations_live.html.heex:692
+#: lib/tuist_web/live/project_automations_live.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "Window"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:790
+#: lib/tuist_web/live/project_automations_live.ex:810
 #, elixir-autogen, elixir-format
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:839
+#: lib/tuist_web/live/project_automations_live.ex:859
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:660
+#: lib/tuist_web/live/project_automations_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is manually flagged as flaky."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:669
+#: lib/tuist_web/live/project_automations_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is muted (still runs, failures ignored)."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:672
+#: lib/tuist_web/live/project_automations_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is skipped entirely."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:666
+#: lib/tuist_web/live/project_automations_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Fires when a test returns to the default enabled state."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:663
+#: lib/tuist_web/live/project_automations_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "Fires when the flaky flag is manually removed."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:648
+#: lib/tuist_web/live/project_automations_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -1395,38 +1395,38 @@ msgstr ""
 msgid "On these events"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:651
+#: lib/tuist_web/live/project_automations_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "State changed to Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:653
+#: lib/tuist_web/live/project_automations_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "State changed to Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:655
+#: lib/tuist_web/live/project_automations_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "State changed to Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:645
+#: lib/tuist_web/live/project_automations_live.ex:665
 #: lib/tuist_web/live/project_automations_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Test updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:649
+#: lib/tuist_web/live/project_automations_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:777
+#: lib/tuist_web/live/project_automations_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "When a test is updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:781
+#: lib/tuist_web/live/project_automations_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "When a test is updated: %{events}"
 msgstr ""
@@ -1436,13 +1436,13 @@ msgstr ""
 msgid "New Project"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:644
+#: lib/tuist_web/live/project_automations_live.ex:664
 #: lib/tuist_web/live/project_automations_live.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:763
+#: lib/tuist_web/live/project_automations_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "When test reliability across branches %{symbol} %{threshold}% over %{window}"
 msgstr ""
@@ -1482,21 +1482,13 @@ msgstr ""
 msgid "can't be blank"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:479
+#: lib/tuist_web/live/project_automations_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "This automation uses an unsupported trigger configuration. Edit it before enabling it."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:330
-#: lib/tuist_web/live/project_automations_live.html.heex:335
-#: lib/tuist_web/live/project_automations_live.html.heex:742
-#: lib/tuist_web/live/project_automations_live.html.heex:747
-#, elixir-autogen, elixir-format
-msgid "In any state"
-msgstr ""
-
 #: lib/tuist_web/live/project_automations_live.html.heex:323
-#: lib/tuist_web/live/project_automations_live.html.heex:735
+#: lib/tuist_web/live/project_automations_live.html.heex:723
 #, elixir-autogen, elixir-format
-msgid "Only apply when the test is"
+msgid "Only apply to tests in these states"
 msgstr ""

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -35,10 +35,10 @@ defmodule Tuist.Automations.Alerts.AlertTest do
               "threshold" => 10,
               "window_type" => "last_days",
               "window" => "30d",
-              "state" => "enabled"
+              "states" => ["enabled", "muted"]
             },
             "recovery_enabled" => true,
-            "recovery_config" => %{"window_type" => "last_days", "window" => "14d", "state" => "muted"},
+            "recovery_config" => %{"window_type" => "last_days", "window" => "14d", "states" => ["muted"]},
             "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
           })
         )
@@ -57,7 +57,7 @@ defmodule Tuist.Automations.Alerts.AlertTest do
               "threshold" => 10,
               "window_type" => "last_days",
               "window" => "30d",
-              "state" => "unknown"
+              "states" => ["unknown"]
             }
           })
         )

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -24,6 +24,48 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert changeset.valid?
     end
 
+    test "accepts state filters for trigger and recovery" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "state" => "enabled"
+            },
+            "recovery_enabled" => true,
+            "recovery_config" => %{"window_type" => "last_days", "window" => "14d", "state" => "muted"},
+            "recovery_actions" => [%{"type" => "change_state", "state" => "enabled"}]
+          })
+        )
+
+      assert changeset.valid?
+    end
+
+    test "rejects an unknown state filter" do
+      project = ProjectsFixtures.project_fixture()
+
+      changeset =
+        Alert.changeset(
+          %Alert{},
+          valid_attrs(project, %{
+            "trigger_config" => %{
+              "threshold" => 10,
+              "window_type" => "last_days",
+              "window" => "30d",
+              "state" => "unknown"
+            }
+          })
+        )
+
+      refute changeset.valid?
+      assert errors_on(changeset).trigger_config
+    end
+
     test "requires project_id, name, monitor_type, trigger_actions" do
       changeset = Alert.changeset(%Alert{}, %{})
       refute changeset.valid?

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -866,7 +866,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     automation =
       AutomationsFixtures.automation_alert_fixture(
         recovery_enabled: false,
-        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 1000}
+        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 1000, "state" => "skipped"}
       )
 
     recovered_id = Ecto.UUID.generate()
@@ -880,8 +880,9 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     end)
 
     # No dwell evaluation at all on the disabled path → no runs-since-trigger
-    # query, proving the stale rolling config is ignored.
+    # query or state lookup, proving the stale recovery config is ignored.
     reject(&ClickHouseRepo.all/1)
+    reject(&Tests.get_test_case_states/2)
 
     expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^recovered_id} ->
       assert actions == []

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -534,11 +534,15 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
-  test "does not recover a test whose state no longer matches the recovery filter" do
+  test "re-arms without running recovery actions when the state no longer matches the filter" do
+    # A test the automation skipped was manually moved to muted, so it no
+    # longer matches the recovery filter ("skipped"). Recovery must leave it
+    # alone, but the alert still re-arms once the dwell elapses — otherwise it
+    # latches and can never trigger again for that test.
     automation =
       AutomationsFixtures.automation_alert_fixture(
         recovery_enabled: true,
-        recovery_config: %{"window_type" => "last_days", "window" => "1d", "state" => "skipped"},
+        recovery_config: %{"window_type" => "last_days", "window" => "1d", "states" => ["skipped"]},
         recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
       )
 
@@ -557,8 +561,14 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       %{recovered_id => %{state: "muted", is_flaky: true}}
     end)
 
-    reject(&ActionExecutor.execute_actions/3)
-    reject(&Automations.create_alert_event/1)
+    # No recovery actions run (the test was manually moved out of the filter),
+    # but the alert re-arms so it can fire again later.
+    expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^recovered_id} ->
+      assert actions == []
+      :ok
+    end)
+
+    expect(Automations, :create_alert_event, fn %{test_case_id: ^recovered_id, status: "recovered"} -> :ok end)
 
     assert :ok = run(automation.id)
   end
@@ -866,7 +876,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     automation =
       AutomationsFixtures.automation_alert_fixture(
         recovery_enabled: false,
-        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 1000, "state" => "skipped"}
+        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 1000, "states" => ["skipped"]}
       )
 
     recovered_id = Ecto.UUID.generate()

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -534,6 +534,35 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
+  test "does not recover a test whose state no longer matches the recovery filter" do
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        recovery_enabled: true,
+        recovery_config: %{"window_type" => "last_days", "window" => "1d", "state" => "skipped"},
+        recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+      )
+
+    recovered_id = Ecto.UUID.generate()
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+      %{triggered: [], all: [recovered_id]}
+    end)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [%{test_case_id: recovered_id, triggered_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -3, :day)}]
+    end)
+
+    expect(Tests, :get_test_case_states, fn project_id, [^recovered_id] ->
+      assert project_id == automation.project_id
+      %{recovered_id => %{state: "muted", is_flaky: true}}
+    end)
+
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert :ok = run(automation.id)
+  end
+
   test "does not run recovery actions when window has not elapsed" do
     automation =
       AutomationsFixtures.automation_alert_fixture(

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -516,7 +516,7 @@ defmodule Tuist.AutomationsTest do
     test "skips alerts whose trigger state filter does not match the test case" do
       project = ProjectsFixtures.project_fixture()
       test_case = %{id: Ecto.UUID.generate(), project_id: project.id}
-      alert = test_updated_alert(project, trigger_config: %{"events" => ["marked_flaky"], "state" => "skipped"})
+      alert = test_updated_alert(project, trigger_config: %{"events" => ["marked_flaky"], "states" => ["skipped"]})
       project_id = project.id
       test_case_id = test_case.id
 

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -9,6 +9,7 @@ defmodule Tuist.AutomationsTest do
   alias Tuist.Automations.Alerts.Alert
   alias Tuist.Automations.Workers.AlertEvaluationWorker
   alias Tuist.Repo
+  alias Tuist.Tests
   alias TuistTestSupport.Fixtures.AutomationsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
@@ -510,6 +511,23 @@ defmodule Tuist.AutomationsTest do
       reject(&ActionExecutor.execute_actions/3)
 
       assert :ok = Automations.dispatch_test_case_event(:marked_flaky, test_case)
+    end
+
+    test "skips alerts whose trigger state filter does not match the test case" do
+      project = ProjectsFixtures.project_fixture()
+      test_case = %{id: Ecto.UUID.generate(), project_id: project.id}
+      alert = test_updated_alert(project, trigger_config: %{"events" => ["marked_flaky"], "state" => "skipped"})
+      project_id = project.id
+      test_case_id = test_case.id
+
+      expect(Tests, :get_test_case_states, fn ^project_id, [^test_case_id] ->
+        %{test_case_id => %{state: "muted", is_flaky: false}}
+      end)
+
+      reject(&ActionExecutor.execute_actions/3)
+
+      assert :ok = Automations.dispatch_test_case_event(:marked_flaky, test_case)
+      assert Automations.list_active_alert_events(alert.id) == []
     end
 
     test ":unmarked_flaky fires an alert subscribed to unmarked_flaky" do

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -308,14 +308,29 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
 
       render_hook(lv, "open_create_automation_modal", %{})
       render_hook(lv, "update_create_automation_form_name", %{"value" => "State-aware recovery"})
-      render_hook(lv, "update_create_automation_form_trigger_state", %{"data" => "enabled"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "enabled"})
       render_hook(lv, "toggle_create_automation_form_recovery", %{})
-      render_hook(lv, "update_create_automation_form_recovery_state", %{"data" => "muted"})
+      render_hook(lv, "toggle_create_automation_form_recovery_state", %{"data" => "muted"})
       render_hook(lv, "save_automation", %{})
 
       assert [automation] = Automations.list_alerts(project.id)
-      assert automation.trigger_config["state"] == "enabled"
-      assert automation.recovery_config["state"] == "muted"
+      assert automation.trigger_config["states"] == ["enabled"]
+      assert automation.recovery_config["states"] == ["muted"]
+    end
+
+    test "state filters are multi-select", %{conn: conn, organization: organization, project: project} do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Reliability for live tests"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "enabled"})
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
+      # Toggling the same state again removes it.
+      render_hook(lv, "toggle_create_automation_form_trigger_state", %{"data" => "muted"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      assert automation.trigger_config["states"] == ["enabled"]
     end
 
     test "creates a test_updated automation subscribed to the default marked_flaky event", %{

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -303,6 +303,21 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       refute Map.has_key?(automation.recovery_config, "rolling_window_size")
     end
 
+    test "persists trigger and recovery state filters", %{conn: conn, organization: organization, project: project} do
+      {:ok, lv, _html} = open(conn, organization, project)
+
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "State-aware recovery"})
+      render_hook(lv, "update_create_automation_form_trigger_state", %{"data" => "enabled"})
+      render_hook(lv, "toggle_create_automation_form_recovery", %{})
+      render_hook(lv, "update_create_automation_form_recovery_state", %{"data" => "muted"})
+      render_hook(lv, "save_automation", %{})
+
+      assert [automation] = Automations.list_alerts(project.id)
+      assert automation.trigger_config["state"] == "enabled"
+      assert automation.recovery_config["state"] == "muted"
+    end
+
     test "creates a test_updated automation subscribed to the default marked_flaky event", %{
       conn: conn,
       organization: organization,


### PR DESCRIPTION
## What changed

- Add optional current-state filters to test automation triggers and recoveries.
- Expose the filter in the automation form for enabled, muted, and skipped tests.
- Read current test state in batches before applying actions, with tests covering validation and manual state overrides.

## Why

Teams may manually move a test from skipped to muted while an automation is waiting to recover it. Recovery must respect that current choice instead of applying a stale action from the automation ledger.

## Root cause

Recovery decisions considered only whether the automation had fired previously. They did not check the test's current state before applying recovery actions.

## Approach

State conditions are optional and default to any state, preserving existing automations. The selected state is evaluated for baseline, trigger, and recovery candidates before actions run.

## Impact

Teams can configure a skipped-test recovery to act only on skipped tests, or a muting trigger to act only on enabled tests. Manual overrides to another state are left intact.

## Validation

- `mix format --check-formatted` for the changed server files.
- Added focused unit and LiveView test coverage. The local test process was still compiling dependencies at publication time.
- Verified the filter in a local headless Chrome session.

## Screenshot

The state filter in the create automation flow.

![Automation state filter](https://github.com/user-attachments/assets/210107e5-399c-4347-a955-8ed93539e26a)
