### PR TITLE
fix(server): stop the completed workflow_job webhook crashing on a rolled-back transaction

### DIFF
--- a/server/lib/tuist/runners/dispatch.ex
+++ b/server/lib/tuist/runners/dispatch.ex
@@ -372,9 +372,15 @@ defmodule Tuist.Runners.Dispatch do
                 conclusion
               )
 
-            ignored ->
-              ignored
+            other ->
+              other
           end
+
+        # Any other failure of the completion write (a rolled-back
+        # transaction, an ordering lock we could not take) is transient, so
+        # the reason goes back to the worker for a retry.
+        {:error, reason} ->
+          {:error, reason}
       end
     end)
   end
@@ -417,6 +423,9 @@ defmodule Tuist.Runners.Dispatch do
     else
       {:error, reason} when reason in [:no_account, :runners_disabled, :no_matching_pool, :no_pools, :ambiguous_pool] ->
         {:ignored, reason}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -88,16 +88,30 @@ defmodule Tuist.Runners.Jobs do
   ClickHouse is still the lifecycle history store, but queued/completed
   webhooks need a Postgres lock so a late `queued` or `waiting` delivery cannot
   observe "missing", race a concurrent completion, and write a newer queued row.
+
+  Re-entrant: inside an existing `Repo` transaction the lock is taken inline
+  rather than through a nested `Repo.transaction/1`. `pg_advisory_xact_lock`
+  is re-entrant within a transaction and released on its commit, so the
+  serialization is identical. A nested transaction is not: it carries no
+  savepoint, and on an aborted connection it skips `fun` entirely and hands
+  back `{:error, :rollback}` as an ordinary value, which callers cannot
+  distinguish from a domain result. Inline, that failure unwinds the caller's
+  transaction instead of being pattern-matched by it.
   """
   def with_workflow_job_ordering_lock(workflow_job_id, fun) when is_integer(workflow_job_id) and is_function(fun, 0) do
-    fn ->
+    if Repo.in_transaction?() do
       acquire_workflow_job_ordering_lock(workflow_job_id)
       fun.()
-    end
-    |> Repo.transaction()
-    |> case do
-      {:ok, result} -> result
-      {:error, reason} -> {:error, reason}
+    else
+      fn ->
+        acquire_workflow_job_ordering_lock(workflow_job_id)
+        fun.()
+      end
+      |> Repo.transaction()
+      |> case do
+        {:ok, result} -> result
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 

--- a/server/test/tuist/runners/dispatch_test.exs
+++ b/server/test/tuist/runners/dispatch_test.exs
@@ -370,6 +370,44 @@ defmodule Tuist.Runners.DispatchTest do
       end
     end
 
+    test "propagates an unexpected error from the completion write so Oban retries" do
+      stub(Jobs, :complete, fn _id, _conclusion -> {:error, :rollback} end)
+
+      payload =
+        completed_payload(
+          id: 4400,
+          conclusion: "success",
+          steps: [%{"name" => "Set up job", "status" => "completed", "number" => 1}]
+        )
+
+      assert {:error, :rollback} = Dispatch.handle_webhook(payload, 1)
+
+      refute_enqueued(worker: FetchLogsWorker, args: %{workflow_job_id: 4400})
+    end
+
+    test "propagates an unexpected error from the completed-before-queued write" do
+      account = enabled_account()
+
+      stub(Accounts, :get_account_by_handle, fn _ -> account end)
+
+      stub(Client, :list_runner_pools, fn _ns ->
+        {:ok, [pool_cr(name: "macos-pool", label: "tuist-macos")]}
+      end)
+
+      stub(Jobs, :complete, fn _id, _conclusion -> {:error, :not_found} end)
+      stub(Jobs, :record_completed, fn _attrs, _conclusion -> {:error, :rollback} end)
+
+      payload =
+        completed_payload(
+          owner: account.name,
+          id: 4410,
+          conclusion: "cancelled",
+          labels: ["self-hosted", "tuist-macos"]
+        )
+
+      assert {:error, :rollback} = Dispatch.handle_webhook(payload, 1)
+    end
+
     test "does not resurrect a canceled job when completed arrives before queued" do
       account = enabled_account()
       workflow_job_id = System.unique_integer([:positive])

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -80,6 +80,29 @@ defmodule Tuist.Runners.JobsTest do
     :ok
   end
 
+  describe "with_workflow_job_ordering_lock/2" do
+    test "aborts the caller's transaction instead of handing the failure back as a value" do
+      test_pid = self()
+
+      result =
+        Repo.transaction(fn ->
+          Jobs.with_workflow_job_ordering_lock(8_100_001, fn -> Repo.rollback(:lock_failed) end)
+          send(test_pid, :ran_after_lock)
+          :done
+        end)
+
+      assert result == {:error, :lock_failed}
+      refute_received :ran_after_lock
+    end
+
+    test "returns the function's value when called inside an existing transaction" do
+      assert {:ok, :from_fun} =
+               Repo.transaction(fn ->
+                 Jobs.with_workflow_job_ordering_lock(8_100_002, fn -> :from_fun end)
+               end)
+    end
+  end
+
   describe "enqueue/1" do
     test "inserts a queued row" do
       account = account_fixture()


### PR DESCRIPTION
Fixes [TUIST-4G4](https://tuist.sentry.io/issues/140030827/)

The `workflow_job.completed` webhook crashed in production with `CaseClauseError: no case clause matching {:error, :rollback}` at `Tuist.Runners.Dispatch.mark_completed/7`, failing the `DispatchWorker` Oban job for a delivery that should have been either applied or retried with a meaningful reason.

### Root cause

`Dispatch.mark_completed/7` opens the workflow-job ordering transaction and then calls `Jobs.complete/2`, which takes the same ordering lock a second time. That second call is a nested `Repo.transaction/1`.

A nested transaction carries no savepoint, so it adds no isolation, but it does add a return value. Once DBConnection has marked the connection aborted (`Holder` status `:aborted`, set by `fail/1` when a nested transaction rolls back or raises), `DBConnection.transaction/3` skips the function entirely and returns `{:error, :rollback}`. `with_workflow_job_ordering_lock/2` passed that straight through to a `case` that only modelled `{:ok, _}` and `{:error, :not_found}`, so a transient database failure surfaced as a `CaseClauseError` rather than a retry. The same hole existed on the completed-before-queued path, where `record_completed_without_queued/3`'s `with/else` only matched a fixed list of ignore reasons and would have raised `WithClauseError`.

### What changed

1. `Jobs.with_workflow_job_ordering_lock/2` is now re-entrant. Inside an existing `Repo` transaction it takes the advisory lock inline instead of opening a nested transaction. `pg_advisory_xact_lock` is re-entrant within a transaction and released on its commit, so the serialization guarantee is unchanged, but a failure inside the lock now unwinds the caller's transaction instead of being handed back as a value the caller has to pattern-match.
2. The completion path handles unexpected errors explicitly. Both the `Jobs.complete/2` case and the `record_completed_without_queued/3` `with/else` propagate `{:error, reason}`, so `DispatchWorker` returns it to Oban and the delivery is retried with the real reason.

The alternative of only adding a catch-all clause at the crash site was rejected: it would silence this stacktrace while leaving the nested transaction free to keep manufacturing transaction-machinery values that callers cannot distinguish from domain results. Removing the nesting fixes the class; the explicit error clauses make the remaining failure modes retryable rather than fatal.

### Impact

A `completed` delivery that hits a rolled-back transaction or an unavailable ordering lock is now retried by Oban with the underlying reason attached, instead of burning an attempt on a `CaseClauseError` that hides it. No behaviour change on the healthy path.

### How to test locally

Both dispatch cases fail before the change (the first reproduces the production stacktrace at `dispatch.ex:349` exactly, the second raises `WithClauseError`), and the jobs case fails returning the same `{:error, :rollback}` seen in Sentry.

```
cd server
mix test test/tuist/runners/dispatch_test.exs test/tuist/runners/jobs_test.exs
```

Validation that was run:

- `mix test test/tuist/runners test/tuist/runners_test.exs` — 518 passed
- `mix test test/tuist_web/live/runners_live_test.exs test/tuist_web/live/runner_jobs_live_test.exs test/tuist_web/live/runner_workflows_live_test.exs test/tuist_web/live/runner_job_live_test.exs test/tuist_web/live/runner_workflow_live_test.exs test/tuist_web/controllers/runners_controller_test.exs test/tuist_web/controllers/api/runner_interactive_shell_session_controller_test.exs test/tuist_web/controllers/runner_job_logs_controller_test.exs` — 78 passed
- `mix credo` on both changed modules — no issues

### Reviewer note

The re-entrancy change means that under the Ecto sandbox every test invocation of `with_workflow_job_ordering_lock/2` now takes the inline path, since the sandbox always holds an open transaction. The full runners suite passes unchanged, but that is the behavioural delta worth a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
