### PR TITLE
fix(server): re-read a registry archive before declaring it unverified

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -74,6 +74,8 @@ config :tuist, Tuist.OpsClickHouseRepo,
     session_timezone: "UTC"
   ]
 
+config :tuist, Tuist.Registry.Swift.ReleaseWorker, verification_backoff_ms: 0
+
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -26,6 +26,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   @metadata_lock_max_attempts 5
   @metadata_lock_backoff_ms 200
   @metadata_lock_snooze_seconds 30
+  @verify_max_attempts 6
+  @verify_backoff_ms 500
   # Symlinks nested inside these code-signed bundles are part of the bundle's
   # sealed layout (e.g. a Mac Catalyst framework's `Versions/Current -> A` and
   # the `Binary`/`Resources` links). Code signing records them as symlinks in
@@ -792,19 +794,79 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   # single requests. Confirming the stored object records the digest we just
   # uploaded, before the catalog is updated, keeps a catalog entry from
   # advertising a checksum that object storage does not actually hold.
+  #
+  # The read is retried because a completed write is not necessarily visible to
+  # the read that follows it, and both failure shapes are far more often that
+  # lag than a genuinely wrong archive: a missing object where nothing was
+  # stored before, a stale digest where a previous generation was. Failing
+  # instead is actively harmful — Oban restarts the job from the build step, and
+  # archive construction is not deterministic (#12195), so the retry uploads
+  # *different* bytes to the same key and leaves two generations competing for
+  # it. That is how a transient read failure became a permanently divergent
+  # version. Waiting a few seconds is cheap next to refetching and rebuilding.
+  #
+  # No jitter, unlike the metadata lock above: each job waits on its own object
+  # rather than contending with siblings, so there is no herd to spread out.
   defp verify_stored_archive(scope, name, version, checksum) do
-    key = source_archive_key(scope, name, version)
+    verify_stored_archive(source_archive_key(scope, name, version), checksum, @verify_max_attempts)
+  end
 
-    case S3.head_object(key) do
-      {:ok, headers} ->
-        case Map.get(headers, "x-amz-meta-sha256") do
-          ^checksum -> :ok
-          stored -> {:error, {:stored_archive_mismatch, key, %{expected: checksum, stored: stored}}}
+  defp verify_stored_archive(key, checksum, attempts_remaining) do
+    case stored_archive_digest(key) do
+      {:ok, ^checksum} ->
+        log_delayed_visibility(key, attempts_remaining)
+        :ok
+
+      result ->
+        if retryable_verification?(result) and attempts_remaining > 1 do
+          Process.sleep(verify_backoff_ms(attempts_remaining))
+          verify_stored_archive(key, checksum, attempts_remaining - 1)
+        else
+          verification_error(key, checksum, result)
         end
-
-      {:error, reason} ->
-        {:error, {:stored_archive_unverifiable, key, reason}}
     end
+  end
+
+  defp stored_archive_digest(key) do
+    case S3.head_object(key) do
+      {:ok, headers} -> {:ok, Map.get(headers, "x-amz-meta-sha256")}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # A digest that disagrees and a missing object are both "not visible yet".
+  # Anything else — a permission or configuration failure — will not resolve by
+  # waiting, so it fails on the first read rather than burning the budget.
+  defp retryable_verification?({:ok, _stale_digest}), do: true
+  defp retryable_verification?({:error, :not_found}), do: true
+  defp retryable_verification?({:error, _reason}), do: false
+
+  defp verification_error(key, checksum, {:ok, stored}) do
+    {:error, {:stored_archive_mismatch, key, %{expected: checksum, stored: stored}}}
+  end
+
+  defp verification_error(key, _checksum, {:error, reason}) do
+    {:error, {:stored_archive_unverifiable, key, reason}}
+  end
+
+  defp verify_backoff_ms(attempts_remaining) do
+    step = @verify_max_attempts - attempts_remaining + 1
+
+    :tuist
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(:verification_backoff_ms, @verify_backoff_ms)
+    |> Kernel.*(step)
+  end
+
+  # How long a write takes to become visible is not otherwise observable: the
+  # job succeeds either way, so without this the only trace is the failures.
+  defp log_delayed_visibility(_key, @verify_max_attempts), do: :ok
+
+  defp log_delayed_visibility(key, attempts_remaining) do
+    Logger.info(
+      "Registry archive #{key} became visible on verification attempt " <>
+        "#{@verify_max_attempts - attempts_remaining + 1}"
+    )
   end
 
   defp source_archive_key(scope, name, version) do

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -577,7 +577,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
 
     # Storage still holds a different object than the one just uploaded, which
     # is what leaves a catalog entry advertising a checksum nothing can serve.
-    expect(ExAws, :request, 2, fn
+    # Read six times: a stale digest is usually a write that is not yet visible,
+    # so it is only conclusive once re-reading stops changing the answer.
+    expect(ExAws, :request, 7, fn
       %S3{http_method: :head}, _config ->
         {:ok, %{status_code: 200, headers: [{"x-amz-meta-sha256", "a-previously-stored-archive"}]}}
 
@@ -588,6 +590,92 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     reject(Metadata, :put_package, 3)
 
     assert {:error, {:stored_archive_mismatch, _key, %{stored: "a-previously-stored-archive"}}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "publishes once a write that was not yet visible becomes visible" do
+    stub_successful_fetch()
+
+    stub(Metadata, :get_package, fn "apple", "swift-argument-parser", _opts ->
+      {:error, :not_found}
+    end)
+
+    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired} end)
+
+    {:ok, uploaded_digest} = Agent.start_link(fn -> nil end)
+    {:ok, head_reads} = Agent.start_link(fn -> 0 end)
+
+    expect(Upload, :stream_file, fn path ->
+      Agent.update(uploaded_digest, fn _previous -> sha256(path) end)
+      [File.read!(path)]
+    end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    # The first read misses the object entirely. That is what a completed but
+    # not yet propagated write looks like, and failing here would restart the
+    # job at the build step and upload a second, different archive.
+    expect(ExAws, :request, 4, fn
+      %S3{http_method: :head}, _config ->
+        case Agent.get_and_update(head_reads, &{&1 + 1, &1 + 1}) do
+          1 -> {:ok, %{status_code: 404}}
+          _ -> {:ok, %{status_code: 200, headers: [{"x-amz-meta-sha256", Agent.get(uploaded_digest, & &1)}]}}
+        end
+
+      _operation, _config ->
+        {:ok, %{status_code: 200, body: ""}}
+    end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      assert metadata["releases"]["1.0.0"]["checksum"] == Agent.get(uploaded_digest, & &1)
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+
+    assert Agent.get(head_reads, & &1) == 2
+  end
+
+  test "stops reading back when the verification failure cannot resolve by waiting" do
+    stub_successful_fetch()
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    # Exactly one head request: waiting cannot turn a rejected read into an
+    # accepted one, so the retry budget is not spent on it.
+    expect(ExAws, :request, 2, fn
+      %S3{http_method: :head}, _config -> {:ok, %{status_code: 403}}
+      _operation, _config -> {:ok, %{status_code: 200, body: ""}}
+    end)
+
+    reject(Metadata, :put_package, 3)
+
+    assert {:error, {:stored_archive_unverifiable, _key, {:s3_error, 403}}} =
              ReleaseWorker.perform(%Oban.Job{
                args: %{
                  "scope" => "apple",


### PR DESCRIPTION
## What changed

`ReleaseWorker` re-reads the stored archive up to six times, with a linear backoff, before concluding that a publish failed verification. Errors that cannot resolve by waiting still fail on the first read.

## Why

A read immediately after an upload can miss. `upload_file/3` goes through the multipart path, and `S3.request(%Upload{})` skips `with_tigris_consistency/1` — the consistency header is only added to single requests — so a completed write is not necessarily visible to the verification read that follows it.

Both failure shapes the verification can produce mean that lag far more often than they mean the archive is wrong:

| Prior object at the key? | What the read returns |
|---|---|
| No | `404` → `stored_archive_unverifiable` |
| Yes | the previous generation's digest → `stored_archive_mismatch` |

Both occurred in production within 47 seconds of each other, on unrelated packages.

## Root cause of the damage this prevents

Failing the job on the first read is worse than the fault it reports. Oban restarts `perform/1` from the top, so the retry re-runs the **build** — and archive construction is not deterministic (#12195). The retry therefore uploads *different* bytes to the same key while the first write may still be settling.

One version has already diverged permanently this way:

```
15:23:33  attempt 1  built A → uploaded → read back the previous generation  ✗ failed
15:23:52  attempt 2  built B → uploaded → read back B                        ✓ catalog := B
```

Three digests for one version. The two overlapping writes settled with storage keeping A and the catalog advertising B, and the divergence is not self-correcting. The other case that day recovered on its own — the difference between them was only whether the rebuild happened to produce equivalent bytes.

So the recovery path was more dangerous than the error it was recovering from. Re-reading costs a few seconds; rebuilding costs a GitHub refetch, a repack, a second upload, and the risk above.

## Choices worth flagging

**Which errors retry.** Only a stale digest and a missing object. A rejected read — permissions, configuration — will not become an accepted one by waiting, so it fails immediately rather than spending the budget. There is a test asserting exactly one read in that case.

**No jitter**, unlike the metadata-lock retry directly above it in the same module. That one exists to spread sibling jobs contending for a shared lock; here each job waits on its own object, so there is no herd.

**A recovered read is logged.** How long a write takes to become visible is otherwise unobservable — the job succeeds either way, so without this the only trace in production is the failures. The log line reports which attempt succeeded, which is what would tell us whether six attempts is the right budget.

**Backoff is configurable** so tests do not sleep. Default 500 ms linear, ~7.5 s total.

## What this does not fix

Publishing is still not safe against a concurrent overwrite. As long as archives live at a mutable key, a rebuild can collide with an in-flight write to the same key, and a stale cached copy of the old generation can outlive the new one (#12208). The structural fix is content-addressed object keys, where a rebuild that produces different bytes writes a different key and the catalog switches between immutable objects. This change removes the trigger; it does not remove the hazard.

## Validation

`mix test test/tuist/registry/swift/release_worker_test.exs` — 17 passed, including two new cases:

- a first read that 404s, then succeeds: asserts the release publishes, the catalog records the uploaded digest, and exactly two reads happened
- a read rejected with a 403: asserts the failure is immediate and the catalog is untouched

The existing mismatch test was updated from 2 storage requests to 7, which is the assertion that a stale digest is now re-read rather than trusted on the first look.

## Related

- #12195 — non-deterministic archive construction, which is what turns a retried upload into two competing objects rather than two identical ones
- #12208 — archive downloads bypass storage consistency; same underlying gap, on the read path, where it is not guarded at all
