### PR TITLE
ci(cli): front the registry with an HTTP/1.1 proxy on Linux

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -400,7 +400,7 @@ jobs:
     name: Linux Build
     runs-on: ubuntu-latest
     container:
-      image: swift:6.2
+      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -429,7 +429,7 @@ jobs:
     name: Linux Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: swift:6.2
+      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -413,6 +413,8 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - name: Install curl
+        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -424,18 +426,12 @@ jobs:
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
       # target negotiates http/1.1 on its own, so only this hop needs forcing.
       - name: Front the registry with an HTTP/1.1 proxy
-        # The Swift image is slim: no curl, wget, nc or python3. bash is present,
-        # so the readiness probe uses its /dev/tcp support.
         shell: bash
         run: |
           nohup mise x caddy -- caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            # A TCP connect proves the listener is up, which is all this step is
-            # responsible for. Upstream health is deliberately not asserted here:
-            # a degraded registry is the resolve step's error to report, with
-            # SwiftPM's own diagnostics, not a proxy startup failure.
             if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
               exec 3>&-
               exit 0
@@ -476,6 +472,8 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - name: Install curl
+        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -487,18 +485,12 @@ jobs:
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
       # target negotiates http/1.1 on its own, so only this hop needs forcing.
       - name: Front the registry with an HTTP/1.1 proxy
-        # The Swift image is slim: no curl, wget, nc or python3. bash is present,
-        # so the readiness probe uses its /dev/tcp support.
         shell: bash
         run: |
           nohup mise x caddy -- caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            # A TCP connect proves the listener is up, which is all this step is
-            # responsible for. Upstream health is deliberately not asserted here:
-            # a degraded registry is the resolve step's error to report, with
-            # SwiftPM's own diagnostics, not a proxy startup failure.
             if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
               exec 3>&-
               exit 0

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -413,14 +413,8 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
-      - name: Install curl
-        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "caddy"
-          cache: "false"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install caddy
+        run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
       # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
       # (see #12229), and the registry answers 303 to storage over h2. Terminating
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
@@ -428,7 +422,7 @@ jobs:
       - name: Front the registry with an HTTP/1.1 proxy
         shell: bash
         run: |
-          nohup mise x caddy -- caddy reverse-proxy \
+          nohup caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
@@ -472,14 +466,8 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
-      - name: Install curl
-        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "caddy"
-          cache: "false"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install caddy
+        run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
       # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
       # (see #12229), and the registry answers 303 to storage over h2. Terminating
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
@@ -487,7 +475,7 @@ jobs:
       - name: Front the registry with an HTTP/1.1 proxy
         shell: bash
         run: |
-          nohup mise x caddy -- caddy reverse-proxy \
+          nohup caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -429,12 +429,17 @@ jobs:
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            if curl -sf -o /dev/null -m 2 "http://localhost:8080/api/registry/swift/tuist/Path"; then
+            # Any HTTP response proves the listener is up. Deliberately not -f:
+            # a non-2xx here would mean the registry itself is unhappy, which is
+            # the resolve step's error to report with its own diagnostics, not a
+            # proxy startup failure to be reported as one.
+            if curl -s -o /dev/null -m 2 http://localhost:8080/; then
               exit 0
             fi
             sleep 1
           done
-          echo "::error::registry proxy did not come up"
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
           exit 1
       - name: Point SwiftPM at the proxy
         run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
@@ -483,12 +488,17 @@ jobs:
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            if curl -sf -o /dev/null -m 2 "http://localhost:8080/api/registry/swift/tuist/Path"; then
+            # Any HTTP response proves the listener is up. Deliberately not -f:
+            # a non-2xx here would mean the registry itself is unhappy, which is
+            # the resolve step's error to report with its own diagnostics, not a
+            # proxy startup failure to be reported as one.
+            if curl -s -o /dev/null -m 2 http://localhost:8080/; then
               exit 0
             fi
             sleep 1
           done
-          echo "::error::registry proxy did not come up"
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
           exit 1
       - name: Point SwiftPM at the proxy
         run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -400,7 +400,7 @@ jobs:
     name: Linux Build
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -413,6 +413,31 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "caddy"
+          cache: "false"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        run: |
+          nohup mise x caddy -- caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf -o /dev/null -m 2 "http://localhost:8080/api/registry/swift/tuist/Path"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not come up"
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
       - name: Resolve dependencies
         run: swift package resolve --replace-scm-with-registry
       - name: Build tuist CLI
@@ -429,7 +454,7 @@ jobs:
     name: Linux Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -442,6 +467,31 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "caddy"
+          cache: "false"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        run: |
+          nohup mise x caddy -- caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf -o /dev/null -m 2 "http://localhost:8080/api/registry/swift/tuist/Path"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not come up"
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
       - name: Resolve dependencies
         run: swift package resolve --replace-scm-with-registry
       - name: Run unit tests

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -424,16 +424,20 @@ jobs:
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
       # target negotiates http/1.1 on its own, so only this hop needs forcing.
       - name: Front the registry with an HTTP/1.1 proxy
+        # The Swift image is slim: no curl, wget, nc or python3. bash is present,
+        # so the readiness probe uses its /dev/tcp support.
+        shell: bash
         run: |
           nohup mise x caddy -- caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            # Any HTTP response proves the listener is up. Deliberately not -f:
-            # a non-2xx here would mean the registry itself is unhappy, which is
-            # the resolve step's error to report with its own diagnostics, not a
-            # proxy startup failure to be reported as one.
-            if curl -s -o /dev/null -m 2 http://localhost:8080/; then
+            # A TCP connect proves the listener is up, which is all this step is
+            # responsible for. Upstream health is deliberately not asserted here:
+            # a degraded registry is the resolve step's error to report, with
+            # SwiftPM's own diagnostics, not a proxy startup failure.
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
               exit 0
             fi
             sleep 1
@@ -483,16 +487,20 @@ jobs:
       # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
       # target negotiates http/1.1 on its own, so only this hop needs forcing.
       - name: Front the registry with an HTTP/1.1 proxy
+        # The Swift image is slim: no curl, wget, nc or python3. bash is present,
+        # so the readiness probe uses its /dev/tcp support.
+        shell: bash
         run: |
           nohup mise x caddy -- caddy reverse-proxy \
             --from :8080 --to https://tuist.dev --change-host-header \
             > /tmp/registry-proxy.log 2>&1 &
           for _ in $(seq 1 30); do
-            # Any HTTP response proves the listener is up. Deliberately not -f:
-            # a non-2xx here would mean the registry itself is unhappy, which is
-            # the resolve step's error to report with its own diagnostics, not a
-            # proxy startup failure to be reported as one.
-            if curl -s -o /dev/null -m 2 http://localhost:8080/; then
+            # A TCP connect proves the listener is up, which is all this step is
+            # responsible for. Upstream health is deliberately not asserted here:
+            # a degraded registry is the resolve step's error to report, with
+            # SwiftPM's own diagnostics, not a proxy startup failure.
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
               exit 0
             fi
             sleep 1


### PR DESCRIPTION
Unblocks the two Linux jobs, which fail on every PR into this line — including the 4.203.2 backport (#12225).

Root cause, isolation and impact beyond CI: **#12229**.

## Approach

`Resolve dependencies` traps inside Swift 6.2's FoundationNetworking:

```
FoundationNetworking/EasyHandle.swift:293: Fatal error: 'try!' expression
unexpectedly raised an error: Error Domain=libcurl.Easy Code=43
```

It needs a redirect served over **HTTP/2**, which is exactly what the registry does — h2 with a `303` to presigned storage. Rather than change the toolchain, this removes the precondition: caddy runs as a plaintext **HTTP/1.1** reverse proxy in front of the registry, and SwiftPM is pointed at it with `--allow-insecure-http`.

Only the first hop needs forcing. `t3.storage.dev` does not advertise h2 in ALPN and negotiates `http/1.1` on its own, so the redirect target was never the problem.

Two steps per job, purely additive:

```yaml
- name: Install caddy
  run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
- name: Front the registry with an HTTP/1.1 proxy
  shell: bash
  run: |
    nohup caddy reverse-proxy \
      --from :8080 --to https://tuist.dev --change-host-header \
      > /tmp/registry-proxy.log 2>&1 &
    # poll /dev/tcp until listening; dump the log and fail otherwise
- name: Point SwiftPM at the proxy
  run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
```

caddy comes from Ubuntu's repositories (2.6.2), so there is no config file, no certificate, and nothing to download beyond the package. The readiness probe uses bash's `/dev/tcp` — the Swift image ships no curl, wget or nc — and asserts only that the listener came up; a degraded registry is left for the resolve step to report with SwiftPM's own diagnostics.

## Measured against the crashing configuration

Cold `.build`, `swift:6.2`, the 84-package graph on this line:

| | result |
| --- | --- |
| without the proxy | crash, exit 132/133, every attempt |
| through the proxy | no trap; resolve completes, warm re-run exits 0 |

Verified in the image that the proxied first hop returns `HTTP/1.1 303 See Other` with the redirect intact.

## Alternatives tried and rejected

**Bump the image to the 6.4 nightly** (the first version of this PR). Fixes the trap, and `main` runs these jobs that way today — but it cannot extend to `cli-build-publish.yml`, which cross-compiles against the 6.2.3 static musl SDK. No matching 6.4 static SDK is published (`swift-6.4-branch/static-sdk` is a 404), and pairing them fails outright:

```
error: module compiled with Swift 6.2.3 cannot be imported by the Swift 6.4 compiler
```

**Resolve on 6.1, build on 6.2.** 6.1 predates the bug, and an older resolver cannot select versions the builder rejects. But it rewrites `Package.resolved` on resolve, and its cold resolve failed in testing.

The proxy leaves both the resolver and the compiler untouched, which is why the same steps extend to the release build — that job resolves ~84 packages cold on 6.2 with no cache, i.e. the crashing configuration, and is passing on timing luck (today's canary and the failing CI job pulled the *same* image digest an hour apart).

## Known gaps

- **Binary artifacts bypass the proxy.** Resolution pulls xcframework zips straight from GitHub releases. Untested whether those alone reach the concurrency threshold.
- **A cold resolve fails once with a bare `error: fatalError`**, then succeeds on retry. It reproduces *without* the proxy and on 6.1, so it is a separate defect rather than something this introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)