### PR TITLE
fix(infra): harden fleet against CAPI webhook cert expiry and egress drain

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -42,6 +42,7 @@ on:
       - 'infra/k8s/clusters/**'
       - 'infra/k8s/mgmt/cluster-autoscaler.yaml'
       - 'infra/k8s/mgmt/etcd-snapshot.yaml'
+      - 'infra/k8s/mgmt/capi-webhook-cert-reloader.yaml'
       - 'infra/k8s/mgmt/tailscale.yaml'
       - 'infra/k8s/mgmt/hetzner-robot-controller.yaml'
       - 'infra/k8s/mgmt/observability-namespace.yaml'
@@ -242,6 +243,7 @@ jobs:
           kubectl apply -f infra/k8s/mgmt/hetzner-robot-controller.yaml
           kubectl apply -f infra/k8s/mgmt/cluster-autoscaler.yaml
           kubectl apply -f infra/k8s/mgmt/etcd-snapshot.yaml
+          kubectl apply -f infra/k8s/mgmt/capi-webhook-cert-reloader.yaml
           kubectl apply -f infra/k8s/mgmt/tailscale.yaml
 
           # These regional clusters were retired, but kubectl apply does not

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -187,6 +187,69 @@ absent_over_time(
 - Pending period: 0 minutes
 - Summary: `Control-plane desired and ready replica telemetry is missing`
 
+### Cluster API admission webhook failing (fleet-wide write freeze)
+
+The management cluster serves the CAPI/CAPH admission webhooks with a
+cert-manager certificate. If it expires — or the controllers keep serving a
+stale one after cert-manager renews it, which is what happened on 2026-07-30 —
+the API server can no longer call the webhooks, and because they are
+`failurePolicy: Fail` every write to a `cluster.x-k8s.io` object is rejected
+across all workload clusters. Node replacement and autoscaling freeze
+fleet-wide (production included; it was spared last time only because nothing
+needed replacing). This is the root-cause detector; nothing else here catches
+it directly. The rejections surface as `calling_webhook_error` on the mgmt
+API server.
+
+```promql
+sum by (name) (
+  rate(
+    apiserver_admission_webhook_rejection_count{
+      cluster="tuist-management",
+      error_type="calling_webhook_error",
+      name=~".+\.cluster\.x-k8s\.io"
+    }[5m]
+  )
+) > 0
+```
+
+- Pending period: 5 minutes
+- Summary: `Cluster API admission webhook {{ $labels.name }} is failing on the management cluster — cluster.x-k8s.io writes are frozen fleet-wide`
+
+### Worker node pool below desired replicas
+
+Catches a worker MachineDeployment (the stable-egress gateway pool, or a
+production processor/kura pool) running with fewer ready nodes than desired —
+for example when MachineHealthCheck deleted nodes that CAPI then could not
+recreate. Independent of the stable-egress-gateway signal, so it also covers
+non-egress pools. Both series are exported by the management cluster's
+kube-state-metrics CustomResourceState.
+
+```promql
+kube_customresource_machinedeployment_ready_replicas{
+  cluster="tuist-management"
+}
+<
+kube_customresource_machinedeployment_spec_replicas{
+  cluster="tuist-management"
+}
+```
+
+- Pending period: 15 minutes
+- Summary: `Worker pool {{ $labels.machinedeployment }} ({{ $labels.workload_cluster }}) has fewer ready nodes than desired`
+
+### Worker node pool telemetry missing
+
+```promql
+absent_over_time(
+  kube_customresource_machinedeployment_spec_replicas{
+    cluster="tuist-management"
+  }[15m]
+)
+```
+
+- Pending period: 0 minutes
+- Summary: `Worker MachineDeployment replica telemetry is missing on the management cluster`
+
 ### Node exporter coverage incomplete
 
 ```promql

--- a/infra/helm/k8s-monitoring/values-management.yaml
+++ b/infra/helm/k8s-monitoring/values-management.yaml
@@ -36,6 +36,7 @@ k8s-monitoring:
       metricsTuning:
         includeMetrics:
           - kube_customresource_kubeadmcontrolplane_.*
+          - kube_customresource_machinedeployment_.*
 
   integrations:
     alloy:
@@ -70,6 +71,9 @@ k8s-monitoring:
             verbs: ["list", "watch"]
           - apiGroups: ["controlplane.cluster.x-k8s.io"]
             resources: ["kubeadmcontrolplanes"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["cluster.x-k8s.io"]
+            resources: ["machinedeployments"]
             verbs: ["list", "watch"]
       customResourceState:
         enabled: true
@@ -116,3 +120,34 @@ k8s-monitoring:
                       type: Gauge
                       gauge:
                         path: [status, upToDateReplicas]
+              # Worker MachineDeployments (md-egress, processor, kura, ...).
+              # Exposes desired vs ready so a pool running below its replica
+              # count — e.g. MHC deleting nodes CAPI can't recreate — is alertable
+              # beyond just the control plane and the egress-gateway signal.
+              - groupVersionKind:
+                  group: cluster.x-k8s.io
+                  version: v1beta2
+                  kind: MachineDeployment
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  machinedeployment: [metadata, name]
+                  workload_cluster: [metadata, labels, "cluster.x-k8s.io/cluster-name"]
+                metrics:
+                  - name: machinedeployment_spec_replicas
+                    help: Desired worker replicas for this MachineDeployment.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, replicas]
+                  - name: machinedeployment_ready_replicas
+                    help: Ready worker replicas for this MachineDeployment.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, readyReplicas]
+                  - name: machinedeployment_available_replicas
+                    help: Available worker replicas for this MachineDeployment.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, availableReplicas]

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -799,7 +799,7 @@ k8s-monitoring:
         prometheus.relabel "tuist_kube_apiserver" {
           rule {
             source_labels = ["__name__"]
-            regex = "up|scrape_samples_scraped|process_cpu_seconds_total|process_resident_memory_bytes|process_open_fds|process_max_fds|go_goroutines|go_gc_duration_seconds(_sum|_count)?|go_sched_latencies_seconds_(bucket|count|sum)|apiserver_current_inflight_requests|apiserver_flowcontrol_current_executing_requests|apiserver_flowcontrol_current_executing_seats|apiserver_flowcontrol_current_limit_seats|apiserver_flowcontrol_nominal_limit_seats|apiserver_flowcontrol_rejected_requests_total|apiserver_request_duration_seconds_(bucket|count|sum)|apiserver_request_terminations_total|apiserver_request_total"
+            regex = "up|scrape_samples_scraped|process_cpu_seconds_total|process_resident_memory_bytes|process_open_fds|process_max_fds|go_goroutines|go_gc_duration_seconds(_sum|_count)?|go_sched_latencies_seconds_(bucket|count|sum)|apiserver_current_inflight_requests|apiserver_flowcontrol_current_executing_requests|apiserver_flowcontrol_current_executing_seats|apiserver_flowcontrol_current_limit_seats|apiserver_flowcontrol_nominal_limit_seats|apiserver_flowcontrol_rejected_requests_total|apiserver_request_duration_seconds_(bucket|count|sum)|apiserver_request_terminations_total|apiserver_request_total|apiserver_admission_webhook_rejection_count"
             action = "keep"
           }
           rule {
@@ -841,6 +841,12 @@ k8s-monitoring:
         # keep flowing from the dedicated Dedibox/OVH cache boxes.
         tolerations:
           - key: tuist.dev/kura-cache
+            operator: Exists
+            effect: NoSchedule
+          # Keep scraping host/pod metrics from the tainted stable-egress
+          # gateway nodes — otherwise the egress pool is a monitoring blind spot
+          # and the egress alerts can't see it.
+          - key: tuist.dev/stable-egress
             operator: Exists
             effect: NoSchedule
       # Custom scrape jobs for the macOS fleet's node_exporter (:9100)
@@ -1341,6 +1347,10 @@ k8s-monitoring:
           # Same reason for the customer-facing cache nodes: keep tailing pod
           # logs (and node journal) from the dedicated Dedibox/OVH cache boxes.
           - key: tuist.dev/kura-cache
+            operator: Exists
+            effect: NoSchedule
+          # Keep tailing logs from the tainted stable-egress gateway nodes.
+          - key: tuist.dev/stable-egress
             operator: Exists
             effect: NoSchedule
     # Kubernetes Events must come from exactly one replica — otherwise

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -115,13 +115,19 @@ server:
     storeRef:
       kind: ClusterSecretStore
       name: onepassword
-    # Source the Tuist license from 1Password instead of the blob, so the blob
-    # can be removed. Environments can override this with certificateItem to
-    # use a locally verified air-gapped license.
+    # All managed envs (staging, canary, production) validate the license
+    # OFFLINE from a signed air-gapped certificate (Ed25519-verified locally),
+    # so the server has zero network dependency on api.keygen.sh at boot. This
+    # is deliberate: a Keygen/egress outage must not crash-loop the server on
+    # startup (see the 2026-07-30 canary incident, where a dead egress gateway
+    # made the online key path time out and CrashLoopBackOff the server). The
+    # three envs share one license, so the same certificate item is valid in
+    # each vault. `item` (the online TUIST_LICENSE_KEY path) is intentionally
+    # left empty; set it only for an env whose vault lacks the certificate.
     license:
-      item: TUIST_LICENSE_KEY
+      item: ""
       field: password
-      certificateItem: ""
+      certificateItem: TUIST_LICENSE_CERTIFICATE_BASE64
       certificateField: password
 
   # ESO-synced GitHub App + bot PATs. The PEM file attachment name

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -40,9 +40,8 @@ server:
   # cache volume's binaries never validate as local hits across VMs. Same
   # keypair as staging (the CLI's baked public key pins it).
   externalSecrets:
-    license:
-      item: ""
-      certificateItem: TUIST_LICENSE_CERTIFICATE_BASE64
+    # The offline-certificate license config is now the shared default in
+    # values-managed-common.yaml, so production no longer overrides it here.
     cacheGrant:
       item: TUIST_CACHE_GRANT_PRIVATE_KEY
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -68,12 +68,33 @@ spec:
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: egress
+          # HA floor for the 2-node egress gateway pool. Overrides the
+          # hcloud-worker class default (unhealthyInRange "[0-2]", which permits
+          # remediating BOTH nodes at once). Never auto-remediate the whole pair:
+          # a single bad node is replaced, but if both go unhealthy the cause is
+          # almost always systemic (control-plane blip, network partition), so
+          # CAPI holds and pages instead of deleting the pool — the failure that
+          # left canary with no egress gateway on 2026-07-30, when both nodes
+          # were remediated and an expired CAPI webhook then blocked recreation.
+          healthCheck:
+            remediation:
+              triggerIf:
+                unhealthyInRange: "[0-1]"
+              # Belt-and-suspenders: even within range, only one replacement in
+              # flight so a rolling remediation always keeps a gateway serving.
+              maxInFlight: 1
           variables:
             overrides:
               - name: hcloudWorkerMachineType
                 value: cpx32
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
+              # Isolate the gateway pool: only cilium, hcloud-csi, the egress
+              # host-configurer and the (tolerating) monitoring agents run here.
+              # Keeps ingress-nginx/CoreDNS/Redis off these 4 GB nodes so they
+              # can't OOM the egress gateway.
+              - name: workerNodeTaints
+                value: tuist.dev/stable-egress=true:NoSchedule
         # Linux runner pool on Hetzner Robot bare metal. The
         # `hetzner-robot-controller` reflects `tuist-bm-canary-*`
         # Robot servers into HBM CRs stamped

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -95,6 +95,21 @@ spec:
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: egress
+          # HA floor for the 2-node egress gateway pool. Overrides the
+          # hcloud-worker class default (unhealthyInRange "[0-2]", which permits
+          # remediating BOTH nodes at once). Never auto-remediate the whole pair:
+          # a single bad node is replaced, but if both go unhealthy the cause is
+          # almost always systemic (control-plane blip, network partition), so
+          # CAPI holds and pages instead of deleting the pool — the failure mode
+          # behind the 2026-07-30 canary outage, which is fleet-wide (this pool
+          # backs customer egress-allowlist IPs in production).
+          healthCheck:
+            remediation:
+              triggerIf:
+                unhealthyInRange: "[0-1]"
+              # Belt-and-suspenders: even within range, only one replacement in
+              # flight so a rolling remediation always keeps a gateway serving.
+              maxInFlight: 1
           variables:
             overrides:
               # Forwards/SNATs server egress only — runs no application
@@ -104,6 +119,12 @@ spec:
                 value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
+              # Isolate the gateway pool: only cilium, hcloud-csi, the egress
+              # host-configurer and the (tolerating) monitoring agents run here.
+              # Keeps ingress-nginx/CoreDNS/Redis off these nodes so they can't
+              # OOM the egress gateway that serves customer allowlist IPs.
+              - name: workerNodeTaints
+                value: tuist.dev/stable-egress=true:NoSchedule
         # Dedicated processor pool: xcactivitylog parsing.
         # CA annotations declared here propagate to the rendered
         # MachineDeployment via topology mode. Without them the

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -84,12 +84,33 @@ spec:
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: egress
+          # HA floor for the 2-node egress gateway pool. Overrides the
+          # hcloud-worker class default (unhealthyInRange "[0-2]", which permits
+          # remediating BOTH nodes at once). Never auto-remediate the whole pair:
+          # a single bad node is replaced, but if both go unhealthy the cause is
+          # almost always systemic (control-plane blip, network partition), so
+          # CAPI holds and pages instead of deleting the pool — the failure that
+          # left canary with no egress gateway on 2026-07-30, when both nodes
+          # were remediated and an expired CAPI webhook then blocked recreation.
+          healthCheck:
+            remediation:
+              triggerIf:
+                unhealthyInRange: "[0-1]"
+              # Belt-and-suspenders: even within range, only one replacement in
+              # flight so a rolling remediation always keeps a gateway serving.
+              maxInFlight: 1
           variables:
             overrides:
               - name: hcloudWorkerMachineType
                 value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
+              # Isolate the gateway pool: only cilium, hcloud-csi, the egress
+              # host-configurer and the (tolerating) monitoring agents run here.
+              # Keeps ingress-nginx/CoreDNS/Redis off these nodes so they can't
+              # OOM the egress gateway.
+              - name: workerNodeTaints
+                value: tuist.dev/stable-egress=true:NoSchedule
         # Linux runner pool on Hetzner Robot bare metal. Each
         # claimable `HetznerBareMetalHost` CR (see
         # `bare-metal-staging.yaml`) gets picked up by caph, which

--- a/infra/k8s/clusters/clusterclass-tuist.yaml
+++ b/infra/k8s/clusters/clusterclass-tuist.yaml
@@ -235,6 +235,22 @@ spec:
         openAPIV3Schema:
           type: string
           default: ""
+    # Extra kubelet taints for a worker pool, in kubelet's
+    # `key=value:Effect,key=value:Effect` form. Set as a per-MachineDeployment
+    # override so a dedicated pool registers tainted and general workloads can't
+    # colonize it. Used to isolate the stable-egress gateway pool (md-egress):
+    # untainted, those 4 GB nodes hosted ingress-nginx/CoreDNS/Redis and were
+    # OOM-killed, which is what set off the 2026-07-30 egress outage. Only the
+    # DaemonSets that tolerate this taint (cilium, hcloud-csi, the egress
+    # host-configurer, and the monitoring agents) land there. Like
+    # workerNodeLabels this reaches the node at registration and survives
+    # MachineHealthCheck remediation.
+    - name: workerNodeTaints
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
     # Bare-metal cluster gate. Each per-cluster topology sets this
     # to its own env (`staging` / `canary` / `production`) so the
     # `HetznerBareMetalMachineTemplateClusterSelector` patch below
@@ -408,6 +424,26 @@ spec:
               path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/-"
               valueFrom:
                 template: '{"name":"node-labels","value":{{ .workerNodeLabels | quote }}}'
+    # Append per-pool kubelet taints to the worker bootstrap, mirroring the
+    # node-labels patch above. Adds `--register-with-taints=<workerNodeTaints>`
+    # for any MachineDeployment that sets the variable (no-op otherwise). This
+    # is how the stable-egress gateway pool registers tainted so only tolerating
+    # workloads schedule on it.
+    - name: KubeadmConfigTemplateWorkerNodeTaints
+      enabledIf: '{{ if ne .workerNodeTaints "" }}true{{end}}'
+      definitions:
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: KubeadmConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - hcloud-worker
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/-"
+              valueFrom:
+                template: '{"name":"register-with-taints","value":{{ .workerNodeTaints | quote }}}'
     # Inject the per-cluster gate into the shared bare-metal HBMM
     # template. `hetzner-robot-controller` stamps each HBM with
     # `tuist.dev/cluster=<env>` based on the Robot server name; the

--- a/infra/k8s/mgmt/capi-webhook-cert-reloader.yaml
+++ b/infra/k8s/mgmt/capi-webhook-cert-reloader.yaml
@@ -1,0 +1,157 @@
+# Watchdog that stops the CAPI / CAPH admission webhooks from serving an
+# EXPIRED serving certificate — the root cause of the 2026-07-30 fleet incident.
+#
+# What happened: cert-manager renewed the four webhook serving certs in their
+# Secrets on schedule, but the controller-manager pods (running for ~2 months)
+# never reloaded the new cert from the mounted Secret and kept presenting the
+# old one. When the old cert expired, the API server could no longer call the
+# mutating webhooks (failurePolicy: Fail), so EVERY write to a cluster.x-k8s.io
+# object was rejected across the WHOLE fleet — canary, staging AND production.
+# Node replacement and autoscaling were frozen for all clusters; production was
+# spared only because nothing needed replacing during the window. Canary went
+# down because its two egress Machines had just been deleted and could not be
+# recreated, so the server lost outbound internet.
+#
+# This CronJob rolls the four controller Deployments on a schedule so a renewed
+# cert is always reloaded. cert-manager renews 30 days before expiry, so a
+# weekly restart guarantees pickup with ~23 days of margin. `rollout restart`
+# is a rolling, surge-first update, so the single-replica webhook Deployments
+# stay available throughout (no admission blip).
+#
+# This is the reliable stopgap for the reload gap. The durable follow-up is to
+# bring the CAPI cert-manager Certificate objects into GitOps and/or add
+# event-driven reload (e.g. stakater/Reloader keyed on the cert Secrets), plus
+# a Grafana alert on the SERVED cert expiry (not just the Certificate resource,
+# which looked healthy while the served cert was stale).
+#
+# Namespace `mgmt-system` is created by etcd-snapshot.yaml, which
+# mgmt-cluster-apply.yml applies before this file.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: mgmt-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-webhook-cert-reloader
+rules:
+  # rollout restart = patch the Deployment's pod-template restartedAt annotation.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+---
+# Least privilege: grant the SA those verbs only in the four provider
+# namespaces, not cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: capi-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-webhook-cert-reloader
+subjects:
+  - kind: ServiceAccount
+    name: capi-webhook-cert-reloader
+    namespace: mgmt-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: capi-kubeadm-bootstrap-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-webhook-cert-reloader
+subjects:
+  - kind: ServiceAccount
+    name: capi-webhook-cert-reloader
+    namespace: mgmt-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: capi-kubeadm-control-plane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-webhook-cert-reloader
+subjects:
+  - kind: ServiceAccount
+    name: capi-webhook-cert-reloader
+    namespace: mgmt-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: caph-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-webhook-cert-reloader
+subjects:
+  - kind: ServiceAccount
+    name: capi-webhook-cert-reloader
+    namespace: mgmt-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: capi-webhook-cert-reloader
+  namespace: mgmt-system
+spec:
+  # Mondays 04:00 UTC. cert-manager renews 30 days before expiry, so weekly is
+  # ample to reload a freshly renewed cert well before the old one lapses.
+  schedule: "0 4 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: capi-webhook-cert-reloader
+          restartPolicy: OnFailure
+          # Single-node mgmt cluster: the only node is a control-plane, so the
+          # Job must tolerate its taint to schedule.
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: reload
+              image: registry.k8s.io/kubectl:v1.34.6
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  kubectl -n capi-system rollout restart deploy/capi-controller-manager
+                  kubectl -n capi-kubeadm-bootstrap-system rollout restart deploy/capi-kubeadm-bootstrap-controller-manager
+                  kubectl -n capi-kubeadm-control-plane-system rollout restart deploy/capi-kubeadm-control-plane-controller-manager
+                  kubectl -n caph-system rollout restart deploy/caph-controller-manager
+                  echo "rolled 4 CAPI/CAPH controllers so they reload renewed webhook serving certs"


### PR DESCRIPTION
## Background

On 2026-07-30 canary went down and the production deployment cascade stayed red for hours. The visible symptom was a failed post-deploy smoke test, but that was three layers downstream of the real fault.

The CAPI webhook serving certificate on the management cluster expired. cert-manager had actually renewed it in the Secret, but the CAPI/CAPH controller pods (running for two months) never reloaded the new cert and kept presenting the expired one. With the webhook uncallable and `failurePolicy: Fail`, every write to a `cluster.x-k8s.io` object was rejected across the whole fleet. Node replacement and autoscaling froze for canary, staging and production alike. Production kept serving only because nothing happened to need a new node in that window.

Canary is where it surfaced: its two egress Machines had been deleted by MachineHealthCheck and could not be recreated (frozen admission), so it lost its Cilium egress gateway and all outbound internet. The server then crash-looped, because it validated its license against api.keygen.sh at boot and that call now timed out.

The incident itself is resolved (the controllers were restarted so they picked up the renewed cert, admission unfroze, the egress pool recreated, canary recovered). This PR is the prevention work so none of these links can fire again, and so the next occurrence is not invisible for two days.

## What this changes

Each change targets one link in the chain above.

**Offline license for all managed envs.** Production already validated its license offline from a signed certificate; canary and staging were still on the online keygen path, which is the only reason their servers crash-looped when egress died. This makes the offline certificate the shared default in `values-managed-common.yaml` and removes the now-redundant production override. Validation stays strict, it is just done locally (Ed25519) with no network dependency at boot. The three envs share one license, so the same certificate is valid in each vault (already provisioned).

**Cert-reload watchdog.** The root cause was not a broken cert-manager, it was the controllers not reloading a renewed cert. `infra/k8s/mgmt/capi-webhook-cert-reloader.yaml` is a weekly CronJob that rolls the four CAPI/CAPH controllers so a renewed cert is always picked up with weeks of margin. This is a stopgap; the durable fix (moving the CAPI cert objects into GitOps) is being handled separately with Flux.

**MHC HA floor on the egress pools.** The class default let MachineHealthCheck remediate both nodes of the 2-node egress pair at once, which is exactly what drained the pool during a correlated failure. A per-pool override (`unhealthyInRange: "[0-1]"` plus `maxInFlight: 1`) means one bad node is replaced but the whole pair is never remediated at once. This piece is already applied live to all three clusters, since it is inert and needed no node disruption.

**Dedicated-node taint on md-egress.** The egress nodes OOM-killed because, untainted, they hosted ingress-nginx, CoreDNS and Redis on 4 GB boxes. This adds a `workerNodeTaints` ClusterClass variable (a direct mirror of the existing `workerNodeLabels` mechanism) and taints the pool `tuist.dev/stable-egress=true:NoSchedule`, with matching tolerations added to the monitoring agents so the nodes stay observable. This follows the same dedicated-node pattern already used for the bare-metal runner and kura-cache pools.

**Alerting.** Two gaps this incident exposed: nothing detected the admission freeze itself, and there was no worker-pool shortfall alert. Added a fleet-wide CAPI admission-frozen detector (`apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error"}`, which would have fired on day one) and a worker MachineDeployment shortfall alert, each wired with the metrics they need (the admission metric added to the apiserver keep-list, and MachineDeployment added to the management CustomResourceState). The two Grafana rules still need to be created from `alerts.md`.

## Approaches considered

For the license, the alternative was making the boot-time check non-fatal on transient errors (the hotfix that was reverted when the HA egress gateway landed). We kept validation mandatory and removed the network dependency instead, which is strictly better: the offline path always succeeds without weakening enforcement.

For the reload gap, the event-driven option is a Reloader keyed on the cert Secrets. The CronJob is a self-contained stopgap that needs no new controller, and the durable GitOps version is in flight separately, so a heavier mechanism here was not worth it.

For the egress pool, a rolling-update strategy would only have protected the instance-type-change path, not the MHC remediation that actually drained it. The MHC floor addresses the real mechanism.

## Deploy notes

Two changes do something on deploy. The taint triggers a one-time rolling replacement of the egress nodes (only md-egress; the patch is a no-op for the other pools), and the MHC floor plus `maxInFlight: 1` keep a gateway node serving throughout. The offline-license switch re-deploys the servers, and the deployment cascade validates canary first, so a bad offline cert would stop before production. Everything else (the CronJob, MHC thresholds, alert metrics) has no runtime disruption.

## Validation

Every cluster and management-cluster change was validated with `kubectl --dry-run=server` against the live management cluster. The helm charts render for production, canary and staging with license refs pointing only at the offline certificate. The MHC floor is confirmed live on all three egress pools. The `apiserver_admission_webhook_rejection_count` metric and labels were confirmed present on the live management API server. The kubectl image tag used by the watchdog was confirmed to resolve.

## Not in this PR

Extending the cpx32 upsize to staging and production (canary already has it), capping the Alloy DaemonSet memory, gating `/ready` on the license check so a broken deploy is caught by `helm --wait`, creating the two Grafana rules, and moving the CAPI cert objects into GitOps (Flux, separate work).
