### PR TITLE
feat(server): expose GitHub API rate limit metrics from response headers

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -344,6 +344,7 @@ defmodule Tuist.Application do
         {Phoenix.PubSub, name: Tuist.PubSub},
         {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
         {Tuist.API.Pipeline, []},
+        TuistCommon.GitHub.RateLimit,
         TuistWeb.Telemetry
       ] ++
         ops_clickhouse_children() ++

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -79,7 +79,8 @@ defmodule Tuist.PromEx do
         Tuist.HTTP.PromExPlugin,
         Tuist.License.PromExPlugin,
         Tuist.Runners.PromExPlugin,
-        TuistCommon.HTTP.TransportPromExPlugin
+        TuistCommon.HTTP.TransportPromExPlugin,
+        TuistCommon.GitHub.PromExPlugin
       ]
 
     plugins =

--- a/tuist_common/lib/tuist_common/github.ex
+++ b/tuist_common/lib/tuist_common/github.ex
@@ -10,8 +10,9 @@ defmodule TuistCommon.GitHub do
 
   @doc """
   Telemetry event emitted with the rate-limit budget GitHub reports on API
-  responses. Measurements are `:limit` and `:used`, with the `:resource`
-  metadata naming the budget the request was accounted against.
+  responses. Measurements are `:limit`, `:used`, and `:reset` when GitHub
+  sends it, with the `:resource` metadata naming the budget the request was
+  accounted against.
   """
   @spec rate_limit_event_name() :: [atom()]
   def rate_limit_event_name, do: @rate_limit_event
@@ -262,7 +263,15 @@ defmodule TuistCommon.GitHub do
 
     with limit when is_integer(limit) <- header_integer(headers, "x-ratelimit-limit"),
          used when is_integer(used) <- header_integer(headers, "x-ratelimit-used") do
-      :telemetry.execute(@rate_limit_event, %{limit: limit, used: used}, %{
+      measurements = %{limit: limit, used: used}
+
+      measurements =
+        case header_integer(headers, "x-ratelimit-reset") do
+          reset when is_integer(reset) -> Map.put(measurements, :reset, reset)
+          nil -> measurements
+        end
+
+      :telemetry.execute(@rate_limit_event, measurements, %{
         resource: header_value(headers, "x-ratelimit-resource") || "unknown"
       })
     end

--- a/tuist_common/lib/tuist_common/github.ex
+++ b/tuist_common/lib/tuist_common/github.ex
@@ -6,6 +6,15 @@ defmodule TuistCommon.GitHub do
   @api_base "https://api.github.com"
   @per_page 100
   @user_agent "tuist"
+  @rate_limit_event [:tuist_common, :github, :rate_limit]
+
+  @doc """
+  Telemetry event emitted with the rate-limit budget GitHub reports on API
+  responses. Measurements are `:limit` and `:used`, with the `:resource`
+  metadata naming the budget the request was accounted against.
+  """
+  @spec rate_limit_event_name() :: [atom()]
+  def rate_limit_event_name, do: @rate_limit_event
 
   @doc """
   Lists all tags for a repository.
@@ -239,8 +248,59 @@ defmodule TuistCommon.GitHub do
       |> maybe_add_opt(:decode_body, decode_body)
       |> maybe_add_opt(:into, into)
 
-    Req.request(req_opts)
+    req_opts
+    |> Req.request()
+    |> tap(&emit_rate_limit_telemetry/1)
   end
+
+  # GitHub reports the budget on every API response, including the 403 that
+  # denies the request. Reading it here covers every call site and every
+  # resource bucket, which `/rate_limit` polling does not: a 403 can be raised
+  # against a bucket other than the one a poller looks at.
+  defp emit_rate_limit_telemetry({:ok, response}) when is_map(response) do
+    headers = Map.get(response, :headers)
+
+    with limit when is_integer(limit) <- header_integer(headers, "x-ratelimit-limit"),
+         used when is_integer(used) <- header_integer(headers, "x-ratelimit-used") do
+      :telemetry.execute(@rate_limit_event, %{limit: limit, used: used}, %{
+        resource: header_value(headers, "x-ratelimit-resource") || "unknown"
+      })
+    end
+
+    :ok
+  end
+
+  defp emit_rate_limit_telemetry(_result), do: :ok
+
+  defp header_integer(headers, name) do
+    case header_value(headers, name) do
+      nil ->
+        nil
+
+      value ->
+        case Integer.parse(value) do
+          {integer, _rest} -> integer
+          :error -> nil
+        end
+    end
+  end
+
+  defp header_value(headers, name) when is_map(headers) do
+    headers |> Map.get(name) |> first_header_value()
+  end
+
+  defp header_value(headers, name) when is_list(headers) do
+    Enum.find_value(headers, fn
+      {^name, value} -> first_header_value(value)
+      _header -> nil
+    end)
+  end
+
+  defp header_value(_headers, _name), do: nil
+
+  defp first_header_value([value | _rest]), do: first_header_value(value)
+  defp first_header_value(value) when is_binary(value), do: value
+  defp first_header_value(_value), do: nil
 
   defp maybe_add_opt(opts, _key, nil), do: opts
   defp maybe_add_opt(opts, :decode_body, true), do: opts

--- a/tuist_common/lib/tuist_common/github/prom_ex_plugin.ex
+++ b/tuist_common/lib/tuist_common/github/prom_ex_plugin.ex
@@ -1,33 +1,62 @@
 defmodule TuistCommon.GitHub.PromExPlugin do
   @moduledoc """
   Exposes the GitHub REST API rate-limit budget reported on API responses.
+
+  The gauges are re-emitted from `TuistCommon.GitHub.RateLimit` on a poll
+  rather than straight from the response, so a scrape that follows no GitHub
+  call still carries the last known budget.
   """
   use PromEx.Plugin
 
-  alias TuistCommon.GitHub
+  alias TuistCommon.GitHub.RateLimit
+
+  @poll_event [:tuist_common, :github, :rate_limit, :poll]
+
+  @doc false
+  def poll_event_name, do: @poll_event
 
   @impl true
-  def event_metrics(_opts) do
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, to_timeout(second: 15))
+    server = Keyword.get(opts, :rate_limit_server, RateLimit)
+
     [
-      Event.build(
-        :tuist_github_rate_limit_event_metrics,
+      Polling.build(
+        :tuist_github_rate_limit_polling_metrics,
+        poll_rate,
+        {__MODULE__, :execute_rate_limit_telemetry, [server]},
         [
           last_value(
             [:tuist, :github, :rate_limit, :limit],
-            event_name: GitHub.rate_limit_event_name(),
+            event_name: @poll_event,
             measurement: :limit,
             tags: [:resource],
             description: "The `x-ratelimit-limit` value on the most recent GitHub API response."
           ),
           last_value(
             [:tuist, :github, :rate_limit, :used],
-            event_name: GitHub.rate_limit_event_name(),
+            event_name: @poll_event,
             measurement: :used,
             tags: [:resource],
             description: "The `x-ratelimit-used` value on the most recent GitHub API response."
+          ),
+          last_value(
+            [:tuist, :github, :rate_limit, :reset, :timestamp, :seconds],
+            event_name: @poll_event,
+            measurement: :reset,
+            tags: [:resource],
+            description:
+              "The `x-ratelimit-reset` value, as a Unix timestamp, on the most recent GitHub API response."
           )
         ]
       )
     ]
+  end
+
+  @doc false
+  def execute_rate_limit_telemetry(server \\ RateLimit) do
+    Enum.each(RateLimit.snapshot(server), fn {resource, measurements} ->
+      :telemetry.execute(@poll_event, measurements, %{resource: resource})
+    end)
   end
 end

--- a/tuist_common/lib/tuist_common/github/prom_ex_plugin.ex
+++ b/tuist_common/lib/tuist_common/github/prom_ex_plugin.ex
@@ -1,0 +1,33 @@
+defmodule TuistCommon.GitHub.PromExPlugin do
+  @moduledoc """
+  Exposes the GitHub REST API rate-limit budget reported on API responses.
+  """
+  use PromEx.Plugin
+
+  alias TuistCommon.GitHub
+
+  @impl true
+  def event_metrics(_opts) do
+    [
+      Event.build(
+        :tuist_github_rate_limit_event_metrics,
+        [
+          last_value(
+            [:tuist, :github, :rate_limit, :limit],
+            event_name: GitHub.rate_limit_event_name(),
+            measurement: :limit,
+            tags: [:resource],
+            description: "The `x-ratelimit-limit` value on the most recent GitHub API response."
+          ),
+          last_value(
+            [:tuist, :github, :rate_limit, :used],
+            event_name: GitHub.rate_limit_event_name(),
+            measurement: :used,
+            tags: [:resource],
+            description: "The `x-ratelimit-used` value on the most recent GitHub API response."
+          )
+        ]
+      )
+    ]
+  end
+end

--- a/tuist_common/lib/tuist_common/github/rate_limit.ex
+++ b/tuist_common/lib/tuist_common/github/rate_limit.ex
@@ -1,0 +1,68 @@
+defmodule TuistCommon.GitHub.RateLimit do
+  @moduledoc """
+  Holds the last rate-limit budget GitHub reported for each resource.
+
+  GitHub only reports the budget on API responses, and the PromEx storage
+  adapter flushes its tables on every scrape. A gauge emitted straight from
+  the response would therefore only land in the scrape that happens to follow
+  a GitHub call, and would vanish entirely while a worker backs off after
+  being rate limited. Keeping the last observation here lets the PromEx
+  plugin re-emit it on a schedule, so every scrape carries a sample.
+  """
+  use GenServer
+
+  alias TuistCommon.GitHub
+
+  @handler_id __MODULE__
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Returns the last budget observed per resource, keyed by resource name.
+
+  Returns an empty map when the tracker is not running so a scrape can never
+  fail because of it.
+  """
+  def snapshot(server \\ __MODULE__) do
+    GenServer.call(server, :snapshot)
+  catch
+    :exit, _reason -> %{}
+  end
+
+  @impl true
+  def init(opts) do
+    handler_id = Keyword.get(opts, :handler_id, @handler_id)
+
+    :telemetry.attach(
+      handler_id,
+      GitHub.rate_limit_event_name(),
+      &__MODULE__.handle_rate_limit_event/4,
+      self()
+    )
+
+    {:ok, %{handler_id: handler_id, budgets: %{}}}
+  end
+
+  @impl true
+  def terminate(_reason, %{handler_id: handler_id}) do
+    :telemetry.detach(handler_id)
+  end
+
+  @doc false
+  def handle_rate_limit_event(_event, measurements, metadata, server) do
+    GenServer.cast(server, {:record, metadata.resource, measurements})
+  end
+
+  @impl true
+  def handle_cast({:record, resource, measurements}, state) do
+    {:noreply, %{state | budgets: Map.put(state.budgets, resource, measurements)}}
+  end
+
+  @impl true
+  def handle_call(:snapshot, _from, state) do
+    {:reply, state.budgets, state}
+  end
+end

--- a/tuist_common/test/tuist_common/github/prom_ex_plugin_test.exs
+++ b/tuist_common/test/tuist_common/github/prom_ex_plugin_test.exs
@@ -1,0 +1,93 @@
+defmodule TuistCommon.GitHub.PromExPluginTest do
+  use ExUnit.Case, async: true
+
+  alias TuistCommon.GitHub
+  alias TuistCommon.GitHub.PromExPlugin
+  alias TuistCommon.GitHub.RateLimit
+
+  describe "polling_metrics/1" do
+    test "exposes the budget as gauges keyed by the measurements the client emits" do
+      [polling] = PromExPlugin.polling_metrics([])
+      [limit, used, reset] = polling.metrics
+
+      assert polling.poll_rate == to_timeout(second: 15)
+
+      assert polling.measurements_mfa ==
+               {PromExPlugin, :execute_rate_limit_telemetry, [RateLimit]}
+
+      assert limit.name == [:tuist, :github, :rate_limit, :limit]
+      assert limit.event_name == PromExPlugin.poll_event_name()
+      assert limit.measurement == :limit
+      assert limit.tags == [:resource]
+
+      assert used.name == [:tuist, :github, :rate_limit, :used]
+      assert used.event_name == PromExPlugin.poll_event_name()
+      assert used.measurement == :used
+      assert used.tags == [:resource]
+
+      assert reset.name == [:tuist, :github, :rate_limit, :reset, :timestamp, :seconds]
+      assert reset.event_name == PromExPlugin.poll_event_name()
+      assert reset.measurement == :reset
+      assert reset.tags == [:resource]
+    end
+  end
+
+  describe "execute_rate_limit_telemetry/0" do
+    # Asserts against what `TuistCommon.GitHub` actually emits rather than a
+    # hand-written map, so renaming a measurement key or dropping the
+    # `:resource` metadata fails here instead of silently producing a gauge
+    # that never yields a sample.
+    test "re-emits every budget the client has reported" do
+      unique = System.unique_integer([:positive])
+      server = :"rate_limit_#{unique}"
+      start_supervised!({RateLimit, name: server, handler_id: "tracker-#{unique}"})
+
+      handler_id = "poll-#{unique}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        PromExPlugin.poll_event_name(),
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:poll, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      :telemetry.execute(
+        GitHub.rate_limit_event_name(),
+        %{limit: 5000, used: 4998, reset: 1_780_000_000},
+        %{resource: "core"}
+      )
+
+      # The tracker records via a cast; the snapshot call behind
+      # execute_rate_limit_telemetry/1 serialises behind it.
+      PromExPlugin.execute_rate_limit_telemetry(server)
+
+      assert_receive {:poll, %{limit: 5000, used: 4998, reset: 1_780_000_000},
+                      %{resource: "core"}}
+    end
+
+    test "emits nothing, and does not raise, when the tracker is not running" do
+      handler_id = "poll-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        PromExPlugin.poll_event_name(),
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:poll, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      PromExPlugin.execute_rate_limit_telemetry(:rate_limit_not_running)
+
+      refute_received {:poll, _measurements, _metadata}
+    end
+  end
+end

--- a/tuist_common/test/tuist_common/github_test.exs
+++ b/tuist_common/test/tuist_common/github_test.exs
@@ -266,4 +266,98 @@ defmodule TuistCommon.GitHubTest do
                GitHub.fetch_packages_json("test-token")
     end
   end
+
+  describe "rate limit telemetry" do
+    setup do
+      handler_id = "github-rate-limit-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        GitHub.rate_limit_event_name(),
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:rate_limit, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      :ok
+    end
+
+    test "emits the budget reported on a successful response" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [%{"name" => "1.0.0"}],
+           headers: %{
+             "x-ratelimit-limit" => ["5000"],
+             "x-ratelimit-used" => ["4998"],
+             "x-ratelimit-resource" => ["core"]
+           }
+         }}
+      end)
+
+      assert {:ok, ["1.0.0"]} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      assert_receive {:rate_limit, %{limit: 5000, used: 4998}, %{resource: "core"}}
+    end
+
+    test "emits the budget reported on a rate-limited response" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 403,
+           body: %{},
+           headers: %{
+             "x-ratelimit-limit" => ["5000"],
+             "x-ratelimit-used" => ["5000"],
+             "x-ratelimit-remaining" => ["0"],
+             "x-ratelimit-resource" => ["core"]
+           }
+         }}
+      end)
+
+      assert {:error, {:rate_limited, 403}} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      assert_receive {:rate_limit, %{limit: 5000, used: 5000}, %{resource: "core"}}
+    end
+
+    test "falls back to an unknown resource when the header is absent" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [],
+           headers: [{"x-ratelimit-limit", "60"}, {"x-ratelimit-used", "1"}]
+         }}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", nil)
+
+      assert_receive {:rate_limit, %{limit: 60, used: 1}, %{resource: "unknown"}}
+    end
+
+    test "does not emit when the response carries no rate limit headers" do
+      stub(Req, :request, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: [], headers: %{}}}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      refute_receive {:rate_limit, _measurements, _metadata}
+    end
+
+    test "does not emit when the request fails at the transport level" do
+      stub(Req, :request, fn _opts ->
+        {:error, %Req.TransportError{reason: :closed}}
+      end)
+
+      assert {:error, %Req.TransportError{}} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      refute_receive {:rate_limit, _measurements, _metadata}
+    end
+  end
 end

--- a/tuist_common/test/tuist_common/github_test.exs
+++ b/tuist_common/test/tuist_common/github_test.exs
@@ -295,6 +295,7 @@ defmodule TuistCommon.GitHubTest do
            headers: %{
              "x-ratelimit-limit" => ["5000"],
              "x-ratelimit-used" => ["4998"],
+             "x-ratelimit-reset" => ["1780000000"],
              "x-ratelimit-resource" => ["core"]
            }
          }}
@@ -302,7 +303,28 @@ defmodule TuistCommon.GitHubTest do
 
       assert {:ok, ["1.0.0"]} = GitHub.list_tags("tuist/tuist", "test-token")
 
-      assert_receive {:rate_limit, %{limit: 5000, used: 4998}, %{resource: "core"}}
+      assert_receive {:rate_limit, %{limit: 5000, used: 4998, reset: 1_780_000_000},
+                      %{resource: "core"}}
+    end
+
+    test "omits the reset measurement when GitHub does not send the header" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [],
+           headers: %{
+             "x-ratelimit-limit" => ["5000"],
+             "x-ratelimit-used" => ["1"],
+             "x-ratelimit-resource" => ["core"]
+           }
+         }}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      assert_receive {:rate_limit, measurements, %{resource: "core"}}
+      assert measurements == %{limit: 5000, used: 1}
     end
 
     test "emits the budget reported on a rate-limited response" do
@@ -347,7 +369,7 @@ defmodule TuistCommon.GitHubTest do
 
       assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
 
-      refute_receive {:rate_limit, _measurements, _metadata}
+      refute_received {:rate_limit, _measurements, _metadata}
     end
 
     test "does not emit when the request fails at the transport level" do
@@ -357,7 +379,56 @@ defmodule TuistCommon.GitHubTest do
 
       assert {:error, %Req.TransportError{}} = GitHub.list_tags("tuist/tuist", "test-token")
 
-      refute_receive {:rate_limit, _measurements, _metadata}
+      refute_received {:rate_limit, _measurements, _metadata}
+    end
+
+    # The header helpers exist so a malformed header can't blow up `request/4`,
+    # which the telemetry call sits inline in. Pinning them keeps a later
+    # simplification to `String.to_integer/1` from turning a cosmetic header
+    # anomaly into a failed job on every registry sync.
+    test "does not emit when only one half of the budget is reported" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [],
+           headers: %{"x-ratelimit-limit" => ["5000"], "x-ratelimit-resource" => ["core"]}
+         }}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      refute_received {:rate_limit, _measurements, _metadata}
+    end
+
+    test "does not emit or raise when a budget header is not a number" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [],
+           headers: %{"x-ratelimit-limit" => ["n/a"], "x-ratelimit-used" => ["1"]}
+         }}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      refute_received {:rate_limit, _measurements, _metadata}
+    end
+
+    test "does not emit or raise when a budget header carries no value" do
+      stub(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [],
+           headers: %{"x-ratelimit-limit" => [], "x-ratelimit-used" => ["1"]}
+         }}
+      end)
+
+      assert {:ok, []} = GitHub.list_tags("tuist/tuist", "test-token")
+
+      refute_received {:rate_limit, _measurements, _metadata}
     end
   end
 end


### PR DESCRIPTION
## What changed

Three Prometheus gauges reporting GitHub's rate-limit budget, sourced from the headers GitHub returns on API responses:

```
tuist_github_rate_limit_limit{resource="core"} 5000
tuist_github_rate_limit_used{resource="core"} 4998
tuist_github_rate_limit_reset_timestamp_seconds{resource="core"} 1780000000
```

- **`tuist_common/lib/tuist_common/github.ex`** — every GitHub call in the codebase funnels through one private `request/4`, so instrumentation lives there. After each response it parses `x-ratelimit-limit`, `x-ratelimit-used`, `x-ratelimit-reset`, and `x-ratelimit-resource`, and emits `[:tuist_common, :github, :rate_limit]`.
- **`tuist_common/lib/tuist_common/github/rate_limit.ex`** (new) — a supervised tracker holding the last budget observed per resource, fed by that event.
- **`tuist_common/lib/tuist_common/github/prom_ex_plugin.ex`** (new) — re-emits the tracker's contents on a 15s poll, exposed as `last_value` gauges labeled by `resource`.
- **`server/lib/tuist/prom_ex.ex`**, **`server/lib/tuist/application.ex`** — register the plugin and supervise the tracker.

## Why

The registry sync writer regularly hits GitHub `403`s while `/rate_limit` still reports remaining quota, and today there is no signal to tell which budget is actually exhausted — or whether a primary budget is involved at all.

## Why response headers rather than polling `/rate_limit`

Reading the headers off live responses covers every call site and, critically, **every resource bucket**. GitHub reports which budget a request was accounted against via `x-ratelimit-resource`; polling `/rate_limit` and eyeballing `core` can show headroom while a different bucket is pegged. The `403` that denies the request carries these headers too, so the denying response is itself sampled — which a poller, sampling at a different instant against a different bucket, cannot guarantee.

`resource` is included as a label beyond the two raw values because it is the dimension that discriminates between the competing explanations. The set is bounded (`core`, `search`, `graphql`, `code_search`, …), so there is no cardinality risk.

## Why the gauges are poll-driven rather than emitted from the response

The first version emitted the gauges directly from the response. That is wrong here, and the reason is specific to this repo's storage adapter: `Tuist.PromEx.StripedPeep.scrape/1` deletes all ETS objects after every scrape (`striped_peep.ex:19,31`). An event-driven `last_value` therefore only appears in the scrape that happens to follow a GitHub call. With a 10-minute sync cron against ~30s scrapes the series would be absent from nearly every scrape — and would go fully dark once a worker backs off after a `403`, i.e. precisely during the incident the metric exists to explain. Every other `last_value` in the repo is polling-backed, which is why the flush is harmless for them.

Measured directly, before the fix:

```
--- scrape 1, right after a GitHub call: 2 sample line(s)
--- scrape 2, no GitHub call since: 0 sample line(s)
--- scrape 3, no GitHub call since: 0 sample line(s)
```

and after:

```
--- scrape 1, right after a GitHub call: 3 sample line(s)
--- scrape 2, no GitHub call since (simulates a 403 backoff): 3 sample line(s)
--- scrape 3, still no GitHub call since: 3 sample line(s)
```

`x-ratelimit-reset` is exposed as a direct consequence: once a stale budget is re-emitted indefinitely, a dashboard needs a way to tell a live sample from one whose window has already rolled over. Reading it against `time()` gives that.

## Impact

Pair the new gauges with the existing outgoing-HTTP counter, which already labels by host and status:

```promql
tuist_github_rate_limit_used / tuist_github_rate_limit_limit
rate(tuist_http_request_count{request_host="api.github.com", response_status="403"}[5m])
```

- 403s spiking while `used` sits well below `limit` on every resource ⇒ a **secondary** (abuse) rate limit, invisible to the primary counters by design; `retry-after` is the next thing to look at.
- A non-`core` resource at `used == limit` ⇒ the bucket that `/rate_limit` inspection was missing.
- `tuist_github_rate_limit_reset_timestamp_seconds < time()` ⇒ the sample predates the current window; treat the usage figure as stale.

Two limits worth stating explicitly:

- Zipball downloads redirect to `codeload.github.com`, whose final response carries no rate-limit headers, so those requests produce no sample.
- The `git clone` path in `release_worker.ex` goes through `GitAuthentication`, not the REST API, so it is outside this budget entirely.

Purely additive: no behavior change to any GitHub call. Missing or unparseable headers and transport-level errors emit nothing, and a scrape cannot fail if the tracker is not running.

## Collection in production

Verified the metrics will actually be scraped from the writer pod:

- The `swift-registry-sync` Deployment carries `prometheus.io/scrape: "true"` on port `9091`.
- `TuistWeb.Telemetry` (which starts `Tuist.PromEx`) is in the unconditional supervision children, so it runs under `TUIST_MODE=swift_registry_sync`.
- `TUIST_PROMETHEUS_ENABLED` is unset in the chart, so `prometheus_enabled?` defaults true outside dev/test.
- `replicaCount: 1`, so there is no cross-pod gauge divergence.
- The 15s poll is shorter than any scrape interval in use, so every scrape sees a fresh sample.

## Validation

- **31/31** GitHub tests pass across the client and the plugin.
  - Client: a 200, a 403 rate-limited response, the tuple-list header shape with a missing `resource`, a response with no rate-limit headers, a transport failure, a missing `reset` header, plus the guards that keep a malformed header from breaking `request/4` (one-header-present, non-numeric value, empty value).
  - Plugin: per-metric name / event / measurement / tags, and a round trip asserting against what `TuistCommon.GitHub` actually emits. This last one matters because the client tests read the event name from the same accessor the plugin uses, so they structurally cannot catch an emitter↔plugin key mismatch — rename a measurement and the client tests would all still pass while the gauge silently produced nothing.
- **End-to-end**: booted the app and PromEx, emitted the event, and confirmed the gauges render in the Prometheus scrape output with correct per-resource labels and values, and persist across scrapes with no intervening GitHub call (output above).
- Server compiles; **39/39** `server/test/tuist/registry/` tests pass.
- `mix format --check-formatted` clean on all changed files; `mix credo` clean on both projects (the single `tuist_common` warning is pre-existing and unrelated).

Two review notes worth recording: the negative telemetry assertions use `refute_received` rather than `refute_receive` — the events are delivered synchronously in the calling process, so the 100ms default wait bought nothing and was 200ms of the file's 300ms runtime; the file now runs in 0.08s.

Note on the `tuist_common` suite: running it in full shows 1–3 non-deterministic failures on **both** this branch and a clean tree. `TuistCommon.AWS.ClientTest` is `async: true` with `set_mimic_global`, which breaks concurrent Mimic stubs in other modules. Excluding that module, the suite is a consistent **156/156**. Pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
