### PR TITLE
feat(server): order quarantined and flaky tests by when they were marked

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -2760,6 +2760,7 @@ defmodule Tuist.Tests do
           name: test_case.name,
           module_name: test_case.module_name,
           suite_name: test_case.suite_name,
+          marked_flaky_at: flaky.marked_flaky_at,
           flaky_runs_count: coalesce(stats.flaky_runs_count, 0),
           # ClickHouse's LEFT JOIN fills missing rows with each type's
           # zero value rather than NULL. `nullIf` collapses those zero
@@ -2823,7 +2824,9 @@ defmodule Tuist.Tests do
       where: e.test_case_id in subquery(project_tc_ids),
       group_by: e.test_case_id,
       having: fragment("argMax(?, ?) = 'marked_flaky'", e.event_type, e.inserted_at),
-      select: %{test_case_id: e.test_case_id}
+      # The `having` guarantees the latest event is `marked_flaky`, so the max
+      # timestamp is the moment the test case entered its current flaky state.
+      select: %{test_case_id: e.test_case_id, marked_flaky_at: max(e.inserted_at)}
     )
   end
 
@@ -2874,6 +2877,12 @@ defmodule Tuist.Tests do
 
   defp apply_flaky_order(query, :name, :asc), do: from([tc, _flaky, _stats] in query, order_by: [asc: tc.name])
 
+  defp apply_flaky_order(query, :marked_flaky_at, :desc),
+    do: from([tc, flaky, _stats] in query, order_by: [desc: flaky.marked_flaky_at, asc: tc.id])
+
+  defp apply_flaky_order(query, :marked_flaky_at, :asc),
+    do: from([tc, flaky, _stats] in query, order_by: [asc: flaky.marked_flaky_at, asc: tc.id])
+
   defp apply_flaky_order(query, _, _),
     do: from([tc, _flaky, stats] in query, order_by: [desc: coalesce(stats.flaky_runs_count, 0)])
 
@@ -2883,6 +2892,7 @@ defmodule Tuist.Tests do
       name: row.name,
       module_name: row.module_name,
       suite_name: row.suite_name,
+      marked_flaky_at: row.marked_flaky_at,
       flaky_runs_count: row.flaky_runs_count,
       last_flaky_at: row.last_flaky_at,
       last_flaky_run_id: row.last_flaky_run_id
@@ -2920,14 +2930,9 @@ defmodule Tuist.Tests do
       |> from(limit: ^page_size, offset: ^offset)
       |> ClickHouseRepo.all()
 
-    test_case_ids = Enum.map(results, & &1.id)
-    quarantine_info = get_quarantine_info_for_test_cases(test_case_ids)
+    account_names = get_actor_account_names(results)
 
-    quarantined_tests =
-      Enum.map(results, fn row ->
-        info = Map.get(quarantine_info, row.id, %{})
-        row_to_quarantined_test_case(row, info)
-      end)
+    quarantined_tests = Enum.map(results, &row_to_quarantined_test_case(&1, account_names))
 
     total_count =
       project_id
@@ -2987,48 +2992,31 @@ defmodule Tuist.Tests do
          suite_name_filter,
          state_filter
        ) do
-    base_query =
-      from(test_case in TestCase,
-        as: :test_case,
-        hints: ["FINAL"],
-        inner_join: quarantined in subquery(quarantined_test_case_states_subquery(project_id, state_filter)),
-        as: :test_case_state,
-        on: test_case.id == quarantined.test_case_id,
-        where: test_case.project_id == ^project_id,
-        select: %{
-          id: test_case.id,
-          name: test_case.name,
-          module_name: test_case.module_name,
-          suite_name: test_case.suite_name,
-          last_ran_at: test_case.last_ran_at,
-          last_run_id: test_case.last_run_id,
-          last_status: test_case.last_status,
-          state: quarantined.state
-        }
-      )
-
-    base_query =
-      if quarantined_by_filter do
-        quarantine_info_subquery =
-          from(e in TestCaseEvent,
-            where: e.event_type in ^@active_quarantine_event_types,
-            group_by: e.test_case_id,
-            select: %{
-              test_case_id: e.test_case_id,
-              actor_id: fragment("argMax(?, ?)", e.actor_id, e.inserted_at)
-            }
-          )
-
-        from([test_case: test_case] in base_query,
-          left_join: quarantine in subquery(quarantine_info_subquery),
-          as: :quarantine,
-          on: test_case.id == quarantine.test_case_id
-        )
-      else
-        base_query
-      end
-
-    base_query
+    from(test_case in TestCase,
+      as: :test_case,
+      hints: ["FINAL"],
+      inner_join: quarantined in subquery(quarantined_test_case_states_subquery(project_id, state_filter)),
+      as: :test_case_state,
+      on: test_case.id == quarantined.test_case_id,
+      left_join: quarantine in subquery(quarantine_info_subquery(project_id)),
+      as: :quarantine,
+      on: test_case.id == quarantine.test_case_id,
+      where: test_case.project_id == ^project_id,
+      select: %{
+        id: test_case.id,
+        name: test_case.name,
+        module_name: test_case.module_name,
+        suite_name: test_case.suite_name,
+        last_ran_at: test_case.last_ran_at,
+        last_run_id: test_case.last_run_id,
+        last_status: test_case.last_status,
+        state: quarantined.state,
+        quarantined_by_account_id: quarantine.actor_id,
+        # ClickHouse's LEFT JOIN zero-fills non-nullable columns, so a test
+        # case without quarantine events would surface as `1970-01-01`.
+        quarantined_at: fragment("nullIf(?, toDateTime64(0, 6))", quarantine.quarantined_at)
+      }
+    )
     |> apply_name_search(search_term)
     |> apply_quarantined_by_filter(quarantined_by_filter)
     |> apply_module_name_filter(module_name_filter)
@@ -3056,18 +3044,8 @@ defmodule Tuist.Tests do
 
     base_query =
       if quarantined_by_filter do
-        quarantine_info_subquery =
-          from(e in TestCaseEvent,
-            where: e.event_type in ^@active_quarantine_event_types,
-            group_by: e.test_case_id,
-            select: %{
-              test_case_id: e.test_case_id,
-              actor_id: fragment("argMax(?, ?)", e.actor_id, e.inserted_at)
-            }
-          )
-
         from([test_case: test_case] in base_query,
-          left_join: quarantine in subquery(quarantine_info_subquery),
+          left_join: quarantine in subquery(quarantine_info_subquery(project_id)),
           as: :quarantine,
           on: test_case.id == quarantine.test_case_id
         )
@@ -3110,46 +3088,37 @@ defmodule Tuist.Tests do
     end
   end
 
-  defp get_quarantine_info_for_test_cases([]), do: %{}
+  # The latest active quarantine event per test case: who quarantined it and
+  # when. `argMax` and `max` resolve to the same event, because for a currently
+  # quarantined test case the most recent `muted`/`skipped` event is the one
+  # that put it in that state.
+  defp quarantine_info_subquery(project_id) do
+    from(e in TestCaseEvent,
+      where: e.project_id == ^project_id,
+      where: e.event_type in ^@active_quarantine_event_types,
+      group_by: e.test_case_id,
+      select: %{
+        test_case_id: e.test_case_id,
+        actor_id: fragment("argMax(?, ?)", e.actor_id, e.inserted_at),
+        quarantined_at: max(e.inserted_at)
+      }
+    )
+  end
 
-  defp get_quarantine_info_for_test_cases(test_case_ids) do
-    query =
-      from(e in TestCaseEvent,
-        where: e.test_case_id in ^test_case_ids,
-        where: e.event_type in ^@active_quarantine_event_types,
-        group_by: e.test_case_id,
-        select: %{
-          test_case_id: e.test_case_id,
-          actor_id: fragment("argMax(?, ?)", e.actor_id, e.inserted_at)
-        }
-      )
-
-    events = ClickHouseRepo.all(query)
-
+  defp get_actor_account_names(results) do
     actor_ids =
-      events
-      |> Enum.map(& &1.actor_id)
+      results
+      |> Enum.map(& &1.quarantined_by_account_id)
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
-    accounts =
-      if Enum.any?(actor_ids) do
-        from(a in Account, where: a.id in ^actor_ids)
-        |> Repo.all()
-        |> Map.new(&{&1.id, &1})
-      else
-        %{}
-      end
-
-    Map.new(events, fn event ->
-      account = Map.get(accounts, event.actor_id)
-
-      {event.test_case_id,
-       %{
-         actor_id: event.actor_id,
-         actor_name: if(account, do: account.name)
-       }}
-    end)
+    if Enum.any?(actor_ids) do
+      from(a in Account, where: a.id in ^actor_ids)
+      |> Repo.all()
+      |> Map.new(&{&1.id, &1.name})
+    else
+      %{}
+    end
   end
 
   # Secondary `id` keeps the sort deterministic when the primary column has
@@ -3167,6 +3136,12 @@ defmodule Tuist.Tests do
 
   defp apply_quarantined_order(query, :name, :asc),
     do: from([test_case: tc] in query, order_by: [asc: tc.name, asc: tc.id])
+
+  defp apply_quarantined_order(query, :quarantined_at, :desc),
+    do: from([test_case: tc, quarantine: quarantine] in query, order_by: [desc: quarantine.quarantined_at, asc: tc.id])
+
+  defp apply_quarantined_order(query, :quarantined_at, :asc),
+    do: from([test_case: tc, quarantine: quarantine] in query, order_by: [asc: quarantine.quarantined_at, asc: tc.id])
 
   defp apply_quarantined_order(query, _, _),
     do: from([test_case: tc] in query, order_by: [desc: tc.last_ran_at, asc: tc.id])
@@ -3235,14 +3210,15 @@ defmodule Tuist.Tests do
 
   defp apply_suite_name_filter(query, term), do: from([test_case: tc] in query, where: ilike(tc.suite_name, ^"%#{term}%"))
 
-  defp row_to_quarantined_test_case(row, quarantine_info) do
+  defp row_to_quarantined_test_case(row, account_names) do
     %QuarantinedTestCase{
       id: row.id,
       name: row.name,
       module_name: row.module_name,
       suite_name: row.suite_name,
-      quarantined_by_account_id: Map.get(quarantine_info, :actor_id),
-      quarantined_by_account_name: Map.get(quarantine_info, :actor_name),
+      quarantined_by_account_id: row.quarantined_by_account_id,
+      quarantined_by_account_name: Map.get(account_names, row.quarantined_by_account_id),
+      quarantined_at: row.quarantined_at,
       last_ran_at: row.last_ran_at,
       last_run_id: row.last_run_id,
       last_status: row.last_status,

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -3042,6 +3042,11 @@ defmodule Tuist.Tests do
         select: count(test_case.id)
       )
 
+    # Unlike the list query, which always joins :quarantine because it selects
+    # and sorts on its columns, the count needs the join only when filtering by
+    # quarantined_by. The shapes can differ without the totals diverging: the
+    # subquery groups by test_case_id, so the join is at most 1:1 and can
+    # neither drop nor duplicate rows.
     base_query =
       if quarantined_by_filter do
         from([test_case: test_case] in base_query,

--- a/server/lib/tuist/tests/flaky_test_case.ex
+++ b/server/lib/tuist/tests/flaky_test_case.ex
@@ -4,5 +4,14 @@ defmodule Tuist.Tests.FlakyTestCase do
   This is used to display test cases that have had flaky runs.
   """
 
-  defstruct [:id, :name, :module_name, :suite_name, :flaky_runs_count, :last_flaky_at, :last_flaky_run_id]
+  defstruct [
+    :id,
+    :name,
+    :module_name,
+    :suite_name,
+    :marked_flaky_at,
+    :flaky_runs_count,
+    :last_flaky_at,
+    :last_flaky_run_id
+  ]
 end

--- a/server/lib/tuist/tests/quarantined_test_case.ex
+++ b/server/lib/tuist/tests/quarantined_test_case.ex
@@ -11,6 +11,7 @@ defmodule Tuist.Tests.QuarantinedTestCase do
     :suite_name,
     :quarantined_by_account_id,
     :quarantined_by_account_name,
+    :quarantined_at,
     :last_ran_at,
     :last_run_id,
     :last_status,

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -167,7 +167,7 @@ defmodule TuistWeb.FlakyTestsLive do
     {:noreply, socket}
   end
 
-  @allowed_sort_fields ~w(name flaky_runs_count last_flaky_at)
+  @allowed_sort_fields ~w(name flaky_runs_count last_flaky_at marked_flaky_at)
   @default_sort_field "flaky_runs_count"
 
   defp assign_flaky_tests(%{assigns: %{selected_project: project}} = socket, params) do

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -350,6 +350,7 @@
             case @flaky_tests_sort_by do
               "name" -> dgettext("dashboard_tests", "Test Case")
               "last_flaky_at" -> dgettext("dashboard_tests", "Last flaky run")
+              "marked_flaky_at" -> dgettext("dashboard_tests", "Marked flaky at")
               _ -> dgettext("dashboard_tests", "Flaky runs")
             end
           }
@@ -376,6 +377,14 @@
             label={dgettext("dashboard_tests", "Last flaky run")}
             patch={sort_by_patch(@uri, "last_flaky_at")}
             data-selected={@flaky_tests_sort_by == "last_flaky_at"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+          <.dropdown_item
+            value="marked_flaky_at"
+            label={dgettext("dashboard_tests", "Marked flaky at")}
+            patch={sort_by_patch(@uri, "marked_flaky_at")}
+            data-selected={@flaky_tests_sort_by == "marked_flaky_at"}
           >
             <:right_icon><.check /></:right_icon>
           </.dropdown_item>
@@ -427,6 +436,21 @@
                 end
               }
             />
+          </:col>
+          <:col
+            :let={test_case}
+            label={dgettext("dashboard_tests", "Marked flaky at")}
+            patch={
+              @flaky_tests_sort_by == "marked_flaky_at" &&
+                column_sort_patch(assigns, "marked_flaky_at")
+            }
+            sort_order={@flaky_tests_sort_by == "marked_flaky_at" && @flaky_tests_sort_order}
+          >
+            <.text_cell
+              :if={test_case.marked_flaky_at}
+              sublabel={Tuist.Utilities.DateFormatter.from_now(test_case.marked_flaky_at)}
+            />
+            <span :if={is_nil(test_case.marked_flaky_at)}>—</span>
           </:col>
           <:col
             :let={test_case}

--- a/server/lib/tuist_web/live/quarantined_tests_live.ex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.ex
@@ -14,7 +14,7 @@ defmodule TuistWeb.QuarantinedTestsLive do
   alias TuistWeb.Helpers.DatePicker
   alias TuistWeb.Utilities.Query
 
-  @allowed_sort_fields ~w(name last_ran_at)
+  @allowed_sort_fields ~w(name last_ran_at quarantined_at)
   @default_sort_field "last_ran_at"
 
   def mount(_params, _session, %{assigns: %{selected_project: project, selected_account: account}} = socket) do

--- a/server/lib/tuist_web/live/quarantined_tests_live.html.heex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.html.heex
@@ -274,6 +274,7 @@
           label={
             case @quarantined_tests_sort_by do
               "name" -> dgettext("dashboard_tests", "Test Case")
+              "quarantined_at" -> dgettext("dashboard_tests", "Quarantined at")
               _ -> dgettext("dashboard_tests", "Last run")
             end
           }
@@ -292,6 +293,14 @@
             label={dgettext("dashboard_tests", "Test Case")}
             patch={sort_by_patch(@uri, "name")}
             data-selected={@quarantined_tests_sort_by == "name"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+          <.dropdown_item
+            value="quarantined_at"
+            label={dgettext("dashboard_tests", "Quarantined at")}
+            patch={sort_by_patch(@uri, "quarantined_at")}
+            data-selected={@quarantined_tests_sort_by == "quarantined_at"}
           >
             <:right_icon><.check /></:right_icon>
           </.dropdown_item>
@@ -376,6 +385,23 @@
                 size="large"
               />
             <% end %>
+          </:col>
+          <:col
+            :let={test_case}
+            label={dgettext("dashboard_tests", "Quarantined at")}
+            patch={
+              @quarantined_tests_sort_by == "quarantined_at" &&
+                column_sort_patch(assigns, "quarantined_at")
+            }
+            sort_order={
+              @quarantined_tests_sort_by == "quarantined_at" && @quarantined_tests_sort_order
+            }
+          >
+            <.text_cell
+              :if={test_case.quarantined_at}
+              sublabel={Tuist.Utilities.DateFormatter.from_now(test_case.quarantined_at)}
+            />
+            <span :if={is_nil(test_case.quarantined_at)}>—</span>
           </:col>
           <:col :let={test_case} label={dgettext("dashboard_tests", "Last status")}>
             <.status_badge_cell

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Expectation failed: %{message}"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:388
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:414
 #: lib/tuist_web/live/shards_live.ex:32
 #: lib/tuist_web/live/shards_live.html.heex:573
 #: lib/tuist_web/live/test_case_live.ex:95
@@ -416,8 +416,8 @@ msgid "File"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:106
-#: lib/tuist_web/live/flaky_tests_live.html.heex:385
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:301
+#: lib/tuist_web/live/flaky_tests_live.html.heex:394
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:310
 #: lib/tuist_web/live/shards_live.html.heex:531
 #: lib/tuist_web/live/test_case_live.html.heex:498
 #: lib/tuist_web/live/test_cases_live.html.heex:529
@@ -470,9 +470,9 @@ msgstr ""
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:353
-#: lib/tuist_web/live/flaky_tests_live.html.heex:360
-#: lib/tuist_web/live/flaky_tests_live.html.heex:433
+#: lib/tuist_web/live/flaky_tests_live.html.heex:354
+#: lib/tuist_web/live/flaky_tests_live.html.heex:361
+#: lib/tuist_web/live/flaky_tests_live.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
@@ -573,8 +573,8 @@ msgid "Last Status"
 msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:352
-#: lib/tuist_web/live/flaky_tests_live.html.heex:376
-#: lib/tuist_web/live/flaky_tests_live.html.heex:444
+#: lib/tuist_web/live/flaky_tests_live.html.heex:377
+#: lib/tuist_web/live/flaky_tests_live.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "Last flaky run"
 msgstr ""
@@ -587,9 +587,9 @@ msgstr ""
 msgid "Last ran at"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:277
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:284
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:399
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:278
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:285
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Last run"
 msgstr ""
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Last run duration"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:380
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:406
 #: lib/tuist_web/live/test_cases_live.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "Last status"
@@ -718,7 +718,7 @@ msgstr ""
 msgid "No failures detected"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:479
+#: lib/tuist_web/live/flaky_tests_live.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "No flaky tests"
 msgstr ""
@@ -733,7 +733,7 @@ msgstr ""
 msgid "No modules found"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:425
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "No quarantined tests"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:383
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:409
 #: lib/tuist_web/live/shards_live.ex:31
 #: lib/tuist_web/live/shards_live.html.heex:568
 #: lib/tuist_web/live/test_case_live.ex:94
@@ -865,7 +865,7 @@ msgid "Quarantined Tests"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:75
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:363
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Quarantined by"
 msgstr ""
@@ -989,8 +989,8 @@ msgid "Signal"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:64
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:357
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:393
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:366
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:419
 #: lib/tuist_web/live/shards_live.html.heex:583
 #: lib/tuist_web/live/test_case_live.ex:96
 #: lib/tuist_web/live/test_case_live.ex:468
@@ -1020,8 +1020,8 @@ msgstr ""
 msgid "Slowest test cases"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:356
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:280
+#: lib/tuist_web/live/flaky_tests_live.html.heex:357
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:281
 #: lib/tuist_web/live/test_case_live.html.heex:477
 #: lib/tuist_web/live/test_cases_live.html.heex:500
 #: lib/tuist_web/live/test_run_live.html.heex:1137
@@ -1074,11 +1074,11 @@ msgid "Summary"
 msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:351
-#: lib/tuist_web/live/flaky_tests_live.html.heex:368
-#: lib/tuist_web/live/flaky_tests_live.html.heex:408
+#: lib/tuist_web/live/flaky_tests_live.html.heex:369
+#: lib/tuist_web/live/flaky_tests_live.html.heex:417
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:276
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:292
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:324
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:293
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:333
 #: lib/tuist_web/live/test_cases_live.html.heex:495
 #: lib/tuist_web/live/test_cases_live.html.heex:512
 #: lib/tuist_web/live/test_cases_live.html.heex:562
@@ -1302,7 +1302,7 @@ msgid "Try updating your search"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:80
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:366
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Tuist"
 msgstr ""
@@ -1701,13 +1701,13 @@ msgid "Number of distinct test cases with at least one run in the 14 days ending
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:59
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:347
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Mode"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:63
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:350
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:359
 #: lib/tuist_web/live/test_case_live.ex:467
 #: lib/tuist_web/live/test_case_live.ex:496
 #: lib/tuist_web/live/test_case_live.html.heex:75
@@ -1809,4 +1809,18 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:1763
 #, elixir-autogen, elixir-format
 msgid "Test Failures"
+msgstr ""
+
+#: lib/tuist_web/live/flaky_tests_live.html.heex:353
+#: lib/tuist_web/live/flaky_tests_live.html.heex:385
+#: lib/tuist_web/live/flaky_tests_live.html.heex:442
+#, elixir-autogen, elixir-format
+msgid "Marked flaky at"
+msgstr ""
+
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:277
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:301
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:391
+#, elixir-autogen, elixir-format
+msgid "Quarantined at"
 msgstr ""

--- a/server/priv/marketing/changelog/2026.08.04-sort-quarantined-flaky-tests-by-marked-time.md
+++ b/server/priv/marketing/changelog/2026.08.04-sort-quarantined-flaky-tests-by-marked-time.md
@@ -1,0 +1,10 @@
+---
+title: Sort quarantined and flaky tests by when they were marked
+description: "The quarantined and flaky test lists can now be ordered by the time each test entered its current state."
+category: "Product"
+pull_request: 12215
+---
+
+The quarantined tests page now shows a sortable "Quarantined at" column, and the flaky tests page a "Marked flaky at" column. Both timestamps come from the test's event history and reflect when the test entered its current state — re-quarantining a test starts a new period, and the timestamp always describes the same event as the "Quarantined by" attribution next to it.
+
+Sorting by these columns lets you review the lists chronologically: surface the tests that have been parked the longest and are overdue for a fix, or check what was quarantined most recently and why.

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -5733,6 +5733,42 @@ defmodule Tuist.TestsTest do
       assert Enum.all?(desc_results, & &1.marked_flaky_at)
     end
 
+    test "marked_flaky_at reflects the current flaky period after a re-mark" do
+      project = ProjectsFixtures.project_fixture()
+      now = NaiveDateTime.utc_now()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "remarkedFlakyTest",
+          is_flaky: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      second_marked_at = NaiveDateTime.add(now, -1200)
+
+      for {event_type, inserted_at} <- [
+            {"marked_flaky", NaiveDateTime.add(now, -3600)},
+            {"unmarked_flaky", NaiveDateTime.add(now, -2400)},
+            {"marked_flaky", second_marked_at}
+          ] do
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: event_type,
+          inserted_at: inserted_at
+        )
+      end
+
+      {[flaky_test], _} = Tests.list_flaky_test_cases(project.id, %{})
+
+      assert NaiveDateTime.compare(
+               NaiveDateTime.truncate(flaky_test.marked_flaky_at, :second),
+               NaiveDateTime.truncate(second_marked_at, :second)
+             ) == :eq
+    end
+
     test "supports pagination" do
       project = ProjectsFixtures.project_fixture()
 
@@ -9116,6 +9152,79 @@ defmodule Tuist.TestsTest do
 
       assert Enum.map(desc_results, & &1.name) == ["newest", "middle", "oldest"]
       assert Enum.all?(desc_results, & &1.quarantined_at)
+    end
+
+    test "quarantined_at reflects the current quarantine period after a re-quarantine" do
+      project = ProjectsFixtures.project_fixture()
+      now = NaiveDateTime.utc_now()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "requarantinedTest",
+          is_quarantined: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      second_muted_at = NaiveDateTime.add(now, -1200)
+
+      for {event_type, inserted_at} <- [
+            {"muted", NaiveDateTime.add(now, -3600)},
+            {"unmuted", NaiveDateTime.add(now, -2400)},
+            {"muted", second_muted_at}
+          ] do
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: event_type,
+          inserted_at: inserted_at
+        )
+      end
+
+      {[quarantined_test], _} = Tests.list_quarantined_test_cases(project.id, %{})
+
+      assert NaiveDateTime.compare(
+               NaiveDateTime.truncate(quarantined_test.quarantined_at, :second),
+               NaiveDateTime.truncate(second_muted_at, :second)
+             ) == :eq
+    end
+
+    test "quarantined_at resets when the quarantine mode changes" do
+      project = ProjectsFixtures.project_fixture()
+      now = NaiveDateTime.utc_now()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "modeChangedTest",
+          state: "skipped"
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      skipped_at = NaiveDateTime.add(now, -600)
+
+      for {event_type, inserted_at} <- [
+            {"muted", NaiveDateTime.add(now, -7200)},
+            {"skipped", skipped_at}
+          ] do
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: event_type,
+          inserted_at: inserted_at
+        )
+      end
+
+      {[quarantined_test], _} = Tests.list_quarantined_test_cases(project.id, %{})
+
+      assert quarantined_test.state == "skipped"
+
+      assert NaiveDateTime.compare(
+               NaiveDateTime.truncate(quarantined_test.quarantined_at, :second),
+               NaiveDateTime.truncate(skipped_at, :second)
+             ) == :eq
     end
 
     test "exposes when the latest quarantine event happened" do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -5693,6 +5693,46 @@ defmodule Tuist.TestsTest do
       assert flaky_test.flaky_runs_count == 1
     end
 
+    test "supports ordering by marked_flaky_at" do
+      project = ProjectsFixtures.project_fixture()
+      now = NaiveDateTime.utc_now()
+
+      for {name, offset} <- [{"oldestFlaky", -3600}, {"middleFlaky", -1800}, {"newestFlaky", -60}] do
+        test_case =
+          RunsFixtures.test_case_fixture(
+            project_id: project.id,
+            name: name,
+            is_flaky: true
+          )
+
+        IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: "marked_flaky",
+          inserted_at: NaiveDateTime.add(now, offset)
+        )
+      end
+
+      {asc_results, _} =
+        Tests.list_flaky_test_cases(project.id, %{
+          order_by: [:marked_flaky_at],
+          order_directions: [:asc]
+        })
+
+      assert Enum.map(asc_results, & &1.name) == ["oldestFlaky", "middleFlaky", "newestFlaky"]
+
+      {desc_results, _} =
+        Tests.list_flaky_test_cases(project.id, %{
+          order_by: [:marked_flaky_at],
+          order_directions: [:desc]
+        })
+
+      assert Enum.map(desc_results, & &1.name) == ["newestFlaky", "middleFlaky", "oldestFlaky"]
+      assert Enum.all?(desc_results, & &1.marked_flaky_at)
+    end
+
     test "supports pagination" do
       project = ProjectsFixtures.project_fixture()
 
@@ -8922,12 +8962,14 @@ defmodule Tuist.TestsTest do
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: test_case.id,
+        project_id: project.id,
         event_type: "muted",
         inserted_at: now
       )
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: test_case.id,
+        project_id: project.id,
         event_type: "marked_flaky",
         inserted_at: now
       )
@@ -9036,6 +9078,74 @@ defmodule Tuist.TestsTest do
       assert Enum.map(desc_results, & &1.name) == ["zebra", "beta", "alpha"]
     end
 
+    test "supports ordering by quarantined_at" do
+      project = ProjectsFixtures.project_fixture()
+      now = NaiveDateTime.utc_now()
+
+      for {name, offset} <- [{"oldest", -3600}, {"middle", -1800}, {"newest", -60}] do
+        test_case =
+          RunsFixtures.test_case_fixture(
+            project_id: project.id,
+            name: name,
+            is_quarantined: true
+          )
+
+        IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: "muted",
+          inserted_at: NaiveDateTime.add(now, offset)
+        )
+      end
+
+      {asc_results, _} =
+        Tests.list_quarantined_test_cases(project.id, %{
+          order_by: [:quarantined_at],
+          order_directions: [:asc]
+        })
+
+      assert Enum.map(asc_results, & &1.name) == ["oldest", "middle", "newest"]
+
+      {desc_results, _} =
+        Tests.list_quarantined_test_cases(project.id, %{
+          order_by: [:quarantined_at],
+          order_directions: [:desc]
+        })
+
+      assert Enum.map(desc_results, & &1.name) == ["newest", "middle", "oldest"]
+      assert Enum.all?(desc_results, & &1.quarantined_at)
+    end
+
+    test "exposes when the latest quarantine event happened" do
+      project = ProjectsFixtures.project_fixture()
+      quarantined_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -900)
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "quarantinedTest",
+          is_quarantined: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      RunsFixtures.test_case_event_fixture(
+        test_case_id: test_case.id,
+        project_id: project.id,
+        event_type: "muted",
+        inserted_at: quarantined_at
+      )
+
+      {[quarantined_test], _} = Tests.list_quarantined_test_cases(project.id, %{})
+
+      assert NaiveDateTime.compare(
+               NaiveDateTime.truncate(quarantined_test.quarantined_at, :second),
+               NaiveDateTime.truncate(quarantined_at, :second)
+             ) == :eq
+    end
+
     test "does not return test cases from other projects" do
       project1 = ProjectsFixtures.project_fixture()
       project2 = ProjectsFixtures.project_fixture()
@@ -9077,6 +9187,7 @@ defmodule Tuist.TestsTest do
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: tuist_test_case.id,
+        project_id: project.id,
         event_type: "muted",
         actor_id: nil
       )
@@ -9093,6 +9204,7 @@ defmodule Tuist.TestsTest do
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: user_test_case.id,
+        project_id: project.id,
         event_type: "muted",
         actor_id: user.account.id
       )
@@ -9124,6 +9236,7 @@ defmodule Tuist.TestsTest do
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: user1_test_case.id,
+        project_id: project.id,
         event_type: "muted",
         actor_id: user1.account.id
       )
@@ -9140,6 +9253,7 @@ defmodule Tuist.TestsTest do
 
       RunsFixtures.test_case_event_fixture(
         test_case_id: user2_test_case.id,
+        project_id: project.id,
         event_type: "muted",
         actor_id: user2.account.id
       )


### PR DESCRIPTION
## What

Users asked whether the quarantined / flaky test lists could be ordered by the time a test was marked as such. This adds that:

- **Quarantined tests page**: a sortable **"Quarantined at"** column (also in the *Sort by* dropdown), showing when the test entered its current muted/skipped state.
- **Flaky tests page**: a sortable **"Marked flaky at"** column, showing when the test entered its current flaky state.

## Why / how

No new data was needed: the `test_case_events` ClickHouse ledger already records every `muted`/`skipped`/`marked_flaky` event with a microsecond `inserted_at`. Both timestamps are the `max(inserted_at)` of the relevant event type per test case — the same event the existing "Quarantined by" attribution (`argMax(actor_id, inserted_at)`) already resolves, so *who* and *when* always describe the same event.

**Semantics** (deliberate): the timestamp is when the test entered its *current* state. A muted → unmuted → muted test shows the second mute (the current quarantine period). A muted → skipped transition resets the timestamp to the transition — consistent with "Quarantined by", which likewise attributes the latest event. "Continuously quarantined since" semantics would pair a latest-actor with an older date, describing an event that never happened.

**Query changes** in `Tuist.Tests`:

- `list_quarantined_test_cases/3` now always left-joins the per-test-case quarantine-info aggregate (previously joined only when the *quarantined by* filter was active) and selects `actor_id` + `quarantined_at` from it. This *removes* one ClickHouse query per page render: the separate `get_quarantine_info_for_test_cases` round-trip that re-fetched actor ids for the page is gone; only the Postgres account-name lookup remains.
- The aggregate subquery is newly scoped by `e.project_id` (the previous inline version scanned events unscoped). The column was denormalized + backfilled in `20260721115000`; verified in production that zero state-change events carry `project_id = 0`.
- `quarantined_at` is wrapped in `nullIf(..., toDateTime64(0, 6))` since ClickHouse zero-fills non-nullable columns on LEFT JOIN misses.
- The flaky side adds `marked_flaky_at: max(inserted_at)` to `currently_flaky_test_case_ids_subquery` — its existing `HAVING argMax(event_type) = 'marked_flaky'` guarantees the max timestamp is the marking event.
- New order clauses carry the `test_case.id` tiebreak that keeps ClickHouse pagination stable under ties.

**Performance / storage**: no migrations, no new storage. The events table only records state transitions, so it stays small relative to run data; the always-on aggregate is noise next to the existing `test_cases FINAL` join — and the page previously ran an equivalent aggregate per render anyway.

**Test fixture change**: five existing `test_case_event_fixture` call sites now pass `project_id`. They previously leaned on the events subquery being unscoped; the fixture's own docs already require `project_id` whenever a test asserts on resolved state, and production events always carry it.

## Impact

- Both pages gain the new sortable column; default sorts are unchanged.
- One fewer ClickHouse query per quarantined-tests page render.
- New user-facing strings extracted to `dashboard_tests.pot` only (translations flow through Weblate).

## Validation

- New ExUnit coverage: asc/desc ordering by `quarantined_at` and `marked_flaky_at`, plus a timestamp-accuracy assertion; existing quarantined/flaky/actors describe blocks all green. Full `tests_test.exs` + `tests_live_test.exs` + both page LiveView suites: **260 passed, 0 failures**. `mix credo` clean.
- Deployed this branch to a self-hosted k3s environment and ran `list_quarantined_test_cases` / `list_flaky_test_cases` with the new sort inside the release against seeded data (12 quarantined, 8 flaky, staggered timestamps, mixed actors): both returned the exact expected order with actor names resolved, and the dashboard renders the new sortable columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
