### PR TITLE
fix(cache): stop a stranded Oban job from wedging key-value eviction

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -61,8 +61,10 @@ config :cache, Oban,
   plugins: [
     {Oban.Plugins.Pruner, interval: to_timeout(minute: 5), max_age: to_timeout(day: 1)},
     # Containers are stopped mid-job on every deploy, which strands `executing`
-    # rows that no other plugin clears. `rescue_after` has to clear the longest
-    # legitimate run: Registry.SyncWorker holds its lock for up to 50m.
+    # rows that no other plugin clears. 2h is deliberately well above anything
+    # expected to run here rather than a measured ceiling — a rescue that fires
+    # while the original is still running double-runs the job — and the queues
+    # this can touch are concurrency-1 or do idempotent deletes.
     {Oban.Plugins.Lifeline, rescue_after: to_timeout(hour: 2)},
     {Oban.Plugins.Cron,
      crontab: [

--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -60,6 +60,10 @@ config :cache, Oban,
   ],
   plugins: [
     {Oban.Plugins.Pruner, interval: to_timeout(minute: 5), max_age: to_timeout(day: 1)},
+    # Containers are stopped mid-job on every deploy, which strands `executing`
+    # rows that no other plugin clears. `rescue_after` has to clear the longest
+    # legitimate run: Registry.SyncWorker holds its lock for up to 50m.
+    {Oban.Plugins.Lifeline, rescue_after: to_timeout(hour: 2)},
     {Oban.Plugins.Cron,
      crontab: [
        {"*/10 * * * *", Cache.DiskEvictionWorker},

--- a/cache/lib/cache/key_value_eviction_worker.ex
+++ b/cache/lib/cache/key_value_eviction_worker.ex
@@ -9,10 +9,17 @@ defmodule Cache.KeyValueEvictionWorker do
   already deleted.
   """
 
+  # The unique period must sit between the worker deadline
+  # (KEY_VALUE_EVICTION_MAX_DURATION_MS, 5m) and the cron interval (15m): long
+  # enough that a pass still running blocks a second one onto the single-writer
+  # KV database, short enough that it always lapses before the next tick. It was
+  # :infinity until an orphaned `executing` row — left by a container stopped
+  # mid-pass, which nothing rescued — silently blocked every subsequent insert
+  # and let the KV database grow unbounded.
   use Oban.Worker,
     queue: :maintenance,
     max_attempts: 1,
-    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
+    unique: [period: 600, states: [:available, :scheduled, :executing, :retryable]]
 
   alias Cache.Config
   alias Cache.KeyValueEntries

--- a/cache/lib/cache/key_value_eviction_worker.ex
+++ b/cache/lib/cache/key_value_eviction_worker.ex
@@ -9,12 +9,13 @@ defmodule Cache.KeyValueEvictionWorker do
   already deleted.
   """
 
-  # The unique period must sit between the worker deadline
-  # (KEY_VALUE_EVICTION_MAX_DURATION_MS, 5m) and the cron interval (15m): long
-  # enough that a pass still running blocks a second one onto the single-writer
-  # KV database, short enough that it always lapses before the next tick. It was
-  # :infinity until an orphaned `executing` row — left by a container stopped
-  # mid-pass, which nothing rescued — silently blocked every subsequent insert
+  # `maintenance` runs at concurrency 1, so the queue — not this period — is
+  # what keeps two passes off the single-writer KV database; the period only
+  # stops the 15m cron stacking duplicates, and since Oban measures it from
+  # `inserted_at` a job queued behind another maintenance worker can outlive it.
+  # 600s stays under that 15m interval so the guard always lapses: it was
+  # :infinity until an orphaned `executing` row, left by a container stopped
+  # mid-pass with nothing to rescue it, silently blocked every subsequent insert
   # and let the KV database grow unbounded.
   use Oban.Worker,
     queue: :maintenance,

--- a/cache/test/cache/key_value_eviction_worker_test.exs
+++ b/cache/test/cache/key_value_eviction_worker_test.exs
@@ -3,6 +3,7 @@ defmodule Cache.KeyValueEvictionWorkerTest do
   use Mimic
   use Oban.Testing, repo: Cache.Repo
 
+  import Ecto.Query, only: [from: 2]
   import ExUnit.CaptureLog
 
   alias Cache.Config
@@ -601,6 +602,42 @@ defmodule Cache.KeyValueEvictionWorkerTest do
     assert args["account_handle"] == "acme"
     assert args["project_handle"] == "ios"
     assert args["cas_hashes"] == ["SIZE_HASH"]
+  end
+
+  describe "uniqueness" do
+    test "an in-flight job blocks a second one from being enqueued" do
+      {:ok, first} = Oban.insert(KeyValueEvictionWorker.new(%{}))
+      mark_executing(first, DateTime.utc_now())
+
+      {:ok, second} = Oban.insert(KeyValueEvictionWorker.new(%{}))
+
+      assert second.id == first.id
+      assert second.conflict?
+    end
+
+    test "an orphaned executing job stops blocking once the unique period lapses" do
+      {:ok, orphan} = Oban.insert(KeyValueEvictionWorker.new(%{}))
+      mark_executing(orphan, DateTime.add(DateTime.utc_now(), -601, :second))
+
+      {:ok, fresh} = Oban.insert(KeyValueEvictionWorker.new(%{}))
+
+      refute fresh.id == orphan.id
+      refute fresh.conflict?
+    end
+  end
+
+  # Reproduces a container stopped mid-pass: the row stays `executing` with
+  # nothing running behind it.
+  defp mark_executing(job, inserted_at) do
+    Cache.Repo.update_all(
+      from(j in Oban.Job, where: j.id == ^job.id),
+      set: [
+        state: "executing",
+        attempt: 1,
+        attempted_at: DateTime.truncate(inserted_at, :second),
+        inserted_at: DateTime.truncate(inserted_at, :second)
+      ]
+    )
   end
 
   defp capture_eviction_telemetry(fun) do


### PR DESCRIPTION
## What changed

- `Cache.KeyValueEvictionWorker`'s unique period goes from `:infinity` to 600s.
- `Oban.Plugins.Lifeline` is added to the cache Oban plugins with `rescue_after: 2h`.
- Two regression tests covering both halves of the uniqueness contract.

## Why

`cache-us-east-2` filled its root filesystem and went down on 2026-07-31. The Sentry issue (CACHE-71, `Exqlite.Error: database or disk is full`) is a symptom; by the time it was reported the app could no longer boot at all:

```
[error] Exqlite.Connection ... failed to connect: ** (Exqlite.Error) disk I/O error
[error] Could not create schema migrations table
Kernel pid terminated (application_controller) ... application_start_failure
```

`/data` is bind-mounted from `/var/lib/cache` (`config/deploy.yml`), so the SQLite databases live on `/`, not on the `/cas` artifact disk. `key_value.sqlite` had reached **79 GB** against a 25 GiB cap and was still growing when the host died. `/cas` had 145 GB free the whole time.

## Root cause

`KEY_VALUE_MAX_DB_SIZE_BYTES` is enforced only by `KeyValueEvictionWorker`. That worker had not run on the affected nodes in at least 30 days.

The worker declared:

```elixir
unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
```

The cache app runs `engine: Oban.Engines.Lite`, whose `fetch_unique/2` computes the window as:

```elixir
since = seconds_from_now(min(period, @forever) * -1)   # @forever = 99 years
```

Elixir orders numbers below atoms, so `min(:infinity, @forever)` returns `@forever` and the filter becomes "inserted after ~1927" — always true. (`Oban.Engines.Basic` reaches the same place by a different route, dropping the filter outright with `defp since_period(query, :infinity, _timestamp), do: query`.) Either way the uniqueness query matches any row in a non-terminal state, with no effective time bound. Containers are stopped mid-job on every deploy — and this worker runs for up to `KEY_VALUE_EVICTION_MAX_DURATION_MS` (5m) — which strands rows in `executing`. Nothing cleared them: `plugins` was `[Pruner, Cron]`, and the Pruner only touches `completed`/`cancelled`/`discarded`. `max_attempts: 1` means genuine failures land in `discarded` and are harmless; only orphaned `executing` rows persist.

One stranded row therefore blocked every subsequent Cron insert on that node, permanently.

### Evidence

`Oban.Plugins.Cron` telemetry returns the *existing* job on a unique conflict, so the blocker shows up in each `*/15` tick with an ID hundreds of thousands older than everything around it:

```
16:45:00 eu-central  jobs:[9426907, 9765762, 9765763]
16:45:00 us-east     jobs:[12161888, 12362950, 12362951]
16:45:00 us-east-3   jobs:[29595, 331943, 331944]
16:45:00 us-west     jobs:[738029, 1007182, 1007183]
```

On `cache-eu-central`, `9426907` appears in 89 of ~96 ticks per day and at the earliest point in Loki's 30-day retention — the same ID throughout.

The control is `Cache.SQLiteMaintenanceWorker`: same queue, same `*/15` schedule, no `unique:` option. It ran 167–192 times in 24h on every node. `KeyValueEvictionWorker` ran on only the four nodes that were never wedged — and those are exactly the four whose databases are healthy:

| Node | KV DB | `/` used | KV eviction |
|---|---|---|---|
| us-east-2 | 79 GB | 100% — down | never |
| us-east-3 | 80 GB | 92.5% | never |
| eu-central | 134 GB | 83.3% | never |
| us-east | 30.8 GB | 51% | never |
| us-west | n/a | n/a | never |
| eu-north / ap-southeast / us-central / eu-central-canary | 0.1–17 GB | healthy | every 15m |

`cache-eu-central` has already been through this once: its database reached 213 GB in mid-June, was wiped to 2.6 GB around 18 June, and has climbed back to 134 GB since. The stranded job survived that; only the symptom was cleared.

## Why this fix

**Bounded period rather than dropping `:executing`.** The original intent is sound — PR #9751 turned this from a one-shot into a loop that can hold the single-writer KV database for five minutes, and overlapping passes on the same file are worth preventing. Dropping `:executing` from the states would remove exactly the protection that was wanted. Bounding the period keeps it and makes it self-healing: 600s is longer than the 5m worker deadline (a pass still running blocks a second one) and shorter than the 15m Cron interval (the guard always lapses before the next tick). `XcodeCleanupWorker` already uses a bounded `period: 300`; this worker was the only one on `:infinity`.

**Lifeline in addition, not instead.** The bounded period alone unblocks insertion, but stranded rows would still accumulate in `executing` forever, distorting Oban Web and evading the Pruner. Lifeline is the documented remedy for "Jobs Stuck Executing Forever" and is opt-in. `rescue_after` is set to 2h rather than the 1h default because it applies to every worker in the app and rescuing a job that is genuinely still running would double-execute it. 2h is a margin chosen to sit well above anything expected to run here, not a derived ceiling — `Registry.SyncWorker`'s `sync_packages/2` has no deadline at all, and `S3TransferWorker`'s theoretical ceiling is larger still. What actually bounds the cost of being wrong is that the queues this can touch are concurrency-1 or do idempotent deletes. Recovering in 2h instead of 1h is immaterial against the current behaviour of never.

## Impact

Key-value eviction resumes on the five wedged production nodes, and `KEY_VALUE_MAX_DB_SIZE_BYTES` starts being enforced again. Expect a large one-off size-based eviction pass on `eu-central` and `us-east-3` on first run, with `XcodeCleanupWorker` jobs following it — the first pass is bounded by the 5-minute deadline and the 1-day `KEY_VALUE_EVICTION_MIN_RETENTION_DAYS` floor, so it will take several passes to converge rather than doing it all at once.

## Validation

- `mix test test/cache/key_value_eviction_worker_test.exs` — 24 passed.
- The orphan test was confirmed to fail against the previous `:infinity` config and pass after the change; the overlap test passes both before and after, guarding that the original protection is intact.
- `mix credo --strict` clean on the changed files; `mix format` applied.
- **Lifeline is not exercised by the suite** (`config/test.exs` sets `plugins: false`), and `Oban.Engines.Lite` does not implement `rescue_jobs/3` — it falls back to `Oban.Engines.Basic` via `with_compatible_engine/3`. That fallback is plain `update_all` + `select`, which SQLite supports (Lite's own `cancel_all_jobs/2` uses the same `UPDATE … RETURNING`), so it is expected to work, but this is read-verified rather than executed. **On deploy, check the `[:oban, :plugin, :stop]` telemetry for Lifeline on one node** — it carries `rescued_jobs`/`discarded_jobs`, so whether the stranded rows are actually reaped will be immediately visible.

## Not included

- **The stranded rows still need clearing.** This PR stops new ones from wedging the worker, but the existing blockers pre-date it and Lifeline will only reap them once deployed. `9426907` (eu-central), `12161888` (us-east), `29595` (us-east-3), `738029` (us-west) can be cancelled from `/oban` for immediate recovery.
- **`cache-us-east-2` needs its root disk freed by hand** before it will boot; no code change reaches a host whose app cannot start.
- **The alert gap is not fixed here.** `Cache Node Disk Usage Watermark` (uid `ff5dn2b82u3nke`) only queries `mountpoint="/cas"`, so `/` — where these databases live — went from 88% to 100% over two weeks with nothing firing. Grafana alert rules are not in this repo (only dashboards under `infra/grafana-dashboards/`), so that has to change in Grafana. It should become `mountpoint=~"/|/cas"`.
- **Structural follow-up:** nothing watches the filesystem the SQLite databases sit on. `DiskEvictionWorker` monitors `STORAGE_DIR` (`/cas`) only. Either move `/data` onto the `/cas` disk or give the worker a root-disk guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

