### PR TITLE
fix(server): serialize Kura runtime rollouts

### DIFF
--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -51,7 +51,11 @@ defmodule Tuist.Kura do
   # to rescue and forces manual intervention. Only terminal servers
   # (`:destroying`/`:destroyed`) are skipped.
   @version_rollout_statuses [:provisioning, :replicating, :active, :failed]
-  @version_rollout_batch_size 100
+  # Until the durable rollout controller is deployed, advance runtime updates
+  # one server at a time. A Kura pod replacement briefly removes its cache
+  # endpoint, so fanning an image change out to every account at once turns a
+  # single rollout problem into a fleet-wide outage.
+  @version_rollout_batch_size 1
 
   @doc "Reconciles desired Kura server rows with the observed Kubernetes state."
   def reconcile_orphaned_deployments, do: Reconciler.reconcile()
@@ -103,7 +107,17 @@ defmodule Tuist.Kura do
   end
 
   defp schedule_runtime_image_deployments(image_tag) do
-    schedule_version_deployments(image_tag)
+    if open_runtime_deployments?(image_tag) do
+      {:ok, %{scheduled: [], failures: []}}
+    else
+      schedule_version_deployments(image_tag)
+    end
+  end
+
+  defp open_runtime_deployments?(image_tag) do
+    Deployment
+    |> where([deployment], deployment.image_tag == ^image_tag and deployment.status in [:pending, :running])
+    |> Repo.exists?()
   end
 
   defp runtime_image_tag do

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -345,12 +345,35 @@ defmodule Tuist.KuraTest do
       assert {:ok, %{scheduled: first_batch, failures: []}} =
                Kura.schedule_version_deployments("0.5.3")
 
-      assert length(first_batch) == 100
+      assert length(first_batch) == 1
 
       assert {:ok, %{scheduled: second_batch, failures: []}} =
                Kura.schedule_version_deployments("0.5.3")
 
       assert length(second_batch) == 1
+    end
+
+    test "waits for the prior runtime deployment before scheduling the next server" do
+      first_account = Accounts.get_account_from_user(AccountsFixtures.user_fixture())
+      second_account = Accounts.get_account_from_user(AccountsFixtures.user_fixture())
+
+      for account <- [first_account, second_account] do
+        {:ok, server} =
+          %Server{}
+          |> Server.create_changeset(%{
+            account_id: account.id,
+            region: "local-controller",
+            provisioner_node_ref: "kura-#{account.name}-local-controller"
+          })
+          |> Repo.insert()
+
+        mark_initial_deployment_succeeded(server)
+      end
+
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "sha-abcdef123456" end)
+
+      assert {:ok, %{scheduled: [_deployment], failures: []}} = Kura.schedule_runtime_image_deployments()
+      assert {:ok, %{scheduled: [], failures: []}} = Kura.schedule_runtime_image_deployments()
     end
   end
 


### PR DESCRIPTION
## What changed

- Limit the existing runtime-image scheduler to one Kura server deployment at a time.
- Wait until that deployment closes before scheduling the next server.

## Why

This is a small safeguard that can ship ahead of the larger health-gated rollout controller.

## Root cause

The production scheduler admitted up to 100 runtime deployments in one pass. The last Kura image update therefore replaced cache pods across the fleet together, causing transient 503 responses.

## Impact

A Kura runtime update now affects only one account-region cache at a time. This reduces the blast radius while the fuller progressive rollout work remains under review.

## Validation

- `git diff --check`
- Focused test command started: `mise exec -- mix test test/tuist/kura_test.exs`
- The local dependency compiler stalled while another workspace held the build lock, so this draft awaits a clean focused test run.