### PR TITLE
fix(cli): attribute manifest dump failures to the package that failed [4.203.x backport]

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -19,13 +19,17 @@ enum SwiftPackageManagerGraphGeneratorError: FatalError, Equatable {
     case missingPathInLocalSwiftPackage(String)
     /// Thrown when dependencies were not installed before loading the graph SwiftPackageManagerGraph
     case installRequired
+    /// Thrown when a dependency's `Package.swift` cannot be loaded from the directory the
+    /// workspace state points at. Swift Package Manager reports this against its own working
+    /// directory without naming the dependency, so the package and folder are attached here.
+    case packageManifestLoadFailed(name: String, path: AbsolutePath, reason: String)
 
     /// Error type.
     var type: ErrorType {
         switch self {
         case .unsupportedDependencyKind, .missingPathInLocalSwiftPackage:
             return .bug
-        case .installRequired:
+        case .installRequired, .packageManifestLoadFailed:
             return .abort
         }
     }
@@ -39,6 +43,8 @@ enum SwiftPackageManagerGraphGeneratorError: FatalError, Equatable {
             return "The local package \(name) does not contain the path in the generated `workspace-state.json` file."
         case .installRequired:
             return "We could not find external dependencies. Run `tuist install` before you continue."
+        case let .packageManifestLoadFailed(name, path, reason):
+            return "We could not load the manifest of the package \(name) at \(path.pathString): \(reason)"
         }
     }
 }
@@ -172,12 +178,24 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     throw SwiftPackageManagerGraphGeneratorError.unsupportedDependencyKind(dependency.packageRef.kind)
                 }
 
-                let packageInfo = if let packageInfoCache,
-                                     let cachedPackageInfo = packageInfoCache.packageInfo(for: packageFolder)
+                let packageInfo: PackageInfo
+                if let packageInfoCache,
+                   let cachedPackageInfo = packageInfoCache.packageInfo(for: packageFolder)
                 {
-                    cachedPackageInfo
+                    packageInfo = cachedPackageInfo
                 } else {
-                    try await manifestLoader.loadPackage(at: packageFolder, disableSandbox: disableSandbox)
+                    do {
+                        packageInfo = try await manifestLoader.loadPackage(
+                            at: packageFolder,
+                            disableSandbox: disableSandbox
+                        )
+                    } catch {
+                        throw SwiftPackageManagerGraphGeneratorError.packageManifestLoadFailed(
+                            name: name,
+                            path: packageFolder,
+                            reason: "\(error)"
+                        )
+                    }
                 }
                 let targetToArtifactPaths = try workspaceState.object.artifacts
                     .filter { $0.packageRef.identity == dependency.packageRef.identity }

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -228,6 +228,79 @@ struct SwiftPackageManagerGraphLoaderTests {
         }
     }
 
+    @Test
+    func load_attributesAManifestLoadFailureToTheDependency() async throws {
+        struct ManifestFailure: Error, CustomStringConvertible {
+            var description: String { "boom" }
+        }
+
+        try await withMockedDependencies {
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) {
+                temporaryDirectory in
+                // Given
+                let workspacePath = temporaryDirectory.appending(components: [
+                    ".build", "workspace-state.json",
+                ])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : [
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Alamofire.Alamofire",
+                              "kind" : "registry",
+                              "location" : "Alamofire.Alamofire",
+                              "name" : "Alamofire.Alamofire"
+                            },
+                            "state" : {
+                              "name" : "registryDownload",
+                              "version" : "5.10.2"
+                            },
+                            "subpath" : "Alamofire/Alamofire/5.10.2"
+                          }
+                        ],
+                      }
+                    }
+                    """,
+                    at: workspacePath
+                )
+
+                // The dependency's manifest fails to load; the root's still resolves, so a
+                // failure attributed to the root would pass the assertion below only by
+                // accident. The interesting property is that the error names the dependency
+                // and the folder the workspace state pointed at, not the root package.
+                let packageFolder = temporaryDirectory.appending(components: [
+                    ".build", "registry", "downloads", "Alamofire", "Alamofire", "5.10.2",
+                ])
+                given(manifestLoader)
+                    .loadPackage(at: .any, disableSandbox: .value(true))
+                    .willProduce { path, _ in
+                        if path == packageFolder { throw ManifestFailure() }
+                        return .test()
+                    }
+
+                // When / Then
+                await #expect(
+                    throws: SwiftPackageManagerGraphGeneratorError.packageManifestLoadFailed(
+                        name: "Alamofire.Alamofire",
+                        path: packageFolder,
+                        reason: "boom"
+                    )
+                ) {
+                    try await subject.load(
+                        packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                        packageSettings: PackageSettings.test(),
+                        disableSandbox: true
+                    )
+                }
+            }
+        }
+    }
+
     @Test(.inTemporaryDirectory, .withMockedDependencies())
     func load_doesNotHoldSwiftPackageManagerLock_whenLoadingManifests() async throws {
         // The Swift package manager scratch-directory lock is acquired by every

--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -61,13 +61,31 @@ enum ManifestLoader {
     }
 
     static func dumpPackage(packageDir: URL, disableSandbox: Bool) async throws -> Any {
-        let data = try await ManifestLoader.dumpPackageJSON(
-            packageDir: packageDir, disableSandbox: disableSandbox
-        )
-        return try JSONSerialization.jsonObject(with: data)
+        do {
+            let data = try await loadPackageJSON(
+                packageDir: packageDir, disableSandbox: disableSandbox
+            )
+            return try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw await dumpFailure(packageDir: packageDir, underlying: error)
+        }
     }
 
     static func dumpPackageJSON(packageDir: URL, disableSandbox: Bool) async throws -> Data {
+        do {
+            return try await loadPackageJSON(
+                packageDir: packageDir, disableSandbox: disableSandbox
+            )
+        } catch {
+            throw await dumpFailure(packageDir: packageDir, underlying: error)
+        }
+    }
+
+    /// The unattributed load. Both entry points wrap it in `dumpFailure`, so the reading of the
+    /// cache, the `dump-package` hop, and (for `dumpPackage`) the JSON parse are all attributed
+    /// once, by whichever entry point the caller used — a toolchain that prints ahead of the
+    /// JSON must not fail as anonymously as the missing manifest this change is about.
+    private static func loadPackageJSON(packageDir: URL, disableSandbox: Bool) async throws -> Data {
         if let cached = try await readCachedManifest(packageDir: packageDir) {
             return cached
         }
@@ -86,6 +104,56 @@ enum ManifestLoader {
             try? await ManifestEnvironmentFingerprint.write(forCacheFile: cachePath)
         }
         return result.stdout
+    }
+
+    /// `swift package dump-package` resolves the package root from its working directory and
+    /// walks up from there, so a directory that holds no manifest fails with SwiftPM's
+    /// "Could not find Package.swift in this directory or any of its parent directories" —
+    /// which names neither the directory swifterpm chose nor the package it stands for. Every
+    /// dump in the graph reaches the user as that same line, so attribute the failure to the
+    /// directory here, and separate a missing manifest (a package that was never materialized,
+    /// or a local dependency pointing at the wrong path) from a manifest that failed to
+    /// evaluate: the two need different fixes.
+    ///
+    /// The classification is a hint layered on the evidence, never a replacement for it: the
+    /// probe can be wrong (a directory the process cannot traverse reads as absent), so the
+    /// underlying error is always appended. The sentence also carries no verb, so it composes
+    /// under callers that add one ("failed to load the manifest for X: no Package.swift in …")
+    /// without saying it twice.
+    static func dumpFailure(packageDir: URL, underlying: any Error) async -> ToolError {
+        let description =
+            switch await manifestPresence(packageDir: packageDir) {
+            case .present, .indeterminate: packageDir.path
+            case .absent: "no Package.swift in \(packageDir.path)"
+            // Deliberately not "does not exist": `exists` reports an unreadable directory as
+            // absent, so that claim would be false for a package under a parent the process
+            // cannot traverse. "Could not read" holds either way, and the underlying error
+            // below already distinguishes ENOENT from EACCES.
+            case .unreadable: "could not read \(packageDir.path)"
+            }
+        return ToolError.message("\(description): \(underlying)")
+    }
+
+    private enum ManifestPresence {
+        case present
+        case absent
+        /// Missing, or present but not readable — `exists` cannot tell the two apart.
+        case unreadable
+        /// The filesystem could not answer, so the failure is reported without a claim about
+        /// what is on disk rather than with a claim that may be false.
+        case indeterminate
+    }
+
+    private static func manifestPresence(packageDir: URL) async -> ManifestPresence {
+        do {
+            let path = try packageDir.absolutePath
+            if try await fileSystem.exists(path.appending(component: "Package.swift")) {
+                return .present
+            }
+            return try await fileSystem.exists(path) ? .absent : .unreadable
+        } catch {
+            return .indeterminate
+        }
     }
 
     private static func readCachedManifest(packageDir: URL) async throws -> Data? {
@@ -143,10 +211,21 @@ enum ManifestFileSystemDependencyGraph {
                 continue
             }
 
-            let manifest = try await ManifestLoader.dumpPackage(
-                packageDir: canonicalPath,
-                disableSandbox: disableSandbox
-            )
+            let manifest: Any
+            do {
+                manifest = try await ManifestLoader.dumpPackage(
+                    packageDir: canonicalPath,
+                    disableSandbox: disableSandbox
+                )
+            } catch {
+                throw ToolError.message(
+                    """
+                    failed to load the manifest for the local package \
+                    \(item.dependency.identity), declared as "\(item.dependency.path)" by \
+                    \(item.parentPackageDir.path): \(error)
+                    """
+                )
+            }
             result.append(
                 ManifestFileSystemPackage(
                     dependency: item.dependency,

--- a/swifterpm/Sources/swifterpm/PackageInfoCache.swift
+++ b/swifterpm/Sources/swifterpm/PackageInfoCache.swift
@@ -73,9 +73,15 @@ enum PackageInfoCacheWriter {
                 .appendingPathComponent("packages")
                 .appendingPathComponent(
                     "\(SafeFileName.make(pin.identity))-\(entryHash(pin)).json")
-            _ = try await cachedOrDumpPackageJSON(
-                packageDir: packagePath, destination: packageInfoPath,
-                disableSandbox: disableSandbox)
+            do {
+                _ = try await cachedOrDumpPackageJSON(
+                    packageDir: packagePath, destination: packageInfoPath,
+                    disableSandbox: disableSandbox)
+            } catch {
+                throw ToolError.message(
+                    "failed to load the manifest for \(pin.identity): \(error)"
+                )
+            }
             return packageEntry(
                 pin: pin, packagePath: packagePath, packageInfoPath: packageInfoPath)
         }.sorted { $0.identity < $1.identity }
@@ -98,9 +104,18 @@ enum PackageInfoCacheWriter {
                 cacheDir
                 .appendingPathComponent("packages")
                 .appendingPathComponent(packageInfoFileName)
-            _ = try await cachedOrDumpPackageJSON(
-                packageDir: packagePath, destination: packageInfoPath,
-                disableSandbox: disableSandbox)
+            do {
+                _ = try await cachedOrDumpPackageJSON(
+                    packageDir: packagePath, destination: packageInfoPath,
+                    disableSandbox: disableSandbox)
+            } catch {
+                throw ToolError.message(
+                    """
+                    failed to load the manifest for the local package \
+                    \(dependency.identity), declared as "\(dependency.path)": \(error)
+                    """
+                )
+            }
             let entry = PackageInfoEntry(
                 identity: dependency.identity,
                 kind: "fileSystem",

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -5,6 +5,11 @@ enum WorkspaceRestorer {
         let packageRef: [String: String]
         let packagePath: URL
         let canonicalizeLocalBinaryPaths: Bool
+
+        func manifestLoadError(_ error: any Error) -> ToolError {
+            let identity = packageRef["identity"] ?? packagePath.lastPathComponent
+            return ToolError.message("failed to load the manifest for \(identity): \(error)")
+        }
     }
 
     private struct BinaryArtifact {
@@ -101,10 +106,15 @@ enum WorkspaceRestorer {
         // slower ones. Per-target downloads still run concurrently within each
         // context, preserving total parallelism on multi-package restores.
         try await ConcurrentTasks.forEach(contexts) { context in
-            let manifest = try await ManifestLoader.dumpPackage(
-                packageDir: context.packagePath,
-                disableSandbox: disableSandbox
-            )
+            let manifest: Any
+            do {
+                manifest = try await ManifestLoader.dumpPackage(
+                    packageDir: context.packagePath,
+                    disableSandbox: disableSandbox
+                )
+            } catch {
+                throw context.manifestLoadError(error)
+            }
             let binaryTargets = try ManifestParser.binaryTargets(manifest)
             try await ConcurrentTasks.forEach(binaryTargets) { target in
                 try await restoreBinaryArtifact(

--- a/swifterpm/Tests/swifterpmTests/ManifestTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestTests.swift
@@ -275,6 +275,107 @@ struct ManifestTests {
     }
 
     @Test
+    func dumpFailureNamesTheDirectoryMissingAManifest() async throws {
+        try await withTemporaryDirectory { directory in
+            let packageDir = directory.appendingPathComponent("Empty")
+            try await fileSystem.makeDirectory(
+                at: packageDir.absolutePath, options: [.createTargetParentDirectories])
+
+            let error = await ManifestLoader.dumpFailure(
+                packageDir: packageDir,
+                underlying: ToolError.message("could not find Package.swift")
+            )
+
+            #expect(
+                error.description
+                    == "no Package.swift in \(packageDir.path): could not find Package.swift")
+        }
+    }
+
+    @Test
+    func dumpFailureDistinguishesAnUnreadableDirectoryFromAMissingManifest() async throws {
+        try await withTemporaryDirectory { directory in
+            let packageDir = directory.appendingPathComponent("Absent")
+
+            let error = await ManifestLoader.dumpFailure(
+                packageDir: packageDir, underlying: ToolError.message("chdir error")
+            )
+
+            #expect(error.description == "could not read \(packageDir.path): chdir error")
+        }
+    }
+
+    @Test
+    func dumpFailureKeepsTheUnderlyingErrorWhenTheManifestExists() async throws {
+        try await withTemporaryDirectory { directory in
+            let packageDir = directory.appendingPathComponent("Broken")
+            try await writeMinimalPackageManifest(at: packageDir, name: "Broken")
+
+            let error = await ManifestLoader.dumpFailure(
+                packageDir: packageDir, underlying: ToolError.message("compile error")
+            )
+
+            #expect(error.description == "\(packageDir.path): compile error")
+        }
+    }
+
+    @Test
+    func dumpFailureKeepsTheUnderlyingErrorWhenTheProbeCannotAnswer() async throws {
+        try await withTemporaryDirectory { directory in
+            // A package the probe cannot examine: the parent denies traversal, so `exists`
+            // cannot distinguish "absent" from "unreadable". The classification may be wrong;
+            // the underlying error must survive it either way.
+            let locked = directory.appendingPathComponent("locked")
+            let packageDir = locked.appendingPathComponent("Feature")
+            try await writeMinimalPackageManifest(at: packageDir, name: "Feature")
+            _ = try await SystemProcess.run("/bin/chmod", ["000", locked.path])
+
+            let error = await ManifestLoader.dumpFailure(
+                packageDir: packageDir, underlying: ToolError.message("permission denied")
+            )
+
+            _ = try await SystemProcess.run("/bin/chmod", ["755", locked.path])
+
+            #expect(error.description.hasSuffix(": permission denied"))
+            #expect(error.description.contains(packageDir.path))
+        }
+    }
+
+    @Test
+    func localPackageManifestFailureNamesTheDeclaringPackageAndPath() async throws {
+        try await withTemporaryDirectory { directory in
+            let rootPackageDir = directory.appendingPathComponent("Root")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            // The declared directory exists but holds no manifest: the shape SwiftPM reports
+            // as a bare "Could not find Package.swift ..." with no mention of the dependency.
+            let localPackageDir = directory.appendingPathComponent("Packages/Feature")
+            try await fileSystem.makeDirectory(
+                at: localPackageDir.absolutePath, options: [.createTargetParentDirectories])
+
+            let rootManifest: [String: Any] = [
+                "dependencies": [
+                    ["fileSystem": [["identity": "feature", "path": localPackageDir.path]]]
+                ]
+            ]
+
+            do {
+                _ = try await ManifestFileSystemDependencyGraph.collect(
+                    rootPackageDir: rootPackageDir,
+                    rootManifest: rootManifest,
+                    disableSandbox: true
+                )
+                Issue.record("expected the local package manifest to fail to load")
+            } catch {
+                let description = "\(error)"
+                #expect(description.contains("the local package feature"))
+                #expect(description.contains("declared as \"\(localPackageDir.path)\""))
+                #expect(description.contains(rootPackageDir.path))
+                #expect(description.contains("no Package.swift in"))
+            }
+        }
+    }
+
+    @Test
     func versionRangeMatchesExactAndOpenRanges() throws {
         let exact = try #require(ManifestParser.versionRange(for: .exact(SemVer("1.2.3"))))
         #expect(try exact.contains(SemVer("1.2.3")))


### PR DESCRIPTION
Backport of #12224 (`da030c77f6`) onto the 4.203 line, to ship as 4.203.2.

## Why this is worth a patch release

Stable users on 4.203.x are hitting `tuist install` failures whose entire output is SwiftPM's bare `Could not find Package.swift in this directory or any of its parent directories.` The line names neither the directory SwifterPM chose nor the package it stands for, and SwifterPM dumps a manifest for the root, for every pin, and for every local `.package(path:)` dependency, so any of them failing produces the identical sentence.

The failures are intermittent and mostly happen on CI, so the tree cannot be inspected after the fact, and verbose logs from unrelated projects are indistinguishable from one another. Until the message identifies the package and path, every report of this is undiagnosable — which is what makes it worth shipping on the stable line rather than waiting for the next minor.

This does not fix the underlying failure. It makes the next occurrence tell us what the underlying failure actually is.

## What it changes

Error paths only. The successful dump is unchanged, and nothing differs for a graph that loads cleanly. Failures now name the package and directory, say what was found there, and keep SwiftPM's own message underneath as evidence.

## Validation on this branch

- Cherry-picked cleanly from `da030c77f6`; the branch is rooted on `4.203.1`, so the backport workflow's base-tag guard passes.
- 140 SwifterPM unit tests pass on this branch (`swift test`). The 2 tests short of main's 142 cover code that does not exist on 4.203.x.

Once merged, cut the release with `cli-backport.yml` against `releases/4.203.x`.