### PR TITLE
fix(cli): decode devicectl "sameMachine" transport type and skip simulators when listing physical devices

### DIFF
--- a/cli/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/cli/Sources/TuistAutomation/Device/DeviceController.swift
@@ -139,6 +139,7 @@ private struct DeviceList: Codable {
                 enum TransportType: String, Codable {
                     case localNetwork
                     case wired
+                    case sameMachine
                 }
 
                 enum TunnelState: String, Codable {
@@ -167,6 +168,10 @@ private struct DeviceList: Codable {
 
                 let udid: String?
                 let platform: Platform?
+                /// Decoded as a raw string on purpose: `devicectl` may report values
+                /// beyond "physical"/"simulated", and a strict enum would fail the whole
+                /// device list decode (the same fragility that broke on "sameMachine").
+                let reality: String?
             }
         }
     }
@@ -177,6 +182,10 @@ extension PhysicalDevice {
         // Some properties from the `devicectl` can be `nil`.
         // However, when some properties, like the `platform`, are missing, we can't properly work with the device.
         // In those cases, we return `nil` here and filter such devices out before passing them to the caller.
+        // `devicectl` also lists simulators (reality == "simulated"). Those are surfaced
+        // separately through the simulator controller, so we skip them here to avoid
+        // duplicated destinations and attempting a `devicectl` install on a simulator.
+        if device.hardwareProperties.reality == "simulated" { return nil }
         guard let udid = device.hardwareProperties.udid,
               let hardwarePlatform = device.hardwareProperties.platform,
               let name = device.deviceProperties.name
@@ -191,6 +200,7 @@ extension PhysicalDevice {
         let transportType: PhysicalDevice.TransportType? = switch device.connectionProperties.transportType {
         case .localNetwork: .wifi
         case .wired: .usb
+        case .sameMachine: .none
         case .none: .none
         }
 

--- a/cli/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/cli/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -110,6 +110,33 @@ final class DeviceControllerTests: TuistUnitTestCase {
         )
     }
 
+    func test_findAvailableDevices_skips_simulators_with_sameMachine_transport_type() async throws {
+        // Given
+        given(commandRunner)
+            .run(arguments: .any, environment: .any, workingDirectory: .any)
+            .willProduce { arguments, _, _ in
+                self.write(text: self.sameMachineDevicesOutputJSON, at: arguments.last!)
+            }
+
+        // When
+        let got = try await subject.findAvailableDevices()
+
+        // Then
+        XCTAssertEqual(
+            [
+                PhysicalDevice(
+                    id: "00008132-0103524335E2F624",
+                    name: "My iPhone",
+                    platform: .iOS,
+                    osVersion: "18.0",
+                    transportType: .usb,
+                    connectionState: .connected
+                ),
+            ],
+            got
+        )
+    }
+
     func test_installApp() async throws {
         // Given
         given(commandRunner)
@@ -717,6 +744,52 @@ final class DeviceControllerTests: TuistUnitTestCase {
 
             ],
             "visibilityClass" : "default"
+          }
+        ]
+      }
+    }
+    """
+
+    private let sameMachineDevicesOutputJSON = """
+    {
+      "info" : {
+        "outcome" : "success",
+        "version" : "629.3",
+        "jsonVersion" : 4
+      },
+      "result" : {
+        "devices" : [
+          {
+            "connectionProperties" : {
+              "transportType" : "wired",
+              "tunnelState" : "connected"
+            },
+            "deviceProperties" : {
+              "name" : "My iPhone",
+              "osVersionNumber" : "18.0"
+            },
+            "hardwareProperties" : {
+              "platform" : "iOS",
+              "reality" : "physical",
+              "udid" : "00008132-0103524335E2F624"
+            },
+            "identifier" : "physical-identifier"
+          },
+          {
+            "connectionProperties" : {
+              "transportType" : "sameMachine",
+              "tunnelState" : "disconnected"
+            },
+            "deviceProperties" : {
+              "name" : "iPhone 17",
+              "osVersionNumber" : "26.0"
+            },
+            "hardwareProperties" : {
+              "platform" : "iOS",
+              "reality" : "simulated",
+              "udid" : "simulator-udid"
+            },
+            "identifier" : "simulator-identifier"
           }
         ]
       }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/12052

Running any preview with `tuist run <preview-url>` (or the macOS menu-bar app) fails on Xcode 26 with **"Fetching the list of devices failed."**, before any device can be selected — even for simulator targets.

**Root cause:** `DeviceController.findAvailableDevices()` decodes `xcrun devicectl list devices --json-output` with a single strict `JSONDecoder`, mapping any decode error to `DeviceControllerError.fetchingDevicesFailed`. On Xcode 26, `devicectl` also lists simulators, and every simulator entry carries `"transportType": "sameMachine"` — a value missing from the `TransportType` enum. Decoding this present-but-unknown value throws, and since the whole list is decoded at once, the entire fetch fails.

**Fix:** This applies the recommendation from @dosu in the issue:
- Add the `sameMachine` case to `ConnectionProperties.TransportType`.
- Handle it in the `PhysicalDevice` transport-type mapping (`.sameMachine` → `nil`, since simulators have no physical transport).

In addition, it decodes `hardwareProperties.reality` and skips `"simulated"` entries in `PhysicalDevice.init?`. Without this, simulators (which carry a `udid`, `name` and `platform`) would leak into the physical-device list — duplicated with the simulator-controller output and installed via `devicectl` instead of `simctl`. `reality` is decoded as a raw `String?` on purpose, to avoid reintroducing the same strict-enum fragility for a field whose value set may grow.

### How to test locally

1. On a machine with Xcode 26 and at least one simulator installed, confirm `devicectl` emits the offending value:
   ```sh
   xcrun devicectl list devices --json-output - | grep '"transportType"'
   # -> "transportType" : "sameMachine"   (for every simulator entry)
   ```
2. Run any preview:
   ```sh
   tuist run <any-preview-url>
   ```
   - Before: fails with "Fetching the list of devices failed."
   - After: device/simulator selection proceeds normally.

Automated coverage: `DeviceControllerTests.test_findAvailableDevices_skips_simulators_with_sameMachine_transport_type` feeds a payload with a physical device and a `sameMachine` simulator, and asserts the fetch succeeds and returns only the physical device.