### PR TITLE
feat(infra): add Tuist Cache Server overview dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-cache-server-overview.json
+++ b/infra/grafana-dashboards/tuist-cache-server-overview.json
@@ -1,0 +1,193 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "defu61g6uzswsgf"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "label_replace(100 * (1 - (node_filesystem_avail_bytes{instance=~\"cache-.*\", mountpoint=\"/cas\"} / node_filesystem_size_bytes{instance=~\"cache-.*\", mountpoint=\"/cas\"})), \"region\", \"$1\", \"instance\", \"cache-(.*)\")",
+                        "instant": true,
+                        "legendFormat": "{{region}}",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 1,
+          "links": [],
+          "title": "CAS Disk Usage",
+          "vizConfig": {
+            "group": "gauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 60
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.54,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": false,
+                  "gradient": false
+                },
+                "endpointMarker": "point",
+                "minVizHeight": 75,
+                "minVizWidth": 75,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 63,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sizing": "auto",
+                "sparkline": true,
+                "textMode": "auto"
+              }
+            },
+            "version": "13.2.0-30402795349"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 0
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
+        }
+      }
+    },
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Tuist Cache Server / Overview",
+    "variables": []
+  }
+}


### PR DESCRIPTION
## What changed

Adds `infra/grafana-dashboards/tuist-cache-server-overview.json`, a new Git Sync'd Grafana Cloud dashboard titled **Tuist Cache Server / Overview** (UID `defu61g6uzswsgf`).

It currently holds a single full-width gauge panel, **CAS Disk Usage**, showing per-region `/cas` filesystem utilization on the legacy cache hosts:

```promql
label_replace(
  100 * (1 - (node_filesystem_avail_bytes{instance=~"cache-.*", mountpoint="/cas"}
            / node_filesystem_size_bytes{instance=~"cache-.*", mountpoint="/cas"})),
  "region", "$1", "instance", "cache-(.*)"
)
```

The `label_replace` rewrites the `cache-<region>` instance label into a `region` legend so each host reads as its region rather than its raw instance name. Thresholds are percentage-based: green below 60%, amber at 60%, red at 80%. Default window is `now-6h`, with a sparkline under each gauge so a slow fill trend is visible next to the instantaneous value.

## Why

The cache hosts serve CAS artifacts off a dedicated `/cas` filesystem, and a full disk there is a hard outage for that region — there was no at-a-glance view of headroom per host. `cache-service.json` covers application-level cache behavior; this dashboard is the host/capacity view that sits beside it, so disk pressure is visible before it becomes a write failure.

The gauge is deliberately instant + per-region rather than a time series: the question being answered is "how much room is left, right now, in each region", and 80% red is the point where reclaiming space still has slack to work with.

## How it was produced

The dashboard was authored in the Grafana Cloud UI inside the `Tuist Dashboards` folder, which is bound to `infra/grafana-dashboards/` via [Git Sync](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/). Saving there emits the wrapped `dashboard.grafana.app/v2` resource (`apiVersion` / `kind` / `metadata.name` around the raw dashboard under `spec`) and opens this PR — direct commits to `main` from Grafana are disabled, so every UI save goes through review. `metadata.name` matches the dashboard UID, as required by the sync contract documented in `infra/AGENTS.md`.

## Impact

- Merging provisions the dashboard back into Grafana Cloud on the next pull (60s sync interval, or immediately via webhook).
- No runtime, chart, or service change. Nothing outside `infra/grafana-dashboards/` is touched.
- Self-hosters importing this into their own Grafana should extract `spec` first (`jq '.spec' tuist-cache-server-overview.json`), as the Import UI expects raw dashboard JSON.

## Validation

- Rendered live in Grafana Cloud before saving — the panel returns data for the current `cache-*` hosts and the `region` legend resolves correctly.
- File parses as JSON and carries the required `apiVersion: dashboard.grafana.app/v2` + `kind: Dashboard` wrapper with `metadata.name` equal to the dashboard UID.
- Diff against `main` is a single added file (+193 lines); no existing dashboard was modified.
