### PR TITLE
fix(cli): restore registry original locations in the release-line lockfile

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,6 +5,7 @@
       "identity" : "1024jp.gzipswift",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/1024jp/gzipswift",
       "state" : {
         "version" : "5.2.0"
       }
@@ -13,6 +14,7 @@
       "identity" : "apple.swift-algorithms",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-algorithms",
       "state" : {
         "version" : "1.2.1"
       }
@@ -21,6 +23,7 @@
       "identity" : "apple.swift-argument-parser",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "version" : "1.7.1"
       }
@@ -29,6 +32,7 @@
       "identity" : "apple.swift-asn1",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-asn1",
       "state" : {
         "version" : "1.7.0"
       }
@@ -37,6 +41,7 @@
       "identity" : "apple.swift-async-algorithms",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-async-algorithms",
       "state" : {
         "version" : "1.1.3"
       }
@@ -45,6 +50,7 @@
       "identity" : "apple.swift-atomics",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-atomics",
       "state" : {
         "version" : "1.3.0"
       }
@@ -53,6 +59,7 @@
       "identity" : "apple.swift-certificates",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-certificates",
       "state" : {
         "version" : "1.19.0"
       }
@@ -61,6 +68,7 @@
       "identity" : "apple.swift-collections",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-collections",
       "state" : {
         "version" : "1.2.1"
       }
@@ -69,6 +77,7 @@
       "identity" : "apple.swift-crypto",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-crypto",
       "state" : {
         "version" : "3.15.1"
       }
@@ -77,6 +86,7 @@
       "identity" : "apple.swift-http-structured-headers",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-http-structured-headers",
       "state" : {
         "version" : "1.7.0"
       }
@@ -85,6 +95,7 @@
       "identity" : "apple.swift-http-types",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-http-types",
       "state" : {
         "version" : "1.5.1"
       }
@@ -93,6 +104,7 @@
       "identity" : "apple.swift-log",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-log",
       "state" : {
         "version" : "1.13.1"
       }
@@ -101,6 +113,7 @@
       "identity" : "apple.swift-nio",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio",
       "state" : {
         "version" : "2.99.0"
       }
@@ -109,6 +122,7 @@
       "identity" : "apple.swift-nio-extras",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio-extras",
       "state" : {
         "version" : "1.34.0"
       }
@@ -117,6 +131,7 @@
       "identity" : "apple.swift-nio-http2",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio-http2",
       "state" : {
         "version" : "1.43.0"
       }
@@ -125,6 +140,7 @@
       "identity" : "apple.swift-nio-ssl",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
         "version" : "2.37.0"
       }
@@ -133,6 +149,7 @@
       "identity" : "apple.swift-nio-transport-services",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio-transport-services",
       "state" : {
         "version" : "1.27.0"
       }
@@ -141,6 +158,7 @@
       "identity" : "apple.swift-numerics",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-numerics",
       "state" : {
         "version" : "1.1.1"
       }
@@ -149,6 +167,7 @@
       "identity" : "apple.swift-openapi-runtime",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
         "version" : "1.9.0"
       }
@@ -157,6 +176,7 @@
       "identity" : "apple.swift-openapi-urlsession",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
         "version" : "1.2.0"
       }
@@ -165,6 +185,7 @@
       "identity" : "apple.swift-protobuf",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-protobuf",
       "state" : {
         "version" : "1.35.1"
       }
@@ -181,6 +202,7 @@
       "identity" : "apple.swift-system",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-system",
       "state" : {
         "version" : "1.6.4"
       }
@@ -197,6 +219,7 @@
       "identity" : "coreoffice.xmlcoder",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/coreoffice/xmlcoder",
       "state" : {
         "version" : "0.18.1"
       }
@@ -221,6 +244,7 @@
       "identity" : "davewoodcom.xcglogger",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/davewoodcom/xcglogger",
       "state" : {
         "version" : "7.1.5"
       }
@@ -261,6 +285,7 @@
       "identity" : "getguaka.colorizer",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/getguaka/colorizer",
       "state" : {
         "version" : "0.2.1"
       }
@@ -269,6 +294,7 @@
       "identity" : "grpc.grpc-swift-2",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/grpc/grpc-swift-2",
       "state" : {
         "version" : "2.2.0"
       }
@@ -293,6 +319,7 @@
       "identity" : "johnsundell.shellout",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/johnsundell/shellout",
       "state" : {
         "version" : "2.3.0"
       }
@@ -301,6 +328,7 @@
       "identity" : "jpsim.yams",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/jpsim/yams",
       "state" : {
         "version" : "5.4.0"
       }
@@ -325,6 +353,7 @@
       "identity" : "kolos65.Mockable",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/kolos65/mockable",
       "state" : {
         "version" : "0.6.2"
       }
@@ -333,6 +362,7 @@
       "identity" : "krzysztofzablocki.Difference",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/krzysztofzablocki/difference",
       "state" : {
         "version" : "1.1.0"
       }
@@ -341,6 +371,7 @@
       "identity" : "krzyzanowskim.cryptoswift",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/krzyzanowskim/cryptoswift",
       "state" : {
         "version" : "1.3.3"
       }
@@ -349,6 +380,7 @@
       "identity" : "kylef.pathkit",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/kylef/pathkit",
       "state" : {
         "version" : "1.0.1"
       }
@@ -357,6 +389,7 @@
       "identity" : "kylef.spectre",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/kylef/spectre",
       "state" : {
         "version" : "0.10.1"
       }
@@ -365,6 +398,7 @@
       "identity" : "leif-ibsen.asn1",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/leif-ibsen/asn1",
       "state" : {
         "version" : "2.7.0"
       }
@@ -373,6 +407,7 @@
       "identity" : "leif-ibsen.bigint",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/leif-ibsen/bigint",
       "state" : {
         "version" : "1.23.0"
       }
@@ -381,6 +416,7 @@
       "identity" : "leif-ibsen.digest",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/leif-ibsen/digest",
       "state" : {
         "version" : "1.13.0"
       }
@@ -414,6 +450,7 @@
       "identity" : "onevcat.rainbow",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/onevcat/rainbow",
       "state" : {
         "version" : "4.2.1"
       }
@@ -422,6 +459,7 @@
       "identity" : "p-x9.MachOKit",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/p-x9/machokit",
       "state" : {
         "version" : "0.46.1"
       }
@@ -430,6 +468,7 @@
       "identity" : "p-x9.swift-binary-parse-support",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/p-x9/swift-binary-parse-support",
       "state" : {
         "version" : "0.2.1"
       }
@@ -438,6 +477,7 @@
       "identity" : "p-x9.swift-fileio",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/p-x9/swift-fileio",
       "state" : {
         "version" : "0.13.0"
       }
@@ -446,6 +486,7 @@
       "identity" : "p-x9.swift-fileio-extra",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/p-x9/swift-fileio-extra",
       "state" : {
         "version" : "0.2.2"
       }
@@ -454,6 +495,7 @@
       "identity" : "pointfreeco.swift-custom-dump",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
         "version" : "1.5.0"
       }
@@ -462,6 +504,7 @@
       "identity" : "pointfreeco.swift-snapshot-testing",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "version" : "1.18.7"
       }
@@ -479,6 +522,7 @@
       "identity" : "shibapm.komondor",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/shibapm/komondor",
       "state" : {
         "version" : "1.1.3"
       }
@@ -487,6 +531,7 @@
       "identity" : "shibapm.packageconfig",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/shibapm/packageconfig",
       "state" : {
         "version" : "1.1.3"
       }
@@ -503,8 +548,18 @@
       "identity" : "stencilproject.Stencil",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/stencilproject/stencil",
       "state" : {
         "version" : "0.15.1"
+      }
+    },
+    {
+      "identity" : "stephencelis.csqlite",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/stephencelis/CSQLite",
+      "state" : {
+        "version" : "3.53.3"
       }
     },
     {
@@ -519,6 +574,7 @@
       "identity" : "swift-server.swift-service-lifecycle",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
         "version" : "2.11.0"
       }
@@ -527,6 +583,7 @@
       "identity" : "swiftGen.StencilSwiftKit",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swiftgen/stencilswiftkit",
       "state" : {
         "version" : "2.10.1"
       }
@@ -551,6 +608,7 @@
       "identity" : "swiftlang.swift-docc-symbolkit",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "version" : "1.0.0"
       }
@@ -567,6 +625,7 @@
       "identity" : "swiftlang.swift-syntax",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "version" : "602.0.0"
       }
@@ -591,6 +650,7 @@
       "identity" : "tadija.aexml",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tadija/aexml",
       "state" : {
         "version" : "4.7.0"
       }
@@ -599,6 +659,7 @@
       "identity" : "tid-kijyun.kanna",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tid-kijyun/kanna",
       "state" : {
         "version" : "5.3.0"
       }
@@ -607,6 +668,7 @@
       "identity" : "tuist.Command",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/command",
       "state" : {
         "version" : "0.14.9"
       }
@@ -615,6 +677,7 @@
       "identity" : "tuist.FileSystem",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/filesystem",
       "state" : {
         "version" : "0.18.0"
       }
@@ -639,6 +702,7 @@
       "identity" : "tuist.Path",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/path",
       "state" : {
         "version" : "0.3.8"
       }
@@ -671,6 +735,7 @@
       "identity" : "tuist.ZIPFoundation",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/zipfoundation",
       "state" : {
         "version" : "0.9.21"
       }


### PR DESCRIPTION
Removes a pointless full dependency re-solve on every `releases/4.203.x` CI run.

**Scope correction:** I originally opened this claiming it would unblock the failing Linux jobs on this line. CI has disproved that — the jobs still fail with the same crash. See "What this does not fix" below. The change stands on its own merits, but it is not a prerequisite for the 4.203.2 backport (#12225).

## What this fixes

`Package.resolved` here carries `originalLocation` on 2 of its 84 registry pins. Main carries it on 58.

Under `--replace-scm-with-registry`, `originalLocation` is what maps a registry pin back to the source-control dependency the manifest declares. Without it the pins cannot be matched, so SwiftPM discards the lockfile and re-solves the entire graph on every single run.

Verified in the exact container the workflow pins (`swiftlang/swift:nightly-6.4.x-jammy`, same digest), each run from a clean `.build`:

| | exit | `Computing version for` |
| --- | --- | --- |
| before | 0 | **85** — whole graph re-solved |
| after | 0 | **0** — lockfile honoured |

The field goes missing because the toolchain's lockfile writer strips it, which is the same failure mode this line has been repaired for twice already (#12159, and `8f58effc68`).

The 26 pins still without `originalLocation` are exactly the ones main also lacks: packages declared against the registry directly, with no source-control original to record.

## What this does not fix

The Linux jobs still fail at `Resolve dependencies` with exit 132. With this change the crash moves past the solve into the *fetch* phase, but it still happens:

```
FoundationNetworking/EasyHandle.swift:293: Fatal error: 'try!' expression
unexpectedly raised an error: Error Domain=libcurl.Easy Code=43 "(null)"
```

The trigger is a **cold registry fetch of the whole graph**, and the reason release-line PRs always get one is the cache configuration in `cli.yml`:

- `Save cache` runs only `if: github.ref == 'refs/heads/main'`, so caches exist only for main's exact `(Package.resolved, Package.swift)` hash.
- The `restore-keys` fallback can never match: it is built from `hashFiles('Package.swift')` alone, while primary keys begin with the *combined* hash of both files — a different string, so there is no prefix hit.

So any branch whose lockfile differs from main's fetches all 85 packages cold, and `try!` on a libcurl option makes any error there an unconditional trap rather than a retryable failure. This is not specific to this line; it is specific to a cold cache. It also predates this work — #12167, the backport that shipped 4.203.1, merged with the same two jobs red.

Fixing it properly (a retry around the resolve, a cache save for release branches, and the never-matching restore key) belongs on main rather than in a hotfix line, and I have not attempted it here.

## Why grafted rather than regenerated

Insertions only, taken per identity from main, so every pin keeps this line's own resolved version and the diff stays reviewable. Regenerating with a toolchain would rewrite the file wholesale and strip the field again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)