### PR TITLE
chore(server): document conservative test-case state join settings

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -76,6 +76,16 @@ defmodule Tuist.Tests do
     max_memory_usage: 128 * 1024 * 1024,
     optimize_aggregation_in_order: 1
   ]
+  # The `:joined` listing path joins `test_cases` FINAL against the current-state
+  # aggregate. The right side is now a compact pre-merged table rather than the
+  # raw-ledger aggregation, so it has more headroom, but the `FINAL` over a whole
+  # project's `test_cases` on the left is unchanged and remains the dominant cost
+  # here, and `FINAL` cannot spill. These settings therefore stay conservative
+  # (512 MiB ceiling + grace-hash + external group-by so the join/aggregation can
+  # spill instead of OOMing). Relaxing the ceiling or dropping the spill paths is
+  # deferred to a follow-up gated on measuring the real per-project peak memory of
+  # this query in production; doing it blind risks re-introducing the OOM this
+  # change exists to remove.
   @test_case_state_join_settings [
     max_threads: 1,
     max_memory_usage: 512 * 1024 * 1024,


### PR DESCRIPTION
## Why

Third and last part of the test-analytics current-states change. After the reader flip, the joined listing path joins `test_cases` against a compact pre-merged aggregate instead of the raw ledger, which invites the question of whether the conservative join settings can now be relaxed.

## What this PR does

Documents the decision rather than changing behavior. It adds a comment to `@test_case_state_join_settings` explaining that the settings stay conservative on purpose: the right side of the join is now small, but the `FINAL` over a whole project's `test_cases` on the left is unchanged and cannot spill, so it remains the dominant cost. Keeping the 512 MiB ceiling plus grace-hash and external group-by is what lets the join and aggregation spill instead of OOMing.

Relaxing the ceiling or dropping the spill paths is deferred to a separate follow-up, gated on measuring the real per-project peak memory of this query in production. Doing it blind risks re-introducing the exact OOM this whole change removes, which an adversarial review flagged.

## Validation

Comment-only change. Full suite stays green.

## Rollout

Stacked change, part 3 of 3. Depends on part 2. Safe to merge any time after it.
