### PR TITLE
fix(cache): always track CAS artifact metadata so eviction can reclaim disk

### DIFF
--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -153,6 +153,15 @@ defmodule Cache.Config do
 
   def server_url, do: Application.get_env(:cache, :server_url)
 
+  @doc """
+  Gates the Xcode key-value database (`Cache.KeyValueRepo`) and the S3 transfer
+  enqueues for Xcode CAS artifacts.
+
+  It must never gate `Cache.CacheArtifacts.track_artifact_access/1`:
+  `Cache.DiskEvictionWorker` evicts only keys that have a `cache_artifacts` row,
+  so artifacts written while tracking is off are invisible to eviction and the
+  storage volume fills up (only the rate-limited orphan scan can reclaim them).
+  """
   def xcode_database_interactions_enabled? do
     Application.get_env(:cache, :xcode_database_interactions_enabled, true)
   end

--- a/cache/lib/cache_web/controllers/xcode_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_controller.ex
@@ -55,7 +55,7 @@ defmodule CacheWeb.XcodeController do
   def download(conn, %{id: id, account_handle: account_handle, project_handle: project_handle}) do
     :telemetry.execute([:cache, :xcode, :download, :request], %{}, %{})
     key = Xcode.Disk.key(account_handle, project_handle, id)
-    track_artifact_access(key)
+    :ok = CacheArtifacts.track_artifact_access(key)
 
     case Xcode.Disk.stat(account_handle, project_handle, id) do
       {:ok, %File.Stat{size: size}} ->
@@ -190,7 +190,7 @@ defmodule CacheWeb.XcodeController do
         })
 
         key = Xcode.Disk.key(account_handle, project_handle, id)
-        track_artifact_access(key)
+        :ok = CacheArtifacts.track_artifact_access(key)
         enqueue_xcode_upload_if_missing(account_handle, project_handle, key)
         send_resp(conn, :no_content, "")
 
@@ -214,14 +214,6 @@ defmodule CacheWeb.XcodeController do
 
   defp cleanup_tmp_file({:file, tmp_path}), do: File.rm(tmp_path)
   defp cleanup_tmp_file(_binary_data), do: :ok
-
-  defp track_artifact_access(key) do
-    if Config.xcode_database_interactions_enabled?() do
-      :ok = CacheArtifacts.track_artifact_access(key)
-    end
-
-    :ok
-  end
 
   defp enqueue_xcode_download(account_handle, project_handle, key) do
     if Config.xcode_database_interactions_enabled?() do

--- a/cache/lib/cache_web/controllers/xcode_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_controller.ex
@@ -55,6 +55,11 @@ defmodule CacheWeb.XcodeController do
   def download(conn, %{id: id, account_handle: account_handle, project_handle: project_handle}) do
     :telemetry.execute([:cache, :xcode, :download, :request], %{}, %{})
     key = Xcode.Disk.key(account_handle, project_handle, id)
+
+    # Tracked before the stat on purpose: on a miss, enqueue_xcode_download/3 may
+    # hydrate the file from S3 outside this request, and the row created here is
+    # what keeps the hydrated file visible to eviction and safe from the orphan
+    # scan. Moving this into the hit branch would orphan hydrated artifacts.
     :ok = CacheArtifacts.track_artifact_access(key)
 
     case Xcode.Disk.stat(account_handle, project_handle, id) do

--- a/cache/test/cache_web/controllers/xcode_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_controller_test.exs
@@ -476,6 +476,9 @@ defmodule CacheWeb.XcodeControllerTest do
       assert conn.resp_body == ""
     end
 
+    # Deliberately mock-identical to the flag-on local-hit test above: it pins
+    # that tracking stays ungated when the flag is off, which is the regression
+    # #12252 fixed. Do not remove it as a duplicate.
     test "tracks artifact access when serving a local file with Xcode database interactions disabled", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"

--- a/cache/test/cache_web/controllers/xcode_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_controller_test.exs
@@ -78,20 +78,21 @@ defmodule CacheWeb.XcodeControllerTest do
       assert upload.key == key
     end
 
-    test "saves artifact without metadata or S3 transfer DB writes when Xcode database interactions are disabled", %{
+    test "tracks artifact access but skips the S3 upload enqueue when Xcode database interactions are disabled", %{
       conn: conn
     } do
       account_handle = "test-account"
       project_handle = "test-project"
       id = "abc123"
       body = "test artifact content"
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
       end)
 
-      expect(Cache.Config, :xcode_database_interactions_enabled?, 2, fn -> false end)
-      reject(CacheArtifacts, :track_artifact_access, 1)
+      stub(Cache.Config, :xcode_database_interactions_enabled?, fn -> false end)
+      expect(CacheArtifacts, :track_artifact_access, fn ^key -> :ok end)
       reject(S3Transfers, :enqueue_upload_if_missing, 4)
 
       Xcode.Disk
@@ -475,17 +476,18 @@ defmodule CacheWeb.XcodeControllerTest do
       assert conn.resp_body == ""
     end
 
-    test "returns local file without tracking metadata when Xcode database interactions are disabled", %{conn: conn} do
+    test "tracks artifact access when serving a local file with Xcode database interactions disabled", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"
       id = "abc123"
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
       end)
 
-      expect(Cache.Config, :xcode_database_interactions_enabled?, fn -> false end)
-      reject(CacheArtifacts, :track_artifact_access, 1)
+      stub(Cache.Config, :xcode_database_interactions_enabled?, fn -> false end)
+      expect(CacheArtifacts, :track_artifact_access, fn ^key -> :ok end)
 
       expect(Xcode.Disk, :stat, fn ^account_handle, ^project_handle, ^id ->
         {:ok, %File.Stat{size: 1024, type: :regular}}
@@ -543,19 +545,20 @@ defmodule CacheWeb.XcodeControllerTest do
       assert conn.resp_body == ""
     end
 
-    test "returns remote redirect without transfer queue writes when Xcode database interactions are disabled", %{
+    test "tracks artifact access but skips the S3 download enqueue when Xcode database interactions are disabled", %{
       conn: conn
     } do
       account_handle = "test-account"
       project_handle = "test-project"
       id = "abc123"
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
       end)
 
-      expect(Cache.Config, :xcode_database_interactions_enabled?, 2, fn -> false end)
-      reject(CacheArtifacts, :track_artifact_access, 1)
+      stub(Cache.Config, :xcode_database_interactions_enabled?, fn -> false end)
+      expect(CacheArtifacts, :track_artifact_access, fn ^key -> :ok end)
       reject(S3Transfers, :enqueue_xcode_download, 3)
 
       expect(Xcode.Disk, :stat, fn ^account_handle, ^project_handle, ^id ->


### PR DESCRIPTION
## What changed

The two `CacheArtifacts.track_artifact_access/1` calls in `CacheWeb.XcodeController` are
unconditional again, exactly as they were before #11153. The private wrapper that held the
flag check is gone. `Cache.Config.xcode_database_interactions_enabled?/0` now carries a doc
that states its scope: it gates the `KeyValueRepo` and the Xcode S3 transfer enqueues, and
it must never gate artifact tracking.

The flag keeps gating everything it was introduced for in #11153 — the `KeyValueRepo`
interactions, the `/up` healthcheck repo set, and the two S3 mirroring enqueues
(`enqueue_xcode_download`, `enqueue_upload_if_missing`). Only the eviction bookkeeping
comes back out from under it.

## Why

`cache-eu-central.tuist.dev` is at 100% on `/cas` — 0 bytes free of 483.77 GB — and has
been growing monotonically since 2026-08-03. Resizing the volume twice (241.6 → 386.9 →
483.8 GB) did not hold; usage reached 100% each time. The growth is unbounded, not a
sizing problem.

### Root cause

`Cache.DiskEvictionWorker` evicts strictly from `CacheArtifacts.oldest/1`. An artifact
with no `cache_artifacts` row cannot be evicted, and the worker has no fallback to disk
truth.

`XCODE_DATABASE_INTERACTIONS_ENABLED` is `"false"` in `cache/config/deploy.production.yml`,
so `track_artifact_access/1` was a no-op on the Xcode CAS path — the busiest write path on
these nodes. Every object it wrote was invisible to eviction.

The only remaining reclaim path is `Cache.OrphanCleanupWorker`, hard-capped at 50
directories per hourly run (`@default_orphan_scan_max_dirs`, no environment override). CAS
keys shard as `{account}/{project}/xcode/{AB}/{CD}/`, up to 65,536 leaf directories per
project, so a single full pass over the current file count needs well over a year.

### Production evidence

- Every 10 minutes, 144 times a day since 2026-08-03 18:00 UTC:
  `Disk usage 100.00% exceeded 75.00% but no CAS metadata entries were available for eviction`
- Successful evictions in the last 24 hours: zero. Note the worker prints no summary when
  it exhausts the table, so the missing summary is itself the signal.
- `Orphan scan: scanned 50 directories, checked 955 files, deleted 955 orphans freeing
  38.03 MB` — a 100% orphan rate, i.e. nothing on disk is tracked, and about 1 GB/day of
  reclaim against roughly 60 GB/day of ingest.
- Inode count on `/cas` left a stable 6.6M and reached 12.2M.
- Before the break, usage held a clean sawtooth between 155 and 190 GB — exactly the 60%
  and 75% band of the then 241.6 GB volume. Eviction worked correctly until it lost its
  metadata.

The `cache_artifacts` buffer itself is healthy: `Flushing N row(s) from cache_artifacts
(artifact_accesses)` still appears at hundreds per minute from the gradle, module and
registry paths, which never stopped tracking. The table is not broken — it is drained every
cycle and refilled by everything except CAS.

## Why this approach

The obvious alternative is flipping `XCODE_DATABASE_INTERACTIONS_ENABLED` back to `true`.
That was rejected: the same flag re-enables `enqueue_xcode_download` and
`enqueue_upload_if_missing`, restoring S3 mirroring for the Xcode cache, which was turned
off deliberately. The two concerns were conflated in one flag. Eviction bookkeeping writes
to `Cache.Repo` — a database the node already uses unconditionally for Oban and for the
other cache domains — so it never belonged behind a flag whose subject is the
`KeyValueRepo` and S3.

The tracking write is an ETS insert (`Cache.SQLiteBuffer`); the SQLite write happens on
the background flush, so the hot-path cost the flag was added to remove is not
reintroduced on the request path.

## Impact

New CAS writes become evictable immediately, which restores the 60–75% watermark loop the
nodes ran on for months.

**This does not recover the existing backlog.** The objects already on disk stay untracked
and are still reachable only by the orphan scan, so the affected hosts need a manual sweep
of the CAS trees, or a raised orphan-scan cap, before they drop below the watermark.

Follow-ups worth doing separately, not in this PR:
- Give `DiskEvictionWorker` an mtime-ordered disk fallback for when the table is exhausted.
- Make the orphan-scan cap pressure-aware and configurable by environment.
- Alert on the warning line, or on `/cas` above 90%. It repeated every 10 minutes for a
  week with no alarm.

## Validation

- `mix test` — 535 passed.
- `mix test test/cache_web/controllers/xcode_controller_test.exs` — 20 passed.
- `mix format --check-formatted` on all three changed files.
- `mix credo --strict` — no issues across 139 files.

The three tests that asserted the artifact was *not* tracked while the flag is off now
assert the opposite, pinning the exact sharded key with a pin match. They still assert
that the S3 transfer enqueues stay suppressed, which is what the flag is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
