### PR TITLE
fix(registry): attribute submodule failures to the path that produced them

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -334,7 +334,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   # that produced it, so a skippable failure drops only that path instead of the
   # required subtree that happened to lead to it.
   defp update_submodules_in(repository_directory, path_prefix, context) do
-    with {:ok, submodule_paths} <- submodule_paths(repository_directory) do
+    with {:ok, submodule_paths} <- submodule_paths(repository_directory, path_prefix) do
       Enum.reduce_while(submodule_paths, :ok, fn submodule_path, :ok ->
         update_submodule_tree(repository_directory, submodule_path, path_prefix, context)
       end)
@@ -343,24 +343,43 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
   defp update_submodule_tree(repository_directory, submodule_path, path_prefix, context) do
     full_path = join_submodule_path(path_prefix, submodule_path)
+    submodule_directory = Path.join(repository_directory, submodule_path)
 
     case update_submodule(repository_directory, submodule_path, context.git_credentials) do
       :ok ->
-        repository_directory
-        |> Path.join(submodule_path)
-        |> update_submodules_in(full_path, context)
-        |> case do
-          :ok -> {:cont, :ok}
-          {:error, reason} -> {:halt, {:error, reason}}
-        end
+        descend_into_submodule(submodule_directory, full_path, context)
 
       {:skip, output} ->
         handle_skipped_submodule(repository_directory, submodule_path, full_path, context, output)
+
+      {:throttled, status, output} ->
+        {:halt, {:error, {:git_submodule_update_throttled, full_path, status, output}}}
 
       {:failed, status, output} ->
         {:halt, {:error, {:git_submodule_update_failed, full_path, status, output}}}
     end
   end
+
+  defp descend_into_submodule(submodule_directory, full_path, context) do
+    if submodule_checkout?(submodule_directory) do
+      case update_submodules_in(submodule_directory, full_path, context) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    else
+      {:cont, :ok}
+    end
+  end
+
+  # A zero exit status does not by itself mean the submodule was populated: a
+  # `.gitmodules` declaring `update = none` makes git report success while
+  # leaving the empty directory the superproject checkout created. Listing that
+  # directory finds the *superproject*, whose repository discovery walks up from
+  # the gitlink and renders the gitlink itself as the relative path `./`, so
+  # descending would re-enter the same directory without ever reaching a fixed
+  # point. Requiring a checkout of its own restores what `--recursive` did here,
+  # which was to skip the submodule and move on.
+  defp submodule_checkout?(directory), do: File.exists?(Path.join(directory, ".git"))
 
   defp join_submodule_path(nil, submodule_path), do: submodule_path
   defp join_submodule_path(path_prefix, submodule_path), do: "#{path_prefix}/#{submodule_path}"
@@ -408,25 +427,38 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             trimmed -> trimmed
           end
 
-        if skippable_submodule_failure?(output) do
-          {:skip, output}
-        else
-          {:failed, status, output}
+        case classify_submodule_failure(output) do
+          :permanent -> {:skip, output}
+          :transient -> {:throttled, status, output}
+          :unknown -> {:failed, status, output}
         end
     end
   end
+
+  @doc false
+  def skippable_submodule_failure?(output), do: classify_submodule_failure(output) == :permanent
 
   # Skipping is permanent: the release ships an archive that no longer contains
   # the submodule, so a host that is merely throttling us must not be read as one
   # that will never serve the repository. GitHub answers a throttled clone with
   # the same 403 it uses for a repository the token cannot see, and only the
-  # accompanying message tells the two apart.
-  @doc false
-  def skippable_submodule_failure?(output) do
+  # accompanying message tells the two apart. Throttling is kept distinct from an
+  # unclassified failure rather than folded into it, so the release can be
+  # deferred instead of retried against a host that has just asked us to slow
+  # down.
+  defp classify_submodule_failure(output) do
     downcased_output = String.downcase(output)
 
-    not Enum.any?(@transient_submodule_failure_markers, &String.contains?(downcased_output, &1)) and
-      Enum.any?(@skippable_submodule_failure_markers, &String.contains?(downcased_output, &1))
+    cond do
+      Enum.any?(@transient_submodule_failure_markers, &String.contains?(downcased_output, &1)) ->
+        :transient
+
+      Enum.any?(@skippable_submodule_failure_markers, &String.contains?(downcased_output, &1)) ->
+        :permanent
+
+      true ->
+        :unknown
+    end
   end
 
   defp remove_failed_submodule_contents(repository_directory, submodule_path) do
@@ -436,8 +468,14 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     end
   end
 
-  defp submodule_paths(repository_directory) do
-    case System.cmd("git", ["-C", repository_directory, "ls-files", "--stage"], stderr_to_stdout: true) do
+  # `core.quotePath=false` keeps git from C-quoting paths that contain non-ASCII
+  # bytes, tabs or newlines: the quoted rendering (`"caf\303\251"`) is handed
+  # straight back to git as a pathspec, where it matches nothing, and to
+  # `File.rm_rf/1`, where it would silently delete nothing.
+  defp submodule_paths(repository_directory, path_prefix) do
+    case System.cmd("git", ["-c", "core.quotePath=false", "-C", repository_directory, "ls-files", "--stage"],
+           stderr_to_stdout: true
+         ) do
       {output, 0} ->
         paths =
           output
@@ -445,16 +483,16 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
           |> Enum.filter(&String.starts_with?(&1, "160000"))
           |> Enum.map(fn line ->
             case String.split(line, "\t", parts: 2) do
-              [_, path] -> String.trim(path)
+              [_, path] -> path |> String.trim() |> String.trim_trailing("/")
               _ -> nil
             end
           end)
-          |> Enum.reject(&is_nil/1)
+          |> Enum.reject(&(&1 in [nil, "", "."]))
 
         {:ok, paths}
 
       {output, status} ->
-        {:error, {:git_list_submodules_failed, status, String.trim(output)}}
+        {:error, {:git_list_submodules_failed, path_prefix || ".", status, String.trim(output)}}
     end
   end
 
@@ -970,6 +1008,25 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp metadata_lock_backoff_ms(attempts_remaining) do
     step = @metadata_lock_max_attempts - attempts_remaining + 1
     @metadata_lock_backoff_ms * step + :rand.uniform(@metadata_lock_backoff_ms)
+  end
+
+  # Retrying re-clones the repository and every submodule already walked, aimed
+  # at a host that has just asked us to slow down, and reports each attempt
+  # separately. Deferring to the next sync tick is what `SyncWorker` already does
+  # with throttling responses, and the version stays unrecorded so that tick
+  # picks it up again.
+  defp maybe_skip_release(
+         scope,
+         name,
+         _full_handle,
+         version,
+         {:git_submodule_update_throttled, submodule_path, _status, _output} = reason
+       ) do
+    Logger.warning(
+      "Deferring registry release #{scope}/#{name}@#{version}: the host serving submodule #{submodule_path} is throttling requests"
+    )
+
+    {:discard, reason}
   end
 
   defp maybe_skip_release(scope, name, full_handle, version, {:missing_manifests, failed_full_handle, tag}) do

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -44,7 +44,6 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     "repository not found",
     "does not appear to be a git repository",
     "the requested url returned error: 404",
-    "the requested url returned error: 403",
     "write access to repository not granted",
     "fatal: could not read username for",
     "not our ref",
@@ -60,6 +59,20 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     "temporarily blocked",
     "try again later"
   ]
+
+  # Git renders an HTTP failure as the bare status line and only relays the
+  # host's explanation when the error body is `text/plain`, so a throttled host
+  # serving HTML or an empty body matches none of the prose markers above.
+  # Matching the status itself is what covers those.
+  @transient_http_statuses ~w(429 502 503 504)
+
+  # GitHub answers a throttled clone with the same 403 it uses for a repository
+  # the token cannot see, so a 403 from it says nothing durable. Elsewhere a 403
+  # is an access-control decision that will not change on retry, which is how
+  # Gerrit hosts such as review.mlplatform.org refuse anonymous clones. A
+  # private GitHub repository the token cannot see answers 404, which is already
+  # classified permanent, so scoping this away from GitHub loses no coverage.
+  @ambiguous_forbidden_hosts ["github.com"]
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -410,6 +423,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
                "--init",
                "--depth",
                "1",
+               "--",
                submodule_path
              ],
            stderr_to_stdout: true,
@@ -453,12 +467,41 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
       Enum.any?(@transient_submodule_failure_markers, &String.contains?(downcased_output, &1)) ->
         :transient
 
+      http_status(downcased_output) in @transient_http_statuses ->
+        :transient
+
       Enum.any?(@skippable_submodule_failure_markers, &String.contains?(downcased_output, &1)) ->
+        :permanent
+
+      forbidden_by_policy?(downcased_output) ->
         :permanent
 
       true ->
         :unknown
     end
+  end
+
+  defp http_status(downcased_output) do
+    case Regex.run(~r/returned error: (\d{3})/, downcased_output, capture: :all_but_first) do
+      [status] -> status
+      _ -> nil
+    end
+  end
+
+  # Git reports the refused URL and its status on one line, so the host that
+  # denied us is read from that line rather than from anywhere else in the
+  # output, which may mention several remotes.
+  defp forbidden_by_policy?(downcased_output) do
+    case Regex.run(~r/unable to access '([^']+)'[^\n]*returned error: 403/, downcased_output, capture: :all_but_first) do
+      [url] -> not ambiguous_forbidden_host?(url)
+      _ -> false
+    end
+  end
+
+  defp ambiguous_forbidden_host?(url) do
+    host = URI.parse(url).host || ""
+
+    Enum.any?(@ambiguous_forbidden_hosts, &(host == &1 or String.ends_with?(host, "." <> &1)))
   end
 
   defp remove_failed_submodule_contents(repository_directory, submodule_path) do
@@ -468,26 +511,29 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     end
   end
 
-  # `core.quotePath=false` keeps git from C-quoting paths that contain non-ASCII
-  # bytes, tabs or newlines: the quoted rendering (`"caf\303\251"`) is handed
-  # straight back to git as a pathspec, where it matches nothing, and to
-  # `File.rm_rf/1`, where it would silently delete nothing.
+  # `-z` is what keeps the path usable rather than merely readable: without it
+  # git C-quotes any path containing non-ASCII bytes, quotes, backslashes or
+  # control characters, and the quoted rendering (`"caf\303\251"`) is handed
+  # straight back to git as a pathspec that matches nothing and to
+  # `File.rm_rf/1`, where a skip would delete nothing. NUL termination also
+  # means a path may be taken verbatim, since trimming would corrupt the paths
+  # git emits with leading or trailing whitespace.
   defp submodule_paths(repository_directory, path_prefix) do
-    case System.cmd("git", ["-c", "core.quotePath=false", "-C", repository_directory, "ls-files", "--stage"],
-           stderr_to_stdout: true
-         ) do
+    case System.cmd("git", ["-C", repository_directory, "ls-files", "--stage", "-z"], stderr_to_stdout: true) do
       {output, 0} ->
         paths =
           output
-          |> String.split("\n", trim: true)
+          |> String.split(<<0>>, trim: true)
           |> Enum.filter(&String.starts_with?(&1, "160000"))
-          |> Enum.map(fn line ->
-            case String.split(line, "\t", parts: 2) do
-              [_, path] -> path |> String.trim() |> String.trim_trailing("/")
+          |> Enum.map(fn record ->
+            case String.split(record, "\t", parts: 2) do
+              [_, path] -> path
               _ -> nil
             end
           end)
-          |> Enum.reject(&(&1 in [nil, "", "."]))
+          # A submodule git left unpopulated lists the superproject's own gitlink
+          # back as `./`, which would walk the tree into itself.
+          |> Enum.reject(&(&1 in [nil, "", ".", "./"]))
 
         {:ok, paths}
 

--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -44,6 +44,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     "repository not found",
     "does not appear to be a git repository",
     "the requested url returned error: 404",
+    "the requested url returned error: 403",
     "write access to repository not granted",
     "fatal: could not read username for",
     "not our ref",
@@ -51,6 +52,13 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     "unable to find current revision in submodule path",
     "reference is not a tree",
     "needed a single revision"
+  ]
+
+  @transient_submodule_failure_markers [
+    "rate limit",
+    "too many requests",
+    "temporarily blocked",
+    "try again later"
   ]
 
   @impl Oban.Worker
@@ -309,29 +317,59 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
 
   @doc false
   def update_submodules(%{destination: destination, repository_full_handle: full_handle, tag: tag} = opts) do
-    git_credentials = Map.get(opts, :git_credentials)
+    context = %{
+      repository_full_handle: full_handle,
+      tag: tag,
+      git_credentials: Map.get(opts, :git_credentials)
+    }
 
-    with {:ok, submodule_paths} <- submodule_paths(destination) do
+    update_submodules_in(destination, nil, context)
+  end
+
+  # `git submodule update --recursive` reports a failure anywhere in the tree as
+  # a failure of the top-level submodule it was reached through, so an
+  # unreachable third-party dependency nested several levels down is
+  # indistinguishable from the package's own submodule being unreachable.
+  # Descending one level at a time attributes every failure to the exact path
+  # that produced it, so a skippable failure drops only that path instead of the
+  # required subtree that happened to lead to it.
+  defp update_submodules_in(repository_directory, path_prefix, context) do
+    with {:ok, submodule_paths} <- submodule_paths(repository_directory) do
       Enum.reduce_while(submodule_paths, :ok, fn submodule_path, :ok ->
-        case update_submodule(destination, submodule_path, git_credentials) do
-          :ok ->
-            {:cont, :ok}
-
-          {:skip, output} ->
-            handle_skipped_submodule(destination, submodule_path, full_handle, tag, output)
-
-          {:error, reason} ->
-            {:halt, {:error, reason}}
-        end
+        update_submodule_tree(repository_directory, submodule_path, path_prefix, context)
       end)
     end
   end
 
-  defp handle_skipped_submodule(destination, submodule_path, full_handle, tag, output) do
-    case remove_failed_submodule_contents(destination, submodule_path) do
+  defp update_submodule_tree(repository_directory, submodule_path, path_prefix, context) do
+    full_path = join_submodule_path(path_prefix, submodule_path)
+
+    case update_submodule(repository_directory, submodule_path, context.git_credentials) do
+      :ok ->
+        repository_directory
+        |> Path.join(submodule_path)
+        |> update_submodules_in(full_path, context)
+        |> case do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+
+      {:skip, output} ->
+        handle_skipped_submodule(repository_directory, submodule_path, full_path, context, output)
+
+      {:failed, status, output} ->
+        {:halt, {:error, {:git_submodule_update_failed, full_path, status, output}}}
+    end
+  end
+
+  defp join_submodule_path(nil, submodule_path), do: submodule_path
+  defp join_submodule_path(path_prefix, submodule_path), do: "#{path_prefix}/#{submodule_path}"
+
+  defp handle_skipped_submodule(repository_directory, submodule_path, full_path, context, output) do
+    case remove_failed_submodule_contents(repository_directory, submodule_path) do
       :ok ->
         Logger.warning(
-          "Skipping submodule #{submodule_path} for #{full_handle}@#{tag} after permanent git submodule update failure: #{output}"
+          "Skipping submodule #{full_path} for #{context.repository_full_handle}@#{context.tag} after permanent git submodule update failure: #{output}"
         )
 
         {:cont, :ok}
@@ -341,17 +379,16 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     end
   end
 
-  defp update_submodule(destination, submodule_path, git_credentials) do
+  defp update_submodule(repository_directory, submodule_path, git_credentials) do
     case System.cmd(
            "git",
            GitAuthentication.config_args(git_credentials) ++
              [
                "-C",
-               destination,
+               repository_directory,
                "submodule",
                "update",
                "--init",
-               "--recursive",
                "--depth",
                "1",
                submodule_path
@@ -371,53 +408,36 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
             trimmed -> trimmed
           end
 
-        nested_submodule_path = nested_submodule_path(output)
-
-        cond do
-          nested_submodule_failure?(output, submodule_path, nested_submodule_path) ->
-            {:error, {:nested_git_submodule_update_failed, submodule_path, nested_submodule_path, status, output}}
-
-          skippable_submodule_failure?(output) ->
-            {:skip, output}
-
-          true ->
-            {:error, {:git_submodule_update_failed, submodule_path, status, output}}
+        if skippable_submodule_failure?(output) do
+          {:skip, output}
+        else
+          {:failed, status, output}
         end
     end
   end
 
-  defp nested_submodule_path(output) do
-    case Regex.run(~r/registered for path '([^']+)'/, output, capture: :all_but_first) ||
-           Regex.run(~r/submodule path '([^']+)'/, output, capture: :all_but_first) do
-      [nested_submodule_path] -> nested_submodule_path
-      _ -> nil
-    end
-  end
-
-  defp nested_submodule_failure?(output, submodule_path, nested_submodule_path) do
-    output =~ "Failed to recurse into submodule path '#{submodule_path}'" and
-      is_binary(nested_submodule_path) and
-      nested_submodule_path != submodule_path and
-      String.starts_with?(nested_submodule_path, submodule_path <> "/")
-  end
-
+  # Skipping is permanent: the release ships an archive that no longer contains
+  # the submodule, so a host that is merely throttling us must not be read as one
+  # that will never serve the repository. GitHub answers a throttled clone with
+  # the same 403 it uses for a repository the token cannot see, and only the
+  # accompanying message tells the two apart.
   @doc false
   def skippable_submodule_failure?(output) do
-    Enum.any?(
-      @skippable_submodule_failure_markers,
-      &(output |> String.downcase() |> String.contains?(&1))
-    )
+    downcased_output = String.downcase(output)
+
+    not Enum.any?(@transient_submodule_failure_markers, &String.contains?(downcased_output, &1)) and
+      Enum.any?(@skippable_submodule_failure_markers, &String.contains?(downcased_output, &1))
   end
 
-  defp remove_failed_submodule_contents(destination, submodule_path) do
-    case File.rm_rf(Path.join(destination, submodule_path)) do
+  defp remove_failed_submodule_contents(repository_directory, submodule_path) do
+    case File.rm_rf(Path.join(repository_directory, submodule_path)) do
       {:ok, _removed_paths} -> :ok
       {:error, reason, path} -> {:error, {:remove_failed_submodule_contents_failed, path, reason}}
     end
   end
 
-  defp submodule_paths(destination) do
-    case System.cmd("git", ["-C", destination, "ls-files", "--stage"], stderr_to_stdout: true) do
+  defp submodule_paths(repository_directory) do
+    case System.cmd("git", ["-C", repository_directory, "ls-files", "--stage"], stderr_to_stdout: true) do
       {output, 0} ->
         paths =
           output

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -2,6 +2,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  import ExUnit.CaptureLog
+
   alias Ecto.Adapters.SQL.Sandbox
   alias ExAws.Operation.S3
   alias ExAws.S3.Upload
@@ -419,11 +421,73 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     refute ReleaseWorker.skippable_submodule_failure?(output)
   end
 
+  test "a throttling marker vetoes an otherwise permanent submodule failure" do
+    output = """
+    remote: Repository not found. Please try again later.
+    fatal: repository 'https://github.com/apple/swift-nio/' not found
+    """
+
+    # "repository not found" alone is permanent; the throttling hint must win.
+    assert ReleaseWorker.skippable_submodule_failure?("fatal: repository not found")
+    refute ReleaseWorker.skippable_submodule_failure?(output)
+  end
+
+  test "treats a submodule host asking us to retry as a non-skippable failure" do
+    for marker <- ["Too Many Requests", "please try again later"] do
+      refute ReleaseWorker.skippable_submodule_failure?("fatal: repository not found\nremote: #{marker}")
+    end
+  end
+
   describe "update_submodules/1" do
     test "removes only the failing nested submodule and keeps the submodule that reached it" do
       root = Briefly.create!(directory: true)
       clone = superproject_clone_with_nested_submodule(root, nil)
 
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   ReleaseWorker.update_submodules(%{
+                     destination: clone,
+                     repository_full_handle: "apple/swift-argument-parser",
+                     tag: "v1.0.0"
+                   })
+        end)
+
+      assert File.exists?(Path.join(clone, "Vendor/Required/README.md"))
+      refute File.exists?(Path.join(clone, "Vendor/Required/NestedDep"))
+      # The skip branch's only observable is this line, so the composed path is
+      # asserted here the way the error branch asserts its own.
+      assert log =~ "Skipping submodule Vendor/Required/NestedDep"
+    end
+
+    test "continues past a skipped submodule to the siblings that follow it" do
+      root = Briefly.create!(directory: true)
+      clone = superproject_clone_with_unresolvable_submodules(root, ["Vendor/First", "Vendor/Second"])
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   ReleaseWorker.update_submodules(%{
+                     destination: clone,
+                     repository_full_handle: "apple/swift-argument-parser",
+                     tag: "v1.0.0"
+                   })
+        end)
+
+      # A walk that halted on the first skip would never reach the second, and
+      # with a single submodule per level `{:cont, :ok}` and `{:halt, :ok}` are
+      # indistinguishable.
+      assert log =~ "Skipping submodule Vendor/First"
+      assert log =~ "Skipping submodule Vendor/Second"
+    end
+
+    test "does not descend into a submodule git declined to populate" do
+      root = Briefly.create!(directory: true)
+      clone = superproject_clone_with_update_none_submodule(root)
+
+      # `update = none` makes git exit 0 without populating the directory.
+      # Listing it finds the superproject, which reports its gitlink back as
+      # `./`, so descending would re-enter the same directory forever.
       assert :ok =
                ReleaseWorker.update_submodules(%{
                  destination: clone,
@@ -431,8 +495,24 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
                  tag: "v1.0.0"
                })
 
-      assert File.exists?(Path.join(clone, "Vendor/Required/README.md"))
-      refute File.exists?(Path.join(clone, "Vendor/Required/NestedDep"))
+      assert File.dir?(Path.join(clone, "Vendor/Dep"))
+    end
+
+    test "defers the release when a submodule host is throttling us" do
+      stub(System, :cmd, fn "git", args, _opts ->
+        if "ls-files" in args do
+          {"160000 0123456789012345678901234567890123456789 0\tVendor/Throttled\n", 0}
+        else
+          {"remote: You have exceeded a secondary rate limit and have been temporarily blocked.", 1}
+        end
+      end)
+
+      assert {:error, {:git_submodule_update_throttled, "Vendor/Throttled", 1, _output}} =
+               ReleaseWorker.update_submodules(%{
+                 destination: "/nonexistent",
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
     end
 
     test "fails against the nested path instead of deleting the submodule that reached it" do
@@ -508,6 +588,55 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     # git announces `registered for path 'Vendor/Required'` ahead of any nested
     # failure in the same output.
     git!(clone, ["config", "--unset", "submodule.Vendor/Required.url"])
+
+    clone
+  end
+
+  # Gitlinks with no matching `.gitmodules` entry, which git rejects with the
+  # permanently skippable "no url found for submodule path".
+  defp superproject_clone_with_unresolvable_submodules(root, submodule_paths) do
+    superproject = Path.join(root, "superproject")
+    clone = Path.join(root, "clone")
+
+    init_git_repo(superproject)
+    File.write!(Path.join(superproject, "Package.swift"), @default_manifest_content)
+    git!(superproject, ["add", "Package.swift"])
+    git!(superproject, ["commit", "-m", "initial"])
+
+    for submodule_path <- submodule_paths do
+      git!(superproject, [
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        "160000,0123456789012345678901234567890123456789,#{submodule_path}"
+      ])
+    end
+
+    git!(superproject, ["commit", "-m", "add submodules"])
+    git!(root, ["clone", superproject, clone])
+
+    clone
+  end
+
+  defp superproject_clone_with_update_none_submodule(root) do
+    dependency = Path.join(root, "dependency")
+    superproject = Path.join(root, "superproject")
+    clone = Path.join(root, "clone")
+
+    init_git_repo(dependency)
+    File.write!(Path.join(dependency, "README.md"), "dependency")
+    git!(dependency, ["add", "README.md"])
+    git!(dependency, ["commit", "-m", "initial"])
+
+    init_git_repo(superproject)
+    File.write!(Path.join(superproject, "Package.swift"), @default_manifest_content)
+    git!(superproject, ["add", "Package.swift"])
+    git!(superproject, ["commit", "-m", "initial"])
+    git!(superproject, ["-c", "protocol.file.allow=always", "submodule", "add", dependency, "Vendor/Dep"])
+    git!(superproject, ["config", "-f", ".gitmodules", "submodule.Vendor/Dep.update", "none"])
+    git!(superproject, ["add", ".gitmodules"])
+    git!(superproject, ["commit", "-m", "add submodule with update = none"])
+    git!(root, ["clone", superproject, clone])
 
     clone
   end

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -412,6 +412,84 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     assert ReleaseWorker.skippable_submodule_failure?(output)
   end
 
+  test "discards the job when a submodule host throttles the clone" do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:ok, "[submodule \"Vendor/Dep\"]\n\tpath = Vendor/Dep\n\turl = https://example.com/dep.git\n"}
+    end)
+
+    stub_git(fn args ->
+      cond do
+        "clone" in args -> {"", 0}
+        "ls-files" in args -> {gitlink_record("Vendor/Dep"), 0}
+        true -> {"fatal: unable to access 'https://example.com/dep/': The requested URL returned error: 429", 1}
+      end
+    end)
+
+    # The version must be left in neither releases nor skipped_releases, which is
+    # what lets the next sync tick pick it up again.
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected metadata write") end)
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+
+    assert {:discard, {:git_submodule_update_throttled, "Vendor/Dep", 1, _output}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "does not treat a bare 403 from GitHub as permanent, since it also means throttling" do
+    # Git only relays a host's explanation when the error body is text/plain, so
+    # a throttled GitHub clone can arrive as the status line alone.
+    output = """
+    fatal: unable to access 'https://github.com/apple/swift-nio/': The requested URL returned error: 403
+    fatal: clone of 'https://github.com/apple/swift-nio' into submodule path 'Vendor/NIO' failed
+    """
+
+    refute ReleaseWorker.skippable_submodule_failure?(output)
+  end
+
+  test "defers rather than retries when a submodule host returns a bare throttling status" do
+    # Asserting the throttled tag rather than `refute skippable?` is what
+    # separates deferral from an unclassified failure, which would instead be
+    # retried against the host that is already throttling us.
+    for status <- ["429", "502", "503", "504"] do
+      stub_git(fn args ->
+        if "ls-files" in args do
+          {gitlink_record("Vendor/Dep"), 0}
+        else
+          {"fatal: unable to access 'https://example.com/dep/': The requested URL returned error: #{status}", 1}
+        end
+      end)
+
+      assert {:error, {:git_submodule_update_throttled, "Vendor/Dep", 1, _output}} =
+               ReleaseWorker.update_submodules(%{
+                 destination: "/nonexistent",
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+    end
+  end
+
   test "does not treat a throttled submodule host as a skippable submodule failure" do
     output = """
     remote: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.
@@ -499,9 +577,9 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     end
 
     test "defers the release when a submodule host is throttling us" do
-      stub(System, :cmd, fn "git", args, _opts ->
+      stub_git(fn args ->
         if "ls-files" in args do
-          {"160000 0123456789012345678901234567890123456789 0\tVendor/Throttled\n", 0}
+          {gitlink_record("Vendor/Throttled"), 0}
         else
           {"remote: You have exceeded a secondary rate limit and have been temporarily blocked.", 1}
         end
@@ -513,6 +591,65 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
                  repository_full_handle: "apple/swift-argument-parser",
                  tag: "v1.0.0"
                })
+    end
+
+    test "never hands git a self-referential index entry" do
+      # An unpopulated submodule lists the superproject's gitlink back as `./`.
+      # This pins the index-parsing guard on its own: the checkout guard cannot
+      # absorb it, because the entry is dropped before anything is descended into.
+      stub_git(fn args ->
+        if "ls-files" in args, do: {gitlink_record("./"), 0}, else: {"", 0}
+      end)
+
+      assert :ok =
+               ReleaseWorker.update_submodules(%{
+                 destination: "/nonexistent",
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+
+      assert [["-C", "/nonexistent", "ls-files", "--stage", "-z"]] == git_invocations()
+    end
+
+    test "does not list a submodule directory git left unpopulated" do
+      # This pins the checkout guard on its own: the path is well-formed, so the
+      # index-parsing guard has nothing to reject, and only the missing `.git`
+      # stops the descent.
+      stub_git(fn args ->
+        if "ls-files" in args, do: {gitlink_record("Vendor/Declined"), 0}, else: {"Skipping submodule", 0}
+      end)
+
+      assert :ok =
+               ReleaseWorker.update_submodules(%{
+                 destination: "/nonexistent",
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+
+      refute Enum.any?(git_invocations(), &Enum.member?(&1, "/nonexistent/Vendor/Declined"))
+    end
+
+    test "initializes each submodule shallowly and passes its path as a pathspec" do
+      stub_git(fn args ->
+        if "ls-files" in args, do: {gitlink_record("Vendor/Dep"), 0}, else: {"", 0}
+      end)
+
+      assert :ok =
+               ReleaseWorker.update_submodules(%{
+                 destination: "/nonexistent",
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+
+      update_args = Enum.find(git_invocations(), &("update" in &1))
+
+      # `--init` is what makes the walk populate each level itself, now that no
+      # single invocation recurses through the tree; `--` keeps a submodule path
+      # beginning with `-` from being read as an option.
+      assert Enum.take(update_args, -9) ==
+               ["-C", "/nonexistent", "submodule", "update", "--init", "--depth", "1", "--", "Vendor/Dep"]
+
+      refute "--recursive" in update_args
     end
 
     test "fails against the nested path instead of deleting the submodule that reached it" do
@@ -591,6 +728,27 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
 
     clone
   end
+
+  # Records each git invocation so a test can assert on the commands the walk
+  # issues, which is the only observable for the guards that stop it descending.
+  defp stub_git(handler) do
+    test_pid = self()
+
+    stub(System, :cmd, fn "git", args, _opts ->
+      send(test_pid, {:git, args})
+      handler.(args)
+    end)
+  end
+
+  defp git_invocations do
+    receive do
+      {:git, args} -> [args | git_invocations()]
+    after
+      0 -> []
+    end
+  end
+
+  defp gitlink_record(path), do: "160000 0123456789012345678901234567890123456789 0\t#{path}" <> <<0>>
 
   # Gitlinks with no matching `.gitmodules` entry, which git rejects with the
   # permanently skippable "no url found for submodule path".

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -400,6 +400,132 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
     assert ReleaseWorker.skippable_submodule_failure?(output)
   end
 
+  test "treats a submodule host that denies anonymous access as a skippable submodule failure" do
+    output = """
+    fatal: unable to access 'https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver/': The requested URL returned error: 403
+    fatal: clone of 'https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver' into submodule path 'backends/arm/third-party/ethos-u-core-driver' failed
+    Failed to clone 'backends/arm/third-party/ethos-u-core-driver' a second time, aborting
+    """
+
+    assert ReleaseWorker.skippable_submodule_failure?(output)
+  end
+
+  test "does not treat a throttled submodule host as a skippable submodule failure" do
+    output = """
+    remote: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.
+    fatal: unable to access 'https://github.com/apple/swift-nio/': The requested URL returned error: 403
+    """
+
+    refute ReleaseWorker.skippable_submodule_failure?(output)
+  end
+
+  describe "update_submodules/1" do
+    test "removes only the failing nested submodule and keeps the submodule that reached it" do
+      root = Briefly.create!(directory: true)
+      clone = superproject_clone_with_nested_submodule(root, nil)
+
+      assert :ok =
+               ReleaseWorker.update_submodules(%{
+                 destination: clone,
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+
+      assert File.exists?(Path.join(clone, "Vendor/Required/README.md"))
+      refute File.exists?(Path.join(clone, "Vendor/Required/NestedDep"))
+    end
+
+    test "fails against the nested path instead of deleting the submodule that reached it" do
+      root = Briefly.create!(directory: true)
+      clone = superproject_clone_with_nested_submodule(root, "ssh://127.0.0.1:1/nested-private-dep.git")
+
+      assert {:error, {:git_submodule_update_failed, "Vendor/Required/NestedDep", _status, _output}} =
+               ReleaseWorker.update_submodules(%{
+                 destination: clone,
+                 repository_full_handle: "apple/swift-argument-parser",
+                 tag: "v1.0.0"
+               })
+
+      assert File.exists?(Path.join(clone, "Vendor/Required/README.md"))
+    end
+  end
+
+  # Builds a superproject whose `Vendor/Required` submodule pins a `NestedDep`
+  # submodule of its own. A `nested_url` of `nil` leaves the pin out of
+  # `.gitmodules`, which git rejects with a permanently skippable "no url found"
+  # error; any other value is registered as the nested submodule's URL.
+  # `Vendor/Required` is checked out up front because the production code
+  # deliberately runs git without `protocol.file.allow`, so only the nested
+  # update is left for the walk to resolve.
+  defp superproject_clone_with_nested_submodule(root, nested_url) do
+    parent_repository = Path.join(root, "parent-submodule")
+    superproject = Path.join(root, "superproject")
+    clone = Path.join(root, "clone")
+
+    init_git_repo(parent_repository)
+    File.write!(Path.join(parent_repository, "README.md"), "required")
+    git!(parent_repository, ["add", "README.md"])
+    git!(parent_repository, ["commit", "-m", "initial"])
+
+    if nested_url do
+      File.write!(Path.join(parent_repository, ".gitmodules"), """
+      [submodule "NestedDep"]
+      \tpath = NestedDep
+      \turl = #{nested_url}
+      """)
+
+      git!(parent_repository, ["add", ".gitmodules"])
+    end
+
+    git!(parent_repository, [
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,0123456789012345678901234567890123456789,NestedDep"
+    ])
+
+    git!(parent_repository, ["commit", "-m", "add nested submodule"])
+
+    init_git_repo(superproject)
+    File.write!(Path.join(superproject, "Package.swift"), @default_manifest_content)
+    git!(superproject, ["add", "Package.swift"])
+    git!(superproject, ["commit", "-m", "initial"])
+
+    git!(superproject, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      parent_repository,
+      "Vendor/Required"
+    ])
+
+    git!(superproject, ["commit", "-am", "add submodule"])
+    git!(root, ["-c", "protocol.file.allow=always", "clone", superproject, clone])
+    git!(clone, ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "Vendor/Required"])
+    # Dropping the registration while keeping the checkout leaves `Vendor/Required`
+    # in the state production sees: the update that walks it also registers it, so
+    # git announces `registered for path 'Vendor/Required'` ahead of any nested
+    # failure in the same output.
+    git!(clone, ["config", "--unset", "submodule.Vendor/Required.url"])
+
+    clone
+  end
+
+  defp init_git_repo(path) do
+    File.mkdir_p!(path)
+    git!(path, ["init"])
+    git!(path, ["config", "user.name", "Tuist Test"])
+    git!(path, ["config", "user.email", "test@tuist.dev"])
+  end
+
+  defp git!(working_directory, args) do
+    case System.cmd("git", args, cd: working_directory, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed with status #{status}: #{output}")
+    end
+  end
+
   describe "zip_directory/2" do
     test "preserves symlinks inside code-signed bundles while flattening other symlinks" do
       tmp = Path.join(System.tmp_dir!(), "zip_directory_test_#{System.unique_integer([:positive])}")


### PR DESCRIPTION
## What changed

The Swift registry's `ReleaseWorker` no longer runs `git submodule update --recursive`. It walks the submodule tree one level at a time: each submodule is updated on its own with `--init --depth 1`, and only after that succeeds are its own gitlinks enumerated and descended into.

Also in this change:

- `nested_submodule_path/1`, `nested_submodule_failure?/3`, and the `:nested_git_submodule_update_failed` tag are deleted — the walk makes parsing git's output for nesting unnecessary.
- Submodule failures are classified three ways — permanent, throttled, or unclassified — replacing a single skippable/not-skippable test. A throttled host defers the release instead of being retried against.
- A 403 counts as permanent only from hosts where it is unambiguous, and throttling is recognised by HTTP status as well as by the remote's prose.
- The nested-submodule regression tests dropped when the registry was extracted into `server/` in #11081 are restored.

## Why

Sentry `TUIST-3VD`: `Tuist.Registry.Swift.ReleaseWorker` failing with `{:git_submodule_update_failed, "llama-stack", 1, ...}` for `meta-llama/llama-stack-client-swift@0.0.58`.

### Root cause

`git submodule update --recursive` reports a failure anywhere in the tree as a failure of the *top-level* submodule it was reached through. The worker was therefore unable to distinguish an unreachable third-party dependency nested several levels down from the package's own submodule being unreachable.

The classifier tried to recover the nested path with a regex, but `nested_submodule_path/1` took the **first** `registered for path '...'` line in the output. When a submodule is being initialized — always, in production — that first line is the top-level submodule's own registration. So `nested_submodule_failure?/3` compared the parent path against itself, and the nested guard never fired. Verified against the real captured output:

```
nested_submodule_path/1 returns: "llama-stack"
nested_submodule_failure?: false
matching skippable markers: []
```

The guard only worked in its unit test because that test pre-initialized the parent submodule, so the misleading registration line was absent.

Two defects followed:

1. **Silent data loss (latent).** A nested failure matching a skippable marker fell past the dead guard into the skip branch, which `rm -rf`s the failing path — the *parent* path. The release then shipped an archive missing a required submodule. This is exactly the regression the test added in #10256 was written to prevent.
2. **Hard failure (the Sentry issue).** A nested failure matching no marker became a hard error that burned every Oban attempt. For a version not yet published, the next `SyncWorker` tick re-enqueues it, so such a package can never be added at all.

`review.mlplatform.org` answers anonymous clones of executorch's `ethos-u-core-driver` and `serialization_lib` with **403**, three levels below the package root, and the marker list covered 404 but not 403. Reproduced locally before changing anything:

```
fatal: unable to access 'https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver/': The requested URL returned error: 403
Failed to clone 'backends/arm/third-party/ethos-u-core-driver' a second time, aborting
fatal: Failed to recurse into submodule path 'llama-stack/llama_stack/providers/inline/ios/inference/executorch'
fatal: Failed to recurse into submodule path 'llama-stack'
```

That 403 is an access-control policy rather than throttling: the host answers 200 at its root but 403 on `info/refs?service=git-upload-pack` for both repositories. That is what justifies classifying it as permanently skippable.

### Why the walk rather than just adding 403

Adding `403` to the markers alone makes the Sentry error stop, but it does so by triggering defect 1: the whole `llama-stack` submodule gets deleted and the archive is published anyway. Harmless for this particular package, wrong in general, and it leaves the underlying misattribution in place.

Walking level by level fixes both defects at once, because each git invocation can only fail for the path it was given. It also removes the output parsing entirely rather than trying to make it more clever — there is no output shape left to misread.

### How failures are classified

Skipping is the irreversible direction: the release ships an archive without the submodule, the incomplete archive is checksummed and recorded, and `do_sync_release/5` short-circuits that version from then on. The bucket keeps no object versions, so there is no earlier copy to fall back to, and a corrected archive is refused by `ensure_checksum_change_allowed/5` because it checksums differently. Getting a *permanent* verdict wrong therefore costs far more than getting a *transient* one wrong, and the classifier is shaped around that asymmetry.

Git only relays a remote's explanation when the error body is `text/plain`. With an HTML or empty body it prints the status line alone, so prose markers cannot be relied on as the only signal. Three rules follow:

- **Prose markers** catch hosts that do explain themselves, in both directions (`repository not found`, `rate limit`).
- **Status** catches throttling that arrives bare: 429, 502, 503 and 504 defer. Previously 429 — the least ambiguous throttling signal there is — matched nothing and fell through to a hard error that Oban retries up to twenty times, each attempt re-cloning the repository and re-walking the tree.
- **Host** decides the ambiguous case. Reusing 403 for throttling is GitHub's behaviour specifically; elsewhere a 403 is an access-control decision that will not change on retry, which is how the Gerrit host in this incident refuses anonymous clones. A private GitHub repository the token cannot see answers 404, already classified permanent, so scoping 403 away from GitHub loses no coverage while removing the case where a temporary GitHub throttle could permanently drop a required submodule.

Anything unrecognised stays an ordinary error and retries, which is the safe default.

## Impact

- A nested submodule failure can no longer delete the required submodule that led to it.
- Failure reasons now name the full path (`llama-stack/.../third-party/ethos-u-core-driver` instead of `llama-stack`), so Sentry groups by the actual culprit.
- Packages whose submodule tree reaches an unreachable third-party dependency can publish, with only the unreachable leaves omitted.

**What this does *not* immediately change**, which is worth knowing when assessing risk: all 8 published versions of `llama-stack-client-swift` were synced before the `.gitmodules` routing landed in #10256, so they are zipball archives of 34 KB–400 KB and are already present in `releases`. A normal sync skips them. The Sentry event was therefore almost certainly a **forced** resync, and after this change such a resync performs the full clone, builds a ~546 MB archive, and is then correctly discarded by `ensure_checksum_change_allowed/5` because the checksum differs from the published one. Merging this does not cause a large archive to be published for that package; a genuinely new tag would be the first case where one lands.

The flip side is that a forced resync of such a package now does considerably more work before being refused. That cost, and the broader question of fetching submodule trees no target references, are tracked in #12233.

### Relationship to SwiftPM

SwiftPM gates on exactly the same signal this worker uses — `localFileSystem.exists(path/.gitmodules)` in `GitRepository.updateSubmoduleAndCleanIfNecessary()` — and then runs `git submodule update --init --recursive` with no depth limit. It has no skip logic, so an unreachable submodule fails the whole checkout. This package is consequently unresolvable from source control today, while the registry serves it successfully. Per-leaf skipping is therefore strictly more useful than strict parity, and this change moves *toward* parity relative to the previous behaviour, which silently dropped the entire parent submodule.

## Hardening from review

Three follow-up commits harden the walk itself.

**Re-entry.** A zero exit from `git submodule update` does not mean the submodule was populated: a `.gitmodules` declaring `update = none` makes git print `Skipping submodule` and exit 0, leaving the empty directory the superproject checkout created. Listing that directory finds the *superproject*, which renders its gitlink back as the relative path `./`, so the walk re-entered the same directory without ever reaching a fixed point. `--recursive` skipped such a submodule and moved on, so this was a regression introduced by walking level by level. Two independent guards now close it — descend only into a child that is a checkout in its own right, and drop self-referential entries when parsing the index — and each is pinned separately.

**Index parsing.** `ls-files --stage -z` replaces `core.quotePath=false`, which only suppresses quoting of non-ASCII bytes — quotes, backslashes and control characters are C-quoted regardless, and the quoted rendering was handed back to git as a pathspec that matches nothing. NUL termination also removes the trim that was corrupting paths with leading or trailing whitespace. `--` now precedes the pathspec.

**Deferral.** A throttled submodule previously became an unclassified failure that Oban retried up to twenty times, each attempt re-cloning the repository and re-walking the tree, aimed at the host that had just asked us to slow down. It now defers the release the way `SyncWorker` already defers throttled catalog fetches, leaving the version unrecorded so the next sync tick picks it up.

Also: `:git_list_submodules_failed` now names the path it came from, which was the one error the walk produced that did not.

## Validation

Both restored integration tests are red against the pre-fix code for the right reasons — the parent-deletion test fails on `assert File.exists?(".../Vendor/Required/README.md")`, i.e. the old code deletes the parent outright.

Making that repro faithful required one non-obvious fixture step: the parent submodule has to be populated but *unregistered* (`git config --unset submodule.<path>.url`), because the misleading `registered for path '<parent>'` line is only emitted when the parent is registered during the same run — which is what happens in production and what defeated the old regex.

End-to-end against a real clone of `meta-llama/llama-stack-client-swift@0.0.58`, calling `update_submodules/1` directly:

```
update_submodules: :ok
parent submodule kept: true            # llama-stack
sibling nested submodule kept: true    # executorch/.../XNNPACK
403 submodule present?: false          # ethos-u-core-driver
403 submodule 2 present?: false        # serialization_lib
```

Every behaviour added in review is mutation-checked — each of these leaves the suite failing the test that owns it: neutering `submodule_checkout?/1`, dropping the self-referential index rejection, removing `--init`, deleting the throttling `maybe_skip_release/5` clause, un-scoping the 403 rule from host, and disabling status-based throttling classification.

- `mix test test/tuist/registry/` → 54 passed
- `mix format` clean
- `mix credo lib/tuist/registry/swift/release_worker.ex` → no issues

## Post-Deploy Monitoring & Validation

Runs in the `swift-registry-sync` pod (`TUIST_MODE=swift_registry_sync`), queue `swift_registry_release`.

**Watch**
- Sentry issue `TUIST-3VD` (`Oban.PerformError` / `Tuist.Registry.Swift.ReleaseWorker`).
- Logs, `cluster="tuist-production"`, for `Skipping submodule` warnings. Expect entries naming deep paths such as `llama-stack/.../backends/arm/third-party/ethos-u-core-driver`.
- Oban `swift_registry_release` failure and discard rates.

**Healthy signals**
- No further `git_submodule_update_failed` hard errors naming a bare top-level submodule name.
- Any new `git_submodule_update_failed` errors name a full nested path, so the culprit is identifiable.
- Packages that previously could not be added because of an unreachable nested submodule begin appearing in `releases`.

**Failure signals / rollback trigger**
- A rise in `git_submodule_update_failed` across *unrelated* packages, or `git_list_submodules_failed` appearing at all (a new failure mode introduced by descending into nested checkouts) → revert this commit.
- `Skipping submodule` warnings naming a package's own top-level submodule where the release previously succeeded — would suggest the transient guard is mis-tuned.
- Sustained growth in `/tmp` usage on the sync pod, since completing these trees is more disk-intensive than aborting early. Mitigation is tracked in #12233.

**Window / owner:** first 24h of sync cycles after deploy, author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

