### PR TITLE
fix(server): stop attributing automation re-quarantines to earlier manual actors

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -3080,8 +3080,8 @@ defmodule Tuist.Tests do
         where: e.test_case_id in subquery(quarantined_ids_subquery),
         where: e.event_type in ^@active_quarantine_event_types,
         group_by: e.test_case_id,
-        having: fragment("argMax(?, ?) IS NOT NULL", e.actor_id, e.inserted_at),
-        select: fragment("argMax(?, ?)", e.actor_id, e.inserted_at)
+        having: fragment("tupleElement(argMax(tuple(?), ?), 1) IS NOT NULL", e.actor_id, e.inserted_at),
+        select: fragment("tupleElement(argMax(tuple(?), ?), 1)", e.actor_id, e.inserted_at)
       )
       |> ClickHouseRepo.all()
       |> Enum.uniq()
@@ -3094,9 +3094,16 @@ defmodule Tuist.Tests do
   end
 
   # The latest active quarantine event per test case: who quarantined it and
-  # when. `argMax` and `max` resolve to the same event, because for a currently
+  # when. Both aggregates resolve to the same event, because for a currently
   # quarantined test case the most recent `muted`/`skipped` event is the one
   # that put it in that state.
+  #
+  # `actor_id` is wrapped in `tuple(...)` because ClickHouse aggregates skip
+  # NULL arguments: a bare `argMax(actor_id, inserted_at)` ignores
+  # automation-written events (NULL actor) and resurrects the last *human*
+  # actor — e.g. a test muted by an automation showed the user who had
+  # manually skipped it months earlier. A tuple is never NULL, so `argMax`
+  # considers every event and NULL correctly wins as "quarantined by Tuist".
   defp quarantine_info_subquery(project_id) do
     from(e in TestCaseEvent,
       where: e.project_id == ^project_id,
@@ -3104,7 +3111,7 @@ defmodule Tuist.Tests do
       group_by: e.test_case_id,
       select: %{
         test_case_id: e.test_case_id,
-        actor_id: fragment("argMax(?, ?)", e.actor_id, e.inserted_at),
+        actor_id: fragment("tupleElement(argMax(tuple(?), ?), 1)", e.actor_id, e.inserted_at),
         quarantined_at: max(e.inserted_at)
       }
     )

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -9190,6 +9190,53 @@ defmodule Tuist.TestsTest do
              ) == :eq
     end
 
+    test "an automation re-quarantine is not attributed to an earlier manual actor" do
+      project = ProjectsFixtures.project_fixture()
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      now = NaiveDateTime.utc_now()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "automationRequarantinedTest",
+          is_quarantined: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      automation_muted_at = NaiveDateTime.add(now, -1200)
+
+      # A manual quarantine episode, reverted, then an automation (nil actor)
+      # re-quarantines. ClickHouse aggregates skip NULLs, so a bare argMax
+      # would resurrect the manual actor here.
+      for {event_type, actor_id, inserted_at} <- [
+            {"skipped", user.account.id, NaiveDateTime.add(now, -3600)},
+            {"unskipped", user.account.id, NaiveDateTime.add(now, -2400)},
+            {"muted", nil, automation_muted_at}
+          ] do
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: event_type,
+          actor_id: actor_id,
+          inserted_at: inserted_at
+        )
+      end
+
+      {[quarantined_test], _} = Tests.list_quarantined_test_cases(project.id, %{})
+
+      assert quarantined_test.quarantined_by_account_id == nil
+      assert quarantined_test.quarantined_by_account_name == nil
+
+      # A nil actor is also what an unmatched left join yields, so the
+      # timestamp is what pins the aggregate to the automation event — and
+      # proves attribution and `quarantined_at` describe the same one.
+      assert NaiveDateTime.compare(
+               NaiveDateTime.truncate(quarantined_test.quarantined_at, :second),
+               NaiveDateTime.truncate(automation_muted_at, :second)
+             ) == :eq
+    end
+
     test "quarantined_at resets when the quarantine mode changes" do
       project = ProjectsFixtures.project_fixture()
       now = NaiveDateTime.utc_now()
@@ -9528,6 +9575,41 @@ defmodule Tuist.TestsTest do
       actors = Tests.get_quarantine_actors(project.id)
 
       assert actors == []
+    end
+
+    test "excludes an actor whose manual quarantine an automation has superseded" do
+      project = ProjectsFixtures.project_fixture()
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      now = NaiveDateTime.utc_now()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "automationRequarantinedTest",
+          is_quarantined: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      # The dropdown must not offer a user whose only attribution is a manual
+      # episode they reverted themselves before an automation re-quarantined.
+      # Every other test here has a single event per test case, which resolves
+      # the same way with or without the NULL-aware aggregate.
+      for {event_type, actor_id, inserted_at} <- [
+            {"skipped", user.account.id, NaiveDateTime.add(now, -3600)},
+            {"unskipped", user.account.id, NaiveDateTime.add(now, -2400)},
+            {"muted", nil, NaiveDateTime.add(now, -1200)}
+          ] do
+        RunsFixtures.test_case_event_fixture(
+          test_case_id: test_case.id,
+          project_id: project.id,
+          event_type: event_type,
+          actor_id: actor_id,
+          inserted_at: inserted_at
+        )
+      end
+
+      assert Tests.get_quarantine_actors(project.id) == []
     end
 
     test "returns accounts that have quarantined test cases" do


### PR DESCRIPTION
## What

Fixes the "Quarantined by" attribution showing a *user's* name on test cases that were actually quarantined by an automation.

## Root cause

ClickHouse aggregate functions skip NULL arguments. The attribution aggregate, `argMax(actor_id, inserted_at)` over `muted`/`skipped` events, therefore ignored every automation-written event (automations record `actor_id = NULL`, attributing via `alert_id` instead) and returned the most recent **human** actor — no matter how stale.

Concrete sequence from a user report (event ledger of the affected test case):

1. automation mutes the test (`actor = NULL`)
2. automation unmutes it
3. **user manually skips it**
4. **user manually unskips it**
5. automation re-mutes it ← current quarantine

The page attributed the current, automation-driven quarantine to the user from steps 3–4 — an action they had themselves reverted weeks earlier. Verified against the live ledger: the bare `argMax` returns the user's account, the fixed expression returns NULL.

## Fix

Wrap the argument in `tuple(...)` — a tuple is never NULL, so `argMax` considers every event, the latest event always wins, and a NULL actor correctly renders as the "Tuist" badge. Applied to both consumers of the pattern:

- `quarantine_info_subquery` — feeds the "Quarantined by" column, the `quarantined_at` timestamp, and the quarantined-by filter, so attribution and timestamp now provably describe the same (latest) event even when that event is automation-written.
- `get_quarantine_actors` — the filter dropdown; previously it could list users who only had stale, superseded attributions.

## Impact

Any project where an automation re-quarantined a test after a manual mute/skip episode displays the wrong actor today; the fix needs no backfill since it's purely a read-side aggregate.

## Validation

- One regression test per consumer, both reproducing the manual-episode-then-automation sequence (skipped → unskipped → automation mute): the `list_quarantined_test_cases` one asserts the attribution is NULL, the `get_quarantine_actors` one asserts the superseded user is no longer offered in the dropdown. Each fails on the pre-fix aggregate — every pre-existing `get_quarantine_actors` test has a single event per test case, which resolves identically with or without the NULL-aware aggregate.
- The list-side test also asserts `quarantined_at` against the automation event's timestamp. A NULL actor is equally what an unmatched left join yields, so the timestamp is what pins the aggregate to that event — and what proves attribution and `quarantined_at` now describe the same one. Verified by simulating non-landing fixtures: the NULL assertions still pass, only the timestamp assertion catches it.
- The `list_quarantined_test_cases` (19) and `get_quarantine_actors` (7) blocks pass, as does the page's LiveView suite.
- The fixed expression was validated directly against the production event ledger of the reported test case before landing in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
