### PR TITLE
fix(cli): pin Colorizer as a registry dependency in Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,11 +1,11 @@
 {
-  "originHash" : "1465ec8d5fa9379820cc52eec4970022e9c1667d85b39a67b96d47241f7a076c",
+  "originHash" : "16c29ce833f01572bc6afd554ec70177e2bd993c456ced7d61924a7705268d9f",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/1024jp/GzipSwift",
+      "originalLocation" : "https://github.com/1024jp/gzipswift",
       "state" : {
         "version" : "5.2.0"
       }
@@ -14,7 +14,7 @@
       "identity" : "apple.swift-algorithms",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-algorithms.git",
+      "originalLocation" : "https://github.com/apple/swift-algorithms",
       "state" : {
         "version" : "1.2.1"
       }
@@ -32,7 +32,7 @@
       "identity" : "apple.swift-asn1",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-asn1.git",
+      "originalLocation" : "https://github.com/apple/swift-asn1",
       "state" : {
         "version" : "1.7.0"
       }
@@ -41,7 +41,7 @@
       "identity" : "apple.swift-async-algorithms",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-async-algorithms.git",
+      "originalLocation" : "https://github.com/apple/swift-async-algorithms",
       "state" : {
         "version" : "1.1.3"
       }
@@ -50,7 +50,7 @@
       "identity" : "apple.swift-atomics",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-atomics.git",
+      "originalLocation" : "https://github.com/apple/swift-atomics",
       "state" : {
         "version" : "1.3.0"
       }
@@ -59,7 +59,7 @@
       "identity" : "apple.swift-certificates",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-certificates.git",
+      "originalLocation" : "https://github.com/apple/swift-certificates",
       "state" : {
         "version" : "1.19.0"
       }
@@ -68,7 +68,7 @@
       "identity" : "apple.swift-collections",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-collections.git",
+      "originalLocation" : "https://github.com/apple/swift-collections",
       "state" : {
         "version" : "1.2.1"
       }
@@ -77,7 +77,7 @@
       "identity" : "apple.swift-crypto",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-crypto.git",
+      "originalLocation" : "https://github.com/apple/swift-crypto",
       "state" : {
         "version" : "3.15.1"
       }
@@ -86,7 +86,7 @@
       "identity" : "apple.swift-http-structured-headers",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-http-structured-headers.git",
+      "originalLocation" : "https://github.com/apple/swift-http-structured-headers",
       "state" : {
         "version" : "1.7.0"
       }
@@ -104,7 +104,7 @@
       "identity" : "apple.swift-log",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-log.git",
+      "originalLocation" : "https://github.com/apple/swift-log",
       "state" : {
         "version" : "1.13.1"
       }
@@ -122,7 +122,7 @@
       "identity" : "apple.swift-nio-extras",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-nio-extras.git",
+      "originalLocation" : "https://github.com/apple/swift-nio-extras",
       "state" : {
         "version" : "1.34.0"
       }
@@ -131,7 +131,7 @@
       "identity" : "apple.swift-nio-http2",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-nio-http2.git",
+      "originalLocation" : "https://github.com/apple/swift-nio-http2",
       "state" : {
         "version" : "1.43.0"
       }
@@ -140,7 +140,7 @@
       "identity" : "apple.swift-nio-ssl",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-nio-ssl.git",
+      "originalLocation" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
         "version" : "2.37.0"
       }
@@ -149,7 +149,7 @@
       "identity" : "apple.swift-nio-transport-services",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-nio-transport-services.git",
+      "originalLocation" : "https://github.com/apple/swift-nio-transport-services",
       "state" : {
         "version" : "1.27.0"
       }
@@ -158,7 +158,7 @@
       "identity" : "apple.swift-numerics",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-numerics.git",
+      "originalLocation" : "https://github.com/apple/swift-numerics",
       "state" : {
         "version" : "1.1.1"
       }
@@ -185,7 +185,7 @@
       "identity" : "apple.swift-protobuf",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-protobuf.git",
+      "originalLocation" : "https://github.com/apple/swift-protobuf",
       "state" : {
         "version" : "1.35.1"
       }
@@ -202,7 +202,7 @@
       "identity" : "apple.swift-system",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/apple/swift-system.git",
+      "originalLocation" : "https://github.com/apple/swift-system",
       "state" : {
         "version" : "1.6.4"
       }
@@ -219,7 +219,7 @@
       "identity" : "coreoffice.xmlcoder",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/CoreOffice/XMLCoder.git",
+      "originalLocation" : "https://github.com/coreoffice/xmlcoder",
       "state" : {
         "version" : "0.18.1"
       }
@@ -244,7 +244,7 @@
       "identity" : "davewoodcom.xcglogger",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/DaveWoodCom/XCGLogger.git",
+      "originalLocation" : "https://github.com/davewoodcom/xcglogger",
       "state" : {
         "version" : "7.1.5"
       }
@@ -282,11 +282,11 @@
       }
     },
     {
-      "identity" : "colorizer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getGuaka/Colorizer.git",
+      "identity" : "getguaka.colorizer",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/getguaka/colorizer",
       "state" : {
-        "revision" : "2ccc99bf1715e73c4139e8d40b6e6b30be975586",
         "version" : "0.2.1"
       }
     },
@@ -294,7 +294,7 @@
       "identity" : "grpc.grpc-swift-2",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/grpc/grpc-swift-2.git",
+      "originalLocation" : "https://github.com/grpc/grpc-swift-2",
       "state" : {
         "version" : "2.2.0"
       }
@@ -319,7 +319,7 @@
       "identity" : "johnsundell.shellout",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/JohnSundell/ShellOut.git",
+      "originalLocation" : "https://github.com/johnsundell/shellout",
       "state" : {
         "version" : "2.3.0"
       }
@@ -328,7 +328,7 @@
       "identity" : "jpsim.yams",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/jpsim/Yams.git",
+      "originalLocation" : "https://github.com/jpsim/yams",
       "state" : {
         "version" : "5.4.0"
       }
@@ -353,7 +353,7 @@
       "identity" : "kolos65.Mockable",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/Kolos65/Mockable",
+      "originalLocation" : "https://github.com/kolos65/mockable",
       "state" : {
         "version" : "0.6.2"
       }
@@ -362,7 +362,7 @@
       "identity" : "krzysztofzablocki.Difference",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/krzysztofzablocki/Difference.git",
+      "originalLocation" : "https://github.com/krzysztofzablocki/difference",
       "state" : {
         "version" : "1.1.0"
       }
@@ -371,7 +371,7 @@
       "identity" : "krzyzanowskim.cryptoswift",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "originalLocation" : "https://github.com/krzyzanowskim/cryptoswift",
       "state" : {
         "version" : "1.3.3"
       }
@@ -380,7 +380,7 @@
       "identity" : "kylef.pathkit",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/kylef/PathKit.git",
+      "originalLocation" : "https://github.com/kylef/pathkit",
       "state" : {
         "version" : "1.0.1"
       }
@@ -389,7 +389,7 @@
       "identity" : "kylef.spectre",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/kylef/Spectre.git",
+      "originalLocation" : "https://github.com/kylef/spectre",
       "state" : {
         "version" : "0.10.1"
       }
@@ -398,7 +398,7 @@
       "identity" : "leif-ibsen.asn1",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/leif-ibsen/ASN1",
+      "originalLocation" : "https://github.com/leif-ibsen/asn1",
       "state" : {
         "version" : "2.7.0"
       }
@@ -407,7 +407,7 @@
       "identity" : "leif-ibsen.bigint",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/leif-ibsen/BigInt",
+      "originalLocation" : "https://github.com/leif-ibsen/bigint",
       "state" : {
         "version" : "1.23.0"
       }
@@ -416,7 +416,7 @@
       "identity" : "leif-ibsen.digest",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/leif-ibsen/Digest",
+      "originalLocation" : "https://github.com/leif-ibsen/digest",
       "state" : {
         "version" : "1.13.0"
       }
@@ -450,7 +450,7 @@
       "identity" : "onevcat.rainbow",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/onevcat/Rainbow",
+      "originalLocation" : "https://github.com/onevcat/rainbow",
       "state" : {
         "version" : "4.2.1"
       }
@@ -459,7 +459,7 @@
       "identity" : "p-x9.MachOKit",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/p-x9/MachOKit",
+      "originalLocation" : "https://github.com/p-x9/machokit",
       "state" : {
         "version" : "0.46.1"
       }
@@ -468,7 +468,7 @@
       "identity" : "p-x9.swift-binary-parse-support",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/p-x9/swift-binary-parse-support.git",
+      "originalLocation" : "https://github.com/p-x9/swift-binary-parse-support",
       "state" : {
         "version" : "0.2.1"
       }
@@ -477,7 +477,7 @@
       "identity" : "p-x9.swift-fileio",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/p-x9/swift-fileio.git",
+      "originalLocation" : "https://github.com/p-x9/swift-fileio",
       "state" : {
         "version" : "0.13.0"
       }
@@ -486,7 +486,7 @@
       "identity" : "p-x9.swift-fileio-extra",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/p-x9/swift-fileio-extra.git",
+      "originalLocation" : "https://github.com/p-x9/swift-fileio-extra",
       "state" : {
         "version" : "0.2.2"
       }
@@ -522,7 +522,7 @@
       "identity" : "shibapm.komondor",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/shibapm/Komondor.git",
+      "originalLocation" : "https://github.com/shibapm/komondor",
       "state" : {
         "version" : "1.1.3"
       }
@@ -531,7 +531,7 @@
       "identity" : "shibapm.packageconfig",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/shibapm/PackageConfig.git",
+      "originalLocation" : "https://github.com/shibapm/packageconfig",
       "state" : {
         "version" : "1.1.3"
       }
@@ -548,7 +548,7 @@
       "identity" : "stencilproject.Stencil",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/stencilproject/Stencil.git",
+      "originalLocation" : "https://github.com/stencilproject/stencil",
       "state" : {
         "version" : "0.15.1"
       }
@@ -565,7 +565,7 @@
       "identity" : "swift-server.swift-service-lifecycle",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "originalLocation" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
         "version" : "2.11.0"
       }
@@ -574,7 +574,7 @@
       "identity" : "swiftGen.StencilSwiftKit",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/SwiftGen/StencilSwiftKit.git",
+      "originalLocation" : "https://github.com/swiftgen/stencilswiftkit",
       "state" : {
         "version" : "2.10.1"
       }
@@ -616,7 +616,7 @@
       "identity" : "swiftlang.swift-syntax",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/swiftlang/swift-syntax.git",
+      "originalLocation" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "version" : "602.0.0"
       }
@@ -641,7 +641,7 @@
       "identity" : "tadija.aexml",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tadija/AEXML.git",
+      "originalLocation" : "https://github.com/tadija/aexml",
       "state" : {
         "version" : "4.7.0"
       }
@@ -650,7 +650,7 @@
       "identity" : "tid-kijyun.kanna",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tid-kijyun/Kanna.git",
+      "originalLocation" : "https://github.com/tid-kijyun/kanna",
       "state" : {
         "version" : "5.3.0"
       }
@@ -659,7 +659,7 @@
       "identity" : "tuist.Command",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tuist/Command.git",
+      "originalLocation" : "https://github.com/tuist/command",
       "state" : {
         "version" : "0.14.9"
       }
@@ -668,7 +668,7 @@
       "identity" : "tuist.FileSystem",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tuist/FileSystem.git",
+      "originalLocation" : "https://github.com/tuist/filesystem",
       "state" : {
         "version" : "0.18.0"
       }
@@ -726,7 +726,7 @@
       "identity" : "tuist.ZIPFoundation",
       "kind" : "registry",
       "location" : "",
-      "originalLocation" : "https://github.com/tuist/ZIPFoundation",
+      "originalLocation" : "https://github.com/tuist/zipfoundation",
       "state" : {
         "version" : "0.9.21"
       }


### PR DESCRIPTION
## What

Regenerates `Package.resolved` so `getGuaka/Colorizer` is pinned as a registry dependency (`getguaka.colorizer`) instead of a remote source-control one.

## Why

The canary release run [30613275374](https://github.com/tuist/tuist/actions/runs/30613275374) failed on the macOS `Release CLI` job, at the `Install Tuist dependencies` step (`tuist install --force-resolved-versions`):

```
error: an out-of-date resolved file was detected at .../Package.resolved, which is not
allowed when automatic dependency resolution is disabled; please make sure to update the
file to reflect the changes in dependencies. Running resolver because the following
dependencies were added: 'getguaka.colorizer' (getguaka.colorizer)
```

The two Linux release jobs passed, and `Publish CLI release` was skipped, so no canary was published.

Root cause: `Package.resolved` still pinned Colorizer as `"identity": "colorizer", "kind": "remoteSourceControl"`, the last source-control straggler in an otherwise all-registry file. That pin was written on 2026-07-28 in #12109, back when the git URL had no registry identity. It does now:

```
GET https://registry.tuist.dev/api/registry/swift/identifiers?url=https://github.com/getGuaka/Colorizer.git
→ {"identifiers":["getguaka.colorizer"]}
```

Once resolution runs with `--replace-scm-with-registry`, that URL maps to a registry identity that has no matching pin, so the resolver sees a newly added dependency. `--force-resolved-versions` maps to `--disable-automatic-resolution`, which turns that into a hard error rather than a silent re-resolve. Regular CI stays green because it does not pin resolved versions, so this only bites the canary and release paths, and it blocks every one of them until the file is updated.

This is the same situation #12113 handled for `lfroms/fluid-menu-bar-extra`: a package lands in the registry, and the stale source-control pin has to be converted. Worth expecting more of these as the registry backfill continues, so a periodic regeneration, or a non-release job that runs resolution in strict mode and fails early, would surface it before a release does.

## How

Ran `tuist install` at the repository root with the CLI version pinned in `mise.toml` (`4.204.0-canary.2`), the same version CI installs, and committed the result. No manual editing.

Considered hand-editing just the Colorizer pin to keep the diff to a few lines, but `originHash` is tool-computed and a hand-assembled file would not match what any resolver actually produces, so regenerating with the pinned CLI was the safer option.

The diff is larger than the one entry because that CLI version also rewrites `originalLocation` values to lowercase and drops the `.git` suffix. Those fields are informational and are not consulted by resolution. #12113 produced the same kind of churn.

## Validation

- `tuist install --force-resolved-versions` (the exact failing CI step) passes on the new file, and leaves it unchanged on a second run.
- `swift package resolve --replace-scm-with-registry --disable-automatic-resolution` passes on the new file too, confirming the strict path SwiftPM itself takes accepts it.

One caveat on local reproduction: with the old file, both commands still succeed on my machine. The failure needs an environment where resolution actually consults the registry identity mapping for that URL, which CI does and my local setup did not. The fix is the pin the CI resolver asked for, so the real confirmation is the canary run on this branch.
