### PR TITLE
perf(server): optimize test case run hydration

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1483,15 +1483,23 @@ defmodule Tuist.Tests do
 
   defp fetch_full_test_case_runs(slim_results) do
     ids = Enum.map(slim_results, & &1.id)
+    {runs_with_test_case_id, runs_without_test_case_id} =
+      Enum.split_with(slim_results, &(not is_nil(&1.test_case_id)))
 
-    # `test_case_runs.proj_by_id` is ordered by id. Adding the project, test
-    # case, and ran-at predicates from the slim result turns this into a wide
-    # intersection and prevents ClickHouse from selecting that point-lookup
-    # projection. Run identifiers are globally unique, so the ids alone
-    # identify the rows we need to hydrate.
+    lookup_keys =
+      Enum.map(runs_with_test_case_id, &{&1.project_id, &1.test_case_id, &1.ran_at, &1.id})
+
+    ids_without_test_case_id = Enum.map(runs_without_test_case_id, & &1.id)
+
+    # A correlated tuple preserves the primary-key lookup. Independent IN
+    # predicates create a wide cross-product for a page of runs. Nullable test
+    # case identifiers use the id index because ClickHouse does not compare NULL
+    # values in tuple sets.
     base_query =
       from(tcr in TestCaseRun,
-        where: tcr.id in ^ids,
+        where:
+          {tcr.project_id, tcr.test_case_id, tcr.ran_at, tcr.id} in ^lookup_keys or
+            tcr.id in ^ids_without_test_case_id,
         order_by: [desc: tcr.inserted_at]
       )
 

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1483,16 +1483,14 @@ defmodule Tuist.Tests do
 
   defp fetch_full_test_case_runs(slim_results) do
     ids = Enum.map(slim_results, & &1.id)
-    project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
-    test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
-    {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
 
+    # `test_case_runs.proj_by_id` is ordered by id. Adding the project, test
+    # case, and ran-at predicates from the slim result turns this into a wide
+    # intersection and prevents ClickHouse from selecting that point-lookup
+    # projection. Run identifiers are globally unique, so the ids alone
+    # identify the rows we need to hydrate.
     base_query =
       from(tcr in TestCaseRun,
-        where: tcr.project_id in ^project_ids,
-        where: tcr.test_case_id in ^test_case_ids,
-        where: tcr.ran_at >= ^min_ran_at,
-        where: tcr.ran_at <= ^max_ran_at,
         where: tcr.id in ^ids,
         order_by: [desc: tcr.inserted_at]
       )
@@ -1546,26 +1544,6 @@ defmodule Tuist.Tests do
     if Enum.all?(versions, fn {_id, inserted_at} -> not is_nil(inserted_at) end) do
       Map.new(versions)
     end
-  end
-
-  defp ran_at_bounds([first | rest]) do
-    Enum.reduce(rest, {first.ran_at, first.ran_at}, fn run, {min_ran_at, max_ran_at} ->
-      min_ran_at =
-        if NaiveDateTime.before?(run.ran_at, min_ran_at) do
-          run.ran_at
-        else
-          min_ran_at
-        end
-
-      max_ran_at =
-        if NaiveDateTime.after?(run.ran_at, max_ran_at) do
-          run.ran_at
-        else
-          max_ran_at
-        end
-
-      {min_ran_at, max_ran_at}
-    end)
   end
 
   # Filter precedence for routing: a narrower scope wins so we use the

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1483,23 +1483,37 @@ defmodule Tuist.Tests do
 
   defp fetch_full_test_case_runs(slim_results) do
     ids = Enum.map(slim_results, & &1.id)
+
     {runs_with_test_case_id, runs_without_test_case_id} =
       Enum.split_with(slim_results, &(not is_nil(&1.test_case_id)))
 
-    lookup_keys =
-      Enum.map(runs_with_test_case_id, &{&1.project_id, &1.test_case_id, &1.ran_at, &1.id})
-
     ids_without_test_case_id = Enum.map(runs_without_test_case_id, & &1.id)
 
-    # A correlated tuple preserves the primary-key lookup. Independent IN
-    # predicates create a wide cross-product for a page of runs. Nullable test
-    # case identifiers use the id index because ClickHouse does not compare NULL
-    # values in tuple sets.
+    # `test_case_runs` is ordered by `(project_id, test_case_id, ran_at, id)`,
+    # so hydrating by `id` alone reads the whole table. Correlating each run's
+    # full primary key turns the hydration into one point read per run. Ecto
+    # cannot compile a tuple `in` against an interpolated list, so the same
+    # condition is expressed as an OR of per-run key equalities, which
+    # ClickHouse still resolves through the primary key. Runs without a test
+    # case id fall back to the id predicate because NULL never matches a key
+    # comparison.
+    key_condition =
+      Enum.reduce(
+        runs_with_test_case_id,
+        dynamic([tcr], tcr.id in ^ids_without_test_case_id),
+        fn run, acc ->
+          dynamic(
+            [tcr],
+            ^acc or
+              (tcr.project_id == ^run.project_id and tcr.test_case_id == ^run.test_case_id and
+                 tcr.ran_at == ^run.ran_at and tcr.id == ^run.id)
+          )
+        end
+      )
+
     base_query =
       from(tcr in TestCaseRun,
-        where:
-          {tcr.project_id, tcr.test_case_id, tcr.ran_at, tcr.id} in ^lookup_keys or
-            tcr.id in ^ids_without_test_case_id,
+        where: ^key_condition,
         order_by: [desc: tcr.inserted_at]
       )
 


### PR DESCRIPTION
## What changed

Test case run hydration now looks rows up by their full correlated primary key `(project_id, test_case_id, ran_at, id)` instead of by `id` alone, and the condition is built with `dynamic/2` so Ecto can actually compile it.

## Why it is slow today

`list_test_case_runs` runs in two steps. A materialized view returns a slim page of runs, then `fetch_full_test_case_runs/1` goes back to the `test_case_runs` base table to hydrate the full records. That second step is what shows up in the slow query alerts.

The hydration predicate did not line up with how the base table is physically sorted. `test_case_runs` is a `SharedReplacingMergeTree` with roughly 2.5B rows across 170 GiB, sorted by:

```
(project_id, test_case_id, ran_at, id)
```

`id` is the last column in that key, so `WHERE id IN (...)` has no usable key prefix. ClickHouse cannot binary search to the rows and falls back to scanning. Hydrating a 50 row page therefore reads an enormous amount of data to return 50 records.

## Root cause of the stale reasoning

An earlier iteration of this branch removed the project and test case predicates on the theory that they were blocking the identifier ordered `test_case_runs.proj_by_id` projection, and that ids alone were enough because they are globally unique. The uniqueness part is true. The performance part is not, at least not against the table as it exists now.

`proj_by_id` was added in February 2026, when the table was sorted by `(test_run_id, test_module_run_id, id)`. The table has been re-keyed since. Measured against production, the projection is not rescuing an id only lookup today, so the comment justifying that approach was describing a table layout that no longer exists.

## What I measured

Run against the production ClickHouse replica, read only, using a real 50 run page taken from test run `60a3c816` on project 2382. The query endpoint enforces strict scan and memory limits, so "exceeds scan limits" below means the query could not complete within them, not that it returned an error of its own.

| Predicate | Result |
| --- | --- |
| `WHERE id = <single id>` | Exceeds scan limits |
| `WHERE id IN (<50 ids>)` | Exceeds scan limits |
| `WHERE project_id = 2382 AND test_case_id = <uuid>` | 23,531 rows, returns immediately |
| `WHERE (project_id, test_case_id, ran_at, id) IN (<10 keys>)` | 10 rows matched, 10 distinct ids |
| `WHERE (key) OR (key) ...` for the same 10 keys | 10 rows matched |
| `WHERE (0) OR (key) ...` for 5 keys | 5 rows matched |

The single id case is the striking one. Resolving one row out of 2.5B by `id` alone cannot complete inside the scan limits, while the correlated key returns a full page of runs as point reads. The `(project_id, test_case_id)` row is there to confirm the key prefix hypothesis directly.

I could not capture `read_rows` or `EXPLAIN indexes = 1` output, because system tables and `EXPLAIN` are both blocked on that endpoint. The pass and fail split against a fixed scan budget is the signal available, and it is a clear one.

## Approach and tradeoffs

The natural way to express this is a tuple `IN`:

```elixir
where: {tcr.project_id, tcr.test_case_id, tcr.ran_at, tcr.id} in ^lookup_keys
```

ClickHouse supports that form, and it is the fastest of the variants tested. Ecto does not. It rejects the query at compile time with "Tuples can only be used in comparisons with literal tuples of the same size", since tuple comparison only works against a literal tuple, never an interpolated list. That failure is what broke the Gettext CI job and, through it, every downstream Elixir job on this branch.

Two ways out:

1. A raw `fragment` emitting the tuple `IN` directly. Fastest to write, but it bypasses Ecto's type casting for the UUID and `DateTime64(6)` values and hands unbound terms to the driver.
2. An OR of per run key equalities, assembled with `dynamic/2`.

I went with the second. It keeps Ecto's casting, and production confirms ClickHouse still resolves the OR form through the primary key with the same result as the tuple form.

Runs with a null `test_case_id` cannot use the key, since NULL never matches a key comparison, so they keep the id predicate as a fallback. In the common case that list is empty and Ecto renders it as `WHERE (0)`. That constant false disjunct is what production actually emits, so I verified separately that `WHERE (0) OR (...)` is still index resolved rather than silently degrading into a scan.

## Impact

Hydrating a page of test case runs becomes a set of primary key point reads instead of a base table scan. No change to the records returned. The existing timestamp based version selection and the replica visibility fallback for `ReplacingMergeTree` are untouched.

## Validation

- `mix compile` clean. This is the check that actually mattered, since the previous head of the branch did not compile at all.
- `mix format --check-formatted` and `mix credo` clean on `lib/tuist/tests.ex`.
- Inspected the generated Ecto query. For two correlated runs plus the fallback it produces `id IN ^[...] OR (4 way key) OR (4 way key)` with 9 bound params, and it collapses to `WHERE (0)` when the fallback list is empty.
- Behaviour of each predicate variant checked against production ClickHouse as tabulated above.
- I did not run `test/tuist/tests_test.exs` locally, so CI is the first test coverage on this change.

## Follow up

Worth checking whether `test_case_runs.proj_by_id` still exists and still earns its storage. It was built for a sorting key the table no longer uses.
