### PR TITLE
fix(linux-runner-image): install the Android SDK so release-android can build on the fleet

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -207,15 +207,11 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-  # This job stays on a GitHub-hosted runner: gradle needs the Android SDK
-  # (ANDROID_HOME), which the hosted image pre-installs but the in-house
-  # tuist-linux runner image does not. Moving it onto the fleet needs the SDK
-  # baked into that image first.
   release-android:
     name: Release Android App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -207,12 +207,22 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+  # This job stays on a GitHub-hosted runner: gradle needs the Android SDK
+  # (ANDROID_HOME), which the hosted image pre-installs but the in-house
+  # tuist-linux runner image does not. Moving it onto the fleet needs the SDK
+  # baked into that image first.
   release-android:
     name: Release Android App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: tuist-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     steps:
@@ -223,9 +233,13 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "--locked java gradle 1password-cli"
+          install_args: "--locked java gradle 1password-cli tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
+
+      - name: Authenticate with Tuist
+        working-directory: android
+        run: tuist auth login
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -83,11 +83,23 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   `platform_min_version` / `build_tools_min_version`. Do NOT
   re-pin these to whatever `android/` happens to target; that
   breaks any customer on a newer platform.
-  No NDK is installed. It is the bulk of the hosted image's
-  Android footprint (three majors, roughly 10GB expanded) and only
-  native-code builds need it. `cmdline-tools` ships in the image,
-  so a workflow that needs it can `sdkmanager ndk;<version>`;
-  revisit baking it in if that becomes common.
+  No NDK is installed, and that is a standing decision rather than
+  a gap to close. It is the bulk of the hosted image's Android
+  footprint (three majors, roughly 10GB expanded) and only
+  native-code builds need it — a pure Kotlin/Java app never
+  touches it. Heavy toolchains that serve a minority of jobs
+  belong in per-account cache volumes, not in an image every job
+  on the fleet pulls. Note that those are macOS-only today
+  (`runnerCacheVolume` provisions APFS volumes on Mac minis via
+  tart-kubelet); until the Linux fleet has an equivalent, a
+  workflow that needs the NDK installs it per job with
+  `$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager ndk;<version>`,
+  which works because cmdline-tools ships here and the licenses are
+  already accepted.
+  `ANDROID_NDK_HOME` and its siblings are deliberately left unset.
+  The hosted image sets them, and customer builds do read them, but
+  a variable pointing at an NDK that is not installed fails deep
+  inside CMake instead of failing fast.
   Resolved in the `android-sdk` builder stage (sdkmanager needs a
   JVM) so no JDK lands in the final image — workflow steps get
   theirs from mise.

--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -72,16 +72,25 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   and `ANDROID_SDK_ROOT` exported. Same path and same
   bake-it-into-the-image posture as GitHub's hosted Ubuntu image,
   because Gradle cannot even configure an Android project without
-  a platform + build-tools ("SDK location not found"). Scoped to
-  the single platform and build-tools release `android/` builds
-  against, with no NDK — the hosted image carries every platform
-  from android-34 up plus three NDK majors, which is the bulk of
-  its Android footprint. The versions are `--build-arg`s and must
-  track `compileSdk` / `targetSdk` in
-  `android/app/build.gradle.kts`; a bump there without a bump here
-  fails the release job at Gradle configuration. Resolved in the
-  `android-sdk` builder stage (sdkmanager needs a JVM) so no JDK
-  lands in the final image — workflow steps get theirs from mise.
+  a platform + build-tools ("SDK location not found"). Platforms
+  and build-tools are selected by a version FLOOR
+  (`ANDROID_PLATFORM_MIN_VERSION` / `ANDROID_BUILD_TOOLS_MIN_VERSION`
+  build-args), not pinned: this image runs customer workflows, so
+  it cannot assume anyone's `compileSdk`. Everything Google
+  publishes at or above the floor is installed, which means new
+  platforms roll in on the next image rebuild with no version bump
+  anywhere — the same approach the hosted image takes with
+  `platform_min_version` / `build_tools_min_version`. Do NOT
+  re-pin these to whatever `android/` happens to target; that
+  breaks any customer on a newer platform.
+  No NDK is installed. It is the bulk of the hosted image's
+  Android footprint (three majors, roughly 10GB expanded) and only
+  native-code builds need it. `cmdline-tools` ships in the image,
+  so a workflow that needs it can `sdkmanager ndk;<version>`;
+  revisit baking it in if that becomes common.
+  Resolved in the `android-sdk` builder stage (sdkmanager needs a
+  JVM) so no JDK lands in the final image — workflow steps get
+  theirs from mise.
 
 No `inject-env.sh`, no launchd plist, no VM-halt trap — kubelet
 projects env + SA token natively, container exit IS the

--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -68,6 +68,20 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   attached to the same Pod by the runners-controller. The
   runner's `docker` group is pinned to GID 123 to match the
   socket GID dockerd creates in the sidecar.
+- `/usr/local/lib/android/sdk` — Android SDK, with `ANDROID_HOME`
+  and `ANDROID_SDK_ROOT` exported. Same path and same
+  bake-it-into-the-image posture as GitHub's hosted Ubuntu image,
+  because Gradle cannot even configure an Android project without
+  a platform + build-tools ("SDK location not found"). Scoped to
+  the single platform and build-tools release `android/` builds
+  against, with no NDK — the hosted image carries every platform
+  from android-34 up plus three NDK majors, which is the bulk of
+  its Android footprint. The versions are `--build-arg`s and must
+  track `compileSdk` / `targetSdk` in
+  `android/app/build.gradle.kts`; a bump there without a bump here
+  fails the release job at Gradle configuration. Resolved in the
+  `android-sdk` builder stage (sdkmanager needs a JVM) so no JDK
+  lands in the final image — workflow steps get theirs from mise.
 
 No `inject-env.sh`, no launchd plist, no VM-halt trap — kubelet
 projects env + SA token natively, container exit IS the

--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -36,6 +36,55 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /out/runner-shell-agent ./cmd/runner-shell-agent
 
+# Android SDK resolver. sdkmanager is a JVM tool, so it runs here in a
+# JDK stage and only the resolved SDK is copied into the final image —
+# workflow steps bring their own JDK via mise, so the runner image
+# itself stays JDK-free.
+#
+# Versions are pinned rather than tracking "latest": they must match
+# what `android/app/build.gradle.kts` builds against, so bump them
+# alongside `compileSdk` / `targetSdk` there. The cmdline-tools archive
+# is fetched straight from Google because sdkmanager is what installs
+# every other component (it cannot install itself).
+#
+# cmdline-tools is held at the release GitHub's hosted image pins.
+# sdkmanager stamps a schema version into each installed package's
+# package.xml, and current cmdline-tools writes v4 while AGP 8.7.3
+# only parses up to v3 — which makes every Gradle invocation warn
+# about the skew. Bump this in step with AGP, not ahead of it.
+FROM eclipse-temurin:21-jdk-jammy AS android-sdk
+
+ARG ANDROID_CMDLINE_TOOLS_ARCHIVE=commandlinetools-linux-11076708_latest.zip
+ARG ANDROID_PLATFORM_VERSION=35
+ARG ANDROID_BUILD_TOOLS_VERSION=35.0.1
+
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" \
+    && curl -fSL "https://dl.google.com/android/repository/${ANDROID_CMDLINE_TOOLS_ARCHIVE}" \
+         -o /tmp/cmdline-tools.zip \
+    && unzip -qq /tmp/cmdline-tools.zip -d "${ANDROID_SDK_ROOT}/cmdline-tools" \
+    && rm /tmp/cmdline-tools.zip \
+    # sdkmanager only resolves ANDROID_SDK_ROOT when it sits at
+    # cmdline-tools/latest; the archive unpacks to cmdline-tools/.
+    && mv "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest" \
+    # Licenses are accepted at build time. Without the hashes under
+    # $ANDROID_SDK_ROOT/licenses, Gradle refuses the platform at
+    # configuration time the same way a missing SDK does.
+    && yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null \
+    && "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" \
+         "platform-tools" \
+         "platforms;android-${ANDROID_PLATFORM_VERSION}" \
+         "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+    # World-writable, matching the hosted image: AGP writes into the SDK
+    # root (temp dirs, package installs) and the workflow runs as
+    # `runner`, not root.
+    && chmod -R a+rwX "${ANDROID_SDK_ROOT}"
+
 FROM ubuntu:22.04
 
 # renovate: datasource=github-releases depName=actions/runner
@@ -197,6 +246,31 @@ RUN install -m 0755 -d /etc/apt/keyrings \
         docker-compose-plugin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Android SDK, resolved in the `android-sdk` stage above. Gradle
+# cannot configure an Android project without a platform + build-tools:
+# it fails the task graph with "SDK location not found" before any task
+# runs. GitHub's hosted Ubuntu image bakes the SDK in the same way
+# (`install-android-sdk.sh`, exporting ANDROID_HOME + ANDROID_SDK_ROOT),
+# so workflows assume it is on the machine rather than installing it
+# per job — and the path below matches theirs for workflows that
+# hardcode it.
+#
+# Deliberately narrower than the hosted image, which carries every
+# platform from android-34 up, six build-tools releases and three NDK
+# majors. We ship the single platform + build-tools pair `android/`
+# builds against and no NDK at all (the app has no native code), which
+# is what keeps this a few hundred MB rather than the ~10GB the hosted
+# image spends here.
+COPY --from=android-sdk /opt/android-sdk /usr/local/lib/android/sdk
+# The copied tree keeps the modes set in the builder stage, but COPY
+# creates the destination directory itself as 0755, so the SDK root
+# alone would be read-only for `runner`. Re-chmod just that directory —
+# a recursive chmod here would rewrite every file into a second ~460MB
+# layer.
+RUN chmod a+rwx /usr/local/lib/android/sdk
+ENV ANDROID_HOME=/usr/local/lib/android/sdk \
+    ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
 
 # Non-root runner user. `actions/runner` refuses to register as
 # root unless `RUNNER_ALLOW_RUNASROOT=1` is set. Passwordless sudo

--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -41,22 +41,27 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # workflow steps bring their own JDK via mise, so the runner image
 # itself stays JDK-free.
 #
-# Versions are pinned rather than tracking "latest": they must match
-# what `android/app/build.gradle.kts` builds against, so bump them
-# alongside `compileSdk` / `targetSdk` there. The cmdline-tools archive
-# is fetched straight from Google because sdkmanager is what installs
-# every other component (it cannot install itself).
+# Platforms and build-tools are selected by a version FLOOR, not pinned:
+# every release at or above it that Google publishes gets installed. This
+# image runs customer workflows, so it cannot assume anyone's compileSdk
+# — a customer on a newer platform than we happened to pin would fail at
+# Gradle configuration exactly like a missing SDK. GitHub's hosted image
+# takes the same approach (`platform_min_version` / `build_tools_min_version`
+# in its toolset), which also means new platforms roll in on the next
+# image rebuild with no version bump anywhere.
 #
-# cmdline-tools is held at the release GitHub's hosted image pins.
+# The cmdline-tools archive is fetched straight from Google because
+# sdkmanager is what installs every other component (it cannot install
+# itself), and is held at the release GitHub's hosted image pins.
 # sdkmanager stamps a schema version into each installed package's
-# package.xml, and current cmdline-tools writes v4 while AGP 8.7.3
-# only parses up to v3 — which makes every Gradle invocation warn
-# about the skew. Bump this in step with AGP, not ahead of it.
+# package.xml, and current cmdline-tools writes v4 while AGP 8.7 parses
+# only up to v3 — which makes every Gradle invocation warn about the
+# skew. Keep it behind the AGP releases customers are likely to run.
 FROM eclipse-temurin:21-jdk-jammy AS android-sdk
 
 ARG ANDROID_CMDLINE_TOOLS_ARCHIVE=commandlinetools-linux-11076708_latest.zip
-ARG ANDROID_PLATFORM_VERSION=35
-ARG ANDROID_BUILD_TOOLS_VERSION=35.0.1
+ARG ANDROID_PLATFORM_MIN_VERSION=34
+ARG ANDROID_BUILD_TOOLS_MIN_VERSION=34
 
 ENV ANDROID_SDK_ROOT=/opt/android-sdk
 
@@ -76,10 +81,28 @@ RUN mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" \
     # $ANDROID_SDK_ROOT/licenses, Gradle refuses the platform at
     # configuration time the same way a missing SDK does.
     && yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null \
+    # Enumerate what Google currently publishes and keep everything at or
+    # above the floor, rather than hardcoding a list that silently rots.
+    # `rc` build-tools are excluded the way the hosted image excludes them.
+    # Take package ids from the first column of the "Available Packages"
+    # table rather than grepping the raw text: ids are matched whole, so
+    # preview channels (android-37.2-beta1, build-tools;36.0.0-rc1) drop
+    # out instead of being truncated into ids that do not exist. Platform
+    # ids carry an optional minor (android-37.0) and an optional extension
+    # suffix (android-36-ext18); both are real, separate packages.
+    && available="$("${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --list \
+         | sed -n '/Available Packages:/,$p' | cut -d'|' -f1 | tr -d ' ' | sort -u)" \
+    && platforms="$(echo "$available" | grep -E '^platforms;android-[0-9]+(\.[0-9]+)?(-ext[0-9]+)?$' \
+         | awk -F'android-' -v min="${ANDROID_PLATFORM_MIN_VERSION}" '{ split($2, v, "-"); if (v[1] + 0 >= min + 0) print $0 }')" \
+    && build_tools="$(echo "$available" | grep -E '^build-tools;[0-9]+\.[0-9]+\.[0-9]+$' \
+         | awk -F'build-tools;' -v min="${ANDROID_BUILD_TOOLS_MIN_VERSION}" '{ split($2, v, "."); if (v[1] + 0 >= min + 0) print $0 }')" \
+    && test -n "$platforms" && test -n "$build_tools" \
+    && echo "Installing platforms:" $platforms \
+    && echo "Installing build-tools:" $build_tools \
     && "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" \
          "platform-tools" \
-         "platforms;android-${ANDROID_PLATFORM_VERSION}" \
-         "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+         $platforms \
+         $build_tools \
     # World-writable, matching the hosted image: AGP writes into the SDK
     # root (temp dirs, package installs) and the workflow runs as
     # `runner`, not root.


### PR DESCRIPTION
## What changed

1. `infra/linux-runner-image/Dockerfile` installs the Android SDK to `/usr/local/lib/android/sdk` and exports `ANDROID_HOME` + `ANDROID_SDK_ROOT`. sdkmanager is a JVM tool, so it runs in an `android-sdk` builder stage and only the resolved SDK is copied into the final image, keeping the runner image JDK-free.
2. The `release-android` job in `.github/workflows/app-release.yml` now authenticates with Tuist: `id-token: write` added to its permissions, `tuist` added to the mise install list, and a `tuist auth login` step before the Gradle steps.

The job stays on `tuist-linux`.

## Why

### Android releases have been failing outright

Every app release run since 2026-07-20 has failed during Gradle task-graph configuration with:

```
> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/home/runner/work/tuist/tuist/android/local.properties'.
```

Root cause: the job moved onto `tuist-linux` from an external runner provider in #11052 (2026-06-03), and the Linux runner image installs no Android SDK — no `sdkmanager`, no `cmdline-tools`, no `ANDROID_HOME`. mise supplies `java` and `gradle` at job time, so Gradle starts up fine and then cannot resolve the Android platform. This went unnoticed for seven weeks because no app-releasable change landed between the runner move and 2026-07-20, so the job was never exercised.

#11062 (2026-06-04) already recorded the gap for regular CI: `android.yml:36` says all Android jobs stay on GitHub-hosted runners because `tuist-linux` lacks the SDK, and that moving them onto the fleet requires baking the SDK into the image first. This change does that, rather than moving the release job off the fleet.

### Baking it in is what the hosted runners do

GitHub's hosted Ubuntu image installs the SDK at image-build time via `install-android-sdk.sh`, to the same `/usr/local/lib/android/sdk` path, exporting `ANDROID_HOME` and `ANDROID_SDK_ROOT`. Workflows therefore assume the SDK is on the machine rather than installing it per job. The Dockerfile's stated goal is to close most of the gap against that image, so this is in line with its existing posture.

Platforms and build-tools are selected by a version **floor** (34 and up), not pinned to specific releases. That matters because this image runs customer workflows, not just ours: pinning to whatever `android/app/build.gradle.kts` targets would break any customer building against a newer `compileSdk`, failing their build at Gradle configuration with the same "SDK location not found" this PR is fixing. The hosted image solves it the same way, with `platform_min_version` / `build_tools_min_version` in its toolset, and the useful side effect is that new platforms roll in on the next image rebuild with no version bump anywhere — nothing to keep in sync, and no coupling between this image and our own app's Gradle config.

At today's manifest the floor resolves to 15 platform packages (android-34 through android-37.1, including the `-ext` variants) and 6 build-tools releases.

The one thing we do not copy is the NDK. The hosted image carries three majors, which is roughly 10GB expanded and the bulk of its Android footprint, and only native-code builds need it:

| Scope | Download |
| --- | --- |
| platforms + build-tools + cmdline-tools + platform-tools | ~0.7 GB |
| + one NDK major | ~1.4 GB |
| + all three NDK majors (hosted parity) | ~2.9 GB |

The NDK stays out, and not just as a first pass. A toolchain that large, serving a minority of jobs, belongs in a per-account cache volume rather than in an image every job on the fleet pulls — growing the base image to cover the long tail is a cost everyone pays for something few use. Only native-code builds need it: an `externalNativeBuild` block, a declared `ndkVersion`, or a framework that compiles native sources instead of shipping prebuilt ones. A pure Kotlin/Java app assembling an APK or AAB never touches it.

Worth being precise that cache volumes are the destination, not an available workaround: `runnerCacheVolume` is macOS-only today, provisioning APFS volumes on Mac minis through tart-kubelet, and the Linux fleet has no equivalent yet. Until it does, a workflow that needs the NDK installs it per job:

```yaml
- run: $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.3.13750724"
```

That works because cmdline-tools ships in the image and the licenses are accepted at build time, but it downloads ~700MB on every run, since runners are ephemeral. Fine occasionally, poor for a team running native CI continuously — which is the case cache volumes on Linux would actually solve.

`ANDROID_NDK_HOME` and its siblings are deliberately left unset. The hosted image sets all four, and its install script notes that many customer builds read them, but a variable pointing at an NDK that is not installed fails deep inside CMake rather than failing fast.

Image size is a one-time pull per Hetzner node, since kubelet caches the layers for subsequent Pods on the same host.

`cmdline-tools` is deliberately held at the release the hosted image pins rather than the newest one. sdkmanager stamps a schema version into each installed package's `package.xml`; current cmdline-tools writes v4 while AGP 8.7.3 parses only up to v3, which makes every Gradle invocation emit a version-skew warning. Verified by building both ways.

### The Android build never used the remote cache

Separately, the job logs:

```
Not authenticated with Tuist. Run 'tuist auth login' or set the TUIST_TOKEN environment variable
The remote build cache was disabled during the build due to errors
```

on every run. Unlike the sibling `release-app` and `release-ios` jobs, `release-android` never ran `tuist auth login`, and it declared no `permissions:` block at all, so it inherited the workflow-level one, which omits `id-token`. The `dev.tuist` Gradle plugin declared in `android/settings.gradle.kts` found no credentials and fell back to a cache-less build.

The `tuist auth login` step runs with `working-directory: android` on purpose. The OIDC exchange is scoped to the project resolved from the working directory: the repository root `Tuist.swift` resolves to `tuist/tuist`, while `android/tuist.toml` resolves to `tuist/android`. Running the login at the root would mint a token for the wrong project. This matches `android.yml`, where a workflow-level `defaults.run.working-directory: android` puts the same step in the same directory.

## This job has no recorded successful run

Worth flagging before the first release after this ships: I could not find a single recorded successful execution of `release-android`, on the fleet or before it.

The job was added on 2026-02-20, while it still ran on an external provider's runners, and it has never carried an SDK install step. Every accessible run since shows it `skipped`, because no releasable app change landed. The runs from before the move belong to a workflow that has since been recreated, and that history is no longer reachable. The runs older than that predate the job entirely.

So "this regressed when the job moved onto the fleet" is not something the run history actually supports. It is equally consistent with the job never having worked, with the move only changing which error it fails on. That does not change the fix — the SDK gap is real, reproduced, and a prerequisite either way — but it does change what to expect on the first real release.

Practically: the Android SDK may not be the last thing standing between this job and Google Play. The keystore and service-account path it takes, and `publishReleaseBundle` itself, appear never to have been exercised end to end by CI. If the first release after this lands fails somewhere downstream of Gradle configuration, that is the likely reason, and it is not evidence that this change did not work.

## Rollout ordering

Merging this does not by itself fix the next release. The image has to ship first: the squashed commit is a `fix` touching `infra/linux-runner-image/**`, which triggers `release-linux-runner-image` to build, push, and tag `linux-runner-image@<semver>`. The deploy then resolves `runnersFleetLinux.shapeRunnerImage` from that tag, and runner Pods created after it carry the SDK. Until that deploy lands, `release-android` fails exactly as it does today.

`server-deployment.yml` accepts a `linux_runner_image_tag` input to pin an in-flight `:sha-<git-sha>` build, if we want to validate on staging before the tagged release.

## Impact

- App releases are unblocked on the Android side once the new image rolls out.
- The Android release build gets the remote build cache instead of building cold every time.
- `android.yml`'s jobs can move onto the fleet in a follow-up now that the prerequisite its comment names is satisfied. This PR does not move them.

Note that this only unblocks the Android half of `app-release.yml`. The macOS half of the same workflow is failing for an unrelated reason and is being fixed separately via a `runner-image` Homebrew ownership fix.

## Validation

Built the `android-sdk` stage locally and exercised the real project against it.

- Reproduced the release failure: `./gradlew :app:assembleRelease --dry-run` against a copy of `android/` with no SDK present fails with the exact reported error, `Could not determine the dependencies of task ':app:lintVitalReportRelease'. > SDK location not found.` Note that `:app:tasks` is not sufficient to reproduce it, as AGP resolves the SDK lazily and only needs it once the task graph is built.
- Confirmed the fix: the same command with `ANDROID_HOME` pointing at the baked SDK gives `BUILD SUCCESSFUL`.
- Confirmed the second issue is real and reproduces in the same run: `Could not load entry ... from remote build cache: Not authenticated with Tuist` followed by `The remote build cache was disabled during the build due to errors`.
- Verified the installed tree: 7 license files accepted under `licenses/`, and `platforms/android-35/android.jar`, `build-tools/35.0.1/aapt2`, `platform-tools/adb` all present. That build was the earlier single-platform variant, which came to 458 MB on disk.
- Verified the version-skew warning disappears with the pinned cmdline-tools release, and that the build still succeeds.
- Verified the final-stage `COPY` as a non-root `runner` user: the platform is readable, build-tools executable, and the SDK root writable. That last one needed the explicit `chmod` in the Dockerfile, because BuildKit creates a `COPY` destination directory as 0755 even though the copied contents keep their builder-stage modes. The `chmod` is scoped to that one directory, so it adds a 0 B metadata layer instead of rewriting the whole tree.
- `actionlint .github/workflows/app-release.yml` reports nothing on the modified job. Its remaining output is pre-existing and on unmodified lines: unknown-label warnings for the self-hosted `tuist-linux` / `tuist-macos` labels, a stale `steps.upload.outputs.uploaded` reference, and shellcheck notes in untouched `run` blocks.

The local build ran on arm64, which is fine for what it proves: the SDK components Google ships for Linux are x86_64-only regardless of build host, and configuration-time resolution does not execute build-tools binaries. The full amd64 image build is covered by `linux-runner-image.yml`, which builds without pushing on pull requests.

### What is not yet validated locally

The floor-based selection replaced the pinned single-platform install late, and the local Docker daemon died before a clean end-to-end build of the final version. Specifically:

- **Verified against live sdkmanager**: the enumeration resolves the expected set — 15 platforms including the `-ext` variants, `android-36.1`, `android-37.0`, `android-37.1`, and 6 build-tools. That run is what surfaced both parsing bugs.
- **Verified offline against Google's package manifest**: the final anchored-column filters select android-34/35/36 and build-tools 34.0.0 through 37.0.0, reject every `-beta`/`-rc` package, and admit nothing below the floor.
- **Not verified locally**: a full build installing all 15 platforms and 6 build-tools in one go, and the resulting image size. `linux-runner-image.yml` builds this on the PR, so CI is the gate before merge. The earlier single-platform variant was validated end to end against the real `android/` project, and none of the copy, permissions, or licensing logic changed since.


