### PR TITLE
fix(server): forward object metadata on registry archive uploads

### DIFF
--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -51,12 +51,15 @@ defmodule Tuist.Registry.S3 do
 
   def upload_file(key, local_path, opts \\ []) when is_binary(key) and is_binary(local_path) do
     bucket = Registry.registry_bucket()
-    content_type_opt = Keyword.get(opts, :content_type)
 
+    # Forwards every option the caller set rather than only `:content_type`.
+    # `:meta` was previously dropped here, so the archive digest a caller asked
+    # to store never reached object storage and the read-back verification could
+    # only ever observe `nil` — failing every upload it was meant to protect.
     upload_opts =
-      if content_type_opt,
-        do: [content_type: content_type_opt, timeout: 120_000, max_concurrency: 8],
-        else: [timeout: 120_000, max_concurrency: 8]
+      [timeout: 120_000, max_concurrency: 8]
+      |> put_upload_opt(:content_type, Keyword.get(opts, :content_type))
+      |> put_upload_opt(:meta, Keyword.get(opts, :meta))
 
     {duration, result} =
       :timer.tc(fn ->
@@ -150,6 +153,9 @@ defmodule Tuist.Registry.S3 do
     |> Map.get("etag", Map.get(headers, "ETag"))
     |> normalize_etag()
   end
+
+  defp put_upload_opt(opts, _key, nil), do: opts
+  defp put_upload_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp downcase_headers(headers) when is_list(headers) do
     Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -56,10 +56,15 @@ defmodule Tuist.Registry.S3 do
     # `:meta` was previously dropped here, so the archive digest a caller asked
     # to store never reached object storage and the read-back verification could
     # only ever observe `nil` — failing every upload it was meant to protect.
+    #
+    # Rejecting nils is load-bearing rather than tidiness: `put_object_headers/1`
+    # reads `Map.get(opts, :meta, [])`, and a map default only applies to an
+    # absent key, so a literal `meta: nil` would reach `build_meta_headers/1`
+    # and raise.
     upload_opts =
       [timeout: 120_000, max_concurrency: 8]
-      |> put_upload_opt(:content_type, Keyword.get(opts, :content_type))
-      |> put_upload_opt(:meta, Keyword.get(opts, :meta))
+      |> Keyword.merge(opts)
+      |> Keyword.reject(fn {_key, value} -> is_nil(value) end)
 
     {duration, result} =
       :timer.tc(fn ->
@@ -86,8 +91,9 @@ defmodule Tuist.Registry.S3 do
 
   def upload_content(key, content, opts \\ []) when is_binary(key) do
     bucket = Registry.registry_bucket()
-    content_type_opt = Keyword.get(opts, :content_type)
-    put_opts = if content_type_opt, do: [content_type: content_type_opt], else: []
+    # Same shape as `upload_file/3` above, for the same reason: an option a
+    # caller sets should be used or absent, never silently ignored.
+    put_opts = Keyword.reject(opts, fn {_key, value} -> is_nil(value) end)
 
     {duration, result} =
       :timer.tc(fn ->
@@ -153,9 +159,6 @@ defmodule Tuist.Registry.S3 do
     |> Map.get("etag", Map.get(headers, "ETag"))
     |> normalize_etag()
   end
-
-  defp put_upload_opt(opts, _key, nil), do: opts
-  defp put_upload_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp downcase_headers(headers) when is_list(headers) do
     Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -71,9 +71,16 @@ defmodule Tuist.Registry.S3Test do
 
     # The digest only survives the round trip if `:meta` reaches ExAws. Dropping
     # it silently is what made every read-back verification observe `nil`.
+    #
+    # `:unrelated` stands in for whatever option is added next: the defect was
+    # the class "an option the caller set is discarded", not those two keys, so
+    # pinning only the keys we already know about would not catch a repeat.
     expect(ExAws.S3, :upload, fn _stream, "registry-bucket", "archive.zip", opts ->
       assert Keyword.get(opts, :meta) == [{"sha256", "abc123"}]
       assert Keyword.get(opts, :content_type) == "application/zip"
+      assert Keyword.get(opts, :unrelated) == :forwarded
+      assert Keyword.get(opts, :timeout) == 120_000
+      assert Keyword.get(opts, :max_concurrency) == 8
       upload
     end)
 
@@ -82,7 +89,27 @@ defmodule Tuist.Registry.S3Test do
     assert :ok =
              S3.upload_file("archive.zip", "/tmp/archive.zip",
                content_type: "application/zip",
-               meta: [{"sha256", "abc123"}]
+               meta: [{"sha256", "abc123"}],
+               unrelated: :forwarded
              )
+  end
+
+  test "drops nil options so a default-bearing header builder is not handed nil" do
+    config = [host: "registry.example.com"]
+    upload = %Upload{src: [], bucket: "registry-bucket", path: "archive.zip", opts: []}
+
+    expect(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    expect(Registry, :registry_s3_config, fn -> config end)
+    expect(Upload, :stream_file, fn _path -> [] end)
+
+    expect(ExAws.S3, :upload, fn _stream, "registry-bucket", "archive.zip", opts ->
+      refute Keyword.has_key?(opts, :meta)
+      refute Keyword.has_key?(opts, :content_type)
+      upload
+    end)
+
+    expect(ExAws, :request, fn ^upload, ^config -> {:ok, %{status_code: 200}} end)
+
+    assert :ok = S3.upload_file("archive.zip", "/tmp/archive.zip", content_type: nil, meta: nil)
   end
 end

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.Registry.S3Test do
   use Mimic
 
   alias ExAws.Operation.S3, as: S3Operation
+  alias ExAws.S3.Upload
   alias Tuist.Registry
   alias Tuist.Registry.S3
 
@@ -58,5 +59,30 @@ defmodule Tuist.Registry.S3Test do
     end)
 
     assert {:ok, %{status_code: 200}} = S3.request(operation)
+  end
+
+  test "forwards object metadata to the upload so a stored digest can be read back" do
+    config = [host: "registry.example.com"]
+    upload = %Upload{src: [], bucket: "registry-bucket", path: "archive.zip", opts: []}
+
+    expect(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    expect(Registry, :registry_s3_config, fn -> config end)
+    expect(Upload, :stream_file, fn _path -> [] end)
+
+    # The digest only survives the round trip if `:meta` reaches ExAws. Dropping
+    # it silently is what made every read-back verification observe `nil`.
+    expect(ExAws.S3, :upload, fn _stream, "registry-bucket", "archive.zip", opts ->
+      assert Keyword.get(opts, :meta) == [{"sha256", "abc123"}]
+      assert Keyword.get(opts, :content_type) == "application/zip"
+      upload
+    end)
+
+    expect(ExAws, :request, fn ^upload, ^config -> {:ok, %{status_code: 200}} end)
+
+    assert :ok =
+             S3.upload_file("archive.zip", "/tmp/archive.zip",
+               content_type: "application/zip",
+               meta: [{"sha256", "abc123"}]
+             )
   end
 end


### PR DESCRIPTION
Production hotfix. The registry can currently publish **no version at all** — ordinary catalog syncing and repairs alike.

## What is broken

`Tuist.Registry.S3.upload_file/3` reads only `:content_type` from its options and discards the rest:

```elixir
upload_opts =
  if content_type_opt,
    do: [content_type: content_type_opt, timeout: 120_000, max_concurrency: 8],
    else: [timeout: 120_000, max_concurrency: 8]
```

`ReleaseWorker.upload_source_archive/5` passes `meta: [{"sha256", checksum}]`, which is dropped here and never reaches object storage.

That makes the read-back verification added in #12193 unsatisfiable. It HEADs the object and compares `x-amz-meta-sha256` against the digest just uploaded — but the digest was never stored, so the header is always absent:

```
Tuist.Registry.Swift.ReleaseWorker failed with
  {:error, {:stored_archive_mismatch,
     "registry/swift/sochalewski/textfieldalert/2.0.0/source_archive.zip",
     %{expected: "5314263db388...", stored: nil}}}
```

Identical on all 8 attempts, across unrelated packages — so it is not eventual consistency, the metadata is simply never written.

## Impact

Every `ReleaseWorker` job fails and retries to exhaustion. Observed across ordinary sync traffic (`sochalewski/TextFieldAlert`, `smbcloudXYZ/smbcloud-auth-swift`, `speechall/speechall-swift-sdk`, `superuser404notfound/AetherEngine`), not only versions being repaired.

**Ordinary syncing is undamaged.** `ensure_checksum_change_allowed/5` refuses a differing checksum *before* the upload runs, so a rebuild that would change bytes never reaches storage. A rebuild that matches writes identical bytes. Either way the object is unchanged and the failure is a frozen mirror.

**Repairs are not**, and an earlier revision of this description was wrong to say otherwise. A repair passes `allow_checksum_change: true`, which by design skips that guard, and the chain is upload → verify → catalog write. During the broken window the archive was overwritten with rebuilt bytes, verification then failed, and the catalog kept advertising the old checksum.

72 `ReleaseWorker` jobs ran in that state, all discarded with `stored_archive_mismatch`. Confirmed on a live version:

```
catalog says  : ef206ff28851d87f…
archive hashes: a46585381038764d…
```

Those versions now fail with `invalid registry source archive checksum` instead of the extraction error they had before — a different symptom, not a worse one, and self-correcting: the archives already hold the correct rebuilt bytes, so re-running the repair once this deploys will verify successfully and write the catalog entry. No bytes are lost and no further action is needed beyond the re-run.

## Why fix forward rather than revert

Reverting would restore publishing but also remove the guard that refuses a resync changing an already-published checksum — the protection against the pin breakage in #12191, which affected 22,113 versions. A frozen mirror is recoverable; resuming unguarded rewrites is not.

The verification is correct in principle: a catalog entry must never advertise a checksum object storage does not hold. What was wrong is that the option carrying the digest was silently dropped one layer below its caller.

## The change

Merge the caller's options over the defaults, so an option is either used or absent rather than quietly ignored — and callers can now override `:timeout` and `:max_concurrency`, which they could not before.

Rejecting nils is load-bearing rather than tidiness: `put_object_headers/1` reads `Map.get(opts, :meta, [])`, and a map default only applies to an absent key, so a literal `meta: nil` would reach `build_meta_headers/1` and raise. A test pins that so a later refactor cannot drop the filter.

`upload_content/3` had the same shape and gets the same treatment. Its three callers (`metadata.ex`, `release_worker.ex`, `purge.ex`) pass only a content type today, so it was latent rather than live — but leaving one silently-ignoring setter beside a fixed one invites the next occurrence.

## Validation

- `mix test test/tuist/registry/` — 38 passing.
- The regression test asserts the options ExAws actually receives. With the fix reverted it fails with `left: nil` — exactly the production symptom — and passes with it.
- It asserts the *class* rather than the instance: an unrelated option must survive the trip and the defaults must still arrive, so a repeat with a different key is caught too.
- A second test pins the nil-rejection, since dropping it would raise inside ExAws rather than fail a comparison.
- `mix format --check-formatted` clean.

## Follow-up

The pairing is what made this dangerous: a setter that silently ignores unknown options, and a verifier that treats a missing value as a mismatch. The verifier behaved correctly; the setter should not accept options it does not honour. Both helpers in this module are now fixed.

After deploy, the 72 versions above need their repair re-run. They are the ones whose archive `LastModified` falls inside the window while their catalog checksum predates it.
