### PR TITLE
fix(kura): stop counting reclaimable slab as memory pressure

### DIFF
--- a/kura/src/memory/cgroup.rs
+++ b/kura/src/memory/cgroup.rs
@@ -5,6 +5,8 @@ pub struct ContainerMemorySnapshot {
     pub anon_bytes: Option<u64>,
     pub file_bytes: Option<u64>,
     pub kernel_bytes: Option<u64>,
+    pub slab_reclaimable_bytes: Option<u64>,
+    pub slab_unreclaimable_bytes: Option<u64>,
     pub inactive_file_bytes: Option<u64>,
     pub shmem_bytes: Option<u64>,
     pub sock_bytes: Option<u64>,
@@ -31,6 +33,7 @@ struct MemoryPressureComponents {
     anon_bytes: Option<u64>,
     file_bytes: Option<u64>,
     kernel_bytes: Option<u64>,
+    slab_reclaimable_bytes: Option<u64>,
     shmem_bytes: Option<u64>,
     sock_bytes: Option<u64>,
     file_dirty_bytes: Option<u64>,
@@ -49,6 +52,7 @@ impl ContainerMemorySnapshot {
             anon_bytes: self.anon_bytes,
             file_bytes: self.file_bytes,
             kernel_bytes: self.kernel_bytes,
+            slab_reclaimable_bytes: self.slab_reclaimable_bytes,
             shmem_bytes: self.shmem_bytes,
             sock_bytes: self.sock_bytes,
             file_dirty_bytes: self.file_dirty_bytes,
@@ -80,6 +84,7 @@ pub fn container_memory_pressure_sample() -> Option<ContainerMemoryPressureSampl
                     anon_bytes: named_value(&stat, "anon"),
                     file_bytes: named_value(&stat, "file"),
                     kernel_bytes: named_value(&stat, "kernel"),
+                    slab_reclaimable_bytes: named_value(&stat, "slab_reclaimable"),
                     shmem_bytes: named_value(&stat, "shmem"),
                     sock_bytes: named_value(&stat, "sock"),
                     file_dirty_bytes: named_value(&stat, "file_dirty"),
@@ -113,6 +118,7 @@ pub fn container_memory_pressure_sample() -> Option<ContainerMemoryPressureSampl
                 anon_bytes: named_value(&stat, "total_rss"),
                 file_bytes: named_value(&stat, "cache"),
                 kernel_bytes: None,
+                slab_reclaimable_bytes: None,
                 shmem_bytes: named_value(&stat, "total_shmem"),
                 sock_bytes: None,
                 file_dirty_bytes: named_value(&stat, "total_dirty"),
@@ -144,6 +150,7 @@ fn pressure_bytes(components: MemoryPressureComponents) -> u64 {
         anon_bytes,
         file_bytes,
         kernel_bytes,
+        slab_reclaimable_bytes,
         shmem_bytes,
         sock_bytes,
         file_dirty_bytes,
@@ -151,13 +158,34 @@ fn pressure_bytes(components: MemoryPressureComponents) -> u64 {
         inactive_file_bytes,
     } = components;
     if let (Some(anon_bytes), Some(kernel_bytes)) = (anon_bytes, kernel_bytes) {
+        // `slab_reclaimable` is nested inside `kernel`, but it is cache the kernel drops
+        // on demand, not memory this process can release. Excluding it applies the same
+        // rule already used for clean page cache below.
+        //
+        // It normally stays small: it is dominated by `buffer_head`, ~105B per resident
+        // page-cache page (measured at 104.9B/page on a healthy node), and page cache is
+        // itself charged to the cgroup — so a 2GiB limit caps it near 52MiB even if the
+        // container held nothing else. One production node nevertheless accumulated
+        // ~1GiB of it, ~19x that ceiling, against only 255MiB of page cache. Why is not
+        // yet understood; the gauges added alongside this exist to catch the next one.
+        //
+        // Counting it pinned that node at Critical, which both zeroes the action-cache
+        // snapshot index and denies its rebuild (rebuilds require Normal), so it served
+        // 0% hits while staying Ready until restarted. Kura cannot trim its way out: the
+        // charge is the kernel's, not its own.
+        //
+        // Subtracted from the aggregate rather than summing `kernel`'s other leaves on
+        // purpose: an allowlist of leaves silently drops rows this code does not know
+        // about (see `sock`), and for a pressure signal undercounting is the more
+        // dangerous error.
+        //
         // `sock` (network transmission buffers) is charged separately from `anon`,
         // `kernel`, and the file rows in cgroup v2 `memory.stat`, so it has to be added
         // back explicitly. The old `current - inactive_file` signal counted it, and a node
         // streaming to many slow clients can hold a meaningful amount of it. The v1 and
         // working-set fallbacks below keep it implicitly through `current`.
         return anon_bytes
-            .saturating_add(kernel_bytes)
+            .saturating_add(kernel_bytes.saturating_sub(slab_reclaimable_bytes.unwrap_or(0)))
             .saturating_add(shmem_bytes.unwrap_or(0))
             .saturating_add(sock_bytes.unwrap_or(0))
             .saturating_add(file_dirty_bytes.unwrap_or(0))
@@ -189,6 +217,8 @@ pub fn container_memory_snapshot() -> Option<ContainerMemorySnapshot> {
                 anon_bytes: named_value(&stat, "anon"),
                 file_bytes: named_value(&stat, "file"),
                 kernel_bytes: named_value(&stat, "kernel"),
+                slab_reclaimable_bytes: named_value(&stat, "slab_reclaimable"),
+                slab_unreclaimable_bytes: named_value(&stat, "slab_unreclaimable"),
                 inactive_file_bytes: named_value(&stat, "inactive_file"),
                 shmem_bytes: named_value(&stat, "shmem"),
                 sock_bytes: named_value(&stat, "sock"),
@@ -217,6 +247,8 @@ pub fn container_memory_snapshot() -> Option<ContainerMemorySnapshot> {
             anon_bytes: named_value(&stat, "rss"),
             file_bytes: named_value(&stat, "cache"),
             kernel_bytes: None,
+            slab_reclaimable_bytes: None,
+            slab_unreclaimable_bytes: None,
             inactive_file_bytes: named_value(&stat, "total_inactive_file"),
             shmem_bytes: named_value(&stat, "total_shmem"),
             sock_bytes: None,
@@ -324,6 +356,8 @@ mod tests {
             anon_bytes: Some(600),
             file_bytes: Some(300),
             kernel_bytes: Some(100),
+            slab_reclaimable_bytes: None,
+            slab_unreclaimable_bytes: None,
             inactive_file_bytes: Some(250),
             shmem_bytes: Some(25),
             sock_bytes: Some(15),
@@ -341,6 +375,62 @@ mod tests {
     }
 
     #[test]
+    fn pressure_excludes_reclaimable_slab_nested_in_kernel() {
+        // Reproduces the production wedge: a node carried ~1GiB of reclaimable slab
+        // nested inside `kernel`, which counting put over the recovery watermark on its
+        // own, latching Critical. Figures are the observed ones, in MiB.
+        let observed = |slab_reclaimable_bytes| {
+            pressure_bytes(MemoryPressureComponents {
+                current_bytes: 1_827,
+                anon_bytes: Some(544),
+                file_bytes: Some(255),
+                kernel_bytes: Some(1_029),
+                slab_reclaimable_bytes,
+                shmem_bytes: Some(0),
+                sock_bytes: Some(0),
+                file_dirty_bytes: Some(0),
+                file_writeback_bytes: Some(0),
+                inactive_file_bytes: Some(255),
+            })
+        };
+
+        // Reclaimable slab is excluded, leaving the ~9MiB of kernel memory the process
+        // genuinely cannot release.
+        assert_eq!(observed(Some(1_020)), 544 + 9);
+        // The pre-fix accounting, kept explicit.
+        assert_eq!(observed(None), 544 + 1_029);
+
+        // Why the node never recovered: leaving Critical for Normal requires dropping to
+        // 9/10 of the 1_228MiB soft watermark, and only Normal admits a snapshot index
+        // rebuild. Counting reclaimable slab left the node above that line with every
+        // Kura-owned cache already trimmed to zero, so there was no path back.
+        let normal_recovery = 1_228 * 9 / 10;
+        assert!(observed(None) > normal_recovery);
+        assert!(observed(Some(1_020)) < normal_recovery);
+    }
+
+    #[test]
+    fn pressure_never_underflows_when_reclaimable_slab_exceeds_kernel() {
+        // `slab_reclaimable` is nested in `kernel`, so this cannot happen on a coherent
+        // read, but the two rows are parsed independently and must not wrap.
+        assert_eq!(
+            pressure_bytes(MemoryPressureComponents {
+                current_bytes: 1_000,
+                anon_bytes: Some(300),
+                file_bytes: Some(0),
+                kernel_bytes: Some(40),
+                slab_reclaimable_bytes: Some(500),
+                shmem_bytes: None,
+                sock_bytes: None,
+                file_dirty_bytes: None,
+                file_writeback_bytes: None,
+                inactive_file_bytes: None,
+            }),
+            300
+        );
+    }
+
+    #[test]
     fn pressure_excludes_clean_file_cache_regardless_of_recency() {
         assert_eq!(
             pressure_bytes(MemoryPressureComponents {
@@ -348,6 +438,7 @@ mod tests {
                 anon_bytes: Some(300),
                 file_bytes: Some(700),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: Some(25),
                 sock_bytes: None,
                 file_dirty_bytes: Some(10),
@@ -362,6 +453,7 @@ mod tests {
                 anon_bytes: Some(300),
                 file_bytes: Some(700),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: Some(25),
                 sock_bytes: None,
                 file_dirty_bytes: Some(10),
@@ -380,6 +472,7 @@ mod tests {
                 anon_bytes: Some(300),
                 file_bytes: Some(700),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: Some(25),
                 sock_bytes: Some(60),
                 file_dirty_bytes: Some(10),
@@ -394,6 +487,7 @@ mod tests {
                 anon_bytes: Some(100),
                 file_bytes: Some(50),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: Some(60),
                 sock_bytes: Some(200),
                 file_dirty_bytes: Some(10),
@@ -412,6 +506,7 @@ mod tests {
                 anon_bytes: Some(300),
                 file_bytes: Some(1_500),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: None,
                 sock_bytes: None,
                 file_dirty_bytes: None,
@@ -426,6 +521,7 @@ mod tests {
                 anon_bytes: Some(300),
                 file_bytes: Some(100),
                 kernel_bytes: Some(40),
+                slab_reclaimable_bytes: None,
                 shmem_bytes: None,
                 sock_bytes: None,
                 file_dirty_bytes: None,
@@ -444,6 +540,7 @@ mod tests {
                 anon_bytes: None,
                 file_bytes: None,
                 kernel_bytes: None,
+                slab_reclaimable_bytes: None,
                 shmem_bytes: None,
                 sock_bytes: None,
                 file_dirty_bytes: None,
@@ -462,6 +559,7 @@ mod tests {
                 anon_bytes: Some(100),
                 file_bytes: Some(200),
                 kernel_bytes: None,
+                slab_reclaimable_bytes: None,
                 shmem_bytes: Some(150),
                 sock_bytes: None,
                 file_dirty_bytes: Some(100),

--- a/kura/src/memory/cgroup.rs
+++ b/kura/src/memory/cgroup.rs
@@ -159,8 +159,12 @@ fn pressure_bytes(components: MemoryPressureComponents) -> u64 {
     } = components;
     if let (Some(anon_bytes), Some(kernel_bytes)) = (anon_bytes, kernel_bytes) {
         // `slab_reclaimable` is nested inside `kernel`, but it is cache the kernel drops
-        // on demand, not memory this process can release. Excluding it applies the same
-        // rule already used for clean page cache below.
+        // on demand, not memory this process can release, so it is excluded for the same
+        // reason clean file cache is excluded below. Scoped to this signal only:
+        // `working_set_bytes` stays the conventional `current - inactive_file`, so it
+        // still counts reclaimable slab and can hold `should_reclaim_file_cache` on. That
+        // costs a warm node its mmap-serving fast path, not its correctness, and keeping
+        // the working-set figure comparable to what the kubelet reports is worth more.
         //
         // It normally stays small: it is dominated by `buffer_head`, ~105B per resident
         // page-cache page (measured at 104.9B/page on a healthy node), and page cache is
@@ -400,11 +404,13 @@ mod tests {
         // The pre-fix accounting, kept explicit.
         assert_eq!(observed(None), 544 + 1_029);
 
-        // Why the node never recovered: leaving Critical for Normal requires dropping to
-        // 9/10 of the 1_228MiB soft watermark, and only Normal admits a snapshot index
-        // rebuild. Counting reclaimable slab left the node above that line with every
-        // Kura-owned cache already trimmed to zero, so there was no path back.
-        let normal_recovery = 1_228 * 9 / 10;
+        // Why the node never recovered: leaving Critical for Normal means dropping below
+        // the soft watermark's recovery line, and only Normal lets the cache targets stop
+        // trimming the index to zero. Counting reclaimable slab left the node above that
+        // line with every Kura-owned cache already trimmed to zero, so there was no path
+        // back. Call the real transition rule rather than restating it, so this keeps
+        // testing recovery if the watermark or the recovery ratio moves.
+        let normal_recovery = crate::memory::pressure::recovery_bytes(1_228);
         assert!(observed(None) > normal_recovery);
         assert!(observed(Some(1_020)) < normal_recovery);
     }

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -2553,8 +2553,8 @@ mod tests {
                 anon_bytes: Some(700),
                 file_bytes: Some(600),
                 kernel_bytes: Some(200),
-                slab_reclaimable_bytes: None,
-                slab_unreclaimable_bytes: None,
+                slab_reclaimable_bytes: Some(150),
+                slab_unreclaimable_bytes: Some(50),
                 inactive_file_bytes: Some(100),
                 shmem_bytes: Some(50),
                 sock_bytes: Some(30),
@@ -2694,6 +2694,10 @@ mod tests {
         assert!(rendered.contains("kura_container_memory_working_set_bytes"));
         assert!(rendered.contains("kura_container_memory_reclaimable_inactive_file_bytes"));
         assert!(rendered.contains("kura_container_memory_file_bytes"));
+        // Values, not just names: a name-only assertion still passes if the gauge is
+        // registered but never set, which is the branch worth pinning here.
+        assert!(rendered.contains("kura_container_memory_slab_reclaimable_bytes 150"));
+        assert!(rendered.contains("kura_container_memory_slab_unreclaimable_bytes 50"));
         assert!(rendered.contains("kura_container_memory_shmem_bytes"));
         assert!(rendered.contains("kura_container_memory_file_dirty_bytes"));
         assert!(rendered.contains("kura_container_memory_file_writeback_bytes"));

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -127,6 +127,8 @@ pub struct Metrics {
     container_memory_anon_bytes: Gauge,
     container_memory_file_bytes: Gauge,
     container_memory_kernel_bytes: Gauge,
+    container_memory_slab_reclaimable_bytes: Gauge,
+    container_memory_slab_unreclaimable_bytes: Gauge,
     container_memory_inactive_file_bytes: Gauge,
     container_memory_reclaimable_inactive_file_bytes: Gauge,
     container_memory_shmem_bytes: Gauge,
@@ -324,6 +326,8 @@ impl Metrics {
         let container_memory_anon_bytes = Gauge::default();
         let container_memory_file_bytes = Gauge::default();
         let container_memory_kernel_bytes = Gauge::default();
+        let container_memory_slab_reclaimable_bytes = Gauge::default();
+        let container_memory_slab_unreclaimable_bytes = Gauge::default();
         let container_memory_inactive_file_bytes = Gauge::default();
         let container_memory_reclaimable_inactive_file_bytes = Gauge::default();
         let container_memory_shmem_bytes = Gauge::default();
@@ -847,6 +851,16 @@ impl Metrics {
             container_memory_kernel_bytes.clone(),
         );
         registry.register(
+            "kura_container_memory_slab_reclaimable_bytes",
+            "Reclaimable slab memory charged to the container control group",
+            container_memory_slab_reclaimable_bytes.clone(),
+        );
+        registry.register(
+            "kura_container_memory_slab_unreclaimable_bytes",
+            "Unreclaimable slab memory charged to the container control group",
+            container_memory_slab_unreclaimable_bytes.clone(),
+        );
+        registry.register(
             "kura_container_memory_inactive_file_bytes",
             "Inactive file-backed memory charged to the container control group",
             container_memory_inactive_file_bytes.clone(),
@@ -1213,6 +1227,8 @@ impl Metrics {
             container_memory_anon_bytes,
             container_memory_file_bytes,
             container_memory_kernel_bytes,
+            container_memory_slab_reclaimable_bytes,
+            container_memory_slab_unreclaimable_bytes,
             container_memory_inactive_file_bytes,
             container_memory_reclaimable_inactive_file_bytes,
             container_memory_shmem_bytes,
@@ -1909,6 +1925,14 @@ impl Metrics {
         if let Some(value) = snapshot.kernel_bytes {
             self.container_memory_kernel_bytes.set(value as i64);
         }
+        if let Some(value) = snapshot.slab_reclaimable_bytes {
+            self.container_memory_slab_reclaimable_bytes
+                .set(value as i64);
+        }
+        if let Some(value) = snapshot.slab_unreclaimable_bytes {
+            self.container_memory_slab_unreclaimable_bytes
+                .set(value as i64);
+        }
         if let Some(value) = snapshot.inactive_file_bytes {
             self.container_memory_inactive_file_bytes.set(value as i64);
         }
@@ -2529,6 +2553,8 @@ mod tests {
                 anon_bytes: Some(700),
                 file_bytes: Some(600),
                 kernel_bytes: Some(200),
+                slab_reclaimable_bytes: None,
+                slab_unreclaimable_bytes: None,
                 inactive_file_bytes: Some(100),
                 shmem_bytes: Some(50),
                 sock_bytes: Some(30),


### PR DESCRIPTION
## What changed

`pressure_bytes` no longer counts `slab_reclaimable` as memory pressure. It is subtracted from the cgroup v2 `kernel` row before that row is added to the pressure signal.

Also exports `kura_container_memory_slab_reclaimable_bytes` and `kura_container_memory_slab_unreclaimable_bytes`.

## Why

A Kura node served a **0% cache hit rate for ~19 hours** while reporting `1/1 Running`, `/ready` 200, and `kura_ready_state=1`. Builds pointed at it got no cached data; at least one CI job timed out against it. It recovered only when the pod was deleted.

Its manifest cache hit rate went from ~99.9% to **exactly zero**, with every subsequent lookup missing, flipping at the moment pressure went Critical. `kura_manifest_index_entries` dropped to 0 and stayed there.

## Root cause

`pressure_bytes` added the `kernel` row wholesale. That row nests `slab_reclaimable` — cache the kernel drops on demand, which Kura cannot free by trimming anything of its own.

The node carried roughly 1 GiB of it. Together with anonymous memory that left pressure above the Critical-to-Normal recovery threshold (9/10 of the soft watermark) permanently, with every Kura-owned cache already trimmed to zero.

Critical is also self-sealing: it sets `snapshot_cache_target_bytes()` to 0, zeroing the action-cache snapshot index, *and* `allow_background_admission()` requires Normal, so `run_index_build` short-circuits to the gate-only pass and never reconciles. The same threshold empties the index and forbids rebuilding it. Logs show the resulting loop: `action-cache snapshot index build started` immediately followed by `trimmed action-cache snapshot cache reason=critical target_bytes=0`.

## How far the slab was outside normal

`slab_reclaimable` is dominated by `buffer_head`: one 105.0 B struct per resident page-cache page. That ratio is the diagnostic, measured across live nodes:

| node | bytes of `slab_reclaimable` per resident page-cache page |
|---|---|
| healthy node A | **104.9** |
| healthy node B | 112.1 |
| freshly restarted node | 10.6 |
| **affected node** | **16,428** |

On a healthy node the ratio matches the object size to within 0.1% — one buffer_head per page. It is not a fixed rate: a freshly restarted node sits an order of magnitude lower, since access pattern determines whether ext4 allocates buffer_heads at all.

Page cache is itself charged to the cgroup, so the memory limit puts a hard ceiling on how much buffer_head a container can back: at a 2 GiB limit that is ~52.5 MiB (524,288 pages x 105 B), even if the container held nothing else.

The affected node was at **19.5x that ceiling**, with a ratio 156x the healthy one, while holding only a few hundred MiB of page cache. That cannot be backed by live page cache. Those buffer_heads were orphaned or pinned — consistent with the observed shape, two discrete step increases then dead-flat for 18h, which is nothing like the smooth tracking healthy nodes show.

**Why that happened is not yet understood, and this PR does not address it.** What it does is make the pressure signal robust to it: reclaimable cache is not pressure at 30 MiB and is not pressure at 1 GiB. Today the anomaly is fatal because it feeds a latch; after this it is inert.

## Why subtract, rather than sum the leaves

The obvious alternative is to sum `kernel`'s non-reclaimable leaves (`slab_unreclaimable + pagetables + kernel_stack + percpu + vmalloc + sock`). That was rejected: it is another allowlist, and this code has already been bitten by exactly that. #12129 switched pressure accounting from a denylist (`current - inactive_file`) to an allowlist, and #12133 landed 1h36m later purely to add `sock` back with the note "the old `current - inactive_file` signal counted it". A leaf allowlist also silently drops `sec_pagetables` and any row a future kernel adds.

Subtracting keeps the aggregate authoritative, so unknown and future kernel rows stay counted. For a pressure signal, undercounting (missed pressure, OOM kill) is the more dangerous error than overcounting.

## Not a regression

Under the pre-#12129 formula slab was counted too — it sits in `current` and is not covered by `inactive_file` — so `old_pressure >= new_pressure` always. Both formulas latch given this much slab. #12129 halved the exposure and left this half standing; the trigger was the slab accumulation, not the formula change. This is an incomplete fix being completed, not a regression being reverted.

## Observability

Only the `kernel` aggregate was exported, so the sub-rows were invisible to every dashboard and alert — diagnosing this required a shell on the pod, and by then the pod had been restarted and the evidence lost. The two slab gauges make the next occurrence visible from metrics alone, which is also how the open question above gets answered.

## Impact

A node carrying a large reclaimable-slab charge stays in Normal instead of latching Critical, so **the action-cache snapshot index is no longer zeroed**. `snapshot_cache_target_bytes()` and `manifest_cache_target_bytes()` read the pressure tier alone, so at Normal they stop trimming it to 0 and the index survives to keep serving.

To be precise about what this does *not* fix: the index *rebuild* gate is `allow_background_admission()` = `pressure() == Normal && !container_at_hard_limit()`, and that second arm is raw `memory.current >= hard_limit` (mod.rs:271) — a quantity that still includes the reclaimable slab excluded here. On the figures the new test encodes, that arm was true and this PR does not move it. `allow_manifest_cache_admission()`, `allow_segment_refresh()` and `pause_outbox()` sit behind the same flag.

That arm is deliberate — the reasoning at mod.rs:255-269 makes the case that a warm serving node holds clean pages at the hard watermark as normal steady state, and it is also what makes discounting a gigabyte from the tier safe. So the outcome here is a **stale index rather than an empty one**: the catastrophic mode (0% hits, no path to recovery) is closed; a degraded mode (index survives but may not refresh while the raw charge is high) can remain. That is a large improvement and not a complete one.

No protocol, wire-format, or on-disk changes; safe under mixed-version rollout since this is a node-local admission signal.

## Follow-ups not in this PR

- **The raw-charge arm of `allow_background_admission()`.** `container_at_hard_limit()` reads `memory.current`, which includes reclaimable slab. A node with a large slab charge can therefore still have background rebuilds, manifest-cache admission, segment refresh and the outbox held closed even at Normal pressure. Deciding whether that arm should discount reclaimable slab too is a separate change with real risk — it is the backstop that stops the node adding charge before the kernel kills it.
- **`working_set_bytes` counts reclaimable slab.** It stays the conventional `current - inactive_file` here so the reported figure matches the kubelet, but it drives `should_reclaim_file_cache()`, so a node with a large slab charge sits in forced drop-behind with the accelerated mmap serving path denied. Correct bytes, no fast path.
- **The root cause of the slab accumulation is open.** The new gauges exist to catch the next occurrence.

## Validation

- `cargo test --lib` — 500 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `mise run format`
- New `pressure_excludes_reclaimable_slab_nested_in_kernel` encodes the observed figures and asserts both that the fixed signal clears the Normal-recovery threshold and that the pre-fix signal does not.
- New `pressure_never_underflows_when_reclaimable_slab_exceeds_kernel` covers the independently-parsed-rows case.

Evidence gathered by reading `/sys/fs/cgroup/memory.stat` and `slabtop` on several live nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
