### PR TITLE
fix(cli): force-load static xcframeworks from BUILT_PRODUCTS_DIR

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -431,8 +431,12 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         return flags
     }
 
+    /// `ProcessXCFramework` always writes the extracted slice into `$(BUILT_PRODUCTS_DIR)`, which is
+    /// where the flag has to point. The two directories only coincide outside install builds: with
+    /// `SKIP_INSTALL=YES` under `archive`, `$(TARGET_BUILD_DIR)` moves to `UninstalledProducts/`
+    /// while the slice stays behind in the shared products directory.
     private func forceLoadFlag(for library: XCFrameworkInfoPlist.Library) -> String {
-        "-Wl,-force_load,$(TARGET_BUILD_DIR)/\(library.forceLoadPath)"
+        "-Wl,-force_load,$(BUILT_PRODUCTS_DIR)/\(library.forceLoadPath)"
     }
 
     private func rewrittenHeaderContents(

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -865,6 +865,40 @@ struct XcodeBuildArchiveCommandAcceptanceTests {
     }
 }
 
+struct XcodeBuildArchiveStaticXCFrameworkAcceptanceTests {
+    /// A dynamic framework linking a static xcframework gets a generated `-force_load` flag
+    /// pointing at the slice `ProcessXCFramework` extracts. Archiving is the only action that
+    /// tells the two build directories apart: `SKIP_INSTALL=YES` moves the framework's
+    /// `TARGET_BUILD_DIR` to `UninstalledProducts/` while the slice stays in `BUILT_PRODUCTS_DIR`.
+    /// Building the same fixture passes either way, so this has to archive to catch a regression.
+    @Test(
+        .withFixture("generated_ios_app_with_xcframeworks"),
+        .inTemporaryDirectory,
+        .withMockedEnvironment()
+    ) func xcodebuild_archive_dynamic_framework_linking_static_xcframework() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
+
+        try await TuistTest.run(
+            XcodeBuildArchiveCommand.self,
+            [
+                "archive",
+                "-workspace",
+                fixtureDirectory.pathString + "/App.xcworkspace",
+                "-scheme",
+                "App",
+                "-destination",
+                "generic/platform=iOS",
+                "-archivePath",
+                temporaryDirectory.pathString + "/App.xcarchive",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+}
+
 struct XcodeBuildUnorderedBuildCommandAcceptanceTests {
     @Test(
         .disabled(),

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -142,7 +142,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                                 ],
                                 "OTHER_LDFLAGS[sdk=iphoneos*]": [
                                     "$(inherited)",
-                                    "-Wl,-force_load,$(TARGET_BUILD_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
+                                    "-Wl,-force_load,$(BUILT_PRODUCTS_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
                                     "-lz",
                                     "-framework",
                                     "JavaScriptCore",
@@ -257,7 +257,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                             base: [
                                 "OTHER_LDFLAGS[sdk=iphoneos*]": [
                                     "$(inherited)",
-                                    "-Wl,-force_load,$(TARGET_BUILD_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
+                                    "-Wl,-force_load,$(BUILT_PRODUCTS_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
                                     "-framework",
                                     "JavaScriptCore",
                                 ],
@@ -364,7 +364,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                             base: [
                                 "OTHER_LDFLAGS[sdk=iphoneos*]": [
                                     "$(inherited)",
-                                    "-Wl,-force_load,$(TARGET_BUILD_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
+                                    "-Wl,-force_load,$(BUILT_PRODUCTS_DIR)/GoogleMobileAds.framework/GoogleMobileAds",
                                     "-framework",
                                     "JavaScriptCore",
                                 ],
@@ -453,7 +453,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                             base: [
                                 "OTHER_LDFLAGS[sdk=iphoneos*]": [
                                     "$(inherited)",
-                                    "-Wl,-force_load,$(TARGET_BUILD_DIR)/libGoogleMobileAds.a",
+                                    "-Wl,-force_load,$(BUILT_PRODUCTS_DIR)/libGoogleMobileAds.a",
                                     "-framework",
                                     "JavaScriptCore",
                                 ],

--- a/examples/xcode/generated_ios_app_with_xcframeworks/DynamicFrameworkLinkingStaticXCFramework/DynamicFrameworkLinkingStaticXCFramework.swift
+++ b/examples/xcode/generated_ios_app_with_xcframeworks/DynamicFrameworkLinkingStaticXCFramework/DynamicFrameworkLinkingStaticXCFramework.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public func dynamicFrameworkLinkingStaticXCFrameworkName() -> String {
+    "DynamicFrameworkLinkingStaticXCFramework"
+}

--- a/examples/xcode/generated_ios_app_with_xcframeworks/Project.swift
+++ b/examples/xcode/generated_ios_app_with_xcframeworks/Project.swift
@@ -12,6 +12,7 @@ let project = Project(
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "StaticFrameworkA", path: "Modules/StaticFrameworkA"),
+                .target(name: "DynamicFrameworkLinkingStaticXCFramework"),
                 .xcframework(path: "XCFrameworks/MyFramework/prebuilt/MyFramework.xcframework"),
             ],
             settings: .settings(base: [
@@ -21,6 +22,20 @@ let project = Project(
                 ],
                 "BITCODE_ENABLED": "NO",
             ])
+        ),
+        // A dynamic framework linking a static xcframework is what makes Tuist generate a
+        // `-force_load` flag pointing at the slice `ProcessXCFramework` extracts. The flag has to
+        // resolve under `archive`, where `SKIP_INSTALL=YES` moves this target's build directory
+        // away from the shared products directory the slice lands in.
+        .target(
+            name: "DynamicFrameworkLinkingStaticXCFramework",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "dev.tuist.DynamicFrameworkLinkingStaticXCFramework",
+            sources: ["DynamicFrameworkLinkingStaticXCFramework/**"],
+            dependencies: [
+                .xcframework(path: "XCFrameworks/MyStaticLibrary/prebuilt/MyStaticLibrary.xcframework"),
+            ]
         ),
         .target(
             name: "AppTests",


### PR DESCRIPTION
### What changed

The `-force_load` flag that `StaticXCFrameworkModuleMapGraphMapper` generates for a dynamic target
directly linking a static xcframework now points at `$(BUILT_PRODUCTS_DIR)` instead of
`$(TARGET_BUILD_DIR)`.

### Why

Xcode's `ProcessXCFramework` always extracts the xcframework slice into `$(BUILT_PRODUCTS_DIR)`.
The flag was pointing somewhere nothing ever writes.

The two directories are equal for a plain `xcodebuild build`, so this only breaks when archiving.
Under `ACTION=install` with `SKIP_INSTALL=YES`, which is every generated framework during an
archive, they diverge:

| setting | value during archive |
|---|---|
| `BUILT_PRODUCTS_DIR` | `ArchiveIntermediates/<scheme>/BuildProductsPath/<Config>-<sdk>` |
| `TARGET_BUILD_DIR` | `ArchiveIntermediates/<scheme>/IntermediateBuildFilesPath/UninstalledProducts/<sdk>` |

Xcode treats the `-force_load` path as a build input node, so a path nothing produces fails the
link step:

```
error: Build input file cannot be found:
'.../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Foo.framework/Foo'.
Did you forget to declare this file as an output of a script phase or custom build rule
which produces it?
```

### Root cause

Introduced in #10953, which added the force-load behaviour for static xcframework wrapper slices.
Before that, static xcframeworks behind dynamic targets were routed via search paths only, so
projects that upgrade past that change and archive a dynamic framework linking a static
xcframework regress.

`$(TARGET_BUILD_DIR)` remains correct where a target refers to its own output location, such as
the embed destination in `EmbedScriptGenerator`. It is only wrong when referring to a sibling
product, which is exactly what this flag does.

### Impact

Two user-visible symptoms, both from the same defect:

1. Archives fail while simulator builds pass. Projects whose PR checks build for a simulator
   destination see green checks and a broken release lane, because that is precisely where the
   two directories coincide.
2. `tuist inspect build` reports no activity log. This failure class aborts the build during task
   construction, so Xcode leaves the `.xcactivitylog` at 0 bytes and writes an empty `logs`
   dictionary into `LogStoreManifest.plist`. `XCActivityLogController.mostRecentActivityLogFile`
   then finds nothing and `InspectBuildCommandService` throws `mostRecentActivityLogNotFound`.
   No configuration change could work around this, since there is genuinely no log to upload.

### Regression coverage

`StaticXCFrameworkModuleMapGraphMapperTests` only asserts the generated string, so it locks in
whichever build setting is written rather than proving the path resolves. This branch also adds an
acceptance test that generates and archives a dynamic framework linking a static xcframework,
which is the only action where the two directories differ.

`generated_ios_app_with_xcframeworks` gains a `DynamicFrameworkLinkingStaticXCFramework` target
linking the static xcframework already checked into that fixture, so no new binaries enter the
repository. Verified red against the previous flag and green with the current one:

| | previous flag | this branch |
|---|---|---|
| `XcodeBuildArchiveStaticXCFrameworkAcceptanceTests` | fails, `Build input file cannot be found: .../UninstalledProducts/iphoneos/libMyStaticLibrary.a` | passes in 9.9s |

Two fixture notes for reviewers:

- The test uses `MyStaticLibrary.xcframework` rather than `MyStaticFramework.xcframework` because
  the latter is missing its root `Info.plist` in the repository, so generation rejects it. That
  looks like the reason the one existing test on this fixture is `.disabled()`. Left alone here to
  keep this change focused. Both variants reach the same `forceLoadFlag` code path.
- `CODE_SIGNING_ALLOWED=NO` is passed because this fixture otherwise fails the archive on a
  missing development team, which would make the test red for an unrelated reason.

### How to test locally

Unit tests:

```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

End to end, build a static-framework `.xcframework` for `ios-arm64` plus `ios-arm64-simulator`,
then have a generated dynamic `.framework` target depend on it through `.xcframework(path:)` and
an app target depend on that framework. Run `tuist generate`, then:

```
xcodebuild archive -workspace Repro.xcworkspace -scheme App -destination 'generic/platform=iOS' -derivedDataPath ./DD CODE_SIGNING_ALLOWED=NO
```

### Validation performed

Reproduced with the released `4.204.0-canary.10` and verified against a source build of this
branch, on the same fixture and the same commands:

| | 4.204.0-canary.10 | this branch |
|---|---|---|
| generated flag | `force_load,$(TARGET_BUILD_DIR)/Foo.framework/Foo` | `force_load,$(BUILT_PRODUCTS_DIR)/Foo.framework/Foo` |
| resolves to | `.../UninstalledProducts/iphoneos/...` | `.../BuildProductsPath/Release-iphoneos/...` |
| `xcodebuild archive` | `Build input file cannot be found` | `ARCHIVE SUCCEEDED` |
| `.xcactivitylog` | 0 bytes, `"logs" => {}` | 42556 bytes, 1 manifest entry |
| simulator build | succeeded, masking the bug | succeeded, no regression |

The flag still does its job after the change: `_OBJC_CLASS_$_Foo` and `_OBJC_METACLASS_$_Foo` are
defined in the archived dynamic framework's binary, so the static xcframework's symbols are
absorbed as #10953 intended. Only the directory the linker looks in changed.

`StaticXCFrameworkModuleMapGraphMapperTests` passes 23/23 and `swiftformat --lint` is clean on
both changed files.
