### PR TITLE
fix(cli): strip registry package root directories [4.203.x backport]

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,6 +13,9 @@ on:
       # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
       # inside the CLI, so its changes must run CLI build/test/acceptance.
       - "cas-plugin/**"
+      # SwifterPMCore is compiled into the command-line binary through
+      # TuistSupport, so its changes must run the command-line test suite.
+      - "swifterpm/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"
@@ -36,6 +39,9 @@ on:
       # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
       # inside the CLI, so its changes must run CLI build/test/acceptance.
       - "cas-plugin/**"
+      # SwifterPMCore is compiled into the command-line binary through
+      # TuistSupport, so its changes must run the command-line test suite.
+      - "swifterpm/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"

--- a/.github/workflows/swifterpm.yml
+++ b/.github/workflows/swifterpm.yml
@@ -1,0 +1,42 @@
+name: SwifterPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "swifterpm/**"
+      - ".github/workflows/swifterpm.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "swifterpm/**"
+      - ".github/workflows/swifterpm.yml"
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERSION: "2026.5.15"
+
+concurrency:
+  group: swifterpm-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: tuist-macos
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "bazel"
+          working_directory: swifterpm
+          cache: "false"
+          github_token: ${{ github.token }}
+      - name: Test
+        working-directory: swifterpm
+        run: mise run test:unit

--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -115,12 +115,16 @@ extension FileSystem {
         return url
     }
 
-    /// If `directory` contains exactly one subdirectory, replace `directory` with that subdirectory's contents.
+    /// If `directory` contains exactly one subdirectory, move that subdirectory's contents up one level.
     func flattenSingleDirectory(_ url: URL) async throws {
-        let entries = try await contentsOfDirectory(url.absolutePath)
-        guard entries.count == 1 else { return }
-        let nested = entries[0].fileURL
-        guard isDirectoryAndNotSymlink(nested) else { return }
+        let subdirectories = try await contentsOfDirectory(at: url)
+            .filter { isDirectoryAndNotSymlink($0) }
+        guard subdirectories.count == 1, let nested = subdirectories.first else { return }
+        if try await exists(url.appendingPathComponent("Package.swift").absolutePath),
+           ["Plugins", "Sources", "Tests"].contains(nested.lastPathComponent)
+        {
+            return
+        }
 
         let temp = url.deletingLastPathComponent().appendingPathComponent(
             "\(url.lastPathComponent).flattening")
@@ -128,8 +132,14 @@ extension FileSystem {
             try await remove(temp.absolutePath)
         }
         try await move(from: nested.absolutePath, to: temp.absolutePath, options: [])
-        try await remove(url.absolutePath)
-        try await move(from: temp.absolutePath, to: url.absolutePath, options: [])
+        for entry in try await contentsOfDirectory(at: temp) {
+            try await move(
+                from: entry.absolutePath,
+                to: url.appendingPathComponent(entry.lastPathComponent).absolutePath,
+                options: []
+            )
+        }
+        try await remove(temp.absolutePath)
     }
 
     /// Materialise `source` at `destination`, removing any existing item first. By default,

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -87,4 +87,48 @@ struct FileSystemSupportTests {
             #expect(!fileSystem.existsIncludingSymlinks(link))
         }
     }
+
+    @Test
+    func flattenSingleDirectoryPreservesTopLevelFiles() async throws {
+        try await withTemporaryDirectory { root in
+            let packageManifest = root.appendingPathComponent("Package.swift")
+            let nestedSource = root.appendingPathComponent("discarded/Sources/Package/Package.swift")
+            try await fileSystem.atomicWrite("// package manifest", to: packageManifest)
+            try await fileSystem.atomicWrite("// package source", to: nestedSource)
+
+            try await fileSystem.flattenSingleDirectory(root)
+
+            #expect(try await fileSystem.exists(packageManifest.absolutePath))
+            #expect(
+                try await fileSystem.exists(
+                    root.appendingPathComponent("Sources/Package/Package.swift").absolutePath
+                )
+            )
+            #expect(
+                !(try await fileSystem.exists(
+                    root.appendingPathComponent("discarded").absolutePath
+                ))
+            )
+        }
+    }
+
+    @Test
+    func flattenSingleDirectoryPreservesPackageSourcesAtRoot() async throws {
+        try await withTemporaryDirectory { root in
+            let packageManifest = root.appendingPathComponent("Package.swift")
+            let packageSource = root.appendingPathComponent("Sources/Package/Package.swift")
+            try await fileSystem.atomicWrite("// package manifest", to: packageManifest)
+            try await fileSystem.atomicWrite("// package source", to: packageSource)
+
+            try await fileSystem.flattenSingleDirectory(root)
+
+            #expect(try await fileSystem.exists(packageManifest.absolutePath))
+            #expect(try await fileSystem.exists(packageSource.absolutePath))
+            #expect(
+                !(try await fileSystem.exists(
+                    root.appendingPathComponent("Package").absolutePath
+                ))
+            )
+        }
+    }
 }


### PR DESCRIPTION
## What changed

Cherry-pick of #12077 onto `releases/4.203.x`: strips registry package root directories so SwifterPM produces valid source file globs for registry-resolved packages.

## Why

Reported in #11463, found while testing against **4.201.0-rc.1** with SwifterPM enabled. On a fresh clean of all SPM caches, `tuist install` fails with invalid source file globs because the resulting `.build` folder has an invalid file path due to a top-level directory not being stripped. Since the 4.203 line is cut from the same code, it has the same bug.

## Approach

Straight cherry-pick of the fix from `main`. Includes the new `FileSystemSupport` behavior and its regression test.

(cherry picked from commit 196021cb54)

## Impact

Fixes `tuist install` for projects using package registries with SwifterPM enabled. No migration needed.

## Validation

- Cherry-pick applies cleanly on `releases/4.203.x`.
- CI (`cli.yml`) validates the build/tests on this PR.
