### PR TITLE
fix(server): resolve a build run's command by earliest event

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -502,10 +502,14 @@ defmodule Tuist.CommandEvents do
   end
 
   # Multiple rows may share the same build_run_id because the ID is derived
-  # from the `.xcactivitylog`. In a split test run, the test execution event
+  # from the `.xcactivitylog`. In a split test run, every test execution event
   # intentionally reuses the build phase's ID to link its test report to the
   # build. Prefer the event without a test run so build details retain the
-  # command that produced the build.
+  # command that produced the build, then fall back to the earliest event:
+  # whichever command produced the activity log necessarily ran before anything
+  # that reuses its ID. The fallback carries the decision on its own whenever
+  # `test_run_id` is absent, which is the case for a test execution whose
+  # xcresult upload never completed.
   #
   # Pass `project_id:` when known so the lookup hits the
   # `(project_id, name, ran_at)` primary key instead of relying solely on
@@ -516,7 +520,7 @@ defmodule Tuist.CommandEvents do
     Event
     |> scope_to_project(project_id)
     |> where([e], e.build_run_id == ^build_run_id)
-    |> order_by([e], desc: is_nil(e.test_run_id), desc: e.ran_at, desc: e.created_at)
+    |> order_by([e], desc: is_nil(e.test_run_id), asc: e.ran_at, asc: e.created_at)
     |> limit(1)
     |> ClickHouseRepo.one()
     |> case do

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1505,6 +1505,38 @@ defmodule Tuist.CommandEventsTest do
       assert {:ok, event} = got
       assert event.id == build_event.id
     end
+
+    test "prefers the build event when the sharded test events carry no test run id" do
+      # Given
+      build_run_id = UUIDv7.generate()
+
+      build_event =
+        CommandEventsFixtures.command_event_fixture(
+          build_run_id: build_run_id,
+          command_arguments: ["test", "--build-only", "--shard-granularity", "suite"],
+          ran_at: ~U[2024-01-01 10:00:00Z]
+        )
+
+      for shard_index <- 0..3 do
+        CommandEventsFixtures.command_event_fixture(
+          build_run_id: build_run_id,
+          command_arguments: [
+            "test",
+            "--without-building",
+            "--shard-index",
+            to_string(shard_index)
+          ],
+          ran_at: ~U[2024-01-01 10:05:00Z]
+        )
+      end
+
+      # When
+      got = CommandEvents.get_command_event_by_build_run_id(build_run_id)
+
+      # Then
+      assert {:ok, event} = got
+      assert event.id == build_event.id
+    end
   end
 
   describe "cache_hit_rate_period_percentile/4" do


### PR DESCRIPTION
A build run page could show the command of a sharded test execution instead of the command that produced the build. Reported by a customer running split `--build-only` + sharded `--without-building` jobs, who still saw the test command on their build run URL after #12143 shipped.

### Root cause

Every `test --without-building` shard reuses the build phase's `build_run_id` so its test report links back to the build (`RunMetadataStorage.restoreMetadata`). A build run therefore routinely has many command events — one for the build, one per shard.

#12143 broke that tie by preferring the event with no `test_run_id`. That signal turns out to be structurally insufficient, because plenty of test executions have no test run either:

- `--inspect-mode off` never creates a test run at all, by design.
- A test execution whose xcresult upload fails leaves `testRunId` unset (the CLI only assigns it after a successful `uploadResultBundle`).

When every candidate is NULL the tie-breaker is inert and the ordering collapses to `ran_at DESC`, so a shard wins again. That is exactly the reported case: all of the customer's shard events carry `test_run_id = NULL`.

### What changed

Fall back to the *earliest* event rather than the most recent. Whichever command produced the `.xcactivitylog` necessarily ran before anything that reuses its ID, so the fallback resolves the ordering on its own without depending on a nullable column.

The `test_run_id` preference stays in front of it as the explicit signal when present, so #12143's behaviour is unchanged wherever it already worked.

This also matches the scenario the function was originally written for — a second `tuist test` that short-circuits before building and picks up the previous activity log. There too, the event that actually produced the build is the earlier one. The previous `desc: ran_at` was a stated placeholder ("until we can source the build_run_id independently of the activity log"), not a considered preference.

### Why not the alternatives

- *Stop stamping `build_run_id` onto shard test-execution events.* Cleaner in principle, but it needs a CLI release, does nothing for existing rows, and does nothing for anyone on an older CLI. The linkage the product actually needs already lives on `test_runs.build_run_id`, so this stays open as a possible follow-up.
- *Sniff `command_arguments` for `--build-only` / `--without-building`.* Fragile, and does not generalise across `tuist test` and `tuist xcodebuild`.

### Impact

Build run pages now show the command that produced the build rather than a shard's test command. Verified against production over ~2.5 days: 549 build runs change their resolved event, 451 of which previously surfaced a `--without-building` command.

Note this fixes only the command shown on the build run. Two related issues found while investigating are **not** addressed here: the Selective Tests tab is hidden on sharded test runs (`test_run_live.ex` skips the command-event lookup when `shard_plan_id` is set, which needs a real correlation model since a sharded run has N events), and `@suite_catch_all_minimum_cli_version` in `shards_controller.ex` is still `4.202.0-canary.21` when the `tuist test` path only applies the catch-all skip list from canary.26.

### How to test locally

```bash
cd server && mix test test/tuist/command_events_test.exs --only describe:"get_command_event_by_build_run_id/1"
```

The added test builds the reported shape — one `--build-only` event plus four `--without-building` shard events, all with `test_run_id` NULL. It fails under the old ordering (returns a shard event) and passes under the new one. #12143's existing test still passes, confirming the `test_run_id` preference is intact.

To check the resolved event by hand, open any build run page for a project using split build/test sharding and confirm the command shown is the `--build-only` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
