### PR TITLE
chore(registry): document the production registry repair with its operator scripts

### DIFF
--- a/server/priv/registry_repair/README.md
+++ b/server/priv/registry_repair/README.md
@@ -1,0 +1,125 @@
+# Registry repair runbook
+
+Operator scripts for repairing Swift package registry state, plus a record of how
+they are run. Context and measurements are in
+[#12191](https://github.com/tuist/tuist/issues/12191).
+
+These run **directly against production** rather than through a deploy, so they
+live in the repository to be reviewable and repeatable rather than reconstructed
+from shell history.
+
+## Why `eval` and not `remote`
+
+The `swift-registry-sync` pod runs with `RELEASE_DISTRIBUTION=none`:
+`rel/env.sh.eex` only enables distribution when the chart supplies
+`TUIST_CLUSTER_DNS_SERVICE` and `POD_IP`, and only the server Deployment sets
+those. The node is therefore not alive, and `bin/tuist rpc` / `remote` fail with
+`Cannot run --rpc-eval if the node is not alive`.
+
+`bin/tuist eval` starts a separate BEAM that still evaluates `config/runtime.exs`,
+so the registry bucket and credentials are configured. `boot.exs` supplies the
+one missing piece — a Finch instance for `ex_aws` — and deliberately does not
+start `:tuist`, which would boot a second Oban and consume release jobs
+alongside the live pod.
+
+`priv/` ships inside the release, so `SCRIPT` accepts a bare filename and no
+files need copying into the pod.
+
+## Work orders
+
+| Mode | Population | Effect |
+| --- | --- | --- |
+| `catalog_restore` | Archive intact, catalog entry missing | Writes metadata only. **No byte changes**, so pinned consumers are healed silently |
+| `regenerate` | Archive unextractable, or catalog advertises a version storage lacks | Enqueues the ordinary release worker with an explicit checksum-change override |
+
+`regenerate` requires the `allow_checksum_change` option from
+[#12193](https://github.com/tuist/tuist/pull/12193). `catalog_restore` runs
+against the currently deployed release.
+
+## Running
+
+```sh
+POD=$(kubectl --context "$CTX" -n "$NS" get pod \
+  -l app.kubernetes.io/component=swift-registry-sync \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl --context "$CTX" -n "$NS" cp ./catalog_restore_input.csv \
+  "$NS/$POD:/tmp/catalog_restore_input.csv" -c swift-registry-sync
+```
+
+Dry run first — nothing is written and nothing is logged, so the same input
+applies cleanly afterwards:
+
+```sh
+kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
+  env SCRIPT=repair.exs \
+      REPAIR_MODE=catalog_restore \
+      REPAIR_INPUT=/tmp/catalog_restore_input.csv \
+      REPAIR_LIMIT=20 \
+  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
+```
+
+Apply once the dry-run output looks right, raising the limit as confidence grows:
+
+```sh
+kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
+  env SCRIPT=repair.exs \
+      REPAIR_MODE=catalog_restore \
+      REPAIR_INPUT=/tmp/catalog_restore_input.csv \
+      REPAIR_LIMIT=500 \
+      REPAIR_APPLY=1 \
+  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
+```
+
+Regeneration, after #12193 has shipped. Keep the limit low: each entry enqueues a
+job that calls GitHub, and the sync has been rate-limited to `403` under load.
+
+```sh
+kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
+  env SCRIPT=repair.exs \
+      REPAIR_MODE=regenerate \
+      REPAIR_INPUT=/tmp/unextractable_reachable.csv \
+      REPAIR_LIMIT=25 \
+      REPAIR_APPLY=1 \
+  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
+```
+
+## Options
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `REPAIR_MODE` | required | `catalog_restore` or `regenerate` |
+| `REPAIR_INPUT` | required | CSV path inside the pod |
+| `REPAIR_APPLY` | unset | `1` writes; anything else is a dry run |
+| `REPAIR_LIMIT` | `100` | entries processed this run |
+| `REPAIR_LOG` | `/tmp/repair_log.tsv` | applied decisions; already-recorded entries are skipped |
+| `REPAIR_VERIFY` | `1` | hash the stored archive rather than trusting the published checksum |
+
+## Safety properties
+
+- **Dry run by default.** Dry runs are not logged, so an input can be inspected
+  and then applied.
+- **Resumable.** Every applied decision is appended to `REPAIR_LOG` and those
+  identifiers are skipped on subsequent runs, so a run can be interrupted or
+  repeated freely.
+- **`catalog_restore` never writes archive bytes.** It hashes the stored archive
+  and, when a published checksum is known, refuses to write if the two disagree —
+  the guard against advertising a checksum object storage does not hold, which is
+  the failure this repair exists to undo.
+- **Locking.** Metadata is re-read and written under the same package lock the
+  release worker takes, so a repair cannot race the live sync.
+- **`regenerate` reuses `ReleaseWorker`** through the force path rather than
+  reimplementing archive construction. It passes `allow_checksum_change: true`,
+  correct here because both populations are unusable today and so no working pin
+  exists to break.
+
+Column 4 differs between inputs — a published checksum in
+`catalog_restore_input.csv`, free text in `unextractable_reachable.csv` — so it is
+accepted only when it is a valid sha256, and a detail string can never reach a
+catalog entry.
+
+## Input files
+
+Samples are in `samples/`, using public packages and synthetic checksums. The real
+inputs are derived from a storage/catalog/baseline join and are not committed:
+they enumerate which packages and versions each account served and consumed.

--- a/server/priv/registry_repair/boot.exs
+++ b/server/priv/registry_repair/boot.exs
@@ -1,0 +1,32 @@
+# Boot shim for `bin/tuist eval`.
+#
+# The swift-registry-sync pod runs with RELEASE_DISTRIBUTION=none (rel/env.sh.eex
+# only enables distribution when the chart supplies TUIST_CLUSTER_DNS_SERVICE +
+# POD_IP, which it does for the server Deployment only), so `rpc` and `remote`
+# cannot attach to the running node. `eval` starts a separate BEAM instead.
+#
+# Runtime configuration still runs under `eval`, so Tuist.Registry already has
+# the registry bucket and credentials. What's missing is the HTTP stack: ex_aws
+# is configured to call through TuistCommon.AWS.Client, which dispatches to a
+# Finch instance the application supervisor would normally own.
+#
+# Deliberately does NOT start :tuist — that would boot Oban in a second BEAM and
+# start consuming release jobs alongside the live pod.
+#
+#   SCRIPT  script to run. A bare filename resolves inside this directory, so
+#           `SCRIPT=repair.exs` works against the copy shipped in the release
+#           without copying anything into the pod.
+
+{:ok, _} = Application.ensure_all_started(:ex_aws)
+{:ok, _} = Application.ensure_all_started(:finch)
+{:ok, _} = Application.ensure_all_started(:req)
+{:ok, _} = Finch.start_link(name: Application.get_env(:tuist_common, :finch_name, Tuist.Finch))
+
+script =
+  case System.fetch_env!("SCRIPT") do
+    "/" <> _ = absolute -> absolute
+    relative -> Application.app_dir(:tuist, Path.join("priv/registry_repair", relative))
+  end
+
+IO.puts("running #{script}")
+Code.eval_file(script)

--- a/server/priv/registry_repair/boot.exs
+++ b/server/priv/registry_repair/boot.exs
@@ -22,11 +22,20 @@
 {:ok, _} = Application.ensure_all_started(:req)
 {:ok, _} = Finch.start_link(name: Application.get_env(:tuist_common, :finch_name, Tuist.Finch))
 
-script =
-  case System.fetch_env!("SCRIPT") do
-    "/" <> _ = absolute -> absolute
-    relative -> Application.app_dir(:tuist, Path.join("priv/registry_repair", relative))
-  end
+# EVAL runs a snippet instead of a file, so ad-hoc inspection does not need a
+# copy-and-rerun cycle. SCRIPT is still the way to run a repair, because a repair
+# should be a reviewed file rather than a shell fragment.
+case System.get_env("EVAL") do
+  nil ->
+    script =
+      case System.fetch_env!("SCRIPT") do
+        "/" <> _ = absolute -> absolute
+        relative -> Application.app_dir(:tuist, Path.join("priv/registry_repair", relative))
+      end
 
-IO.puts("running #{script}")
-Code.eval_file(script)
+    IO.puts("running #{script}")
+    Code.eval_file(script)
+
+  code ->
+    Code.eval_string(code)
+end

--- a/server/priv/registry_repair/repair.exs
+++ b/server/priv/registry_repair/repair.exs
@@ -1,0 +1,283 @@
+# Applies the three repairs the audit produced. Dry-run unless REPAIR_APPLY=1.
+#
+#   REPAIR_MODE=catalog_restore  work order 2 — archive intact, catalog entry gone.
+#                                Writes only metadata; the archive is never touched,
+#                                so every pinned consumer is healed with no checksum
+#                                change and nothing to announce.
+#
+#   REPAIR_MODE=regenerate       work orders 1 and 4 — the archive cannot be
+#                                extracted, or the catalog advertises a version
+#                                storage does not hold. Both are unusable today, so
+#                                regenerating breaks no working pin. Enqueues the
+#                                ordinary release worker with the explicit
+#                                checksum-change override rather than reimplementing
+#                                the build.
+#
+# Resumable: every decision is appended to REPAIR_LOG and idents already recorded
+# there are skipped, so a run can be interrupted or repeated freely.
+#
+#   REPAIR_INPUT   CSV from the audit (package,version,...)
+#   REPAIR_LIMIT   entries to process this run (default 100)
+#   REPAIR_APPLY   "1" to write; anything else reports what it would do
+#   REPAIR_LOG     default /tmp/repair_log.tsv
+#   REPAIR_VERIFY  "0" to trust the published checksum instead of hashing the
+#                  stored archive. Default hashes, because writing a catalog entry
+#                  whose checksum storage does not actually hold is the exact
+#                  failure this repair exists to undo.
+
+alias Tuist.Registry
+alias Tuist.Registry.S3
+alias Tuist.Registry.Swift.Lock
+alias Tuist.Registry.Swift.Metadata
+alias TuistCommon.Registry.Swift.AlternateManifest
+alias TuistCommon.Registry.Swift.KeyNormalizer
+
+mode = System.fetch_env!("REPAIR_MODE")
+input = System.fetch_env!("REPAIR_INPUT")
+apply? = System.get_env("REPAIR_APPLY") == "1"
+verify? = System.get_env("REPAIR_VERIFY", "1") == "1"
+limit = String.to_integer(System.get_env("REPAIR_LIMIT", "100"))
+log_path = System.get_env("REPAIR_LOG", "/tmp/repair_log.tsv")
+
+bucket = Registry.registry_bucket()
+config = Registry.registry_s3_config()
+
+unless mode in ["catalog_restore", "regenerate"] do
+  raise "REPAIR_MODE must be catalog_restore or regenerate, got #{inspect(mode)}"
+end
+
+IO.puts("mode=#{mode} apply=#{apply?} verify=#{verify?} limit=#{limit}")
+IO.puts(if apply?, do: "APPLYING CHANGES", else: "dry run — nothing will be written")
+
+done =
+  if File.exists?(log_path) do
+    log_path
+    |> File.stream!()
+    |> Stream.map(&(&1 |> String.split("\t") |> List.first()))
+    |> Stream.reject(&(&1 in [nil, ""]))
+    |> MapSet.new()
+  else
+    MapSet.new()
+  end
+
+IO.puts("already processed: #{MapSet.size(done)}")
+
+entries =
+  input
+  |> File.stream!()
+  |> Stream.map(&String.trim_trailing/1)
+  |> Stream.reject(&(&1 == ""))
+  |> Stream.drop(1)
+  |> Stream.map(&String.split(&1, ",", parts: 5))
+  |> Stream.filter(&(length(&1) >= 2))
+  |> Stream.map(fn fields ->
+    package = Enum.at(fields, 0)
+    version = Enum.at(fields, 1)
+    {scope, name} = package |> String.split("/", parts: 2) |> List.to_tuple()
+
+    # Column 4 is a published checksum in catalog_missing.csv but a free-text
+    # detail in unextractable.csv. Accept it only when it is actually a sha256,
+    # so a detail string can never be written into a catalog entry.
+    published =
+      case Enum.at(fields, 3) do
+        value when is_binary(value) ->
+          if Regex.match?(~r/^[0-9a-f]{64}$/, value), do: value, else: nil
+
+        _ ->
+          nil
+      end
+
+    %{ident: "#{package}@#{version}", scope: scope, name: name, version: version, published: published}
+  end)
+  |> Stream.reject(&MapSet.member?(done, &1.ident))
+  |> Stream.take(limit)
+  |> Enum.to_list()
+
+IO.puts("processing this run: #{length(entries)}\n")
+
+version_prefix = fn scope, name, version ->
+  {s, n} = KeyNormalizer.normalize_scope_name(scope, name)
+  "registry/swift/#{s}/#{n}/#{KeyNormalizer.normalize_version(version)}/"
+end
+
+archive_checksum = fn key ->
+  path = Path.join(System.tmp_dir!(), "repair-#{:erlang.unique_integer([:positive])}.zip")
+
+  try do
+    case bucket |> ExAws.S3.download_file(key, path) |> ExAws.request(config) do
+      {:ok, _} ->
+        hash =
+          path
+          |> File.stream!(2_048_000)
+          |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+          |> :crypto.hash_final()
+          |> Base.encode16(case: :lower)
+
+        {:ok, hash}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  after
+    File.rm(path)
+  end
+end
+
+# Rebuilds the release's manifest list from the objects already in storage, the
+# same shape the release worker records: one entry per manifest, carrying the
+# Swift version the filename encodes and the tools version its content declares.
+stored_manifests = fn prefix ->
+  keys =
+    bucket
+    |> ExAws.S3.list_objects_v2(prefix: prefix)
+    |> ExAws.stream!(config)
+    |> Stream.map(& &1.key)
+    |> Enum.filter(fn key -> key |> Path.basename() |> AlternateManifest.registry_manifest_path?() end)
+
+  Enum.reduce_while(keys, {:ok, []}, fn key, {:ok, acc} ->
+    case S3.get_object(key) do
+      {:ok, content} ->
+        manifest = %{
+          "swift_version" => AlternateManifest.swift_version_from_filename(Path.basename(key)),
+          "swift_tools_version" => AlternateManifest.swift_tools_version(content)
+        }
+
+        {:cont, {:ok, [manifest | acc]}}
+
+      {:error, reason} ->
+        {:halt, {:error, {:manifest_unreadable, key, reason}}}
+    end
+  end)
+end
+
+restore_catalog_entry = fn entry ->
+  %{scope: scope, name: name, version: version, published: published} = entry
+  prefix = version_prefix.(scope, name, version)
+  archive_key = prefix <> "source_archive.zip"
+
+  # Deliberately not S3.head_object/1: that helper ships with the fix PR, and
+  # this repair must be runnable against the currently deployed release.
+  archive_present? = fn key ->
+    case bucket |> ExAws.S3.head_object(key) |> ExAws.request(config) do
+      {:ok, %{status_code: 200}} -> :ok
+      {:ok, %{status_code: status}} -> {:error, {:archive_missing, status}}
+      {:error, {:http_error, status, _}} -> {:error, {:archive_missing, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  with {:ok, metadata} <- Metadata.get_package(scope, name),
+       false <- Map.has_key?(Map.get(metadata, "releases", %{}) || %{}, version),
+       :ok <- archive_present?.(archive_key),
+       {:ok, checksum} <-
+         (if verify? or published in [nil, ""],
+            do: archive_checksum.(archive_key),
+            else: {:ok, published}),
+       :ok <-
+         (if published not in [nil, ""] and checksum != published,
+            do: {:error, {:checksum_mismatch, published, checksum}},
+            else: :ok),
+       {:ok, manifests} <- stored_manifests.(prefix) do
+    if apply? do
+      lock_key = {:package, scope, name}
+
+      case Lock.try_acquire(lock_key, 60) do
+        {:ok, :acquired} ->
+          try do
+            # Re-read under the lock: the live sync may have written this package
+            # between the check above and here.
+            {:ok, current} = Metadata.get_package(scope, name)
+
+            if Map.has_key?(Map.get(current, "releases", %{}) || %{}, version) do
+              {:skip, :already_present}
+            else
+              updated =
+                current
+                |> Map.update("releases", %{version => %{"checksum" => checksum, "manifests" => manifests}}, fn releases ->
+                  Map.put(releases || %{}, version, %{"checksum" => checksum, "manifests" => manifests})
+                end)
+                |> Map.update("skipped_releases", %{}, &Map.delete(&1 || %{}, version))
+
+              case Metadata.put_package(scope, name, updated) do
+                :ok -> {:ok, "restored checksum=#{String.slice(checksum, 0, 12)} manifests=#{length(manifests)}"}
+                {:error, reason} -> {:error, reason}
+              end
+            end
+          after
+            Lock.release(lock_key)
+          end
+
+        {:error, :already_locked} ->
+          {:skip, :package_locked}
+      end
+    else
+      {:ok, "would restore checksum=#{String.slice(checksum, 0, 12)} manifests=#{length(manifests)}"}
+    end
+  else
+    true -> {:skip, :already_present}
+    {:error, reason} -> {:error, reason}
+  end
+end
+
+regenerate = fn entry ->
+  %{scope: scope, name: name, version: version} = entry
+
+  case Metadata.get_package(scope, name) do
+    {:ok, metadata} ->
+      case Map.get(metadata, "repository_full_handle") do
+        handle when is_binary(handle) and handle != "" ->
+          if apply? do
+            case Registry.force_resync_swift_package_version(handle, version, allow_checksum_change: true) do
+              {:ok, job} -> {:ok, "enqueued job=#{job.id} handle=#{handle}"}
+              {:error, reason} -> {:error, reason}
+            end
+          else
+            {:ok, "would enqueue handle=#{handle}"}
+          end
+
+        _ ->
+          {:error, :no_repository_handle}
+      end
+
+    {:error, reason} ->
+      {:error, reason}
+  end
+end
+
+{:ok, log} = File.open(log_path, [:append, :raw])
+
+outcomes =
+  Enum.reduce(entries, %{}, fn entry, acc ->
+    result =
+      try do
+        case mode do
+          "catalog_restore" -> restore_catalog_entry.(entry)
+          "regenerate" -> regenerate.(entry)
+        end
+      rescue
+        error -> {:error, Exception.message(error)}
+      end
+
+    {tag, detail} =
+      case result do
+        {:ok, detail} -> {:ok, detail}
+        {:skip, reason} -> {:skip, to_string(reason)}
+        {:error, reason} -> {:error, inspect(reason)}
+      end
+
+    # Dry runs are not recorded, so the same input can be applied afterwards.
+    if apply?, do: IO.binwrite(log, [entry.ident, "\t", to_string(tag), "\t", detail, "\n"])
+
+    if tag != :ok or rem(map_size(acc), 1) == 0 do
+      IO.puts("  #{String.pad_trailing(to_string(tag), 6)} #{entry.ident}  #{detail}")
+    end
+
+    Map.update(acc, tag, 1, &(&1 + 1))
+  end)
+
+File.close(log)
+IO.inspect(outcomes, label: "\noutcomes")
+
+unless apply? do
+  IO.puts("\ndry run — re-run with REPAIR_APPLY=1 to write")
+end

--- a/server/priv/registry_repair/repair.exs
+++ b/server/priv/registry_repair/repair.exs
@@ -150,6 +150,19 @@ stored_manifests = fn prefix ->
   end)
 end
 
+# `Metadata` sanitizes on both read and write: a version whose identifier is not
+# a valid storage version is invisible to `get_package/2` and stripped again by
+# `put_package/3`. Restoring one is therefore not merely useless — the write
+# would rewrite the whole document and silently drop every other non-normalized
+# entry it still holds, including `skipped_releases`, which would make the sync
+# re-enqueue and rebuild those versions. Such archives cannot be served by any
+# code path and are dead storage, not a repair.
+storage_version? = fn version ->
+  if KeyNormalizer.valid_storage_version?(version),
+    do: :ok,
+    else: {:skip, :not_a_storage_version}
+end
+
 restore_catalog_entry = fn entry ->
   %{scope: scope, name: name, version: version, published: published} = entry
   prefix = version_prefix.(scope, name, version)
@@ -166,7 +179,8 @@ restore_catalog_entry = fn entry ->
     end
   end
 
-  with {:ok, metadata} <- Metadata.get_package(scope, name),
+  with :ok <- storage_version?.(version),
+       {:ok, metadata} <- Metadata.get_package(scope, name),
        false <- Map.has_key?(Map.get(metadata, "releases", %{}) || %{}, version),
        :ok <- archive_present?.(archive_key),
        {:ok, checksum} <-
@@ -177,7 +191,11 @@ restore_catalog_entry = fn entry ->
          (if published not in [nil, ""] and checksum != published,
             do: {:error, {:checksum_mismatch, published, checksum}},
             else: :ok),
-       {:ok, manifests} <- stored_manifests.(prefix) do
+       {:ok, manifests} <- stored_manifests.(prefix),
+       # A release entry with no manifests advertises a version whose
+       # Package.swift the read frontend cannot serve, so the version would
+       # resolve and then fail. Leaving it absent is the better state.
+       :ok <- (if manifests == [], do: {:error, :no_stored_manifests}, else: :ok) do
     if apply? do
       lock_key = {:package, scope, name}
 
@@ -215,6 +233,10 @@ restore_catalog_entry = fn entry ->
     end
   else
     true -> {:skip, :already_present}
+    {:skip, reason} -> {:skip, reason}
+    # No catalog document at all, so there is no entry to restore. Creating one
+    # is a different operation with different risks and is left to the sync.
+    {:error, :not_found} -> {:skip, :no_catalog_document}
     {:error, reason} -> {:error, reason}
   end
 end

--- a/server/priv/registry_repair/repair.exs
+++ b/server/priv/registry_repair/repair.exs
@@ -49,6 +49,24 @@ end
 IO.puts("mode=#{mode} apply=#{apply?} verify=#{verify?} limit=#{limit}")
 IO.puts(if apply?, do: "APPLYING CHANGES", else: "dry run — nothing will be written")
 
+# `regenerate` enqueues through `Oban.insert/1`, which resolves the instance via
+# `Oban.Registry` and therefore needs Oban running — `boot.exs` starts neither it
+# nor `:tuist`. Start one here that can only insert: no queues, so this BEAM
+# never executes a job; no plugins, so no cron or pruner; no peer, so it never
+# contends for leadership with the live pod. Uniqueness is still enforced,
+# because that is checked by `Oban.insert/1` rather than by the changeset.
+if mode == "regenerate" and apply? do
+  {:ok, _} = Application.ensure_all_started(:ecto_sql)
+  {:ok, _} = Application.ensure_all_started(:postgrex)
+  # Starts Oban.Registry, which `Oban.start_link/1` registers into. The
+  # application itself starts no instances — those come from a host
+  # supervision tree — so this cannot begin consuming jobs.
+  {:ok, _} = Application.ensure_all_started(:oban)
+  {:ok, _} = Tuist.Repo.start_link()
+  {:ok, _} = Oban.start_link(repo: Tuist.Repo, queues: false, plugins: false, peer: false)
+  IO.puts("oban: insert-only instance started (no queues, no plugins, no peer)")
+end
+
 done =
   if File.exists?(log_path) do
     log_path
@@ -290,7 +308,15 @@ outcomes =
       end
 
     # Dry runs are not recorded, so the same input can be applied afterwards.
-    if apply?, do: IO.binwrite(log, [entry.ident, "\t", to_string(tag), "\t", detail, "\n"])
+    #
+    # Errors are not recorded either. The log exists to stop work being repeated,
+    # and an entry that failed was not done — recording it would retire the
+    # version permanently on a transient fault (a rate limit, a dropped
+    # connection, a missing dependency). Permanent errors simply re-fail on the
+    # next run, which is noisy but visible; a silently skipped repair is not.
+    if apply? and tag != :error do
+      IO.binwrite(log, [entry.ident, "\t", to_string(tag), "\t", detail, "\n"])
+    end
 
     if tag != :ok or rem(map_size(acc), 1) == 0 do
       IO.puts("  #{String.pad_trailing(to_string(tag), 6)} #{entry.ident}  #{detail}")

--- a/server/priv/registry_repair/repair.exs
+++ b/server/priv/registry_repair/repair.exs
@@ -183,6 +183,13 @@ restore_catalog_entry = fn entry ->
        {:ok, metadata} <- Metadata.get_package(scope, name),
        false <- Map.has_key?(Map.get(metadata, "releases", %{}) || %{}, version),
        :ok <- archive_present?.(archive_key),
+       # Checked before hashing: listing a prefix is far cheaper than
+       # downloading an archive, and a version with no manifests is refused
+       # either way. A release entry with an empty manifest list advertises a
+       # version whose Package.swift the read frontend cannot serve, so the
+       # version would resolve and then fail. Absent is the better state.
+       {:ok, manifests} <- stored_manifests.(prefix),
+       :ok <- (if manifests == [], do: {:error, :no_stored_manifests}, else: :ok),
        {:ok, checksum} <-
          (if verify? or published in [nil, ""],
             do: archive_checksum.(archive_key),
@@ -190,12 +197,7 @@ restore_catalog_entry = fn entry ->
        :ok <-
          (if published not in [nil, ""] and checksum != published,
             do: {:error, {:checksum_mismatch, published, checksum}},
-            else: :ok),
-       {:ok, manifests} <- stored_manifests.(prefix),
-       # A release entry with no manifests advertises a version whose
-       # Package.swift the read frontend cannot serve, so the version would
-       # resolve and then fail. Leaving it absent is the better state.
-       :ok <- (if manifests == [], do: {:error, :no_stored_manifests}, else: :ok) do
+            else: :ok) do
     if apply? do
       lock_key = {:package, scope, name}
 

--- a/server/priv/registry_repair/samples/archive_missing.csv
+++ b/server/priv/registry_repair/samples/archive_missing.csv
@@ -1,0 +1,3 @@
+package,version,serving_checksum
+elegantchaos/docopt.swift,1.0.2,3c9f1a7e5d2b8046c1e7a3f9b5d2c8e40a6f1b3d7e9c5a2f8b4d0e6c2a8f4b0d
+duhnnie/lastfm.swift,0.4.0,7e2a9c4f1b6d3085a2f7c1e9b4d6a0f3c8e5b2d7a1f4c9e6b3d0a7f2c5e8b1d4

--- a/server/priv/registry_repair/samples/catalog_restore_input.csv
+++ b/server/priv/registry_repair/samples/catalog_restore_input.csv
@@ -1,0 +1,5 @@
+package,version,archive_written,published_checksum,catalog_state
+alamofire/alamofire,4.0.1,2026-07-27T02:00:05Z,a4400a525fba74d03d86fe9422a7e8bb72bad2d973be83b09df1b6dbf35fe5c6,absent
+alamofire/alamofire,4.3.0,2026-02-19T04:11:52Z,,absent
+kean/nuke,12.8.0,2026-02-19T05:02:18Z,1f0e5cbb2b7a6d4c9e83a1d7f4b2c6e8a9d0f3b5c7e1a4d6f8b0c2e4a6d8f0b2,absent
+scinfu/swiftsoup,2.8.7,2026-07-28T16:14:40Z,,absent

--- a/server/priv/registry_repair/samples/unextractable_reachable.csv
+++ b/server/priv/registry_repair/samples/unextractable_reachable.csv
@@ -1,0 +1,4 @@
+package,version,archive_written,detail
+apple/swift-tools-support-core,0.0.1,2026-02-19T03:44:10Z,12/12 dirs — apple-swift-tools-support-core-693aba4/ mode=40644 host=3 ifdir=true
+auth0/auth0_swift,2.10.0,2026-07-28T16:17:24Z,9/9 dirs — auth0-Auth0.swift-1c2d3e4/ mode=40644 host=3 ifdir=true
+jb55/secp256k1.swift,0.1.0,2026-02-19T03:51:02Z,4/4 dirs — jb55-secp256k1.swift-a1b2c3d/ mode=40644 host=3 ifdir=true


### PR DESCRIPTION
Documents the registry repair for #12191 by committing the scripts it runs, rather than leaving them as shell history on one laptop.

## What changed

Adds `server/priv/registry_repair/` containing two operator scripts, a runbook, and sample inputs. No production code is touched.

## Why this is not a migration

The repair reconciles object storage against catalog state. It reads S3, hashes archives, and writes catalog documents in the registry bucket — none of which a migration can express, and none of which belongs in the release boot path. It runs directly against production, so the scripts should be reviewable before they run and repeatable afterwards.

They live in `priv/` because that ships inside the release: an operator runs a repair without copying anything into the pod.

## Why `eval` rather than `rpc` or `remote`

The `swift-registry-sync` pod runs with `RELEASE_DISTRIBUTION=none`. `rel/env.sh.eex` only enables distribution when the chart supplies `TUIST_CLUSTER_DNS_SERVICE` and `POD_IP`, and only the server Deployment sets those. The node is not alive, so both `rpc` and `remote` fail with:

```
--rpc-eval : Cannot run --rpc-eval if the node is not alive (set --name or --sname)
```

`bin/tuist eval` starts a separate BEAM that still evaluates `config/runtime.exs`, so the registry bucket and credentials are configured. `boot.exs` supplies the one missing piece — a Finch instance, since `ex_aws` dispatches through `TuistCommon.AWS.Client` — and deliberately does **not** start `:tuist`, which would boot a second Oban and consume release jobs alongside the live pod.

## Why these two repairs

The audit behind #12191 separated the damage into populations with different remedies:

| Population | Count | Remedy |
| --- | --- | --- |
| Checksum diverged, archive healthy | 22,113 | Notification only; nothing to repair |
| Unextractable, reachable via catalog | 188 | `regenerate` |
| Catalog advertises a version storage lacks | 38 | `regenerate` |
| Archive present, catalog entry missing | 0 repairable | See below — `catalog_restore` found nothing to do |

`catalog_restore` was written for the fourth row and, run as a dry run against production, found **nothing to repair**. The population it targeted turned out to be 3,141 versions whose identifiers `Metadata` sanitizes away on both read and write, ~493 partial writes from release jobs that died between uploading the archive and uploading the manifests, and ~150 versions the sync had already restored. None is repairable by writing a catalog entry.

The mode is kept because the guards are the useful part: it is the check that establishes there is nothing to do, and it will be needed again the next time an inventory suggests otherwise. It refuses rather than writes when a version's identifier is not servable, when no manifests are stored beside the archive, when the package has no catalog document, and when the stored bytes no longer hash to the published checksum.

`regenerate` is only correct for the two unusable populations. An archive that cannot be extracted, or one that is absent, was never resolved successfully by anyone — so regenerating it breaks no working pin. That is why it passes `allow_checksum_change: true` from #12193 rather than reimplementing the build, and why it is not offered for the diverged set.

## Safety properties

- Dry run unless `REPAIR_APPLY=1`. Dry runs are not logged, so the same input applies cleanly afterwards.
- Applied decisions append to a log whose identifiers are skipped on later runs, so a run is safe to interrupt or repeat.
- `catalog_restore` hashes the stored archive and refuses to write when it disagrees with the published checksum. This is the guard against advertising a checksum object storage does not hold — the exact failure the repair exists to undo.
- It resolves the package through `Metadata.get_package/2`, so scope and name are canonicalized before lookup and a version that already has a catalog entry is skipped rather than rewritten. This caught a defect in the analysis that produced the inputs: object keys are not uniformly canonical, and an earlier join compared raw keys against canonical catalog identifiers, overstating the missing-entry population several-fold. The script reported `already_present` and wrote nothing.
- Metadata is written under the same package lock `ReleaseWorker` takes, and re-read inside it, so a repair cannot race the live sync.
- Column 4 is a published checksum in one input and free text in another, so it is accepted only when it is a valid sha256. A detail string can never reach a catalog entry.

## Commands

```sh
POD=$(kubectl --context "$CTX" -n "$NS" get pod \
  -l app.kubernetes.io/component=swift-registry-sync \
  -o jsonpath='{.items[0].metadata.name}')

kubectl --context "$CTX" -n "$NS" cp ./catalog_restore_input.csv \
  "$NS/$POD:/tmp/catalog_restore_input.csv" -c swift-registry-sync
```

Dry run:

```sh
kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
  env SCRIPT=repair.exs \
      REPAIR_MODE=catalog_restore \
      REPAIR_INPUT=/tmp/catalog_restore_input.csv \
      REPAIR_LIMIT=20 \
  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
```

Apply:

```sh
kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
  env SCRIPT=repair.exs \
      REPAIR_MODE=catalog_restore \
      REPAIR_INPUT=/tmp/catalog_restore_input.csv \
      REPAIR_LIMIT=500 \
      REPAIR_APPLY=1 \
  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
```

Regenerate, after #12193 ships. The limit stays low because each entry enqueues a job that calls GitHub, and the sync has been rate-limited to `403` under load:

```sh
kubectl --context "$CTX" -n "$NS" exec "$POD" -c swift-registry-sync -- \
  env SCRIPT=repair.exs \
      REPAIR_MODE=regenerate \
      REPAIR_INPUT=/tmp/unextractable_reachable.csv \
      REPAIR_LIMIT=25 \
      REPAIR_APPLY=1 \
  /app/bin/tuist eval 'Code.eval_file(Application.app_dir(:tuist, "priv/registry_repair/boot.exs"))'
```

## Input formats

Samples are committed under `samples/`, using public packages and synthetic checksums. Real inputs are not committed — they enumerate which packages and versions each account served and consumed.

`catalog_restore_input.csv` — archive intact, catalog entry gone. An empty `published_checksum` means no legacy baseline exists and the checksum is recomputed from the stored archive, still without changing bytes.

```csv
package,version,archive_written,published_checksum,catalog_state
alamofire/alamofire,4.0.1,2026-07-27T02:00:05Z,a4400a525fba74d03d86fe9422a7e8bb72bad2d973be83b09df1b6dbf35fe5c6,absent
alamofire/alamofire,4.3.0,2026-02-19T04:11:52Z,,absent
```

`unextractable_reachable.csv` — archives whose directory entries are not traversable after extraction.

```csv
package,version,archive_written,detail
apple/swift-tools-support-core,0.0.1,2026-02-19T03:44:10Z,12/12 dirs — apple-swift-tools-support-core-693aba4/ mode=40644 host=3 ifdir=true
auth0/auth0_swift,2.10.0,2026-07-28T16:17:24Z,9/9 dirs — auth0-Auth0.swift-1c2d3e4/ mode=40644 host=3 ifdir=true
```

`archive_missing.csv` — the catalog advertises a version object storage does not hold.

```csv
package,version,serving_checksum
elegantchaos/docopt.swift,1.0.2,3c9f1a7e5d2b8046c1e7a3f9b5d2c8e40a6f1b3d7e9c5a2f8b4d0e6c2a8f4b0d
```

## Validation

- Both scripts parse under Elixir 1.20.
- The CSV reader was exercised against all three input shapes, including the sha256 guard rejecting a free-text detail string and an empty field.
- `catalog_restore` was written against the **currently deployed** release: it uses `ExAws.S3.head_object` directly rather than `Tuist.Registry.S3.head_object/1`, which ships with #12193. Work order 2 therefore does not wait on that PR.
- Redirect handling was checked for the one affected package whose upstream repository has been renamed: `download_zipball/5` calls `Req.request/1` without `redirect: false`, and the renamed handle resolves through two hops to a valid archive. No handle rewriting is needed before regeneration.

## Follow-ups not in this PR

- Deterministic archive packing. Building the same version twice through the clone path produces different bytes, because `git clone` records checkout mtimes while `unzip` restores them from the zipball. Any package with submodules therefore gets a new checksum on every rebuild, independent of any incident.
- Stored `repository_full_handle` values are resolved through GitHub's rename redirect at fetch time. If an abandoned owner/name pair is re-registered by a third party, the mirror would follow it. Worth recording the canonical location and refusing a resolved-identity change.
