### PR TITLE
fix(infra): specify worker rollout strategy type

### DIFF
--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -63,6 +63,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0
@@ -76,6 +77,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -75,6 +75,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0
@@ -103,6 +104,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0
@@ -154,6 +156,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -78,6 +78,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0
@@ -92,6 +93,7 @@ spec:
           failureDomain: fsn1
           rollout:
             strategy:
+              type: RollingUpdate
               rollingUpdate:
                 maxSurge: 1
                 maxUnavailable: 0


### PR DESCRIPTION
## What changed

Added the explicit `RollingUpdate` type to every worker rollout strategy that already defines rolling-update settings in the canary, staging, and production cluster manifests.

## Why

The management-cluster deployment must be able to apply all environment manifests after the Kubernetes rollout configuration update.

## Root cause

The rollout strategy type became required, while the manifests specified only the rolling-update parameters. The deployment therefore rejected the canary cluster before applying the remaining environments.

## Approach

Declared `type: RollingUpdate` alongside the existing rollout parameters. This preserves the intended maximum-surge and maximum-unavailable behavior without changing rollout capacity.

## Impact

Management-cluster deployments can apply the affected environment manifests successfully.

## Validation

- Confirmed every declared worker rollout strategy resolves to `RollingUpdate` with `yq`.
- Ran `git diff --check`.
