### PR TITLE
fix(cli): expand leading tilde paths

### DIFF
--- a/cli/Sources/ProjectDescription/Path.swift
+++ b/cli/Sources/ProjectDescription/Path.swift
@@ -1,3 +1,5 @@
+internal import Foundation
+
 /// A path represents to a file, directory, or a group of files represented by a glob expression.
 ///
 /// Paths can be relative and absolute. We discourage using absolute paths because they create a dependency with the environment
@@ -46,9 +48,16 @@ public struct Path: ExpressibleByStringInterpolation, Codable, Hashable, Sendabl
 
     // MARK: - ExpressibleByStringInterpolation
 
-    /// Initializer uses `.relativeToRoot` if path starts with `//` otherwise it is `.relativeToManifest` by default
+    /// Initializer uses `.relativeToRoot` if the path starts with `//` or `~`; otherwise it is `.relativeToManifest` by default.
     public init(stringLiteral: String) {
-        if stringLiteral.starts(with: "//") {
+        if stringLiteral == "~" || stringLiteral.hasPrefix("~/") {
+            let pathString = stringLiteral == "~"
+                ? FileManager.default.homeDirectoryForCurrentUser.path
+                : FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(String(stringLiteral.dropFirst(2)))
+                .path
+            self.init(pathString, type: .relativeToRoot)
+        } else if stringLiteral.starts(with: "//") {
             self.init(stringLiteral.replacingOccurrences(of: "//", with: ""), type: .relativeToRoot)
         } else {
             self.init(stringLiteral, type: .relativeToManifest)

--- a/cli/Tests/ProjectDescriptionTests/PathTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/PathTests.swift
@@ -23,6 +23,19 @@ final class PathTests: TuistUnitTestCase {
         XCTAssertEqual(path, Path.relativeToRoot("file.swift"))
     }
 
+    func test_init_when_the_path_is_prefixed_with_a_tilde() {
+        let path: Path = "~/file.swift"
+        let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("file.swift")
+            .path
+        XCTAssertEqual(path, Path.relativeToRoot(expectedPath))
+    }
+
+    func test_init_when_the_path_is_a_tilde() {
+        let path: Path = "~"
+        XCTAssertEqual(path, Path.relativeToRoot(FileManager.default.homeDirectoryForCurrentUser.path))
+    }
+
     func test_init_when_the_path_is_not_prefixed() {
         let path: Path = "file.swift"
         XCTAssertEqual(path, Path.relativeToManifest("file.swift"))


### PR DESCRIPTION
## What

Support home-directory shorthand in `Path` string literals.

## Why

Fixes #11693. Paths such as `~/Projects/App` were treated as manifest-relative strings instead of resolving from the current user home directory.

## Root cause

`Path.init(stringLiteral:)` only recognized the existing `//` root-relative syntax and had no tilde expansion branch.

## Solution

Expand `~` and `~/...` with `FileManager.default.homeDirectoryForCurrentUser` and preserve the `.relativeToRoot` path type. Added regression coverage for both forms.

## Impact

Existing ordinary paths and `//...` paths keep their current behavior. Only the exact home shorthand forms are expanded.

## Validation

- SwiftFormat lint passes for both changed files.
- `tuist generate tuist ProjectDescription --no-open` succeeds.
- `xcodebuild build -project Tuist.xcodeproj -target ProjectDescription CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` succeeds.
- Runtime assertions against the built `ProjectDescription` framework pass for `~` and `~/file.swift`.
- The repository currently has no `ProjectDescriptionTests` Xcode target, so the focused XCTest suite cannot be invoked through the generated workspace.