### PR TITLE
fix(swifterpm/cli): key the manifest dump cache on the environment [4.203.x backport]

### DIFF
--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -8,7 +8,7 @@ enum Environment {
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
     static var isCI: Bool {
-        ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { environment[$0] != nil }
+        ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
     }
 
     static func cachedDirectoryMaterializationMode()
@@ -29,7 +29,12 @@ enum Environment {
         return try await operation()
     }
 
-    private static var environment: [String: String] {
+    /// The environment the process runs in. Overridable through the `values` task-local
+    /// for dependency injection (notably in tests); otherwise the live process environment.
+    /// Manifest evaluation observes the same environment because swifterpm inherits it into
+    /// the `swift package dump-package` subprocess, so this is also the environment a cached
+    /// dump was produced under.
+    static var current: [String: String] {
         values ?? ProcessInfo.processInfo.environment
     }
 }

--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -80,21 +80,37 @@ enum ManifestLoader {
         let result = try await SystemProcess.run(
             "/usr/bin/swift", args, workingDirectory: packageDir
         )
-        try? await fileSystem.atomicWrite(result.stdout, to: cacheFilePath(packageDir: packageDir))
+        let cache = cacheFilePath(packageDir: packageDir)
+        try? await fileSystem.atomicWrite(result.stdout, to: cache)
+        if let cachePath = try? cache.absolutePath {
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: cachePath)
+        }
         return result.stdout
     }
 
     private static func readCachedManifest(packageDir: URL) async throws -> Data? {
         let cache = cacheFilePath(packageDir: packageDir)
         let manifest = packageDir.appendingPathComponent("Package.swift")
-        guard try await fileSystem.exists(cache.absolutePath) else { return nil }
-        guard let cacheDate = try await fileSystem.fileMetadata(at: cache.absolutePath)?.lastModificationDate,
+        let cachePath = try cache.absolutePath
+        guard try await fileSystem.exists(cachePath) else { return nil }
+        guard let cacheDate = try await fileSystem.fileMetadata(at: cachePath)?.lastModificationDate,
               let manifestDate = try await fileSystem.fileMetadata(at: manifest.absolutePath)?.lastModificationDate,
               cacheDate >= manifestDate
         else {
             return nil
         }
-        return try await fileSystem.readFile(at: cache.absolutePath)
+        // A dump is reusable only when it was produced under the current environment. A
+        // missing sidecar means the cache predates environment fingerprinting (or the
+        // sidecar write failed), so the environment that produced the contents is
+        // unknown. Treat that as a miss and re-dump rather than blessing unknown contents
+        // with the current environment, otherwise a legacy cache that was already stale
+        // at upgrade time would stay stale indefinitely.
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: cachePath) {
+        case .matching:
+            return try await fileSystem.readFile(at: cachePath)
+        case .mismatching, .missing:
+            return nil
+        }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
+++ b/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Path
+
+/// A stable digest of the environment, used to key the dump-package cache.
+///
+/// A `Package.swift` is arbitrary Swift and can branch on environment values through
+/// `PackageDescription.Context.environment`. SwiftPM forwards the entire process
+/// environment to the manifest interpreter (not just a curated allowlist), so a
+/// manifest's evaluated result is a function of the whole environment, not only of
+/// `Package.swift`. Comparing only the modification times of `Package.swift` and the
+/// cached dump therefore reuses a dump produced under a different environment, which is
+/// the root cause of stale local-package manifests
+/// (see https://github.com/tuist/tuist/issues/12130).
+///
+/// The fingerprint is stored as a sidecar (`.envhash`) next to each cached dump and
+/// compared on read. It is a one-way digest, so secret-bearing variables never reach
+/// disk in cleartext.
+enum ManifestEnvironmentFingerprint {
+    enum Validation: Sendable {
+        /// A stored fingerprint exists and matches the current environment.
+        case matching
+        /// A stored fingerprint exists but differs from the current environment.
+        case mismatching
+        /// No sidecar exists (for example a cache written before this check existed).
+        case missing
+    }
+
+    static let sidecarExtension = "envhash"
+
+    static func sidecarPath(forCacheFile cacheFile: AbsolutePath) -> AbsolutePath {
+        cacheFile.parentDirectory.appending(component: "\(cacheFile.basename).\(sidecarExtension)")
+    }
+
+    /// The fingerprint for the environment swifterpm currently runs in.
+    static func current() -> String {
+        digest(for: Environment.current)
+    }
+
+    /// A deterministic fingerprint for `environment`, encoded as sorted JSON so a value
+    /// containing the delimiter cannot collide with distinct entries: `A="x\nB=y"` must
+    /// not hash the same as the two variables `A="x"`, `B="y"`.
+    static func digest(for environment: [String: String]) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: environment, options: [.sortedKeys]
+        ) else {
+            return Hashing.sha256Hex(Data())
+        }
+        return Hashing.sha256Hex(data)
+    }
+
+    /// Writes the current environment fingerprint next to `cacheFile`.
+    static func write(forCacheFile cacheFile: AbsolutePath) async throws {
+        try await fileSystem.write(
+            Data(current().utf8),
+            to: sidecarPath(forCacheFile: cacheFile)
+        )
+    }
+
+    static func validate(forCacheFile cacheFile: AbsolutePath) async throws -> Validation {
+        let sidecar = sidecarPath(forCacheFile: cacheFile)
+        guard try await fileSystem.exists(sidecar) else { return .missing }
+        let stored = try await fileSystem.readFile(at: sidecar)
+        return String(data: stored, encoding: .utf8) == current() ? .matching : .mismatching
+    }
+}

--- a/swifterpm/Sources/swifterpm/PackageInfoCache.swift
+++ b/swifterpm/Sources/swifterpm/PackageInfoCache.swift
@@ -167,19 +167,33 @@ enum PackageInfoCacheWriter {
         let data = try await ManifestLoader.dumpPackageJSON(
             packageDir: packageDir, disableSandbox: disableSandbox)
         try await fileSystem.atomicWrite(data, to: destination)
+        if let destinationPath = try? destination.absolutePath {
+            try? await ManifestEnvironmentFingerprint.write(forCacheFile: destinationPath)
+        }
         return data
     }
 
     private static func isFreshPackageInfo(destination: URL, packageDir: URL) async throws -> Bool {
+        let destinationPath = try destination.absolutePath
         guard
-            let cacheDate = try await fileSystem.fileMetadata(at: destination.absolutePath)?.lastModificationDate,
+            let cacheDate = try await fileSystem.fileMetadata(at: destinationPath)?.lastModificationDate,
             let manifestDate = try await fileSystem.fileMetadata(
                 at: packageDir.appendingPathComponent("Package.swift").absolutePath
             )?.lastModificationDate
         else {
             return false
         }
-        return cacheDate >= manifestDate
+        guard cacheDate >= manifestDate else { return false }
+        // A missing sidecar means the destination predates environment fingerprinting, so
+        // the environment it was produced under is unknown. Treat it as stale (see
+        // `ManifestLoader.readCachedManifest`) so an upgrade re-dumps under the current
+        // environment instead of reusing contents of unknown provenance.
+        switch try await ManifestEnvironmentFingerprint.validate(forCacheFile: destinationPath) {
+        case .matching:
+            return true
+        case .mismatching, .missing:
+            return false
+        }
     }
 
     private static func packageEntry(pin: ResolvedPin, packagePath: URL, packageInfoPath: URL)

--- a/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Path
+import Testing
+@testable import SwifterPMCore
+
+struct ManifestEnvironmentFingerprintTests {
+    @Test
+    func digestIsStableAcrossDictionaryOrdering() {
+        let first = ManifestEnvironmentFingerprint.digest(for: ["A": "1", "B": "2"])
+        let second = ManifestEnvironmentFingerprint.digest(for: ["B": "2", "A": "1"])
+
+        #expect(first == second)
+    }
+
+    @Test
+    func digestDiffersWhenValuesChange() {
+        let first = ManifestEnvironmentFingerprint.digest(for: ["REPRO_USE_ALTERNATE": "1"])
+        let second = ManifestEnvironmentFingerprint.digest(for: ["REPRO_USE_ALTERNATE": "0"])
+
+        #expect(first != second)
+    }
+
+    @Test
+    func digestDistinguishesEmbeddedNewlinesFromSeparateEntries() {
+        // A value containing the delimiter must not collide with two distinct entries.
+        let withNewline = ManifestEnvironmentFingerprint.digest(for: ["A": "x\nB=y"])
+        let split = ManifestEnvironmentFingerprint.digest(for: ["A": "x", "B": "y"])
+
+        #expect(withNewline != split)
+    }
+
+    @Test
+    func sidecarPathAppendsEnvhashExtension() throws {
+        let cache = try AbsolutePath(
+            validating: "/tmp/Package/.build/swifterpm/manifests/package.json")
+
+        #expect(
+            ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache).pathString
+                == "/tmp/Package/.build/swifterpm/manifests/package.json.envhash")
+    }
+
+    @Test
+    func validateReturnsMissingWhenNoSidecarExists() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .missing)
+        }
+    }
+
+    @Test
+    func validateReturnsMatchingWhenSidecarMatchesCurrentEnvironment() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
+            try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .matching)
+        }
+    }
+
+    @Test
+    func validateReturnsMismatchingWhenSidecarDiffersFromCurrentEnvironment() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+            try await fileSystem.write(Data("{}".utf8), to: cache)
+            try await fileSystem.write(
+                Data("a-fingerprint-produced-under-a-different-environment".utf8),
+                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache)
+            )
+
+            let validation = try await ManifestEnvironmentFingerprint.validate(forCacheFile: cache)
+
+            #expect(validation == .mismatching)
+        }
+    }
+
+    @Test
+    func writeRecordsCurrentEnvironmentFingerprint() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try root.appendingPathComponent("package.json").absolutePath
+
+            try await ManifestEnvironmentFingerprint.write(forCacheFile: cache)
+
+            let stored = String(
+                data: try await fileSystem.readFile(
+                    at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: cache)),
+                encoding: .utf8
+            )
+            #expect(stored == ManifestEnvironmentFingerprint.current())
+        }
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
@@ -50,6 +50,9 @@ struct PackageInfoCacheTests {
             try await fileSystem.atomicWrite(
                 try JSONFormatter.prettyData(emptyManifest(name: "CachedRoot")),
                 to: cacheDir.appendingPathComponent("root.json"))
+            if let rootPath = try? cacheDir.appendingPathComponent("root.json").absolutePath {
+                try await ManifestEnvironmentFingerprint.write(forCacheFile: rootPath)
+            }
 
             try await PackageInfoCacheWriter.write(
                 packageDir: package,
@@ -95,6 +98,9 @@ struct PackageInfoCacheTests {
             try await fileSystem.atomicWrite(
                 try JSONFormatter.prettyData(emptyManifest(name: "CachedDependency")),
                 to: packageInfoPath)
+            if let packageInfoAbsolute = try? packageInfoPath.absolutePath {
+                try await ManifestEnvironmentFingerprint.write(forCacheFile: packageInfoAbsolute)
+            }
 
             try await PackageInfoCacheWriter.write(
                 packageDir: package,
@@ -257,6 +263,52 @@ struct PackageInfoCacheTests {
                 packages.compactMap { $0["identity"] as? String } == [
                     "local-one", "local-two",
                 ])
+        }
+    }
+
+    @Test
+    func writePackageInfoCacheInvalidatesDestinationWhenEnvironmentChanged() async throws {
+        try await withTemporaryDirectory { root in
+            let package = root.appendingPathComponent("Package")
+            let scratch = root.appendingPathComponent("scratch")
+            let cacheDir = root.appendingPathComponent("package-info")
+            let rootPath = cacheDir.appendingPathComponent("root.json")
+
+            // The ManifestLoader cache holds a manifest produced under the current
+            // environment with a matching sidecar, so it reads as fresh and is reused to
+            // refill the destination without invoking `swift`.
+            try await writeCachedManifest(emptyManifest(name: "FreshFromManifestLoader"), packageDir: package)
+
+            // The package-info destination is newer than `Package.swift`, so the mtime
+            // check alone would consider it fresh, but its env sidecar records a
+            // different environment and must force a refresh.
+            try await Task.sleep(nanoseconds: 10_000_000)
+            try await fileSystem.atomicWrite(
+                try JSONFormatter.prettyData(emptyManifest(name: "StaleDestination")),
+                to: rootPath)
+            let rootAbsolutePath = try rootPath.absolutePath
+            try await fileSystem.write(
+                Data("a-fingerprint-produced-under-a-different-environment".utf8),
+                to: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootAbsolutePath))
+
+            try await PackageInfoCacheWriter.write(
+                packageDir: package,
+                scratchDir: scratch,
+                resolved: ResolvedPins(originHash: "origin", pins: [], version: 3),
+                cacheDir: cacheDir,
+                disableSandbox: false,
+                quiet: true
+            )
+
+            let rootInfo = try #require(
+                JSONSerialization.jsonObject(
+                    with: try await fileSystem.readFile(at: rootAbsolutePath))
+                    as? [String: Any])
+            #expect(rootInfo["name"] as? String == "FreshFromManifestLoader")
+
+            let sidecar = try await fileSystem.readFile(
+                at: ManifestEnvironmentFingerprint.sidecarPath(forCacheFile: rootAbsolutePath))
+            #expect(String(data: sidecar, encoding: .utf8) == ManifestEnvironmentFingerprint.current())
         }
     }
 

--- a/swifterpm/Tests/swifterpmTests/TestSupport.swift
+++ b/swifterpm/Tests/swifterpmTests/TestSupport.swift
@@ -27,10 +27,13 @@ func writeCachedManifest(_ manifest: [String: Any], packageDir: URL) async throw
     try await fileSystem.makeDirectory(
         at: packageDir.absolutePath, options: [.createTargetParentDirectories])
     try await writeMinimalPackageManifest(at: packageDir, name: "Fixture")
-    try await fileSystem.atomicWrite(
-        JSONFormatter.prettyData(manifest),
-        to: ManifestLoader.cacheFilePath(packageDir: packageDir)
-    )
+    let cachePath = ManifestLoader.cacheFilePath(packageDir: packageDir)
+    try await fileSystem.atomicWrite(JSONFormatter.prettyData(manifest), to: cachePath)
+    // A seeded cache is only reusable once it carries a matching environment sidecar;
+    // otherwise the freshness check treats it as a miss (see readCachedManifest).
+    if let cacheAbsolutePath = try? cachePath.absolutePath {
+        try await ManifestEnvironmentFingerprint.write(forCacheFile: cacheAbsolutePath)
+    }
 }
 
 func writeMinimalPackageManifest(at packageDir: URL, name: String) async throws {


### PR DESCRIPTION
## What changed

Cherry-pick of #12144 onto `releases/4.203.x`: keys SwifterPM's local package manifest dump cache on the environment (via a `ManifestEnvironmentFingerprint`), so a stale cached manifest is not reused when the environment changes.

## Why

Reported in #12130 against **4.202.5**: the local package manifest cache ignores environment changes, so e.g. switching `TUIST_BIN` does not invalidate the cached manifest. The 4.203 line has the same behavior.

## Approach

Straight cherry-pick of the fix from `main`, including the new `ManifestEnvironmentFingerprint` and the `PackageInfoCache` keying, plus tests.

(cherry picked from commit 7249714549)

## Impact

Manifest dumps are correctly invalidated when the environment changes, avoiding stale manifests causing incorrect resolution.

## Validation

- Cherry-pick applies cleanly on `releases/4.203.x`.
- CI (`cli.yml`) validates the build/tests on this PR.
