### PR TITLE
fix(cli): give local-SPM dependency acceptance tests 4-minute time limits

### DIFF
--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -266,7 +266,10 @@ struct DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies
     @Test(
         .withFixture("generated_command_line_tool_with_local_spm_test_only_dependencies"),
         .inTemporaryDirectory,
-        .timeLimit(.minutes(1))
+        // Install + generate of local packages wrapped in the `.withFixture` server lifecycle
+        // is highly variable under CI load (observed 15s to >60s cold). Match the headroom of the
+        // analogous `install_then_generate_does_not_deadlock` test rather than the 1-minute default.
+        .timeLimit(.minutes(4))
     )
     func install_then_generate_ignores_local_package_test_only_dependencies() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
@@ -280,7 +283,7 @@ struct DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies
     @Test(
         .withFixture("generated_command_line_tool_with_local_spm_test_only_dependencies"),
         .inTemporaryDirectory,
-        .timeLimit(.minutes(1))
+        .timeLimit(.minutes(4))
     )
     func install_then_generate_whenLocalPackageTestsAreEnabled_failsForExternalProductDependency() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)


### PR DESCRIPTION
## What changed

- Bumped the `.timeLimit` of the two `DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies` acceptance tests from `.minutes(1)` to `.minutes(4)`, matching the analogous `install_then_generate_does_not_deadlock` test.

## Why

`main` is red: `Acceptance Tests (1)` failed on `install_then_generate_ignores_local_package_test_only_dependencies`, which was killed at exactly its 1-minute limit (run twice under `-retry-tests-on-failure -test-iterations 2`, both iterations timed out).
https://github.com/tuist/tuist/actions/runs/30546646500/job/90888149742

## Root cause

The test does `tuist install --force-resolved-versions` + `tuist generate` on a project with local Swift packages, all wrapped in the `.withFixture` acceptance trait (server login, organization + project creation, remote-cache setup, teardown). Its cold-run duration is highly variable under CI load, and the 1-minute limit had no headroom for the variance:

| Run | Date | Cold / warm |
| --- | --- | --- |
| `30429173129` (green) | Jul 29 | 14.9s / 8.4s |
| `30539436734` | Jul 30 AM | 36.8s / 5.3s |
| `30546646500` (red) | Jul 30 PM | 60.0s timeout (both iterations) |

Warm iterations stay fast (5-8s), so manifest-dump cache reuse still works. Nothing between the last green run and the red run adds meaningful time to this fresh-directory test — I inspected every candidate commit (`50d05177f8` back-deployment runpath, `387d3ed484` Kura memory-pressure, `2b020257e2` module-map reanchoring, `7249714549` manifest-dump env fingerprinting) and none of them change the work done on a freshly copied fixture. The variance tracks CI/server/cache load, and only this single test (the slowest, most borderline one) tipped over; shard 0, unit tests, and the build all passed in the same run.

## Approach

Align the limit with `install_then_generate_does_not_deadlock`, which already uses `.timeLimit(.minutes(4))` for the same shape of work (local-package install + generate inside the acceptance fixture). 4 minutes gives ~4x headroom over the worst observed cold run. I bumped both tests in the struct since they share the same `install` cost and fixture; the second test's `generate` fails fast but its `install` is identical and equally exposed to the same variance.

## Impact

None on product behavior; acceptance-tests-only change.

## Validation

- Locally, `tuist install --force-resolved-versions` + `tuist generate` against the `generated_command_line_tool_with_local_spm_test_only_dependencies` fixture completes in ~1.6s with no hang, confirming the CLI code path itself is not the bottleneck. The timeout is not reproducible locally because it depends on the CI acceptance-test environment (live server, remote cache/Kura, runner contention), which is exactly why the test needs the headroom.
- Confirmed the timing variance and the passing sibling-test precedent directly from the CI logs cited above.
