### PR TITLE
fix(infra): capture processor termination context

### DIFF
--- a/infra/grafana-dashboards/processor-service.json
+++ b/infra/grafana-dashboards/processor-service.json
@@ -842,6 +842,144 @@
         "title": "Build Parse Duration",
         "type": "timeseries",
         "description": "XCActivityLog NIF parse duration percentiles."
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "id": 19,
+        "panels": [],
+        "title": "Container Lifecycle",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": true,
+              "drawStyle": "bars",
+              "lineWidth": 1,
+              "showPoints": "never"
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 27
+        },
+        "id": 20,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (pod, container) (increase(kube_pod_container_status_restarts_total{namespace=\"tuist\", container=\"processor\"}[$__rate_interval]))",
+            "legendFormat": "{{pod}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Restarts by Processor Pod",
+        "type": "timeseries",
+        "description": "Restart count per evaluation interval. Use this with the termination table to distinguish a crash from a deliberate rollout."
+      },
+      {
+        "datasource": "$datasource",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 27
+        },
+        "id": 21,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (pod, container, reason, node) ((kube_pod_container_status_last_terminated_reason{namespace=\"tuist\", container=\"processor\"} == 1) * on (namespace, pod) group_left (node) kube_pod_info{namespace=\"tuist\"})",
+            "format": "table",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Last Processor Termination",
+        "transformations": [
+          {
+            "id": "labelsToFields",
+            "options": {}
+          },
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "Value": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "container": "Container",
+                "node": "Node",
+                "pod": "Pod",
+                "reason": "Reason"
+              }
+            }
+          }
+        ],
+        "type": "table",
+        "description": "The most recent Kubernetes termination reason, enriched with the node. For non-zero exits, inspect the container runtime journal on that node for the exact exit status."
       }
     ],
     "schemaVersion": 39,

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -81,6 +81,11 @@ spec:
           # priv/secrets exactly in sync with what enqueued the job.
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          # Preserve the last container output in the pod's termination
+          # message whenever the processor exits unsuccessfully. This gives
+          # `kubectl describe pod` and Kubernetes event consumers the failure
+          # context even when the BEAM cannot write its own crash report.
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - /app/bin/tuist
             - start


### PR DESCRIPTION
## What changed

- Preserve a processor container's final output in its Kubernetes termination message when it exits unsuccessfully.
- Add processor lifecycle panels that show per-pod restarts and the latest termination reason and node.

## Why

The recent processor crash loop exposed only a restart count in the alert. The precise exit status was available in the container runtime journal but not in the alert context.

## Root cause

One processor container exited twice with status 132, the operating system's [illegal-instruction signal](https://man7.org/linux/man-pages/man7/signal.7.html). The existing observability did not identify the container, node, or termination reason needed to reach that evidence quickly.

## Approach

The chart uses Kubernetes's `FallbackToLogsOnError` termination-message policy so failed processor containers preserve their final output. The dashboard pairs restart data with the latest termination reason and pod node, while the active restart alert now includes the same labels.

## Impact

Future processor-restart alerts will identify the affected container, its last termination reason, and the node whose runtime journal contains the exact exit status. The dashboard provides the same context for follow-up investigation.

### How to test locally

- `jq empty infra/grafana-dashboards/processor-service.json`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values.yaml -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml -f infra/helm/tuist/values-ci.yaml`
- Run the processor restart and termination queries against the production Grafana instance.
