### PR TITLE
fix(server): discard build jobs for deleted projects

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -59,6 +59,10 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
           _ -> :ok
         end
 
+      {:error, :project_not_found} ->
+        Logger.warning("Build processing skipped: project #{project_id} not found for build #{build_id}")
+        {:discard, :project_not_found}
+
       {:error, reason} ->
         if attempt >= max_attempts do
           Logger.error("Build processing failed permanently for build #{build_id}: #{inspect(reason)}")

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -192,17 +192,15 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
-    test "marks build as failed when project is not found on final attempt", %{
+    test "discards the job when the project is not found", %{
       account: account,
       build: build
     } do
-      expect(Tuist.Builds, :create_build, fn attrs ->
-        assert attrs.status == "failed_processing"
-        {:ok, %{id: build.id}}
-      end)
+      reject(&Tuist.Builds.create_build/1)
+      reject(&Tuist.Storage.download_to_file/3)
 
-      assert {:error, :project_not_found} =
-               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, "999999"), 3, 3))
+      assert {:discard, :project_not_found} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, "999999")))
     end
   end
 


### PR DESCRIPTION
Related: [TUIST-100](https://tuist.sentry.io/issues/TUIST-100)

> Discard build-processing jobs when the project has already been deleted.

The project can be removed by an automated test immediately after its build upload completes. The processor then cannot resolve the project, but previously treated that permanent condition as retryable and emitted an error for every attempt. The worker now records a warning and discards the job without downloading the artifact or marking the build as failed.

### How to test locally

- `mix format lib/tuist/builds/workers/process_build_worker.ex test/tuist/builds/workers/process_build_worker_test.exs`
- `git diff --check`
- Attempted `mix test test/tuist/builds/workers/process_build_worker_test.exs`; local ClickHouse setup is missing the `build_runs` table, so the test database migration could not complete.
