### PR TITLE
fix(cli): correct no-upload flag inversion

### DIFF
--- a/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
@@ -58,11 +58,15 @@
         var generateOnly: Bool = false
 
         @Flag(
-            name: .long,
+            name: .customLong("upload"),
+            inversion: .prefixedNo,
             help: "When passed, the generated artifacts are stored only in the local cache and not uploaded to the remote cache.",
-            envKey: .cacheNoUpload
+            envKey: .cacheNoUpload,
+            envValueInverted: true
         )
-        var noUpload: Bool = false
+        var upload: Bool = true
+
+        var noUpload: Bool { !upload }
 
         @Option(
             name: .long,

--- a/cli/Sources/TuistEnvKey/ParseableArgument+Extension.swift
+++ b/cli/Sources/TuistEnvKey/ParseableArgument+Extension.swift
@@ -134,6 +134,26 @@ extension Flag where Value == Bool {
             )
         }
     }
+
+    public init(
+        wrappedValue: Bool,
+        name: NameSpecification = .long,
+        inversion: FlagInversion,
+        exclusivity: FlagExclusivity = .chooseLast,
+        help: ArgumentHelp? = nil,
+        envKey: EnvKey,
+        envValueInverted: Bool = false
+    ) {
+        let envValue: Value? = envKey.envValue()
+        let value = envValue.map { envValueInverted ? !$0 : $0 } ?? wrappedValue
+        self.init(
+            wrappedValue: value,
+            name: name,
+            inversion: inversion,
+            exclusivity: exclusivity,
+            help: help?.withEnvKey(envKey)
+        )
+    }
 }
 
 extension Flag where Value == Bool? {

--- a/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -973,6 +973,13 @@ struct CommandEnvironmentVariableTests {
         #expect(commandWithArgs.scratchDirectory == "/cache/warm-scratch-directory")
         #expect(commandWithArgs.targets == ["Fmk1", "Fmk2"])
 
+        let commandWithUpload = try CacheWarmCommand.parse(["--upload"])
+        #expect(commandWithUpload.noUpload == false)
+
+        #expect(throws: (any Error).self) {
+            try CacheWarmCommand.parse(["--no-no-upload"])
+        }
+
         #expect(throws: (any Error).self) {
             try CacheWarmCommand.parse(["--scratch-directory", "/cache/warm-scratch-directory"])
         }


### PR DESCRIPTION
## What changed

- Model cache warm uploads as an enabled-by-default flag with Swift Argument Parser inversion, exposing `--upload` and `--no-upload`.
- Preserve the existing `TUIST_CACHE_NO_UPLOAD` environment-variable behavior.
- Cover the valid positive flag and reject the incorrect `--no-no-upload` spelling.

## Root cause

The environment-aware flag helper already adds a `no-` inversion. Defining the flag itself as `noUpload` caused the generated command specification to add the prefix twice.

## Impact

Published command reference pages will show the correct `--no-upload` option. Users can also explicitly re-enable uploads with `--upload`.

### How to test locally

- `mise run cli:lint --fix`
- `git diff --check`
