### PR TITLE
ci(cli): front the registry with an HTTP/1.1 proxy on Linux

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -191,6 +191,30 @@ jobs:
         run: |
           sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
 
+      - name: Install caddy
+        run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        shell: bash
+        run: |
+          nohup caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
       - name: Bundle CLI
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -388,7 +388,7 @@ jobs:
     name: Linux Build
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -401,6 +401,30 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - name: Install caddy
+        run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        shell: bash
+        run: |
+          nohup caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
       - name: Resolve dependencies
         run: swift package resolve --replace-scm-with-registry
       - name: Build tuist CLI
@@ -417,7 +441,7 @@ jobs:
     name: Linux Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.4.x-jammy@sha256:763b14501faf5ecd4400316aeea94cc3f5419850230742236e8b3eb6261aa0b0
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -430,6 +454,30 @@ jobs:
           key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             linux-cli-${{ hashFiles('Package.swift') }}-
+      - name: Install caddy
+        run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        shell: bash
+        run: |
+          nohup caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
       - name: Resolve dependencies
         run: swift package resolve --replace-scm-with-registry
       - name: Run unit tests


### PR DESCRIPTION
Fixes the Linux release build's exposure to #12229, and retires the 6.4 nightly bump now that a better fix exists.

## What breaks today

Swift 6.2's FoundationNetworking traps on a redirect served over **HTTP/2**:

```
FoundationNetworking/EasyHandle.swift:293: Fatal error: 'try!' expression
unexpectedly raised an error: Error Domain=libcurl.Easy Code=43
```

`try!` around `curl_easy_setopt` turns anything libcurl rejects into an unconditional crash. The registry answers h2 with a `303` to presigned storage, so every package download takes that path, and it needs both the redirect and concurrency past roughly six requests — which any cold resolve of this graph (~84 packages) crosses. Full isolation in #12229.

## The Linux release build is exposed, not safe

`release-cli-linux` resolves the whole graph **cold on `swift:6.2` with no cache** — precisely the crashing configuration — behind a three-attempt retry that cannot help, because a crashed attempt leaves nothing downloaded (verified: five consecutive attempts, no progress).

It has been passing on timing luck. Today's canary release and a CI job that crashed pulled the **same image digest** an hour apart, on the same runner class, with the same cold cache and the same 84-package burst. There is no protective mechanism to point at.

## The fix

Terminate the first hop as plaintext HTTP/1.1 with caddy, and point SwiftPM at it:

```yaml
- name: Install caddy
  run: apt-get update -qq && apt-get install -y --no-install-recommends caddy
- name: Front the registry with an HTTP/1.1 proxy
  shell: bash
  run: |
    nohup caddy reverse-proxy \
      --from :8080 --to https://tuist.dev --change-host-header \
      > /tmp/registry-proxy.log 2>&1 &
    # poll /dev/tcp until listening; dump the log and fail otherwise
- name: Point SwiftPM at the proxy
  run: swift package-registry set --allow-insecure-http http://localhost:8080/api/registry/swift
```

Only that hop matters — `t3.storage.dev` does not advertise h2 in ALPN and negotiates `http/1.1` on its own. caddy comes from Ubuntu's repositories, so there is no config file, no certificate, and nothing to download beyond the package. The readiness probe uses bash's `/dev/tcp` because the Swift image ships no curl, wget or nc, and it asserts only that the listener came up: a degraded registry is left for the resolve step to report with SwiftPM's own diagnostics.

Measured against the crashing configuration (cold `.build`, `swift:6.2`, 84 packages):

| | result |
| --- | --- |
| without the proxy | crash, exit 132/133, every attempt |
| through the proxy | no trap; resolve completes, warm re-run exits 0 |

## Retiring the 6.4 nightly

The two CI jobs go back to `swift:6.2`. The nightly (`2c06f93908`) was a genuine fix for the trap, but it only ever covered CI: the release build cannot follow it, because it cross-compiles against the 6.2.3 static musl SDK, no matching 6.4 static SDK is published (`swift-6.4-branch/static-sdk` is a 404), and pairing them fails with

```
error: module compiled with Swift 6.2.3 cannot be imported by the Swift 6.4 compiler
```

With the proxy in place the bump is redundant, and dropping it puts CI back on the toolchain that actually ships — which is the point of running these jobs.

## Known gaps

- **Binary artifacts bypass the proxy.** Resolution pulls xcframework zips straight from GitHub releases. Untested whether those alone reach the concurrency threshold.
- **A cold resolve fails once with a bare `error: fatalError`**, then succeeds on retry. It reproduces without the proxy and on Swift 6.1, so it is a separate defect; the release job's retry loop rides through it.

The same change for `releases/4.203.x` CI is #12230. This PR covers the release build for every channel, since `cli-build-publish.yml` resolves from `main` even for backport releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)