### PR TITLE
fix(cache): stop legacy cache nodes from syncing registry packages

### DIFF
--- a/cache/config/runtime.exs
+++ b/cache/config/runtime.exs
@@ -164,6 +164,7 @@ if config_env() == :prod do
     xcode_database_interactions_enabled: Cache.Config.bool_env("XCODE_DATABASE_INTERACTIONS_ENABLED", true),
     registry_github_token: System.get_env("REGISTRY_GITHUB_TOKEN"),
     registry_sync_allowlist: Cache.Config.list_env("REGISTRY_SYNC_ALLOWLIST"),
+    registry_sync_enabled: Cache.Config.bool_env("REGISTRY_SYNC_ENABLED", false),
     key_value_max_db_size_bytes: String.to_integer(System.get_env("KEY_VALUE_MAX_DB_SIZE_BYTES") || "26843545600"),
     key_value_eviction_min_retention_days:
       String.to_integer(System.get_env("KEY_VALUE_EVICTION_MIN_RETENTION_DAYS") || "1"),

--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -130,6 +130,16 @@ defmodule Cache.Config do
   """
   def registry_enabled?, do: registry_bucket() != nil and registry_github_token() != nil
 
+  @doc """
+  Returns true if this node may write to the registry.
+
+  Scheduled writes moved to the server-owned `Tuist.Registry.Swift.SyncWorker`,
+  so this defaults to false: cache serves registry reads but is not a writer
+  unless an operator opts in explicitly. Reads are gated by `registry_enabled?/0`
+  and are unaffected by this flag.
+  """
+  def registry_sync_enabled?, do: Application.get_env(:cache, :registry_sync_enabled, false) == true
+
   def s3_protocols do
     case Application.get_env(:cache, :s3)[:protocols] do
       protocols when is_list(protocols) and protocols != [] -> protocols

--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -38,6 +38,15 @@ defmodule Cache.Registry.ReleaseWorker do
   def perform(%Oban.Job{
         args: %{"scope" => scope, "name" => name, "repository_full_handle" => full_handle, "tag" => tag}
       }) do
+    if Config.registry_sync_enabled?() do
+      sync_release(scope, name, full_handle, tag)
+    else
+      Logger.debug("Registry release sync skipped for #{scope}/#{name}@#{tag}: cache is not a registry writer")
+      :ok
+    end
+  end
+
+  defp sync_release(scope, name, full_handle, tag) do
     lock_key = {:release, scope, name, KeyNormalizer.normalize_version(tag)}
 
     case Lock.try_acquire(lock_key, @lock_ttl_seconds) do

--- a/cache/lib/cache/registry/sync_worker.ex
+++ b/cache/lib/cache/registry/sync_worker.ex
@@ -7,6 +7,10 @@ defmodule Cache.Registry.SyncWorker do
   worker stays around so an operator can still trigger a one-shot
   cache-side sync via `Oban.insert(Cache.Registry.SyncWorker.new(%{}))`
   during the cutover window.
+
+  Writing is off unless `REGISTRY_SYNC_ENABLED` is set, so neither a
+  re-added cron nor a job left over in the queue can make cache a second
+  writer. Registry reads are gated separately by `registry_enabled?/0`.
   """
 
   use Oban.Worker, queue: :registry_sync
@@ -28,6 +32,15 @@ defmodule Cache.Registry.SyncWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
+    if Config.registry_sync_enabled?() do
+      perform_sync(args)
+    else
+      Logger.debug("Registry sync skipped: cache is not a registry writer")
+      :ok
+    end
+  end
+
+  defp perform_sync(args) do
     if Config.registry_enabled?() do
       case Lock.try_acquire(:sync, @sync_lock_ttl_seconds) do
         {:ok, :acquired} ->

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -22,8 +22,26 @@ defmodule Cache.Registry.ReleaseWorkerTest do
     stub(Config, :registry_github_token, fn -> "token" end)
     stub(Config, :registry_bucket, fn -> "test-bucket" end)
     stub(Config, :registry_enabled?, fn -> true end)
+    stub(Config, :registry_sync_enabled?, fn -> true end)
     stub(Lock, :release, fn _ -> :ok end)
     :ok
+  end
+
+  @tag capture_log: true
+  test "skips the release when the node is not a registry writer" do
+    stub(Config, :registry_sync_enabled?, fn -> false end)
+
+    stub(Lock, :try_acquire, fn _, _ -> flunk("unexpected lock acquisition") end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "1.0.0"
+               }
+             })
   end
 
   test "skips when release already exists" do

--- a/cache/test/cache/registry/sync_worker_test.exs
+++ b/cache/test/cache/registry/sync_worker_test.exs
@@ -24,6 +24,7 @@ defmodule Cache.Registry.SyncWorkerTest do
 
     stub(Config, :registry_bucket, fn -> "test-bucket" end)
     stub(Config, :registry_enabled?, fn -> true end)
+    stub(Config, :registry_sync_enabled?, fn -> true end)
     stub(Lock, :try_acquire, fn _, _ -> {:ok, :acquired} end)
     stub(SwiftPackageIndex, :list_packages, fn _ -> {:ok, []} end)
     stub(Lock, :release, fn _ -> :ok end)
@@ -202,6 +203,18 @@ defmodule Cache.Registry.SyncWorkerTest do
         "tag" => "0.0.24b"
       }
     )
+  end
+
+  @tag capture_log: true
+  test "skips sync when the node is not a registry writer" do
+    stub(Config, :registry_sync_enabled?, fn -> false end)
+
+    stub(SwiftPackageIndex, :list_packages, fn _ ->
+      flunk("unexpected package list fetch")
+    end)
+
+    assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
+    refute_enqueued(worker: ReleaseWorker)
   end
 
   @tag capture_log: true


### PR DESCRIPTION
> Stops the legacy cache nodes from writing to the Swift package registry, and moves that guard from a Kamal environment variable into code so a deploy cannot silently undo it.

### What changed

- Added `Cache.Config.registry_sync_enabled?/0`, backed by a new `REGISTRY_SYNC_ENABLED` environment variable that **defaults to false**.
- Gated `Cache.Registry.SyncWorker.perform/1` on it, so neither a re-added cron entry nor a manually inserted job makes cache a writer.
- Gated `Cache.Registry.ReleaseWorker.perform/1` on it too, so release jobs already sitting in the `registry_release` queue drain as no-ops instead of writing and erroring.
- Added a test per worker covering the disabled path.

The registry read path is untouched. Reads are gated separately by `Cache.Config.registry_enabled?/0`, which checks the bucket and the GitHub token, and production registry traffic still resolves to the legacy cache.

### Why

Scheduled registry writes moved to the server-owned `Tuist.Registry.Swift.SyncWorker`. Cache was meant to have stopped writing weeks ago. Today it started again, and Sentry filled with `Cache.Registry.ReleaseWorker failed with {:error, {:missing_manifests, ...}}` for packages like `alexeyxo/protobuf-swift` and `adjust/ios_sdk`.

Two writers against one bucket is the thing to avoid here. The immediate symptom is Sentry noise, but the real risk is the legacy writer disagreeing with the server writer on keys, since the deployed cache image predates PR #11136 and normalizes prerelease versions differently (rewriting `2.0.0-convergence.1` to `2.0.0-convergence+1`).

### Root cause

The disable was never expressed as a disable. There is no on/off switch for cache-side sync, so PR #11773 reused the package filter as a sentinel: `REGISTRY_SYNC_ALLOWLIST: tuist/__sync-disabled__`, a handle no package can match, which made `apply_allowlist/2` filter every package out.

That sentinel could not live in `main`. The `cache-deploy.yml` workflow triggers on any `cache/**` push and runs `kamal deploy`, a full image roll, so merging it would have shipped a five-week-stale image to production. PR #11773 therefore removed it from `main` and it was applied out of band with `kamal env push -d production`, existing only on the hosts and in a draft branch.

Then PR #12187 fixed the cache deploy workflow, and the run at 18:34Z on 2026-07-31 went green, the first successful cache deploy since 2026-06-03. `kamal deploy` pushes environment variables from the working tree's `deploy.production.yml`, which no longer contained the sentinel. The guard was wiped and the containers restarted.

One caveat worth stating plainly: `main` has no `SyncWorker` cron entry, since PR #11081 removed it. So the jobs running now are most likely pre-existing rows in the `registry_release` queue that the container restart released, rather than a fresh cron tick. I have not confirmed that against the hosts' Oban tables. The fix does not depend on which it is, because both workers are gated.

### Approach

The guard belongs in code, not in deploy configuration.

An environment variable in `deploy.production.yml` is exactly what just failed. It is invisible to code review, it does not survive being removed from `main`, and its correctness depends on an operator remembering to re-run `kamal env push` after every deploy. Defaulting the flag to false in `Cache.Config` inverts that: the safe state is the one you get by doing nothing, and turning cache back into a writer requires an explicit, greppable opt-in.

Gating `ReleaseWorker` as well as `SyncWorker` is deliberate. Gating only the scheduler would leave the already-enqueued release jobs, the ones currently in Sentry, free to run to completion. With both gated, the backlog completes as no-ops.

I did not re-add an explicit `REGISTRY_SYNC_ENABLED: "false"` to `deploy.production.yml`. It is redundant with the code default, and reintroducing a sentinel into `main` is the pattern PR #11773 was written to avoid.

### Impact

- Production cache nodes stop writing to the registry. The server-owned writer has been the healthy writer since PR #11779 landed on 2026-07-13.
- Canary also stops writing. It currently carries `REGISTRY_SYNC_ALLOWLIST: alamofire/alamofire` and has been dual-writing that one package. That key is now inert unless `REGISTRY_SYNC_ENABLED` is set. This is intentional and slightly beyond the immediate fix, since cache should not be a writer in any environment.
- The Sentry `Oban.PerformError` alerts on the `cache` project should stop once the queued release jobs drain.
- No change to registry reads, to any other cache queue, or to the cache API.

### Deploy note

Merging this touches `cache/**` and therefore triggers `cache-deploy.yml`, which now works again after PR #12187. That is the intended way to ship it. Worth being aware that the previously stale image is already rolled out as of the 18:34Z deploy, so this is a normal deploy rather than another five-week jump.

### How to test locally

```
cd cache
mix test test/cache/registry/sync_worker_test.exs test/cache/registry/release_worker_test.exs
```

The two new cases assert that each worker returns `:ok` without acquiring a lock, fetching the Swift Package Index catalog, or enqueueing anything when `registry_sync_enabled?/0` is false.

### Validation

I could not run the suite or the formatter in this worktree: `cache/deps` is not populated and `mix deps.get` was not run, so both `mix test` and `mix format` fail on missing dependencies. Verified by inspection instead:

- No line in the changed files exceeds the 120 character limit from `cache/.formatter.exs`; the two over-long lines in `release_worker.ex` are pre-existing and untouched.
- `Cache.Config` is already in `Mimic.copy` in `cache/test/test_helper.exs`, and both existing test setups now stub `registry_sync_enabled?` to true, so the existing cases keep exercising the enabled path.

CI should be the real check here.
