### PR TITLE
fix(cli): fall back to local cache during server outages [4.203.x backport]

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -144,6 +144,8 @@ jobs:
         run: tuist setup
       - name: Install Tuist dependencies
         run: tuist install --force-resolved-versions
+      - name: Resolve registry replacements
+        run: swift package resolve --replace-scm-with-registry
       - name: Build
         run: swift build --configuration debug --replace-scm-with-registry --force-resolved-versions
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -291,11 +291,11 @@
       }
     },
     {
-      "identity" : "getguaka.colorizer",
-      "kind" : "registry",
-      "location" : "",
-      "originalLocation" : "https://github.com/getGuaka/Colorizer.git",
+      "identity" : "colorizer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getGuaka/Colorizer.git",
       "state" : {
+        "revision" : "2ccc99bf1715e73c4139e8d40b6e6b30be975586",
         "version" : "0.2.1"
       }
     },

--- a/cli/Sources/TuistCAS/Services/CacheURLStore.swift
+++ b/cli/Sources/TuistCAS/Services/CacheURLStore.swift
@@ -166,12 +166,12 @@ public struct CacheURLStore: CacheURLStoring {
     }
 }
 
-enum CacheURLStoreError: LocalizedError, Equatable {
+public enum CacheURLStoreError: LocalizedError, Equatable {
     case noEndpointsAvailable
     case noReachableEndpoints
     case invalidURL(String)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .noEndpointsAvailable:
             return "No cache endpoints are available."

--- a/cli/Sources/TuistKit/Services/GenerateService.swift
+++ b/cli/Sources/TuistKit/Services/GenerateService.swift
@@ -2,6 +2,7 @@ import Foundation
 import Path
 import TuistAlert
 import TuistCache
+import TuistCAS
 import TuistConfig
 import TuistConfigLoader
 import TuistCore
@@ -130,7 +131,19 @@ public struct GenerateService {
             }
         }
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage: CacheStoring
+        do {
+            cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        } catch where
+            ServerErrorClassifier.isTransient(error)
+            || (error as? CacheURLStoreError) == .noReachableEndpoints
+        {
+            AlertController.current.warning(.alert(
+                "The remote cache is temporarily unavailable.",
+                takeaway: "Generation will continue using the local cache."
+            ))
+            cacheStorage = try await cacheStorageFactory.cacheLocalStorage()
+        }
 
         let resolvedCacheProfile = try config.resolveCacheProfile(
             ignoreBinaryCache: ignoreBinaryCache,

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -750,13 +750,10 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                 )
             return newTokens
         } catch let error as ClientError {
-            let underlyingError = error.underlyingError as NSError
-            switch URLError.Code(rawValue: underlyingError.code) {
-            case .notConnectedToInternet:
+            if ServerErrorClassifier.isTransient(error) {
                 throw error
-            default:
-                throw ClientAuthenticationError.notAuthenticated
             }
+            throw ClientAuthenticationError.notAuthenticated
         } catch let error as RefreshAuthTokenServiceError {
             throw error
         } catch {

--- a/cli/Sources/TuistServer/Utilities/ServerErrorClassifier.swift
+++ b/cli/Sources/TuistServer/Utilities/ServerErrorClassifier.swift
@@ -1,0 +1,38 @@
+import Foundation
+import OpenAPIRuntime
+
+public enum ServerErrorClassifier {
+    public static func isTransient(_ error: Error) -> Bool {
+        switch error {
+        case let error as RefreshAuthTokenServiceError:
+            guard case let .unknownError(statusCode) = error else { return false }
+            return isTransient(statusCode: statusCode)
+        case let error as GetCacheEndpointsServiceError:
+            guard case let .unknownError(statusCode) = error else { return false }
+            return isTransient(statusCode: statusCode)
+        case let error as ClientError:
+            return isTransient(error.underlyingError)
+        default:
+            return isTransientURLLoadingError(error)
+        }
+    }
+
+    private static func isTransient(statusCode: Int) -> Bool {
+        statusCode == 408 || statusCode == 429 || (500 ... 599).contains(statusCode)
+    }
+
+    private static func isTransientURLLoadingError(_ error: Error) -> Bool {
+        let error = error as NSError
+        guard error.domain == NSURLErrorDomain else { return false }
+
+        return [
+            URLError.Code.timedOut,
+            .cannotFindHost,
+            .cannotConnectToHost,
+            .networkConnectionLost,
+            .dnsLookupFailed,
+            .notConnectedToInternet,
+            .resourceUnavailable,
+        ].contains(URLError.Code(rawValue: error.code))
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import Mockable
 import Path
 import Testing
+import TuistAlert
 import TuistCache
+import TuistCAS
 import TuistConfig
 import TuistCore
 import TuistGenerator
@@ -412,6 +414,120 @@ struct GenerateServiceTests {
                 cacheProfile: "missing"
             )
         }
+    }
+
+    @Test func usesLocalCacheStorageWhenRemoteCacheHasTransientServerFailure() async throws {
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .testGeneratedProject())
+        )
+        let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
+        let localCacheStorage = MockCacheStoring()
+        let cacheStorageFactory = MockCacheStorageFactorying()
+        let alertController = AlertController()
+        let subject = GenerateService(
+            cacheStorageFactory: cacheStorageFactory,
+            generatorFactory: generatorFactory,
+            configLoader: configLoader,
+            generationMetadataStore: generationMetadataStore
+        )
+        given(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .willThrow(RefreshAuthTokenServiceError.unknownError(503))
+        given(cacheStorageFactory)
+            .cacheLocalStorage()
+            .willReturn(localCacheStorage)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willReturn((workspacePath, .test(), MapperEnvironment()))
+
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(
+                path: nil,
+                includedTargets: [],
+                noOpen: true,
+                configuration: nil,
+                ignoreBinaryCache: false,
+                cacheProfile: nil
+            )
+        }
+
+        verify(cacheStorageFactory)
+            .cacheLocalStorage()
+            .called(1)
+        #expect(
+            alertController.warnings().map(\.message).map { $0.plain() } == [
+                "The remote cache is temporarily unavailable.",
+            ]
+        )
+    }
+
+    @Test func usesLocalCacheStorageWhenNoRemoteCacheEndpointIsReachable() async throws {
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .testGeneratedProject())
+        )
+        let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
+        let localCacheStorage = MockCacheStoring()
+        let cacheStorageFactory = MockCacheStorageFactorying()
+        let subject = GenerateService(
+            cacheStorageFactory: cacheStorageFactory,
+            generatorFactory: generatorFactory,
+            configLoader: configLoader,
+            generationMetadataStore: generationMetadataStore
+        )
+        given(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .willThrow(CacheURLStoreError.noReachableEndpoints)
+        given(cacheStorageFactory)
+            .cacheLocalStorage()
+            .willReturn(localCacheStorage)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willReturn((workspacePath, .test(), MapperEnvironment()))
+
+        try await subject.run(
+            path: nil,
+            includedTargets: [],
+            noOpen: true,
+            configuration: nil,
+            ignoreBinaryCache: false,
+            cacheProfile: nil
+        )
+
+        verify(cacheStorageFactory)
+            .cacheLocalStorage()
+            .called(1)
+    }
+
+    @Test func propagatesPermanentAuthenticationFailure() async {
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .testGeneratedProject())
+        )
+        let cacheStorageFactory = MockCacheStorageFactorying()
+        let expectedError = RefreshAuthTokenServiceError.unauthorized("Invalid token")
+        let subject = GenerateService(
+            cacheStorageFactory: cacheStorageFactory,
+            generatorFactory: generatorFactory,
+            configLoader: configLoader,
+            generationMetadataStore: generationMetadataStore
+        )
+        given(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .willThrow(expectedError)
+
+        await #expect(throws: expectedError) {
+            try await subject.run(
+                path: nil,
+                includedTargets: [],
+                noOpen: true,
+                configuration: nil,
+                ignoreBinaryCache: false,
+                cacheProfile: nil
+            )
+        }
+
+        verify(cacheStorageFactory)
+            .cacheLocalStorage()
+            .called(0)
     }
 }
 

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -1,6 +1,7 @@
 import FileSystem
 import Foundation
 import Mockable
+import OpenAPIRuntime
 import Path
 import Testing
 import TuistConstants
@@ -462,6 +463,38 @@ struct ServerAuthenticationControllerTests {
             // Then
             let expiresAt = try #require(result?.expiresAt)
             #expect(expiresAt == date.addingTimeInterval(+570))
+        }
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) func executeRefresh_preserves_transient_client_errors() async throws {
+        let date = Date()
+        try await Date.$now.withValue({ date }) {
+            let serverURL: URL = .test()
+            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
+            )
+            let error = ClientError(
+                operationID: "refreshToken",
+                operationInput: "",
+                causeDescription: "Request timed out",
+                underlyingError: URLError(.timedOut)
+            )
+
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+            given(refreshAuthTokenService)
+                .refreshTokens(serverURL: .value(serverURL), refreshToken: .value(refreshToken.token))
+                .willThrow(error)
+
+            await #expect(throws: ClientError.self) {
+                try await subject.executeRefresh(serverURL: serverURL, forceRefresh: false)
+            }
         }
     }
 

--- a/cli/Tests/TuistServerTests/Utilities/ServerErrorClassifierTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerErrorClassifierTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import TuistServer
+
+struct ServerErrorClassifierTests {
+    @Test(
+        arguments: [408, 429, 500, 502, 503, 599]
+    )
+    func transientStatusCodesAreTransient(statusCode: Int) {
+        #expect(
+            ServerErrorClassifier.isTransient(
+                RefreshAuthTokenServiceError.unknownError(statusCode)
+            )
+        )
+        #expect(
+            ServerErrorClassifier.isTransient(
+                GetCacheEndpointsServiceError.unknownError(statusCode)
+            )
+        )
+    }
+
+    @Test(
+        arguments: [400, 401, 403, 404]
+    )
+    func permanentStatusCodesAreNotTransient(statusCode: Int) {
+        #expect(
+            !ServerErrorClassifier.isTransient(
+                RefreshAuthTokenServiceError.unknownError(statusCode)
+            )
+        )
+        #expect(
+            !ServerErrorClassifier.isTransient(
+                GetCacheEndpointsServiceError.unknownError(statusCode)
+            )
+        )
+    }
+
+    @Test func authenticationAndPermissionErrorsAreNotTransient() {
+        #expect(
+            !ServerErrorClassifier.isTransient(
+                RefreshAuthTokenServiceError.unauthorized("Invalid token")
+            )
+        )
+        #expect(
+            !ServerErrorClassifier.isTransient(
+                RefreshAuthTokenServiceError.badRequest
+            )
+        )
+        #expect(
+            !ServerErrorClassifier.isTransient(
+                GetCacheEndpointsServiceError.forbidden("Forbidden")
+            )
+        )
+    }
+
+    @Test(
+        arguments: [
+            URLError.Code.timedOut,
+            .cannotFindHost,
+            .cannotConnectToHost,
+            .networkConnectionLost,
+            .dnsLookupFailed,
+            .notConnectedToInternet,
+            .resourceUnavailable,
+        ]
+    )
+    func transientURLLoadingErrorsAreTransient(code: URLError.Code) {
+        #expect(ServerErrorClassifier.isTransient(URLError(code)))
+    }
+
+    @Test func unrelatedErrorsAreNotTransient() {
+        #expect(!ServerErrorClassifier.isTransient(NSError(domain: "Test", code: 1)))
+    }
+}


### PR DESCRIPTION
## What changed

Cherry-pick of #12109 onto `releases/4.203.x`: makes `tuist generate` fall back to the local cache when the server is unavailable (e.g. transient 503 on `/api/auth/refresh_token`) instead of hard-failing.

## Why

Reported in #12089 against **4.202.5**: a transient 503 on `/api/auth/refresh_token` hard-fails `tuist generate` even though a usable artifact exists in the local cache. The 4.203 line has the same behavior.

## Approach

Straight cherry-pick of the fix from `main`, including the new `ServerErrorClassifier` and the `GenerateService` fallback path, plus their tests. The `Package.resolved` change from the original PR is included as part of the fix.

(cherry picked from commit a2369eeed5)

## Impact

`tuist generate` degrades gracefully to the local cache during transient server outages instead of failing the build.

## Validation

- Cherry-pick applies cleanly on `releases/4.203.x`.
- CI (`cli.yml`) validates the build/tests on this PR.
