### PR TITLE
fix(cli): read package deployment target floors from the selected SDKs

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -876,8 +876,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             }
         }
 
-        let version = try Version(versionString: try await SwiftVersionProvider.current.swiftVersion(), usesLenientParsing: true)
-        let minDeploymentTargets = ProjectDescription.DeploymentTargets.oldestVersions(for: version)
+        let minDeploymentTargets = try await ProjectDescription.DeploymentTargets.minimumSupportedVersions()
 
         let deploymentTargets = try ProjectDescription.DeploymentTargets.from(
             minDeploymentTargets: minDeploymentTargets,
@@ -1788,6 +1787,33 @@ private struct StaticLibraryArtifactBundleSliceIdentifier: Hashable, Comparable 
 }
 
 extension ProjectDescription.DeploymentTargets {
+    /// The oldest version of each platform that packages can be generated for.
+    ///
+    /// The versions come from the SDKs of the selected Xcode, which is what rejects a deployment target that is too
+    /// old at build time. `oldestVersions(for:)` covers the platforms whose SDK can't be read, and every platform
+    /// where Xcode is not available.
+    static func minimumSupportedVersions() async throws -> ProjectDescription.DeploymentTargets {
+        let sdkVersions = await SDKDeploymentTargetsProvider.current.minimumDeploymentTargets()
+        if let iOS = sdkVersions.iOS, let macOS = sdkVersions.macOS, let watchOS = sdkVersions.watchOS,
+           let tvOS = sdkVersions.tvOS, let visionOS = sdkVersions.visionOS
+        {
+            return .multiplatform(iOS: iOS, macOS: macOS, watchOS: watchOS, tvOS: tvOS, visionOS: visionOS)
+        }
+
+        let swiftVersion = try Version(
+            versionString: try await SwiftVersionProvider.current.swiftVersion(),
+            usesLenientParsing: true
+        )
+        let fallback = oldestVersions(for: swiftVersion)
+        return .multiplatform(
+            iOS: sdkVersions.iOS ?? fallback.iOS,
+            macOS: sdkVersions.macOS ?? fallback.macOS,
+            watchOS: sdkVersions.watchOS ?? fallback.watchOS,
+            tvOS: sdkVersions.tvOS ?? fallback.tvOS,
+            visionOS: sdkVersions.visionOS ?? fallback.visionOS
+        )
+    }
+
     /// A dictionary that contains the oldest supported version of each platform
     public static func oldestVersions(for swiftVersion: TSCUtility.Version) -> ProjectDescription.DeploymentTargets {
         if swiftVersion < Version(5, 7, 0) {

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -878,8 +878,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         let minDeploymentTargets = try await ProjectDescription.DeploymentTargets.minimumSupportedVersions()
 
-        let deploymentTargets = try ProjectDescription.DeploymentTargets.from(
+        let deploymentTargets = try await ProjectDescription.DeploymentTargets.from(
             minDeploymentTargets: minDeploymentTargets,
+            minMacCatalystDeploymentTarget: ProjectDescription.DeploymentTargets.minimumSupportedMacCatalystVersion(),
             package: packageInfo.platforms,
             destinations: destinations,
             packageName: packageInfo.name
@@ -1814,6 +1815,14 @@ extension ProjectDescription.DeploymentTargets {
         )
     }
 
+    /// The oldest deployment target that a Mac Catalyst build can use, or `nil` when the SDK can't be read.
+    ///
+    /// Catalyst targets carry the iOS deployment target, and the Catalyst variant of the macOS SDK stops
+    /// supporting versions that the iOS SDK still builds for.
+    static func minimumSupportedMacCatalystVersion() async -> String? {
+        await SDKDeploymentTargetsProvider.current.minimumDeploymentTargets().macCatalyst
+    }
+
     /// A dictionary that contains the oldest supported version of each platform
     public static func oldestVersions(for swiftVersion: TSCUtility.Version) -> ProjectDescription.DeploymentTargets {
         if swiftVersion < Version(5, 7, 0) {
@@ -1869,6 +1878,7 @@ extension ProjectDescription.DeploymentTargets {
 
     fileprivate static func from(
         minDeploymentTargets: ProjectDescription.DeploymentTargets,
+        minMacCatalystDeploymentTarget: String?,
         package: [PackageInfo.Platform],
         destinations: ProjectDescription.Destinations,
         packageName _: String
@@ -1883,7 +1893,11 @@ extension ProjectDescription.DeploymentTargets {
 
         func versionFor(platform: ProjectDescription.Platform) throws -> String? {
             guard destinationTypes.contains(platform) else { return nil }
-            return try max(minDeploymentTargets[platform], platformInfos[platform])
+            var minimum = minDeploymentTargets[platform]
+            if platform == .iOS, destinations.contains(.macCatalyst) {
+                minimum = try max(minimum, minMacCatalystDeploymentTarget)
+            }
+            return try max(minimum, platformInfos[platform])
         }
 
         return .multiplatform(

--- a/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
+++ b/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
@@ -129,36 +129,3 @@ public struct SwiftVersionProvider: SwiftVersionProviding {
         }
     }
 }
-
-private actor AsyncThrowableCaching<T: Sendable> {
-    private var cachedValue: T?
-    private var inFlightTask: Task<T, Error>?
-    private let builder: @Sendable () async throws -> T
-
-    init(_ builder: @Sendable @escaping () async throws -> T) {
-        self.builder = builder
-    }
-
-    func value() async throws -> T {
-        if let cachedValue {
-            return cachedValue
-        }
-        // Coalesce concurrent first-callers onto a single task. Storing the task synchronously
-        // (before any suspension point) ensures callers that arrive while the builder is running
-        // await the same result instead of each kicking off a duplicate `builder()`.
-        if let inFlightTask {
-            return try await inFlightTask.value
-        }
-        let task = Task { try await builder() }
-        inFlightTask = task
-        do {
-            let realizedValue = try await task.value
-            cachedValue = realizedValue
-            inFlightTask = nil
-            return realizedValue
-        } catch {
-            inFlightTask = nil
-            throw error
-        }
-    }
-}

--- a/cli/Sources/TuistSupport/Utils/AsyncCaching.swift
+++ b/cli/Sources/TuistSupport/Utils/AsyncCaching.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Caches the first realized value, coalescing concurrent callers onto a single build.
+///
+/// `AsyncThrowableCaching` is the same cache for builders that throw. They can't be one generic
+/// actor over the failure type because `Task` is only constructible with `Never` or `any Error`.
+actor AsyncCaching<T: Sendable> {
+    private var cachedValue: T?
+    private var inFlightTask: Task<T, Never>?
+    private let builder: @Sendable () async -> T
+
+    init(_ builder: @Sendable @escaping () async -> T) {
+        self.builder = builder
+    }
+
+    func value() async -> T {
+        if let cachedValue {
+            return cachedValue
+        }
+        // Coalesce concurrent first-callers onto a single task. Storing the task synchronously
+        // (before any suspension point) ensures callers that arrive while the builder is running
+        // await the same result instead of each kicking off a duplicate `builder()`.
+        if let inFlightTask {
+            return await inFlightTask.value
+        }
+        let task = Task { await builder() }
+        inFlightTask = task
+        let realizedValue = await task.value
+        cachedValue = realizedValue
+        inFlightTask = nil
+        return realizedValue
+    }
+}
+
+actor AsyncThrowableCaching<T: Sendable> {
+    private var cachedValue: T?
+    private var inFlightTask: Task<T, Error>?
+    private let builder: @Sendable () async throws -> T
+
+    init(_ builder: @Sendable @escaping () async throws -> T) {
+        self.builder = builder
+    }
+
+    func value() async throws -> T {
+        if let cachedValue {
+            return cachedValue
+        }
+        if let inFlightTask {
+            return try await inFlightTask.value
+        }
+        let task = Task { try await builder() }
+        inFlightTask = task
+        do {
+            let realizedValue = try await task.value
+            cachedValue = realizedValue
+            inFlightTask = nil
+            return realizedValue
+        } catch {
+            inFlightTask = nil
+            throw error
+        }
+    }
+}

--- a/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
+++ b/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
@@ -1,0 +1,118 @@
+import struct Command.CommandRunner
+import protocol Command.CommandRunning
+import Foundation
+import Mockable
+import TuistLogging
+
+/// The oldest deployment target that each platform SDK supports.
+public struct SDKDeploymentTargets: Equatable, Sendable {
+    public let iOS: String?
+    public let macOS: String?
+    public let watchOS: String?
+    public let tvOS: String?
+    public let visionOS: String?
+
+    public static let none = SDKDeploymentTargets(iOS: nil, macOS: nil, watchOS: nil, tvOS: nil, visionOS: nil)
+
+    public init(
+        iOS: String? = nil,
+        macOS: String? = nil,
+        watchOS: String? = nil,
+        tvOS: String? = nil,
+        visionOS: String? = nil
+    ) {
+        self.iOS = iOS
+        self.macOS = macOS
+        self.watchOS = watchOS
+        self.tvOS = tvOS
+        self.visionOS = visionOS
+    }
+}
+
+@Mockable
+public protocol SDKDeploymentTargetsProviding: Sendable {
+    /// Returns the oldest deployment target that each SDK of the selected Xcode can build for.
+    ///
+    /// Building for a version below it fails with "the range of supported deployment target versions is X to Y".
+    /// A platform whose SDK is not installed, and every platform when no Xcode is available, is `nil`.
+    func minimumDeploymentTargets() async -> SDKDeploymentTargets
+}
+
+public struct SDKDeploymentTargetsProvider: SDKDeploymentTargetsProviding {
+    @TaskLocal public static var current: SDKDeploymentTargetsProviding = SDKDeploymentTargetsProvider()
+
+    private let cachedDeploymentTargets: AsyncCaching<SDKDeploymentTargets>
+
+    public init(commandRunner: CommandRunning = CommandRunner()) {
+        cachedDeploymentTargets = AsyncCaching {
+            let deploymentTargets = await SDKDeploymentTargets(
+                iOS: Self.minimumDeploymentTarget(sdk: "iphoneos", commandRunner: commandRunner),
+                macOS: Self.minimumDeploymentTarget(sdk: "macosx", commandRunner: commandRunner),
+                watchOS: Self.minimumDeploymentTarget(sdk: "watchos", commandRunner: commandRunner),
+                tvOS: Self.minimumDeploymentTarget(sdk: "appletvos", commandRunner: commandRunner),
+                visionOS: Self.minimumDeploymentTarget(sdk: "xros", commandRunner: commandRunner)
+            )
+            Logger.current.debug("Minimum deployment targets supported by the selected SDKs: \(deploymentTargets)")
+            return deploymentTargets
+        }
+    }
+
+    public func minimumDeploymentTargets() async -> SDKDeploymentTargets {
+        await cachedDeploymentTargets.value()
+    }
+
+    private static func minimumDeploymentTarget(sdk: String, commandRunner: CommandRunning) async -> String? {
+        do {
+            let path = try await commandRunner
+                .capture(arguments: ["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let settings = try Data(contentsOf: URL(fileURLWithPath: path).appendingPathComponent("SDKSettings.plist"))
+            guard let plist = try PropertyListSerialization.propertyList(from: settings, format: nil) as? [String: Any],
+                  let supportedTargets = plist["SupportedTargets"] as? [String: Any],
+                  let target = supportedTargets[sdk] as? [String: Any]
+            else {
+                return nil
+            }
+            switch target["MinimumDeploymentTarget"] {
+            case let version as String: return version
+            case let version as NSNumber: return version.stringValue
+            default: return nil
+            }
+        } catch {
+            Logger.current.debug("Couldn't read the minimum deployment target of the \(sdk) SDK: \(error)")
+            return nil
+        }
+    }
+}
+
+/// Caches the first realized value, coalescing concurrent callers onto a single build.
+private actor AsyncCaching<T: Sendable> {
+    private var cachedValue: T?
+    private var inFlightTask: Task<T, Never>?
+    private let builder: @Sendable () async -> T
+
+    init(_ builder: @Sendable @escaping () async -> T) {
+        self.builder = builder
+    }
+
+    func value() async -> T {
+        if let cachedValue {
+            return cachedValue
+        }
+        if let inFlightTask {
+            return await inFlightTask.value
+        }
+        let task = Task { await builder() }
+        inFlightTask = task
+        let realizedValue = await task.value
+        cachedValue = realizedValue
+        inFlightTask = nil
+        return realizedValue
+    }
+}
+
+#if DEBUG
+    extension SDKDeploymentTargetsProvider {
+        public static var mocked: MockSDKDeploymentTargetsProviding? { current as? MockSDKDeploymentTargetsProviding }
+    }
+#endif

--- a/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
+++ b/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
@@ -94,11 +94,7 @@ public struct SDKDeploymentTargetsProvider: SDKDeploymentTargetsProviding {
 
     private static func minimumDeploymentTarget(of target: String, in supportedTargets: [String: Any]) -> String? {
         guard let target = supportedTargets[target] as? [String: Any] else { return nil }
-        switch target["MinimumDeploymentTarget"] {
-        case let version as String: return version
-        case let version as NSNumber: return version.stringValue
-        default: return nil
-        }
+        return target["MinimumDeploymentTarget"] as? String
     }
 }
 

--- a/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
+++ b/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
@@ -11,21 +11,26 @@ public struct SDKDeploymentTargets: Equatable, Sendable {
     public let watchOS: String?
     public let tvOS: String?
     public let visionOS: String?
+    /// Mac Catalyst builds use the iOS deployment target, but the Catalyst variant of the macOS SDK
+    /// supports a newer floor than the iOS SDK does.
+    public let macCatalyst: String?
 
-    public static let none = SDKDeploymentTargets(iOS: nil, macOS: nil, watchOS: nil, tvOS: nil, visionOS: nil)
+    public static let none = SDKDeploymentTargets()
 
     public init(
         iOS: String? = nil,
         macOS: String? = nil,
         watchOS: String? = nil,
         tvOS: String? = nil,
-        visionOS: String? = nil
+        visionOS: String? = nil,
+        macCatalyst: String? = nil
     ) {
         self.iOS = iOS
         self.macOS = macOS
         self.watchOS = watchOS
         self.tvOS = tvOS
         self.visionOS = visionOS
+        self.macCatalyst = macCatalyst
     }
 }
 
@@ -45,12 +50,14 @@ public struct SDKDeploymentTargetsProvider: SDKDeploymentTargetsProviding {
 
     public init(commandRunner: CommandRunning = CommandRunner()) {
         cachedDeploymentTargets = AsyncCaching {
+            let macOSTargets = await Self.supportedTargets(sdk: "macosx", commandRunner: commandRunner)
             let deploymentTargets = await SDKDeploymentTargets(
                 iOS: Self.minimumDeploymentTarget(sdk: "iphoneos", commandRunner: commandRunner),
-                macOS: Self.minimumDeploymentTarget(sdk: "macosx", commandRunner: commandRunner),
+                macOS: Self.minimumDeploymentTarget(of: "macosx", in: macOSTargets),
                 watchOS: Self.minimumDeploymentTarget(sdk: "watchos", commandRunner: commandRunner),
                 tvOS: Self.minimumDeploymentTarget(sdk: "appletvos", commandRunner: commandRunner),
-                visionOS: Self.minimumDeploymentTarget(sdk: "xros", commandRunner: commandRunner)
+                visionOS: Self.minimumDeploymentTarget(sdk: "xros", commandRunner: commandRunner),
+                macCatalyst: Self.minimumDeploymentTarget(of: "iosmac", in: macOSTargets)
             )
             Logger.current.debug("Minimum deployment targets supported by the selected SDKs: \(deploymentTargets)")
             return deploymentTargets
@@ -62,25 +69,35 @@ public struct SDKDeploymentTargetsProvider: SDKDeploymentTargetsProviding {
     }
 
     private static func minimumDeploymentTarget(sdk: String, commandRunner: CommandRunning) async -> String? {
+        await minimumDeploymentTarget(of: sdk, in: supportedTargets(sdk: sdk, commandRunner: commandRunner))
+    }
+
+    /// Returns the `SupportedTargets` of an SDK, keyed by target name. A single SDK describes more than one
+    /// target: the macOS SDK covers both `macosx` and the Mac Catalyst `iosmac`.
+    private static func supportedTargets(sdk: String, commandRunner: CommandRunning) async -> [String: Any] {
         do {
             let path = try await commandRunner
                 .capture(arguments: ["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let settings = try Data(contentsOf: URL(fileURLWithPath: path).appendingPathComponent("SDKSettings.plist"))
             guard let plist = try PropertyListSerialization.propertyList(from: settings, format: nil) as? [String: Any],
-                  let supportedTargets = plist["SupportedTargets"] as? [String: Any],
-                  let target = supportedTargets[sdk] as? [String: Any]
+                  let supportedTargets = plist["SupportedTargets"] as? [String: Any]
             else {
-                return nil
+                return [:]
             }
-            switch target["MinimumDeploymentTarget"] {
-            case let version as String: return version
-            case let version as NSNumber: return version.stringValue
-            default: return nil
-            }
+            return supportedTargets
         } catch {
-            Logger.current.debug("Couldn't read the minimum deployment target of the \(sdk) SDK: \(error)")
-            return nil
+            Logger.current.debug("Couldn't read the supported targets of the \(sdk) SDK: \(error)")
+            return [:]
+        }
+    }
+
+    private static func minimumDeploymentTarget(of target: String, in supportedTargets: [String: Any]) -> String? {
+        guard let target = supportedTargets[target] as? [String: Any] else { return nil }
+        switch target["MinimumDeploymentTarget"] {
+        case let version as String: return version
+        case let version as NSNumber: return version.stringValue
+        default: return nil
         }
     }
 }

--- a/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
+++ b/cli/Sources/TuistSupport/Xcode/SDKDeploymentTargetsProvider.swift
@@ -98,32 +98,6 @@ public struct SDKDeploymentTargetsProvider: SDKDeploymentTargetsProviding {
     }
 }
 
-/// Caches the first realized value, coalescing concurrent callers onto a single build.
-private actor AsyncCaching<T: Sendable> {
-    private var cachedValue: T?
-    private var inFlightTask: Task<T, Never>?
-    private let builder: @Sendable () async -> T
-
-    init(_ builder: @Sendable @escaping () async -> T) {
-        self.builder = builder
-    }
-
-    func value() async -> T {
-        if let cachedValue {
-            return cachedValue
-        }
-        if let inFlightTask {
-            return await inFlightTask.value
-        }
-        let task = Task { await builder() }
-        inFlightTask = task
-        let realizedValue = await task.value
-        cachedValue = realizedValue
-        inFlightTask = nil
-        return realizedValue
-    }
-}
-
 #if DEBUG
     extension SDKDeploymentTargetsProvider {
         public static var mocked: MockSDKDeploymentTargetsProviding? { current as? MockSDKDeploymentTargetsProviding }

--- a/cli/Sources/TuistTesting/Xcode/SDKDeploymentTargetsProvider+Testing.swift
+++ b/cli/Sources/TuistTesting/Xcode/SDKDeploymentTargetsProvider+Testing.swift
@@ -1,0 +1,22 @@
+import Testing
+import TuistSupport
+
+public struct SDKDeploymentTargetsProviderTestingTrait: TestTrait, SuiteTrait, TestScoping {
+    /// Scopes the mock to each test so that tests stubbing their own deployment targets don't leak into others.
+    public var isRecursive: Bool { true }
+
+    public func provideScope(
+        for _: Test,
+        testCase _: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        try await SDKDeploymentTargetsProvider.$current.withValue(MockSDKDeploymentTargetsProviding()) {
+            try await function()
+        }
+    }
+}
+
+extension Trait where Self == SDKDeploymentTargetsProviderTestingTrait {
+    /// When this trait is applied to a test, the mocked SDK deployment targets provider will be used.
+    public static var withMockedSDKDeploymentTargetsProvider: Self { Self() }
+}

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3128,6 +3128,111 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_whenTargetBuildsForMacCatalyst_clampsIOSToTheCatalystSDKMinimum() async throws {
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        sdkDeploymentTargetsProviderMock.reset()
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(
+                SDKDeploymentTargets(
+                    iOS: "12.0",
+                    macOS: "10.13",
+                    watchOS: "4.0",
+                    tvOS: "12.0",
+                    visionOS: "1.0",
+                    macCatalyst: "13.1"
+                )
+            )
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "12.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(target.destinations.contains(ProjectDescription.Destination.macCatalyst))
+        #expect(target.deploymentTargets?.iOS == "13.1")
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenTargetDoesNotBuildForMacCatalyst_keepsTheIOSSDKMinimum() async throws {
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        sdkDeploymentTargetsProviderMock.reset()
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(
+                SDKDeploymentTargets(
+                    iOS: "12.0",
+                    macOS: "10.13",
+                    watchOS: "4.0",
+                    tvOS: "12.0",
+                    visionOS: "1.0",
+                    macCatalyst: "13.1"
+                )
+            )
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .local,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "12.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ],
+            packageSettings: .test(
+                productDestinations: ["Product1": [.iPhone, .iPad]],
+                baseSettings: .default
+            )
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(!target.destinations.contains(ProjectDescription.Destination.macCatalyst))
+        #expect(target.deploymentTargets?.iOS == "12.0")
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenOnlySomeSDKMinimumsAreAvailable_fallsBackToSwiftVersionMinimumsForTheRest() async throws {
         let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
         swiftVersionProviderMock.reset()

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -13,7 +13,7 @@ import XcodeGraph
 @testable import TuistLoader
 @testable import TuistTesting
 
-@Suite(.withMockedSwiftBackDeploymentLibrariesProvider)
+@Suite(.withMockedSwiftBackDeploymentLibrariesProvider, .withMockedSDKDeploymentTargetsProvider)
 struct PackageInfoMapperTests {
     private var subject: PackageInfoMapper!
     private let fileSystem = FileSystem()
@@ -23,6 +23,10 @@ struct PackageInfoMapperTests {
         given(swiftVersionProviderMock)
             .swiftVersion()
             .willReturn("5.9")
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(.none)
         let swiftBackDeploymentLibrariesProviderMock = try #require(SwiftBackDeploymentLibrariesProvider.mocked)
         given(swiftBackDeploymentLibrariesProviderMock)
             .runpathSearchPaths()
@@ -2962,12 +2966,179 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenUsingSwift64_clampsPackageDeploymentTargetsToXcode27Minimums() async throws {
+    ) func map_whenSDKMinimumsAreUnavailable_clampsPackageDeploymentTargetsToSwiftVersionMinimums() async throws {
         let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
         swiftVersionProviderMock.reset()
         given(swiftVersionProviderMock)
             .swiftVersion()
             .willReturn("6.4")
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "9.0", options: []),
+                        .init(platformName: "macos", version: "10.10", options: []),
+                        .init(platformName: "watchos", version: "2.0", options: []),
+                        .init(platformName: "tvos", version: "9.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(
+            target.deploymentTargets == .multiplatform(
+                iOS: "15.0",
+                macOS: "12.0",
+                watchOS: "9.0",
+                tvOS: "15.0",
+                visionOS: "1.0"
+            )
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenPackageDeploymentTargetsAreOlderThanTheSDKs_clampsThemToTheSDKMinimums() async throws {
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        sdkDeploymentTargetsProviderMock.reset()
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(
+                SDKDeploymentTargets(iOS: "15.0", macOS: "12.0", watchOS: "9.0", tvOS: "15.0", visionOS: "1.0")
+            )
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "9.0", options: []),
+                        .init(platformName: "macos", version: "10.15", options: []),
+                        .init(platformName: "watchos", version: "2.0", options: []),
+                        .init(platformName: "tvos", version: "9.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(
+            target.deploymentTargets == .multiplatform(
+                iOS: "15.0",
+                macOS: "12.0",
+                watchOS: "9.0",
+                tvOS: "15.0",
+                visionOS: "1.0"
+            )
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenPackageDeploymentTargetsAreSupportedByTheSDKs_keepsThem() async throws {
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        swiftVersionProviderMock.reset()
+        given(swiftVersionProviderMock)
+            .swiftVersion()
+            .willReturn("6.3")
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        sdkDeploymentTargetsProviderMock.reset()
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(
+                SDKDeploymentTargets(iOS: "12.0", macOS: "10.13", watchOS: "4.0", tvOS: "12.0", visionOS: "1.0")
+            )
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "14.0", options: []),
+                        .init(platformName: "macos", version: "10.15", options: []),
+                        .init(platformName: "watchos", version: "7.0", options: []),
+                        .init(platformName: "tvos", version: "14.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(
+            target.deploymentTargets == .multiplatform(
+                iOS: "14.0",
+                macOS: "10.15",
+                watchOS: "7.0",
+                tvOS: "14.0",
+                visionOS: "1.0"
+            )
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenOnlySomeSDKMinimumsAreAvailable_fallsBackToSwiftVersionMinimumsForTheRest() async throws {
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        swiftVersionProviderMock.reset()
+        given(swiftVersionProviderMock)
+            .swiftVersion()
+            .willReturn("6.4")
+        let sdkDeploymentTargetsProviderMock = try #require(SDKDeploymentTargetsProvider.mocked)
+        sdkDeploymentTargetsProviderMock.reset()
+        given(sdkDeploymentTargetsProviderMock)
+            .minimumDeploymentTargets()
+            .willReturn(SDKDeploymentTargets(macOS: "12.0"))
 
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))

--- a/cli/Tests/TuistSupportTests/Xcode/SDKDeploymentTargetsProviderTests.swift
+++ b/cli/Tests/TuistSupportTests/Xcode/SDKDeploymentTargetsProviderTests.swift
@@ -1,0 +1,102 @@
+import Command
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Mockable
+import Path
+import Testing
+@testable import TuistSupport
+
+struct SDKDeploymentTargetsProviderTests {
+    private let commandRunner = MockCommandRunning()
+    private let fileSystem = FileSystem()
+    private let subject: SDKDeploymentTargetsProvider
+
+    init() {
+        subject = SDKDeploymentTargetsProvider(commandRunner: commandRunner)
+    }
+
+    @Test(.inTemporaryDirectory) func returns_the_minimum_deployment_target_of_every_sdk() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let minimums = [
+            "iphoneos": "12.0",
+            "macosx": "10.13",
+            "watchos": "4.0",
+            "appletvos": "12.0",
+            "xros": "1.0",
+        ]
+        for (sdk, minimum) in minimums {
+            try await stub(sdk: sdk, in: temporaryDirectory, settings: sdkSettings(sdk: sdk, minimum: minimum))
+        }
+
+        let got = await subject.minimumDeploymentTargets()
+
+        #expect(
+            got == SDKDeploymentTargets(iOS: "12.0", macOS: "10.13", watchOS: "4.0", tvOS: "12.0", visionOS: "1.0")
+        )
+    }
+
+    @Test(.inTemporaryDirectory) func returns_nil_for_sdks_that_are_not_installed() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await stub(sdk: "macosx", in: temporaryDirectory, settings: sdkSettings(sdk: "macosx", minimum: "12.0"))
+        for sdk in ["iphoneos", "watchos", "appletvos", "xros"] {
+            given(commandRunner)
+                .run(
+                    arguments: .value(["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"]),
+                    environment: .any,
+                    workingDirectory: .any
+                )
+                .willProduce { _, _, _ in
+                    AsyncThrowingStream { $0.finish(throwing: TestError("\(sdk) is not installed")) }
+                }
+        }
+
+        let got = await subject.minimumDeploymentTargets()
+
+        #expect(got == SDKDeploymentTargets(macOS: "12.0"))
+    }
+
+    @Test(.inTemporaryDirectory) func caches_the_deployment_targets() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        for sdk in ["iphoneos", "macosx", "watchos", "appletvos", "xros"] {
+            try await stub(sdk: sdk, in: temporaryDirectory, settings: sdkSettings(sdk: sdk, minimum: "12.0"))
+        }
+
+        _ = await subject.minimumDeploymentTargets()
+        _ = await subject.minimumDeploymentTargets()
+
+        verify(commandRunner)
+            .run(arguments: .any, environment: .any, workingDirectory: .any)
+            .called(5)
+    }
+
+    private func stub(sdk: String, in directory: AbsolutePath, settings: [String: Any]) async throws {
+        let sdkPath = directory.appending(component: "\(sdk).sdk")
+        try await fileSystem.makeDirectory(at: sdkPath)
+        try PropertyListSerialization
+            .data(fromPropertyList: settings, format: .xml, options: 0)
+            .write(to: URL(fileURLWithPath: sdkPath.appending(component: "SDKSettings.plist").pathString))
+
+        given(commandRunner)
+            .run(
+                arguments: .value(["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"]),
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willProduce { _, _, _ in
+                AsyncThrowingStream { continuation in
+                    continuation.yield(.standardOutput(Array("\(sdkPath.pathString)\n".utf8)))
+                    continuation.finish()
+                }
+            }
+    }
+
+    private func sdkSettings(sdk: String, minimum: String) -> [String: Any] {
+        ["SupportedTargets": [sdk: ["MinimumDeploymentTarget": minimum, "DefaultDeploymentTarget": "26.5"]]]
+    }
+}
+
+private struct TestError: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
+}

--- a/cli/Tests/TuistSupportTests/Xcode/SDKDeploymentTargetsProviderTests.swift
+++ b/cli/Tests/TuistSupportTests/Xcode/SDKDeploymentTargetsProviderTests.swift
@@ -36,19 +36,30 @@ struct SDKDeploymentTargetsProviderTests {
         )
     }
 
+    @Test(.inTemporaryDirectory) func returns_the_mac_catalyst_minimum_of_the_macos_sdk() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await stub(
+            sdk: "macosx",
+            in: temporaryDirectory,
+            settings: ["SupportedTargets": [
+                "macosx": ["MinimumDeploymentTarget": "10.13"],
+                "iosmac": ["MinimumDeploymentTarget": "13.1"],
+            ]]
+        )
+        for sdk in ["iphoneos", "watchos", "appletvos", "xros"] {
+            stubMissing(sdk: sdk)
+        }
+
+        let got = await subject.minimumDeploymentTargets()
+
+        #expect(got == SDKDeploymentTargets(macOS: "10.13", macCatalyst: "13.1"))
+    }
+
     @Test(.inTemporaryDirectory) func returns_nil_for_sdks_that_are_not_installed() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         try await stub(sdk: "macosx", in: temporaryDirectory, settings: sdkSettings(sdk: "macosx", minimum: "12.0"))
         for sdk in ["iphoneos", "watchos", "appletvos", "xros"] {
-            given(commandRunner)
-                .run(
-                    arguments: .value(["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"]),
-                    environment: .any,
-                    workingDirectory: .any
-                )
-                .willProduce { _, _, _ in
-                    AsyncThrowingStream { $0.finish(throwing: TestError("\(sdk) is not installed")) }
-                }
+            stubMissing(sdk: sdk)
         }
 
         let got = await subject.minimumDeploymentTargets()
@@ -68,6 +79,18 @@ struct SDKDeploymentTargetsProviderTests {
         verify(commandRunner)
             .run(arguments: .any, environment: .any, workingDirectory: .any)
             .called(5)
+    }
+
+    private func stubMissing(sdk: String) {
+        given(commandRunner)
+            .run(
+                arguments: .value(["/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path"]),
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willProduce { _, _, _ in
+                AsyncThrowingStream { $0.finish(throwing: TestError("\(sdk) is not installed")) }
+            }
     }
 
     private func stub(sdk: String, in directory: AbsolutePath, settings: [String: Any]) async throws {


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12249>

Generated SwiftPM targets get `max(platform declared by the package, floor)`. The floor came from a hardcoded table in `PackageInfoMapper` keyed on `xcrun swift --version`. That table matches no real SDK, so it is wrong in both directions.

**Too high on Xcode 26.x.** Swift 6.4 maps to iOS 15.0 / macOS 11.0 / watchOS 8.0 / tvOS 15.0, but the SDKs shipped with Xcode 26.5 accept iOS 12.0 / macOS 10.13 / watchOS 4.0 / tvOS 12.0. A package declaring iOS 14 is generated with `IPHONEOS_DEPLOYMENT_TARGET = 15.0` and consumers silently lose iOS 14 support the toolchain compiles, links and archives fine. That is the p1 regression reported in #12249, where a package declaring macOS 10.15 came out as 11.0.

**Too low on Xcode 27.** Swift 6.2 and 6.3 map to macOS 11.0, below the 12.0 that Xcode 27 accepts. Generating with Xcode 26 command-line tools and building in Xcode 27 fails with `the macOS deployment target is set to 10.15, but the range of supported deployment target versions is 12.0 to 27.0.x`. The table can only ever be corrected after the fact, one Xcode release at a time.

### What changed

The authority on the oldest usable deployment target is the SDK, not the compiler version: `SupportedTargets.<sdk>.MinimumDeploymentTarget` in each SDK's `SDKSettings.plist` is exactly the number Xcode quotes back in that error message.

- `SDKDeploymentTargetsProvider` (`TuistSupport`) resolves the SDK path per platform via `xcrun --sdk <name> --show-sdk-path` and reads that key.
- `PackageInfoMapper` floors packages with those values through a new `DeploymentTargets.minimumSupportedVersions()`.
- Platforms whose SDK is not installed, and every platform where Xcode is unavailable, keep falling back to the existing `oldestVersions(for:)` table per platform. `oldestVersions(for:)` itself is unchanged, so Linux and partial Xcode installs behave exactly as before.

Values are resolved once per process behind an actor that coalesces concurrent callers, because the mapper asks for them per target across a wide fan-out. The five `xcrun` lookups run sequentially and cost about 80 ms total, once.

### Why not just bump the table again

Bumping the table for Xcode 27 fixes the second failure and makes the first one worse, and it has to be redone every Xcode release. Reading the SDK is correct for both without a version map: on Xcode 26.5 the floors become the real 12.0 / 10.13 / 4.0 / 12.0, and on Xcode 27 they become whatever those SDKs declare (macOS 12.0) with no code change.

### Mac Catalyst

The iPhoneOS SDK is not the only floor that applies to an iOS deployment target. Mac Catalyst carries the iOS deployment target too, but it is a separate target of the macOS SDK with a newer floor: on Xcode 26.5 `SupportedTargets.iphoneos` is 12.0 while `SupportedTargets.iosmac` is 13.1, and the compiler rejects everything below it, `arm64-apple-ios13.0-macabi` included.

Generated package targets include `.macCatalyst`, so flooring purely on the iOS SDK would produce deployment targets that cannot build for Catalyst. The old hardcoded floors hid this by sitting at 15.0. `SDKDeploymentTargets` therefore also carries `macCatalyst`, read from the `iosmac` entry, and the mapper raises the iOS floor to it whenever the target's destinations include Catalyst.

The practical consequence is worth calling out: external packages are mapped with every destination, so on Xcode 26.5 their effective iOS floor is 13.1 rather than 12.0, even for an app that never builds Catalyst. Local packages narrowed to iOS destinations keep 12.0. Flooring at 13.1 for a Catalyst-capable target is not optional, an iOS 12 Catalyst target does not exist, and 13.1 is still far below the 15.0 that ships today.

### Impact

Package deployment targets stop being raised above what the selected Xcode requires, so packages declaring older platforms keep the support they declare. Anyone who wants a higher floor sets it explicitly through `PackageSettings.baseSettings`, which continues to win over the computed value.

Note that this lowers the floors that #11169 introduced. That is the intent, and it is what the issue asks for.

### How to test locally

Everything below was run end to end on Xcode 26.5 against a scratch fixture, not just reasoned about.

**1. Ground truth from the SDKs.** What the change reads, and the values it produces on this Xcode:

    for sdk in macosx iphoneos; do
      /usr/libexec/PlistBuddy -c "Print :SupportedTargets" "$(xcrun --sdk $sdk --show-sdk-path)/SDKSettings.plist"
    done

`macosx` reports `macosx` 10.13 and `iosmac` 13.1; `iphoneos` reports 12.0. Against the old table for Swift 6.4: macOS 11.0, iOS 15.0.

That the Catalyst floor is a hard compiler constraint rather than a guideline:

    echo 'public func f() {}' > /tmp/cat.swift
    for t in arm64-apple-ios12.0-macabi arm64-apple-ios13.0-macabi arm64-apple-ios13.1-macabi; do
      xcrun swiftc -target $t -sdk "$(xcrun --sdk macosx --show-sdk-path)" -c /tmp/cat.swift -o /dev/null
    done

12.0 and 13.0 both fail with `invalid version number in '-target'`; 13.1 compiles.

**2. Build the CLI from the branch.**

    xcodebuild build -workspace Tuist.xcworkspace -scheme tuist -derivedDataPath /tmp/dd CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""

The binary lands at `/tmp/dd/Build/Products/Debug/tuist`. Use that binary, not an installed `tuist`, for every step below.

**3. The fixture.** A Tuist project whose `Tuist/Package.swift` declares `.package(path: "../LocalPackage")`, and a `LocalPackage` that declares platforms older than the previous floors:

    // LocalPackage/Package.swift
    platforms: [.macOS(.v10_15), .iOS(.v12)],
    products: [.library(name: "LibA", targets: ["LibA"])],
    targets: [.macro(name: "LibAMacros"), .target(name: "LibA", dependencies: ["LibAMacros"])]

    // Project.swift
    .target(name: "App", destinations: <destinations>, product: .app, bundleId: "dev.tuist.Repro",
            sources: ["App/Sources/**"], dependencies: [.external(name: "LibA")])

Then `tuist install && tuist generate --no-open`, and read the generated `LocalPackage/LocalPackage.xcodeproj/project.pbxproj`. The package is regenerated per run, so delete it plus `~/.cache/tuist/{Projects,Manifests,GenerationMetadata}` between cases.

**4. macOS, the #12249 case.** With `destinations: [.mac]`:

    grep MACOSX_DEPLOYMENT_TARGET LocalPackage/LocalPackage.xcodeproj/project.pbxproj | sort -u

Gives `10.15` for both `LibA` and the `LibAMacros` plugin target. `main` gives `11.0` for the same fixture, which is the reported regression, and it confirms the fix reaches macro plugin targets too.

**5. Mac Catalyst.** With `destinations: [.iPhone, .macCatalyst]`, the same grep for `IPHONEOS_DEPLOYMENT_TARGET` gives `13.1` rather than the iOS SDK's `12.0`, so the generated target is one Catalyst can actually build.

One honest gap in this recipe: the negative case, a target that does not build for Catalyst keeping `12.0`, cannot be reproduced this way. A path dependency declared in `Tuist/Package.swift` is still an *external* package, and external packages are mapped with every destination, so narrowing the app to `[.iPhone]` does not narrow them. That case is covered by a unit test that maps a `.local` package with `productDestinations: ["Product1": [.iPhone, .iPad]]` instead.

**6. Unit tests.**

    xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistLoaderTests/PackageInfoMapperTests -only-testing TuistSupportTests/SDKDeploymentTargetsProviderTests -only-testing TuistSupportTests/SwiftVersionProviderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""

319 cases, green. New coverage: clamping up to SDK minimums, leaving a package alone when the SDK supports what it declares (the #12249 case), per-platform fallback when only some SDKs are readable, the Catalyst floor applying to Catalyst-capable targets and not to others, and the provider's own parsing, caching and missing-SDK handling.

The existing 149 mapper tests keep asserting the Swift-table floors. A `SDKDeploymentTargetsProviderTestingTrait` in `TuistTesting` stubs "no SDK values" at the suite level so those assertions stay host independent, which also means CI does not change behaviour with the Xcode it happens to run.

### Reviewer notes

- The trait sets `isRecursive` so each test gets its own mock. Without it a suite-scoped `TestScoping` trait hands the same mock to every test in the suite, and any test that re-stubs it leaks into the others.
- I could not test against Xcode 27, it is not installed here. The change reads whatever the SDK declares and the error text in the issue thread says macOS 12.0, but that path is inferred rather than observed.
