### PR TITLE
fix(cli): reanchor module map paths to the generated project

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -213,20 +213,26 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             }
         }
 
-        // Source-root build-setting macros and absolute filesystem paths. In generated Xcode projects
-        // `$(SRCROOT)` points at the generated project, but for external SwiftPM packages the module
-        // map lives in the checkout, so a verbatim `$(SRCROOT)` path resolves to the wrong place.
-        // Resolve the macros against the source project's path and reanchor to the generated project's
-        // directory so the reference stays correct for external packages and machine-independent,
-        // which keeps cache hashes stable across checkouts.
+        // Source-root build-setting macros and absolute filesystem paths. `MODULEMAP_FILE` is
+        // authored relative to the source project: `$(SRCROOT)`/`$(SOURCE_ROOT)` resolve to the
+        // checkout (see `PackageInfoMapper`), while `$(PROJECT_DIR)` already anchors to the generated
+        // project. Resolve each macro against its corresponding project, then reanchor to the
+        // generated project's directory as a machine-independent `$(PROJECT_DIR)`-relative path so
+        // cache hashes stay stable across checkouts.
         if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
-            let projectPath = project.path.pathString
+            let sourceProjectPath = project.path.pathString
+            let generatedProjectPath = project.xcodeProjPath.parentDirectory.pathString
             let resolved = moduleMap
-                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath)
-                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath)
-                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath)
+                .replacingOccurrences(of: "$(PROJECT_DIR)", with: generatedProjectPath)
+                .replacingOccurrences(of: "$(SRCROOT)", with: sourceProjectPath)
+                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: sourceProjectPath)
 
-            guard let resolvedPath = try? AbsolutePath(validating: resolved) else { return nil }
+            // Macros we don't model here (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to an absolute
+            // path at generation time. Preserve them verbatim so the module map isn't dropped and Xcode
+            // can evaluate them at build time.
+            guard let resolvedPath = try? AbsolutePath(validating: resolved) else {
+                return moduleMap
+            }
 
             return "$(PROJECT_DIR)/\(resolvedPath.relative(to: project.xcodeProjPath.parentDirectory).pathString)"
         }

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -87,28 +87,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                         project: project
                     ) {
                         switch target.product {
-                        case .framework:
-                            target.scripts.append(
-                                TargetScript(
-                                    name: "Copy Module Map",
-                                    order: .post,
-                                    script: .embedded(
-                                        """
-                                        set -eu
-                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                        cp -f \(Self
-                                            .shellPath(
-                                                from: moduleMapPath
-                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                                        """
-                                    ),
-                                    inputPaths: [moduleMapPath],
-                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                                    showEnvVarsInLog: false,
-                                    basedOnDependencyAnalysis: true
-                                )
-                            )
-                        case .staticFramework:
+                        case .framework, .staticFramework:
                             mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
                         default:
                             break
@@ -241,24 +220,6 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             return nil
         }
         return "$(PROJECT_DIR)/\(moduleMap)"
-    }
-
-    private static func shellPath(from buildSettingPath: String) -> String {
-        let variables = [
-            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
-            ("$(SRCROOT)", "$SRCROOT"),
-            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
-        ]
-        var shellPath = buildSettingPath
-        for (buildSetting, shellVariable) in variables {
-            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
-        }
-        let escapedShellPath = shellPath
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "`", with: "\\`")
-
-        return "\"\(escapedShellPath)\""
     }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -83,7 +83,8 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
                 if hasModuleMap {
                     if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
+                        project: project
                     ) {
                         switch target.product {
                         case .framework:
@@ -196,10 +197,14 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     } // swiftlint:enable function_body_length
 
     private static func moduleMapPath(
-        from value: SettingsDictionary.Value?
+        from value: SettingsDictionary.Value?,
+        project: Project
     ) -> String? {
         guard case let .string(moduleMap) = value else { return nil }
 
+        // Combined dependency module maps live under `tuist-derived/` and are referenced as
+        // `$(SRCROOT)/../../tuist-derived/...`. Rewrite them to the canonical `$(PROJECT_DIR)` form
+        // without depending on the project's generated location.
         for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
             let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
             if moduleMap.hasPrefix(derivedDirectoryPrefix) {
@@ -208,8 +213,22 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             }
         }
 
+        // Source-root build-setting macros and absolute filesystem paths. In generated Xcode projects
+        // `$(SRCROOT)` points at the generated project, but for external SwiftPM packages the module
+        // map lives in the checkout, so a verbatim `$(SRCROOT)` path resolves to the wrong place.
+        // Resolve the macros against the source project's path and reanchor to the generated project's
+        // directory so the reference stays correct for external packages and machine-independent,
+        // which keeps cache hashes stable across checkouts.
         if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
-            return moduleMap
+            let projectPath = project.path.pathString
+            let resolved = moduleMap
+                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath)
+                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath)
+                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath)
+
+            guard let resolvedPath = try? AbsolutePath(validating: resolved) else { return nil }
+
+            return "$(PROJECT_DIR)/\(resolvedPath.relative(to: project.xcodeProjPath.parentDirectory).pathString)"
         }
 
         guard (try? RelativePath(validating: moduleMap)) != nil else {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_modulemap_copy_script() throws {
+    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -418,29 +418,13 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then — the absolute path is reanchored to the generated project's `$(PROJECT_DIR)` so cache
-        // hashes stay machine-independent.
+        // Then — the module map is passed to ExtractAPI through `MODULEMAP_PATH` (reanchored to the
+        // generated project) rather than copied into the framework bundle, which avoids the invalid
+        // top-level `Modules/` directory reported in #12040.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts ==
-            [
-                TargetScript(
-                    name: "Copy Module Map",
-                    order: .post,
-                    script: .embedded(
-                        """
-                        set -eu
-                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f "$PROJECT_DIR/A/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                        """
-                    ),
-                    inputPaths: ["$(PROJECT_DIR)/A/A.modulemap"],
-                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                    showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: true
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -507,14 +491,11 @@ struct ModuleMapMapperTests {
         // correctly in the generated project and stays machine-independent.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].script == .embedded(
-            """
-            set -eu
-            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-            cp -f "$PROJECT_DIR/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-            """
-        ))
-        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -541,7 +522,9 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/../../ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -391,6 +391,7 @@ struct ModuleMapMapperTests {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -401,6 +402,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -416,7 +418,8 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the absolute path is reanchored to the generated project's `$(PROJECT_DIR)` so cache
+        // hashes stay machine-independent.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(gotTarget.scripts ==
@@ -428,10 +431,10 @@ struct ModuleMapMapperTests {
                         """
                         set -eu
                         mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                        cp -f "$PROJECT_DIR/A/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
                         """
                     ),
-                    inputPaths: [moduleMapPath.pathString],
+                    inputPaths: ["$(PROJECT_DIR)/A/A.modulemap"],
                     outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
                     showEnvVarsInLog: false,
                     basedOnDependencyAnalysis: true
@@ -445,6 +448,7 @@ struct ModuleMapMapperTests {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -455,6 +459,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -470,18 +475,19 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the absolute path is reanchored to the generated project's `$(PROJECT_DIR)`.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
         #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .framework,
@@ -489,7 +495,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -497,17 +503,18 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the `$(SRCROOT)`-relative path is reanchored to `$(PROJECT_DIR)` so it resolves
+        // correctly in the generated project and stays machine-independent.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(gotTarget.scripts[0].script == .embedded(
             """
             set -eu
             mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+            cp -f "$PROJECT_DIR/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
             """
         ))
-        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"])
     }
 
     @Test(.inTemporaryDirectory)
@@ -567,10 +574,11 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_static_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .staticFramework,
@@ -578,7 +586,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -591,7 +599,144 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(
             gotTarget.settings?.base["MODULEMAP_PATH"] ==
-                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory, arguments: [
+        (
+            projectPathComponents: ["checkouts", "A"],
+            xcodeProjPathComponents: ["tuist-derived", "Projects", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["registry", "downloads", "A", "1.0.0"],
+            xcodeProjPathComponents: ["registry", "downloads", "A", "1.0.0", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["Packages", "A"],
+            xcodeProjPathComponents: ["Packages", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+    ])
+    func resolves_static_framework_modulemap_path_for_swift_package_layout(
+        projectPathComponents: [String],
+        xcodeProjPathComponents: [String],
+        expectedModuleMapPath: String
+    ) throws {
+        // Given — for external SwiftPM packages the module map lives in the checkout, but the
+        // generated project's `$(SRCROOT)` points at the generated project, so the reference must be
+        // reanchored to the generated project's directory.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: projectPathComponents)
+        let xcodeProjPath = scratchDirectory.appending(components: xcodeProjPathComponents)
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(expectedModuleMapPath))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func produces_identical_modulemap_path_for_external_projects_in_different_absolute_roots() throws {
+        // Given
+        let workspace = Workspace.test()
+
+        func mappedModuleMapPath(in scratchDirectory: AbsolutePath) throws -> SettingsDictionary.Value? {
+            let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+            let xcodeProjPath = scratchDirectory.appending(
+                components: "tuist-derived", "Projects", "A", "A.xcodeproj"
+            )
+            let target = Target.test(
+                name: "A",
+                product: .staticFramework,
+                settings: .test(base: [
+                    "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+                ])
+            )
+            let project = Project.test(
+                path: projectPath,
+                xcodeProjPath: xcodeProjPath,
+                name: "A",
+                targets: [target],
+                type: .external()
+            )
+
+            let (graph, _, _) = try subject.map(
+                graph: .test(workspace: workspace, projects: [projectPath: project]),
+                environment: MapperEnvironment()
+            )
+            return graph.projects[projectPath]?.targets["A"]?.settings?.base["MODULEMAP_PATH"]
+        }
+
+        // When
+        let firstModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "first", ".build")
+        )
+        let secondModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "second", ".build")
+        )
+
+        // Then — reanchoring keeps cache hashes stable across checkouts with different absolute roots.
+        #expect(firstModuleMapPath == secondModuleMapPath)
+    }
+
+    @Test(.inTemporaryDirectory, arguments: ["$(SRCROOT)", "$(SOURCE_ROOT)", "$(PROJECT_DIR)"])
+    func reanchors_static_framework_modulemap_path_from_source_root_macro(sourceRootMacro: String) throws {
+        // Given
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("\(sourceRootMacro)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — every source-root macro resolves to the same generated-project-relative path.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap")
         )
     }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -703,8 +703,8 @@ struct ModuleMapMapperTests {
         #expect(firstModuleMapPath == secondModuleMapPath)
     }
 
-    @Test(.inTemporaryDirectory, arguments: ["$(SRCROOT)", "$(SOURCE_ROOT)", "$(PROJECT_DIR)"])
-    func reanchors_static_framework_modulemap_path_from_source_root_macro(sourceRootMacro: String) throws {
+    @Test(.inTemporaryDirectory, arguments: ["$(SRCROOT)", "$(SOURCE_ROOT)"])
+    func reanchors_srcroot_macros_against_the_source_project_path(sourceRootMacro: String) throws {
         // Given
         let workspace = Workspace.test()
         let scratchDirectory = try temporaryPath().appending(component: ".build")
@@ -731,12 +731,87 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then — every source-root macro resolves to the same generated-project-relative path.
+        // Then — `$(SRCROOT)`/`$(SOURCE_ROOT)` are authored relative to the checkout, so they resolve
+        // through the source project path into a generated-project-relative reference.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(
             gotTarget.settings?.base["MODULEMAP_PATH"] ==
                 .string("$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func keeps_project_dir_anchored_to_the_generated_project() throws {
+        // Given — for a relocated external project the source project (`project.path`) is the checkout
+        // while the generated project lives under `tuist-derived`. `$(PROJECT_DIR)` already anchors to
+        // the generated project, so it must not be redirected into the checkout.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(PROJECT_DIR)/Generated/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the generated-project-relative path is preserved, not redirected into the checkout.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/Generated/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_unrecognized_modulemap_macros() throws {
+        // Given — build-setting macros we don't model (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to
+        // an absolute path at generation time, so they are passed through for Xcode to evaluate.
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(DERIVED_FILE_DIR)/Generated.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the macro is preserved verbatim instead of dropping the module map.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(DERIVED_FILE_DIR)/Generated.modulemap")
         )
     }
 


### PR DESCRIPTION
## What changed

- `ModuleMapMapper` resolves `MODULEMAP_FILE` against the project it belongs to before emitting `MODULEMAP_PATH`, reanchoring source-root macros (`$(SRCROOT)`, `$(SOURCE_ROOT)`) against the source project and `$(PROJECT_DIR)` against the generated project, so the reference is correct for external SwiftPM packages and machine-independent for cache hashing.
- The dynamic-framework `Copy Module Map` script (restored by #12137) is removed. Dynamic and static frameworks now both pass the module map through `MODULEMAP_PATH`.
- Unit tests cover the three real SwiftPM layouts (checkout, registry download, local `Packages`), cache-hash stability across absolute roots, every source-root macro, `$(PROJECT_DIR)` anchoring on relocated external projects, and verbatim passthrough for unrecognized macros such as `$(DERIVED_FILE_DIR)`.

## Why

This reconciles three threads that all rewrite the same `if hasModuleMap` block:

- #12055 switched dynamic frameworks to `MODULEMAP_PATH`, but passed the source-relative `MODULEMAP_FILE` in verbatim, so ExtractAPI got the wrong path. The `GenerateAcceptanceTestiOSAppWithModuleMapPackages` acceptance test (which runs `xcodebuild docbuild`) regressed.
- #12137 reverted dynamic frameworks to a `Copy Module Map` script to fix that regression, and kept `MODULEMAP_PATH` only for static frameworks.
- #12128 reanchored the path relative to the generated project so cache hashes stay machine-independent, but conflicted with #12137.

On its own, #12137 left two gaps: external SwiftPM packages set `MODULEMAP_FILE` as `$(SRCROOT)/<checkout-relative>` (see `PackageInfoMapper`), but in the generated project `$(SRCROOT)` points at the generated project, so the verbatim path resolved to the wrong place; and the copy script it restored is exactly the build phase that causes #12040.

## Root cause

#12137's ExtractAPI regression was caused by the wrong path, not by the absence of copying. With the path correctly reanchored, ExtractAPI resolves the module map through `MODULEMAP_PATH` alone, so the copy step is redundant. Removing it also removes the build phase that writes `Framework.framework/Modules/module.modulemap` into the bundle root, which is invalid layout for a versioned macOS framework and breaks strict codesigning (#12040).

## Approach

Keep path resolution project-aware (source-root macros against the source project, `$(PROJECT_DIR)` against the generated project, unrecognized macros passed through verbatim), and have every framework product emit `MODULEMAP_PATH` instead of a copy script. The `tuist-derived` combined-map special case is unchanged.

## Impact

- Generated projects with module maps reference them at a stable `$(PROJECT_DIR)`-relative location, so cache hashes no longer depend on the checkout's absolute path.
- Dynamic frameworks no longer receive a `Copy Module Map` phase, so the versioned-framework codesign failure from #12040 no longer occurs.
- ExtractAPI/doc builds keep working (validated below).

Fixes #12040. Supersedes #12128 by folding its path resolution into a structure that no longer needs the copy step.

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ModuleMapMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` - 19 tests pass.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestiOSAppWithModuleMapPackages CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` - passes with the copy step removed. This test runs `tuist install`, `tuist generate`, `xcodebuild docbuild` (ExtractAPI), and `xcodebuild build` against the Gzip/GEOSwift/Firebase graph, confirming ExtractAPI resolves the module map through `MODULEMAP_PATH` without the bundled copy.
