### PR TITLE
fix(infra): size the runner cache master cap so masters survive admission

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -645,13 +645,20 @@ macosFleet:
     # none, and warm materializes at ~18%. At cap 20 it leaves 3 or 2. Either
     # covers the account set with dispatch affinity scoring on residency.
     #
-    # Watch the disk after changing this. The bug kept the volume near-empty
-    # (~28 GiB of one master), so restoring 2-3 residents actually occupies the
-    # quota (~60 GiB) and claims that much more of the shared boot container —
-    # 460 GiB with ~330 GiB free idle, but a single job VM's CoW growth
-    # transiently takes it to ~55 GiB. If that tail starts biting jobs, lower
-    # gib rather than raising cap: a smaller cap yields MORE total master bytes
-    # (masters fill to roughly gib - cap), so gib is the footprint lever.
+    # Raising gib is NOT the alternative fix. Masters that survive scale as
+    # gib/cap, so holding 3 at cap 28 needs gib 140, which raises the volume's
+    # PEAK claim on the shared boot container by 60 GiB. There is no room for
+    # that: the container is 460 GiB with ~330 GiB free idle, but a single job
+    # VM's CoW growth transiently takes it to 42-61 GiB, and the volume already
+    # reaches its 80 GiB quota (observed down to 0.5 GiB free). Restoring
+    # residents raises the volume's sustained floor, not that peak, which is
+    # why it fits where a bigger quota would not. gib also needs a host
+    # replacement (the provisioning script never resizes), while cap is an
+    # operator flag that rolls in place, so cap is the tunable one.
+    #
+    # If the tail ever does starve job VMs, lower gib rather than raising cap:
+    # masters fill to roughly gib - cap, so a smaller cap yields MORE total
+    # master bytes. gib is the footprint lever, cap is the master-count lever.
     masterCapGib: 20
     casGib: 11
   # Production tailnet — alloy-metrics scrapes PromEx (xcresult VM)

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -628,14 +628,25 @@ macosFleet:
   runnerCacheVolume:
     gib: 80
     # Fold the Xcode compilation cache (CAS) into the per-account image.
-    # masterCapGib 28 is the sparse per-master ceiling; of it the CAS gets
-    # 16 GiB, the binary cache ~10, and a ~2 GiB reserve stays free. A typical
-    # binary master is ~2.4 GB, so a 10 GiB binary budget still holds ~4x
-    # headroom while the CAS rides the same clone/promote/converge path. The
-    # guest is fail-safe: a store it cannot write falls back to a VM-local cold
-    # compilation cache, so a bad budget costs warmth, not the job.
-    masterCapGib: 28
-    casGib: 16
+    # masterCapGib is the sparse per-master ceiling; of it the CAS gets casGib,
+    # the binary cache the rest minus a ~2 GiB reserve. A typical binary master
+    # is ~2.4 GB, so the ~7 GiB binary budget still holds ~3x headroom while the
+    # CAS rides the same clone/promote/converge path. The guest is fail-safe: a
+    # store it cannot write falls back to a VM-local cold compilation cache, so
+    # a bad budget costs warmth, not the job.
+    #
+    # The cap is bounded by admission, not by taste. Admission reserves
+    # masterCapGib per live branch plus one, so on a gib-sized root with B
+    # concurrent VMs the resident masters that survive are gib/cap - (B+1) + 1.
+    # At 2 VMs per mini on an 80 GiB root that is 80/cap - 2: cap 28 leaves 0.86
+    # (every job evicted the master it was about to use, so warm materializes ran
+    # ~18%), cap 20 leaves 2. Two masters covers the fleet's account set with
+    # dispatch affinity, and 2x20 GiB resident also fits the host's disk budget:
+    # the boot container is 460 GiB with ~330 GiB free idle, but two concurrent
+    # job VMs transiently take it down to ~45 GiB, so the cache's real ceiling is
+    # that trough, not the gib quota.
+    masterCapGib: 20
+    casGib: 11
   # Production tailnet — alloy-metrics scrapes PromEx (xcresult VM)
   # + node_exporter (host) over the tailnet. The pre-auth key lives
   # in the production 1Password vault under TAILSCALE/auth-key.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -636,15 +636,22 @@ macosFleet:
     # a bad budget costs warmth, not the job.
     #
     # The cap is bounded by admission, not by taste. Admission reserves
-    # masterCapGib per live branch plus one, so on a gib-sized root with B
-    # concurrent VMs the resident masters that survive are gib/cap - (B+1) + 1.
-    # At 2 VMs per mini on an 80 GiB root that is 80/cap - 2: cap 28 leaves 0.86
-    # (every job evicted the master it was about to use, so warm materializes ran
-    # ~18%), cap 20 leaves 2. Two masters covers the fleet's account set with
-    # dispatch affinity, and 2x20 GiB resident also fits the host's disk budget:
-    # the boot container is 460 GiB with ~330 GiB free idle, but two concurrent
-    # job VMs transiently take it down to ~45 GiB, so the cache's real ceiling is
-    # that trough, not the gib quota.
+    # masterCapGib for the branch it is admitting plus every branch already
+    # live, so with B branches already held the resident masters that survive
+    # are gib/cap - (B+1). A host runs one job VM, but a branch is reserved at
+    # VM BOOT rather than at dispatch, so a booted warm standby holds one too:
+    # B is 0 or 1 depending on the pool. At cap 28 that leaves 1 or 0 masters —
+    # which is what the fleet showed, hosts flapping between one master and
+    # none, and warm materializes at ~18%. At cap 20 it leaves 3 or 2. Either
+    # covers the account set with dispatch affinity scoring on residency.
+    #
+    # Watch the disk after changing this. The bug kept the volume near-empty
+    # (~28 GiB of one master), so restoring 2-3 residents actually occupies the
+    # quota (~60 GiB) and claims that much more of the shared boot container —
+    # 460 GiB with ~330 GiB free idle, but a single job VM's CoW growth
+    # transiently takes it to ~55 GiB. If that tail starts biting jobs, lower
+    # gib rather than raising cap: a smaller cap yields MORE total master bytes
+    # (masters fill to roughly gib - cap), so gib is the footprint lever.
     masterCapGib: 20
     casGib: 11
   # Production tailnet — alloy-metrics scrapes PromEx (xcresult VM)


### PR DESCRIPTION
Drops the production macOS fleet's per-account cache volume `masterCapGib` from 28 to 20 and `casGib` from 16 to 11, so account masters survive admission instead of evicting each other.

## The problem

Warm cache-volume materializes on the production macOS runner fleet fell from over 90% to roughly 18% on 2026-07-31 and never recovered. Six of nine runner hosts currently hold no account master at all, and the three that do are mid-eviction.

7 day totals from `tart_kubelet_cache_volume_materialize_total`: 281 warm against 914 cold.

## Root cause

Admission arithmetic, not the volume mechanism. `AllocateBranch` reserves `masterCapGib` for the branch it is admitting plus every branch already live, then evicts LRU masters until that reservation fits. With `B` branches already held on a `gib` sized root, the masters that survive are:

```
M <= gib/cap - (B+1)
```

A host runs one job VM, but a branch is reserved at VM boot rather than at dispatch, so a booted warm standby holds one too. That puts `B` at 0 or 1 depending on pool state.

| cap | surviving masters | observed `resident_count` |
| --- | --- | --- |
| 20 (before the CAS fold) | 3 or 2 | 2 to 3 |
| 28 (current) | 1 or 0 | 0 to 1 |

So each job was evicting the master it was about to clone. The cap grew to 28 when the Xcode compilation cache was folded into the image (#12066), which took a master from roughly 2.4 GB to the full 28 GiB ceiling. Nothing else regressed: convergence still runs, volumes still attach, and the guest still mounts and promotes correctly.

The loop is directly observable on a single host over 36 hours. Cache volume free bytes went 53 GiB, down to 16.6 GiB as a branch grew alongside a resident master, then jumped to 79.98 GiB when the master was evicted, and the volume then sat completely empty for 19 hours while jobs kept running on it.

## Why this fix

Restoring 2 to 3 resident masters per host covers the fleet's account set, and dispatch affinity already scores candidates on volume residency (`Tuist.Runners.VolumeAffinities`), so the slots get used rather than thrashed.

Alternatives considered and rejected:

- **Raising `gib` above 80 instead of lowering the cap.** Surviving masters scale as `gib/cap`, so holding 3 at cap 28 needs `gib` 140. That raises the volume's PEAK claim on the shared boot container by 60 GiB, against a container whose 21 day minimum free is 42 to 61 GiB. Lowering the cap reaches the same master count inside the existing quota instead. It would also need a host replacement, since the provisioning script never resizes an existing volume, where the cap is an operator flag that rolls in place and can be tuned back quickly.
- **Lowering the cap further, to 16.** Yields 4 masters, more than the account set needs, and occupies more of the container rather than less.
- **Fixing the double count in admission** (a branch is a copy on write clone of a master whose blocks `statfs` free already reflects, so charging it a full cap counts the same bytes twice). This is the more principled fix and is still worth doing, but it is Go in tart-kubelet and needs an operator roll. At one VM per host the overhead is 1x rather than 2x, so it buys one extra master rather than unblocking the feature. Config first, code second.

## Impact

Expected: warm materialize back toward the pre regression level, and compilation CAS local hit rate back toward the 52% seen while hosts still held 2 to 3 masters (currently 20 to 30%).

Two things a reviewer should weigh:

1. **Existing masters do not shrink.** They are already 28 GiB on disk and only rebuild at the new budget on a successful promote, which is currently rejecting about 92% of the time. Left alone they would sit oversized and keep triggering the eviction they are meant to escape. Masters need evicting once after the operator rolls.
2. **The volume's sustained floor rises, but its peak does not.** Today it sits near empty between jobs at roughly 28 GiB precisely because of this bug. Restoring 2 to 3 residents takes that floor to roughly 60 GiB. The peak is unchanged: `node_filesystem_avail_bytes` shows the volume already reaching its 80 GiB quota (down to 0.5 GiB free on several hosts) while those same hosts' container minimum stayed at 42 to 61 GiB, so the container already absorbs a full volume. Peak is what determines ENOSPC risk for job VMs, which is why this fits where a bigger quota would not. If the tail ever does start starving job VMs, the lever is `gib`, not `cap`: masters fill to roughly `gib - cap`, so a smaller cap yields more total master bytes, not fewer. That inversion is recorded in the values comment so the next person changing it does not get it backwards.

Each account keeps an 11 GiB CAS and a roughly 7 GiB binary slice. A typical binary master is about 2.4 GB, so that is still around 3x headroom. The guest remains fail safe: a store it cannot write falls back to a VM local cold compilation cache, so a bad budget costs warmth, not the job.

## Validation

Derived from production telemetry rather than a local reproduction, since the behaviour only appears under real fleet scheduling:

- `tart_kubelet_cache_volume_materialize_total`: 281 warm / 914 cold over 7 days, with the change point isolated to 2026-07-31 by a 24 day daily series.
- `tart_kubelet_cache_volume_resident_count`: 0 on six of nine runner hosts, and the 2 to 3 per host to 0 to 1 per host transition across the same window.
- `tart_kubelet_cache_volume_root_free_bytes`: 52.19 GiB free where a master is resident, confirming a master really does fill its 28 GiB ceiling.
- `tart_kubelet_cache_volume_admission_declined_total`: 87 over 14 days, confirming room exhaustion reaches the decline path.
- `node_filesystem_avail_bytes` for the boot container and the cache volume, for the idle and peak occupancy figures and to confirm the cache volume's free bytes are quota relative rather than coupled to job VM pressure.

The surviving master formula reproduces both regimes (the pre fold cap and the current one) against observed `resident_count`, which is the main reason to trust it.

## Follow ups, not in this PR

- Promote rejection is about 92% (48 accepted against 553 rejected over 7 days; 47 branches promoted against 1637 discarded). Part of that is downstream of the cold base problem and should be re measured after this rolls, but the pre regression baseline was still 50 to 70%. The compilation CAS is content addressed and append only, so two jobs' CAS deltas cannot conflict, and discarding a loser's entries destroys work for no correctness reason. Splitting the promote decision per subtree (union the CAS, keep fast forward last writer wins for the pruned binary cache) is the likely answer.
- The admission double count described above.

### How to test locally

There is no local reproduction: the behaviour needs a real multi account fleet with concurrent dispatch. Verify in production after the operator rolls.

1. Confirm the operator picked up the new flags, `--cache-volume-cap-gib=20` and `--cache-volume-cas-gib=11`, on the runner hosts.
2. Evict existing masters once so they rebuild at the new budget.
3. Watch `tart_kubelet_cache_volume_resident_count` climb from 0 to 1 toward 2 to 3 per host, and the warm share of `tart_kubelet_cache_volume_materialize_total` rise off roughly 18%.
4. Confirm the end user effect in ClickHouse via `build_runs.cacheable_task_local_hits_count`. Measure this on customer accounts, not on tuist/tuist: the dogfood repo bumps its own CLI version constantly and the binary cache key includes the tool version, so its local hit counts read near zero regardless of volume health.
5. Watch `node_filesystem_avail_bytes` for the boot container for the added occupancy described above.
