### PR TITLE
fix(infra): give the Swift registry sync pod memory headroom

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -330,6 +330,10 @@ swiftRegistrySync:
     databasePassword:
       item: SWIFT_REGISTRY_SYNC_DATABASE_PASSWORD
       field: password
+  # Conservative default so the pod still schedules on the cramped
+  # staging/canary nodepools. Envs that actually sync a real catalog
+  # override this — see values-managed-production.yaml, where the
+  # measured working set needs considerably more than 1Gi.
   resources:
     requests:
       cpu: "250m"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -431,6 +431,29 @@ swiftRegistrySync:
       value: prod
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
+  # Production is the only env syncing the full catalog, so it's the only
+  # one that outgrows the common 512Mi/1Gi default. Enabling the sync
+  # (#12136) took this pod from idle to real work and it started getting
+  # OOMKilled every 10-60 minutes: idle working set is 750-850Mi and
+  # per-release jobs peak at 930-995Mi, leaving no room under a 1Gi cap.
+  #
+  # The request matches the measured idle baseline. At 512Mi the pod
+  # permanently exceeded its own request, which made it a first-choice
+  # eviction target whenever a processor node came under memory pressure.
+  # The limit is deliberately well clear of observed peak rather than
+  # just above it — peak scales with :swift_registry_release running 5
+  # jobs concurrently (server/config/runtime.exs), and each one unpacks
+  # and re-zips a package archive under /tmp, so page cache on that
+  # emptyDir counts against this cgroup too. Archive sizes are set by
+  # whatever upstream publishes, so the ceiling isn't ours to predict.
+  # If this OOMs again, lower queueConcurrency before raising memory.
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "1Gi"
+    limits:
+      cpu: "1000m"
+      memory: "4Gi"
 
 # Runs as the same env as the build processor; the Tart VM reads its secrets
 # from the environment (config Secret via envFrom + object-storage ESO), same


### PR DESCRIPTION
The `swift-registry-sync` pod in production has been getting OOMKilled on a loop since 30 July, firing the "Pod restarts (possible overload)" alert. This gives it a memory envelope that matches what it actually uses.

## Root cause

The deployment was inheriting the chart's conservative `512Mi` request / `1Gi` limit from `values-managed-common.yaml`. That was fine for as long as the pod sat idle, which is why it went twelve days with zero restarts. On 29 July at 21:04 CEST, [#12136](https://github.com/tuist/tuist/pull/12136) enabled the managed registry sync and made this deployment the sole registry synchronization writer. It started doing real work, and the workload does not fit in 1Gi.

Measured in production over the last several days:

- Idle working set: **750 to 850 MiB**
- Per release job peaks: **930 to 995 MiB**
- Limit: **1 GiB**

That leaves 150 to 250 MiB of headroom, and every container death I sampled happened in the 950 to 995 MiB band. Container lifetimes are currently 10 to 60 minutes. The restart rate has run between 9 and 21 per day since it started, and is not settling.

Two things drive the peaks above the idle baseline. The `:swift_registry_release` queue runs 5 jobs concurrently (`server/config/runtime.exs`), and each job unpacks and re-zips a package archive under `/tmp`. Since `/tmp` is an `emptyDir`, page cache generated by that archive work counts against the same memory control group as the process itself.

## What changed

Production now requests `1Gi` and caps at `4Gi`:

```yaml
swiftRegistrySync:
  resources:
    requests:
      cpu: "250m"
      memory: "1Gi"
    limits:
      cpu: "1000m"
      memory: "4Gi"
```

Central processing unit values are untouched. The failure is purely memory, and there is no throttling signal.

The shared default in `values-managed-common.yaml` keeps its original `512Mi` / `1Gi` and picks up a comment explaining that it is deliberately conservative and that real catalog syncing environments override it.

## Approach

Two decisions worth explaining.

**Why the production values file and not the shared defaults.** My first attempt raised the shared default, which would have been a mistake. Staging is squeezed onto 2 `cpx22` workers with roughly 2.5 GiB allocatable each and about 1.5 GiB consumed by system DaemonSets, leaving on the order of 1 GiB free per node. A 1 GiB *request* there would have been close to unschedulable, which is exactly why staging deliberately runs the server at `384Mi` / `1536Mi`. Putting real sizing in the per environment file also matches how `server`, `processor`, and `cnpg` are already configured: the shared file holds a modest default and each environment carries its own envelope. Canary is unaffected because it only syncs a single package allowlist.

**Why the request moved and not just the limit.** At `512Mi` the pod permanently exceeded its own request from the moment it booted. That is a poor Burstable citizen and puts it near the front of the eviction queue whenever a processor node comes under memory pressure. Setting the request to the measured baseline makes it honest and improves its eviction ranking, independently of the OOM fix.

I also considered lowering `:swift_registry_release` concurrency from 5 instead of raising memory. I have left that alone for now since it would slow catalog synchronization, but the production values comment records it as the first lever to pull if this recurs, rather than raising memory again.

Adding node affinity was discussed and deliberately not done. The `md-processor` pool is Hetzner Cloud virtual machines (`cpx62` in `fsn1-dc14`, autoscaled 2 to 6), not bare metal, and it already co-hosts CloudNativePG instances. Pinning a memory hungry workload next to those is the opposite of what we want, and the scheduling question does not require it.

## Impact

The pod should stop restarting and the alert should clear. No configuration, interface, or application behaviour changes.

Scheduling is unaffected in practice. The change adds 512 MiB to the pod's request, the deployment has no `nodeSelector` or affinity so it can land anywhere, and the busiest node in the production cluster currently has roughly 7 GiB of unrequested memory while its current node has about 19 GiB free.

## Validation

Rendered the chart for all three managed environments and confirmed only production changes:

```
helm template tuist . -f values-managed-common.yaml -f values-managed-<env>.yaml \
  --show-only templates/swift-registry-sync-deployment.yaml
```

| Environment | Request | Limit |
|---|---|---|
| production | `1Gi` | `4Gi` |
| canary | `512Mi` (unchanged) | `1Gi` (unchanged) |
| staging | `512Mi` (unchanged) | `1Gi` (unchanged) |

Capacity and restart data were pulled from Grafana Cloud Prometheus: `kube_pod_container_resource_limits`, `kube_pod_container_status_restarts_total`, `container_memory_working_set_bytes`, `kube_node_labels`, and per node request sums. Termination reason `OOMKilled` was confirmed from the alert rule's own instance labels.

### How to test locally

This is a Helm values change with no local runtime component. Render the deployment and check the `resources` block:

```
cd infra/helm/tuist
helm template tuist . -f values-managed-common.yaml -f values-managed-production.yaml \
  --show-only templates/swift-registry-sync-deployment.yaml
```

Note that `helm template` needs placeholder image tags to render this chart at all, because several required value guards fire otherwise: `registry.image.tag`, `server.image.tag`, `kuraController.image.tag`, `runnersFleet.runnerImageSemver`, and `runnersFleetLinux.shapeRunnerImage`. Those are supplied at deploy time and are unrelated to this change.

After deploy, confirm the restart rate goes to zero:

```
sum(increase(kube_pod_container_status_restarts_total{namespace="tuist", container="swift-registry-sync"}[1d]))
```

## Follow up, not addressed here

Every job in both registry queues is currently being discarded with `{:discard, {:rate_limited, 403}}` from GitHub, on both `SyncWorker` and `ReleaseWorker`, as recently as 18:00 UTC on 31 July. That is a separate problem from the restarts. Once the pod stops dying, we will have a stable process failing on rate limits rather than an unstable one, and that is worth looking at next.

Separately, the alert that surfaced this is a generic namespace wide pod restart rule routed to the "Slack ClickHouse" receiver, so registry OOMs land in a ClickHouse channel.
