### PR TITLE
feat(cli): support custom CA certificate bundles for self-hosted servers

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -24,6 +24,7 @@ This node covers the Tuist CLI workspace under `cli/`. Follow downlinks for subs
 
 ## Code Style
 - Do not add one-line comments unless they are truly useful.
+- Report user-facing warnings through `AlertController.current.warning(.alert("..."))` (from `TuistAlert`) so they are collected and presented at the end of the command. Do not use `Logger.current.warning` for this; reserve `Logger` for debug/trace output.
 
 ## Testing
 - Use Swift Testing framework with custom traits for tests that need temporary directories.

--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -34,10 +34,21 @@ public struct Tuist: Codable, Equatable, Sendable {
         /// `HTTPS_PROXY`/`HTTP_PROXY` when present in the environment.
         public let proxy: Bool
 
+        /// Path to a PEM (or DER) CA certificate bundle to trust in addition to the
+        /// system root store when connecting to a self-hosted Tuist/Kura server that
+        /// uses a private CA. The system root store remains trusted, so public CAs
+        /// keep validating normally. The `TUIST_CA_CERTIFICATE` environment variable
+        /// takes precedence over this value.
+        public let caCertificate: Path?
+
         /// Creates network options.
-        /// - Parameter proxy: Whether Tuist should use the proxy defined in the environment. Defaults to `true`.
-        public static func network(proxy: Bool = true) -> Self {
-            Network(proxy: proxy)
+        /// - Parameters:
+        ///   - proxy: Whether Tuist should use the proxy defined in the environment. Defaults to `true`.
+        ///   - caCertificate: Path to a CA certificate bundle to trust on top of the system root store.
+        ///     Useful for self-hosted servers with a private CA on hosts where the root can't be installed
+        ///     in the System keychain (for example headless CI). Defaults to `nil`.
+        public static func network(proxy: Bool = true, caCertificate: Path? = nil) -> Self {
+            Network(proxy: proxy, caCertificate: caCertificate)
         }
     }
 

--- a/cli/Sources/TuistCAS/Services/EndpointLatencyService.swift
+++ b/cli/Sources/TuistCAS/Services/EndpointLatencyService.swift
@@ -21,14 +21,13 @@ struct EndpointLatencyService: EndpointLatencyServicing {
         request.setValue("0", forHTTPHeaderField: "Expires")
 
         #if os(macOS)
-            // Use URLSessionTaskMetrics for precise timing on macOS
+            // Use URLSessionTaskMetrics for precise timing on macOS. Route through the
+            // shared session so a configured CA certificate bundle is honored when probing
+            // private-CA endpoints; the metrics are captured via a per-task delegate.
             return await withCheckedContinuation { continuation in
                 let delegate = MetricsDelegate(continuation: continuation)
-                let session = URLSession(configuration: tuistURLSessionConfiguration(), delegate: delegate, delegateQueue: nil)
-                delegate.session = session
-
                 Task {
-                    _ = try? await session.data(for: request)
+                    _ = try? await URLSession.tuistShared.data(for: request, delegate: delegate)
                 }
             }
         #else
@@ -58,7 +57,6 @@ struct EndpointLatencyService: EndpointLatencyServicing {
 #if os(macOS)
     private final class MetricsDelegate: NSObject, URLSessionTaskDelegate {
         private let latencyContinuation: CheckedContinuation<TimeInterval?, Never>
-        var session: URLSession?
 
         init(continuation: CheckedContinuation<TimeInterval?, Never>) {
             latencyContinuation = continuation
@@ -70,11 +68,6 @@ struct EndpointLatencyService: EndpointLatencyServicing {
             task: URLSessionTask,
             didFinishCollecting metrics: URLSessionTaskMetrics
         ) {
-            defer {
-                session?.invalidateAndCancel()
-                session = nil
-            }
-
             if let httpResponse = task.response as? HTTPURLResponse,
                !(200 ... 299).contains(httpResponse.statusCode)
             {

--- a/cli/Sources/TuistConfig/Tuist.swift
+++ b/cli/Sources/TuistConfig/Tuist.swift
@@ -15,9 +15,11 @@ public enum TuistConfigError: LocalizedError, Equatable {
 public struct Tuist: Equatable, Hashable, Sendable {
     public struct Network: Equatable, Hashable, Sendable {
         public let proxy: Bool
+        public let caCertificate: String?
 
-        public init(proxy: Bool = true) {
+        public init(proxy: Bool = true, caCertificate: String? = nil) {
             self.proxy = proxy
+            self.caCertificate = caCertificate
         }
     }
 

--- a/cli/Sources/TuistConfigLoader/ConfigLoader.swift
+++ b/cli/Sources/TuistConfigLoader/ConfigLoader.swift
@@ -66,11 +66,17 @@ public struct ConfigLoader: ConfigLoading {
             fullHandle: tomlConfig.project,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
             url: tomlConfig.url ?? Constants.URLs.production,
-            network: .init(proxy: tomlConfig.network?.proxy ?? true)
+            network: .init(
+                proxy: tomlConfig.network?.proxy ?? true,
+                caCertificate: tomlConfig.network?.caCertificate
+            )
         )
     }
 
     private func applyRuntimeSettings(from config: TuistConfig.Tuist) {
-        HTTPSettings.current = .init(useEnvironmentProxy: config.network.proxy)
+        HTTPSettings.current = .init(
+            useEnvironmentProxy: config.network.proxy,
+            caCertificatePath: config.network.caCertificate
+        )
     }
 }

--- a/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
+++ b/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
@@ -10,6 +10,11 @@ struct TuistTomlConfig: Equatable, Sendable, Decodable {
             self.proxy = proxy
             self.caCertificate = caCertificate
         }
+
+        private enum CodingKeys: String, CodingKey {
+            case proxy
+            case caCertificate = "ca_certificate"
+        }
     }
 
     let project: String?

--- a/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
+++ b/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
@@ -4,9 +4,11 @@ import TuistConfig
 struct TuistTomlConfig: Equatable, Sendable, Decodable {
     struct Network: Equatable, Sendable, Decodable {
         let proxy: Bool?
+        let caCertificate: String?
 
-        init(proxy: Bool? = nil) {
+        init(proxy: Bool? = nil, caCertificate: String? = nil) {
             self.proxy = proxy
+            self.caCertificate = caCertificate
         }
     }
 

--- a/cli/Sources/TuistHTTP/HTTPSettings.swift
+++ b/cli/Sources/TuistHTTP/HTTPSettings.swift
@@ -2,12 +2,14 @@ import Foundation
 
 public struct HTTPSettings: Equatable, Sendable {
     public var useEnvironmentProxy: Bool
+    public var caCertificatePath: String?
 
     private static let lock = NSLock()
     private static var storedCurrent = HTTPSettings()
 
-    public init(useEnvironmentProxy: Bool = true) {
+    public init(useEnvironmentProxy: Bool = true, caCertificatePath: String? = nil) {
         self.useEnvironmentProxy = useEnvironmentProxy
+        self.caCertificatePath = caCertificatePath
     }
 
     public static var current: HTTPSettings {

--- a/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
@@ -1,5 +1,5 @@
 import Foundation
-import TuistLogging
+import TuistAlert
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -84,16 +84,20 @@ import TuistLogging
         static func load(from path: String) -> [SecCertificate]? {
             let url = URL(fileURLWithPath: path)
             guard let data = try? Data(contentsOf: url) else {
-                Logger.current
+                AlertController.current
                     .warning(
-                        "Could not read the custom CA certificate bundle at '\(path)'. TLS will use the system trust store only."
+                        .alert(
+                            "Could not read the custom CA certificate bundle at '\(path)'. TLS will use the system trust store only."
+                        )
                     )
                 return nil
             }
             let certificates = parse(from: data)
             if certificates.isEmpty {
-                Logger.current
-                    .warning("No certificates could be parsed from '\(path)'. TLS will use the system trust store only.")
+                AlertController.current
+                    .warning(
+                        .alert("No certificates could be parsed from '\(path)'. TLS will use the system trust store only.")
+                    )
                 return nil
             }
             return certificates

--- a/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
@@ -20,6 +20,11 @@ import TuistAlert
     /// `false`, so the system root store keeps validating normally. This lets teams run
     /// a self-hosted Tuist/Kura server with a private CA on hosts where installing a
     /// trusted root in the System keychain isn't practical (for example headless CI).
+    ///
+    /// `@unchecked Sendable` is safe because the only stored state,
+    /// `additionalCertificates`, is an immutable `[SecCertificate]` assigned once at init
+    /// and never mutated, so the instance can be shared across the URLSession delegate
+    /// queue. Adding mutable state here would need to re-establish that invariant.
     final class TuistURLSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
         private let additionalCertificates: [SecCertificate]
 

--- a/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
@@ -1,0 +1,139 @@
+import Foundation
+import TuistLogging
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+#if canImport(TuistHAR)
+    import TuistHAR
+#endif
+
+#if canImport(Security)
+    import Security
+
+    /// A URLSession delegate that trusts an additional set of CA certificates on top of
+    /// the system root store, while preserving HAR metrics collection.
+    ///
+    /// The system keychain is still consulted: the custom anchors are *added* to the
+    /// existing trust evaluation and `SecTrustSetAnchorCertificatesOnly` is set to
+    /// `false`, so the system root store keeps validating normally. This lets teams run
+    /// a self-hosted Tuist/Kura server with a private CA on hosts where installing a
+    /// trusted root in the System keychain isn't practical (for example headless CI).
+    final class TuistURLSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+        private let additionalCertificates: [SecCertificate]
+
+        init(additionalCertificates: [SecCertificate]) {
+            self.additionalCertificates = additionalCertificates
+            super.init()
+        }
+
+        func urlSession(
+            _: URLSession,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+                  let trust = challenge.protectionSpace.serverTrust
+            else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            if TLSValidator.evaluate(trust, addingAdditionalAnchors: additionalCertificates) {
+                completionHandler(.useCredential, URLCredential(trust: trust))
+            } else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
+        }
+
+        #if canImport(TuistHAR)
+            func urlSession(
+                _ session: URLSession,
+                task: URLSessionTask,
+                didFinishCollecting metrics: URLSessionTaskMetrics
+            ) {
+                // Forward to the shared metrics delegate so HAR recording keeps working
+                // when a session uses a custom-trust delegate.
+                URLSessionMetricsDelegate.shared.urlSession(session, task: task, didFinishCollecting: metrics)
+            }
+        #endif
+    }
+
+    enum TLSValidator {
+        /// Evaluates `trust`, optionally adding `additionalAnchors` (for example a private
+        /// CA) on top of the system root store before evaluation. Returns `true` if the
+        /// server is trusted. The system root store is never replaced: extra anchors are
+        /// additive (`SecTrustSetAnchorCertificatesOnly(trust, false)`).
+        static func evaluate(_ trust: SecTrust, addingAdditionalAnchors anchors: [SecCertificate]) -> Bool {
+            if !anchors.isEmpty {
+                SecTrustSetAnchorCertificates(trust, anchors as CFArray)
+                SecTrustSetAnchorCertificatesOnly(trust, false)
+            }
+            var error: CFError?
+            return SecTrustEvaluateWithError(trust, &error)
+        }
+    }
+
+    /// Loads DER `SecCertificate` objects from a PEM bundle (one or more concatenated
+    /// `-----BEGIN CERTIFICATE-----` blocks) or a single DER file.
+    enum CACertificateLoader {
+        /// Returns the certificates in the bundle, or `nil` (with a logged warning) if the
+        /// file can't be read or contains no parseable certificates. Returning `nil` lets
+        /// the caller fall back to the default session rather than failing hard.
+        static func load(from path: String) -> [SecCertificate]? {
+            let url = URL(fileURLWithPath: path)
+            guard let data = try? Data(contentsOf: url) else {
+                Logger.current
+                    .warning(
+                        "Could not read the custom CA certificate bundle at '\(path)'. TLS will use the system trust store only."
+                    )
+                return nil
+            }
+            let certificates = parse(from: data)
+            if certificates.isEmpty {
+                Logger.current
+                    .warning("No certificates could be parsed from '\(path)'. TLS will use the system trust store only.")
+                return nil
+            }
+            return certificates
+        }
+
+        /// Parses certificates from PEM or DER data.
+        static func parse(from data: Data) -> [SecCertificate] {
+            let base64Blocks = pemBlocks(from: data)
+            let derBlocks: [Data]
+            if base64Blocks.isEmpty {
+                // Not PEM: treat the whole blob as a single DER certificate.
+                derBlocks = [data]
+            } else {
+                derBlocks = base64Blocks.compactMap { Data(base64Encoded: $0) }
+            }
+            return derBlocks.compactMap { SecCertificateCreateWithData(nil, $0 as CFData) }
+        }
+
+        private static let beginMarker = "-----BEGIN CERTIFICATE-----"
+        private static let endMarker = "-----END CERTIFICATE-----"
+
+        /// Extracts the base64 body of each PEM certificate block. Returns an empty array
+        /// when the data isn't PEM (for example a raw DER file).
+        private static func pemBlocks(from data: Data) -> [String] {
+            guard let text = String(data: data, encoding: .utf8),
+                  text.contains(beginMarker)
+            else { return [] }
+
+            var blocks: [String] = []
+            var searchRange = text.startIndex ..< text.endIndex
+            while let beginRange = text.range(of: beginMarker, range: searchRange),
+                  let endRange = text.range(of: endMarker, range: beginRange.upperBound ..< text.endIndex)
+            {
+                let base64 = text[beginRange.upperBound ..< endRange.lowerBound]
+                    .filter { !$0.isWhitespace }
+                blocks.append(String(base64))
+                searchRange = endRange.upperBound ..< text.endIndex
+            }
+            return blocks
+        }
+    }
+
+#endif

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -23,6 +23,44 @@ private func resolvedUseEnvironmentProxy(_ useEnvironmentProxy: Bool?) -> Bool {
     useEnvironmentProxy ?? HTTPSettings.current.useEnvironmentProxy
 }
 
+/// Resolves the path to a custom CA certificate bundle. The `TUIST_CA_CERTIFICATE`
+/// environment variable takes precedence over the value declared in the config so it
+/// can be supplied as a CI secret without changing the committed manifest.
+private func resolvedCACertificatePath() -> String? {
+    let environment = Environment.current.variables
+    if let value = environment["TUIST_CA_CERTIFICATE"], !value.isEmpty {
+        return value
+    }
+    return HTTPSettings.current.caCertificatePath
+}
+
+/// The session delegate to use. When a custom CA bundle resolves and parses, a
+/// trust-augmenting delegate is used so a private CA is honored on top of the system
+/// root store. Otherwise the behavior is unchanged from before: HAR metrics delegate
+/// when available, or no delegate at all.
+private func tuistSessionDelegate() -> (URLSessionDelegate & URLSessionTaskDelegate)? {
+    #if canImport(Security)
+        if let path = resolvedCACertificatePath(),
+           let certificates = CACertificateLoader.load(from: path),
+           !certificates.isEmpty
+        {
+            return TuistURLSessionDelegate(additionalCertificates: certificates)
+        }
+    #endif
+    #if canImport(TuistHAR)
+        return URLSessionMetricsDelegate.shared
+    #else
+        return nil
+    #endif
+}
+
+private func makeURLSession(configuration: URLSessionConfiguration) -> URLSession {
+    if let delegate = tuistSessionDelegate() {
+        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    }
+    return URLSession(configuration: configuration)
+}
+
 private func environmentInt(_ key: String, default defaultValue: Int) -> Int {
     guard let value = Environment.current.variables[key], let parsed = Int(value) else {
         return defaultValue
@@ -56,15 +94,7 @@ private func tuistURLSessionConfigurationResolved(useEnvironmentProxy: Bool) -> 
 }
 
 private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
-    #if canImport(TuistHAR)
-        return URLSession(
-            configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy),
-            delegate: URLSessionMetricsDelegate.shared,
-            delegateQueue: nil
-        )
-    #else
-        return URLSession(configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy))
-    #endif
+    makeURLSession(configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy))
 }
 
 private final class SharedTuistURLSession: @unchecked Sendable {
@@ -115,11 +145,7 @@ private func makeTuistCASURLSession(useEnvironmentProxy: Bool) -> URLSession {
     let configuration = tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy)
     configuration.timeoutIntervalForRequest = 15
     configuration.timeoutIntervalForResource = 300
-    #if canImport(TuistHAR)
-        return URLSession(configuration: configuration, delegate: URLSessionMetricsDelegate.shared, delegateQueue: nil)
-    #else
-        return URLSession(configuration: configuration)
-    #endif
+    return makeURLSession(configuration: configuration)
 }
 
 private let sharedTuistURLSession = SharedTuistURLSession { makeTuistURLSession(useEnvironmentProxy: $0) }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -38,7 +38,8 @@ extension TuistConfig.Tuist {
     ) async throws -> TuistConfig.Tuist {
         let fullHandle = manifest.fullHandle
         let inspectOptions = InspectOptions.from(manifest: manifest.inspectOptions)
-        let network = TuistConfig.Tuist.Network(proxy: manifest.network.proxy)
+        let generatorPaths = GeneratorPaths(manifestDirectory: path, rootDirectory: rootDirectory)
+        let network = try makeNetwork(from: manifest, generatorPaths: generatorPaths)
         let xcodeCache = TuistConfig.Tuist.XcodeCache(upload: manifest.xcodeCache.upload)
         let urlString = manifest.url
 
@@ -54,7 +55,6 @@ extension TuistConfig.Tuist {
             installOptions,
             cacheOptions
         ):
-            let generatorPaths = GeneratorPaths(manifestDirectory: path, rootDirectory: rootDirectory)
             let generationOptions = try TuistConfig.TuistGeneratedProjectOptions.GenerationOptions.from(
                 manifest: generationOptions,
                 generatorPaths: generatorPaths,
@@ -95,6 +95,16 @@ extension TuistConfig.Tuist {
                 network: network
             )
         }
+    }
+}
+
+extension TuistConfig.Tuist {
+    fileprivate static func makeNetwork(
+        from manifest: ProjectDescription.Config,
+        generatorPaths: GeneratorPaths
+    ) throws -> TuistConfig.Tuist.Network {
+        let caCertificate = try manifest.network.caCertificate.map { try generatorPaths.resolve(path: $0).pathString }
+        return .init(proxy: manifest.network.proxy, caCertificate: caCertificate)
     }
 }
 

--- a/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
@@ -79,6 +79,25 @@ struct ConfigLoaderTests {
         #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
+    @Test(.inTemporaryDirectory)
+    func loadConfig_propagates_toml_ca_certificate_to_http_settings() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
+
+        given(tomlConfigLoader)
+            .loadConfig(at: .any)
+            .willReturn(TuistTomlConfig(network: .init(proxy: true, caCertificate: "/etc/ssl/certs/ca.pem")))
+
+        let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
+
+        let config = try await subject.loadConfig(path: temporaryDirectory)
+
+        #expect(config.network.caCertificate == "/etc/ssl/certs/ca.pem")
+        #expect(HTTPSettings.current.caCertificatePath == "/etc/ssl/certs/ca.pem")
+    }
+
     private func makeConfigLoader(tomlConfigLoader: TuistTomlConfigLoading) -> ConfigLoader {
         #if os(macOS)
             let swiftConfigLoader = MockSwiftConfigLoading()

--- a/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
@@ -181,7 +181,7 @@
                 .test(
                     fullHandle: "tuist/tuist",
                     url: "https://test.tuist.io",
-                    network: .network(proxy: false)
+                    network: .network(proxy: false, caCertificate: "/etc/ssl/certs/ca.pem")
                 ),
                 at: configPath.parentDirectory
             )
@@ -204,7 +204,7 @@
                 fullHandle: "tuist/tuist",
                 inspectOptions: .test(),
                 url: expectedURL,
-                network: .init(proxy: false)
+                network: .init(proxy: false, caCertificate: "/etc/ssl/certs/ca.pem")
             ))
         }
 

--- a/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
@@ -93,6 +93,32 @@ struct TuistTomlConfigLoaderTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func loadConfig_returns_config_with_network_ca_certificate() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlPath = temporaryDirectory.appending(component: Constants.tuistTomlFileName)
+        try await fileSystem.writeText(
+            """
+            [network]
+            proxy = true
+            caCertificate = "/etc/ssl/certs/ca.pem"
+            """,
+            at: tomlPath
+        )
+
+        let rootDirectoryLocator = MockRootDirectoryLocating()
+        given(rootDirectoryLocator).locate(from: .any).willReturn(temporaryDirectory)
+
+        let subject = TuistTomlConfigLoader(
+            fileSystem: fileSystem,
+            rootDirectoryLocator: rootDirectoryLocator
+        )
+        let config = try await subject.loadConfig(at: temporaryDirectory)
+
+        #expect(config?.network?.proxy == true)
+        #expect(config?.network?.caCertificate == "/etc/ssl/certs/ca.pem")
+    }
+
+    @Test(.inTemporaryDirectory)
     func loadConfig_returns_nil_when_no_root_directory() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 

--- a/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
@@ -100,7 +100,7 @@ struct TuistTomlConfigLoaderTests {
             """
             [network]
             proxy = true
-            caCertificate = "/etc/ssl/certs/ca.pem"
+            ca_certificate = "/etc/ssl/certs/ca.pem"
             """,
             at: tomlPath
         )

--- a/cli/Tests/TuistHTTPTests/CACertificateLoaderTests.swift
+++ b/cli/Tests/TuistHTTPTests/CACertificateLoaderTests.swift
@@ -1,0 +1,117 @@
+#if os(macOS)
+    import Foundation
+    import Security
+    import Testing
+
+    @testable import TuistHTTP
+
+    @Suite
+    struct CACertificateLoaderTests {
+        private static let caPEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIC1jCCAb6gAwIBAgIJAJlwwm+UwR8bMA0GCSqGSIb3DQEBCwUAMBgxFjAUBgNV
+        BAMMDVR1aXN0IFRlc3QgQ0EwHhcNMjYwNzMwMTAyNzQzWhcNMzYwNzI3MTAyNzQz
+        WjAYMRYwFAYDVQQDDA1UdWlzdCBUZXN0IENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
+        AQ8AMIIBCgKCAQEAqFVEuF4ifFLLwqHbmAq8n85/T48H9EZ+JgeNG/hqPohrEdYV
+        xyqVUE3P486kMWiSBvj6DsiE52SYjpQ90UmvmZltgepdy5nas3O+l0PbP4t8RTnT
+        UY8jKBd8XmW3/CXnf4UxRMN54SuY8ehsrxHFLjeW3IErDqwhFIT2okPKNRCZTY2t
+        aUF5brOCenAA4fkrltFgTY6klIggRr4UtUgQXRqLAgNWH6wxiaqNpP+ObtZjNp5e
+        YlgQxcJVkDso3fV+huvdjmh+mIrCmHRtHc6ctNqnH7E4NY6f5e0gURusJV+UX6xS
+        T7UlKn0sGL9xUtKNJXnCH/UOOd5nzuENnSFbdwIDAQABoyMwITAPBgNVHRMBAf8E
+        BTADAQH/MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAQEAfmPzhf94
+        F+CnPseiC6giYtrefx23r9G1P1e1wCSph5atFmdLW6Q2sDeab7LPSQUqnEx1/Q7I
+        mYwgPNZExQoxBYla9zvqyC/TWYSR2768oLSwSAqGKa7iN+QiO+fFZJeelXW1Fz2z
+        QQEd/RMZPotQMWTtoJ36gSwFrk8SraRT4l8E+iWhOTH+nNmPJWmcq3MPgL0j3aaS
+        xuSsMl2S/1JBAVkwnsQt2Ldwxs8si7ACeeneESn1L22jtRiQJAvadurOOvmXYItY
+        JJDM29xzYSuzuf7j46+zSYushfZ0faO9E9lp7PrYcUHNI4PPs1a3I/v5rtl1YtA8
+        NQOawDBP+hdGwA==
+        -----END CERTIFICATE-----
+        """
+
+        private static let leafPEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIC+jCCAeKgAwIBAgIJAIUXHr1OMIzGMA0GCSqGSIb3DQEBCwUAMBgxFjAUBgNV
+        BAMMDVR1aXN0IFRlc3QgQ0EwHhcNMjYwNzMwMTAyNzQzWhcNMjgxMTAxMTAyNzQz
+        WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+        ggEKAoIBAQCnuLlKIfwB1+UO5uF5TcH5Xte3bQKh3SE09tYOZwY6DBnRjlgsItdx
+        OptnVUyLGzOQuld1TTdSTwlKnvehsflI5FnfRgIHnZTmf/K0N6nb69+JtGoQUhLs
+        5PNjb/f8WnhFcV5XXkfaq6ufbEws1CCYiOEgKYVABKzGGnz35KZ5ed0oqmJLhHGX
+        Bx143LiaqInNcYpxTL2VSCwVwDag595DCJLG3iMDznjiANLdHQGsXSabepYXKrP/
+        qQ5e/F9aTdE1sZMeejCTyDzZwnCvTWLmMDbFYf74d5nuekDEzKsVr4/WCApKqr7t
+        XoAln/ClUv7pGQQ0JoaFRj6vJ4oQ6T9TAgMBAAGjSzBJMAwGA1UdEwEB/wQCMAAw
+        DgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMBQGA1UdEQQNMAuC
+        CWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAp/g2avaiOwLIoqeDmIy8cwzy
+        zXS66lX83cQeu+85cRH9vkyzYI+nCcY3ABSjf0rlAXST2LpUClQojfWZNaWaSP3Q
+        scZlT+XJvAEP78AW4E7feUQOEGyRqaX2Qk0/xZf+P636rvubvq3r88JCnAN3h4jM
+        PvPHjSYUPlCFkHi48Tkrlc9/OKrMdOLBMEgykKsaTx74fATC29IIgN3jnCySKNkE
+        vr7vKkTQPNOMBkoDVqSHS/ilOzUm9+iKzDuYfUfjqy60kZWpioEt7dn9W8ittM6i
+        wwJp2Lu3iXN62t6OCSv/QczDa/Q6ShpV8IQkikmAtEtecbzAmZz6m9utqQsugA==
+        -----END CERTIFICATE-----
+        """
+
+        @Test
+        func parses_single_PEM_certificate() {
+            let certificates = CACertificateLoader.parse(from: Data(CACertificateLoaderTests.caPEM.utf8))
+            #expect(certificates.count == 1)
+        }
+
+        @Test
+        func parses_multiple_concatenated_PEM_certificates() {
+            let bundle = CACertificateLoaderTests.caPEM + "\n" + CACertificateLoaderTests.leafPEM
+            let certificates = CACertificateLoader.parse(from: Data(bundle.utf8))
+            #expect(certificates.count == 2)
+        }
+
+        @Test
+        func parses_DER_certificate_when_not_PEM() throws {
+            // Strip the PEM armor to obtain the raw DER bytes, then confirm the loader
+            // recognizes the DER blob as a single certificate.
+            let body = CACertificateLoaderTests.caPEM
+                .components(separatedBy: .whitespacesAndNewlines)
+                .filter { !$0.contains("----") }
+                .joined()
+            let derData = try #require(Data(base64Encoded: body))
+
+            let certificates = CACertificateLoader.parse(from: derData)
+            #expect(certificates.count == 1)
+        }
+
+        @Test
+        func returns_empty_for_non_certificate_data() {
+            let certificates = CACertificateLoader.parse(from: Data("not a certificate".utf8))
+            #expect(certificates.isEmpty)
+        }
+
+        @Test
+        func load_returns_nil_for_missing_file() {
+            let certificates = CACertificateLoader.load(from: "/does/not/exist/ca.pem")
+            #expect(certificates == nil)
+        }
+
+        @Test
+        func validator_trusts_leaf_only_when_ca_is_added_as_anchor() throws {
+            let leaf = try #require(CACertificateLoader.parse(from: Data(CACertificateLoaderTests.leafPEM.utf8)).first)
+            let ca = try #require(CACertificateLoader.parse(from: Data(CACertificateLoaderTests.caPEM.utf8)).first)
+
+            // Without the CA anchor the self-signed leaf is untrusted.
+            let untrusted = try trust(for: leaf, hostname: "localhost")
+            #expect(!TLSValidator.evaluate(untrusted, addingAdditionalAnchors: []))
+
+            // With the CA added on top of the system root store the leaf validates.
+            let trusted = try trust(for: leaf, hostname: "localhost")
+            #expect(TLSValidator.evaluate(trusted, addingAdditionalAnchors: [ca]))
+
+            // Hostname mismatch still fails even with the CA trusted: evaluation is not bypassed.
+            let mismatched = try trust(for: leaf, hostname: "evil.com")
+            #expect(!TLSValidator.evaluate(mismatched, addingAdditionalAnchors: [ca]))
+        }
+
+        private func trust(for certificate: SecCertificate, hostname: String) throws -> SecTrust {
+            let policy = SecPolicyCreateSSL(true, hostname as CFString)
+            var trust: SecTrust?
+            let status = SecTrustCreateWithCertificates(certificate, policy, &trust)
+            try #require(status == errSecSuccess)
+            return try #require(trust)
+        }
+    }
+#endif

--- a/server/priv/docs/en/cli/debugging.md
+++ b/server/priv/docs/en/cli/debugging.md
@@ -118,7 +118,7 @@ You can also declare it in your <.localized_link href="/references/tuist-toml">c
 
 ```toml
 [network]
-caCertificate = "/etc/ssl/certs/self-hosted-ca.pem"
+ca_certificate = "/etc/ssl/certs/self-hosted-ca.pem"
 ```
 
 The `TUIST_CA_CERTIFICATE` environment variable takes precedence over the configuration file, which makes it convenient to provide as a CI secret without changing the committed manifest.

--- a/server/priv/docs/en/cli/debugging.md
+++ b/server/priv/docs/en/cli/debugging.md
@@ -102,3 +102,23 @@ export TUIST_HTTP_RETRY_BASE_DELAY_IN_MILLISECONDS=250
 ```
 
 Raising `TUIST_HTTP_TIMEOUT_INTERVAL_FOR_RESOURCE` lets a recoverable but slow download finish instead of timing out. For cache downloads, that means landing a cache hit rather than falling back to a build from source. Lowering `TUIST_HTTP_MAXIMUM_RETRY_COUNT` can keep a longer timeout from multiplying the worst-case wait across several attempts. Retry delays double after every failure, include up to one base delay of random jitter, and never exceed 30 seconds.
+
+## Trusting a custom CA certificate {#trusting-a-custom-ca-certificate}
+
+By default, Tuist validates TLS certificates against the operating system's root store. When you run a self-hosted Tuist or Kura server that uses a private certificate authority, Tuist needs to trust that CA too. Installing the root in the System keychain (and marking it trusted for SSL) is the standard approach, but that's often impractical on headless CI hosts where there's no GUI session or mobile device management (MDM) to set the trust bit.
+
+In those cases you can point Tuist at a CA certificate bundle directly. The bundle can be PEM (one or more concatenated `-----BEGIN CERTIFICATE-----` blocks) or a single DER file. The system root store stays trusted alongside it, so public certificates keep validating normally and certificate evaluation is never bypassed.
+
+```bash
+# Path to a PEM/DER CA bundle to trust on top of the system root store (default: unset)
+export TUIST_CA_CERTIFICATE=/etc/ssl/certs/self-hosted-ca.pem
+```
+
+You can also declare it in your <.localized_link href="/references/tuist-toml">configuration file</.localized_link>:
+
+```toml
+[network]
+caCertificate = "/etc/ssl/certs/self-hosted-ca.pem"
+```
+
+The `TUIST_CA_CERTIFICATE` environment variable takes precedence over the configuration file, which makes it convenient to provide as a CI secret without changing the committed manifest.

--- a/server/priv/docs/en/references/tuist-toml.md
+++ b/server/priv/docs/en/references/tuist-toml.md
@@ -26,7 +26,7 @@ The `[network]` table configures how Tuist makes outbound HTTP connections.
 | Key | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `proxy` | `Boolean` | No | `true` | When `true`, Tuist uses the proxy defined by `HTTPS_PROXY`/`HTTP_PROXY` when present. See the <.localized_link href="/guides/integrations/http-proxy">HTTP proxy guide</.localized_link>. |
-| `caCertificate` | `String` | No | — | Path to a PEM or DER CA certificate bundle to trust on top of the system root store, for example for a self-hosted server that uses a private CA. The `TUIST_CA_CERTIFICATE` environment variable takes precedence. See <.localized_link href="/cli/debugging#trusting-a-custom-ca-certificate">trusting a custom CA certificate</.localized_link>. |
+| `ca_certificate` | `String` | No | — | Path to a PEM or DER CA certificate bundle to trust on top of the system root store, for example for a self-hosted server that uses a private CA. The `TUIST_CA_CERTIFICATE` environment variable takes precedence. See <.localized_link href="/cli/debugging#trusting-a-custom-ca-certificate">trusting a custom CA certificate</.localized_link>. |
 
 ## Example {#example}
 
@@ -36,7 +36,7 @@ url = "https://tuist.dev"
 
 [network]
 proxy = true
-caCertificate = "/etc/ssl/certs/self-hosted-ca.pem"
+ca_certificate = "/etc/ssl/certs/self-hosted-ca.pem"
 ```
 
 ## Configuration precedence {#configuration-precedence}

--- a/server/priv/docs/en/references/tuist-toml.md
+++ b/server/priv/docs/en/references/tuist-toml.md
@@ -19,11 +19,24 @@ Tuist looks for `tuist.toml` by traversing the directory hierarchy upward from t
 | `project` | `String` | Yes | — | The full handle of your project (e.g. `"tuist/tuist"`). |
 | `url` | `String` | No | `https://tuist.dev` | The URL of the Tuist server. |
 
+### Network {#network}
+
+The `[network]` table configures how Tuist makes outbound HTTP connections.
+
+| Key | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `proxy` | `Boolean` | No | `true` | When `true`, Tuist uses the proxy defined by `HTTPS_PROXY`/`HTTP_PROXY` when present. See the <.localized_link href="/guides/integrations/http-proxy">HTTP proxy guide</.localized_link>. |
+| `caCertificate` | `String` | No | — | Path to a PEM or DER CA certificate bundle to trust on top of the system root store, for example for a self-hosted server that uses a private CA. The `TUIST_CA_CERTIFICATE` environment variable takes precedence. See <.localized_link href="/cli/debugging#trusting-a-custom-ca-certificate">trusting a custom CA certificate</.localized_link>. |
+
 ## Example {#example}
 
 ```toml
 project = "tuist/tuist"
 url = "https://tuist.dev"
+
+[network]
+proxy = true
+caCertificate = "/etc/ssl/certs/self-hosted-ca.pem"
 ```
 
 ## Configuration precedence {#configuration-precedence}


### PR DESCRIPTION
## What changed

- Added a `caCertificate` option to Tuist's network configuration. It can be set through the `[network]` table in `tuist.toml`, through `.network(caCertificate:)` in `Tuist.swift`, or through the `TUIST_CA_CERTIFICATE` environment variable, which takes precedence over the file so it can be supplied as a CI secret.
- A new `URLSession` delegate augments the system root store with the bundle's anchors and evaluates trust normally. It is only installed when a bundle resolves and parses; otherwise behavior is unchanged. It forwards `URLSession` task metrics so HTTP Archive (HAR) recording keeps working.
- Both PEM bundles (one or more concatenated `-----BEGIN CERTIFICATE-----` blocks) and a single DER file are accepted.
- Documented the option in the CLI debugging guide and the `tuist.toml` reference. The `[network]` table was not documented before, so `proxy` is documented alongside `caCertificate`.

## Why

Teams running a self-hosted Tuist or Kura server with a private certificate authority currently have no way to make the CLI trust that authority besides installing the root in the System keychain and marking it trusted for SSL. That works on managed Macs, but it is impractical on headless CI runners where there is no GUI session or mobile device management (MDM) to set the trust bit. This came up directly with the Oura team, who hit "The certificate for this server is invalid" errors from the CAS upload path (`saveCASArtifact`) against their self-hosted Kura and could not install a trusted root without MDM.

## Approach

The CAS upload path runs over Foundation's `URLSession`, so TLS validation is handled by macOS system TLS. Rather than disable validation, the delegate adds the extra anchors to the existing trust object and calls `SecTrustSetAnchorCertificatesOnly(trust, false)` so the system root store stays trusted too. Standard `SecTrustEvaluateWithError` then runs, meaning hostname validation and the rest of the standard checks remain intact. The environment variable takes precedence over the config so it can be supplied as a CI secret without touching the committed manifest, mirroring how the existing `TUIST_HTTP_*` tuning variables work.

## Impact

- Users on self-hosted deployments with a private CA can now point Tuist at their CA bundle and connect from CI without MDM.
- No behavior change when no bundle is configured; existing installs are unaffected.
- The trust evaluation relies on the Security framework, so the option is effective on Apple platforms and ignored elsewhere.

## Validation

- `tuist generate ProjectDescription TuistHTTP TuistConfig TuistConfigLoader TuistLoader`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace` succeeded.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistHTTPTests -only-testing TuistConfigLoaderTests` succeeded. New tests cover PEM (single and multi-certificate bundles), DER, malformed input, the trust-augmentation behavior (a self-signed leaf is trusted only once the CA is added as an anchor, and a hostname mismatch still fails), TOML parsing, manifest path resolution, and propagation into `HTTPSettings`.
- `swiftformat` and `swiftlint` clean on the changed files.
