### PR TITLE
fix(server): snooze build processing while the uploaded archive is not visible yet

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -32,6 +32,15 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
 
   require Logger
 
+  # The CLI completes the multipart upload immediately before the request that
+  # enqueues this job, and object storage occasionally needs a few more seconds
+  # to make the completed object readable. Those first misses are expected and
+  # clear on their own, so snooze instead of failing: a snooze records no
+  # exception, keeping Sentry for artifacts that are genuinely gone. Oban bumps
+  # `max_attempts` per snooze, so the processing attempts below stay intact.
+  @not_visible_snoozes 2
+  @not_visible_snooze_seconds 15
+
   # Cap one job's wall time so a single huge xcactivitylog cannot hold a worker
   # slot indefinitely. The NIF's internal timeout is set lower so it returns
   # a structured error first; this is the outer guard for everything else.
@@ -62,6 +71,9 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
       {:error, :project_not_found} ->
         Logger.warning("Build processing skipped: project #{project_id} not found for build #{build_id}")
         {:discard, :project_not_found}
+
+      {:error, :object_not_found} when attempt <= @not_visible_snoozes ->
+        {:snooze, @not_visible_snooze_seconds}
 
       {:error, reason} ->
         if attempt >= max_attempts do

--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -284,6 +284,7 @@ defmodule Tuist.Storage do
         bucket_name
         |> ExAws.S3.download_file(object_key, file_path)
         |> ExAws.request(Map.merge(config, fast_api_req_opts()))
+        |> normalize_download_error()
     end
   catch
     # ExAws downloads each chunk in a Task.async_stream whose per-chunk timeout
@@ -291,6 +292,19 @@ defmodule Tuist.Storage do
     # and would crash the calling job. Surface it as a retryable error instead.
     :exit, reason -> {:error, reason}
   end
+
+  # `ExAws.S3.Download` sizes the object with `head_object` through
+  # `ExAws.request!` and rescues the raised `ExAws.Error` itself, so a missing
+  # object reaches callers as an opaque struct whose only trace of the status
+  # code is the inspected message. Callers need to tell "not there (yet)" apart
+  # from a transport failure, so collapse it into a named reason here.
+  defp normalize_download_error({:error, %ExAws.Error{message: message}} = error) when is_binary(message) do
+    if String.contains?(message, "{:http_error, 404,"), do: {:error, :object_not_found}, else: error
+  end
+
+  defp normalize_download_error({:error, {:http_error, 404, _response}}), do: {:error, :object_not_found}
+
+  defp normalize_download_error(result), do: result
 
   def get_object_as_string(object_key, actor) do
     {time, result} =

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -192,6 +192,30 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
+    test "snoozes while the uploaded archive is not visible yet", %{
+      account: account,
+      project: project,
+      build: build
+    } do
+      expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:error, :object_not_found} end)
+      reject(&Tuist.Builds.create_build/1)
+
+      assert {:snooze, 15} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 1, 5))
+    end
+
+    test "fails once the archive is still missing after the snoozes", %{
+      account: account,
+      project: project,
+      build: build
+    } do
+      expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:error, :object_not_found} end)
+      reject(&Tuist.Builds.create_build/1)
+
+      assert {:error, :object_not_found} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 7))
+    end
+
     test "discards the job when the project is not found", %{
       account: account,
       build: build

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -402,6 +402,65 @@ defmodule Tuist.StorageTest do
       # Then
       assert {:error, {:timeout, {Task.Supervised, :stream, [60_000]}}} = result
     end
+
+    test "returns :object_not_found when the object is missing" do
+      # Given
+      object_key = UUIDv7.generate()
+      file_path = Path.join(System.tmp_dir!(), "#{UUIDv7.generate()}.zip")
+      bucket_name = UUIDv7.generate()
+      config = %{test: :config}
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> config end)
+
+      operation = %Download{bucket: bucket_name, path: object_key, dest: file_path}
+
+      expect(ExAws.S3, :download_file, fn ^bucket_name, ^object_key, ^file_path -> operation end)
+
+      # ExAws.S3.Download sizes the object with `head_object` through
+      # `ExAws.request!` and rescues the raised error itself, so the status code
+      # only survives in the inspected message.
+      expect(ExAws, :request, fn ^operation, _opts ->
+        {:error,
+         %ExAws.Error{
+           message:
+             "ExAws Request Error!\n\n{:error, {:http_error, 404, %{body: \"\", headers: %{}, status_code: 404}}}\n"
+         }}
+      end)
+
+      # When
+      result = Storage.download_to_file(object_key, file_path, :test)
+
+      # Then
+      assert {:error, :object_not_found} = result
+    end
+
+    test "keeps non-404 ExAws errors as they are" do
+      # Given
+      object_key = UUIDv7.generate()
+      file_path = Path.join(System.tmp_dir!(), "#{UUIDv7.generate()}.zip")
+      bucket_name = UUIDv7.generate()
+      config = %{test: :config}
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> config end)
+
+      operation = %Download{bucket: bucket_name, path: object_key, dest: file_path}
+
+      expect(ExAws.S3, :download_file, fn ^bucket_name, ^object_key, ^file_path -> operation end)
+
+      error = %ExAws.Error{
+        message: "ExAws Request Error!\n\n{:error, {:http_error, 500, %{body: \"\", status_code: 500}}}\n"
+      }
+
+      expect(ExAws, :request, fn ^operation, _opts -> {:error, error} end)
+
+      # When
+      result = Storage.download_to_file(object_key, file_path, :test)
+
+      # Then
+      assert {:error, ^error} = result
+    end
   end
 
   describe "object_exists?/1" do


### PR DESCRIPTION
Fixes [TUIST-4G5](https://tuist.sentry.io/issues/140191877/)

## What changed

- `Storage.download_to_file/3` collapses a 404 from object storage into `{:error, :object_not_found}`.
- `ProcessBuildWorker` returns `{:snooze, 15}` for the first two attempts on that reason instead of `{:error, reason}`.

## Why

The CLI completes the multipart upload of `build.zip` in the request immediately before the one that creates the build and enqueues `ProcessBuildWorker`. Object storage occasionally needs a few more seconds to make the just-completed object readable, so the worker's very first `HEAD` 404s, the job fails, and Sentry pages for something the next attempt resolves on its own.

The production timeline for the alerting job (`79376850`) shows exactly that:

| time (UTC) | event |
| --- | --- |
| 05:12:33.80 | build row created, job enqueued (the upload's `CompleteMultipartUpload` had already returned 200) |
| 05:12:34.10 | attempt 1 starts |
| 05:12:35.46 | `HEAD build.zip` returns 404 after 1208 ms in the storage metadata lookup |
| 05:12:54.13 | attempt 2 starts on the default Oban backoff |
| 05:13:09.39 | attempt 2 succeeds |

The build ended at `status=success`, so nothing was lost. Ordering is provably correct on both sides: the CLI awaits the upload and throws on failure before calling `createBuild`, and the job is only enqueued after `multipart_complete` returned 200. This is the storage backend not yet exposing a completed multipart object to the next reader.

Rate: 1 occurrence in the last 7 days of processor logs, 27 across the whole 404 family in 30 days, and only 18 builds reached `failed_processing` in that window, so escalation past the retry budget is effectively nonexistent. The failure mode is alert noise, not data loss.

## Why this shape

Snoozing is what keeps Sentry quiet: a snooze records no exception, whereas any `{:error, _}` return is reported by the Oban logger on every attempt. Suppressing the event in `Tuist.SentryEventFilter` instead would have had to drop all 404s from this worker, which would also hide artifacts that are genuinely gone. Bounding the snoozes at two keeps that signal: after them, the job fails normally, and because Oban bumps `max_attempts` per snooze, the five processing attempts and the `failed_processing` marking on the last one are unchanged.

The 404 classification has to live in `Storage.download_to_file/3` because `ExAws.S3.Download` sizes the object with `head_object` through `ExAws.request!` and rescues the raised error itself. Callers therefore only ever saw an opaque `%ExAws.Error{}` whose status code survives in the inspected message, with no way to tell "not there yet" apart from a transport failure. `ProcessXcresultWorker` shares the same download call but does not match on the reason, so its behaviour is unchanged.

## Impact

No user-visible change. Builds that already recovered on retry now recover without an error being recorded, and the alert stops firing for a self-healing condition.

## How to test locally

```
mix test test/tuist/storage_test.exs test/tuist/builds/workers/process_build_worker_test.exs
```

Four new cases cover it: the worker snoozes on the first attempt when the object is missing, it fails once the archive is still missing after the snoozes, `download_to_file/3` normalizes a 404 into `:object_not_found`, and non-404 ExAws errors pass through untouched. Full run of both files: 65 passed. `mix format` and `mix credo` are clean.