### PR TITLE
chore(cli): update Tuist CLI to 4.204.0-canary.10

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -574,32 +574,32 @@ url = "https://github.com/realm/SwiftLint/releases/download/0.59.1/portable_swif
 url = "https://github.com/realm/SwiftLint/releases/download/0.59.1/portable_swiftlint.zip"
 
 [[tools.tuist]]
-version = "4.204.0-canary.2"
+version = "4.204.0-canary.10"
 backend = "aqua:tuist/tuist"
 
 [tools.tuist."platforms.linux-arm64"]
-checksum = "sha256:7187f56b952e0da9308d8381c41d0dd1634a34de6b08b18d2486d6a03c59c0c5"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist-linux-aarch64.tar.gz"
+checksum = "sha256:6b37921092907af2c1b9114a8fb96da107efbe44e7103077ff4f61f7af329943"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist-linux-aarch64.tar.gz"
 
 [tools.tuist."platforms.linux-arm64-musl"]
-checksum = "sha256:7187f56b952e0da9308d8381c41d0dd1634a34de6b08b18d2486d6a03c59c0c5"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist-linux-aarch64.tar.gz"
+checksum = "sha256:6b37921092907af2c1b9114a8fb96da107efbe44e7103077ff4f61f7af329943"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist-linux-aarch64.tar.gz"
 
 [tools.tuist."platforms.linux-x64"]
-checksum = "sha256:060f4abfaa19936f8379fc330d5eff6bae1876492ce804151b69b385a11d1e4a"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist-linux-x86_64.tar.gz"
+checksum = "sha256:729e3afe524a13746bd76f81827544ea236a7ad35deeab84e541cc91b78307c0"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist-linux-x86_64.tar.gz"
 
 [tools.tuist."platforms.linux-x64-musl"]
-checksum = "sha256:060f4abfaa19936f8379fc330d5eff6bae1876492ce804151b69b385a11d1e4a"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist-linux-x86_64.tar.gz"
+checksum = "sha256:729e3afe524a13746bd76f81827544ea236a7ad35deeab84e541cc91b78307c0"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist-linux-x86_64.tar.gz"
 
 [tools.tuist."platforms.macos-arm64"]
-checksum = "sha256:2c7d2401d53f2a282f50b71e44e705f85a3353c306791ef19326b7b4a9374a12"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist.zip"
+checksum = "sha256:4a803bfd4799d9bf96b9832c9180eef4a18d7b88386dcb74345489cb6ab352e9"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist.zip"
 
 [tools.tuist."platforms.macos-x64"]
-checksum = "sha256:2c7d2401d53f2a282f50b71e44e705f85a3353c306791ef19326b7b4a9374a12"
-url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.2/tuist.zip"
+checksum = "sha256:4a803bfd4799d9bf96b9832c9180eef4a18d7b88386dcb74345489cb6ab352e9"
+url = "https://github.com/tuist/tuist/releases/download/4.204.0-canary.10/tuist.zip"
 
 [[tools.xcodes]]
 version = "1.6.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
     aube = "1.6.2"
     # Auto-bumped to the latest Tuist CLI release (incl. canary) by the update-tuist-cli workflow.
-    tuist = "4.204.0-canary.2"
+    tuist = "4.204.0-canary.10"
     swiftlint = "0.59.1"
     "elixir" = "1.20.2"
     "erlang" = "29.0.3"


### PR DESCRIPTION
## What changed

Bumps the `tuist` dev-tooling pin in `mise.toml` from `4.204.0-canary.2` to `4.204.0-canary.10`, and regenerates the `[[tools.tuist]]` entry in `mise.lock` (version plus the six per-platform checksums and URLs) in the same commit.

## Why

The pin had drifted several canaries behind the latest release, so local development and CI ran an older CLI than the one we ship. The `update-tuist-cli` workflow normally owns this bump on an hourly schedule; this is the same change made by hand.

## Notes on the diff

`mise.lock` must be regenerated in the same commit, because CI installs with `MISE_LOCKED=1` and a pin without a matching lock entry fails to resolve.

The lock was regenerated with a local mise 2026.7.0, which is newer than the 2026.5.15 the workflow pins. That version additionally writes `url_api` keys on each platform block and unrelated `[tools.erlang.options]` / `[tools.java.options]` blocks. Those five additions were removed so the diff touches only the tuist entry and keeps the exact shape the workflow produces (13 insertions / 13 deletions).

## Impact

Contributors and CI pick up `4.204.0-canary.10` on the next `mise install`. No product code changes.

## Validation

- `MISE_LOCKED=1 mise install tuist` resolves with no lockfile complaint for `tuist`.
- `mise exec -- tuist version` in the repo reports `4.204.0-canary.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)