### PR TITLE
fix(server): let a force resync reach a package the index no longer lists

### DIFF
--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -100,9 +100,12 @@ defmodule Tuist.Registry.Swift.SyncWorker do
                      String.downcase(repository_full_handle))
                ) do
             nil ->
-              Logger.warning("Registry force resync skipped: package is not in the catalog: #{repository_full_handle}")
-
-              {:discard, :package_not_found}
+              resync_unlisted_package_version(
+                repository_full_handle,
+                normalized_version,
+                resync_flags,
+                token
+              )
 
             package ->
               force_resync_package_version(package, normalized_version, resync_flags, token)
@@ -118,6 +121,55 @@ defmodule Tuist.Registry.Swift.SyncWorker do
       Logger.warning("Registry force resync skipped: invalid version #{version} for #{repository_full_handle}")
 
       {:discard, :invalid_version}
+    end
+  end
+
+  # A repository that upstream renamed, transferred, or delisted stops appearing
+  # in the Swift Package Index list under the handle we mirror it as, so the
+  # lookup above cannot find it. Discarding there makes exactly the packages most
+  # likely to need repair the ones that cannot be repaired: the registry keeps
+  # serving them under the original identity while no resync can reach them.
+  #
+  # The gate is that we already serve the package — a catalog document must exist
+  # for the identity derived from the requested handle. That keeps this from
+  # becoming a way to mirror something never mirrored before, and it is why the
+  # requested handle rather than the current upstream name is what matters here.
+  #
+  # The stored `repository_full_handle` is used for the fetch even though it is
+  # the pre-rename name. GitHub redirects it, and adopting the new name instead
+  # would publish under a scope no client resolves, leaving the identity clients
+  # actually pin untouched.
+  defp resync_unlisted_package_version(repository_full_handle, version, resync_flags, token) do
+    case String.split(repository_full_handle, "/", parts: 2) do
+      [scope, name] ->
+        {scope, name} = KeyNormalizer.normalize_scope_name(scope, name)
+        resync_mirrored_package_version(scope, name, repository_full_handle, version, resync_flags, token)
+
+      _ ->
+        Logger.warning("Registry force resync skipped: malformed handle #{repository_full_handle}")
+
+        {:discard, :package_not_found}
+    end
+  end
+
+  defp resync_mirrored_package_version(scope, name, repository_full_handle, version, resync_flags, token) do
+    case Metadata.get_package(scope, name) do
+      {:ok, metadata} ->
+        full_handle = Map.get(metadata, "repository_full_handle") || repository_full_handle
+
+        Logger.info(
+          "Registry force resync for a package absent from the index, using the mirrored handle: #{full_handle}"
+        )
+
+        do_force_resync_package_version(scope, name, full_handle, version, resync_flags, token)
+
+      {:error, :not_found} ->
+        Logger.warning("Registry force resync skipped: package is not in the catalog: #{repository_full_handle}")
+
+        {:discard, :package_not_found}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/server/test/tuist/registry/swift/sync_worker_test.exs
+++ b/server/test/tuist/registry/swift/sync_worker_test.exs
@@ -319,6 +319,9 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
        ]}
     end)
 
+    # Never mirrored, so there is no catalog document to fall back to.
+    expect(Metadata, :get_package, fn "unknown", "package" -> {:error, :not_found} end)
+
     assert {:discard, :package_not_found} =
              SyncWorker.perform(%Oban.Job{
                args: %{
@@ -329,6 +332,53 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
              })
 
     refute_enqueued(worker: ReleaseWorker)
+  end
+
+  test "force resyncs a package the index no longer lists, keeping the mirrored identity" do
+    # Upstream renamed the repository, so the Swift Package Index lists it under
+    # the new handle and the old one -- the identity clients resolve -- is absent.
+    # Without a fallback these versions are permanently unrepairable.
+    expect(SwiftPackageIndex, :list_packages, fn "token" ->
+      {:ok,
+       [
+         %{
+           scope: "swiftlang",
+           name: "swift-tools-support-core",
+           repository_full_handle: "swiftlang/swift-tools-support-core"
+         }
+       ]}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-tools-support-core" ->
+      {:ok, %{"repository_full_handle" => "apple/swift-tools-support-core"}}
+    end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-tools-support-core", "token", _ ->
+      {:ok, ["0.1.8"]}
+    end)
+
+    assert :ok =
+             SyncWorker.perform(%Oban.Job{
+               args: %{
+                 "force" => true,
+                 "allow_checksum_change" => true,
+                 "repository_full_handle" => "apple/swift-tools-support-core",
+                 "version" => "0.1.8"
+               }
+             })
+
+    # The pre-rename scope and name are preserved: publishing under the new
+    # upstream name would create an identity no client pins, leaving the broken
+    # one untouched.
+    assert_enqueued(
+      worker: ReleaseWorker,
+      args: %{
+        "scope" => "apple",
+        "name" => "swift-tools-support-core",
+        "repository_full_handle" => "apple/swift-tools-support-core",
+        "tag" => "0.1.8"
+      }
+    )
   end
 
   test "discards force resync requests when the version is not a current source tag" do


### PR DESCRIPTION
A force resync cannot reach a package whose upstream repository was renamed or delisted — which is a large share of what needs repairing in #12191.

## The problem

`force_resync_package_version_for_handle/4` resolves the package by searching the Swift Package Index list:

```elixir
case Enum.find(packages, &(String.downcase(&1.repository_full_handle) == String.downcase(repository_full_handle))) do
  nil -> {:discard, :package_not_found}
```

When upstream renames a repository, the index lists the **new** handle. The registry keeps serving the package under the **original** identity, because that is what clients pin. So the lookup asks for an old handle in a list that only has the new one, finds nothing, and discards.

The result is that a package stops being repairable at exactly the moment it becomes most likely to need repair.

Hit on **35 of the 188 versions** in the current repair:

- `apple/swift-tools-support-core` — 34 versions; renamed upstream to `swiftlang/swift-tools-support-core`
- `geri-borbas/iOS_Package_Withable` — 1 version; no longer listed

Verified against the live index: both are absent from the 11,448 entries in `packages.json`.

## Why not just use the new handle

Passing `swiftlang/swift-tools-support-core` would resolve, but `ReleaseWorker` derives scope and name from the package record — so it would publish to `swiftlang.swift_tools_support_core`, an identity no client resolves, while `apple.swift-tools-support-core` stayed broken. A correct copy under the wrong name is not a repair.

## The change

Fall back to the mirrored catalog when the index lookup misses.

The gate is that **we already serve the package**: a catalog document must exist for the identity derived from the requested handle. This cannot mirror something never mirrored before — that path still discards, and the existing test now stubs the catalog miss explicitly so it asserts that reason rather than passing because the fallback was absent.

The fetch uses the `repository_full_handle` stored in the catalog even though it is the pre-rename name. GitHub redirects it — verified end to end, two hops to a valid archive — and it keeps the served identity stable.

## Validation

- `mix test test/tuist/registry/` — 40 passing.
- The new test stubs an index listing the renamed handle and a catalog holding the original, then asserts the enqueued `ReleaseWorker` carries the **pre-rename** scope, name and handle. Reverted, it fails with `{:discard, :package_not_found}` — the production symptom.
- `mix format --check-formatted` and `mix credo` clean.

## Related

This also narrows a supply-chain hazard raised in #12191: the mirror resolves a stored handle through GitHub's rename redirect, so an abandoned owner/name pair re-registered by a third party would be followed silently. Recording the canonical location GitHub reports would close it fully — worth doing separately, since it needs a decision about whether to refuse or adopt a changed upstream identity.
