### PR TITLE
fix(infra): escape Alloy log sampling selector

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -448,7 +448,7 @@ k8s-monitoring:
       // status, and duration. Sample routine responses while preserving every
       // warning, error, and unsuccessful response.
       stage.match {
-        selector = "{service_name=\"tuist\", container=\"server\"} |~ \"status=(2[0-9]{2}|3[0-9]{2}).*\\[info\\] Request completed\""
+        selector = "{service_name=\"tuist\", container=\"server\"} |~ \"status=(2[0-9]{2}|3[0-9]{2}).*\\\\[info\\\\] Request completed\""
 
         stage.sampling {
           rate = 0.1


### PR DESCRIPTION
## What changed

Corrected the escaping in the Alloy log-sampling selector for successful Tuist request completions. The generated Alloy configuration now keeps the double backslashes that the embedded LogQL parser requires for literal square brackets around `[info]`.

## Why

The alert reported frequent restarts of the `alloy-logs` collectors in canary and production. Those collectors forward pod logs to Grafana Cloud.

## Root cause

The sampling configuration added in #12126 used two backslashes in the Helm value. Rendering and then parsing the Alloy string reduced those to a single backslash in the embedded LogQL expression. LogQL rejects `\[` as an invalid escape, so every collector failed to load the updated configuration.

## Approach

Use four backslashes in the Helm value. Helm renders two into the Alloy configuration, and Alloy passes the required double escape to LogQL.

## Impact

Alloy log collectors can reload the sampling configuration successfully. Once deployment completes and prior restarts leave the alert one-hour evaluation window, the alert resolves.

## Validation

- `helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-staging.yaml`
- `helm template k8s-monitoring infra/helm/k8s-monitoring -n observability -f infra/helm/k8s-monitoring/values-staging.yaml`
- `helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-management.yaml`
- `helm template k8s-monitoring infra/helm/k8s-monitoring -n observability -f infra/helm/k8s-monitoring/values-management.yaml`
- `kubectl apply --dry-run=client -f /tmp/tuist-k8s-monitoring-staging.yaml` (built-in resources validated; the local client does not have the Alloy and ExternalSecret custom resource definitions)