### PR TITLE
fix(cli): guard TuistAlert import for TuistHTTP's iOS build slice

### DIFF
--- a/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift
@@ -1,5 +1,8 @@
 import Foundation
-import TuistAlert
+
+#if canImport(TuistAlert)
+    import TuistAlert
+#endif
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -89,20 +92,24 @@ import TuistAlert
         static func load(from path: String) -> [SecCertificate]? {
             let url = URL(fileURLWithPath: path)
             guard let data = try? Data(contentsOf: url) else {
-                AlertController.current
-                    .warning(
-                        .alert(
-                            "Could not read the custom CA certificate bundle at '\(path)'. TLS will use the system trust store only."
+                #if canImport(TuistAlert)
+                    AlertController.current
+                        .warning(
+                            .alert(
+                                "Could not read the custom CA certificate bundle at '\(path)'. TLS will use the system trust store only."
+                            )
                         )
-                    )
+                #endif
                 return nil
             }
             let certificates = parse(from: data)
             if certificates.isEmpty {
-                AlertController.current
-                    .warning(
-                        .alert("No certificates could be parsed from '\(path)'. TLS will use the system trust store only.")
-                    )
+                #if canImport(TuistAlert)
+                    AlertController.current
+                        .warning(
+                            .alert("No certificates could be parsed from '\(path)'. TLS will use the system trust store only.")
+                        )
+                #endif
                 return nil
             }
             return certificates


### PR DESCRIPTION
## What changed

`cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift` now wraps the `import TuistAlert` and both `AlertController.current` call sites in `#if canImport(TuistAlert)` guards.

## Why

The Cache job on `main` is failing:

- Failing run: https://github.com/tuist/tuist/actions/runs/30539436734/job/90860454301
- Error: `Unable to resolve module dependency: 'TuistAlert'` at `cli/Sources/TuistHTTP/TuistURLSessionDelegate.swift#2`

This regressed in #12146, which introduced `TuistURLSessionDelegate.swift`.

## Root cause

`TuistHTTP` is a multiplatform module. In `Tuist/ProjectDescriptionHelpers/Module.swift` it declares destinations `[.mac, .iPhone, .iPad]` and deployment targets `iOS: 18.0, macOS: 15.0`. Its `TuistAlert` dependency, however, is conditional and macOS only (`.target(name: Module.alert.targetName, condition: .when([.macos]))`).

The new file added a top-level, unconditional `import TuistAlert`, so when the iOS slice compiles, `canImport(TuistAlert)` is false and the import cannot be resolved. That is exactly what `tuist cache` does: it builds each cacheable target as an xcframework across all its destinations, including the iOS slices, so the iOS compile of `TuistHTTP` fails.

The other jobs are unaffected for predictable reasons:

- `swift build` (SwiftPM Build) uses `Package.swift`, where `tuistHTTPDependencies` lists `TuistAlert` unconditionally and SwiftPM targets are macOS only.
- `tuist test TuistUnitTests` builds a single destination rather than the full multiplatform xcframework, so it happens to compile the macOS slice where `TuistAlert` is available.

## Approach

Guard the import and the `AlertController` usage with `#if canImport(TuistAlert)`, matching the pattern already used in the sibling `OutputWarningsMiddleware.swift` in the same module (which CI does not flag). On macOS `canImport(TuistAlert)` is true, so behavior there is unchanged. On iOS the import is skipped and the warnings are simply not surfaced, which is fine: `CACertificateLoader.load` returns `nil` so the caller falls back to the default session, as its doc comment already documents.

## Impact

Restores the Cache job on `main`. No user-facing behavior change.

## Validation

- `swiftformat` via `mise run cli:lint --fix` (project formatter): clean.
- `swiftc -parse` syntax check of the edited file: clean.
- Confirmed the failing commit `0112f06771` is an ancestor of current `origin/main`, and the unguarded import is still present there, so this is still live on `main`.
- The Cache job is the authoritative reproduction for the iOS slice; CI on this PR will confirm it.