### PR TITLE
fix(server): retain build command for split test runs

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -502,10 +502,10 @@ defmodule Tuist.CommandEvents do
   end
 
   # Multiple rows may share the same build_run_id because the ID is derived
-  # from the `.xcactivitylog`, which Xcode can reuse across runs (e.g. a
-  # second `tuist test` that short-circuits before building picks up the
-  # previous log). We return the most recent event until we can source the
-  # build_run_id independently of the activity log.
+  # from the `.xcactivitylog`. In a split test run, the test execution event
+  # intentionally reuses the build phase's ID to link its test report to the
+  # build. Prefer the event without a test run so build details retain the
+  # command that produced the build.
   #
   # Pass `project_id:` when known so the lookup hits the
   # `(project_id, name, ran_at)` primary key instead of relying solely on
@@ -516,7 +516,7 @@ defmodule Tuist.CommandEvents do
     Event
     |> scope_to_project(project_id)
     |> where([e], e.build_run_id == ^build_run_id)
-    |> order_by([e], desc: e.ran_at, desc: e.created_at)
+    |> order_by([e], desc: is_nil(e.test_run_id), desc: e.ran_at, desc: e.created_at)
     |> limit(1)
     |> ClickHouseRepo.one()
     |> case do

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1479,19 +1479,22 @@ defmodule Tuist.CommandEventsTest do
       assert got == {:error, :not_found}
     end
 
-    test "returns the most recent event when multiple events share the same build_run_id" do
+    test "prefers the build event when a later test event shares its build run id" do
       # Given
       build_run_id = UUIDv7.generate()
 
-      _older =
+      build_event =
         CommandEventsFixtures.command_event_fixture(
           build_run_id: build_run_id,
+          command_arguments: ["test", "--build-only"],
           ran_at: ~U[2024-01-01 10:00:00Z]
         )
 
-      newer =
+      _test_event =
         CommandEventsFixtures.command_event_fixture(
           build_run_id: build_run_id,
+          command_arguments: ["test", "--without-building", "--shard-index", "0"],
+          test_run_id: UUIDv7.generate(),
           ran_at: ~U[2024-01-02 10:00:00Z]
         )
 
@@ -1500,7 +1503,7 @@ defmodule Tuist.CommandEventsTest do
 
       # Then
       assert {:ok, event} = got
-      assert event.id == newer.id
+      assert event.id == build_event.id
     end
   end
 


### PR DESCRIPTION
> Keep the command shown on a build run tied to the build phase when its sharded test executions upload linked test events.

## What changed

- Prefer command events without a test-run identifier when loading a build run's command details.
- Keep the latest event as the tie-breaker among build events.
- Add coverage for a build event followed by a later sharded test event sharing the same build-run identifier.

## Why

Build and test execution are separate steps when tests are sharded. The test events reuse the build-run identifier so their reports remain associated with the build.

## Root cause

The build-run page selected the most recent command event for a build-run identifier. A later `tuist test --without-building` event therefore replaced the `tuist test --build-only` command that created the build.

## Approach

The lookup now treats an event with a test-run identifier as a linked test execution rather than the build's canonical command. This preserves the build command while retaining the existing association between the build and its test reports.

## Impact

Build details continue to show the original build command after sharded test execution completes. Test reports remain linked to the same build run.

### How to test locally

- `MIX_ENV=test mise exec -- mix test test/tuist/command_events_test.exs:1481`
