### PR TITLE
fix(cli): keep precompiled xcframeworks inline in Swift search paths

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
@@ -212,12 +212,16 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
             .map(\.searchPath)
 
         var values: [String] = []
+        // Always register the cleanup directory so stale symbolic links (for example `.xcframework`
+        // links created by older Tuist versions) are removed even when this target now has no active
+        // `.framework` links to link into the consolidated Swift search directory.
+        var activeLinks = activeFrameworkLinksByDirectory[cleanupDirectory, default: []]
         if !linkableArtifacts.isEmpty {
             values.append(LinkGeneratorPath.absolutePath(swiftFrameworkSearchPath).xcodeValue(sourceRootPath: sourceRootPath))
             let linkPaths = Set(linkableArtifacts.map { artifact in
                 swiftFrameworkSearchPath.appending(component: artifact.path.basename)
             })
-            activeFrameworkLinksByDirectory[cleanupDirectory, default: []].formUnion(linkPaths)
+            activeLinks.formUnion(linkPaths)
             generatedSymbolicLinkSideEffects.append(
                 contentsOf: linkableArtifacts.map { artifact in
                     .symbolicLink(
@@ -229,6 +233,7 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                 }
             )
         }
+        activeFrameworkLinksByDirectory[cleanupDirectory] = activeLinks
 
         values.append(
             contentsOf: xcodeValues(

--- a/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
@@ -37,8 +37,16 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
             .absolutePath(path.removingLastComponent())
         }
 
+        /// Whether the artifact can be represented by a symbolic link in the consolidated Swift
+        /// framework search directory.
+        ///
+        /// Only single-slice `.framework` artifacts qualify. `.xcframework` artifacts are kept inline:
+        /// Swift's `-F` flag doesn't resolve `.xcframework` bundles (they're resolved by Xcode through
+        /// the project file references), and symlinking one exposes every platform slice to Xcode's
+        /// resource processing, which on some Xcode versions walks the linked bundle as a plain folder
+        /// and emits conflicting "Multiple commands produce" copy commands for the per-slice resources.
         var canBeLinkedIntoSwiftSearchPath: Bool {
-            path.extension == "framework" || path.extension == "xcframework"
+            path.extension == "framework"
         }
     }
 
@@ -197,7 +205,9 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
         let conflictingFrameworkSearchPaths = frameworkArtifactsByBasename.values
             .filter { $0.count > 1 }
             .flatMap { $0.map(\.searchPath) }
-        let unsupportedSearchPaths = precompiledArtifacts
+        // `.xcframework` and other non-`.framework` artifacts are kept inline because they can't be
+        // safely represented as a symbolic link (see `canBeLinkedIntoSwiftSearchPath`).
+        let inlineSearchPaths = precompiledArtifacts
             .filter { !$0.canBeLinkedIntoSwiftSearchPath }
             .map(\.searchPath)
 
@@ -222,7 +232,7 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
 
         values.append(
             contentsOf: xcodeValues(
-                of: Set(conflictingFrameworkSearchPaths + unsupportedSearchPaths),
+                of: Set(conflictingFrameworkSearchPaths + inlineSearchPaths),
                 sourceRootPath: sourceRootPath
             )
         )

--- a/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
@@ -1,24 +1,15 @@
+import FileSystem
+import FileSystemTesting
 import Foundation
 import Path
-import TuistCore
-import TuistSupport
-import TuistTesting
+import Testing
 import XcodeGraph
-import XCTest
+@testable import TuistCore
 @testable import TuistGenerator
+@testable import TuistTesting
 
-final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
-    private var subject: FrameworkSearchPathsGraphMapper!
-
-    override func setUp() {
-        super.setUp()
-        subject = FrameworkSearchPathsGraphMapper()
-    }
-
-    override func tearDown() {
-        subject = nil
-        super.tearDown()
-    }
+struct FrameworkSearchPathsGraphMapperTests {
+    private let subject = FrameworkSearchPathsGraphMapper()
 
     private func appGraph(
         projectPath: AbsolutePath,
@@ -39,9 +30,10 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         return Graph.test(projects: [projectPath: project], dependencies: graphDependencies)
     }
 
-    func test_map_consolidatesFrameworksIntoSwiftSearchPath_whenManyPrecompiledFrameworks() async throws {
+    @Test(.inTemporaryDirectory)
+    func consolidatesFrameworksIntoSwiftSearchPathWhenManyPrecompiledFrameworks() async throws {
         // Given: many uniquely-named `.framework` artifacts, each in its own directory.
-        let projectPath = try temporaryPath()
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let frameworks: [GraphDependency] = (0 ..< 25).map { i in
             .testFramework(
                 path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
@@ -54,40 +46,44 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
-        XCTAssertTrue(
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        #expect(
             arrayValue(settings.base["OTHER_CFLAGS"]).contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/App.resp\"")
         )
-        XCTAssertTrue(
+        #expect(
             arrayValue(settings.base["OTHER_LDFLAGS"]).contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/App.resp\"")
         )
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
-        XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        #expect(otherSwiftFlags.contains("-F"))
         // `.framework` artifacts are linked into a single consolidated Swift search directory.
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
-        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+        #expect(!otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
         // The precompiled paths live in the response file, not in FRAMEWORK_SEARCH_PATHS.
-        XCTAssertFalse(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains { $0.contains("/Frameworks/") })
+        let frameworkSearchPaths = arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"])
+        #expect(!frameworkSearchPaths.contains(where: { $0.contains("/Frameworks/") }))
 
-        let responseFile = try XCTUnwrap(fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") })
-        let contents = try XCTUnwrap(String(data: try XCTUnwrap(responseFile.contents), encoding: .utf8))
-        XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
+        let responseFile = try #require(
+            fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") }
+        )
+        let responseData = try #require(responseFile.contents)
+        let contents = try #require(String(data: responseData, encoding: .utf8))
+        #expect(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
 
-        let swiftSearchPathCleanupDescriptor = try XCTUnwrap(
+        let swiftSearchPathCleanupDescriptor = try #require(
             generatedFilesCleanupDescriptor(
                 in: sideEffects,
                 include: ["Swift/*/*.framework", "Swift/*/*.xcframework"]
             )
         )
         let swiftSearchPathDirectory = projectPath.appending(components: "Derived", "FrameworkSearchPaths")
-        XCTAssertTrue(swiftSearchPathCleanupDescriptor.directories.contains(swiftSearchPathDirectory))
-        XCTAssertTrue(
+        #expect(swiftSearchPathCleanupDescriptor.directories.contains(swiftSearchPathDirectory))
+        #expect(
             swiftSearchPathCleanupDescriptor.activeFilesByDirectory[swiftSearchPathDirectory]?.contains(
                 projectPath.appending(components: "Derived", "FrameworkSearchPaths", "Swift", "App", "Module0.framework")
             ) ?? false
         )
 
-        XCTAssertTrue(
+        #expect(
             symbolicLinkDescriptors(in: sideEffects).contains(
                 SymbolicLinkDescriptor(
                     path: projectPath.appending(
@@ -103,12 +99,13 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         )
     }
 
-    func test_map_keepsXCFrameworksInlineInSwiftFlagsAndDoesNotSymlinkThem_whenManyPrecompiledXCFrameworks() async throws {
+    @Test(.inTemporaryDirectory)
+    func keepsXCFrameworksInlineInSwiftFlagsAndDoesNotSymlinkThemWhenManyPrecompiledXCFrameworks() async throws {
         // Given: many uniquely-named `.xcframework` artifacts above the consolidation threshold.
         // `.xcframework` must NOT be symlinked into the Swift search directory: Swift's `-F` flag doesn't
         // resolve `.xcframework` bundles, and symlinking one exposes every platform slice to Xcode's
         // resource processing (regression: "Multiple commands produce" for per-slice resources).
-        let projectPath = try temporaryPath()
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let xcframeworks: [GraphDependency] = (0 ..< 25).map { i in
             .testXCFramework(
                 path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
@@ -121,36 +118,45 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
         // Clang and the linker still get the paths via the response file.
-        XCTAssertTrue(
+        #expect(
             arrayValue(settings.base["OTHER_CFLAGS"]).contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/App.resp\"")
         )
-        let responseFile = try XCTUnwrap(fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") })
-        let contents = try XCTUnwrap(String(data: try XCTUnwrap(responseFile.contents), encoding: .utf8))
-        XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
+        let responseFile = try #require(
+            fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") }
+        )
+        let responseData = try #require(responseFile.contents)
+        let contents = try #require(String(data: responseData, encoding: .utf8))
+        #expect(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
 
         // Swift receives every xcframework parent directory inline instead of a consolidated symlink directory.
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
-        XCTAssertTrue(otherSwiftFlags.contains("-F"))
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
-        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+        #expect(otherSwiftFlags.contains("-F"))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
+        #expect(!otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
 
         // No xcframework is ever represented as a symbolic link.
-        XCTAssertTrue(symbolicLinkDescriptors(in: sideEffects).isEmpty)
-        // And no Swift search-path symlink cleanup is emitted.
-        XCTAssertNil(
+        #expect(symbolicLinkDescriptors(in: sideEffects).isEmpty)
+
+        // A Swift search-path cleanup descriptor is still emitted with an empty active-file set so that
+        // stale `.xcframework` links left behind by older Tuist versions are removed on the next generate.
+        let symlinkCleanup = try #require(
             generatedFilesCleanupDescriptor(
                 in: sideEffects,
                 include: ["Swift/*/*.framework", "Swift/*/*.xcframework"]
             )
         )
+        let swiftSearchPathDirectory = projectPath.appending(components: "Derived", "FrameworkSearchPaths")
+        #expect(symlinkCleanup.directories.contains(swiftSearchPathDirectory))
+        #expect((symlinkCleanup.activeFilesByDirectory[swiftSearchPathDirectory] ?? []).isEmpty)
     }
 
-    func test_map_quotesResponseFileReference_whenTargetNameContainsWhitespace() async throws {
+    @Test(.inTemporaryDirectory)
+    func quotesResponseFileReferenceWhenTargetNameContainsWhitespace() async throws {
         // Given
-        let projectPath = try temporaryPath()
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let xcframeworks: [GraphDependency] = (0 ..< 25).map { i in
             .testXCFramework(
                 path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
@@ -163,24 +169,28 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["Etsy Enterprise"]?.settings)
-        XCTAssertTrue(
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["Etsy Enterprise"]?.settings)
+        #expect(
             arrayValue(settings.base["OTHER_CFLAGS"])
                 .contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/Etsy Enterprise.resp\"")
         )
-        XCTAssertTrue(
+        #expect(
             arrayValue(settings.base["OTHER_LDFLAGS"])
                 .contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/Etsy Enterprise.resp\"")
         )
-        XCTAssertTrue(sideEffects.contains { sideEffect in
-            guard case let .file(file) = sideEffect else { return false }
-            return file.path.pathString.hasSuffix("Derived/FrameworkSearchPaths/Etsy Enterprise.resp")
-        })
+        let hasResponseFile = sideEffects.contains { sideEffect in
+            if case let .file(file) = sideEffect {
+                return file.path.pathString.hasSuffix("Derived/FrameworkSearchPaths/Etsy Enterprise.resp")
+            }
+            return false
+        }
+        #expect(hasResponseFile)
     }
 
-    func test_map_quotesSwiftFrameworkSearchPaths_whenTargetNameContainsWhitespace() async throws {
+    @Test(.inTemporaryDirectory)
+    func quotesSwiftFrameworkSearchPathsWhenTargetNameContainsWhitespace() async throws {
         // Given: `.framework` artifacts so the consolidated Swift search directory is created.
-        let projectPath = try temporaryPath()
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let frameworks: [GraphDependency] = (0 ..< 25).map { i in
             .testFramework(
                 path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
@@ -193,21 +203,22 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["Notification Service"]?.settings)
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["Notification Service"]?.settings)
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
-        XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        #expect(otherSwiftFlags.contains("-F"))
         // The search path is quoted so Xcode does not word-split it into two tokens.
-        XCTAssertTrue(
+        #expect(
             otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service\"")
         )
-        XCTAssertFalse(
-            otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service")
+        #expect(
+            !otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service")
         )
     }
 
-    func test_map_deletesStaleFrameworkSearchPathResponseFiles() async throws {
+    @Test(.inTemporaryDirectory)
+    func deletesStaleFrameworkSearchPathResponseFiles() async throws {
         // Given
-        let projectPath = try temporaryPath()
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
         let responseFileDirectory = projectPath.appending(components: "Derived", "FrameworkSearchPaths")
         let activeResponseFilePath = responseFileDirectory.appending(component: "App.resp")
         let staleResponseFilePath = responseFileDirectory.appending(component: "DeletedTarget.resp")
@@ -224,24 +235,26 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (_, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let cleanupDescriptor = try XCTUnwrap(generatedFilesCleanupDescriptor(in: sideEffects))
-        XCTAssertEqual(cleanupDescriptor.include, ["*.resp"])
-        XCTAssertTrue(cleanupDescriptor.directories.contains(responseFileDirectory))
-        XCTAssertEqual(cleanupDescriptor.activeFilesByDirectory[responseFileDirectory], Set([activeResponseFilePath]))
-        XCTAssertFalse(cleanupDescriptor.activeFilesByDirectory[responseFileDirectory]?.contains(staleResponseFilePath) ?? false)
-        XCTAssertTrue(
-            sideEffects.contains { sideEffect in
-                guard case let .file(fileDescriptor) = sideEffect else { return false }
+        let cleanupDescriptor = try #require(generatedFilesCleanupDescriptor(in: sideEffects))
+        #expect(cleanupDescriptor.include == ["*.resp"])
+        #expect(cleanupDescriptor.directories.contains(responseFileDirectory))
+        #expect(cleanupDescriptor.activeFilesByDirectory[responseFileDirectory] == Set([activeResponseFilePath]))
+        #expect(!(cleanupDescriptor.activeFilesByDirectory[responseFileDirectory]?.contains(staleResponseFilePath) ?? true))
+        let hasResponseFile = sideEffects.contains { sideEffect in
+            if case let .file(fileDescriptor) = sideEffect {
                 return fileDescriptor.path == activeResponseFilePath && fileDescriptor.state == .present
             }
-        )
+            return false
+        }
+        #expect(hasResponseFile)
     }
 
-    func test_map_keepsConflictingFrameworkNamesInline_whenConsolidatingSwiftSearchPaths() async throws {
+    @Test(.inTemporaryDirectory)
+    func keepsConflictingFrameworkNamesInlineWhenConsolidatingSwiftSearchPaths() async throws {
         // Given: two `.framework` artifacts that share a basename conflict and stay inline, while the
         // remaining uniquely-named frameworks are linked into the consolidated Swift search directory.
-        let projectPath = try temporaryPath()
-        let frameworks: [GraphDependency] = [
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
+        var frameworks: [GraphDependency] = [
             .testFramework(
                 path: projectPath.appending(components: "Frameworks", "hash0", "Shared.framework"),
                 linking: .dynamic
@@ -250,11 +263,12 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
                 path: projectPath.appending(components: "Frameworks", "hash1", "Shared.framework"),
                 linking: .dynamic
             ),
-        ] + (2 ..< 25).map { i in
-            .testFramework(
+        ]
+        frameworks += (2 ..< 25).map { i in
+            GraphDependency.testFramework(
                 path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
                 linking: .dynamic
-            ) as GraphDependency
+            )
         }
         let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: frameworks)
 
@@ -262,22 +276,23 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
-        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
-        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash2\""))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
+        #expect(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
+        #expect(!otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash2\""))
 
         let symbolicLinks = symbolicLinkDescriptors(in: sideEffects)
-        XCTAssertFalse(symbolicLinks.contains { $0.destination.basename == "Shared.framework" })
-        XCTAssertTrue(symbolicLinks.contains { $0.destination.basename == "Module2.framework" })
+        #expect(!symbolicLinks.contains { $0.destination.basename == "Shared.framework" })
+        #expect(symbolicLinks.contains { $0.destination.basename == "Module2.framework" })
     }
 
-    func test_map_keepsFrameworkSearchPaths_whenFewPrecompiledFrameworks() async throws {
+    @Test(.inTemporaryDirectory)
+    func keepsFrameworkSearchPathsWhenFewPrecompiledFrameworks() async throws {
         // Given
-        let projectPath = try temporaryPath()
-        let xcframework: GraphDependency = .testXCFramework(
+        let projectPath = try #require(FileSystem.temporaryTestDirectory)
+        let xcframework = GraphDependency.testXCFramework(
             path: projectPath.appending(components: "Frameworks", "hash0", "Module0.xcframework"),
             linking: .dynamic
         )
@@ -287,13 +302,13 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
 
         // Then
-        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
-        XCTAssertTrue(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains("$(SRCROOT)/Frameworks/hash0"))
-        XCTAssertNil(settings.base["OTHER_CFLAGS"])
-        XCTAssertTrue(fileDescriptors(in: sideEffects).isEmpty)
-        let cleanupDescriptor = try XCTUnwrap(generatedFilesCleanupDescriptor(in: sideEffects))
-        XCTAssertEqual(cleanupDescriptor.include, ["*.resp"])
-        XCTAssertTrue(
+        let settings = try #require(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        #expect(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains("$(SRCROOT)/Frameworks/hash0"))
+        #expect(settings.base["OTHER_CFLAGS"] == nil)
+        #expect(fileDescriptors(in: sideEffects).isEmpty)
+        let cleanupDescriptor = try #require(generatedFilesCleanupDescriptor(in: sideEffects))
+        #expect(cleanupDescriptor.include == ["*.resp"])
+        #expect(
             cleanupDescriptor.directories.contains(
                 projectPath.appending(components: "Derived", "FrameworkSearchPaths")
             )
@@ -310,15 +325,15 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
 
     private func fileDescriptors(in sideEffects: [SideEffectDescriptor]) -> [FileDescriptor] {
         sideEffects.compactMap { sideEffect in
-            guard case let .file(descriptor) = sideEffect else { return nil }
-            return descriptor
+            if case let .file(descriptor) = sideEffect { return descriptor }
+            return nil
         }
     }
 
     private func symbolicLinkDescriptors(in sideEffects: [SideEffectDescriptor]) -> [SymbolicLinkDescriptor] {
         sideEffects.compactMap { sideEffect in
-            guard case let .symbolicLink(descriptor) = sideEffect else { return nil }
-            return descriptor
+            if case let .symbolicLink(descriptor) = sideEffect { return descriptor }
+            return nil
         }
     }
 
@@ -327,8 +342,10 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         include: [String] = ["*.resp"]
     ) -> GeneratedFilesCleanupDescriptor? {
         sideEffects.compactMap { sideEffect in
-            guard case let .generatedFilesCleanup(descriptor) = sideEffect else { return nil }
-            return descriptor.include == include ? descriptor : nil
+            if case let .generatedFilesCleanup(descriptor) = sideEffect {
+                return descriptor.include == include ? descriptor : nil
+            }
+            return nil
         }.first
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
@@ -20,27 +20,35 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_map_consolidatesIntoResponseFile_whenManyPrecompiledFrameworks() async throws {
-        // Given
+    private func appGraph(
+        projectPath: AbsolutePath,
+        targetName: String,
+        dependencies: [GraphDependency]
+    ) -> Graph {
+        var graphDependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: targetName, path: projectPath): Set(dependencies),
+        ]
+        for dependency in dependencies {
+            graphDependencies[dependency] = Set()
+        }
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            targets: [Target.test(name: targetName, product: .app)]
+        )
+        return Graph.test(projects: [projectPath: project], dependencies: graphDependencies)
+    }
+
+    func test_map_consolidatesFrameworksIntoSwiftSearchPath_whenManyPrecompiledFrameworks() async throws {
+        // Given: many uniquely-named `.framework` artifacts, each in its own directory.
         let projectPath = try temporaryPath()
-        let app = Target.test(name: "App", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
-        var xcframeworks: [GraphDependency] = []
-        for i in 0 ..< 25 {
-            xcframeworks.append(
-                .testXCFramework(
-                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
-                    linking: .dynamic
-                )
+        let frameworks: [GraphDependency] = (0 ..< 25).map { i in
+            .testFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
+                linking: .dynamic
             )
         }
-        var dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: "App", path: projectPath): Set(xcframeworks),
-        ]
-        for xcframework in xcframeworks {
-            dependencies[xcframework] = Set()
-        }
-        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+        let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: frameworks)
 
         // When
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
@@ -55,17 +63,13 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         )
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
         XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        // `.framework` artifacts are linked into a single consolidated Swift search directory.
         XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
         XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
         // The precompiled paths live in the response file, not in FRAMEWORK_SEARCH_PATHS.
         XCTAssertFalse(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains { $0.contains("/Frameworks/") })
 
-        let responseFile = try XCTUnwrap(sideEffects.compactMap { sideEffect -> FileDescriptor? in
-            guard case let .file(file) = sideEffect,
-                  file.path.pathString.hasSuffix("Derived/FrameworkSearchPaths/App.resp")
-            else { return nil }
-            return file
-        }.first)
+        let responseFile = try XCTUnwrap(fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") })
         let contents = try XCTUnwrap(String(data: try XCTUnwrap(responseFile.contents), encoding: .utf8))
         XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
 
@@ -79,7 +83,7 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         XCTAssertTrue(swiftSearchPathCleanupDescriptor.directories.contains(swiftSearchPathDirectory))
         XCTAssertTrue(
             swiftSearchPathCleanupDescriptor.activeFilesByDirectory[swiftSearchPathDirectory]?.contains(
-                projectPath.appending(components: "Derived", "FrameworkSearchPaths", "Swift", "App", "Module0.xcframework")
+                projectPath.appending(components: "Derived", "FrameworkSearchPaths", "Swift", "App", "Module0.framework")
             ) ?? false
         )
 
@@ -91,10 +95,55 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
                         "FrameworkSearchPaths",
                         "Swift",
                         "App",
-                        "Module0.xcframework"
+                        "Module0.framework"
                     ),
-                    destination: projectPath.appending(components: "Frameworks", "hash0", "Module0.xcframework")
+                    destination: projectPath.appending(components: "Frameworks", "hash0", "Module0.framework")
                 )
+            )
+        )
+    }
+
+    func test_map_keepsXCFrameworksInlineInSwiftFlagsAndDoesNotSymlinkThem_whenManyPrecompiledXCFrameworks() async throws {
+        // Given: many uniquely-named `.xcframework` artifacts above the consolidation threshold.
+        // `.xcframework` must NOT be symlinked into the Swift search directory: Swift's `-F` flag doesn't
+        // resolve `.xcframework` bundles, and symlinking one exposes every platform slice to Xcode's
+        // resource processing (regression: "Multiple commands produce" for per-slice resources).
+        let projectPath = try temporaryPath()
+        let xcframeworks: [GraphDependency] = (0 ..< 25).map { i in
+            .testXCFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
+                linking: .dynamic
+            )
+        }
+        let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: xcframeworks)
+
+        // When
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        // Clang and the linker still get the paths via the response file.
+        XCTAssertTrue(
+            arrayValue(settings.base["OTHER_CFLAGS"]).contains("\"@$(SRCROOT)/Derived/FrameworkSearchPaths/App.resp\"")
+        )
+        let responseFile = try XCTUnwrap(fileDescriptors(in: sideEffects).first { $0.path.pathString.hasSuffix("App.resp") })
+        let contents = try XCTUnwrap(String(data: try XCTUnwrap(responseFile.contents), encoding: .utf8))
+        XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
+
+        // Swift receives every xcframework parent directory inline instead of a consolidated symlink directory.
+        let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
+        XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
+        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+
+        // No xcframework is ever represented as a symbolic link.
+        XCTAssertTrue(symbolicLinkDescriptors(in: sideEffects).isEmpty)
+        // And no Swift search-path symlink cleanup is emitted.
+        XCTAssertNil(
+            generatedFilesCleanupDescriptor(
+                in: sideEffects,
+                include: ["Swift/*/*.framework", "Swift/*/*.xcframework"]
             )
         )
     }
@@ -102,24 +151,13 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
     func test_map_quotesResponseFileReference_whenTargetNameContainsWhitespace() async throws {
         // Given
         let projectPath = try temporaryPath()
-        let app = Target.test(name: "Etsy Enterprise", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
-        var xcframeworks: [GraphDependency] = []
-        for i in 0 ..< 25 {
-            xcframeworks.append(
-                .testXCFramework(
-                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
-                    linking: .dynamic
-                )
+        let xcframeworks: [GraphDependency] = (0 ..< 25).map { i in
+            .testXCFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
+                linking: .dynamic
             )
         }
-        var dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: "Etsy Enterprise", path: projectPath): Set(xcframeworks),
-        ]
-        for xcframework in xcframeworks {
-            dependencies[xcframework] = Set()
-        }
-        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+        let graph = appGraph(projectPath: projectPath, targetName: "Etsy Enterprise", dependencies: xcframeworks)
 
         // When
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
@@ -141,26 +179,15 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
     }
 
     func test_map_quotesSwiftFrameworkSearchPaths_whenTargetNameContainsWhitespace() async throws {
-        // Given
+        // Given: `.framework` artifacts so the consolidated Swift search directory is created.
         let projectPath = try temporaryPath()
-        let app = Target.test(name: "Notification Service", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
-        var xcframeworks: [GraphDependency] = []
-        for i in 0 ..< 25 {
-            xcframeworks.append(
-                .testXCFramework(
-                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
-                    linking: .dynamic
-                )
+        let frameworks: [GraphDependency] = (0 ..< 25).map { i in
+            .testFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
+                linking: .dynamic
             )
         }
-        var dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: "Notification Service", path: projectPath): Set(xcframeworks),
-        ]
-        for xcframework in xcframeworks {
-            dependencies[xcframework] = Set()
-        }
-        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+        let graph = appGraph(projectPath: projectPath, targetName: "Notification Service", dependencies: frameworks)
 
         // When
         let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
@@ -185,24 +212,13 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         let activeResponseFilePath = responseFileDirectory.appending(component: "App.resp")
         let staleResponseFilePath = responseFileDirectory.appending(component: "DeletedTarget.resp")
 
-        let app = Target.test(name: "App", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
-        var xcframeworks: [GraphDependency] = []
-        for i in 0 ..< 25 {
-            xcframeworks.append(
-                .testXCFramework(
-                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
-                    linking: .dynamic
-                )
+        let xcframeworks: [GraphDependency] = (0 ..< 25).map { i in
+            .testXCFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
+                linking: .dynamic
             )
         }
-        var dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: "App", path: projectPath): Set(xcframeworks),
-        ]
-        for xcframework in xcframeworks {
-            dependencies[xcframework] = Set()
-        }
-        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+        let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: xcframeworks)
 
         // When
         let (_, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
@@ -222,35 +238,25 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
     }
 
     func test_map_keepsConflictingFrameworkNamesInline_whenConsolidatingSwiftSearchPaths() async throws {
-        // Given
+        // Given: two `.framework` artifacts that share a basename conflict and stay inline, while the
+        // remaining uniquely-named frameworks are linked into the consolidated Swift search directory.
         let projectPath = try temporaryPath()
-        let app = Target.test(name: "App", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
-        var xcframeworks: [GraphDependency] = [
-            .testXCFramework(
-                path: projectPath.appending(components: "Frameworks", "hash0", "Shared.xcframework"),
+        let frameworks: [GraphDependency] = [
+            .testFramework(
+                path: projectPath.appending(components: "Frameworks", "hash0", "Shared.framework"),
                 linking: .dynamic
             ),
-            .testXCFramework(
-                path: projectPath.appending(components: "Frameworks", "hash1", "Shared.xcframework"),
+            .testFramework(
+                path: projectPath.appending(components: "Frameworks", "hash1", "Shared.framework"),
                 linking: .dynamic
             ),
-        ]
-        for i in 2 ..< 25 {
-            xcframeworks.append(
-                .testXCFramework(
-                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
-                    linking: .dynamic
-                )
-            )
+        ] + (2 ..< 25).map { i in
+            .testFramework(
+                path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).framework"),
+                linking: .dynamic
+            ) as GraphDependency
         }
-        var dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: "App", path: projectPath): Set(xcframeworks),
-        ]
-        for xcframework in xcframeworks {
-            dependencies[xcframework] = Set()
-        }
-        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+        let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: frameworks)
 
         // When
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
@@ -264,26 +270,18 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash2\""))
 
         let symbolicLinks = symbolicLinkDescriptors(in: sideEffects)
-        XCTAssertFalse(symbolicLinks.contains { $0.destination.basename == "Shared.xcframework" })
-        XCTAssertTrue(symbolicLinks.contains { $0.destination.basename == "Module2.xcframework" })
+        XCTAssertFalse(symbolicLinks.contains { $0.destination.basename == "Shared.framework" })
+        XCTAssertTrue(symbolicLinks.contains { $0.destination.basename == "Module2.framework" })
     }
 
     func test_map_keepsFrameworkSearchPaths_whenFewPrecompiledFrameworks() async throws {
         // Given
         let projectPath = try temporaryPath()
-        let app = Target.test(name: "App", product: .app)
-        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
         let xcframework: GraphDependency = .testXCFramework(
             path: projectPath.appending(components: "Frameworks", "hash0", "Module0.xcframework"),
             linking: .dynamic
         )
-        let graph = Graph.test(
-            projects: [projectPath: project],
-            dependencies: [
-                .target(name: "App", path: projectPath): Set([xcframework]),
-                xcframework: Set(),
-            ]
-        )
+        let graph = appGraph(projectPath: projectPath, targetName: "App", dependencies: [xcframework])
 
         // When
         let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())


### PR DESCRIPTION
Reported by a customer (Migros) who have been pinned to Tuist 4.197.1 because every release from 4.202.0 onward fails their app build with `error: Multiple commands produce '.../migros.app/FirebaseFirestoreInternal_Privacy.bundle'`, with copy commands originating from every platform slice of a multi-slice `.xcframework`.

### What changed

`FrameworkSearchPathsGraphMapper` no longer symlinks `.xcframework` artifacts into the per-target consolidated Swift framework search directory (`Derived/FrameworkSearchPaths/Swift/<target>/`). Such artifacts are now passed to Swift inline, through `OTHER_SWIFT_FLAGS`, exactly like they were before [perf(cli): consolidate Swift framework search paths (#11555)](https://github.com/tuist/tuist/pull/11555). Single-slice `.framework` artifacts continue to be symlinked and consolidated, and the Clang/linker `@file` response file behavior is unchanged.

- `PrecompiledArtifact.canBeLinkedIntoSwiftSearchPath` now returns `true` only for `.framework`.
- The previously named `unsupportedSearchPaths` collection is renamed `inlineSearchPaths` to reflect that `.xcframework` is fully supported, just not symlink-safe.
- The Swift search-path cleanup glob still includes `*.xcframework` so stale links produced by older Tuist versions are removed on the next `tuist generate`.
- Tests updated: the symlink-consolidation case now uses `.framework` dependencies, and a new regression test asserts `.xcframework` dependencies stay inline and produce no symlinks.

### Why

#11555 introduced the symlink directory to cut down the number of `-F` flags Swift walks during import resolution. That goal is legitimate, but the implementation symlinked `.xcframework` artifacts too, which turns out to be both useless and harmful.

### Root cause

The regression ships entirely from #11555 (4.202.0). The mapper symlinks the whole `.xcframework` into the Swift search directory. On some Xcode versions the build system does not recognize the linked `.xcframework` as an [xcframework](https://developer.apple.com/documentation/xcode/distributing-external-builds-for-beta-testing) (a wrapper that bundles one framework per supported platform and slice) and instead walks it as a plain folder. That walk copies per-slice resources such as `<Framework>_Privacy.bundle` to the same destination in the app bundle once per slice (and once per macOS-style `Resources/` alias), so Xcode detects two or more tasks producing the same file and aborts with `Multiple commands produce`.

### Approach

Keep `.xcframework` inline and only consolidate `.framework`. This is safe and loss-free for two reasons established while reproducing the issue:

1. Swift's `-F` flag does not resolve `.xcframework` bundles at all (only `.framework`). I verified this directly: `-F <dir>` containing a real `.xcframework` with `.swiftinterface` files yields `no such module`, while the same directory with a plain `.framework` resolves fine. `.xcframework` modules are resolved by Xcode through the project file references, not through `-F`. So the `.xcframework` symlinks never helped Swift import resolution in the first place, and removing them costs nothing there.
2. Inline `-F` points at the real parent directory of the xcframework (never a symlink to the bundle), which is the exact 4.197.1 behavior that worked for the customer. A real directory on the search path is recognized correctly and never triggers the folder walk.

The `.framework` symlinks, which Swift does resolve through `-F`, are preserved, so the consolidation benefit from #11555 still applies to them.

### Impact

- Projects with only `.framework` precompiled dependencies are unchanged (still consolidated).
- Projects with only `.xcframework` precompiled dependencies (the customer's case) get those paths inline in `OTHER_SWIFT_FLAGS` and no longer produce the symlink directory, so the build stops failing.
- Mixed projects consolidate their `.framework` dependencies and keep `.xcframework` dependencies inline.
- On Xcode 26 (explicit-module builds), there is no measurable cost because `-F` is not searched for module resolution. On older Xcode, correctness is restored at the same performance the customer already had on 4.197.1.

### How to test locally

The reproduction is the meaningful validation here. I built a project with 27 precompiled `.xcframework` binary dependencies (one multi-slice with a per-slice `_Privacy.bundle`, plus padding), each in its own directory like a real cache layout.

- With Tuist 4.202.5 (before this change), `tuist generate` created `Derived/FrameworkSearchPaths/Swift/ReproApp/RealKit.xcframework -> .../RealKit.xcframework` and set `OTHER_SWIFT_FLAGS = -F $(SRCROOT)/Derived/FrameworkSearchPaths/Swift/ReproApp`.
- After this change, built from the worktree, that symlink directory is not created at all and `OTHER_SWIFT_FLAGS` carries the xcframework parent directories inline; the app builds successfully.

```
# Unit tests
tuist generate TuistGenerator TuistGeneratorTests --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistGeneratorTests/FrameworkSearchPathsGraphMapperTests \
  -destination 'platform=macOS,arch=arm64' \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
  COMPILATION_CACHE_ENABLE_CACHING=NO
# Result: Executed 7 tests, with 0 failures
```
