### PR TITLE
fix(cli): actually allow target scripts during cache warm

### DIFF
--- a/cli/Sources/TuistCache/CacheWarmForeignBuildOutputValidator.swift
+++ b/cli/Sources/TuistCache/CacheWarmForeignBuildOutputValidator.swift
@@ -6,7 +6,6 @@ import XcodeGraph
 
 public enum CacheWarmForeignBuildOutputValidatorError: LocalizedError, Equatable {
     case unsupported(scratchDirectory: AbsolutePath, targetNames: [String])
-    case unsupportedTargetScripts(scratchDirectory: AbsolutePath, targetNames: [String])
 
     public var errorDescription: String? {
         switch self {
@@ -15,12 +14,6 @@ public enum CacheWarmForeignBuildOutputValidatorError: LocalizedError, Equatable
             The cache warm scratch directory at \(scratchDirectory
                 .pathString) cannot be used with foreign build targets: \(targetNames.joined(separator: ", ")). \
             Foreign build scripts control their output locations, so Tuist cannot guarantee that every build output stays inside the scratch directory.
-            """
-        case let .unsupportedTargetScripts(scratchDirectory, targetNames):
-            return """
-            The cache warm scratch directory at \(scratchDirectory
-                .pathString) cannot be used with targets that contain build scripts: \(targetNames.joined(separator: ", ")). \
-            Build scripts can write outside their declared output paths, so Tuist cannot guarantee that every build output stays inside the scratch directory.
             """
         }
     }
@@ -49,24 +42,13 @@ public struct CacheWarmForeignBuildOutputValidator: CacheWarmForeignBuildOutputV
             .filter { $0.target.foreignBuild != nil }
             .map(\.target.name)
             .sorted()
-        if !foreignBuildTargetNames.isEmpty {
-            throw CacheWarmForeignBuildOutputValidatorError.unsupported(
-                scratchDirectory: path,
-                targetNames: foreignBuildTargetNames
-            )
-        }
-
-        let targetScriptNames = targets
-            .filter { $0.target.foreignBuild == nil && !$0.target.scripts.isEmpty }
-            .map(\.target.name)
-            .sorted()
-        guard !targetScriptNames.isEmpty else {
+        guard !foreignBuildTargetNames.isEmpty else {
             return
         }
 
-        throw CacheWarmForeignBuildOutputValidatorError.unsupportedTargetScripts(
+        throw CacheWarmForeignBuildOutputValidatorError.unsupported(
             scratchDirectory: path,
-            targetNames: targetScriptNames
+            targetNames: foreignBuildTargetNames
         )
     }
 }

--- a/cli/Tests/TuistCacheTests/CacheWarmForeignBuildOutputValidatorTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheWarmForeignBuildOutputValidatorTests.swift
@@ -43,21 +43,14 @@ struct CacheWarmForeignBuildOutputValidatorTests {
         }
     }
 
-    @Test func validateRejectsTargetScriptsWithCallerOwnedScratchDirectory() throws {
-        let scratchDirectory = try AbsolutePath(validating: "/scratch")
-
-        #expect(throws: CacheWarmForeignBuildOutputValidatorError.unsupportedTargetScripts(
-            scratchDirectory: scratchDirectory,
-            targetNames: ["ScriptA", "ScriptB"]
-        )) {
-            try subject.validate(
-                targets: [
-                    targetScriptGraphTarget(name: "ScriptB"),
-                    targetScriptGraphTarget(name: "ScriptA"),
-                ],
-                scratchDirectory: .callerOwned(scratchDirectory)
-            )
-        }
+    @Test func validateAcceptsTargetScriptsWithCallerOwnedScratchDirectory() throws {
+        try subject.validate(
+            targets: [
+                targetScriptGraphTarget(name: "ScriptB"),
+                targetScriptGraphTarget(name: "ScriptA"),
+            ],
+            scratchDirectory: .callerOwned(try AbsolutePath(validating: "/scratch"))
+        )
     }
 
     private func targetScriptGraphTarget(name: String) -> GraphTarget {


### PR DESCRIPTION
## What changed

`CacheWarmForeignBuildOutputValidator` no longer rejects regular targets that carry Xcode build scripts when a caller-owned scratch directory is used. The only remaining guard is for foreign builds. The `unsupportedTargetScripts` error case and its rejection test are removed, and a new test asserts target scripts are accepted with a caller-owned scratch directory.

## Why

#12138 was meant to unblock caller-owned cache warm scratch directories (`TUIST_CACHE_WARM_SCRATCH_DIRECTORY`, added in #12108) for graphs whose cacheable targets carry build scripts. That was the exact ask from a customer whose security policy requires build outputs to live under a path they manage, and two of their cacheable targets carry a `.post` script.

The first commit on that branch removed the target-script rejection as intended. A second commit then reintroduced it under a new `unsupportedTargetScripts` error. So on the merged HEAD the validator still throws for any target with `foreignBuild == nil && !scripts.isEmpty`, which is the same condition that blocked their graph before. The PR description said the validator now checks only for foreign builds, so the description and the shipped behavior disagreed, and the customer's graph still failed before the build started.

## Root cause

The reintroduced guard treated all build scripts as unbounded. That framing is wrong for target scripts. Foreign build scripts pick their own output locations, so Tuist genuinely cannot guarantee their outputs stay inside the scratch directory, and that guard stays. Target scripts run inside the Xcode build graph against `TARGET_BUILD_DIR` and `BUILT_PRODUCTS_DIR`, which resolve under `SYMROOT`, which cache warm already points at `<scratch>/derived-data/Build/Products`. Their outputs land inside the scratch directory by construction, and the caller-owned mode is the more controlled of the two since the caller owns and manages that path. The risk is identical to the temporary mode, which already returns early and never checks scripts.

## Solution and alternatives

Drop the target-script rejection entirely and keep only the foreign-build guard. The customer offered an opt-out flag as a fallback, but an extra flag is not warranted here: there is no additional risk in the caller-owned path over the temporary path that already accepts these scripts unchecked, so gating it behind a flag would only add friction without buying safety.

## Validation

Regenerated the workspace and ran the suite:

```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistCacheTests/CacheWarmForeignBuildOutputValidatorTests
```

All four tests pass, including the new `validateAcceptsTargetScriptsWithCallerOwnedScratchDirectory`. The foreign-build rejection and the temporary-directory acceptance tests are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)