### PR TITLE
fix(runner-image): give the runner user ownership of the Homebrew prefix

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -17,6 +17,19 @@ The Cirrus base image's pre-existing `admin` user is kept around
 as the Packer SSH provisioning identity but is not used at
 runtime — no service, sudo entry, or auto-login targets it.
 
+Because the base images provision as `admin` and jobs run as
+`runner`, anything the base installs under `admin` has to be
+handed over explicitly. `/opt/homebrew` is the case that bit us:
+the prefix shipped owned by `admin`, so `brew install` from a
+workflow step failed its writability audit while `brew` itself
+resolved fine on `PATH`. GitHub-hosted images build and run under
+one account, so the job user owns the prefix — this image chowns
+it to `runner` to match. When adding tooling to the base, check
+ownership, not just reachability. The `brew install hello`
+sanity check at the end of the Packer template exists because a
+reachability-only check stayed green through months of broken
+installs.
+
 - `/Users/runner/actions-runner/` — GitHub Actions runner binary
   (no registration; we register at runtime via JIT config minted
   by `Tuist.Runners.Reconciler` / `Tuist.Runners.Dispatch`).

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -59,14 +59,18 @@ packer {
 #   /opt/tuist/runner-shell-agent               <- trusted interactive shell bridge
 #   /Applications/Xcode_<version>.app           <- inherited from the base
 #
-# The macos-tahoe-xcode base inherits macos-tahoe-base's `admin` user
-# with a `/Users/runner` symlink to `/Users/admin` plus a configured
-# `~/.zprofile` (brew shellenv, mise, rbenv init). Our flow creates
-# a real `runner` user that *also* points at `/Users/runner` —
-# sysadminctl can't overwrite the existing path, so it assigns a
-# fresh UID against the symlinked home. Both users end up sharing
-# `.zprofile`, which is how the runner's login shell sees the
-# brew-installed tools from the base.
+# The macos-tahoe-xcode base inherits macos-tahoe-base's `admin`
+# user and a `/Users/runner` placeholder. Our flow wipes that
+# placeholder and creates a real `runner` user with a home of its
+# own (see the addUser provisioner below), so `admin` and `runner`
+# are distinct accounts with distinct homes — the account that
+# builds the image is not the account that runs jobs.
+#
+# That split is the thing to keep in mind when changing this file.
+# Anything the base set up under `admin` is not automatically
+# usable by `runner`: the Homebrew prefix has to be handed over
+# explicitly (see the chown provisioner below), and the sanity
+# checks at the end assert against `runner`, never `admin`.
 #
 # Note that the runner is registered with GitHub at *job* time,
 # not image-build time — the image carries the runner binary but
@@ -187,6 +191,34 @@ build {
       "echo 'admin' | sudo -S sysadminctl -addUser runner -fullName 'GitHub Actions Runner' -password runner -admin",
       "echo 'admin' | sudo -S mkdir -p /opt/tuist /etc/tuist",
       "echo 'admin' | sudo -S chown root:wheel /opt/tuist"
+    ]
+  }
+
+  # Hand the Homebrew prefix to `runner`. The base images install
+  # brew and its formulae as `admin`, so the prefix ends up owned
+  # by an account that never runs jobs — `brew install <formula>`
+  # from a workflow step then fails the writability audit with
+  # "/opt/homebrew is not writable" across ~16 directories.
+  #
+  # GitHub-hosted macOS images build and run under a single
+  # account, so the job user owns the prefix and unprivileged
+  # `brew install` just works. Customer workflows assume that.
+  # Reachability was never the problem (the login shell resolves
+  # `brew` fine, and the sanity check below has always covered
+  # it) — ownership was.
+  #
+  # This belongs here and not in macos-xcode-image: that base is
+  # shared with xcresult-processor, which keeps running as `admin`
+  # and drives brew-installed binaries itself (`sudo
+  # /opt/homebrew/bin/tailscaled install-system-daemon`). Chowning
+  # in the shared layer would fix this image and break that one.
+  #
+  # `runner:admin` matches Homebrew's own default ownership on
+  # macOS rather than inventing a scheme.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "echo 'admin' | sudo -S chown -R runner:admin /opt/homebrew"
     ]
   }
 
@@ -406,6 +438,27 @@ build {
       "set -euo pipefail",
       "sudo -u runner /bin/zsh -lc 'for tool in brew mise gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage xcodes xcrun; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in runner login shell — base image regression\" >&2; exit 1; }; done'",
       "sudo -u runner /bin/zsh -lc '/usr/bin/xcrun xcresulttool version'"
+    ]
+  }
+
+  # Sanity check: `brew` being on PATH says nothing about whether a
+  # workflow step can install with it. The check above passed for
+  # months while every `brew install` on this image failed on prefix
+  # ownership, so assert the operation rather than the binary.
+  # `hello` is Homebrew's own smoke-test formula: no dependencies,
+  # installs in seconds, and uninstalling leaves the image clean.
+  #
+  # HOMEBREW_NO_AUTO_UPDATE keeps the check off the network's
+  # critical path — it would otherwise re-fetch every tap and make
+  # image builds fail on transient GitHub blips. The chown is
+  # recursive, so tap writability moves with the prefix; what's
+  # actually at risk of regressing, and what this exercises, is
+  # writing into Cellar and the lock/var dirs.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "sudo -u runner /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew install hello' || { echo 'sanity check: unprivileged brew install failed for the runner user — Homebrew prefix ownership regression' >&2; exit 1; }",
+      "sudo -u runner /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall hello'"
     ]
   }
 }


### PR DESCRIPTION
## What changed

`brew install <formula>` has been failing on every `tuist-macos` runner with `/opt/homebrew is not writable`, listing about 16 directories. This hands the Homebrew prefix to the `runner` account:

- A provisioner right after `sysadminctl -addUser runner` runs `chown -R runner:admin /opt/homebrew`.
- A new sanity check runs `brew install hello` / `brew uninstall hello` as `runner`, so the image build fails on this class of regression instead of a customer workflow.
- The file header comment is corrected. It still described an older model where `admin` and `runner` shared a home through a `/Users/runner` symlink, which stopped being true when [#10833](https://github.com/tuist/tuist/pull/10833) added the `rm -rf /Users/runner` before `addUser`.
- `infra/runner-image/AGENTS.md` records the underlying rule: when adding tooling to a base image, check ownership, not just reachability.

## Why

The base images (macos-tahoe-base, then `infra/macos-xcode-image`) provision over SSH as `admin`, so Homebrew and every formula it installs end up owned by `admin`. This image then creates a separate `runner` account that jobs actually execute as, and never hands the prefix over.

GitHub-hosted macOS images build and run under a single account, so the job user owns the prefix and unprivileged `brew install` just works. Their `install-homebrew.sh` runs the Homebrew installer as the build user and never chowns afterwards, because the build user and the job user are the same. Customer workflows are written against that behaviour, and `tuist-macos` is a product surface, so this is a parity bug rather than a CI bug.

## Root cause

Reachability was never the problem. `brew` resolves fine on `PATH` for `runner`, and the existing sanity check has always asserted that. Only writability was broken, which is exactly why image-build CI stayed green the whole time.

The regression dates to [#10793](https://github.com/tuist/tuist/pull/10793) (2026-05-18), which moved macOS release jobs from `macos-26` to `tuist-macos`. Nothing exercised it until the first app-releasable change landed on 2026-07-20, so it sat latent for two months.

## Why this approach

Two alternatives were considered and rejected:

**Bake `create-dmg` into the image.** This would unblock our own release while leaving every customer workflow that calls `brew install` broken. It treats the symptom.

**Chown in `infra/macos-xcode-image` instead.** That base is shared with `infra/xcresult-processor-image`, which keeps running as `admin` and drives brew-installed binaries itself, for example `sudo /opt/homebrew/bin/tailscaled install-system-daemon`. Chowning in the shared layer would fix this image and break that one. The chown belongs in the layer that introduces the `runner` user.

`runner:admin` matches Homebrew's own default ownership on macOS rather than inventing a scheme.

`HOMEBREW_NO_AUTO_UPDATE=1` on the sanity check keeps it off the network's critical path. Without it, every image build would re-fetch all taps and could fail on a transient GitHub blip. The chown is recursive, so tap writability moves with the prefix; what is actually at risk of regressing, and what the check exercises, is writing into Cellar and the lock and var directories.

## Impact

Any customer workflow on `tuist-macos` calling `brew install` has been failing since 2026-05-18.

Our own macOS app release is one of those workflows. `Release App` in `app-release.yml` dies at `brew install create-dmg`, and since `publish-app` is gated on all three platform jobs succeeding, no app release has been published since `app@0.25.4` on 2026-05-06. That also means the Sparkle appcast feed asset the shipped app points at through `SUFeedURL` has never been published, so in-app auto-update is broken for existing users too.

This unblocks the macOS half only. The Android half of the same workflow fails separately because `tuist-linux` carries no Android SDK, and is being fixed in its own PR.

## How to test locally

The Packer build needs the bare-metal Mac mini with a live GUI session, since Tart requires Virtualization.framework. What can be checked without it:

```bash
cd infra/runner-image && packer fmt -check -diff . && packer validate -syntax-only .
```

Both pass. Full validation is the image build itself: the new sanity check is the test, and it fails the build if the prefix is not writable by `runner`.

To smoke-test the Packer change before merge:

```bash
gh workflow run runner-image.yml --ref claude/tuist-macos-release-396d78 -f xcode_version=26.4.1
```

## Note for reviewers

The commit is deliberately scoped `fix(runner-image):` and not `ci(...)`. `infra/runner-image/cliff.toml` skips `ci` commits, so a `ci`-scoped message would merge without cutting a new image and the fleet would never pick the change up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
