### PR TITLE
fix(infra): increase canary egress memory

### DIFF
--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -32,7 +32,7 @@ clusters/
 | Cluster | CP | Workers |
 |---|---|---|
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: bare-metal Robot (`pool=runners-linux`) |
-| `tuist-canary` | 3× cpx32 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
+| `tuist-canary` | 3× cpx32 | md-0: 2× cpx32; md-egress: 2× cpx32 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
 | `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -71,7 +71,7 @@ spec:
           variables:
             overrides:
               - name: hcloudWorkerMachineType
-                value: cpx22
+                value: cpx32
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
         # Linux runner pool on Hetzner Robot bare metal. The


### PR DESCRIPTION
## What changed

- Increase the canary stable-egress pool from Hetzner `cpx22` instances to `cpx32` instances.
- Update the cluster inventory documentation to match the new capacity.

## Why

The canary egress node exhausted its four gigabytes of allocatable memory, causing repeated container restarts and disrupting the Kubernetes access gateway.

## Root cause

The egress pool was sized with too little headroom for the operating system and the colocated gateway and application workloads. Scheduled memory requests already consumed most of the available capacity, and burst usage triggered the kernel out-of-memory killer.

## Approach

Use the eight-gigabyte `cpx32` instance shape for canary's high-availability egress pool. This preserves the existing topology and failover behavior while providing the headroom needed by its workloads.

## Impact

The management-cluster reconciliation will replace the two canary egress nodes with larger instances. Canary's stable outbound gateway retains its two-node failover design during the rollout.

## Validation

- Parsed `infra/k8s/clusters/cluster-canary.yaml` with Ruby's YAML parser.
- Ran `git diff --check`.
