### PR TITLE
fix(swifterpm/cli): key the manifest dump cache on the environment

### DIFF
--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -8,7 +8,7 @@ enum Environment {
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
     static var isCI: Bool {
-        ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { environment[$0] != nil }
+        ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
     }
 
     static func cachedDirectoryMaterializationMode()
@@ -29,7 +29,12 @@ enum Environment {
         return try await operation()
     }
 
-    private static var environment: [String: String] {
+    /// The environment the process runs in. Overridable through the `values` task-local
+    /// for dependency injection (notably in tests); otherwise the live process environment.
+    /// Manifest evaluation observes the same environment because swifterpm inherits it into
+    /// the `swift package dump-package` subprocess, so this is also the environment a cached
+    /// dump was produced under.
+    static var current: [String: String] {
         values ?? ProcessInfo.processInfo.environment
     }
 }

--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -82,30 +82,34 @@ enum ManifestLoader {
         )
         let cache = cacheFilePath(packageDir: packageDir)
         try? await fileSystem.atomicWrite(result.stdout, to: cache)
-        try? await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+        if let cachePath = try? cache.absolutePath {
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: cachePath)
+        }
         return result.stdout
     }
 
     private static func readCachedManifest(packageDir: URL) async throws -> Data? {
         let cache = cacheFilePath(packageDir: packageDir)
         let manifest = packageDir.appendingPathComponent("Package.swift")
-        guard try await fileSystem.exists(cache.absolutePath) else { return nil }
-        guard let cacheDate = try await fileSystem.fileMetadata(at: cache.absolutePath)?.lastModificationDate,
+        let cachePath = try cache.absolutePath
+        guard try await fileSystem.exists(cachePath) else { return nil }
+        guard let cacheDate = try await fileSystem.fileMetadata(at: cachePath)?.lastModificationDate,
               let manifestDate = try await fileSystem.fileMetadata(at: manifest.absolutePath)?.lastModificationDate,
               cacheDate >= manifestDate
         else {
             return nil
         }
-        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache) {
+        // A dump is reusable only when it was produced under the current environment. A
+        // missing sidecar means the cache predates environment fingerprinting (or the
+        // sidecar write failed), so the environment that produced the contents is
+        // unknown. Treat that as a miss and re-dump rather than blessing unknown contents
+        // with the current environment, otherwise a legacy cache that was already stale
+        // at upgrade time would stay stale indefinitely.
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: cachePath) {
         case .matching:
-            return try await fileSystem.readFile(at: cache.absolutePath)
-        case .mismatching:
+            return try await fileSystem.readFile(at: cachePath)
+        case .mismatching, .missing:
             return nil
-        case .missing:
-            // Backfill so a later environment change is detected even for caches that
-            // predate the fingerprint sidecar.
-            try? await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
-            return try await fileSystem.readFile(at: cache.absolutePath)
         }
     }
 }

--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -80,7 +80,9 @@ enum ManifestLoader {
         let result = try await SystemProcess.run(
             "/usr/bin/swift", args, workingDirectory: packageDir
         )
-        try? await fileSystem.atomicWrite(result.stdout, to: cacheFilePath(packageDir: packageDir))
+        let cache = cacheFilePath(packageDir: packageDir)
+        try? await fileSystem.atomicWrite(result.stdout, to: cache)
+        try? await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
         return result.stdout
     }
 
@@ -94,7 +96,17 @@ enum ManifestLoader {
         else {
             return nil
         }
-        return try await fileSystem.readFile(at: cache.absolutePath)
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache) {
+        case .matching:
+            return try await fileSystem.readFile(at: cache.absolutePath)
+        case .mismatching:
+            return nil
+        case .missing:
+            // Backfill so a later environment change is detected even for caches that
+            // predate the fingerprint sidecar.
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+            return try await fileSystem.readFile(at: cache.absolutePath)
+        }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
+++ b/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// A stable digest of the process environment, used to key the dump-package cache.
+///
+/// A `Package.swift` is arbitrary Swift and can branch on environment values through
+/// `PackageDescription.Context.environment`. SwiftPM forwards the entire process
+/// environment to the manifest interpreter (not just a curated allowlist), so a
+/// manifest's evaluated result is a function of the whole environment — not only of
+/// `Package.swift`. Comparing only the modification times of `Package.swift` and the
+/// cached dump therefore reuses a dump that was produced under a different environment,
+/// which is the root cause of stale local-package manifests
+/// (see https://github.com/tuist/tuist/issues/12130).
+///
+/// The fingerprint is stored as a sidecar (`.envhash`) next to each cached dump and
+/// compared on read. It is a one-way digest, so secret-bearing variables never reach
+/// disk in cleartext.
+enum ManifestEnvironmentFingerprint {
+    enum Validation: Sendable {
+        /// A stored fingerprint exists and matches the current environment.
+        case matching
+        /// A stored fingerprint exists but differs from the current environment.
+        case mismatching
+        /// No sidecar exists (for example a cache written before this check existed).
+        case missing
+    }
+
+    static let sidecarExtension = "envhash"
+
+    static func sidecarPath(forCacheFile cacheFile: URL) -> URL {
+        cacheFile.appendingPathExtension(sidecarExtension)
+    }
+
+    /// The fingerprint for the current process environment.
+    static func current() -> String {
+        digest(for: ProcessInfo.processInfo.environment)
+    }
+
+    /// A deterministic fingerprint for `environment`. Key-value pairs are sorted so the
+    /// digest is independent of dictionary iteration order.
+    static func digest(for environment: [String: String]) -> String {
+        Hashing.stable(
+            environment
+                .map { "\($0.key)=\($0.value)" }
+                .sorted()
+                .joined(separator: "\n")
+        )
+    }
+
+    /// Writes the current environment fingerprint next to `cacheFile`.
+    static func write(forCacheFile cacheFile: URL) async throws {
+        try await fileSystem.atomicWrite(
+            Data(current().utf8),
+            to: sidecarPath(forCacheFile: cacheFile)
+        )
+    }
+
+    static func validate(forCacheFile cacheFile: URL) async throws -> Validation {
+        let sidecar = sidecarPath(forCacheFile: cacheFile)
+        guard try await fileSystem.exists(sidecar.absolutePath) else { return .missing }
+        let stored = try await fileSystem.readFile(at: sidecar.absolutePath)
+        return String(data: stored, encoding: .utf8) == current() ? .matching : .mismatching
+    }
+}

--- a/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
+++ b/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
@@ -1,14 +1,15 @@
 import Foundation
+import Path
 
-/// A stable digest of the process environment, used to key the dump-package cache.
+/// A stable digest of the environment, used to key the dump-package cache.
 ///
 /// A `Package.swift` is arbitrary Swift and can branch on environment values through
 /// `PackageDescription.Context.environment`. SwiftPM forwards the entire process
 /// environment to the manifest interpreter (not just a curated allowlist), so a
-/// manifest's evaluated result is a function of the whole environment — not only of
+/// manifest's evaluated result is a function of the whole environment, not only of
 /// `Package.swift`. Comparing only the modification times of `Package.swift` and the
-/// cached dump therefore reuses a dump that was produced under a different environment,
-/// which is the root cause of stale local-package manifests
+/// cached dump therefore reuses a dump produced under a different environment, which is
+/// the root cause of stale local-package manifests
 /// (see https://github.com/tuist/tuist/issues/12130).
 ///
 /// The fingerprint is stored as a sidecar (`.envhash`) next to each cached dump and
@@ -26,38 +27,39 @@ enum ManifestEnvironmentFingerprint {
 
     static let sidecarExtension = "envhash"
 
-    static func sidecarPath(forCacheFile cacheFile: URL) -> URL {
-        cacheFile.appendingPathExtension(sidecarExtension)
+    static func sidecarPath(forCacheFile cacheFile: AbsolutePath) -> AbsolutePath {
+        cacheFile.parentDirectory.appending(component: "\(cacheFile.basename).\(sidecarExtension)")
     }
 
-    /// The fingerprint for the current process environment.
+    /// The fingerprint for the environment swifterpm currently runs in.
     static func current() -> String {
-        digest(for: ProcessInfo.processInfo.environment)
+        digest(for: Environment.current)
     }
 
-    /// A deterministic fingerprint for `environment`. Key-value pairs are sorted so the
-    /// digest is independent of dictionary iteration order.
+    /// A deterministic fingerprint for `environment`, encoded as sorted JSON so a value
+    /// containing the delimiter cannot collide with distinct entries: `A="x\nB=y"` must
+    /// not hash the same as the two variables `A="x"`, `B="y"`.
     static func digest(for environment: [String: String]) -> String {
-        Hashing.stable(
-            environment
-                .map { "\($0.key)=\($0.value)" }
-                .sorted()
-                .joined(separator: "\n")
-        )
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: environment, options: [.sortedKeys]
+        ) else {
+            return Hashing.sha256Hex(Data())
+        }
+        return Hashing.sha256Hex(data)
     }
 
     /// Writes the current environment fingerprint next to `cacheFile`.
-    static func write(forCacheFile cacheFile: URL) async throws {
-        try await fileSystem.atomicWrite(
+    static func write(forCacheFile cacheFile: AbsolutePath) async throws {
+        try await fileSystem.write(
             Data(current().utf8),
             to: sidecarPath(forCacheFile: cacheFile)
         )
     }
 
-    static func validate(forCacheFile cacheFile: URL) async throws -> Validation {
+    static func validate(forCacheFile cacheFile: AbsolutePath) async throws -> Validation {
         let sidecar = sidecarPath(forCacheFile: cacheFile)
-        guard try await fileSystem.exists(sidecar.absolutePath) else { return .missing }
-        let stored = try await fileSystem.readFile(at: sidecar.absolutePath)
+        guard try await fileSystem.exists(sidecar) else { return .missing }
+        let stored = try await fileSystem.readFile(at: sidecar)
         return String(data: stored, encoding: .utf8) == current() ? .matching : .mismatching
     }
 }

--- a/swifterpm/Sources/swifterpm/PackageInfoCache.swift
+++ b/swifterpm/Sources/swifterpm/PackageInfoCache.swift
@@ -167,13 +167,16 @@ enum PackageInfoCacheWriter {
         let data = try await ManifestLoader.dumpPackageJSON(
             packageDir: packageDir, disableSandbox: disableSandbox)
         try await fileSystem.atomicWrite(data, to: destination)
-        try? await ManifestEnvironmentFingerprint.write(forCacheFile: destination)
+        if let destinationPath = try? destination.absolutePath {
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: destinationPath)
+        }
         return data
     }
 
     private static func isFreshPackageInfo(destination: URL, packageDir: URL) async throws -> Bool {
+        let destinationPath = try destination.absolutePath
         guard
-            let cacheDate = try await fileSystem.fileMetadata(at: destination.absolutePath)?.lastModificationDate,
+            let cacheDate = try await fileSystem.fileMetadata(at: destinationPath)?.lastModificationDate,
             let manifestDate = try await fileSystem.fileMetadata(
                 at: packageDir.appendingPathComponent("Package.swift").absolutePath
             )?.lastModificationDate
@@ -181,16 +184,15 @@ enum PackageInfoCacheWriter {
             return false
         }
         guard cacheDate >= manifestDate else { return false }
-        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: destination) {
+        // A missing sidecar means the destination predates environment fingerprinting, so
+        // the environment it was produced under is unknown. Treat it as stale (see
+        // `ManifestLoader.readCachedManifest`) so an upgrade re-dumps under the current
+        // environment instead of reusing contents of unknown provenance.
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: destinationPath) {
         case .matching:
             return true
-        case .mismatching:
+        case .mismatching, .missing:
             return false
-        case .missing:
-            // Backfill so a later environment change is detected even for caches that
-            // predate the fingerprint sidecar.
-            try? await ManifestEnvironmentFingerprint.write(forCacheFile: destination)
-            return true
         }
     }
 

--- a/swifterpm/Sources/swifterpm/PackageInfoCache.swift
+++ b/swifterpm/Sources/swifterpm/PackageInfoCache.swift
@@ -167,6 +167,7 @@ enum PackageInfoCacheWriter {
         let data = try await ManifestLoader.dumpPackageJSON(
             packageDir: packageDir, disableSandbox: disableSandbox)
         try await fileSystem.atomicWrite(data, to: destination)
+        try? await ManifestEnvironmentFingerprint.write(forCacheFile: destination)
         return data
     }
 
@@ -179,7 +180,18 @@ enum PackageInfoCacheWriter {
         else {
             return false
         }
-        return cacheDate >= manifestDate
+        guard cacheDate >= manifestDate else { return false }
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: destination) {
+        case .matching:
+            return true
+        case .mismatching:
+            return false
+        case .missing:
+            // Backfill so a later environment change is detected even for caches that
+            // predate the fingerprint sidecar.
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: destination)
+            return true
+        }
     }
 
     private static func packageEntry(pin: ResolvedPin, packagePath: URL, packageInfoPath: URL)

--- a/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import SwifterPMCore
+
+struct ManifestEnvironmentFingerprintTests {
+    @Test
+    func digestIsStableAcrossDictionaryOrdering() {
+        let first = ManifestEnvironmentFingerprint.digest(for: ["A": "1", "B": "2"])
+        let second = ManifestEnvironmentFingerprint.digest(for: ["B": "2", "A": "1"])
+
+        #expect(first == second)
+    }
+
+    @Test
+    func digestDiffersWhenValuesChange() {
+        let first = ManifestEnvironmentFingerprint.digest(for: ["REPRO_USE_ALTERNATE": "1"])
+        let second = ManifestEnvironmentFingerprint.digest(for: ["REPRO_USE_ALTERNATE": "0"])
+
+        #expect(first != second)
+    }
+
+    @Test
+    func sidecarPathAppendsEnvhashExtension() {
+        let cache = URL(fileURLWithPath: "/tmp/Package/.build/swifterpm/manifests/package.json")
+
+        #expect(
+            ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).path
+                == "/tmp/Package/.build/swifterpm/manifests/package.json.envhash")
+    }
+
+    @Test
+    func validateReturnsMissingWhenNoSidecarExists() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = root.appendingPathComponent("package.json")
+            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .missing)
+        }
+    }
+
+    @Test
+    func validateReturnsMatchingWhenSidecarMatchesCurrentEnvironment() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = root.appendingPathComponent("package.json")
+            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
+            try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .matching)
+        }
+    }
+
+    @Test
+    func validateReturnsMismatchingWhenSidecarDiffersFromCurrentEnvironment() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = root.appendingPathComponent("package.json")
+            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
+            try await fileSystem.atomicWrite(
+                Data("a-fingerprint-produced-under-a-different-environment".utf8),
+                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache)
+            )
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .mismatching)
+        }
+    }
+
+    @Test
+    func writeRecordsCurrentEnvironmentFingerprint() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = root.appendingPathComponent("package.json")
+
+            try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+
+            let stored = String(
+                data: try await fileSystem.readFile(
+                    at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).absolutePath),
+                encoding: .utf8
+            )
+            #expect(stored == ManifestEnvironmentFingerprint.current())
+        }
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Path
 import Testing
 @testable import SwifterPMCore
 
@@ -20,19 +21,29 @@ struct ManifestEnvironmentFingerprintTests {
     }
 
     @Test
-    func sidecarPathAppendsEnvhashExtension() {
-        let cache = URL(fileURLWithPath: "/tmp/Package/.build/swifterpm/manifests/package.json")
+    func digestDistinguishesEmbeddedNewlinesFromSeparateEntries() {
+        // A value containing the delimiter must not collide with two distinct entries.
+        let withNewline = ManifestEnvironmentFingerprint.digest(for: ["A": "x\nB=y"])
+        let split = ManifestEnvironmentFingerprint.digest(for: ["A": "x", "B": "y"])
+
+        #expect(withNewline != split)
+    }
+
+    @Test
+    func sidecarPathAppendsEnvhashExtension() throws {
+        let cache = try AbsolutePath(
+            validating: "/tmp/Package/.build/swifterpm/manifests/package.json")
 
         #expect(
-            ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).path
+            ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).pathString
                 == "/tmp/Package/.build/swifterpm/manifests/package.json.envhash")
     }
 
     @Test
     func validateReturnsMissingWhenNoSidecarExists() async throws {
         try await withTemporaryDirectory { root in
-            let cache = root.appendingPathComponent("package.json")
-            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
 
             let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
 
@@ -43,8 +54,8 @@ struct ManifestEnvironmentFingerprintTests {
     @Test
     func validateReturnsMatchingWhenSidecarMatchesCurrentEnvironment() async throws {
         try await withTemporaryDirectory { root in
-            let cache = root.appendingPathComponent("package.json")
-            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
             try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
 
             let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
@@ -56,9 +67,9 @@ struct ManifestEnvironmentFingerprintTests {
     @Test
     func validateReturnsMismatchingWhenSidecarDiffersFromCurrentEnvironment() async throws {
         try await withTemporaryDirectory { root in
-            let cache = root.appendingPathComponent("package.json")
-            try await fileSystem.atomicWrite(Data("{}".utf8), to: cache)
-            try await fileSystem.atomicWrite(
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
+            try await fileSystem.write(
                 Data("a-fingerprint-produced-under-a-different-environment".utf8),
                 to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache)
             )
@@ -72,13 +83,13 @@ struct ManifestEnvironmentFingerprintTests {
     @Test
     func writeRecordsCurrentEnvironmentFingerprint() async throws {
         try await withTemporaryDirectory { root in
-            let cache = root.appendingPathComponent("package.json")
+            let cache = try root.appendingPathComponent("package.json").absolutePath
 
             try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
 
             let stored = String(
                 data: try await fileSystem.readFile(
-                    at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).absolutePath),
+                    at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache)),
                 encoding: .utf8
             )
             #expect(stored == ManifestEnvironmentFingerprint.current())

--- a/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
@@ -50,6 +50,9 @@ struct PackageInfoCacheTests {
             try await fileSystem.atomicWrite(
                 try JSONFormatter.prettyData(emptyManifest(name: "CachedRoot")),
                 to: cacheDir.appendingPathComponent("root.json"))
+            if let rootPath = try? cacheDir.appendingPathComponent("root.json").absolutePath {
+                try await ManifestEnvironmentFingerprint.write(forCacheFile: rootPath)
+            }
 
             try await PackageInfoCacheWriter.write(
                 packageDir: package,
@@ -95,6 +98,9 @@ struct PackageInfoCacheTests {
             try await fileSystem.atomicWrite(
                 try JSONFormatter.prettyData(emptyManifest(name: "CachedDependency")),
                 to: packageInfoPath)
+            if let packageInfoAbsolute = try? packageInfoPath.absolutePath {
+                try await ManifestEnvironmentFingerprint.write(forCacheFile: packageInfoAbsolute)
+            }
 
             try await PackageInfoCacheWriter.write(
                 packageDir: package,
@@ -268,9 +274,9 @@ struct PackageInfoCacheTests {
             let cacheDir = root.appendingPathComponent("package-info")
             let rootPath = cacheDir.appendingPathComponent("root.json")
 
-            // The ManifestLoader cache holds a manifest produced under a previous
-            // environment. Its own sidecar is missing, so it reads as fresh and is
-            // reused to refill the destination without invoking `swift`.
+            // The ManifestLoader cache holds a manifest produced under the current
+            // environment with a matching sidecar, so it reads as fresh and is reused to
+            // refill the destination without invoking `swift`.
             try await writeCachedManifest(emptyManifest(name: "FreshFromManifestLoader"), packageDir: package)
 
             // The package-info destination is newer than `Package.swift`, so the mtime
@@ -280,9 +286,10 @@ struct PackageInfoCacheTests {
             try await fileSystem.atomicWrite(
                 try JSONFormatter.prettyData(emptyManifest(name: "StaleDestination")),
                 to: rootPath)
-            try await fileSystem.atomicWrite(
+            let rootAbsolutePath = try rootPath.absolutePath
+            try await fileSystem.write(
                 Data("a-fingerprint-produced-under-a-different-environment".utf8),
-                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootPath))
+                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootAbsolutePath))
 
             try await PackageInfoCacheWriter.write(
                 packageDir: package,
@@ -295,12 +302,12 @@ struct PackageInfoCacheTests {
 
             let rootInfo = try #require(
                 JSONSerialization.jsonObject(
-                    with: try await fileSystem.readFile(at: rootPath.absolutePath))
+                    with: try await fileSystem.readFile(at: rootAbsolutePath))
                     as? [String: Any])
             #expect(rootInfo["name"] as? String == "FreshFromManifestLoader")
 
             let sidecar = try await fileSystem.readFile(
-                at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootPath).absolutePath)
+                at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootAbsolutePath))
             #expect(String(data: sidecar, encoding: .utf8) == ManifestEnvironmentFingerprint.current())
         }
     }

--- a/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
@@ -260,6 +260,51 @@ struct PackageInfoCacheTests {
         }
     }
 
+    @Test
+    func writePackageInfoCacheInvalidatesDestinationWhenEnvironmentChanged() async throws {
+        try await withTemporaryDirectory { root in
+            let package = root.appendingPathComponent("Package")
+            let scratch = root.appendingPathComponent("scratch")
+            let cacheDir = root.appendingPathComponent("package-info")
+            let rootPath = cacheDir.appendingPathComponent("root.json")
+
+            // The ManifestLoader cache holds a manifest produced under a previous
+            // environment. Its own sidecar is missing, so it reads as fresh and is
+            // reused to refill the destination without invoking `swift`.
+            try await writeCachedManifest(emptyManifest(name: "FreshFromManifestLoader"), packageDir: package)
+
+            // The package-info destination is newer than `Package.swift`, so the mtime
+            // check alone would consider it fresh, but its env sidecar records a
+            // different environment and must force a refresh.
+            try await Task.sleep(nanoseconds: 10_000_000)
+            try await fileSystem.atomicWrite(
+                try JSONFormatter.prettyData(emptyManifest(name: "StaleDestination")),
+                to: rootPath)
+            try await fileSystem.atomicWrite(
+                Data("a-fingerprint-produced-under-a-different-environment".utf8),
+                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootPath))
+
+            try await PackageInfoCacheWriter.write(
+                packageDir: package,
+                scratchDir: scratch,
+                resolved: ResolvedPins(originHash: "origin", pins: [], version: 3),
+                cacheDir: cacheDir,
+                disableSandbox: false,
+                quiet: true
+            )
+
+            let rootInfo = try #require(
+                JSONSerialization.jsonObject(
+                    with: try await fileSystem.readFile(at: rootPath.absolutePath))
+                    as? [String: Any])
+            #expect(rootInfo["name"] as? String == "FreshFromManifestLoader")
+
+            let sidecar = try await fileSystem.readFile(
+                at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootPath).absolutePath)
+            #expect(String(data: sidecar, encoding: .utf8) == ManifestEnvironmentFingerprint.current())
+        }
+    }
+
     private func writeInvalidManifest(packageDir: URL) async throws {
         try await fileSystem.makeDirectory(at: packageDir.absolutePath, options: [.createTargetParentDirectories])
         try await fileSystem.atomicWrite(

--- a/swifterpm/Tests/swifterpmTests/TestSupport.swift
+++ b/swifterpm/Tests/swifterpmTests/TestSupport.swift
@@ -27,10 +27,13 @@ func writeCachedManifest(_ manifest: [String: Any], packageDir: URL) async throw
     try await fileSystem.makeDirectory(
         at: packageDir.absolutePath, options: [.createTargetParentDirectories])
     try await writeMinimalPackageManifest(at: packageDir, name: "Fixture")
-    try await fileSystem.atomicWrite(
-        JSONFormatter.prettyData(manifest),
-        to: ManifestLoader.cacheFilePath(packageDir: packageDir)
-    )
+    let cachePath = ManifestLoader.cacheFilePath(packageDir: packageDir)
+    try await fileSystem.atomicWrite(JSONFormatter.prettyData(manifest), to: cachePath)
+    // A seeded cache is only reusable once it carries a matching environment sidecar;
+    // otherwise the freshness check treats it as a miss (see readCachedManifest).
+    if let cacheAbsolutePath = try? cachePath.absolutePath {
+        try await ManifestEnvironmentFingerprint.write(forCacheFile: cacheAbsolutePath)
+    }
 }
 
 func writeMinimalPackageManifest(at packageDir: URL, name: String) async throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/12130

SwifterPM's local-package manifest cache was reusing a `swift package dump-package` result that had been produced under a different environment, so a `Package.swift` that branches on an environment variable kept emitting the stale graph until the cache was deleted by hand.

## What changed

- Added `ManifestEnvironmentFingerprint`, which computes a stable one-way digest of the process environment and reads, writes, and validates it as a `.envhash` sidecar next to each cached dump.
- `ManifestLoader.readCachedManifest` now treats the cache as fresh only when the stored fingerprint matches the current environment, and `dumpPackageJSON` writes the sidecar whenever it caches a fresh dump.
- `PackageInfoCacheWriter.isFreshPackageInfo` applies the same fingerprint check to the per-package destination files (`root.json`, `packages/<id>.json`), and the refresh path writes the sidecar.

## Why

A `Package.swift` is arbitrary Swift and can branch on environment values through `PackageDescription.Context.environment`. I verified that SwiftPM forwards the entire process environment to the manifest interpreter (not a curated allowlist): a probe manifest saw the full environment (`KEYCOUNT=112`), and a target selected by `REPRO_USE_ALTERNATE` flipped correctly between two `dump-package` runs. Both caches therefore had to treat the environment as part of their key, and they did not.

## Root cause

`readCachedManifest` and `isFreshPackageInfo` compared only the modification times of the cached dump and `Package.swift`. Because the environment is not part of that check, a dump produced under `REPRO_USE_ALTERNATE=1` was reused verbatim after switching to `REPRO_USE_ALTERNATE=0` (and vice versa). This is the same class of bug as #11473, where a `CI`-conditioned manifest differed between local and CI environments.

## Approach

The fingerprint is a SHA-256 digest of the sorted `KEY=VALUE` environment pairs, stored as a sidecar so the cached `package.json` keeps its raw dump format and existing readers are unaffected.

Two decisions worth calling out:

- **A missing sidecar is treated as fresh, but backfilled on read.** Caches written before this change have no sidecar. Treating absence as a miss would force a one-time re-dump of every manifest on upgrade; treating it as a hit and backfilling the sidecar keeps existing caches valid while making them environment-aware from the next run onward. This is exactly the reporter's flow: the first run under a given environment records a fingerprint, and the next run under a different environment mismatches and re-dumps.
- **The whole environment is part of the digest.** Because SwiftPM exposes every variable, any of them can influence a manifest, so narrowing to an allowlist would reintroduce the bug for whatever is excluded. The digest is one-way, so secret-bearing values never reach disk in cleartext. Within a normal workflow the environment is stable across `tuist` invocations, so cache hits are preserved; the cache only re-dumps when something that could affect a manifest actually changed.

## Impact

Stale local-package manifests after an environment change are resolved. There is no migration step: existing caches keep working and become environment-aware automatically. The only observable cost is a fresh `dump-package` the first time the environment changes for a given package, which is the correct behavior.

## Validation

```
mise exec -- bazel test //:swifterpm_tests
# Test run with 134 tests in 20 suites passed after 8.803s
```

Added eight tests:

- `ManifestEnvironmentFingerprintTests`: digest stability across dictionary ordering, digest differs when values change, sidecar path extension, and validate returning `missing` / `matching` / `mismatching`, plus a write round-trip.
- `PackageInfoCacheTests.writePackageInfoCacheInvalidatesDestinationWhenEnvironmentChanged`: a destination that is newer than `Package.swift` but carries a mismatching env sidecar is invalidated and refilled from the `ManifestLoader` cache (no real `swift` invocation required).

### How to test locally

Reproduce the original scenario from the issue with a local package whose `Package.swift` selects a target from `Context.environment`:

1. `tuist install && tuist generate` with `REPRO_USE_ALTERNATE=1`.
2. Remove only the app's generated dependency data (for example `App/Tuist/.build`).
3. `tuist install && tuist generate` with `REPRO_USE_ALTERNATE=0`.

Before the fix the second generation reused `AlternateBackend`; with this change the `.envhash` mismatch forces a fresh dump and the graph contains `DefaultBackend`.
