### PR TITLE
ci(server): document pending Chromium security fixes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,3 +11,16 @@
 # traffic, so the practical exposure is zero. Drop this entry once a
 # helm release bundling grpc >= 1.79.3 lands and Dockerfile is bumped.
 CVE-2026-33186
+
+# The following Common Vulnerabilities and Exposures (CVEs) are high-severity
+# Chromium vulnerabilities fixed in 151.0.7922.47-1. The server runtime uses
+# Debian Bookworm's multi-architecture base image, whose current security
+# repository provides 150.0.7871.181-1~deb12u1. Debian Unstable has the fixed
+# package, but installing it on Bookworm would replace hundreds of core
+# packages, including the core C library and systemd. Keep the supported stable
+# image and remove these entries as soon as Debian backports the fixed Chromium
+# version to Bookworm security. https://www.cve.org/
+CVE-2026-16804
+CVE-2026-16805
+CVE-2026-16806
+CVE-2026-16807


### PR DESCRIPTION
## What changed

- Added documented temporary exceptions for four Chromium Common Vulnerabilities and Exposures (CVEs) in the container image scan.

## Why

The server image scan blocks the main branch because Debian Bookworm does not yet ship Chromium 151.0.7922.47-1, the version that contains the fixes.

## Root cause

The image installs Chromium from Debian Bookworm security, which currently provides 150.0.7871.181-1~deb12u1. The scanner identifies the four findings as fixed only by a package available in Debian Unstable.

## Approach

Keep the supported multi-architecture Debian Bookworm image and suppress only the four findings until Debian backports the fixed Chromium package. Installing the Unstable package would replace hundreds of core runtime packages.

## Impact

The server container scan can proceed while the exception remains explicitly documented and easy to remove when the stable backport lands.

## Validation

- Queried Chromium package availability in Debian Bookworm, Debian Trixie, and Debian Unstable.
- Simulated the Unstable Chromium installation and confirmed it would replace hundreds of core packages.
- Ran git diff --check.

### How to test locally

Run the server image scan after building the image:

```sh
trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 --no-progress --ignorefile .trivyignore tuist/tuist
```
