### PR TITLE
fix(swifterpm): keep resolution when SwiftPM fails to fetch binary artifacts

### DIFF
--- a/swifterpm/Sources/swifterpm/ResolutionProgress.swift
+++ b/swifterpm/Sources/swifterpm/ResolutionProgress.swift
@@ -113,6 +113,13 @@ final class ResolutionProgressReporter: @unchecked Sendable {
         }
     }
 
+    /// A standalone line outside the progress state machine, for explaining something the
+    /// user would otherwise have to infer from a subprocess' output.
+    func note(_ message: String) {
+        guard enabled else { return }
+        withLock { writeLine("\(TerminalStyle.dim("note:")) \(message)") }
+    }
+
     private func emitProgress() {
         guard enabled else { return }
         withLock {

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -65,7 +65,7 @@ enum PackageResolver {
             scmToRegistryTransformation: scmToRegistryTransformation,
             useExistingResolvedFile: useExistingResolvedFile,
             writeResolvedFile: writeResolvedFile,
-            forwardOutput: progress != nil
+            progress: progress
         )
         resolved.originHash = originHash
         resolved.pins = dedupePinsByIdentity(resolved.pins)
@@ -93,8 +93,9 @@ enum PackageResolver {
         scmToRegistryTransformation: SCMToRegistryTransformation,
         useExistingResolvedFile: Bool,
         writeResolvedFile: Bool,
-        forwardOutput: Bool
+        progress: ResolutionProgressReporter?
     ) async throws -> ResolvedPins {
+        let forwardOutput = progress != nil
         let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
         let snapshot =
             (!writeResolvedFile || !useExistingResolvedFile)
@@ -104,7 +105,7 @@ enum PackageResolver {
         }
 
         do {
-            try await SystemProcess.run(
+            let outcome = try await SystemProcess.outcome(
                 "swift",
                 swiftPackageResolveArguments(
                     packageDir: packageDir,
@@ -118,7 +119,21 @@ enum PackageResolver {
                 workingDirectory: packageDir,
                 forwardOutput: forwardOutput
             )
+
+            if !outcome.succeeded, !failedOnlyOnBinaryArtifacts(outcome) {
+                throw resolveFailure(outcome, forwardedOutput: forwardOutput)
+            }
             let resolved = try await ResolvedFile.read(packageDir: packageDir)
+            if !outcome.succeeded, resolved.pins.isEmpty {
+                // Resolution is only proven to have finished by the pins SwiftPM wrote before
+                // it moved on to artifacts. Without them there is nothing to carry forward.
+                throw resolveFailure(outcome, forwardedOutput: forwardOutput)
+            }
+            if !outcome.succeeded {
+                progress?.note(
+                    "swift package resolve failed to fetch binary artifacts; swifterpm restores them itself and continued with the resolved versions"
+                )
+            }
             if !writeResolvedFile, let snapshot {
                 try await restoreResolvedFile(snapshot, at: resolvedPath)
             }
@@ -130,6 +145,63 @@ enum PackageResolver {
             throw error
         }
     }
+
+    /// A forwarded run already printed its diagnostics, so the thrown error carries only the
+    /// exit status to avoid repeating them.
+    private static func resolveFailure(
+        _ outcome: SystemProcess.Outcome,
+        forwardedOutput: Bool
+    ) -> ToolError {
+        ToolError.message(
+            forwardedOutput ? outcome.terminationStatusDescription : outcome.failureMessage
+        )
+    }
+
+    /// `swift package resolve` runs two independent stages: it solves versions and writes
+    /// Package.resolved, then it downloads the graph's binary artifacts. swifterpm only needs
+    /// the first stage, since it downloads, verifies and materializes binary artifacts itself
+    /// right after resolution, so a failure confined to SwiftPM's artifact stage says nothing
+    /// about the resolution swifterpm asked for and must not fail it.
+    ///
+    /// That stage fails for reasons swifterpm's own restore does not share. SwiftPM keys its
+    /// shared artifact cache on the URL alone and checks that entry for existence before
+    /// downloading rather than when moving the finished file into place, so two downloads of
+    /// one URL (two binary targets declaring it, or two resolves sharing a cache directory)
+    /// both miss, both download, and the loser fails moving its copy onto the winner's. The
+    /// failure also deletes the entry, so the next resolve starts cold and fails identically:
+    /// for a graph with a duplicated artifact URL, resolution never succeeds on its own.
+    ///
+    /// Only SwiftPM's own binary-artifact diagnostics count. Anything else in the output,
+    /// including a manifest error that merely mentions a binary target, propagates as before.
+    static func failedOnlyOnBinaryArtifacts(_ outcome: SystemProcess.Outcome) -> Bool {
+        let errors = (outcome.stderrString + "\n" + outcome.stdoutString)
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { $0.hasPrefix("error: ") }
+            .map { String($0.dropFirst("error: ".count)) }
+            // swift-package prints this after the diagnostics that caused it to give up.
+            .filter { $0 != "fatalError" }
+
+        guard !errors.isEmpty else { return false }
+        return errors.allSatisfy { error in
+            binaryArtifactDiagnosticPrefixes.contains { error.hasPrefix($0) }
+                && error.contains("binary target '")
+        }
+    }
+
+    /// Only the diagnostics for fetching an artifact and proving it matches the manifest, all of
+    /// which swifterpm repeats itself: it downloads over its own retrying client, compares the
+    /// checksum against the same manifest value, and rejects an archive that carries no binary
+    /// artifact. SwiftPM's verdicts about an archive's *contents* that swifterpm does not repeat,
+    /// such as refusing an archive whose symlinks escape it, are deliberately absent so they stay
+    /// fatal.
+    private static let binaryArtifactDiagnosticPrefixes = [
+        "failed downloading '",
+        "failed extracting '",
+        "failed validating archive from '",
+        "invalid archive returned from '",
+        "checksum of downloaded artifact of binary target '",
+    ]
 
     private static func swiftPackageResolveArguments(
         packageDir: URL,

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -77,6 +77,29 @@ enum SystemProcess {
         }
     }
 
+    /// A finished process, whether it succeeded or not. Callers that want to inspect a
+    /// failure before deciding what to do with it use this instead of `run`, which turns
+    /// any non-zero exit into a thrown error.
+    struct Outcome {
+        let succeeded: Bool
+        let terminationStatusDescription: String
+        let stdout: Data
+        let stderr: Data
+
+        var stdoutString: String {
+            String(data: stdout, encoding: .utf8) ?? ""
+        }
+
+        var stderrString: String {
+            String(data: stderr, encoding: .utf8) ?? ""
+        }
+
+        var failureMessage: String {
+            let message = stderrString.isEmpty ? stdoutString : stderrString
+            return message.isEmpty ? terminationStatusDescription : message
+        }
+    }
+
     @discardableResult
     static func run(
         _ executable: String,
@@ -86,21 +109,62 @@ enum SystemProcess {
         forwardOutput: Bool = false,
         outputLimit: Int = 64 * 1024 * 1024
     ) async throws -> Result {
+        let outcome = try await outcome(
+            executable,
+            arguments,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            forwardOutput: forwardOutput,
+            outputLimit: outputLimit
+        )
+
+        guard outcome.succeeded else {
+            // A forwarded run already printed its diagnostics to this process' stderr, so
+            // repeating them in the thrown error would duplicate them in the caller's output.
+            throw ToolError.message(
+                forwardOutput ? outcome.terminationStatusDescription : outcome.failureMessage
+            )
+        }
+
+        return Result(stdout: outcome.stdout, stderr: outcome.stderr)
+    }
+
+    static func outcome(
+        _ executable: String,
+        _ arguments: [String],
+        workingDirectory: URL? = nil,
+        environment: [String: String] = [:],
+        forwardOutput: Bool = false,
+        outputLimit: Int = 64 * 1024 * 1024
+    ) async throws -> Outcome {
         if forwardOutput {
+            // Standard error is teed rather than handed to the terminal directly: the child's
+            // diagnostics still stream out as they are produced, and the copy lets callers
+            // recognise a known-recoverable failure instead of only seeing an exit status.
             let result = try await Subprocess.run(
                 subprocessExecutable(executable),
                 arguments: Arguments(arguments),
                 environment: subprocessEnvironment(environment),
                 workingDirectory: workingDirectory.map { FilePath($0.path) },
-                output: .standardOutput,
-                error: .standardError
-            )
-
-            guard result.terminationStatus.isSuccess else {
-                throw ToolError.message(result.terminationStatus.description)
+                output: .standardOutput
+            ) { _, errorSequence in
+                var captured = Data()
+                for try await buffer in errorSequence {
+                    let chunk = buffer.withUnsafeBytes { Data($0) }
+                    FileHandle.standardError.write(chunk)
+                    if captured.count < outputLimit {
+                        captured.append(chunk.prefix(outputLimit - captured.count))
+                    }
+                }
+                return captured
             }
 
-            return Result(stdout: Data(), stderr: Data())
+            return Outcome(
+                succeeded: result.terminationStatus.isSuccess,
+                terminationStatusDescription: result.terminationStatus.description,
+                stdout: Data(),
+                stderr: result.value
+            )
         }
 
         let result = try await Subprocess.run(
@@ -112,16 +176,12 @@ enum SystemProcess {
             error: .bytes(limit: outputLimit)
         )
 
-        guard result.terminationStatus.isSuccess else {
-            let stderrText = String(data: Data(result.standardError), encoding: .utf8) ?? ""
-            let stdoutText = String(data: Data(result.standardOutput), encoding: .utf8) ?? ""
-            let message = stderrText.isEmpty ? stdoutText : stderrText
-            throw ToolError.message(
-                message.isEmpty ? result.terminationStatus.description : message
-            )
-        }
-
-        return Result(stdout: Data(result.standardOutput), stderr: Data(result.standardError))
+        return Outcome(
+            succeeded: result.terminationStatus.isSuccess,
+            terminationStatusDescription: result.terminationStatus.description,
+            stdout: Data(result.standardOutput),
+            stderr: Data(result.standardError)
+        )
     }
 
     static func output(

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -37,6 +37,87 @@ struct ResolveTests {
     }
 
     @Test
+    func resolutionSurvivesSwiftPMFailingToFetchABinaryArtifact() async throws {
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tags: ["1.0.0"])
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(
+                at: package,
+                dependencyURL: dependency.path,
+                // Unroutable, so SwiftPM's artifact stage always fails while version solving,
+                // which is the only stage swifterpm needs from it, still succeeds.
+                binaryArtifactURL: "https://127.0.0.1:1/Artifact.xcframework.zip"
+            )
+
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let resolved = try await PackageResolver.resolve(
+                packageDir: package,
+                scratchDir: root.appendingPathComponent("scratch"),
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                disableSandbox: true,
+                writeResolvedFile: false
+            )
+
+            let pin = try #require(resolved.pins.first)
+            #expect(pin.identity == "dependency")
+            #expect(pin.state.version == "1.0.0")
+        }
+    }
+
+    @Test
+    func binaryArtifactFailuresAreTheOnlySwiftPMFailuresResolutionIgnores() {
+        let collision = """
+        Downloading binary artifact https://example.com/Artifact.xcframework.zip
+        error: failed downloading 'https://example.com/Artifact.xcframework.zip' which is \
+        required by binary target 'Artifact': /cache/artifacts/https___example_com already \
+        exists in file system
+        error: fatalError
+        """
+        #expect(PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: collision)))
+
+        let checksum = """
+        error: checksum of downloaded artifact of binary target 'Artifact' (abc) does not \
+        match checksum specified by the manifest (def)
+        """
+        #expect(PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: checksum)))
+
+        let transport = """
+        error: failed downloading 'https://example.com/Artifact.xcframework.zip' which is \
+        required by binary target 'Artifact': The request timed out.
+        """
+        #expect(PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: transport)))
+
+        let unresolvable = """
+        error: Dependencies could not be resolved because no versions of 'dependency' match \
+        the requirement 9.9.9..<10.0.0.
+        """
+        #expect(!PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: unresolvable)))
+
+        // A manifest that merely mentions a binary target is still a resolution failure.
+        let manifest = """
+        error: invalid URL scheme for binary target 'Artifact'; valid schemes are: 'https'
+        """
+        #expect(!PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: manifest)))
+
+        #expect(!PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: collision + "\n" + unresolvable)))
+        #expect(!PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: "")))
+        #expect(!PackageResolver.failedOnlyOnBinaryArtifacts(outcome(stderr: "error: fatalError")))
+    }
+
+    private func outcome(stderr: String) -> SystemProcess.Outcome {
+        SystemProcess.Outcome(
+            succeeded: false,
+            terminationStatusDescription: "exited(1)",
+            stdout: Data(),
+            stderr: Data(stderr.utf8)
+        )
+    }
+
+    @Test
     func localSourceControlPackageLocationRequiresPackageManifest() async throws {
         try await withTemporaryDirectory { root in
             #expect(try await PackageResolver.localSourceControlPackageLocation(root.path) == nil)
@@ -199,12 +280,24 @@ struct ResolveTests {
     private func writeAppPackageManifest(
         at packageDir: URL,
         dependencyURL: String,
-        exactVersion: String = "1.0.0"
+        exactVersion: String = "1.0.0",
+        binaryArtifactURL: String? = nil
     ) async throws {
         try await fileSystem.makeDirectory(
             at: packageDir.appendingPathComponent("Sources/App").absolutePath,
             options: [.createTargetParentDirectories]
         )
+        let binaryTarget =
+            binaryArtifactURL.map {
+                """
+                        .binaryTarget(
+                            name: "Artifact",
+                            url: "\($0)",
+                            checksum: "\(String(repeating: "0", count: 64))"
+                        ),
+
+                """
+            } ?? ""
         try await fileSystem.atomicWrite(
             """
             // swift-tools-version: 6.0
@@ -219,7 +312,7 @@ struct ResolveTests {
                     .package(url: "\(dependencyURL)", exact: "\(exactVersion)"),
                 ],
                 targets: [
-                    .target(name: "App", dependencies: [
+            \(binaryTarget)        .target(name: "App", dependencies: [
                         .product(name: "Dependency", package: "Dependency"),
                     ]),
                 ]

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -31,6 +31,28 @@ struct SupportTests {
     }
 
     @Test
+    func systemProcessOutcomeReportsFailureWithoutThrowing() async throws {
+        let outcome = try await SystemProcess.outcome(
+            "/bin/sh", ["-c", "printf out; printf err >&2; exit 3"]
+        )
+
+        #expect(!outcome.succeeded)
+        #expect(outcome.stdoutString == "out")
+        #expect(outcome.stderrString == "err")
+        #expect(outcome.failureMessage == "err")
+    }
+
+    @Test
+    func systemProcessCapturesStandardErrorWhileForwardingIt() async throws {
+        let outcome = try await SystemProcess.outcome(
+            "/bin/sh", ["-c", "printf boom >&2; exit 1"], forwardOutput: true
+        )
+
+        #expect(!outcome.succeeded)
+        #expect(outcome.stderrString == "boom")
+    }
+
+    @Test
     func binaryArtifactHeadersAskForRawBytesExactly() async throws {
         let url = try #require(URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1.zip"))
         let headers = await HTTPClient.binaryArtifactHeaders(for: url)


### PR DESCRIPTION
## What changed

`swifterpm` no longer fails a resolution when the `swift package resolve` it shells out to fails while fetching binary artifacts.

- `SystemProcess.outcome` returns a finished process instead of throwing on a non-zero exit, and `SystemProcess.run` becomes a thin wrapper over it, so existing callers behave exactly as before.
- A forwarded run now tees the child's standard error rather than handing it to the terminal, so its diagnostics stream out live and a bounded copy is kept for the caller.
- `PackageResolver` treats a failed resolve whose diagnostics are exclusively SwiftPM binary-artifact fetch failures as successful, provided it produced pins, and prints a `note:` explaining why the command continued.

## Why

Reported in Slack by a customer on 4.202.2 and again on 4.203.1:

```
error: failed downloading 'https://github.com/adjust/adjust_signature_sdk/releases/download/v3.35.2/AdjustSigSdk-iOS-tvOS-Dynamic-3.35.2.xcframework.zip'
which is required by binary target 'AdjustSignature':
/Users/…/.cache/swifterpm/artifacts/https___github_com_adjust_…_xcframework_zip already exists in file system
error: fatalError
```

It reads like network flakiness. It is not. It is deterministic, and it never recovers on its own, which is why upgrading the command line interface changed nothing.

## Root cause

The defect is in the Swift Package Manager, in `Workspace+BinaryArtifacts.swift`. After version solving, it downloads the graph's binary artifacts into a shared cache entry keyed only by the artifact URL. It checks that entry for existence *before* starting the download, then moves the finished file onto the same path afterwards. Two downloads of one URL therefore both miss the cache, both download, and the loser fails moving its copy onto the winner's.

Two ways to trigger it, both reproduced here against the real Adjust archive:

- one artifact URL declared by two binary targets in a single graph, which races inside one process and fails deterministically on a cold cache
- two resolves sharing a cache directory, which races across processes

The failure handler then deletes the cache entry, so the next run starts cold and fails identically. For a graph with a duplicated artifact URL, resolution never succeeds again.

`swifterpm` is exposed because it passes its own cache root to the Swift Package Manager as `--cache-path`. Plain `swift package resolve` hits the same race with no `swifterpm` involved, so this is not a `swifterpm` defect, and it is worth fixing upstream separately.

## Approach

`swift package resolve` does two independent things: it solves versions and writes `Package.resolved`, then it downloads binary artifacts. `swifterpm` only needs the first. It downloads, checksum-verifies and materializes binary artifacts itself immediately afterwards, using its own retrying client and its own cache, so the Swift Package Manager's artifact stage is redundant work that was failing the whole command.

So the fix is not to work around the race but to stop depending on a stage `swifterpm` does not consume. This holds on its own merits: today a cold resolve downloads every binary artifact twice, once by the Swift Package Manager and once by `swifterpm`.

The classification is deliberately narrow. Only the diagnostics for *fetching* an artifact and proving it matches the manifest are tolerated, all of which `swifterpm` repeats itself. The Swift Package Manager's verdicts about an archive's *contents* that `swifterpm` does not repeat, such as refusing an archive whose symlinks escape it, are absent from the list so they stay fatal. If a single unrecognized `error:` line appears, the resolve fails exactly as before. Resolution must also have produced pins, otherwise there is nothing to carry forward.

Alternatives considered and rejected:

- Retrying the failed resolve with `--disable-dependency-cache`. It works, verified, but it costs a second full resolve on the failure path and throws away the shared repositories cache for that run.
- Seeding the Swift Package Manager's artifact cache entry from `swifterpm`'s verified archive. This meant mirroring a private cache-key mangling and writing into another tool's namespace.
- Pre-seeding `workspace-state.json` so the artifact stage is skipped entirely. The Swift Package Manager does skip when the state already lists an artifact, confirmed by testing, but `swifterpm` cannot know a cold graph's transitive binary targets before resolving, so this narrows the window rather than closing it. Worth a follow-up on top of this change.

## Impact

Users whose dependency graph resolves one binary artifact URL through more than one binary target, or who run resolves concurrently against a shared cache, stop being permanently blocked. Nothing is skipped: `swifterpm` still downloads, checksum-verifies and materializes every binary artifact, and a genuine problem with the artifact, such as a bad checksum or an unreachable URL, still fails the command through `swifterpm`'s own restore with its own message.

One behavior change to note: the resolve subprocess' standard error is now a pipe rather than the terminal, so the Swift Package Manager renders plain progress lines instead of an animated bar when `swifterpm` is run directly in a terminal. No output is lost.

The classification depends on the Swift Package Manager's diagnostic text. It fails closed, so a wording change surfaces the error as it does today. It should be deleted once a fixed toolchain is the supported floor.

## Validation

Reproduced against the real archive from the report, with a package declaring the same artifact URL through two binary targets:

- baseline binary fails with the reported error, and fails again on every subsequent run
- patched binary restores both artifacts and exits 0, printing the Swift Package Manager's error followed by the explanatory note
- two concurrent patched invocations sharing one cache directory both succeed
- pre-seeding the Swift Package Manager's cache entry makes the baseline pass, which confirms the mechanism

Negative cases still fail: an unresolvable version requirement, an invalid dependency manifest, and a missing `Package.swift`.

```
swift build --replace-scm-with-registry
swift test --replace-scm-with-registry     # 139 tests in 20 suites passed
swiftformat --lint <changed files>         # no new violations
```

New tests: an offline end to end test that points a binary target at an unroutable URL and asserts the resolution still returns pins, unit coverage for the diagnostic classifier including the manifest error that merely mentions a binary target, and coverage for the teed standard error.

### How to test locally

```bash
cd swifterpm && swift test --replace-scm-with-registry --filter "ResolveTests|SupportTests"
```

To see the original failure, create a package whose manifest declares the same remote `binaryTarget` URL twice, then run `swift package resolve --cache-path <dir>` on a cold cache and observe the "already exists in file system" error. Running the same package through the `swifterpm` built from this branch succeeds.
