### PR TITLE
fix(server): unwrap single-value header lists from registry HEAD responses

### DIFF
--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -41,7 +41,7 @@ defmodule Tuist.Registry.S3 do
     bucket = Registry.registry_bucket()
 
     case bucket |> ExAws.S3.head_object(key) |> request() do
-      {:ok, %{status_code: 200, headers: headers}} -> {:ok, downcase_headers(headers)}
+      {:ok, %{status_code: 200, headers: headers}} -> {:ok, normalize_headers(headers)}
       {:ok, %{status_code: 404}} -> {:error, :not_found}
       {:ok, %{status_code: status}} -> {:error, {:s3_error, status}}
       {:error, {:http_error, 404, _}} -> {:error, :not_found}
@@ -160,20 +160,24 @@ defmodule Tuist.Registry.S3 do
     |> normalize_etag()
   end
 
-  defp downcase_headers(headers) when is_list(headers) do
+  defp normalize_headers(headers) when is_list(headers) do
     Map.new(headers, fn {key, value} -> {String.downcase(key), header_value(value)} end)
   end
 
-  defp downcase_headers(headers) when is_map(headers) do
+  defp normalize_headers(headers) when is_map(headers) do
     Map.new(headers, fn {key, value} -> {String.downcase(key), header_value(value)} end)
   end
 
-  # The HTTP client hands back each header's value as a list. `normalize_etag/1`
-  # below already unwraps that for etags; doing it once here means every caller
-  # of `head_object/1` compares against a binary instead of unknowingly
-  # comparing against `["..."]`, which is never equal to the binary it looks
+  # Whether a value arrives as a binary or wrapped in a list depends on the
+  # configured HTTP client, not on the header, so callers cannot safely compare
+  # against either shape. Normalizing here keeps that detail out of business
+  # logic: a comparison against `["..."]` is never equal to the binary it looks
   # identical to when inspected.
-  defp header_value([value | _]), do: header_value(value)
+  #
+  # Only a single-element list is unwrapped. A header that genuinely repeats
+  # keeps its list, so a caller sees the ambiguity rather than silently
+  # receiving the first value and assuming it was the only one.
+  defp header_value([value]), do: value
   defp header_value(value), do: value
 
   defp normalize_etag(nil), do: nil

--- a/server/lib/tuist/registry/s3.ex
+++ b/server/lib/tuist/registry/s3.ex
@@ -161,12 +161,20 @@ defmodule Tuist.Registry.S3 do
   end
 
   defp downcase_headers(headers) when is_list(headers) do
-    Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)
+    Map.new(headers, fn {key, value} -> {String.downcase(key), header_value(value)} end)
   end
 
   defp downcase_headers(headers) when is_map(headers) do
-    Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)
+    Map.new(headers, fn {key, value} -> {String.downcase(key), header_value(value)} end)
   end
+
+  # The HTTP client hands back each header's value as a list. `normalize_etag/1`
+  # below already unwraps that for etags; doing it once here means every caller
+  # of `head_object/1` compares against a binary instead of unknowingly
+  # comparing against `["..."]`, which is never equal to the binary it looks
+  # identical to when inspected.
+  defp header_value([value | _]), do: header_value(value)
+  defp header_value(value), do: value
 
   defp normalize_etag(nil), do: nil
   defp normalize_etag([value | _]), do: normalize_etag(value)

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -127,11 +127,23 @@ defmodule Tuist.Registry.S3Test do
     # pattern-matching on the digest never matches and reports a mismatch
     # against a value that looks correct.
     expect(ExAws, :request, fn ^consistent, ^config ->
-      {:ok, %{status_code: 200, headers: [{"X-Amz-Meta-Sha256", ["abc123"]}, {"ETag", ["\"etag\""]}]}}
+      {:ok,
+       %{
+         status_code: 200,
+         headers: [
+           {"X-Amz-Meta-Sha256", ["abc123"]},
+           {"ETag", ["\"etag\""]},
+           {"Vary", ["Accept", "Accept-Encoding"]}
+         ]
+       }}
     end)
 
     assert {:ok, headers} = S3.head_object("archive.zip")
     assert Map.get(headers, "x-amz-meta-sha256") == "abc123"
     assert S3.etag_from_headers(headers) == "etag"
+
+    # A header that genuinely repeats keeps its list rather than silently
+    # collapsing to its first value.
+    assert Map.get(headers, "vary") == ["Accept", "Accept-Encoding"]
   end
 end

--- a/server/test/tuist/registry/s3_test.exs
+++ b/server/test/tuist/registry/s3_test.exs
@@ -112,4 +112,26 @@ defmodule Tuist.Registry.S3Test do
 
     assert :ok = S3.upload_file("archive.zip", "/tmp/archive.zip", content_type: nil, meta: nil)
   end
+
+  test "unwraps single-value header lists so callers compare against a binary" do
+    config = [host: "registry.example.com"]
+
+    operation = %S3Operation{http_method: :head, bucket: "registry-bucket", path: "archive.zip", headers: %{}}
+    consistent = %{operation | headers: %{"X-Tigris-Consistent" => "true"}}
+
+    expect(Registry, :registry_bucket, fn -> "registry-bucket" end)
+    expect(Registry, :registry_s3_config, fn -> config end)
+    expect(ExAws.S3, :head_object, fn "registry-bucket", "archive.zip" -> operation end)
+
+    # The HTTP client returns each value as a list. Left wrapped, a caller
+    # pattern-matching on the digest never matches and reports a mismatch
+    # against a value that looks correct.
+    expect(ExAws, :request, fn ^consistent, ^config ->
+      {:ok, %{status_code: 200, headers: [{"X-Amz-Meta-Sha256", ["abc123"]}, {"ETag", ["\"etag\""]}]}}
+    end)
+
+    assert {:ok, headers} = S3.head_object("archive.zip")
+    assert Map.get(headers, "x-amz-meta-sha256") == "abc123"
+    assert S3.etag_from_headers(headers) == "etag"
+  end
 end


### PR DESCRIPTION
Third and final layer of the same failure. The registry still cannot publish after #12197.

## What is happening

#12197 fixed `:meta` being dropped, so the digest now reaches object storage. Verified directly against production — the stored value is exactly `sha256` of the uploaded bytes:

```
expected: ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095
stored:  ["ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095"]
```

The value is right. The shape is not. The HTTP client returns each header value as a list, so `head_object/1` returns `["ba9c…"]` where callers expect `"ba9c…"`.

`verify_stored_archive/4` pattern-matches the stored value against the digest it just uploaded:

```elixir
case Map.get(headers, "x-amz-meta-sha256") do
  ^checksum -> :ok
  stored -> {:error, {:stored_archive_mismatch, key, %{expected: checksum, stored: stored}}}
end
```

A list is never equal to the binary it wraps, so every upload still fails — reporting `stored: ["ba9c…"]` instead of `stored: nil`. Strictly more confusing than before, because the reported value looks correct.

## The fix

Unwrap once in `downcase_headers/1` so every `head_object/1` caller receives binaries, rather than patching the comparison site.

`normalize_etag/1` in this same module already unwraps list values — which is why `etag_from_headers/1` kept working while the newer metadata path did not. The knowledge existed in the module; the new code path just didn't use it.

## Validation

- `mix test test/tuist/registry/s3_test.exs` — 5 passing.
- The new test asserts both the metadata header and the etag helper, so the unwrap can't regress for one and not the other. Reverting the fix fails it with `left: ["abc123"], right: "abc123"` — the production symptom.
- `mix format --check-formatted` and `mix credo` clean.

## Why this took three attempts

Each layer masked the next. `:meta` was dropped, so the header was absent and the comparison never got a value to disagree about. Fixing that produced a value, which then disagreed on shape. The end-to-end path was only ever exercised in production, because the tests stopped at the boundary each time.

The probe that found this compares the stored digest to the expected one directly rather than asserting a return value, which is what a test at this boundary should have done from the start.
