### PR TITLE
chore: disable the Claude Code session bootstrap hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,1 @@
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "mise run claude:bootstrap || true"
-          }
-        ]
-      }
-    ]
-  }
-}
+{}


### PR DESCRIPTION
Turns off the Claude Code `SessionStart` hook by emptying `.claude/settings.json`.

The hook ran `mise run claude:bootstrap` on every session start and every resume. That task regenerates `launch.json`, and when the server fingerprint (mix.lock, migration listings, package.json files) changes, it runs a full `mise run install` inside `server/`, which pulls dependencies, installs assets, and runs migrations and seeds.

The sentinel that lets the task skip repeat work is written to `server/_build/.claude-bootstrap-fingerprint`. Since `_build` is not shared across worktrees, every fresh worktree misses the sentinel and pays the whole server install before the first prompt is answered, including sessions that never touch the server. That is the cost this removes.

The file is left as `{}` rather than deleted, so the hook can be brought back by restoring the block:

```json
{
  "hooks": {
    "SessionStart": [
      { "hooks": [{ "type": "command", "command": "mise run claude:bootstrap || true" }] }
    ]
  }
}
```

`mise/tasks/claude/bootstrap.sh` is untouched, so `mise run claude:bootstrap` still works when run by hand. Anyone who wants the old behavior can run it once per worktree instead of on every session.

### How to test locally

- Start a Claude Code session in a fresh worktree of this branch and confirm no bootstrap output appears before the first prompt.
- Run `mise run claude:bootstrap` manually and confirm it still regenerates `launch.json` and performs the server install.
