### PR TITLE
fix(registry): reject unextractable archives and stop repairs from breaking pins

### DIFF
--- a/server/lib/tuist/registry.ex
+++ b/server/lib/tuist/registry.ex
@@ -79,10 +79,24 @@ defmodule Tuist.Registry do
     end
   end
 
-  def force_resync_swift_package_version(repository_full_handle, version)
+  @doc """
+  Rebuilds a published version in place.
+
+  A rebuild that produces different bytes than the version already advertises
+  is refused, because it turns a working pin into a checksum mismatch for every
+  client that already resolved it. Pass `allow_checksum_change: true` to accept
+  that trade, which is the case for a version whose stored archive cannot be
+  extracted at all and so was never resolved successfully by anyone.
+  """
+  def force_resync_swift_package_version(repository_full_handle, version, opts \\ [])
       when is_binary(repository_full_handle) and is_binary(version) do
-    %{repository_full_handle: repository_full_handle, version: version, force: true}
-    |> SyncWorker.new(unique: [period: 60, keys: [:repository_full_handle, :version, :force]])
+    %{
+      repository_full_handle: repository_full_handle,
+      version: version,
+      force: true,
+      allow_checksum_change: Keyword.get(opts, :allow_checksum_change, false)
+    }
+    |> SyncWorker.new(unique: [period: 60, keys: [:repository_full_handle, :version, :force, :allow_checksum_change]])
     |> Oban.insert()
   end
 

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -37,6 +37,18 @@ defmodule Tuist.Registry.S3 do
     end
   end
 
+  def head_object(key) when is_binary(key) do
+    bucket = Registry.registry_bucket()
+
+    case bucket |> ExAws.S3.head_object(key) |> request() do
+      {:ok, %{status_code: 200, headers: headers}} -> {:ok, downcase_headers(headers)}
+      {:ok, %{status_code: 404}} -> {:error, :not_found}
+      {:ok, %{status_code: status}} -> {:error, {:s3_error, status}}
+      {:error, {:http_error, 404, _}} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   def upload_file(key, local_path, opts \\ []) when is_binary(key) and is_binary(local_path) do
     bucket = Registry.registry_bucket()
     content_type_opt = Keyword.get(opts, :content_type)
@@ -137,6 +149,14 @@ defmodule Tuist.Registry.S3 do
     headers
     |> Map.get("etag", Map.get(headers, "ETag"))
     |> normalize_etag()
+  end
+
+  defp downcase_headers(headers) when is_list(headers) do
+    Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)
+  end
+
+  defp downcase_headers(headers) when is_map(headers) do
+    Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)
   end
 
   defp normalize_etag(nil), do: nil

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -54,13 +54,15 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   ]
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"scope" => scope, "name" => name, "repository_full_handle" => full_handle, "tag" => tag}}) do
+  def perform(%Oban.Job{
+        args: %{"scope" => scope, "name" => name, "repository_full_handle" => full_handle, "tag" => tag} = args
+      }) do
     lock_key = {:release, scope, name, KeyNormalizer.normalize_version(tag)}
 
     case Lock.try_acquire(lock_key, @lock_ttl_seconds) do
       {:ok, :acquired} ->
         try do
-          do_sync_release(scope, name, full_handle, tag)
+          do_sync_release(scope, name, full_handle, tag, resync_opts(args))
         after
           Lock.release(lock_key)
         end
@@ -70,7 +72,15 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     end
   end
 
-  defp do_sync_release(scope, name, full_handle, tag) do
+  defp resync_opts(args) do
+    %{
+      force?: Map.get(args, "force", false),
+      allow_checksum_change?: Map.get(args, "allow_checksum_change", false),
+      published_checksum: nil
+    }
+  end
+
+  defp do_sync_release(scope, name, full_handle, tag, opts) do
     case Registry.swift_registry_github_token() do
       nil ->
         Logger.warning("Registry release sync skipped for #{scope}/#{name}@#{tag}: missing token")
@@ -84,30 +94,50 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             releases = Map.get(metadata, "releases", %{})
             skipped_releases = Map.get(metadata, "skipped_releases", %{})
 
-            if Map.has_key?(releases, normalized_version) or
-                 Metadata.verified_skip?(Map.get(skipped_releases, normalized_version)) do
+            if not opts.force? and
+                 (Map.has_key?(releases, normalized_version) or
+                    Metadata.verified_skip?(Map.get(skipped_releases, normalized_version))) do
               :ok
             else
-              sync_release(scope, name, full_handle, tag, normalized_version, token)
+              opts = %{opts | published_checksum: published_checksum(releases, normalized_version)}
+              sync_release(scope, name, full_handle, tag, normalized_version, token, opts)
             end
 
           {:error, :not_found} ->
-            sync_release(scope, name, full_handle, tag, normalized_version, token)
+            sync_release(scope, name, full_handle, tag, normalized_version, token, opts)
         end
     end
   end
 
-  defp sync_release(scope, name, full_handle, tag, version, token) do
+  defp published_checksum(releases, version) do
+    case Map.get(releases, version) do
+      %{"checksum" => checksum} when is_binary(checksum) -> checksum
+      _release -> nil
+    end
+  end
+
+  defp sync_release(scope, name, full_handle, tag, version, token, opts) do
     {:ok, tmp_dir} = Briefly.create(directory: true)
     archive_path = Path.join(tmp_dir, "source_archive.zip")
 
     with {:ok, manifest_payloads} <- fetch_manifests(full_handle, tag, token),
          :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
+         :ok <- verify_archive_extractable(archive_path),
          {:ok, checksum} <- checksum_for_file(archive_path),
-         :ok <- upload_source_archive(scope, name, version, archive_path),
+         :ok <- ensure_checksum_change_allowed(scope, name, version, checksum, opts),
+         :ok <- upload_source_archive(scope, name, version, archive_path, checksum),
+         :ok <- verify_stored_archive(scope, name, version, checksum),
          {:ok, manifests} <- upload_manifests(scope, name, version, manifest_payloads) do
       update_metadata_with_release(scope, name, full_handle, version, checksum, manifests)
     else
+      {:error, {:checksum_change_refused, details} = reason} ->
+        Logger.warning(
+          "Refusing to republish #{scope}/#{name}@#{version}: rebuilding produced #{details.rebuilt} " <>
+            "but #{details.published} is already published. Re-run with allow_checksum_change to override."
+        )
+
+        {:discard, reason}
+
       {:error, reason} ->
         case maybe_skip_release(scope, name, full_handle, version, reason) do
           :ok ->
@@ -672,22 +702,104 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   end
 
   defp archive_has_symlinks?(archive_path) do
+    with {:ok, entries} <- archive_entries(archive_path) do
+      {:ok, Enum.any?(entries, &String.starts_with?(&1.permissions, "l"))}
+    end
+  end
+
+  # `zipinfo` lines are `<permissions> <version> <os> <size> <bx> <method>
+  # <date> <time> <name>`. The name is captured as the remainder rather than a
+  # field because entry names contain spaces, and the permission column is
+  # length-bounded so the listing's header and summary lines do not match.
+  @zipinfo_entry_regex ~r/^([drwxlstST?bcp-]{7,10})\s+\S+\s+\S+\s+\d+\s+\S+\s+\S+\s+\S+\s+\S+\s+(.+)$/
+
+  defp archive_entries(archive_path) do
     case System.cmd("unzip", ["-Z", archive_path], stderr_to_stdout: true) do
       {output, 0} ->
-        has_symlinks =
+        entries =
           output
           |> String.split("\n")
-          |> Enum.any?(&String.starts_with?(&1, "l"))
+          |> Enum.map(&Regex.run(@zipinfo_entry_regex, &1, capture: :all_but_first))
+          |> Enum.reject(&is_nil/1)
+          |> Enum.map(fn [permissions, name] -> %{permissions: permissions, name: name} end)
 
-        {:ok, has_symlinks}
+        {:ok, entries}
 
       {output, status} ->
         {:error, {:invalid_archive, status, output}}
     end
   end
 
-  defp upload_source_archive(scope, name, version, archive_path) do
-    S3.upload_file(source_archive_key(scope, name, version), archive_path, content_type: "application/zip")
+  # A stored directory entry whose recorded mode has no owner-execute bit
+  # extracts into a directory nobody can descend into, so SwiftPM fails with a
+  # permission error on an archive that is otherwise well-formed and whose
+  # checksum matches its metadata. Entries written by non-Unix hosts carry no
+  # mode at all and extractors apply their own defaults, which is why this
+  # reads the permission column rather than the raw external attributes.
+  defp verify_archive_extractable(archive_path) do
+    with {:ok, entries} <- archive_entries(archive_path) do
+      case Enum.filter(entries, &unreadable_directory?/1) do
+        [] ->
+          :ok
+
+        unreadable ->
+          {:error,
+           {:archive_directories_not_traversable, length(unreadable), unreadable |> Enum.take(3) |> Enum.map(& &1.name)}}
+      end
+    end
+  end
+
+  defp unreadable_directory?(%{name: name, permissions: permissions}) do
+    String.ends_with?(name, "/") and String.at(permissions, 3) != "x"
+  end
+
+  # Republishing a version with different bytes turns a working pin into
+  # `invalid registry source archive checksum` for every client that already
+  # resolved it, and a precautionary resync is otherwise indistinguishable
+  # from a repair. A resync that would change an already-published checksum
+  # stops here unless the operator asked for that explicitly.
+  defp ensure_checksum_change_allowed(_scope, _name, _version, _checksum, %{allow_checksum_change?: true}), do: :ok
+
+  defp ensure_checksum_change_allowed(scope, name, version, checksum, opts) do
+    case opts.published_checksum do
+      nil ->
+        :ok
+
+      ^checksum ->
+        :ok
+
+      published ->
+        {:error,
+         {:checksum_change_refused,
+          %{scope: scope, name: name, version: version, published: published, rebuilt: checksum}}}
+    end
+  end
+
+  defp upload_source_archive(scope, name, version, archive_path, checksum) do
+    S3.upload_file(source_archive_key(scope, name, version), archive_path,
+      content_type: "application/zip",
+      meta: [{"sha256", checksum}]
+    )
+  end
+
+  # The archive upload runs through the multipart path, whose sub-operations do
+  # not carry the storage consistency header the shared request helper adds to
+  # single requests. Confirming the stored object records the digest we just
+  # uploaded, before the catalog is updated, keeps a catalog entry from
+  # advertising a checksum that object storage does not actually hold.
+  defp verify_stored_archive(scope, name, version, checksum) do
+    key = source_archive_key(scope, name, version)
+
+    case S3.head_object(key) do
+      {:ok, headers} ->
+        case Map.get(headers, "x-amz-meta-sha256") do
+          ^checksum -> :ok
+          stored -> {:error, {:stored_archive_mismatch, key, %{expected: checksum, stored: stored}}}
+        end
+
+      {:error, reason} ->
+        {:error, {:stored_archive_unverifiable, key, reason}}
+    end
   end
 
   defp source_archive_key(scope, name, version) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -122,7 +122,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
     with {:ok, manifest_payloads} <- fetch_manifests(full_handle, tag, token),
          :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
-         :ok <- verify_archive_extractable(archive_path),
          {:ok, checksum} <- checksum_for_file(archive_path),
          :ok <- ensure_checksum_change_allowed(scope, name, version, checksum, opts),
          :ok <- upload_source_archive(scope, name, version, archive_path, checksum),
@@ -176,8 +175,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   end
 
   defp build_archive_from_clone(full_handle, tag, token, tmp_dir, archive_path) do
-    with {:ok, source_directory} <- clone_with_submodules(full_handle, tag, token, tmp_dir) do
-      zip_directory(source_directory, archive_path)
+    with {:ok, source_directory} <- clone_with_submodules(full_handle, tag, token, tmp_dir),
+         :ok <- zip_directory(source_directory, archive_path) do
+      verify_archive_directories(archive_path)
     end
   end
 
@@ -198,17 +198,15 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   # packages that contain them (e.g. CLAUDE.md -> AGENTS.md symlinks).
   # This workaround resolves symlinks by repacking the archive before upload.
   # Upstream fix: https://github.com/swiftlang/swift-package-manager/pull/9411
+  # A single listing answers both questions asked of a downloaded archive, so
+  # the archive it passes through untouched is inspected exactly once. An
+  # archive whose directories are already unreadable is rejected rather than
+  # repacked: extracting it lays the same modes down on disk and `zip` records
+  # them again, so repacking cannot repair it.
   defp normalize_archive(tmp_dir, archive_path) do
-    case archive_has_symlinks?(archive_path) do
-      {:ok, has_symlinks} ->
-        if has_symlinks do
-          repackage_archive(tmp_dir, archive_path)
-        else
-          :ok
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, listing} <- inspect_archive(archive_path),
+         :ok <- reject_unreadable_directories(listing) do
+      if listing.symlinks?, do: repackage_archive(tmp_dir, archive_path), else: :ok
     end
   end
 
@@ -563,8 +561,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     with :ok <- ensure_extract_directory(extract_dir),
          :ok <- unzip_archive(archive_path, extract_dir),
          {:ok, top_level_directory} <- extract_archive_root_directory(extract_dir),
-         :ok <- remove_archive(archive_path) do
-      zip_directory(top_level_directory, archive_path)
+         :ok <- remove_archive(archive_path),
+         :ok <- zip_directory(top_level_directory, archive_path) do
+      verify_archive_directories(archive_path)
     end
   end
 
@@ -701,56 +700,62 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     path == root_directory or String.starts_with?(path, root_directory <> "/")
   end
 
-  defp archive_has_symlinks?(archive_path) do
-    with {:ok, entries} <- archive_entries(archive_path) do
-      {:ok, Enum.any?(entries, &String.starts_with?(&1.permissions, "l"))}
-    end
-  end
-
-  # `zipinfo` lines are `<permissions> <version> <os> <size> <bx> <method>
-  # <date> <time> <name>`. The name is captured as the remainder rather than a
-  # field because entry names contain spaces, and the permission column is
-  # length-bounded so the listing's header and summary lines do not match.
-  @zipinfo_entry_regex ~r/^([drwxlstST?bcp-]{7,10})\s+\S+\s+\S+\s+\d+\s+\S+\s+\S+\s+\S+\s+\S+\s+(.+)$/
-
-  defp archive_entries(archive_path) do
+  # Walks the `zipinfo` listing lazily and keeps only the tallies, because a
+  # large package carries tens of thousands of entries and none of them are
+  # needed once counted.
+  defp inspect_archive(archive_path) do
     case System.cmd("unzip", ["-Z", archive_path], stderr_to_stdout: true) do
       {output, 0} ->
-        entries =
-          output
-          |> String.split("\n")
-          |> Enum.map(&Regex.run(@zipinfo_entry_regex, &1, capture: :all_but_first))
-          |> Enum.reject(&is_nil/1)
-          |> Enum.map(fn [permissions, name] -> %{permissions: permissions, name: name} end)
-
-        {:ok, entries}
+        {:ok,
+         output
+         |> String.splitter("\n")
+         |> Enum.reduce(%{symlinks?: false, unreadable_directories: 0, first_unreadable: nil}, &tally_entry/2)}
 
       {output, status} ->
         {:error, {:invalid_archive, status, output}}
     end
   end
 
-  # A stored directory entry whose recorded mode has no owner-execute bit
-  # extracts into a directory nobody can descend into, so SwiftPM fails with a
-  # permission error on an archive that is otherwise well-formed and whose
-  # checksum matches its metadata. Entries written by non-Unix hosts carry no
-  # mode at all and extractors apply their own defaults, which is why this
-  # reads the permission column rather than the raw external attributes.
-  defp verify_archive_extractable(archive_path) do
-    with {:ok, entries} <- archive_entries(archive_path) do
-      case Enum.filter(entries, &unreadable_directory?/1) do
-        [] ->
-          :ok
+  defp tally_entry("l" <> _rest, tally), do: %{tally | symlinks?: true}
 
-        unreadable ->
-          {:error,
-           {:archive_directories_not_traversable, length(unreadable), unreadable |> Enum.take(3) |> Enum.map(& &1.name)}}
-      end
+  defp tally_entry(line, tally) do
+    if unreadable_directory_line?(line) do
+      %{
+        tally
+        | unreadable_directories: tally.unreadable_directories + 1,
+          first_unreadable: tally.first_unreadable || String.trim(line)
+      }
+    else
+      tally
     end
   end
 
-  defp unreadable_directory?(%{name: name, permissions: permissions}) do
-    String.ends_with?(name, "/") and String.at(permissions, 3) != "x"
+  # A stored directory entry whose recorded mode has no owner-execute bit
+  # extracts into a directory nobody can descend into, so SwiftPM fails with a
+  # permission error on an archive that is otherwise well-formed and whose
+  # checksum matches its metadata. `zipinfo` renders a healthy directory as
+  # `drwxr-xr-x` and the entry this rejects as `?rw-r--r--`, so the
+  # owner-execute column is the whole test and the trailing slash is what
+  # marks a directory. Entries written by non-Unix hosts carry no mode at all
+  # and extractors apply their own defaults, which is why this reads the
+  # rendered permissions rather than the raw external attributes.
+  defp unreadable_directory_line?(line) do
+    String.ends_with?(line, "/") and not traversable_directory?(line)
+  end
+
+  defp traversable_directory?(<<_type, _read, _write, ?x, _rest::binary>>), do: true
+  defp traversable_directory?(_line), do: false
+
+  defp verify_archive_directories(archive_path) do
+    with {:ok, listing} <- inspect_archive(archive_path) do
+      reject_unreadable_directories(listing)
+    end
+  end
+
+  defp reject_unreadable_directories(%{unreadable_directories: 0}), do: :ok
+
+  defp reject_unreadable_directories(listing) do
+    {:error, {:archive_directories_not_traversable, listing.unreadable_directories, listing.first_unreadable}}
   end
 
   # Republishing a version with different bytes turns a working pin into

--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -13,7 +13,6 @@ defmodule Tuist.Registry.Swift.SyncWorker do
   alias Tuist.Registry
   alias Tuist.Registry.Swift.Lock
   alias Tuist.Registry.Swift.Metadata
-  alias Tuist.Registry.Swift.Purge
   alias Tuist.Registry.Swift.ReleaseWorker
   alias Tuist.Registry.Swift.SwiftPackageIndex
   alias Tuist.Registry.Swift.SyncCursor
@@ -25,7 +24,6 @@ defmodule Tuist.Registry.Swift.SyncWorker do
 
   @sync_lock_ttl_seconds 3_000
   @package_lock_ttl_seconds 900
-  @release_lock_ttl_seconds 1_800
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -43,8 +41,12 @@ defmodule Tuist.Registry.Swift.SyncWorker do
     end
   end
 
-  defp perform_sync(%{"force" => true, "repository_full_handle" => repository_full_handle, "version" => version}, token) do
-    force_resync_package_version_for_handle(repository_full_handle, version, token)
+  defp perform_sync(
+         %{"force" => true, "repository_full_handle" => repository_full_handle, "version" => version} = args,
+         token
+       ) do
+    resync_flags = [force: true, allow_checksum_change: Map.get(args, "allow_checksum_change", false)]
+    force_resync_package_version_for_handle(repository_full_handle, version, resync_flags, token)
   end
 
   defp perform_sync(args, token) do
@@ -86,7 +88,7 @@ defmodule Tuist.Registry.Swift.SyncWorker do
     end
   end
 
-  defp force_resync_package_version_for_handle(repository_full_handle, version, token) do
+  defp force_resync_package_version_for_handle(repository_full_handle, version, resync_flags, token) do
     normalized_version = KeyNormalizer.normalize_version(version)
 
     if KeyNormalizer.valid_storage_version?(normalized_version) do
@@ -103,7 +105,7 @@ defmodule Tuist.Registry.Swift.SyncWorker do
               {:discard, :package_not_found}
 
             package ->
-              force_resync_package_version(package, normalized_version, token)
+              force_resync_package_version(package, normalized_version, resync_flags, token)
           end
 
         {:discard, _reason} = discard ->
@@ -172,8 +174,13 @@ defmodule Tuist.Registry.Swift.SyncWorker do
     end
   end
 
-  defp force_resync_package_version(%{scope: scope, name: name, repository_full_handle: full_handle}, version, token) do
-    do_force_resync_package_version(scope, name, full_handle, version, token)
+  defp force_resync_package_version(
+         %{scope: scope, name: name, repository_full_handle: full_handle},
+         version,
+         resync_flags,
+         token
+       ) do
+    do_force_resync_package_version(scope, name, full_handle, version, resync_flags, token)
   end
 
   defp do_sync_package(scope, name, full_handle, token) do
@@ -193,7 +200,12 @@ defmodule Tuist.Registry.Swift.SyncWorker do
     end
   end
 
-  defp do_force_resync_package_version(scope, name, full_handle, version, token) do
+  # The rebuilt archive replaces the stored one and the catalog entry is
+  # rewritten in place, so nothing is purged first. Deleting the artifact and
+  # dropping the release ahead of the rebuild made the version resolve as "not
+  # found" for the length of the repair, and left it permanently missing when
+  # the rebuild then failed.
+  defp do_force_resync_package_version(scope, name, full_handle, version, resync_flags, token) do
     case TuistCommon.GitHub.list_tags(full_handle, token, @github_opts) do
       {:ok, tags} ->
         case source_tag_for_version(tags, version) do
@@ -203,47 +215,13 @@ defmodule Tuist.Registry.Swift.SyncWorker do
             {:discard, :version_not_found}
 
           tag ->
-            with {:ok, _result} <- purge_package_version(scope, name, version) do
-              enqueue_release_worker(scope, name, full_handle, tag)
-            end
+            enqueue_release_worker(scope, name, full_handle, tag, resync_flags)
         end
 
       {:error, reason} ->
         Logger.warning("Failed to fetch tags before force resyncing #{scope}/#{name}@#{version}: #{inspect(reason)}")
 
         {:error, reason}
-    end
-  end
-
-  defp purge_package_version(scope, name, version) do
-    lock_key = {:release, scope, name, version}
-
-    case Lock.try_acquire(lock_key, @release_lock_ttl_seconds) do
-      {:ok, :acquired} ->
-        try do
-          purge_package_version_with_package_lock(scope, name, version)
-        after
-          Lock.release(lock_key)
-        end
-
-      {:error, :already_locked} ->
-        {:snooze, 30}
-    end
-  end
-
-  defp purge_package_version_with_package_lock(scope, name, version) do
-    lock_key = {:package, scope, name}
-
-    case Lock.try_acquire(lock_key, @package_lock_ttl_seconds) do
-      {:ok, :acquired} ->
-        try do
-          Purge.purge_version(scope, name, version)
-        after
-          Lock.release(lock_key)
-        end
-
-      {:error, :already_locked} ->
-        {:snooze, 30}
     end
   end
 
@@ -290,10 +268,14 @@ defmodule Tuist.Registry.Swift.SyncWorker do
     end)
   end
 
-  defp enqueue_release_worker(scope, name, full_handle, tag) do
-    case %{scope: scope, name: name, repository_full_handle: full_handle, tag: tag}
-         |> ReleaseWorker.new()
-         |> Oban.insert() do
+  defp enqueue_release_worker(scope, name, full_handle, tag, resync_flags \\ []) do
+    args =
+      Enum.reduce(resync_flags, %{scope: scope, name: name, repository_full_handle: full_handle, tag: tag}, fn
+        {_flag, false}, args -> args
+        {flag, value}, args -> Map.put(args, flag, value)
+      end)
+
+    case args |> ReleaseWorker.new() |> Oban.insert() do
       {:ok, _job} -> :ok
       {:error, _reason} = error -> error
     end

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -497,7 +497,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     reject(ExAws.S3, :upload, 4)
     reject(Metadata, :put_package, 3)
 
-    assert {:error, {:archive_directories_not_traversable, 1, ["repo-v1.0.0/"]}} =
+    assert {:error, {:archive_directories_not_traversable, 1, sample}} =
              ReleaseWorker.perform(%Oban.Job{
                args: %{
                  "scope" => "apple",
@@ -506,6 +506,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
                  "tag" => "v1.0.0"
                }
              })
+
+    assert sample =~ "repo-v1.0.0/"
   end
 
   test "refuses to republish a version whose bytes differ from the published checksum" do

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -79,20 +79,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       :ok
     end)
 
-    expect(Upload, :stream_file, fn path ->
-      assert File.exists?(path)
-      [File.read!(path)]
-    end)
-
-    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
-      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-      %S3{http_method: :put, bucket: "test-bucket", path: key}
-    end)
-
-    expect(ExAws, :request, 2, fn _op, config ->
-      assert config == [host: "registry.example.com"]
-      {:ok, %{status_code: 200, body: ""}}
-    end)
+    stub_archive_upload(3)
 
     expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
       {:ok, :acquired}
@@ -155,15 +142,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       :ok
     end)
 
-    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
-
-    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
-      %S3{http_method: :put, bucket: "test-bucket", path: key}
-    end)
-
-    expect(ExAws, :request, 2, fn _operation, _config ->
-      {:ok, %{status_code: 200, body: ""}}
-    end)
+    stub_archive_upload(3)
 
     stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected metadata write while the lock is contended") end)
 
@@ -323,15 +302,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       :ok
     end)
 
-    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
-
-    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
-      %S3{http_method: :put, bucket: "test-bucket", path: key}
-    end)
-
-    expect(ExAws, :request, 2, fn _operation, _config ->
-      {:ok, %{status_code: 200, body: ""}}
-    end)
+    stub_archive_upload(3)
 
     expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
       assert is_binary(metadata["releases"]["1.0.0"]["checksum"])
@@ -388,19 +359,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       :ok
     end)
 
-    expect(Upload, :stream_file, fn path ->
-      assert File.exists?(path)
-      [File.read!(path)]
-    end)
-
-    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
-      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
-      %S3{http_method: :put, bucket: "test-bucket", path: key}
-    end)
-
-    expect(ExAws, :request, 4, fn _op, _config ->
-      {:ok, %{status_code: 200, body: ""}}
-    end)
+    stub_archive_upload(5)
 
     expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
       {:ok, :acquired}
@@ -507,6 +466,206 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
       assert {:ok, %File.Stat{type: :regular}} =
                File.lstat(Path.join([extract_dir, "repo-v1.0.0", "Widget.framework"]))
     end
+  end
+
+  test "refuses an archive whose directory entries would not be traversable after extraction" do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser", "token", "v1.0.0", archive_path, _ ->
+      write_unreadable_directory_zipball(archive_path)
+      :ok
+    end)
+
+    reject(ExAws.S3, :upload, 4)
+    reject(Metadata, :put_package, 3)
+
+    assert {:error, {:archive_directories_not_traversable, 1, ["repo-v1.0.0/"]}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "refuses to republish a version whose bytes differ from the published checksum" do
+    stub_successful_fetch()
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:ok, %{"releases" => %{"1.0.0" => %{"checksum" => "already-published", "manifests" => []}}}}
+    end)
+
+    reject(ExAws.S3, :upload, 4)
+    reject(Metadata, :put_package, 3)
+
+    assert {:discard, {:checksum_change_refused, %{published: "already-published", rebuilt: rebuilt}}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0",
+                 "force" => true
+               }
+             })
+
+    assert is_binary(rebuilt)
+  end
+
+  test "republishes a version with different bytes when the override is set" do
+    stub_successful_fetch()
+
+    stub(Metadata, :get_package, fn "apple", "swift-argument-parser", _opts ->
+      {:ok, %{"releases" => %{"1.0.0" => %{"checksum" => "already-published", "manifests" => []}}}}
+    end)
+
+    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired} end)
+    stub_archive_upload(3)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      refute metadata["releases"]["1.0.0"]["checksum"] == "already-published"
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0",
+                 "force" => true,
+                 "allow_checksum_change" => true
+               }
+             })
+  end
+
+  test "leaves the catalog alone when storage does not hold the archive that was uploaded" do
+    stub_successful_fetch()
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    # Storage still holds a different object than the one just uploaded, which
+    # is what leaves a catalog entry advertising a checksum nothing can serve.
+    expect(ExAws, :request, 2, fn
+      %S3{http_method: :head}, _config ->
+        {:ok, %{status_code: 200, headers: [{"x-amz-meta-sha256", "a-previously-stored-archive"}]}}
+
+      _operation, _config ->
+        {:ok, %{status_code: 200, body: ""}}
+    end)
+
+    reject(Metadata, :put_package, 3)
+
+    assert {:error, {:stored_archive_mismatch, _key, %{stored: "a-previously-stored-archive"}}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  defp stub_successful_fetch do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser", "token", "v1.0.0", archive_path, _ ->
+      write_basic_zipball(archive_path)
+      :ok
+    end)
+  end
+
+  # Reproduces the shape the pre-2025 writer produced: entries written by
+  # Erlang's :zip carry a bare 0644 mode with no directory type bits, so the
+  # extracted package root has no execute bit and cannot be descended into.
+  defp write_unreadable_directory_zipball(archive_path) do
+    {:ok, _path} =
+      :zip.create(String.to_charlist(archive_path), [
+        {~c"repo-v1.0.0/", <<>>},
+        {~c"repo-v1.0.0/Package.swift", @default_manifest_content}
+      ])
+
+    :ok
+  end
+
+  # The release worker reads the stored object's digest back before it touches
+  # the catalog, so the upload and the HEAD share one agent rather than a fixed
+  # value the test would have to know in advance.
+  defp stub_archive_upload(request_count) do
+    {:ok, uploaded_digest} = Agent.start_link(fn -> nil end)
+
+    expect(Upload, :stream_file, fn path ->
+      assert File.exists?(path)
+      Agent.update(uploaded_digest, fn _previous -> sha256(path) end)
+      [File.read!(path)]
+    end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    expect(ExAws, :request, request_count, fn
+      %S3{http_method: :head}, config ->
+        assert config == [host: "registry.example.com"]
+        {:ok, %{status_code: 200, headers: [{"x-amz-meta-sha256", Agent.get(uploaded_digest, & &1)}]}}
+
+      _operation, config ->
+        assert config == [host: "registry.example.com"]
+        {:ok, %{status_code: 200, body: ""}}
+    end)
+  end
+
+  defp sha256(path) do
+    path
+    |> File.stream!(2048)
+    |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+    |> :crypto.hash_final()
+    |> Base.encode16(case: :lower)
   end
 
   defp write_basic_zipball(archive_path) do

--- a/server/test/tuist/registry/swift/sync_worker_test.exs
+++ b/server/test/tuist/registry/swift/sync_worker_test.exs
@@ -67,6 +67,10 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
         "tag" => "v1.2.3"
       }
     )
+
+    # A catalog pass enqueues only versions the catalog is missing, so it never
+    # asks the release worker to rebuild one that is already published.
+    refute_enqueued(worker: ReleaseWorker, args: %{"force" => true})
   end
 
   test "does not enqueue versions with a verified skip classification" do
@@ -224,7 +228,7 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
     assert {:discard, {:rate_limited, 403}} = SyncWorker.perform(%Oban.Job{args: %{}})
   end
 
-  test "force resyncs only the requested package version without taking the catalog lock" do
+  test "force resyncs the requested version in place, without purging it first" do
     package = %{
       scope: "apple",
       name: "swift-argument-parser",
@@ -233,23 +237,15 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
 
     expect(SwiftPackageIndex, :list_packages, fn "token" -> {:ok, [package]} end)
 
-    expect(Lock, :try_acquire, 2, fn
-      {:release, "apple", "swift-argument-parser", "1.2.3"}, _ -> {:ok, :acquired}
-      {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired}
-    end)
-
-    expect(Lock, :release, 2, fn
-      {:release, "apple", "swift-argument-parser", "1.2.3"} -> :ok
-      {:package, "apple", "swift-argument-parser"} -> :ok
-    end)
-
     expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-argument-parser", "token", _ ->
       {:ok, ["v1.2.3", "2.0.0"]}
     end)
 
-    expect(Purge, :purge_version, fn "apple", "swift-argument-parser", "1.2.3" ->
-      {:ok, %{artifacts_deleted: 1, metadata: %{removed_from: ["releases"]}}}
-    end)
+    # The rebuild replaces the archive and rewrites the catalog entry in place,
+    # so the version keeps resolving for the whole repair instead of going
+    # missing between the purge and a rebuild that may never land.
+    reject(Purge, :purge_version, 3)
+    reject(Lock, :try_acquire, 2)
 
     assert :ok =
              SyncWorker.perform(%Oban.Job{
@@ -266,9 +262,12 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
         "scope" => "apple",
         "name" => "swift-argument-parser",
         "repository_full_handle" => "apple/swift-argument-parser",
-        "tag" => "v1.2.3"
+        "tag" => "v1.2.3",
+        "force" => true
       }
     )
+
+    refute_enqueued(worker: ReleaseWorker, args: %{"allow_checksum_change" => true})
 
     refute_enqueued(
       worker: ReleaseWorker,
@@ -372,7 +371,7 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
     refute_enqueued(worker: ReleaseWorker)
   end
 
-  test "snoozes a version resync while the package is locked" do
+  test "carries an explicit checksum-change override through to the release worker" do
     package = %{
       scope: "apple",
       name: "swift-argument-parser",
@@ -385,52 +384,21 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
       {:ok, ["1.2.3"]}
     end)
 
-    expect(Lock, :try_acquire, 2, fn
-      {:release, "apple", "swift-argument-parser", "1.2.3"}, _ -> {:ok, :acquired}
-      {:package, "apple", "swift-argument-parser"}, _ -> {:error, :already_locked}
-    end)
-
-    expect(Lock, :release, fn {:release, "apple", "swift-argument-parser", "1.2.3"} -> :ok end)
     reject(Purge, :purge_version, 3)
 
-    assert {:snooze, 30} =
+    assert :ok =
              SyncWorker.perform(%Oban.Job{
                args: %{
                  "force" => true,
-                 "repository_full_handle" => "apple/swift-argument-parser",
-                 "version" => "1.2.3"
-               }
-             })
-  end
-
-  test "snoozes a version resync while the release is being synced" do
-    package = %{
-      scope: "apple",
-      name: "swift-argument-parser",
-      repository_full_handle: "apple/swift-argument-parser"
-    }
-
-    expect(SwiftPackageIndex, :list_packages, fn "token" -> {:ok, [package]} end)
-
-    expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-argument-parser", "token", _ ->
-      {:ok, ["1.2.3"]}
-    end)
-
-    expect(Lock, :try_acquire, fn
-      {:release, "apple", "swift-argument-parser", "1.2.3"}, _ -> {:error, :already_locked}
-    end)
-
-    reject(Purge, :purge_version, 3)
-
-    assert {:snooze, 30} =
-             SyncWorker.perform(%Oban.Job{
-               args: %{
-                 "force" => true,
+                 "allow_checksum_change" => true,
                  "repository_full_handle" => "apple/swift-argument-parser",
                  "version" => "1.2.3"
                }
              })
 
-    refute_enqueued(worker: ReleaseWorker)
+    assert_enqueued(
+      worker: ReleaseWorker,
+      args: %{"tag" => "1.2.3", "force" => true, "allow_checksum_change" => true}
+    )
   end
 end


### PR DESCRIPTION
Relates to #12191.

## What happened

A customer reported `auth0.Auth0_swift@2.10.0` failing to resolve. The archive downloads fine and its sha256 matches the checksum in registry metadata — it fails during *extraction*:

```
error: 'auth0.Auth0_swift': failed downloading auth0.Auth0_swift version 2.10.0 source archive:
failed extracting …: Error Domain=NSCocoaErrorDomain Code=257 "The file "<UUID>" couldn't be
opened because you don't have permission to view it." … NSPOSIXErrorDomain Code=13
```

Every entry in that archive, **including directory entries**, has external attributes `0x01a40000` — mode `0644` with the `S_IF*` type bits dropped. Extraction creates the package root as `drw-r--r--`, so nothing can descend into it. `unzip -Zv` shows `version made by 6.1`, host Unix, and directory lines rendering as `?rw-r--r--` instead of `drwxr-xr-x`.

That is Erlang's `:zip`, and the shape reproduces exactly by running `:zip.extract` followed by `:zip.create` on a GitHub zipball — Erlang does not carry Unix permissions across from a FAT-host zipball, so directories land on disk without the execute bit and `:zip.create` records that mode. It is a legacy format; none of the three current paths (zipball passthrough, `unzip` + `zip -r -y` repack, clone + `zip -r -y`) can produce it, and all three were verified to produce correct directory modes.

Investigating how it reached users surfaced three further ways the sync path can publish or repair a version badly. This PR fixes the class rather than the instance; the census of affected versions is in #12191 and the repair that acts on it is in #12194.

## What changed

**Reject an archive at write time when a stored directory entry would not be traversable after extraction.** `sync_release` checksummed and uploaded whatever it built with no gate asserting the artifact was usable, which is why this shape shipped silently and was found only from a customer report. The check reuses the `unzip -Z` listing already parsed for symlink detection, so it adds no work. Entries from non-Unix hosts carry no mode at all and extractors apply their own defaults, so the check reads the permission column rather than the raw external attributes.

**Verify the stored object before the catalog is updated.** The archive now uploads with its digest as object metadata and is read back with a HEAD; a mismatch fails the job. A force resync was observed completing successfully while leaving the catalog advertising a checksum object storage did not hold — which converts a recoverable state into `invalid registry source archive checksum` for every client. Worth noting for review: `Tuist.Registry.S3.request/1` has a separate clause for `%ExAws.S3.Upload{}` that skips the Tigris consistency header, and the multipart sub-operations go through ExAws directly rather than the shared helper, so archive writes are not covered by the guarantee #12166 closed for single requests. Verifying the write is the provider-agnostic guard; the header bypass is called out in #12191 as a separate question.

**Make force resync non-destructive.** It purged the artifact and dropped the release from the catalog *before* rebuilding, so the version resolved as "not found" for the duration of the repair and stayed missing when the rebuild failed. The rebuild now replaces the archive and rewrites the catalog entry in place. The `force` flag rides on the release job instead of being simulated by deleting the catalog entry to defeat the already-published check, which is what required the purge in the first place.

**Refuse a resync that would change an already-published checksum unless explicitly allowed.** Republishing different bytes turns a working pin into a checksum mismatch for every client that already resolved that version, and a precautionary resync is otherwise indistinguishable from a repair. The guard fires only when a version already has a published checksum *and* the rebuild differs, so repairing a version missing from the catalog is unaffected. `Tuist.Registry.force_resync_swift_package_version/3` takes `allow_checksum_change: true` for the case where the stored archive cannot be extracted at all — nobody ever resolved it successfully, so regenerating it breaks no pins. The flag is part of the Oban uniqueness key, otherwise a refused resync would swallow the follow-up override inside the 60s window.

## Why this shape

Blocking regeneration by default is the postmortem's P0 #4 ("treat a published `(package, version, checksum)` as immutable") with the qualifier this incident showed it needs. Restoring bytes is the right default, but it needs an integrity precondition: an artifact that cannot be extracted was never really published, and immutability should not protect it.

No UI affordance for the override — an operator action that knowingly breaks pins should not be one click, and consoles are already how `Purge` is used. Easy to add if reviewers disagree.

## Impact

- Archives with unextractable directory entries can no longer be published.
- A catalog entry can no longer advertise a checksum object storage does not hold.
- A repair no longer makes a version unresolvable while it runs, or permanently if it fails.
- A precautionary resync no longer silently breaks pins; it fails loudly and names the override.

No behaviour change for the steady-state catalog pass, which only enqueues versions the catalog is missing and therefore never trips the guard.

## Validation

- `mix test test/tuist/registry/` — 46 passing, including new regression tests for each behaviour. The unextractable-archive fixture is built with `:zip.create/2`, which reproduces the production shape exactly (`?rw-r--r--` directory entry, `made by 6.1`).
- `mix credo` clean, `mix format --check-formatted` clean.
- Full server suite: 6323/6327. The 4 failures are pre-existing and unrelated — they request non-English routes such as `/ko/customers/...` that only exist when `TUIST_DEV_ALL_LOCALES=1` compiles the full locale set, and they lack the `:locale` tag that would exclude them locally.
- Reproduced the original failure end to end against production with stock Apple SwiftPM 6.2.4 before the change, and confirmed the built fixture triggers the new gate.

## What a full census confirmed

The measurements in this PR's description originally came from sampling. A complete inventory has since been taken — every archive in storage, every catalog document, the full legacy baseline, and an extraction verdict for every archive (#12191). It confirms the fixes here and sizes what they prevent.

**The traversability gate does not false-positive.** This was the biggest risk in the change: rejecting legitimate archives at write time would halt all syncing. Verified against every rendering that occurs in the corpus:

| Rendering | Producer | Result |
| --- | --- | --- |
| `drwx---` | FAT host, GitHub zipball | passes |
| `drwxr-xr-x` | Unix host, Info-ZIP | passes |
| `?rwxr-xr-x` | Unix host, Erlang `:zip` | passes |
| `drw-r--r--` | the defect | rejected |

Reading the permission column rather than the raw external attributes is what makes this correct. A parser written against the raw bytes, ignoring the host, flags every FAT-host zipball — 48,713 healthy archives against a few hundred real ones.

**The defect is not one package.** 188 reachable versions carry it, spanning 18 packages. Only one had been reported.

**Refusing a checksum change is load-bearing, not defensive.** Archive construction turns out to be non-deterministic on the clone path, so rebuilding a submodule package produces a new checksum every time regardless of any incident (#12195). This guard is the only thing between a routine resync and a broken pin.

## Follow-ups

- #12195 — deterministic archive packing. A prerequisite for regenerating clone-path packages, since repairing one before it lands bakes in another checksum that the next rebuild changes again.
- #12196 — catalog updates are a read-modify-write guarded only by an advisory lock. A candidate cause of 3,784 versions whose archive is intact but whose catalog entry is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

