### PR TITLE
ci(infra): move release and deploy jobs back to Tuist runners

### DIFF
--- a/.github/workflows/linux-runner-image.yml
+++ b/.github/workflows/linux-runner-image.yml
@@ -45,10 +45,7 @@ env:
 jobs:
   build:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
-    # GitHub-hosted: this workflow validates and bump-tests the image the
-    # tuist-linux runners boot from, so it must stay runnable when the fleet
-    # is stuck on a retired actions/runner version.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -422,10 +422,7 @@ jobs:
     needs: [build, guard_production_source]
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && needs.guard_production_source.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # GitHub-hosted: cluster access comes from the 1P kubeconfig, not the
-    # runner's network, and the deploy path must stay runnable when the
-    # Tuist runner fleet is down — it's how the fleet gets repaired.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -493,8 +490,7 @@ jobs:
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: [build, guard_production_source]
     if: always() && needs.guard_production_source.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # GitHub-hosted: same reasoning as observability-install.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -573,8 +569,7 @@ jobs:
     name: Platform chart (${{ inputs.environment }})
     needs: [build, guard_production_source]
     if: always() && needs.guard_production_source.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # GitHub-hosted: same reasoning as observability-install.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -648,10 +643,7 @@ jobs:
     # platform settings (including CNPG CRDs the Tuist chart consumes for
     # the in-cluster Postgres rollout) land before the app chart upgrade.
     if: always() && needs.guard_production_source.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-kura-runtime.result == 'success' || needs.build-kura-runtime.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
-    # GitHub-hosted: same reasoning as observability-install. Note
-    # build-kura-runtime stays on tuist-linux (persistent Bazel cache);
-    # it only runs on fresh staging builds, never on the recovery path.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
       url: https://${{ inputs.environment == 'production' && 'tuist.dev' || format('{0}.tuist.dev', inputs.environment) }}

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -72,10 +72,7 @@ env:
 jobs:
   check-releases:
     name: Check for releasable changes
-    # GitHub-hosted: this job gates the runner-image release jobs, so it must
-    # not itself depend on a Tuist runner — a fleet stuck on a retired
-    # actions/runner version could never release the image that fixes it.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 5
     # release:check only needs the git-cliff + jq installed below, but `mise run`
     # otherwise auto-installs the whole merged mise.toml toolset — including
@@ -1226,10 +1223,7 @@ jobs:
     name: Release Linux runner image
     needs: check-releases
     if: needs.check-releases.outputs.linux-runner-image-should-release == 'true'
-    # GitHub-hosted: this job builds the image the tuist-linux runners boot
-    # from, so running it on tuist-linux is a bootstrap cycle when the fleet
-    # is on a retired actions/runner version.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1343,9 +1337,7 @@ jobs:
         needs.check-releases.outputs.runner-image-should-release == 'true' ||
         needs.check-releases.outputs.linux-runner-image-should-release == 'true'
       )
-    # GitHub-hosted: publishes the releases the runner fleet recovery depends
-    # on, so it can't wait on a Tuist runner slot.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 30
     concurrency:
       group: publish-releases-${{ github.run_id }}
@@ -1677,9 +1669,7 @@ jobs:
     # Runs whenever the gate computed, regardless of which (if any) image
     # released; tag_release no-ops the components that didn't.
     if: always() && needs.check-releases.result == 'success'
-    # GitHub-hosted: pushes the tags server-deployment.yml resolves image
-    # versions from, so it can't wait on a Tuist runner slot.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 10
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

Reverts the three `runs-on: ubuntu-latest` flips that shipped as part of the actions/runner 2.336.0 recovery (#12253), returning nine jobs to `tuist-linux`:

- `server-production-deployment.yml`: `check-releases`, `release-linux-runner-image`, `publish-releases`, `tag-infra-releases`
- `linux-runner-image.yml`: `build` (PR validation + dispatch)
- `server-deployment.yml`: `observability-install`, `tailscale-operator-install`, `platform-install`, `deploy`

## Why

The flips existed to break a bootstrap cycle: during the 2026-08-10 incident, GitHub retired runner 2.334.0 and refused work from the entire Tuist fleet, and the jobs that release the fixed runner image were themselves pinned to that fleet. The fleet now runs released 2.336.0 images everywhere (`linux-runner-image@0.7.1`, `runner-image@0.13.1`), so the recovery constraint no longer applies day-to-day and these jobs can go back to dogfooding Tuist runners.

## Trade-off to weigh before merging

Merging this recreates the bootstrap cycle for the next runner-version retirement: if the fleet ever pins a retired `actions/runner` again, the release and deploy paths hang with it, and recovery again requires editing `runs-on` under incident pressure. The #12253 Renovate changes (dependency dashboard, `prPriority` on `actions/runner` bumps) make a stale pin much less likely, but the structural cycle returns with this revert.

An alternative worth considering in review: keep the cluster-touching deploy jobs and the heavier CI on `tuist-linux`, but leave the small release-gate jobs (`check-releases`, `release-linux-runner-image`, `publish-releases`, `tag-infra-releases`) hosted — they are minutes of `ubuntu-latest` per release and they are exactly the jobs a wedged fleet needs.

## Validation

- `git revert` of the three flip commits applied cleanly; no other changes ride along.
- `actionlint` reports only the pre-existing custom-label warnings for `tuist-linux`/`tuist-macos` that predate the incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)