### PR TITLE
fix(cli): remove temporary analytics archive directory after upload

### DIFF
--- a/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -258,6 +258,9 @@
             let passedArtifactPath = artifactPath
             let artifactPath: AbsolutePath
             let artifactLabel = "\(artifact.type)\(artifact.name.map { " (\($0))" } ?? "")"
+            #if canImport(TuistAppleArchiver)
+                var temporaryArchiveDirectory: AbsolutePath?
+            #endif
 
             let archiveStart = Date()
             switch artifact.type {
@@ -271,6 +274,7 @@
                     // `<destination>/<bundle>.xcresult/…` — without it, `find_xcresult`
                     // can't locate the bundle and processing fails with `:xcresult_not_found`.
                     let archiveDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-analytics-archive")
+                    temporaryArchiveDirectory = archiveDirectory
                     let archivePath = archiveDirectory.appending(
                         component: "\(passedArtifactPath.basenameWithoutExt).aar"
                     )
@@ -299,44 +303,58 @@
             }
 
             let uploadStart = Date()
-            let uploadId = try await multipartUploadStartAnalyticsService.uploadAnalyticsArtifact(
-                artifact,
-                accountHandle: accountHandle,
-                projectHandle: projectHandle,
-                commandEventId: commandEventId,
-                serverURL: serverURL
-            )
+            do {
+                let uploadId = try await multipartUploadStartAnalyticsService.uploadAnalyticsArtifact(
+                    artifact,
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
+                    commandEventId: commandEventId,
+                    serverURL: serverURL
+                )
 
-            let parts = try await multipartUploadArtifactService.multipartUploadArtifact(
-                artifactPath: artifactPath,
-                generateUploadURL: { part in
-                    try await multipartUploadGenerateURLAnalyticsService.uploadAnalytics(
-                        artifact,
-                        accountHandle: accountHandle,
-                        projectHandle: projectHandle,
-                        commandEventId: commandEventId,
-                        partNumber: part.number,
-                        uploadId: uploadId,
-                        serverURL: serverURL,
-                        contentLength: part.contentLength
-                    )
-                },
-                updateProgress: { _ in }
-            )
+                let parts = try await multipartUploadArtifactService.multipartUploadArtifact(
+                    artifactPath: artifactPath,
+                    generateUploadURL: { part in
+                        try await multipartUploadGenerateURLAnalyticsService.uploadAnalytics(
+                            artifact,
+                            accountHandle: accountHandle,
+                            projectHandle: projectHandle,
+                            commandEventId: commandEventId,
+                            partNumber: part.number,
+                            uploadId: uploadId,
+                            serverURL: serverURL,
+                            contentLength: part.contentLength
+                        )
+                    },
+                    updateProgress: { _ in }
+                )
 
-            try await multipartUploadCompleteAnalyticsService.uploadAnalyticsArtifact(
-                artifact,
-                accountHandle: accountHandle,
-                projectHandle: projectHandle,
-                commandEventId: commandEventId,
-                uploadId: uploadId,
-                parts: parts,
-                serverURL: serverURL
-            )
-            let uploadElapsed = Date().timeIntervalSince(uploadStart)
-            Logger.current.debug(
-                "Uploaded \(artifactLabel) in \(String(format: "%.2fs", uploadElapsed)) (\(parts.count) parts)"
-            )
+                try await multipartUploadCompleteAnalyticsService.uploadAnalyticsArtifact(
+                    artifact,
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
+                    commandEventId: commandEventId,
+                    uploadId: uploadId,
+                    parts: parts,
+                    serverURL: serverURL
+                )
+                let uploadElapsed = Date().timeIntervalSince(uploadStart)
+                Logger.current.debug(
+                    "Uploaded \(artifactLabel) in \(String(format: "%.2fs", uploadElapsed)) (\(parts.count) parts)"
+                )
+            } catch {
+                #if canImport(TuistAppleArchiver)
+                    if let temporaryArchiveDirectory {
+                        try? await fileSystem.remove(temporaryArchiveDirectory)
+                    }
+                #endif
+                throw error
+            }
+            #if canImport(TuistAppleArchiver)
+                if let temporaryArchiveDirectory {
+                    try await fileSystem.remove(temporaryArchiveDirectory)
+                }
+            #endif
         }
     }
 #endif

--- a/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
@@ -1,6 +1,7 @@
 import FileSystem
 import Foundation
 import Mockable
+import Path
 #if canImport(TuistAppleArchiver)
     import TuistAppleArchiver
 #endif
@@ -319,4 +320,125 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
             serverURL: serverURL
         )
     }
+
+    #if canImport(TuistAppleArchiver)
+        func test_upload_result_bundle_removes_temporary_archive_directory() async throws {
+            // Given
+            let temporaryDirectory = try temporaryPath()
+            let resultBundle = temporaryDirectory.appending(component: "artifact.bundle")
+            try await FileSystem().touch(resultBundle)
+            let serverURL: URL = .test()
+            let commandEventID = UUID().uuidString
+
+            var capturedArchiveDirectory: AbsolutePath?
+            given(appleArchiver)
+                .compress(
+                    directory: .value(resultBundle),
+                    to: .any,
+                    excludePatterns: .value([]),
+                    preservesBaseDirectory: .value(true)
+                )
+                .willProduce { _, archivePath, _, _ in
+                    capturedArchiveDirectory = archivePath.parentDirectory
+                    try Data("fake-aar".utf8).write(to: archivePath.url)
+                }
+
+            given(multipartUploadStartAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .value(.init(type: .resultBundle)),
+                    accountHandle: .value("account"),
+                    projectHandle: .value("project"),
+                    commandEventId: .value(commandEventID),
+                    serverURL: .value(serverURL)
+                )
+                .willReturn("upload-id")
+
+            given(multipartUploadArtifactService)
+                .multipartUploadArtifact(
+                    artifactPath: .matching { $0.extension == "aar" },
+                    generateUploadURL: .any,
+                    updateProgress: .any
+                )
+                .willReturn([(etag: "etag", partNumber: 1)])
+
+            given(multipartUploadCompleteAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .value(.init(type: .resultBundle)),
+                    accountHandle: .value("account"),
+                    projectHandle: .value("project"),
+                    commandEventId: .value(commandEventID),
+                    uploadId: .value("upload-id"),
+                    parts: .any,
+                    serverURL: .value(serverURL)
+                )
+                .willReturn(())
+
+            // When
+            try await subject.uploadResultBundle(
+                resultBundle,
+                fullHandle: "account/project",
+                commandEventId: commandEventID,
+                serverURL: serverURL
+            )
+
+            // Then
+            let archiveDirectory = try XCTUnwrap(capturedArchiveDirectory)
+            let archiveDirectoryExists = try await FileSystem().exists(archiveDirectory)
+            XCTAssertFalse(
+                archiveDirectoryExists,
+                "The temporary analytics archive directory should be removed after the upload completes."
+            )
+        }
+
+        func test_upload_result_bundle_removes_temporary_archive_directory_when_upload_fails() async throws {
+            // Given
+            let temporaryDirectory = try temporaryPath()
+            let resultBundle = temporaryDirectory.appending(component: "artifact.bundle")
+            try await FileSystem().touch(resultBundle)
+            let serverURL: URL = .test()
+            let commandEventID = UUID().uuidString
+
+            var capturedArchiveDirectory: AbsolutePath?
+            given(appleArchiver)
+                .compress(
+                    directory: .value(resultBundle),
+                    to: .any,
+                    excludePatterns: .value([]),
+                    preservesBaseDirectory: .value(true)
+                )
+                .willProduce { _, archivePath, _, _ in
+                    capturedArchiveDirectory = archivePath.parentDirectory
+                    try Data("fake-aar".utf8).write(to: archivePath.url)
+                }
+
+            given(multipartUploadStartAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .value(.init(type: .resultBundle)),
+                    accountHandle: .value("account"),
+                    projectHandle: .value("project"),
+                    commandEventId: .value(commandEventID),
+                    serverURL: .value(serverURL)
+                )
+                .willThrow(TestError("upload failed"))
+
+            // When
+            await XCTAssertThrowsSpecific(
+                try await subject.uploadResultBundle(
+                    resultBundle,
+                    fullHandle: "account/project",
+                    commandEventId: commandEventID,
+                    serverURL: serverURL
+                ),
+                TestError("upload failed")
+            )
+
+            // Then
+            let archiveDirectory = try XCTUnwrap(capturedArchiveDirectory)
+            let archiveDirectoryExists = try await FileSystem().exists(archiveDirectory)
+            XCTAssertFalse(
+                archiveDirectoryExists,
+                "The temporary analytics archive directory should be removed when the upload fails."
+            )
+        }
+    #endif
 }


### PR DESCRIPTION
> Describe here the purpose of your PR.

## Problem

Since the AppleArchive xcresult upload path landed (#10416, refined by #10460), `AnalyticsArtifactUploadService.uploadAnalyticsArtifact` stages each result bundle by compressing it into a fresh temporary directory:

```swift
let archiveDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-analytics-archive")
```

That directory is never removed — there is no cleanup on either the success or failure path — so every result-bundle upload permanently leaks one `tuist-analytics-archive-<UUID>` directory containing the compressed `.aar` (tens of MB for real-world test bundles) in the user temporary directory.

On ephemeral CI this is invisible, but on persistent macOS CI runners it compounds: on our fleet each host had accumulated several hundred of these directories (~60–70 MB each, roughly one per test-shard job) within a few days, amounting to 17–43 GB of dead disk per host. Combined with ordinary transient build load, this eventually produced `ld: write() failed, errno=28` (ENOSPC) build failures. A long-lived development laptop had accumulated 1,000+ of them.

Note the contrast with the invocation-record handling earlier in the same file, which uses the self-cleaning `fileSystem.runInTemporaryDirectory` API — the `.aar` staging path just never got equivalent cleanup.

## Fix

Track the staging directory created in the `canImport(TuistAppleArchiver)` branch and remove it after the multipart upload completes — and also on the upload failure path (via `do`/`catch`, since `defer` cannot `await`), so unauthorized/failed uploads do not accumulate residue either. Scoped to the leaking path; happy to restructure the whole upload into `runInTemporaryDirectory` instead if maintainers prefer.

## Verification

- **Unit tests** (added in this PR, run via `tuist test TuistUnitTests`): `test_upload_result_bundle_removes_temporary_archive_directory` and `test_upload_result_bundle_removes_temporary_archive_directory_when_upload_fails` both pass; the success-path test was red-checked against the unfixed source (it fails without the fix).
- **Live validation**: running `tuist test` end-to-end (real xcresult, real archive staging, upload attempt) with the stock CLI adds exactly one persisted `tuist-analytics-archive-*` directory per run; with this branch's CLI built from source, the count is unchanged after the run (verified on both the upload-failure path and, via the unit test seam, the success path).

### How to test locally

1. Run any `tuist test`/`tuist xcodebuild test` invocation that uploads a result bundle to a Tuist project.
2. Before this change: `ls $(getconf DARWIN_USER_TEMP_DIR) | grep tuist-analytics-archive` gains one new directory per run that persists after the command exits.
3. After this change: the staging directory is gone once the command completes (success or failure).

No existing issue found for this — happy to file one if preferred.