### PR TITLE
fix(server): attribute command events to the user behind an account token

### DIFF
--- a/server/lib/tuist_web/authentication.ex
+++ b/server/lib/tuist_web/authentication.ex
@@ -76,6 +76,38 @@ defmodule TuistWeb.Authentication do
     end
   end
 
+  @doc """
+  Returns the user an ingested record should be attributed to, or `nil`.
+
+  Falls back to the user that authorized an account token. OAuth-issued account
+  tokens carry their issuer in `issued_by`, and authorization already leans on it
+  to scope an `all_projects: true` token to that user's organizations, so the
+  identity is both available and the right one to record. Without this fallback
+  every run uploaded by a CLI holding such a token is stored with no user and
+  surfaces as "Unknown" in the dashboard.
+
+  `issued_by` and not `created_by_account_id`: the two answer different questions
+  and only the first one attributes a run. `issued_by` is set from the token's
+  `user_id` claim, which is present only when the credential is that person's
+  own — it carries their identity, so it is the best available answer to "who
+  ran this". `created_by_account_id` records who once provisioned a shared
+  secret. The runs that secret uploads are not theirs, and attributing them
+  would put one person's name on every CI run in the account.
+
+  The clauses below are enumerated rather than closed with a catch-all: a
+  subject shape nobody taught this function about should raise, not resolve to
+  "attribute to nobody", which is the failure this function exists to fix.
+  """
+  def attributed_user(conn) do
+    case authenticated_subject(conn) do
+      %User{} = user -> user
+      %AuthenticatedAccount{issued_by: %User{} = user} -> user
+      %AuthenticatedAccount{} -> nil
+      %Project{} -> nil
+      nil -> nil
+    end
+  end
+
   def put_current_user(%Plug.Conn{} = conn, user) do
     assign(conn, @current_user_key, user)
   end

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -458,13 +458,10 @@ defmodule TuistWeb.API.AnalyticsController do
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def create(%{body_params: body_params, assigns: %{selected_project: selected_project}} = conn, _params) do
-    current_user = Authentication.current_user(conn)
-
     user_id =
-      if is_nil(current_user) do
-        nil
-      else
-        current_user.id
+      case Authentication.attributed_user(conn) do
+        nil -> nil
+        user -> user.id
       end
 
     git_commit_sha = Map.get(body_params, :git_commit_sha)

--- a/server/test/tuist_web/authentication_test.exs
+++ b/server/test/tuist_web/authentication_test.exs
@@ -61,6 +61,81 @@ defmodule TuistWeb.AuthenticationTest do
     end
   end
 
+  describe "attributed_user/1" do
+    test "when the authenticated subject is a user", %{user: user, conn: conn} do
+      # Given
+      conn = assign(conn, :current_user, user)
+
+      # Then
+      assert Authentication.attributed_user(conn) == user
+    end
+
+    test "when the authenticated subject is an account token that carries its issuer", %{
+      user: user,
+      project: project,
+      conn: conn
+    } do
+      # Given
+      conn =
+        assign(conn, :current_subject, %AuthenticatedAccount{
+          account: project.account,
+          scopes: ["project:runs:write"],
+          issued_by: user
+        })
+
+      # Then
+      assert Authentication.attributed_user(conn) == user
+    end
+
+    test "when the authenticated subject is a long-lived token minted for CI", %{
+      user: user,
+      project: project,
+      conn: conn
+    } do
+      # The account that created the token is recorded, but nobody authorized the
+      # request it is now signing, so the run must not be attributed to them.
+      conn =
+        assign(conn, :current_subject, %AuthenticatedAccount{
+          account: project.account,
+          scopes: ["ci"],
+          all_projects: true,
+          token_id: Ecto.UUID.generate(),
+          created_by_account_id: user.account.id
+        })
+
+      # Then
+      assert Authentication.attributed_user(conn) == nil
+    end
+
+    test "when the authenticated subject is a CI token obtained through OIDC", %{
+      project: project,
+      conn: conn
+    } do
+      # Given
+      conn =
+        assign(conn, :current_subject, %AuthenticatedAccount{
+          account: project.account,
+          scopes: ["ci"],
+          project_ids: [project.id]
+        })
+
+      # Then
+      assert Authentication.attributed_user(conn) == nil
+    end
+
+    test "when the authenticated subject is a project", %{project: project, conn: conn} do
+      # Given
+      conn = assign(conn, :current_project, project)
+
+      # Then
+      assert Authentication.attributed_user(conn) == nil
+    end
+
+    test "when there is no authenticated subject", %{conn: conn} do
+      assert Authentication.attributed_user(conn) == nil
+    end
+  end
+
   describe "log_in_user/3" do
     test "stores the user token in the session", %{conn: conn, user: user} do
       conn = Authentication.log_in_user(conn, user)

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
   import Ecto.Query
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.ClickHouseRepo
   alias Tuist.CommandEvents
   alias Tuist.CommandEvents.Event.Buffer
@@ -167,6 +168,159 @@ defmodule TuistWeb.AnalyticsControllerTest do
       assert command_event.status == :failure
       assert command_event.error_message == "An error occurred"
       assert command_event.user_id == user.id
+    end
+
+    test "attributes the command event to the user that authorized the account token", %{
+      conn: conn,
+      user: user
+    } do
+      # Given
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+
+      conn =
+        conn
+        |> assign(:current_subject, %AuthenticatedAccount{
+          account: account,
+          scopes: ["project:runs:write"],
+          all_projects: true,
+          issued_by: user
+        })
+        |> assign(:selected_project, project)
+        |> put_req_header("content-type", "application/json")
+
+      # When
+      conn =
+        post(
+          conn,
+          "/api/analytics?project_id=#{account.name}/#{project.name}",
+          %{
+            name: "generate",
+            subcommand: "generate",
+            command_arguments: ["App"],
+            duration: 100,
+            tuist_version: "1.0.0",
+            swift_version: "5.0",
+            macos_version: "10.15",
+            params: %{},
+            is_ci: false,
+            client_id: "client-id"
+          }
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+
+      Buffer.flush()
+
+      {:ok, command_event} = CommandEvents.get_command_event_by_id(response["id"])
+
+      assert command_event.user_id == user.id
+    end
+
+    test "attributes the command event when the account token arrives as a bearer header", %{
+      conn: conn,
+      user: user
+    } do
+      # Drives the real pipeline rather than assigning the subject: the bug this
+      # guards against was a mismatch between what AuthenticationPlug assigns and
+      # what the controller reads, which a pre-assigned subject cannot surface.
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+
+      {:ok, access_token, _claims} =
+        Tuist.Authentication.encode_and_sign(
+          account,
+          %{
+            "type" => "account",
+            "scopes" => ["project:runs:write"],
+            "all_projects" => true,
+            "user_id" => user.id,
+            "preferred_username" => account.name
+          },
+          token_type: :access
+        )
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{access_token}")
+        |> post(
+          "/api/analytics?project_id=#{account.name}/#{project.name}",
+          %{
+            name: "generate",
+            subcommand: "generate",
+            command_arguments: ["App"],
+            duration: 100,
+            tuist_version: "1.0.0",
+            swift_version: "5.0",
+            macos_version: "10.15",
+            params: %{},
+            is_ci: false,
+            client_id: "client-id"
+          }
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+
+      Buffer.flush()
+
+      {:ok, command_event} = CommandEvents.get_command_event_by_id(response["id"])
+
+      assert command_event.user_id == user.id
+    end
+
+    test "leaves the command event unattributed when the token was minted for CI", %{
+      conn: conn,
+      user: user
+    } do
+      # A token created for CI records the account that minted it, but no person
+      # authorized the runs it uploads. Attributing those to its creator would put
+      # someone's name on every CI run in the account.
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+
+      conn =
+        conn
+        |> assign(:current_subject, %AuthenticatedAccount{
+          account: account,
+          scopes: ["project:runs:write"],
+          all_projects: true,
+          token_id: Ecto.UUID.generate(),
+          created_by_account_id: account.id
+        })
+        |> assign(:selected_project, project)
+        |> put_req_header("content-type", "application/json")
+
+      # When
+      conn =
+        post(
+          conn,
+          "/api/analytics?project_id=#{account.name}/#{project.name}",
+          %{
+            name: "generate",
+            subcommand: "generate",
+            command_arguments: ["App"],
+            duration: 100,
+            tuist_version: "1.0.0",
+            swift_version: "5.0",
+            macos_version: "10.15",
+            params: %{},
+            is_ci: true,
+            client_id: "client-id"
+          }
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+
+      Buffer.flush()
+
+      {:ok, command_event} = CommandEvents.get_command_event_by_id(response["id"])
+
+      assert command_event.user_id == nil
     end
 
     test "returns newly created command event when CI and authenticated as a project", %{


### PR DESCRIPTION
Closes #12218.

## What changed

`TuistWeb.API.AnalyticsController.create/2` now attributes a command event to the user that authorized an account token, instead of recording no user at all.

The logic moves behind a new `TuistWeb.Authentication.attributed_user/1` helper:

```elixir
def attributed_user(conn) do
  case authenticated_subject(conn) do
    %User{} = user -> user
    %AuthenticatedAccount{issued_by: %User{} = user} -> user
    _ -> nil
  end
end
```

## Why

A developer whose CLI is authenticated with an account token had every run recorded without attribution. In the dashboard those runs render as **"Unknown"** in the "ran by" column (`TuistWeb.Runs.RanByBadge.run_ran_by_badge_cell/1` falls back to that label when `is_ci` is false and no user is set), and the "ran by" filter on the runs pages cannot surface them at all.

This is not a rare edge case: it follows the developer to every project they work on, and it is silent — the CLI reports the upload as successful, so the only symptom is runs quietly losing their owner.

## Root cause

The controller derived the attributed user from `Authentication.current_user/1`:

```elixir
current_user = Authentication.current_user(conn)
user_id = if is_nil(current_user), do: nil, else: current_user.id
```

`current_user` is only assigned when the authenticated subject is a `%User{}` (`TuistWeb.AuthenticationPlug.get_authenticated_subject/2`). When the subject is an `%AuthenticatedAccount{}`, the plug assigns `:current_subject` instead and `current_user` stays `nil`.

But the identity was available the whole time. `Tuist.OAuth.TokenGenerator.generate_user_token/4` mints these tokens with `user_id`, `preferred_username`, and `email` claims, and `Tuist.Guardian.resource_from_claims/1` resolves the first of those into `%AuthenticatedAccount{issued_by: %User{}}`. The authorization layer already depends on that field — `Checks.project_access_permitted/2` uses it to scope an `all_projects: true` token to the issuing user's organizations. So the request was authorized *using* the user, and then attributed to nobody.

## Why this approach

Two alternatives were considered and rejected:

- **Read the `user_id` claim directly in the controller.** Re-parsing claims at the controller layer duplicates work `Guardian` already does and couples an ingestion endpoint to the token format. `issued_by` is the resolved, validated form of the same fact.
- **Assign `current_user` in the plug when `issued_by` is present.** This is the tempting one-liner, but `current_user` is load-bearing for authorization: `Authorization` policies branch on `authenticated_as_user` vs `authenticated_as_account`, and an account token would silently acquire user-level permissions it was never granted. Attribution and authorization must stay separate, hence a dedicated helper used only where a record is being attributed.

The helper lives on `TuistWeb.Authentication` rather than inline in the controller so the other ingestion endpoints have something correct to reach for.

### Tokens minted for CI are not attributed

`issued_by` is set from the token's `user_id` claim, so it means *a person authorized this exchange*. It is deliberately not `created_by_account_id`:

| Token | `user_id` claim | `attributed_user/1` |
|---|---|---|
| Long-lived account token minted for CI | no — records `token_id` + `created_by_account_id` | `nil` |
| CI token obtained through OIDC (`OIDCController.generate_token/1`) | no — only `type`, `scopes: ["ci"]`, `project_ids` | `nil` |
| Project token | n/a, resolves to `%Project{}` | `nil` |
| Interactive OAuth (`OAuth.TokenGenerator.generate_user_token/4`) | yes | the authorizing user |
| Agent auth (`AgentAuth`) | yes | the claiming user |

Attributing CI tokens to `created_by_account_id` would put the name of whoever provisioned the credential on every CI run in the account, months after the fact. Both no-issuer shapes are covered by tests.

## Scope

Only command events were affected. The builds, tests, and runs controllers already attribute via `authenticated_subject_account/1` and never fell into the "Unknown" state; the analytics controller was the only endpoint reading `current_user` directly. This matches the reported symptom being specific to generate runs.

Project tokens and account tokens without an issuer (DB-backed CI tokens) continue to record no user. That is correct — there is no person behind them, and `is_ci` runs render as "CI" rather than "Unknown".

### Divergence from `inviter_from_subject/1`

`invitations_controller.ex:209-219` answers the same "who is the human behind this request" question and *does* fall through to `created_by_account_id`. The codebase is not uniform here, so the difference is deliberate rather than overlooked:

- An invitation is one deliberate act that needs a "from" on an email. A CI token uploads a continuous stream of runs; stamping the provisioner on all of them corrupts the "ran by" dimension rather than filling one field.
- Runs already encode "no human" via `is_ci`, and the badge checks it first. Invitations have no equivalent, so a nil there is worse than a best-effort guess.
- `created_by_account_id` is an *account* id, so that fallback has to hop account → `user_id` → user and lands on nil whenever the creator was an organization account. For runs the same hop would often be attributing to an org, which is meaningless in a `user_id` column.

Changing the invitations behaviour is a separate product call about what an invitation email should say, and is not touched here.

## Impact

Runs uploaded by a CLI holding an OAuth account token are attributed to the right developer from deploy onward, in both the "ran by" badge and the "ran by" filter.

**No backfill is possible.** Events already written carry no record of the issuing user, so existing "Unknown" runs stay that way.

## Validation

```
mix test test/tuist_web/authentication_test.exs test/tuist_web/controllers/analytics_controller_test.exs
→ 85 passed
```

New coverage:

- `attributed_user/1` unit tests for all five subject shapes: user session, account token with issuer, account token without issuer, project, and no subject.
- Controller tests asserting the account-token-with-issuer request records `user_id`, and that a token minted for CI still records `nil`.
- A controller test that authenticates with a real `Authorization: Bearer` account JWT instead of a pre-assigned subject, so the plug-to-controller seam is exercised end to end. The original bug lived exactly there — `AuthenticationPlug` assigns `:current_subject` while the controller read `:current_user`, each half individually correct — and a test handed a ready-made subject cannot see that class of mismatch.

The controller test was checked against a negative control: with the fix reverted it fails with `left: nil, right: 108`, confirming it catches the regression rather than passing vacuously.

`mix format` and `mix credo` are clean on the changed files.

## Related

Three contributing issues are filed separately and are not addressed here:

- #12220 — the Tuist app writes account-type OAuth credentials into the CLI's credentials file, which is how CLIs end up holding these tokens
- #12219 — `tuist auth whoami` reports "You are not logged in" for these credentials, which is what makes the state so hard to diagnose
- #12221 — the CLI never refreshes account-type credentials and discards their refresh token

🤖 Generated with [Claude Code](https://claude.com/claude-code)


