### PR TITLE
feat(infra): track root filesystem usage on the cache service dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-cache-server-overview.json
+++ b/infra/grafana-dashboards/tuist-cache-server-overview.json
@@ -27,7 +27,6 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "",
     "editable": true,
     "elements": {
       "panel-1": {
@@ -68,7 +67,112 @@
           "description": "",
           "id": 1,
           "links": [],
-          "title": "CAS Disk Usage",
+          "title": "mount point: /cas",
+          "vizConfig": {
+            "group": "gauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 60
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.54,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": false,
+                  "gradient": false
+                },
+                "endpointMarker": "point",
+                "minVizHeight": 75,
+                "minVizWidth": 75,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 63,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sizing": "auto",
+                "sparkline": true,
+                "textMode": "auto"
+              }
+            },
+            "version": "13.2.0-30402795349"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "label_replace(100 * (1 - (node_filesystem_avail_bytes{instance=~\"cache-.*\", mountpoint=\"/\"} / node_filesystem_size_bytes{instance=~\"cache-.*\", mountpoint=\"/\"})), \"region\", \"$1\", \"instance\", \"cache-(.*)\")",
+                        "instant": true,
+                        "legendFormat": "{{region}}",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 2,
+          "links": [],
+          "title": "mount point: /",
           "vizConfig": {
             "group": "gauge",
             "kind": "VizConfig",
@@ -144,12 +248,25 @@
             "spec": {
               "element": {
                 "kind": "ElementReference",
-                "name": "panel-1"
+                "name": "panel-2"
               },
-              "height": 11,
+              "height": 4,
               "width": 24,
               "x": 0,
               "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 4,
+              "width": 24,
+              "x": 0,
+              "y": 4
             }
           }
         ]
@@ -187,7 +304,7 @@
       "timezone": "browser",
       "to": "now"
     },
-    "title": "Tuist Cache Server / Overview",
+    "title": "Tuist Cache Service / Overview",
     "variables": []
   }
 }


### PR DESCRIPTION
## What changed

A follow-up Grafana Git Sync save to `infra/grafana-dashboards/tuist-cache-server-overview.json` (UID `defu61g6uzswsgf`), the dashboard added in #12212. Three things:

1. **New panel — `mount point: /`.** A second gauge for root filesystem utilization on the same `cache-*` hosts, mirroring the existing `/cas` query shape:

   ```promql
   label_replace(
     100 * (1 - (node_filesystem_avail_bytes{instance=~"cache-.*", mountpoint="/"}
               / node_filesystem_size_bytes{instance=~"cache-.*", mountpoint="/"})),
     "region", "$1", "instance", "cache-(.*)"
   )
   ```

   Same instant query, same `region` legend rewrite, same percentage thresholds (green / amber at 60% / red at 80%) so the two rows read against one scale.

2. **Panels renamed to the thing they measure.** `CAS Disk Usage` → `mount point: /cas`, and the new one is `mount point: /`. With two filesystems on the board, naming each panel after its mount point is what disambiguates them; "CAS Disk Usage" said which *workload* the disk serves, not which filesystem the gauge is reading.

3. **Layout + dashboard title.** The single 11-high panel becomes two 4-high full-width rows, with `/` on top and `/cas` below, so both fit above the fold without scrolling. Dashboard title corrected `Tuist Cache Server / Overview` → `Tuist Cache Service / Overview`, matching how the component is named everywhere else in the repo (`cache/AGENTS.md`, the `cache` commit scope, `cache-service.json`).

## Why

`/cas` filling up is the outage everyone expects on these hosts, so that's what #12212 covered. But the cache hosts are legacy VMs, not disposable pods — the root filesystem carries logs, the Elixir release, and Docker/journald state, and it fills independently of CAS. When `/` fills, the node stops being able to write logs or restart the service cleanly, and the `/cas` gauge shows nothing wrong. The two failure modes are unrelated, so a dashboard that only watches `/cas` reports "healthy" through half of them.

Putting `/` above `/cas` is deliberate: `/cas` growth is expected and self-managed by eviction, so it sits high by design and a reader learns to skim past it. `/` growth is always unexpected, so it gets the first row where an anomaly actually registers.

## How it was produced

Authored in the Grafana Cloud UI in the `Tuist Dashboards` folder, which is bound to `infra/grafana-dashboards/` via [Git Sync](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/). Saving there emits the wrapped `dashboard.grafana.app/v2` resource and opens this PR — direct commits to `main` from Grafana are disabled, so every UI save goes through review. See `infra/AGENTS.md`.

## Impact

- Merging provisions the updated dashboard back into Grafana Cloud on the next pull (60s sync interval, or immediately via webhook).
- No runtime, chart, or service change — one dashboard JSON file, +122/-5.
- Self-hosters importing this need to extract `spec` first (`jq '.spec' tuist-cache-server-overview.json`); the Import UI expects raw dashboard JSON, not the Git Sync wrapper.

## Validation

- Rendered live in Grafana Cloud before saving: the `/` panel returns data for the current `cache-*` hosts and the `region` legend resolves, same as `/cas`.
- File still parses as JSON and carries `apiVersion: dashboard.grafana.app/v2` + `kind: Dashboard` with `metadata.name` == the dashboard UID (`defu61g6uzswsgf`), per the sync contract.
- Diff against `main` touches only this one file; no other dashboard was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
