### PR TITLE
fix(cli): make module map cache hashes checkout-independent [4.202.x backport]

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -420,6 +420,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
                     .external(name: "XcodeProj"),
+                    .external(name: "Command"),
                 ]
             case .dependencies:
                 [

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -82,15 +82,36 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                 else { return (targetName, target) }
 
                 if hasModuleMap {
-                    if target.product.isFramework,
-                       case let .string(moduleMapFile) = mappedSettingsDictionary[Self.modulemapFileSetting]
-                    {
-                        // ExtractAPI consumes MODULEMAP_PATH as an explicit -fmodule-map-file input. Keeping the
-                        // source map out of the framework product avoids duplicate module-map discovery and the
-                        // static-framework copy fixed in #11588: https://github.com/tuist/tuist/pull/11588
-                        // The original $(SRCROOT)-relative value is preserved so cache hashes stay
-                        // environment-independent.
-                        mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapFile)
+                    if let moduleMapPath = Self.moduleMapPath(
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
+                    ) {
+                        switch target.product {
+                        case .framework:
+                            target.scripts.append(
+                                TargetScript(
+                                    name: "Copy Module Map",
+                                    order: .post,
+                                    script: .embedded(
+                                        """
+                                        set -eu
+                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                                        cp -f \(Self
+                                            .shellPath(
+                                                from: moduleMapPath
+                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                                        """
+                                    ),
+                                    inputPaths: [moduleMapPath],
+                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                                    showEnvVarsInLog: false,
+                                    basedOnDependencyAnalysis: true
+                                )
+                            )
+                        case .staticFramework:
+                            mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
+                        default:
+                            break
+                        }
                     }
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
@@ -173,6 +194,47 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         sideEffects.append(contentsOf: generatedFileSideEffects)
         return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
+
+    private static func moduleMapPath(
+        from value: SettingsDictionary.Value?
+    ) -> String? {
+        guard case let .string(moduleMap) = value else { return nil }
+
+        for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
+            let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
+            if moduleMap.hasPrefix(derivedDirectoryPrefix) {
+                let relativePath = String(moduleMap.dropFirst(derivedDirectoryPrefix.count))
+                return "$(PROJECT_DIR)/../../\(relativePath)"
+            }
+        }
+
+        if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
+            return moduleMap
+        }
+
+        guard (try? RelativePath(validating: moduleMap)) != nil else {
+            return nil
+        }
+        return "$(PROJECT_DIR)/\(moduleMap)"
+    }
+
+    private static func shellPath(from buildSettingPath: String) -> String {
+        let variables = [
+            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
+            ("$(SRCROOT)", "$SRCROOT"),
+            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
+        ]
+        var shellPath = buildSettingPath
+        for (buildSetting, shellVariable) in variables {
+            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
+        }
+        let escapedShellPath = shellPath
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "`", with: "\\`")
+
+        return "\"\(escapedShellPath)\""
+    }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {
         if case .external = project.type,

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -19,6 +19,7 @@ import XcodeGraph
 /// https://github.com/swiftlang/swift-package-manager/blob/ff05594c1267137ed5ee2c0076dfaf78f0289877/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L440-L459
 public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_body_length
     private static let modulemapFileSetting = "MODULEMAP_FILE"
+    private static let modulemapPathSetting = "MODULEMAP_PATH"
     private static let otherCFlagsSetting = "OTHER_CFLAGS"
     private static let otherSwiftFlagsSetting = "OTHER_SWIFT_FLAGS"
     private static let headerSearchPaths = "HEADER_SEARCH_PATHS"
@@ -81,34 +82,15 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                 else { return (targetName, target) }
 
                 if hasModuleMap {
-                    if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
-                        projectPath: project.path
-                    ),
-                        target.product == .framework
+                    if target.product.isFramework,
+                       case let .string(moduleMapFile) = mappedSettingsDictionary[Self.modulemapFileSetting]
                     {
-                        // swift-build gives ExtractAPI dependency module maps explicitly and models framework module maps
-                        // at `Modules/module.modulemap`. Generated Xcode projects need the same canonical framework path.
-                        // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift#L76-L108
-                        // https://github.com/swiftlang/swift-build/blob/af813e185ed298ea7bdb633047f27d15253cdac7/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift#L1197-L1200
-                        let escapedModuleMapPath = Self.shellEscaped(moduleMapPath.pathString)
-                        target.scripts.append(
-                            TargetScript(
-                                name: "Copy Module Map",
-                                order: .post,
-                                script: .embedded(
-                                    """
-                                    set -eu
-                                    mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                    cp '\(escapedModuleMapPath)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                                    """
-                                ),
-                                inputPaths: [moduleMapPath.pathString],
-                                outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                                showEnvVarsInLog: false,
-                                basedOnDependencyAnalysis: true
-                            )
-                        )
+                        // ExtractAPI consumes MODULEMAP_PATH as an explicit -fmodule-map-file input. Keeping the
+                        // source map out of the framework product avoids duplicate module-map discovery and the
+                        // static-framework copy fixed in #11588: https://github.com/tuist/tuist/pull/11588
+                        // The original $(SRCROOT)-relative value is preserved so cache hashes stay
+                        // environment-independent.
+                        mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapFile)
                     }
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
@@ -191,24 +173,6 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         sideEffects.append(contentsOf: generatedFileSideEffects)
         return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
-
-    private static func moduleMapPath(
-        from value: SettingsDictionary.Value?,
-        projectPath: AbsolutePath
-    ) -> AbsolutePath? {
-        guard case let .string(moduleMap) = value else { return nil }
-
-        return try? AbsolutePath(
-            validating: moduleMap
-                .replacingOccurrences(of: "$(PROJECT_DIR)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SRCROOT)", with: projectPath.pathString)
-                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: projectPath.pathString)
-        )
-    }
-
-    private static func shellEscaped(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "'\\''")
-    }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {
         if case .external = project.type,
@@ -404,43 +368,66 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     ) -> SettingsDictionary {
         var settings = settings
 
-        if !onlyExistingKeys || settings[Self.otherSwiftFlagsSetting] != nil,
-           let updated = Self.updatedOtherSwiftFlags(
-               targetID: targetID,
-               oldOtherSwiftFlags: settings[Self.otherSwiftFlagsSetting],
-               dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-               xcodeProjParent: xcodeProjParent,
-               combinedModuleMapPath: combinedModuleMapPath
-           )
-        {
+        if Self.shouldApplyModuleMapFlags(
+            to: settings[Self.otherSwiftFlagsSetting],
+            onlyExistingKeys: onlyExistingKeys
+        ), let updated = Self.updatedOtherSwiftFlags(
+            targetID: targetID,
+            oldOtherSwiftFlags: settings[Self.otherSwiftFlagsSetting],
+            dependenciesDerivedDirectory: dependenciesDerivedDirectory,
+            xcodeProjParent: xcodeProjParent,
+            combinedModuleMapPath: combinedModuleMapPath
+        ) {
             settings[Self.otherSwiftFlagsSetting] = updated
         }
 
-        if !onlyExistingKeys || settings[Self.otherCFlagsSetting] != nil,
-           let updated = Self.updatedOtherCFlags(
-               targetID: targetID,
-               oldOtherCFlags: settings[Self.otherCFlagsSetting],
-               dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-               xcodeProjParent: xcodeProjParent,
-               combinedModuleMapPath: combinedModuleMapPath
-           )
-        {
+        if Self.shouldApplyModuleMapFlags(
+            to: settings[Self.otherCFlagsSetting],
+            onlyExistingKeys: onlyExistingKeys
+        ), let updated = Self.updatedOtherCFlags(
+            targetID: targetID,
+            oldOtherCFlags: settings[Self.otherCFlagsSetting],
+            dependenciesDerivedDirectory: dependenciesDerivedDirectory,
+            xcodeProjParent: xcodeProjParent,
+            combinedModuleMapPath: combinedModuleMapPath
+        ) {
             settings[Self.otherCFlagsSetting] = updated
         }
 
-        if !onlyExistingKeys || settings[Self.headerSearchPaths] != nil,
-           let updated = Self.updatedHeaderSearchPaths(
-               targetID: targetID,
-               oldHeaderSearchPaths: settings[Self.headerSearchPaths],
-               targetToDependenciesMetadata: targetToDependenciesMetadata,
-               dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-               xcodeProjParent: xcodeProjParent
-           )
-        {
+        if Self.shouldApplyModuleMapFlags(
+            to: settings[Self.headerSearchPaths],
+            onlyExistingKeys: onlyExistingKeys
+        ), let updated = Self.updatedHeaderSearchPaths(
+            targetID: targetID,
+            oldHeaderSearchPaths: settings[Self.headerSearchPaths],
+            targetToDependenciesMetadata: targetToDependenciesMetadata,
+            dependenciesDerivedDirectory: dependenciesDerivedDirectory,
+            xcodeProjParent: xcodeProjParent
+        ) {
             settings[Self.headerSearchPaths] = updated
         }
 
         return settings
+    }
+
+    /// A configuration value containing $(inherited) already receives the base flags, so adding the
+    /// flag there again would duplicate it in the generated Xcode project.
+    private static func shouldApplyModuleMapFlags(
+        to setting: SettingsDictionary.Value?,
+        onlyExistingKeys: Bool
+    ) -> Bool {
+        !onlyExistingKeys || (setting != nil && !inheritsBaseSetting(setting))
+    }
+
+    private static func inheritsBaseSetting(_ setting: SettingsDictionary.Value?) -> Bool {
+        switch setting {
+        case let .string(value):
+            value.contains("$(inherited)")
+        case let .array(values):
+            values.contains("$(inherited)")
+        case nil:
+            false
+        }
     }
 
     private static func updatedHeaderSearchPaths(

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -83,31 +83,11 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
                 if hasModuleMap {
                     if let moduleMapPath = Self.moduleMapPath(
-                        from: mappedSettingsDictionary[Self.modulemapFileSetting]
+                        from: mappedSettingsDictionary[Self.modulemapFileSetting],
+                        project: project
                     ) {
                         switch target.product {
-                        case .framework:
-                            target.scripts.append(
-                                TargetScript(
-                                    name: "Copy Module Map",
-                                    order: .post,
-                                    script: .embedded(
-                                        """
-                                        set -eu
-                                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                                        cp -f \(Self
-                                            .shellPath(
-                                                from: moduleMapPath
-                                            )) "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                                        """
-                                    ),
-                                    inputPaths: [moduleMapPath],
-                                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                                    showEnvVarsInLog: false,
-                                    basedOnDependencyAnalysis: true
-                                )
-                            )
-                        case .staticFramework:
+                        case .framework, .staticFramework:
                             mappedSettingsDictionary[Self.modulemapPathSetting] = .string(moduleMapPath)
                         default:
                             break
@@ -196,10 +176,14 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     } // swiftlint:enable function_body_length
 
     private static func moduleMapPath(
-        from value: SettingsDictionary.Value?
+        from value: SettingsDictionary.Value?,
+        project: Project
     ) -> String? {
         guard case let .string(moduleMap) = value else { return nil }
 
+        // Combined dependency module maps live under `tuist-derived/` and are referenced as
+        // `$(SRCROOT)/../../tuist-derived/...`. Rewrite them to the canonical `$(PROJECT_DIR)` form
+        // without depending on the project's generated location.
         for sourceRoot in ["$(SRCROOT)", "$(SOURCE_ROOT)"] {
             let derivedDirectoryPrefix = "\(sourceRoot)/../../tuist-derived/"
             if moduleMap.hasPrefix(derivedDirectoryPrefix) {
@@ -208,32 +192,34 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             }
         }
 
+        // Source-root build-setting macros and absolute filesystem paths. `MODULEMAP_FILE` is
+        // authored relative to the source project: `$(SRCROOT)`/`$(SOURCE_ROOT)` resolve to the
+        // checkout (see `PackageInfoMapper`), while `$(PROJECT_DIR)` already anchors to the generated
+        // project. Resolve each macro against its corresponding project, then reanchor to the
+        // generated project's directory as a machine-independent `$(PROJECT_DIR)`-relative path so
+        // cache hashes stay stable across checkouts.
         if moduleMap.hasPrefix("/") || moduleMap.hasPrefix("$(") {
-            return moduleMap
+            let sourceProjectPath = project.path.pathString
+            let generatedProjectPath = project.xcodeProjPath.parentDirectory.pathString
+            let resolved = moduleMap
+                .replacingOccurrences(of: "$(PROJECT_DIR)", with: generatedProjectPath)
+                .replacingOccurrences(of: "$(SRCROOT)", with: sourceProjectPath)
+                .replacingOccurrences(of: "$(SOURCE_ROOT)", with: sourceProjectPath)
+
+            // Macros we don't model here (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to an absolute
+            // path at generation time. Preserve them verbatim so the module map isn't dropped and Xcode
+            // can evaluate them at build time.
+            guard let resolvedPath = try? AbsolutePath(validating: resolved) else {
+                return moduleMap
+            }
+
+            return "$(PROJECT_DIR)/\(resolvedPath.relative(to: project.xcodeProjPath.parentDirectory).pathString)"
         }
 
         guard (try? RelativePath(validating: moduleMap)) != nil else {
             return nil
         }
         return "$(PROJECT_DIR)/\(moduleMap)"
-    }
-
-    private static func shellPath(from buildSettingPath: String) -> String {
-        let variables = [
-            ("$(PROJECT_DIR)", "$PROJECT_DIR"),
-            ("$(SRCROOT)", "$SRCROOT"),
-            ("$(SOURCE_ROOT)", "$SOURCE_ROOT"),
-        ]
-        var shellPath = buildSettingPath
-        for (buildSetting, shellVariable) in variables {
-            shellPath = shellPath.replacingOccurrences(of: buildSetting, with: shellVariable)
-        }
-        let escapedShellPath = shellPath
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "`", with: "\\`")
-
-        return "\"\(escapedShellPath)\""
     }
 
     private func dependenciesModuleMapDirectory(for project: Project) -> AbsolutePath {

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -1,3 +1,4 @@
+import Command
 import FileSystem
 import FileSystemTesting
 import Path
@@ -543,28 +544,50 @@ struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPrimitiv
 }
 
 struct BuildAcceptanceTestMultiplatformAppWithSDK {
-    @Test(.disabled(), .withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
-    func test() async throws {
-        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
-        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
-        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
-        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
-        try await TuistTest.run(
-            BuildCommand.self,
-            [
-                "App",
-                "--platform",
-                "macos",
-                "--path",
-                fixtureDirectory.pathString,
-                "--derived-data-path",
-                derivedDataPath.pathString,
-            ]
-        )
-        try await TuistTest.run(
-            BuildCommand.self,
-            ["App", "--platform", "ios", "--path", fixtureDirectory.pathString, "--derived-data-path", derivedDataPath.pathString]
-        )
+    @Test(.withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
+    func build_and_test_documentation() async throws {
+        let fixturePath = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await TuistTest.run(InstallCommand.self, ["--path", fixturePath.pathString])
+        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixturePath.pathString])
+
+        let workspace = fixturePath.appending(component: "App.xcworkspace").pathString
+        let codeSigningArgs: [String] = [
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ]
+
+        // iOS — docbuild exercises ExtractAPI, which is the path that needs MODULEMAP_PATH.
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "docbuild",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=iOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=iOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
+
+        // macOS — ensures the multiplatform scheme still builds on macOS.
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace", workspace,
+            "-scheme", "App",
+            "-destination", "generic/platform=macOS",
+            "-derivedDataPath", derivedDataPath.pathString,
+        ] + codeSigningArgs)
     }
 }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -565,6 +565,50 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
+    @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)
+    func ios_app_with_modulemap_packages() async throws {
+        let fixturePath = try fixtureDirectory()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "docbuild",
+            "-workspace",
+            fixturePath.appending(component: "ModuleMapPackages.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace",
+            fixturePath.appending(component: "ModuleMapPackages.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+    }
+}
+
 struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
     /// Regression coverage for the request to include SwiftPM target headers in generated projects
     /// (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -565,6 +565,9 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+/// This integration test resolves a large external package graph and runs two Xcode builds. Serializing it prevents
+/// the intermittent resource contention observed when it runs alongside the rest of the acceptance-test shard.
+@Suite(.serialized)
 struct GenerateAcceptanceTestiOSAppWithModuleMapPackages {
     @Test(.withFixture("generated_ios_app_with_modulemap_packages"), .inTemporaryDirectory)
     func ios_app_with_modulemap_packages() async throws {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_modulemap_copy_script() throws {
+    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -419,29 +419,43 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts ==
-            [
-                TargetScript(
-                    name: "Copy Module Map",
-                    order: .post,
-                    script: .embedded(
-                        """
-                        set -eu
-                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp '\(moduleMapPath.pathString)' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                        """
-                    ),
-                    inputPaths: [moduleMapPath.pathString],
-                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                    showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: true
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
-    func removes_static_framework_modulemap_without_copy_script() throws {
+    func preserves_srcroot_relative_modulemap_path_for_environment_independence() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the $(SRCROOT)-relative form is preserved so cache hashes are
+        // stable across machines with different checkout paths.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func maps_static_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -473,6 +487,7 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
         #expect(gotTarget.scripts.isEmpty)
     }
 
@@ -602,6 +617,82 @@ struct ModuleMapMapperTests {
                 )),
             ]
         )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func does_not_duplicate_modulemap_flags_in_configurations_that_inherit_them() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectAPath = try temporaryPath().appending(component: "A")
+        let projectBPath = try temporaryPath().appending(component: "B")
+        let debugConfig = BuildConfiguration(name: "Debug", variant: .debug)
+
+        let targetA = Target.test(
+            name: "A",
+            settings: .test(
+                base: [
+                    "OTHER_CFLAGS": ["-DBASE"],
+                    "OTHER_SWIFT_FLAGS": ["-D", "BASE"],
+                    "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Headers"],
+                ],
+                configurations: [
+                    debugConfig: Configuration(settings: [
+                        "OTHER_CFLAGS": ["$(inherited)", "-DDEBUG"],
+                        "OTHER_SWIFT_FLAGS": ["$(inherited)", "-D", "DEBUG"],
+                        "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/DebugHeaders"],
+                    ], xcconfig: nil),
+                ]
+            ),
+            dependencies: [
+                .project(target: "B", path: projectBPath),
+            ]
+        )
+        let projectA = Project.test(path: projectAPath, name: "A", targets: [targetA])
+        let targetB = Target.test(
+            name: "B",
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string(projectBPath.appending(components: "B", "B.module").pathString),
+                "HEADER_SEARCH_PATHS": .array(["$(SRCROOT)/B/include"]),
+            ])
+        )
+        let projectB = Project.test(path: projectBPath, name: "B", targets: [targetB])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(
+                workspace: workspace,
+                projects: [projectAPath: projectA, projectBPath: projectB],
+                dependencies: [
+                    .target(name: targetA.name, path: projectAPath): [
+                        .target(name: targetB.name, path: projectBPath),
+                    ],
+                ]
+            ),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTargetA = try #require(gotGraph.projects[projectAPath]?.targets["A"])
+        let baseSettings = try #require(gotTargetA.settings?.base)
+        #expect(baseSettings["OTHER_CFLAGS"] == .array([
+            "-DBASE",
+            "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
+        ]))
+        #expect(baseSettings["OTHER_SWIFT_FLAGS"] == .array([
+            "-D",
+            "BASE",
+            "-Xcc",
+            "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
+        ]))
+        #expect(baseSettings["HEADER_SEARCH_PATHS"] == .array([
+            "$(SRCROOT)/Headers",
+            "$(SRCROOT)/../B/B/include",
+        ]))
+
+        let debugSettings = try #require(gotTargetA.settings?.configurations[debugConfig] as? Configuration).settings
+        #expect(debugSettings["OTHER_CFLAGS"] == .array(["$(inherited)", "-DDEBUG"]))
+        #expect(debugSettings["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)", "-D", "DEBUG"]))
+        #expect(debugSettings["HEADER_SEARCH_PATHS"] == .array(["$(inherited)", "$(SRCROOT)/DebugHeaders"]))
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,10 +387,11 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_modulemap_copy_script() throws {
+    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -401,6 +402,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -416,28 +418,13 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the module map is passed to ExtractAPI through `MODULEMAP_PATH` (reanchored to the
+        // generated project) rather than copied into the framework bundle, which avoids the invalid
+        // top-level `Modules/` directory reported in #12040.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts ==
-            [
-                TargetScript(
-                    name: "Copy Module Map",
-                    order: .post,
-                    script: .embedded(
-                        """
-                        set -eu
-                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-                        """
-                    ),
-                    inputPaths: [moduleMapPath.pathString],
-                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
-                    showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: true
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -445,6 +432,7 @@ struct ModuleMapMapperTests {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
         let target = Target.test(
             name: "A",
@@ -455,6 +443,7 @@ struct ModuleMapMapperTests {
         )
         let project = Project.test(
             path: projectPath,
+            xcodeProjPath: xcodeProjPath,
             name: "A",
             targets: [target]
         )
@@ -470,18 +459,19 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the absolute path is reanchored to the generated project's `$(PROJECT_DIR)`.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/A/A.modulemap"))
         #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .framework,
@@ -489,7 +479,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -497,17 +487,15 @@ struct ModuleMapMapperTests {
             environment: MapperEnvironment()
         )
 
-        // Then
+        // Then — the `$(SRCROOT)`-relative path is reanchored to `$(PROJECT_DIR)` so it resolves
+        // correctly in the generated project and stays machine-independent.
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].script == .embedded(
-            """
-            set -eu
-            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
-            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
-            """
-        ))
-        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+        #expect(gotTarget.scripts.isEmpty)
     }
 
     @Test(.inTemporaryDirectory)
@@ -534,7 +522,9 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/../../ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)
@@ -567,10 +557,11 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+    func reanchors_srcroot_relative_static_framework_modulemap_path_to_project_directory() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
         let target = Target.test(
             name: "A",
             product: .staticFramework,
@@ -578,7 +569,7 @@ struct ModuleMapMapperTests {
                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
             ])
         )
-        let project = Project.test(path: projectPath, name: "A", targets: [target])
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, name: "A", targets: [target])
 
         // When
         let (gotGraph, _, _) = try subject.map(
@@ -591,7 +582,219 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(
             gotTarget.settings?.base["MODULEMAP_PATH"] ==
-                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+                .string("$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory, arguments: [
+        (
+            projectPathComponents: ["checkouts", "A"],
+            xcodeProjPathComponents: ["tuist-derived", "Projects", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["registry", "downloads", "A", "1.0.0"],
+            xcodeProjPathComponents: ["registry", "downloads", "A", "1.0.0", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+        (
+            projectPathComponents: ["Packages", "A"],
+            xcodeProjPathComponents: ["Packages", "A", "A.xcodeproj"],
+            expectedModuleMapPath: "$(PROJECT_DIR)/Derived/ModuleMaps/A.modulemap"
+        ),
+    ])
+    func resolves_static_framework_modulemap_path_for_swift_package_layout(
+        projectPathComponents: [String],
+        xcodeProjPathComponents: [String],
+        expectedModuleMapPath: String
+    ) throws {
+        // Given — for external SwiftPM packages the module map lives in the checkout, but the
+        // generated project's `$(SRCROOT)` points at the generated project, so the reference must be
+        // reanchored to the generated project's directory.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: projectPathComponents)
+        let xcodeProjPath = scratchDirectory.appending(components: xcodeProjPathComponents)
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(expectedModuleMapPath))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func produces_identical_modulemap_path_for_external_projects_in_different_absolute_roots() throws {
+        // Given
+        let workspace = Workspace.test()
+
+        func mappedModuleMapPath(in scratchDirectory: AbsolutePath) throws -> SettingsDictionary.Value? {
+            let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+            let xcodeProjPath = scratchDirectory.appending(
+                components: "tuist-derived", "Projects", "A", "A.xcodeproj"
+            )
+            let target = Target.test(
+                name: "A",
+                product: .staticFramework,
+                settings: .test(base: [
+                    "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+                ])
+            )
+            let project = Project.test(
+                path: projectPath,
+                xcodeProjPath: xcodeProjPath,
+                name: "A",
+                targets: [target],
+                type: .external()
+            )
+
+            let (graph, _, _) = try subject.map(
+                graph: .test(workspace: workspace, projects: [projectPath: project]),
+                environment: MapperEnvironment()
+            )
+            return graph.projects[projectPath]?.targets["A"]?.settings?.base["MODULEMAP_PATH"]
+        }
+
+        // When
+        let firstModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "first", ".build")
+        )
+        let secondModuleMapPath = try mappedModuleMapPath(
+            in: try temporaryPath().appending(components: "second", ".build")
+        )
+
+        // Then — reanchoring keeps cache hashes stable across checkouts with different absolute roots.
+        #expect(firstModuleMapPath == secondModuleMapPath)
+    }
+
+    @Test(.inTemporaryDirectory, arguments: ["$(SRCROOT)", "$(SOURCE_ROOT)"])
+    func reanchors_srcroot_macros_against_the_source_project_path(sourceRootMacro: String) throws {
+        // Given
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("\(sourceRootMacro)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — `$(SRCROOT)`/`$(SOURCE_ROOT)` are authored relative to the checkout, so they resolve
+        // through the source project path into a generated-project-relative reference.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/../../../checkouts/A/Derived/ModuleMaps/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func keeps_project_dir_anchored_to_the_generated_project() throws {
+        // Given — for a relocated external project the source project (`project.path`) is the checkout
+        // while the generated project lives under `tuist-derived`. `$(PROJECT_DIR)` already anchors to
+        // the generated project, so it must not be redirected into the checkout.
+        let workspace = Workspace.test()
+        let scratchDirectory = try temporaryPath().appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "A")
+        let xcodeProjPath = scratchDirectory.appending(components: "tuist-derived", "Projects", "A", "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(PROJECT_DIR)/Generated/A.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target],
+            type: .external()
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the generated-project-relative path is preserved, not redirected into the checkout.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(PROJECT_DIR)/Generated/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_unrecognized_modulemap_macros() throws {
+        // Given — build-setting macros we don't model (e.g. `$(DERIVED_FILE_DIR)`) can't be resolved to
+        // an absolute path at generation time, so they are passed through for Xcode to evaluate.
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let xcodeProjPath = projectPath.appending(component: "A.xcodeproj")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(DERIVED_FILE_DIR)/Generated.modulemap"),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then — the macro is preserved verbatim instead of dropping the module map.
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(DERIVED_FILE_DIR)/Generated.modulemap")
         )
     }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -387,7 +387,7 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func maps_framework_modulemap_to_extractapi_modulemap_path() throws {
+    func maps_framework_modulemap_to_modulemap_copy_script() throws {
         // Given
         let workspace = Workspace.test()
         let projectPath = try temporaryPath().appending(component: "A")
@@ -419,39 +419,25 @@ struct ModuleMapMapperTests {
         // Then
         let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
-        #expect(gotTarget.scripts.isEmpty)
-    }
-
-    @Test(.inTemporaryDirectory)
-    func preserves_srcroot_relative_modulemap_path_for_environment_independence() throws {
-        // Given
-        let workspace = Workspace.test()
-        let projectPath = try temporaryPath().appending(component: "A")
-        let target = Target.test(
-            name: "A",
-            product: .framework,
-            settings: .test(base: [
-                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
-            ])
+        #expect(gotTarget.scripts ==
+            [
+                TargetScript(
+                    name: "Copy Module Map",
+                    order: .post,
+                    script: .embedded(
+                        """
+                        set -eu
+                        mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+                        cp -f "\(moduleMapPath.pathString)" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+                        """
+                    ),
+                    inputPaths: [moduleMapPath.pathString],
+                    outputPaths: ["$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Modules/module.modulemap"],
+                    showEnvVarsInLog: false,
+                    basedOnDependencyAnalysis: true
+                ),
+            ]
         )
-        let project = Project.test(
-            path: projectPath,
-            name: "A",
-            targets: [target]
-        )
-
-        // When
-        let (gotGraph, _, _) = try subject.map(
-            graph: .test(workspace: workspace, projects: [projectPath: project]),
-            environment: MapperEnvironment()
-        )
-
-        // Then — the $(SRCROOT)-relative form is preserved so cache hashes are
-        // stable across machines with different checkout paths.
-        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
-        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
-        #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"))
     }
 
     @Test(.inTemporaryDirectory)
@@ -489,6 +475,124 @@ struct ModuleMapMapperTests {
         #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
         #expect(gotTarget.settings?.base["MODULEMAP_PATH"] == .string(moduleMapPath.pathString))
         #expect(gotTarget.scripts.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].script == .embedded(
+            """
+            set -eu
+            mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
+            cp -f "$SRCROOT/Derived/ModuleMaps/A.modulemap" "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
+            """
+        ))
+        #expect(gotTarget.scripts[0].inputPaths == ["$(SRCROOT)/Derived/ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func rewrites_srcroot_relative_derived_framework_modulemap_path_to_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let temporaryPath = try temporaryPath()
+        let projectPath = temporaryPath.appending(components: "tuist-derived", "Projects", "A")
+        let target = Target.test(
+            name: "A",
+            product: .framework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/../../tuist-derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts[0].inputPaths == ["$(PROJECT_DIR)/../../ModuleMaps/A.modulemap"])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func resolves_relative_static_framework_modulemap_path_against_project_directory() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("Modules/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(PROJECT_DIR)/Modules/A.modulemap")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func preserves_srcroot_relative_static_framework_modulemap_path() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap"),
+            ])
+        )
+        let project = Project.test(path: projectPath, name: "A", targets: [target])
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(workspace: workspace, projects: [projectPath: project]),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(
+            gotTarget.settings?.base["MODULEMAP_PATH"] ==
+                .string("$(SRCROOT)/Derived/ModuleMaps/A.modulemap")
+        )
     }
 
     @Test(.inTemporaryDirectory)

--- a/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_appclip/Tuist.swift
@@ -1,6 +1,3 @@
 import ProjectDescription
 
-let config = Config(
-    fullHandle: "tuist/ios_app_with_appclip",
-    url: "https://canary.tuist.dev"
-)
+let config = Config()

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/.gitignore
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/.gitignore
@@ -1,0 +1,57 @@
+### macOS ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+Icon
+
+._*
+
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+xcuserdata/
+
+*.xcscmblueprint
+*.xccheckout
+
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/App/Project.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/App/Project.swift
@@ -1,0 +1,20 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "dev.tuist.ModuleMapPackages",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .external(name: "Gzip"),
+                .external(name: "GEOSwift"),
+                .external(name: "FirebaseMLModelDownloader"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/App/Sources/App.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/App/Sources/App.swift
@@ -1,0 +1,7 @@
+import FirebaseMLModelDownloader
+import GEOSwift
+import Gzip
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {}

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist()

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Tuist/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(baseProductType: .framework)
+#endif
+
+let package = Package(
+    name: "ModuleMapPackages",
+    dependencies: [
+        .package(url: "https://github.com/1024jp/GzipSwift", exact: "6.0.0"),
+        .package(url: "https://github.com/GEOSwift/GEOSwift", exact: "11.2.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "12.6.0"),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_modulemap_packages/Workspace.swift
+++ b/examples/xcode/generated_ios_app_with_modulemap_packages/Workspace.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "ModuleMapPackages", projects: ["App"])


### PR DESCRIPTION
Backports the module-map cache-hash fixes from `main` onto `releases/4.202.x`. Companion to the same backport on `releases/4.203.x` (#12240).

## What changed

Three commits cherry-picked with `-x`, plus one release-line-specific fix:

| upstream | PR |
|---|---|
| `c9dc276cf6` | #12055 — pass framework modulemaps to ExtractAPI |
| `bc4bc71745` | #12137 — restore dynamic framework module map copying |
| `2b020257e2` | #12145 — reanchor module map paths to the generated project |

After this, both `cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift` and `cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift` are byte-identical to `main`.

## Why

`4.201.0` (#11135) started appending a `Copy Module Map` post-action script to every `product == .framework` target carrying a `MODULEMAP_FILE`, and the script body interpolated the **absolute** module map path:

```sh
set -eu
mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules"
cp '/absolute/path/to/checkout/Foo/module.modulemap' "$TARGET_BUILD_DIR/$WRAPPER_NAME/Modules/module.modulemap"
```

`TargetScriptsContentHasher` hashes `script.embeddedScript` verbatim, so the target's binary-cache hash became a function of **where the project was checked out**. The script's `inputPaths` was already emitted project-relative — only the embedded body carried the absolute path.

Binary-cache hashes are supposed to depend only on content and on paths expressed relative to a build-setting macro. On any setup where the checkout path is not byte-stable across runs — ephemeral CI runners, per-job workspace directories, numbered runner slots — the effect is:

1. every framework target with a `MODULEMAP_FILE` re-hashes on each run and can never hit the cache; and
2. because a target's hash feeds its dependents' `dependenciesHash`, the instability cascades to the whole transitive dependent set — targets whose own inputs never changed still miss.

A handful of low-level module-map targets is therefore enough to pull a large fraction of a graph off the cache permanently, while the cache still looks healthy for everything outside that dependent set.

This line is affected: the regression commit `3069e881b2` is present on `releases/4.202.x` and none of the three fixes are. Reproduced against the released `4.202.6` binary (see Validation).

## Conflict resolution

Unlike the 4.203.x backport, `#12055` conflicted here, in `ModuleMapMapper.swift` and `ModuleMapMapperTests.swift`. The cause is benign: this line predates #11646, so its baseline has `cp` where 4.203.x has `cp -f` — and #12055 deletes that entire block regardless. The incoming side was taken for both hunks.

The check on that resolution is not "no markers left" but convergence: both files are now byte-identical to `main`.

## Why these commits rather than a fresh fix

The three upstream commits already solve this and are what has been running on `main`; authoring a separate fix for the release line would diverge the two. They have to travel as a set — #12137 builds on #12055's restructuring, and #12145 completes it by reanchoring `MODULEMAP_FILE` values that are *already* absolute, which #12137 on its own passed through untouched.

## The fourth commit

`#12055` changes `BuildAcceptanceTests` to use `CommandRunner`, so `TuistAutomationAcceptanceTests` needs `Command` declared explicitly or `tuist inspect dependencies --only implicit` fails the lint job. On `main` that declaration arrived with a server-scoped commit (#11968) that is otherwise irrelevant to a CLI release line, so only the single dependency is added here rather than cherry-picking that commit.

Note `Module.swift` does **not** become identical to `main` — that file has diverged substantially on this line. Only the one `Command` external is added.

## Impact

Affects 4.201.0 through 4.203.x. No stable release currently carries the fix. Projects with framework targets that set `MODULEMAP_FILE` regain stable, location-independent hashes; there is no change for projects without such targets.

The first run after upgrading will still re-hash those targets once — the hash value legitimately changes — and then stabilise.

## Validation

Ran on this branch, on macOS with Xcode 26.3:

- `ModuleMapMapper.swift` and `ModuleMapMapperTests.swift` diffs against `origin/main`: **empty**.
- `tuist inspect dependencies --only implicit` → clean.
- `swiftformat cli/ app/ --lint` → 0/1843 files require formatting.
- `swiftlint cli/Sources` → 0 errors; `swiftlint cli/Tests --only-rule no_fatal_error_in_tests` → clean.
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist` → **BUILD SUCCEEDED** (confirms the cherry-picks compile against this older tree, which a resolved cherry-pick alone does not guarantee).
- `xcodebuild test -only-testing TuistGeneratorTests/ModuleMapMapperTests` → **TEST SUCCEEDED**, 19 tests.
- End-to-end fixture repro: two byte-identical generated projects scaffolded at two different absolute paths, comparing `tuist hash cache` output. The fixture is a framework target with a custom `MODULEMAP_FILE`, a framework that depends on it, and a control framework with no module map anywhere in its closure.

| binary | module-map target | its dependent | control target | result |
|---|---|---|---|---|
| released `4.202.6` | **moved** | **moved** | stable | FAIL — regression confirmed on this line |
| **this branch** | stable | stable | stable | **PASS** |

`Package.resolved` is deliberately untouched; local `tuist install` churn on it was reverted, since that file breaking on a release line previously needed a dedicated repair (#12159).

## Not covered here

Acceptance tests were not run locally. This backport touches `BuildAcceptanceTests` and `GenerateAcceptanceTests` and adds the `generated_ios_app_with_modulemap_packages` example, which resolves third-party packages — those need the full acceptance job in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
