### PR TITLE
fix(cli): bound and retry SwifterPM binary-artifact downloads

### DIFF
--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -159,6 +159,22 @@ enum SystemProcess {
 }
 
 enum HTTPClient {
+    // URLSession.shared uses the default configuration, whose 7-day
+    // timeoutIntervalForResource lets a stalled transfer (a dead-but-open
+    // connection with no reset) hang for hours. This dedicated session bounds
+    // the idle gap between received bytes and the total transfer, so a stall
+    // surfaces as an error that `withRetry` recovers on a fresh connection.
+    private static let idleTimeout: TimeInterval = 60
+    private static let resourceTimeout: TimeInterval = 600
+    private static let maxAttempts = 3
+
+    private static let session: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = idleTimeout
+        configuration.timeoutIntervalForResource = resourceTimeout
+        return URLSession(configuration: configuration)
+    }()
+
     static func defaultHeaders(for url: URL) async -> [String: String] {
         var headers = ["User-Agent": "swifterpm/0.1"]
         if let authorization = await HTTPAuthorization.header(for: url) {
@@ -176,30 +192,31 @@ enum HTTPClient {
     }
 
     static func data(url: URL, headers: [String: String] = [:]) async throws -> Data {
-        var request = URLRequest(url: url)
-        for (key, value) in headers {
-            request.setValue(value, forHTTPHeaderField: key)
+        try await withRetry {
+            var request = URLRequest(url: url)
+            for (key, value) in headers {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+            let (data, response) = try await session.data(for: request)
+            try ensureSuccessfulStatus(response, url: url)
+            return data
         }
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200 ..< 300).contains(httpResponse.statusCode)
-        {
-            throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
-        }
-        return data
     }
 
     static func download(url: URL, destination: URL, headers: [String: String] = [:]) async throws {
-        var request = URLRequest(url: url)
-        for (key, value) in headers {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-        let (downloaded, response) = try await URLSession.shared.download(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200 ..< 300).contains(httpResponse.statusCode)
-        {
-            try? await fileSystem.remove(downloaded.absolutePath)
-            throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
+        let downloaded = try await withRetry { () -> URL in
+            var request = URLRequest(url: url)
+            for (key, value) in headers {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+            let (downloaded, response) = try await session.download(for: request)
+            do {
+                try ensureSuccessfulStatus(response, url: url)
+            } catch {
+                try? await fileSystem.remove(downloaded.absolutePath)
+                throw error
+            }
+            return downloaded
         }
 
         let destinationPath = try destination.absolutePath
@@ -207,6 +224,42 @@ enum HTTPClient {
             at: destinationPath.parentDirectory, options: [.createTargetParentDirectories]
         )
         try await fileSystem.replace(destinationPath, with: downloaded.absolutePath)
+    }
+
+    private static func ensureSuccessfulStatus(_ response: URLResponse, url: URL) throws {
+        if let httpResponse = response as? HTTPURLResponse,
+           !(200 ..< 300).contains(httpResponse.statusCode)
+        {
+            throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
+        }
+    }
+
+    // Retries transient transport failures (timeouts, dropped or half-open
+    // connections) on a fresh connection with linear backoff. HTTP status
+    // failures are not retried: a non-2xx response is deterministic for an
+    // artifact URL, so a retry would only delay the surfaced error.
+    private static func withRetry<T>(
+        _ operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        var attempt = 1
+        while true {
+            do {
+                return try await operation()
+            } catch let error as URLError where attempt < maxAttempts && isRetryable(error) {
+                try? await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
+                attempt += 1
+            }
+        }
+    }
+
+    private static func isRetryable(_ error: URLError) -> Bool {
+        switch error.code {
+        case .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed,
+             .cannotFindHost, .secureConnectionFailed:
+            return true
+        default:
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

Backports the SwifterPM HTTP download hardening from #12069 to the 4.203 release line. The HTTP client now uses a dedicated session with bounded idle and total transfer timeouts, and retries transient transport failures on fresh connections.

## Why

Teams pinned to 4.203 need the same protection from binary-artifact downloads that can remain open without making progress on a self-hosted macOS runner.

## Root cause

SwifterPM used the shared URL session, whose default resource timeout is seven days. A dead but still-open connection could therefore block dependency resolution until the CI job timeout.

## Approach

The backport keeps the upstream behavior intact: it bounds the idle interval to 60 seconds and total transfer duration to 600 seconds, retrying retryable transport errors up to three times. Non-success Hypertext Transfer Protocol responses remain non-retryable.

## Impact

A stalled artifact download now retries or fails within a bounded period instead of blocking installation indefinitely.

## Validation

- `swift test --filter SupportTests --replace-scm-with-registry`
  - Passed: 24 tests across 2 suites