### PR TITLE
fix(cli): make module map cache hashes checkout-independent [4.203.x backport]

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -423,6 +423,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
                     .external(name: "XcodeProj"),
+                    .external(name: "Command"),
                 ]
             case .dependencies:
                 [

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -82,15 +82,36 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                 else { return (targetName, target) }
 
                 if hasModuleMap {
-                    if target.product.isFramework,
-                       case let .string(moduleMapFile) = mappedSettingsDictionary[Self.modulemapFileSetting]
-                    {
-                        // ExtractAPI consumes MODULEMAP_PATH as an explicit -fmodule-map-file input. Keeping the
-                        // source map out of the framework product avoids duplicate module-map discovery and the
-                        // static-framework copy fixed in #11588: https://github.com/tuist/tuist/pull/11588
-                        // The original $(SRCROOT)-relative value is preserved so cache hashes stay
-                        // environment-independent.
-                        mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapFile)
+                    if let moduleMapPath = Self.moduleMapPath(
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
+                    ) {
+                        switch target.product {
+                        case .framework:
+                            target.scripts.append(
+                                TargetScript(
+                                    name: "Copy Module Map",
+                                    order: .post,
+                                    script: .embedded(
+                                        """
+                                        set -eu
+                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                                        cp -f \(Self
+                                            .shellPath(
+                                                from: moduleMapPath
+                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                                        """
+                                    ),
+                                    inputPaths: [moduleMapPath],
+                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                                    showEnvVarsInLog: false,
+                                    basedOnDependencyAnalysis: true
+                                )
+                            )
+                        case .staticFramework:
+                            mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
+                        default:
+                            break
+                        }
                     }
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
@@ -173,6 +194,47 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         sideEffects.append(contentsOf: generatedFileSideEffects)
         return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
+
+    private static func moduleMapPath(
+        from value: SettingsDictionary.Value?
+    ) -> String? {
+        guard case let .string(moduleMap) = value else { return nil }
+
+        for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
+            let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
+            if moduleMap.hasPrefix(derivedDirectoryPrefix) {
+                let relativePath = String(moduleMap.dropFirst(derivedDirectoryPrefix.count))
+                return "$(PROJECT_DIR)/../../\(relativePath)"
+            }
+        }
+
+        if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
+            return moduleMap
+        }
+
+        guard (try? RelativePath(validating: moduleMap)) != nil else {
+            return nil
+        }
+        return "$(PROJECT_DIR)/\(moduleMap)"
+    }
+
+    private static func shellPath(from buildSettingPath: String) -> String {
+        let variables = [
+            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
+            ("$(SRCROOT)", "$SRCROOT"),
+            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
+        ]
+        var shellPath = buildSettingPath
+        for (buildSetting, shellVariable) in variables {
+            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
+        }
+        let escapedShellPath = shellPath
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "`", with: "\\`")
+
+        return "\"\(escapedShellPath)\""
+    }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {
         if case .external = project.type,

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -19,6 +19,7 @@ import XcodeGraph
 /// https://github.com/swiftlang/swift-package-manager/blob/ff05594c1267137ed5ee2c0076dfaf78f0289877/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L440-L459
 public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_body_length
     private static let modulemapFileSetting = "MODULEMAP_FILE"
+    private static let modulemapPathSetting = "MODULEMAP_PATH"
     private static let otherCFlagsSetting = "OTHER_CFLAGS"
     private static let otherSwiftFlagsSetting = "OTHER_SWIFT_FLAGS"
     private static let headerSearchPaths = "HEADER_SEARCH_PATHS"
@@ -81,37 +82,15 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                 else { return (targetName, target) }
 
                 if hasModuleMap {
-                    if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
-                        projectPath: project.path
-                    ),
-                        target.product == .framework
+                    if target.product.isFramework,
+                       case let .string(moduleMapFile) = mappedSettingsDictionary[Self.modulemapFileSetting]
                     {
-                        // swift-build gives ExtractAPI dependency module maps explicitly and models framework module maps
-                        // at `Modules/module.modulemap`. Generated Xcode projects need the same canonical framework path.
-                        // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift#L76-L108
-                        // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift#L1197-L1200
-                        let escapedModuleMapPath = Self.shellEscaped(moduleMapPath.pathString)
-                        target.scripts.append(
-                            TargetScript(
-                                name: "Copy Module Map",
-                                order: .post,
-                                script: .embedded(
-                                    // -f: with Xcode compilation caching enabled, the destination can
-                                    // pre-exist as a read-only CAS-materialized file that plain cp
-                                    // refuses to overwrite (Permission denied).
-                                    """
-                                    set -eu
-                                    mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                    cp -f '\(escapedModuleMapPath)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                                    """
-                                ),
-                                inputPaths: [moduleMapPath.pathString],
-                                outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                                showEnvVarsInLog: false,
-                                basedOnDependencyAnalysis: true
-                            )
-                        )
+                        // ExtractAPI consumes MODULEMAP_PATH as an explicit -fmodule-map-file input. Keeping the
+                        // source map out of the framework product avoids duplicate module-map discovery and the
+                        // static-framework copy fixed in #11588: https://github.com/tuist/tuist/pull/11588
+                        // The original $(SRCROOT)-relative value is preserved so cache hashes stay
+                        // environment-independent.
+                        mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapFile)
                     }
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
@@ -194,24 +173,6 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         sideEffects.append(contentsOf: generatedFileSideEffects)
         return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
-
-    private static func moduleMapPath(
-        from value: SettingsDictionary.Value?,
-        projectPath: AbsolutePath
-    ) -> AbsolutePath? {
-        guard case let .string(moduleMap) = value else { return nil }
-
-        return try? AbsolutePath(
-            validating: moduleMap
-                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath.pathString)
-        )
-    }
-
-    private static func shellEscaped(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "'\\''")
-    }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {
         if case .external = project.type,

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -83,31 +83,11 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
                 if hasModuleMap {
                     if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
+                        project: project
                     ) {
                         switch target.product {
-                        case .framework:
-                            target.scripts.append(
-                                TargetScript(
-                                    name: "Copy Module Map",
-                                    order: .post,
-                                    script: .embedded(
-                                        """
-                                        set -eu
-                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                        cp -f \(Self
-                                            .shellPath(
-                                                from: moduleMapPath
-                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                                        """
-                                    ),
-                                    inputPaths: [moduleMapPath],
-                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                                    showEnvVarsInLog: false,
-                                    basedOnDependencyAnalysis: true
-                                )
-                            )
-                        case .staticFramework:
+                        case .framework, .staticFramework:
                             mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
                         default:
                             break
@@ -196,10 +176,14 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     } // swiftlint:enable function_body_length
 
     private static func moduleMapPath(
-        from value: SettingsDictionary.Value?
+        from value: SettingsDictionary.Value?,
+        project: Project
     ) -> String? {
         guard case let .string(moduleMap) = value else { return nil }
 
+        // Combined dependency module maps live under `tuist-derived/` and are referenced as
+        // `$(SRCROOT)/../../tuist-derived/...`. Rewrite them to the canonical `$(PROJECT_DIR)` form
+        // without depending on the project's generated location.
         for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
             let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
             if moduleMap.hasPrefix(derivedDirectoryPrefix) {
@@ -208,32 +192,34 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             }
         }
 
+        // Source-root build-setting macros and absolute filesystem paths. `MODULEMAP_FILE` is
+        // authored relative to the source project: `$(SRCROOT)`/`$(SOURCE_ROOT)` resolve to the
+        // checkout (see `PackageInfoMapper`), while `$(PROJECT_DIR)` already anchors to the generated
+        // project. Resolve each macro against its corresponding project, then reanchor to the
+        // generated project's directory as a machine-independent `$(PROJECT_DIR)`-relative path so
+        // cache hashes stay stable across checkouts.
         if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
-            return moduleMap
+            let sourceProjectPath = project.path.pathString
+            let generatedProjectPath = project.xcodeProjPath.parentDirectory.pathString
+            let resolved = moduleMap
+                .replacingOccurrences(of: "$(PROJECT_DIR)", with: generatedProjectPath)
+                .replacingOccurrences(of: "$(SRCROOT)", with: sourceProjectPath)
+                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: sourceProjectPath)
+
+            // Macros we don't model here (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to an absolute
+            // path at generation time. Preserve them verbatim so the module map isn't dropped and Xcode
+            // can evaluate them at build time.
+            guard let resolvedPath = try? AbsolutePath(validating: resolved) else {
+                return moduleMap
+            }
+
+            return "$(PROJECT_DIR)/\(resolvedPath.relative(to: project.xcodeProjPath.parentDirectory).pathString)"
         }
 
         guard (try? RelativePath(validating: moduleMap)) != nil else {
             return nil
         }
         return "$(PROJECT_DIR)/\(moduleMap)"
-    }
-
-    private static func shellPath(from buildSettingPath: String) -> String {
-        let variables = [
-            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
-            ("$(SRCROOT)", "$SRCROOT"),
-            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
-        ]
-        var shellPath = buildSettingPath
-        for (buildSetting, shellVariable) in variables {
-            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
-        }
-        let escapedShellPath = shellPath
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "`", with: "\\`")
-
-        return "\"\(escapedShellPath)\""
     }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -1,3 +1,4 @@
+import Command
 import FileSystem
 import FileSystemTesting
 import Path
@@ -545,28 +546,50 @@ struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPrimitiv
 }
 
 struct BuildAcceptanceTestMultiplatformAppWithSDK {
-    @Test(.disabled(), .withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
-    func test() async throws {
-        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
-        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
-        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
-        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
-        try await TuistTest.run(
-            BuildCommand.self,
-            [
-                "App",
-                "--platform",
-                "macos",
-                "--path",
-                fixtureDirectory.pathString,
-                "--derived-data-path",
-                derivedDataPath.pathString,
-            ]
-        )
-        try await TuistTest.run(
-            BuildCommand.self,
-            ["App", "--platform", "ios", "--path", fixtureDirectory.pathString, "--derived-data-path", derivedDataPath.pathString]
-        )
+    @Test(.withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
+    func build_and_test_documentation() async throws {
+        let fixturePath = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await TuistTest.run(InstallCommand.self, ["--path", fixturePath.pathString])
+        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixturePath.pathString])
+
+        let workspace = fixturePath.appending(component: "App.xcworkspace").pathString
+        let codeSigningArgs: [String] = [
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ]
+
+        // iOS — docbuild exercises ExtractAPI, which is the path that needs MODULEMAP_PATH.
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "docbuild",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=iOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=iOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
+
+        // macOS — ensures the multiplatform scheme still builds on macOS.
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=macOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
     }
 }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -601,6 +601,50 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
+    @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)
+    func ios_app_with_modulemap_packages() async throws {
+        let fixturePath = try fixtureDirectory()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "docbuild",
+            "-workspace",
+            fixturePath.appending(component: "ModuleMapPackages.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace",
+            fixturePath.appending(component: "ModuleMapPackages.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+    }
+}
+
 struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
     /// Regression coverage for the request to include SwiftPM target headers in generated projects
     /// (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -601,6 +601,9 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+/// This integration test resolves a large external package graph and runs two Xcode builds. Serializing it prevents
+/// the intermittent resource contention observed when it runs alongside the rest of the acceptance-test shard.
+@Suite(.serialized)
 struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
     @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)
     func ios_app_with_modulemap_packages() async throws {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_modulemap_copy_script() throws {
+    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -419,29 +419,43 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts ==
-            [
-                TargetScript(
-                    name: "Copy Module Map",
-                    order: .post,
-                    script: .embedded(
-                        """
-                        set -eu
-                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f '\(moduleMapPath.pathString)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                        """
-                    ),
-                    inputPaths: [moduleMapPath.pathString],
-                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                    showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: true
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
-    func removes_static_framework_modulemap_without_copy_script() throws {
+    func preserves_srcroot_relative_modulemap_path_for_environment_independence() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the $(SRCROOT)-relative form is preserved so cache hashes are
+        // stable across machines with different checkout paths.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func maps_static_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -473,6 +487,7 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
         #expect(gotTarget.scripts.isEmpty)
     }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,10 +387,11 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_modulemap_copy_script() throws {
+    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -401,6 +402,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -416,28 +418,13 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the module map is passed to ExtractAPI through `MODULEMAP_PATH` (reanchored to the
+        // generated project) rather than copied into the framework bundle, which avoids the invalid
+        // top-level `Modules/` directory reported in #12040.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts ==
-            [
-                TargetScript(
-                    name: "Copy Module Map",
-                    order: .post,
-                    script: .embedded(
-                        """
-                        set -eu
-                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                        """
-                    ),
-                    inputPaths: [moduleMapPath.pathString],
-                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                    showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: true
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -445,6 +432,7 @@ struct ModuleMapMapperTests {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -455,6 +443,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -470,18 +459,19 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the absolute path is reanchored to the generated project's `$(PROJECT_DIR)`.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
         #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .framework,
@@ -489,7 +479,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -497,17 +487,15 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the `$(SRCROOT)`-relative path is reanchored to `$(PROJECT_DIR)` so it resolves
+        // correctly in the generated project and stays machine-independent.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].script == .embedded(
-            """
-            set -eu
-            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-            """
-        ))
-        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -534,7 +522,9 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/../../ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)
@@ -567,10 +557,11 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_static_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .staticFramework,
@@ -578,7 +569,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -591,7 +582,219 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(
             gotTarget.settings?.base["MODULEMAP_PATH"] ==
-                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory, arguments: [
+        (
+            projectPathComponents: ["checkouts", "A"],
+            xcodeProjPathComponents: ["tuist-derived", "Projects", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["registry", "downloads", "A", "1.0.0"],
+            xcodeProjPathComponents: ["registry", "downloads", "A", "1.0.0", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["Packages", "A"],
+            xcodeProjPathComponents: ["Packages", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+    ])
+    func resolves_static_framework_modulemap_path_for_swift_package_layout(
+        projectPathComponents: [String],
+        xcodeProjPathComponents: [String],
+        expectedModuleMapPath: String
+    ) throws {
+        // Given — for external SwiftPM packages the module map lives in the checkout, but the
+        // generated project's `$(SRCROOT)` points at the generated project, so the reference must be
+        // reanchored to the generated project's directory.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: projectPathComponents)
+        let xcodeProjPath = scratchDirectory.appending(components: xcodeProjPathComponents)
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(expectedModuleMapPath))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func produces_identical_modulemap_path_for_external_projects_in_different_absolute_roots() throws {
+        // Given
+        let workspace = Workspace.test()
+
+        func mappedModuleMapPath(in scratchDirectory: AbsolutePath) throws -> SettingsDictionary.Value? {
+            let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+            let xcodeProjPath = scratchDirectory.appending(
+                components: "tuist-derived", "Projects", "A", "A.xcodeproj"
+            )
+            let target = Target.test(
+                name: "A",
+                product: .staticFramework,
+                settings: .test(base: [
+                    "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+                ])
+            )
+            let project = Project.test(
+                path: projectPath,
+                xcodeProjPath: xcodeProjPath,
+                name: "A",
+                targets: [target],
+                type: .external()
+            )
+
+            let (graph, _, _) = try subject.map(
+                graph: .test(workspace: workspace, projects: [projectPath: project]),
+                environment: MapperEnvironment()
+            )
+            return graph.projects[projectPath]?.targets["A"]?.settings?.base["MODULEMAP_PATH"]
+        }
+
+        // When
+        let firstModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "first", ".build")
+        )
+        let secondModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "second", ".build")
+        )
+
+        // Then — reanchoring keeps cache hashes stable across checkouts with different absolute roots.
+        #expect(firstModuleMapPath == secondModuleMapPath)
+    }
+
+    @Test(.inTemporaryDirectory, arguments: ["$(SRCROOT)", "$(SOURCE_ROOT)"])
+    func reanchors_srcroot_macros_against_the_source_project_path(sourceRootMacro: String) throws {
+        // Given
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("\(sourceRootMacro)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — `$(SRCROOT)`/`$(SOURCE_ROOT)` are authored relative to the checkout, so they resolve
+        // through the source project path into a generated-project-relative reference.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func keeps_project_dir_anchored_to_the_generated_project() throws {
+        // Given — for a relocated external project the source project (`project.path`) is the checkout
+        // while the generated project lives under `tuist-derived`. `$(PROJECT_DIR)` already anchors to
+        // the generated project, so it must not be redirected into the checkout.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(PROJECT_DIR)/Generated/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the generated-project-relative path is preserved, not redirected into the checkout.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/Generated/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_unrecognized_modulemap_macros() throws {
+        // Given — build-setting macros we don't model (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to
+        // an absolute path at generation time, so they are passed through for Xcode to evaluate.
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(DERIVED_FILE_DIR)/Generated.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the macro is preserved verbatim instead of dropping the module map.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(DERIVED_FILE_DIR)/Generated.modulemap")
         )
     }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
+    func maps_framework_modulemap_to_modulemap_copy_script() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -419,39 +419,25 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
-        #expect(gotTarget.scripts.isEmpty)
-    }
-
-    @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_modulemap_path_for_environment_independence() throws {
-        // Given
-        let workspace = Workspace.test()
-        let projectPath = try temporaryPath().appending(component: "A")
-        let target = Target.test(
-            name: "A",
-            product: .framework,
-            settings: .test(base: [
-                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
-            ])
+        #expect(gotTarget.scripts ==
+            [
+                TargetScript(
+                    name: "Copy Module Map",
+                    order: .post,
+                    script: .embedded(
+                        """
+                        set -eu
+                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                        """
+                    ),
+                    inputPaths: [moduleMapPath.pathString],
+                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                    showEnvVarsInLog: false,
+                    basedOnDependencyAnalysis: true
+                ),
+            ]
         )
-        let project = Project.test(
-            path: projectPath,
-            name: "A",
-            targets: [target]
-        )
-
-        // When
-        let (gotGraph, _, _) = try subject.map(
-            graph: .test(workspace: workspace, projects: [projectPath: project]),
-            environment: MapperEnvironment()
-        )
-
-        // Then — the $(SRCROOT)-relative form is preserved so cache hashes are
-        // stable across machines with different checkout paths.
-        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
-        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"))
     }
 
     @Test(.inTemporaryDirectory)
@@ -489,6 +475,124 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
         #expect(gotTarget.scripts.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].script == .embedded(
+            """
+            set -eu
+            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+            """
+        ))
+        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func rewrites_srcroot_relative_derived_framework_modulemap_path_to_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let temporaryPath = try temporaryPath()
+        let projectPath = temporaryPath.appending(components: "tuist-derived", "Projects", "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/../../tuist-derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func resolves_relative_static_framework_modulemap_path_against_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("Modules/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Modules/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)

--- a/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
@@ -1,6 +1,3 @@
 import ProjectDescription
 
-let config = Config(
-    fullHandle: "tuist/ios_app_with_appclip",
-    url: "https://canary.tuist.dev"
-)
+let config = Config()

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/.gitignore
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/.gitignore
@@ -1,0 +1,57 @@
+### macOS ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+Icon
+
+._*
+
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+xcuserdata/
+
+*.xcscmblueprint
+*.xccheckout
+
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/App/Project.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/App/Project.swift
@@ -1,0 +1,20 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "dev.tuist.ModuleMapPackages",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .external(name: "Gzip"),
+                .external(name: "GEOSwift"),
+                .external(name: "FirebaseMLModelDownloader"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/App/Sources/App.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/App/Sources/App.swift
@@ -1,0 +1,7 @@
+import FirebaseMLModelDownloader
+import GEOSwift
+import Gzip
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {}

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist()

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(baseProductType: .framework)
+#endif
+
+let package = Package(
+    name: "ModuleMapPackages",
+    dependencies: [
+        .package(url: "https://github.com/1024jp/GzipSwift", exact: "6.0.0"),
+        .package(url: "https://github.com/GEOSwift/GEOSwift", exact: "11.2.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "12.6.0"),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Workspace.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Workspace.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "ModuleMapPackages", projects: ["App"])


### PR DESCRIPTION
Backports the module-map cache-hash fixes from `main` onto `releases/4.203.x`.

## What changed

Three commits cherry-picked with `-x` (no conflicts, original authorship preserved):

| upstream | PR |
|---|---|
| `c9dc276cf6` | #12055 — pass framework modulemaps to ExtractAPI |
| `bc4bc71745` | #12137 — restore dynamic framework module map copying |
| `2b020257e2` | #12145 — reanchor module map paths to the generated project |

After this, `cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift` is byte-identical to `main`.

## Why

Discovered while investigating a binary-cache hit-rate regression that appeared on an upgrade from 4.197.x to 4.203.x.

`4.201.0` (#11135) started appending a `Copy Module Map` post-action script to every `product == .framework` target carrying a `MODULEMAP_FILE`. The script body interpolated the **absolute** module map path:

```sh
set -eu
mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
cp -f '/absolute/path/to/checkout/Foo/module.modulemap' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
```

`TargetScriptsContentHasher` hashes `script.embeddedScript` verbatim, so the target's binary-cache hash became a function of **where the project was checked out**. Note the script's `inputPaths` was already emitted project-relative — only the embedded body carried the absolute path, which is why nothing else in the hash drifted.

## Root cause and blast radius

Binary-cache hashes are supposed to depend only on content and on paths expressed relative to a build-setting macro. This one did not, so on any setup where the checkout path is not byte-stable across runs — ephemeral CI runners, per-job workspace directories, numbered runner slots — the effect is:

1. every framework target with a `MODULEMAP_FILE` re-hashes on each run and can never hit the cache; and
2. because a target's hash feeds its dependents' `dependenciesHash`, the instability cascades to the whole transitive dependent set — targets whose own inputs never changed still miss.

A handful of low-level module-map targets is therefore enough to pull a large fraction of a graph off the cache permanently, while the cache still looks healthy for everything outside that dependent set.

## Why these commits rather than a fresh fix

The three upstream commits already solve this and are what has been running on `main`; authoring a separate fix for the release line would diverge the two. They have to travel as a set — #12137 builds on #12055's restructuring, and #12145 completes it by reanchoring `MODULEMAP_FILE` values that are *already* absolute, which #12137 on its own passed through untouched.

## Impact

Affects 4.201.0 through 4.203.x. No stable release currently carries the fix. Projects with framework targets that set `MODULEMAP_FILE` regain stable, location-independent hashes; there is no change for projects without such targets.

The first run after upgrading will still re-hash those targets once (the hash value legitimately changes), then stabilise.

## Validation

Ran on this branch, on macOS with Xcode 26.3:

- `ModuleMapMapper.swift` diff against `origin/main`: **empty**.
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist` → **BUILD SUCCEEDED** (confirms the cherry-picks compile against the older release-line tree, which a clean cherry-pick alone does not guarantee).
- `xcodebuild test -only-testing TuistGeneratorTests/ModuleMapMapperTests` → **TEST SUCCEEDED**, 19 tests. Includes the four that encode the contract directly: `reanchors_srcroot_macros_against_the_source_project_path`, `keeps_project_dir_anchored_to_the_generated_project`, `preserves_unrecognized_modulemap_macros`, `external_spm_project_anchors_tuist_derived_paths_on_project_dir`.
- End-to-end fixture repro: two byte-identical generated projects scaffolded at two different absolute paths, comparing `tuist hash cache` output. Fixture is a framework target with a custom `MODULEMAP_FILE`, a framework that depends on it, and a control framework with no module map anywhere in its closure.

| version | module-map target | its dependent | control target | result |
|---|---|---|---|---|
| 4.200.0 | stable | stable | stable | PASS |
| 4.201.0-canary.19 | **moved** | **moved** | stable | FAIL |
| 4.204.0-canary.2 | **moved** | **moved** | stable | FAIL |
| 4.204.0-canary.6 | stable | stable | stable | PASS |
| **this branch** | stable | stable | stable | **PASS** |

The hashes produced by this branch are identical to those produced by `4.204.0-canary.6`, so the backport is behaviourally equivalent to the fixed line rather than merely a fix that also happens to work.

## Not covered here

Acceptance tests were not run locally. This backport touches `BuildAcceptanceTests` and `GenerateAcceptanceTests` and adds the `generated_ios_app_with_modulemap_packages` example, which resolves third-party packages — those need the full acceptance job in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
