### PR TITLE
fix(cli): record symlinked registry binary targets in the workspace state

### DIFF
--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -79,6 +79,18 @@ extension FileSystem {
         return (stats.st_mode & S_IFMT) == S_IFDIR
     }
 
+    /// True if a path resolves to a directory, following symbolic links.
+    /// Use this to classify a path a manifest named explicitly; use
+    /// `isDirectoryAndNotSymlink(_:)` when walking a tree, where following links
+    /// risks escaping the tree or cycling.
+    /// Synchronous because `stat` is a single non-blocking metadata call.
+    func isDirectoryFollowingSymlinks(_ url: URL) -> Bool {
+        var stats = stat()
+        let result = url.path.withCString { stat($0, &stats) }
+        guard result == 0 else { return false }
+        return (stats.st_mode & S_IFMT) == S_IFDIR
+    }
+
     /// True if a path exists or is a (potentially broken) symlink.
     /// Synchronous because `lstat` is a single non-blocking metadata call.
     func existsIncludingSymlinks(_ url: URL) -> Bool {

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -526,7 +526,22 @@ enum WorkspaceRestorer {
 
     private static func binaryArtifacts(in directory: URL) async throws -> [BinaryArtifact] {
         guard try await fileSystem.exists(directory.absolutePath) else { return [] }
-        if fileSystem.isDirectoryAndNotSymlink(directory) {
+        // Follows symlinks, unlike the traversal guard below, because `directory`
+        // here is a path a manifest named explicitly.
+        //
+        // How we materialise a cached package decides whether that path is a
+        // symlink. `replaceWithRegistryDownloadDirectory` gives a registry download
+        // a real package root whose entries are individually symlinked into the
+        // shared source cache, so a root-level `.binaryTarget(path: "Foo.xcframework")`
+        // is itself a symlink. `replaceWithCachedDirectory` symlinks a source-control
+        // checkout as one whole tree, so the same declaration resolves through the
+        // parent link to a real directory and lstat accepts it. Classifying the
+        // registry case with lstat dropped the artifact from the workspace state, and
+        // the generated project then referenced a target that no longer existed.
+        //
+        // CI copies rather than symlinks (`shouldCopyCachedDirectories`), which is
+        // why this only ever reproduced locally.
+        if fileSystem.isDirectoryFollowingSymlinks(directory) {
             if directory.pathExtension == "xcframework" {
                 return [BinaryArtifact(path: directory, kind: ["xcframework": [:]])]
             }

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -64,8 +64,12 @@ struct FileSystemSupportTests {
 
             #expect(try await fileSystem.exists(link.absolutePath))
             #expect(!(fileSystem.isDirectoryAndNotSymlink(link)))
+            // A link to a file is not a directory either way, so the two helpers
+            // only disagree when the link resolves to a directory.
+            #expect(!(fileSystem.isDirectoryFollowingSymlinks(link)))
             #expect(try await fileSystem.exists(directoryLink.absolutePath, isDirectory: true))
             #expect(!(fileSystem.isDirectoryAndNotSymlink(directoryLink)))
+            #expect(fileSystem.isDirectoryFollowingSymlinks(directoryLink))
             #expect(!(try await fileSystem.currentWorkingDirectory().pathString.isEmpty))
         }
     }

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -413,6 +413,69 @@ struct RestoreTests {
     }
 
     @Test
+    func writeWorkspaceStateWritesSymlinkedRegistryBinaryArtifacts() async throws {
+        try await withTemporaryDirectory { root in
+            let package = root.appendingPathComponent("Package")
+            let scratch = root.appendingPathComponent("scratch")
+            let pin = ResolvedPin(
+                identity: "example.package",
+                kind: "registry",
+                location: "",
+                state: ResolvedState(branch: nil, revision: nil, version: "2.3.4")
+            )
+
+            // A registry download is a farm of symlinks into the shared source
+            // cache, so a binary target at the package root arrives as a symlink
+            // rather than a directory.
+            let cachedFramework = root.appendingPathComponent("cache/example.package/Foo.xcframework")
+            try await fileSystem.makeDirectory(
+                at: cachedFramework.absolutePath, options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.atomicWrite(
+                validXCFrameworkInfoPlist(),
+                to: cachedFramework.appendingPathComponent("Info.plist")
+            )
+
+            let downloadDir = try scratch
+                .appendingPathComponent("registry/downloads")
+                .appendingPathComponent(PinKind.registryDownloadSubpath(pin))
+            try await writeCachedManifest(
+                localBinaryTargetManifest(name: "Foo", path: "Foo.xcframework"),
+                packageDir: downloadDir
+            )
+            let framework = downloadDir.appendingPathComponent("Foo.xcframework")
+            try await fileSystem.createSymbolicLink(
+                from: framework.absolutePath, to: cachedFramework.absolutePath
+            )
+
+            try await writeCachedManifest(emptyManifest(), packageDir: package)
+
+            let resolved = ResolvedPins(originHash: "origin", pins: [pin], version: 3)
+
+            try await WorkspaceRestorer.writeWorkspaceState(
+                packageDir: package, scratchDir: scratch, resolved: resolved, disableSandbox: false
+            )
+
+            let statePath = scratch.appendingPathComponent("workspace-state.json")
+            let state = try #require(
+                try JSONSerialization.jsonObject(
+                    with: await fileSystem.readFile(at: statePath.absolutePath))
+                    as? [String: Any])
+            let object = try #require(state["object"] as? [String: Any])
+            let artifacts = try #require(object["artifacts"] as? [[String: Any]])
+            let artifact = try #require(artifacts.first)
+            let packageRef = try #require(artifact["packageRef"] as? [String: Any])
+            #expect(artifacts.count == 1)
+            #expect(artifact["targetName"] as? String == "Foo")
+            // The path stays inside the scratch directory rather than pointing at
+            // the cache, matching what a source-control checkout records.
+            #expect(artifact["path"] as? String == framework.path)
+            #expect(packageRef["kind"] as? String == "registry")
+            #expect(packageRef["identity"] as? String == "example.package")
+        }
+    }
+
+    @Test
     func restorePackageDownloadsAndAdvertisesRemoteBinaryArtifacts() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("Package")

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -476,6 +476,55 @@ struct RestoreTests {
     }
 
     @Test
+    func writeWorkspaceStateDoesNotFollowSymlinksOutOfTheScannedDirectory() async throws {
+        try await withTemporaryDirectory { root in
+            let package = root.appendingPathComponent("Package")
+            let scratch = root.appendingPathComponent("scratch")
+
+            // Only the path a manifest names is resolved through symlinks. Walking
+            // a directory still refuses to follow links, so a link planted inside a
+            // scanned directory cannot pull an artifact in from outside the tree.
+            let outsideFramework = root.appendingPathComponent("outside/Escaped.xcframework")
+            try await fileSystem.makeDirectory(
+                at: outsideFramework.absolutePath, options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.atomicWrite(
+                validXCFrameworkInfoPlist(),
+                to: outsideFramework.appendingPathComponent("Info.plist")
+            )
+
+            let vendor = package.appendingPathComponent("Vendor")
+            try await fileSystem.makeDirectory(
+                at: vendor.absolutePath, options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.createSymbolicLink(
+                from: vendor.appendingPathComponent("Escaped.xcframework").absolutePath,
+                to: outsideFramework.absolutePath
+            )
+
+            try await writeCachedManifest(
+                localBinaryTargetManifest(name: "Escaped", path: "Vendor"),
+                packageDir: package
+            )
+
+            let resolved = ResolvedPins(originHash: "origin", pins: [], version: 3)
+
+            try await WorkspaceRestorer.writeWorkspaceState(
+                packageDir: package, scratchDir: scratch, resolved: resolved, disableSandbox: false
+            )
+
+            let statePath = scratch.appendingPathComponent("workspace-state.json")
+            let state = try #require(
+                try JSONSerialization.jsonObject(
+                    with: await fileSystem.readFile(at: statePath.absolutePath))
+                    as? [String: Any])
+            let object = try #require(state["object"] as? [String: Any])
+            let artifacts = try #require(object["artifacts"] as? [[String: Any]])
+            #expect(artifacts.isEmpty)
+        }
+    }
+
+    @Test
     func restorePackageDownloadsAndAdvertisesRemoteBinaryArtifacts() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("Package")


### PR DESCRIPTION
Fixes #12210.

## Where the bug is

In swifterpm. Nothing about the Swift package registry, the registry protocol, or `registry.tuist.dev` is at fault here. The registry serves an ordinary zip archive and it serves it correctly. The defect is entirely in how swifterpm materialises a cached package into the scratch directory, and "registry" only names which resolution path happens to trigger it.

## What changed

`binaryArtifacts(in:)` now classifies the top level path through symlinks, so a local binary target declared at a package root is recorded in the workspace state instead of being silently dropped.

Three files, about 20 lines of production code:

- `FileSystemSupport.swift`: adds `isDirectoryFollowingSymlinks(_:)`, a `stat` based sibling of the existing `lstat` based `isDirectoryAndNotSymlink(_:)`.
- `Restore.swift`: uses it for the top level check in `binaryArtifacts(in:)`. The traversal guard inside the directory walk keeps using `lstat`.
- `RestoreTests.swift`: adds a regression test for a pinned registry package with a symlinked root level xcframework.

## Symptom

`tuist generate` failed on any registry resolved package declaring a local `.binaryTarget(path:)` pointing at an xcframework at the package root:

```
✖ Error
  Couldn't find target 'Checkout3DS' at '.../Tuist/.build/registry/downloads/checkout/checkout-3ds-sdk-ios/3.2.11'
```

The same dependency graph generated fine from source control.

## Root cause

After a package is extracted into the shared source cache, swifterpm links it into the scratch directory, and it uses a **different strategy per pin kind**:

| pin kind | function | resulting layout |
| --- | --- | --- |
| source control | `replaceWithCachedDirectory` → `replaceWithSymlink` | the whole checkout is one symlink to the cached tree |
| registry | `replaceWithRegistryDownloadDirectory` → `replaceWithDirectoryOfSymlinks` | the package root is a real directory whose entries are individually symlinked |

That asymmetry is deliberate and documented in `FileSystemSupport.swift`: Xcode treats a symlinked registry root differently during dependency scanning, so the root is kept real while the contents are shared.

It also decides whether a root level binary target is a symlink:

```
# registry: the entry itself is a link
.build/registry/downloads/checkout/checkout-3ds-sdk-ios/3.2.11/Checkout3DS.xcframework -> ~/.cache/swifterpm/sources/.../Checkout3DS.xcframework

# source control: the parent is the link, so the entry is a real directory
.build/checkouts/checkout-3ds-sdk-ios/Checkout3DS.xcframework   drwxr-xr-x
```

`lstat` only inspects the final path component, so the source control case passes and the registry case does not. From there:

1. `binaryArtifacts(in:)` gated the top level check on `isDirectoryAndNotSymlink`, an `lstat`, so the symlinked `.xcframework` was classified as not an artifact and `binaryArtifact(in:)` returned nil.
2. `workspaceArtifact` returned nil for the target, so it never reached `workspace-state.json`.
3. Tuist's `PackageInfoMapper` only maps a binary target to `.xcframework` when an artifact path exists for it. Without one it fell through to `.target(name:)`.
4. `GraphLoader` could not find a target by that name and threw `targetNotFound`.

Nested binaries were unaffected, because only the top level of a registry package root is symlinked. `processout-ios` declares `Vendor/NetceteraShim.xcframework`, where `Vendor` is the link and the xcframework beneath it is a real directory, and it recorded correctly throughout.

## This is a recent regression, and there is a workaround

Two commits bracket it:

- `60807c4865` (2026-06-29), "handle SwifterPM registry symlinks and xcframework module maps", introduced `replaceWithRegistryDownloadDirectory` and with it the per-entry symlink farm.
- `507589f9d4` (2026-07-13), "enable SwifterPM resolution by default", made that path the default and exposed it to everyone.

Before the second commit `tuist install` shelled out to Apple's SwiftPM, so anyone on an older build never sees this. Verified by A/B on an identical source tree:

| tuist | resolver | `Checkout3DS.xcframework` | artifacts | `generate` |
| --- | --- | --- | --- | --- |
| 4.201.0-canary.19 | stock SwiftPM | real directory | 5 | passes |
| 4.204.0-canary.2 | swifterpm | symlink | 2 | fails |

`TUIST_USE_SWIFTERPM=0 tuist install` reproduces the passing row on a current build, so that is a usable workaround for anyone blocked today.

It also sharpens what this change is for. Apple's SwiftPM extracts registry archives as real directories and records all five artifacts, so the fix restores parity with SwiftPM rather than inventing behaviour.

## Why nobody caught it

`replaceWithCachedDirectory` and `replaceWithRegistryDownloadDirectory` both check `shouldCopyCachedDirectories` first, which is `Environment.isCI` under the default `.automatic` mode. CI copies cached directories rather than symlinking them, so every path is a real directory there and the bug cannot reproduce. It only ever appeared on developer machines.

## Why this fix and not the other one

The issue offered two options. The alternative was flipping `canonicalizeLocalBinaryPaths` to `true` for pinned packages in `packageContexts`, matching how the root package and local path dependencies are already handled.

I did not take it. That flag covers every pinned package, including source control ones, whose checkout directories are themselves symlinks. Turning it on would rewrite artifact paths that already work today, moving them out of the scratch directory and into `~/.cache/swifterpm/...`. This change leaves working paths untouched and keeps registry entries project relative, which is the shape source control already produces.

The narrower framing is also the more accurate one: the path in question is one a manifest named explicitly, so refusing it for being a symlink is simply wrong. The guard inside the directory walk is a different concern, it prevents following links out of the tree or into a cycle during discovery, and it stays as it was.

## Does this let traversal escape the tree?

No, and it narrows traversal rather than widening it.

The two checks answer different questions. The one I changed classifies a single path the manifest named. The one inside the directory walk decides whether to descend, and it is untouched, so a symlink encountered while walking is still skipped and the scan cannot follow a link out of the tree.

The old code did not avoid following the top level symlink either. When `isDirectoryAndNotSymlink` rejected a symlinked `Foo.xcframework`, control fell past the classification block to `contentsOfDirectory(at: directory)`, which lists through the symlink regardless. So the previous behaviour was to descend into the xcframework's internals, walk `ios-arm64`, `_CodeSignature` and friends, and return nothing. The new code early-returns the artifact instead, so that pointless deep scan is gone.

Recorded paths also stay put. `BinaryArtifact(path: directory, ...)` stores the path as written, so the workspace state keeps the link inside the scratch directory rather than the cache target it resolves to. That was the deciding reason for preferring this over canonicalisation, and it is visible in the artifact listing below.

`writeWorkspaceStateDoesNotFollowSymlinksOutOfTheScannedDirectory` pins the boundary: a scanned directory containing a symlink to an xcframework outside the package records nothing. It was previously implicit and untested. Confirmed non vacuous, widening the traversal guard to follow symlinks fails it.

## Validation

**Unit.** New test `writeWorkspaceStateWritesSymlinkedRegistryBinaryArtifacts` covers a pinned registry package with a symlinked root level xcframework. The existing binary target test only covered the root package with a nested real directory, which is why this shipped unnoticed. Confirmed non vacuous: reverting the one line fix fails it with `artifacts → []`. Full swifterpm suite passes, 137 tests in 20 suites.

**End to end**, running the rebuilt `swifterpm` binary against a real graph rooted at `processout-ios` 4.42.0:

```
artifacts recorded: 5   (was 2)
  checkout.checkout-3ds-sdk-ios                Checkout3DS             .build/registry/downloads/.../Checkout3DS.xcframework
  checkout.checkout-3ds-sdk-ios                Checkout3DS-Security    .build/registry/downloads/.../Checkout3DS-Security.xcframework
  checkout.checkout-event-logger-ios-framework CheckoutEventLoggerKit  .build/registry/downloads/.../CheckoutEventLoggerKit.xcframework
  processout.processout-ios                    NetceteraShim           .../Vendor/NetceteraShim.xcframework
  netceteragroup.ios-3ds-sdk-spm               ThreeDS_SDK             .build/artifacts/.../ThreeDS_SDK.xcframework
```

That is exactly the set the source control path produces. `tuist generate` then succeeds where it previously threw, and Xcode processes all three xcframeworks through the symlink: `Checkout3DS.framework`, `Checkout3DS-Security.framework` and `CheckoutEventLoggerKit.framework` all land in the build products.

The fixture's build still fails, but only on a pre-existing incompatibility unrelated to this change: Checkout3DS ships an iOS 13 swiftinterface that cannot be compiled against JOSESwift 2.4.0's iOS 15 floor. Diffing the normalised error sets between the source control run and the registry run gives an exact match, so the registry path now fails only where source control already failed.

## Impact

Any registry resolved package declaring a root level local xcframework was unbuildable through Tuist on a developer machine. This was found on a customer graph of 59 packages where 3 targets across 2 packages were dropped:

| package | targets |
| --- | --- |
| `checkout.checkout-3ds-sdk-ios` | `Checkout3DS`, `Checkout3DS-Security` |
| `checkout.checkout-event-logger-ios-framework` | `CheckoutEventLoggerKit` |

The old failure mode was also hard to act on, since the error named a target and gave no hint that a binary artifact had been dropped during restore.

## Notes

`RestoreTests.swift` has 9 pre-existing `swiftformat --lint` violations, none in the added range. Left alone to keep the diff focused. The two source files pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


