### PR TITLE
fix(infra): run cache deploys on GitHub-hosted runners

### DIFF
--- a/.github/workflows/cache-deploy.yml
+++ b/.github/workflows/cache-deploy.yml
@@ -27,8 +27,13 @@ env:
 
 jobs:
   deploy-canary:
-    # kamal deploy builds the Elixir release image locally; the 2/8 default shape OOMs.
-    runs-on: tuist-linux-large
+    # Must stay on a GitHub-hosted runner: kamal SSHes into the cache hosts, and
+    # the in-house fleet's runner Pods have no TCP 22 egress (the
+    # runners-default-deny NetworkPolicy allows only DNS, 80/443 and Kura 4000),
+    # so kamal dies with Net::SSH::ConnectionTimeout there. ubuntu-latest is
+    # 4 vCPU / 16 GB on public repos — kamal builds the Elixir release image
+    # locally and the 2/8 shape OOMs.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: cache-canary
     steps:
@@ -49,8 +54,13 @@ jobs:
         run: |
           mise run deploy canary
   deploy-production:
-    # kamal deploy builds the Elixir release image locally; the 2/8 default shape OOMs.
-    runs-on: tuist-linux-large
+    # Must stay on a GitHub-hosted runner: kamal SSHes into the cache hosts, and
+    # the in-house fleet's runner Pods have no TCP 22 egress (the
+    # runners-default-deny NetworkPolicy allows only DNS, 80/443 and Kura 4000),
+    # so kamal dies with Net::SSH::ConnectionTimeout there. ubuntu-latest is
+    # 4 vCPU / 16 GB on public repos — kamal builds the Elixir release image
+    # locally and the 2/8 shape OOMs.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: deploy-canary
     if: ${{ needs.deploy-canary.result == 'success' }}


### PR DESCRIPTION
## What changed

`deploy-canary` and `deploy-production` in `.github/workflows/cache-deploy.yml` move from `runs-on: tuist-linux-large` back to `runs-on: ubuntu-latest`.

## Why

Cache Deploy has failed on **every run since 2026-06-03** — 38 consecutive failures — always with the same error:

```
ERROR (Net::SSH::ConnectionTimeout): Exception while executing on host cache-eu-central-canary.tuist.dev
```

The transition is exact:

| Run | Commit | `runs-on` | Result |
|---|---|---|---|
| [26879415682](https://github.com/tuist/tuist/actions/runs/26879415682) (06-03 10:38Z) | `751ee7db31` | `namespace-profile-default` | ✅ last success |
| [26895464566](https://github.com/tuist/tuist/actions/runs/26895464566) (06-03 15:35Z) | `a9e3c96d01` (#11057) | → `tuist-linux` | ❌ first failure |
| everything since | | `tuist-linux-large` | ❌ |

## Root cause

#11057 moved this workflow onto the in-house fleet. In-house Linux runner Pods live in the CNI network namespace and are gated by the `runners-default-deny` NetworkPolicy in the `tuist-runners` namespace (`infra/helm/tuist/templates/runners-namespace.yaml`). Its egress allow-list, read from the live production cluster:

```
rule 0: DNS        → UDP/53, TCP/53
rule 1: 0.0.0.0/0  → TCP/443, TCP/80   (except 10/8, 172.16/12, 192.168/16)
rule 2: Kura       → TCP/4000
```

There is no TCP 22 rule, so kamal's SSH is silently dropped — which is why it surfaces as a connect *timeout* rather than a refusal.

The job logs match precisely: the docker build and push to ghcr.io over :443 succeed on every run, and the job then dies at the very first host interaction (`Running docker login ghcr.io ... on cache-eu-central-canary.tuist.dev`).

The cache hosts themselves are fine — sshd answers externally with `SSH-2.0-OpenSSH_10.2` offering `publickey`, and `cache/platform/configuration.nix` opens port 22 unrestricted. The block is entirely egress-side.

## Why this fix over the alternatives

The obvious fix — adding port 22 to the runner NetworkPolicy — is the wrong one. That policy selects `tuist.dev/runner=true`, i.e. **every customer runner Pod running untrusted workflow code**. Allowing outbound SSH there to unblock one internal deploy job trades a meaningful security boundary for a CI convenience.

The other option is a dedicated runner pool for trusted internal deploy jobs, with its own narrow policy allowing TCP 22 to the cache host IPs only. That's the better end state if we want these deploys back on the in-house fleet, but it's more moving parts than the situation warrants right now, and the backlog has been building for two months. Worth doing as a follow-up if in-house deploys matter.

Moving the job back to a hosted runner is the smallest change that restores known-good behaviour and keeps the runner policy tight. `ubuntu-latest` is 4 vCPU / 16 GB on public repos — the same shape as the `tuist-linux-large` pool it replaces (`4vcpu-16gb`), so the release-image build that motivated the large shape in #11085 still fits and there is no OOM regression.

The `runs-on` comment now records the SSH-egress constraint so this doesn't get moved back onto the in-house fleet a third time.

## Impact

`deploy-production` is gated on `needs.deploy-canary.result == 'success'`, so it has not run since June 3. **No cache change has reached canary or the ten production cache hosts in roughly two months**, including the recent registry-sync, eviction and Oban fixes. Merging this ships that whole backlog at once — worth watching the first canary rollout a little more closely than usual.

## Validation

- Bisected the failure to the exact run boundary shown in the table above, and confirmed every intervening run fails with the identical `Net::SSH::ConnectionTimeout`.
- Read the live `tuist-tuist-runners-default-deny` policy in the production cluster and confirmed the egress rule set contains no TCP 22.
- Verified the canary host is healthy from outside the cluster: ICMP, TCP 22 and TCP 443 all reachable, sshd banner `SSH-2.0-OpenSSH_10.2` offering `publickey`.
- `actionlint .github/workflows/cache-deploy.yml` clean; YAML parses with both jobs resolving to `ubuntu-latest`.

The real end-to-end proof is the post-merge run, since the SSH path can only be exercised from a runner with the deploy key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)