### PR TITLE
fix(server): grant processor access to flaky corrections

### DIFF
--- a/infra/cnpg/tuist-processor-grants.sql
+++ b/infra/cnpg/tuist-processor-grants.sql
@@ -40,8 +40,9 @@ REVOKE ALL ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_processor;
 GRANT CONNECT ON DATABASE tuist TO tuist_processor;
 GRANT USAGE ON SCHEMA :"tuist_schema" TO tuist_processor;
 
--- Oban coordination. DELETE is needed for Oban.Plugins.Pruner.
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE :"tuist_schema".oban_jobs, :"tuist_schema".oban_peers TO tuist_processor;
+-- Oban coordination. DELETE is needed for Oban.Plugins.Pruner. The flaky
+-- correction table is written while processing xcresult test runs.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE :"tuist_schema".oban_jobs, :"tuist_schema".oban_peers, :"tuist_schema".test_case_run_flaky_corrections TO tuist_processor;
 GRANT USAGE, SELECT ON SEQUENCE :"tuist_schema".oban_jobs_id_seq TO tuist_processor;
 
 -- Read-only lookups the workers perform. These rows are not written by the

--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -10,7 +10,7 @@ defmodule Tuist.Release do
   require Logger
 
   @app :tuist
-  @processor_write_tables ~w(oban_jobs oban_peers)
+  @processor_write_tables ~w(oban_jobs oban_peers test_case_run_flaky_corrections)
   @processor_read_tables ~w(accounts projects automation_alerts webhook_endpoints)
   @swift_registry_sync_write_tables ~w(oban_jobs oban_peers)
 

--- a/server/test/tuist/release_test.exs
+++ b/server/test/tuist/release_test.exs
@@ -144,7 +144,7 @@ defmodule Tuist.ReleaseTest do
                ~s(REVOKE ALL ON ALL TABLES IN SCHEMA "public" FROM "tuist_processor"),
                ~s(GRANT CONNECT ON DATABASE "tuist" TO "tuist_processor"),
                ~s(GRANT USAGE ON SCHEMA "public" TO "tuist_processor"),
-               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "public".oban_jobs, "public".oban_peers TO "tuist_processor"),
+               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "public".oban_jobs, "public".oban_peers, "public".test_case_run_flaky_corrections TO "tuist_processor"),
                ~s(GRANT USAGE, SELECT ON SEQUENCE "public".oban_jobs_id_seq TO "tuist_processor"),
                ~s(GRANT SELECT ON TABLE "public".accounts, "public".projects, "public".automation_alerts, "public".webhook_endpoints TO "tuist_processor")
              ]
@@ -163,7 +163,7 @@ defmodule Tuist.ReleaseTest do
       assert occurrences(sql, expected_read_grant) == 1
 
       assert sql =~
-               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE :"tuist_schema".oban_jobs, :"tuist_schema".oban_peers TO tuist_processor;)
+               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE :"tuist_schema".oban_jobs, :"tuist_schema".oban_peers, :"tuist_schema".test_case_run_flaky_corrections TO tuist_processor;)
 
       assert sql =~ ~s(REVOKE ALL ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_processor;)
     end


### PR DESCRIPTION
Resolves [TUIST-3RE](https://tuist.sentry.io/issues/TUIST-3RE).

## What changed

- Grant the processor role access to create and update flaky test-run corrections.
- Keep the bootstrap permission script aligned with the release-time grant list.
- Extend the synchronization test for the processor permission surface.

## Why

The test-result processor needs to persist flaky-test corrections while processing test runs.

## Root cause

`test_case_run_flaky_corrections` was added to the processing path but omitted from the processor role's least-privilege write allowlist. Production processing therefore failed with a PostgreSQL permission-denied error.

## Approach

Add the correction table to the existing write allowlist, rather than broadening the processor's database access. The same grant is included in the bootstrap script to preserve recovery behavior.

## Impact

Test-result processing can persist flaky-test corrections again after deployment, while the processor remains restricted to its explicit table set.

### How to test locally

- `git diff --check`
- The focused release test was started, but local dependency compilation did not complete in this fresh worktree.
