### PR TITLE
fix(cli): keep transitive dependencies behind a non-default linking status

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -54,7 +54,7 @@ public class GraphTraverser: GraphTraversing {
             if !directConditionalTargets.contains(node) {
                 references.insert(node)
             }
-            if let deps = graph.dependencies[node] {
+            if let deps = graph.dependencies[node.graphKey] {
                 for dep in deps where !visited.contains(dep) {
                     stack.append(dep)
                 }
@@ -229,7 +229,7 @@ public class GraphTraverser: GraphTraversing {
                 }
             }
 
-            queue.append(contentsOf: graph.dependencies[dependency, default: []])
+            queue.append(contentsOf: graph.dependencies[dependency.graphKey, default: []])
         }
 
         return result
@@ -559,7 +559,7 @@ public class GraphTraverser: GraphTraversing {
                 from: targetGraphDependency
             )
             .flatMap { dependency -> [GraphDependencyReference] in
-                let dependencies = self.graph.dependencies[dependency, default: []]
+                let dependencies = self.graph.dependencies[dependency.graphKey, default: []]
                 return dependencies.compactMap {
                     dependencyDependency -> GraphDependencyReference? in
                     guard case GraphDependency.sdk = dependencyDependency else { return nil }
@@ -657,7 +657,7 @@ public class GraphTraverser: GraphTraversing {
 
             let staticDependenciesDynamicLibrariesAndFrameworks =
                 transitiveStaticTargetReferences.flatMap { dependency in
-                    self.graph.dependencies[dependency, default: []]
+                    self.graph.dependencies[dependency.graphKey, default: []]
                         .lazy
                         .filter(\.isTarget)
                         .filter(isEmbeddableDependencyTarget)
@@ -665,7 +665,7 @@ public class GraphTraverser: GraphTraversing {
 
             let staticDependenciesPrecompiledLibrariesAndFrameworks =
                 transitiveStaticTargetReferences.flatMap { dependency in
-                    self.graph.dependencies[dependency, default: []]
+                    self.graph.dependencies[dependency.graphKey, default: []]
                         .lazy
                         .filter { $0.isPrecompiled && $0.isLinkable }
                 }
@@ -724,10 +724,10 @@ public class GraphTraverser: GraphTraversing {
         while let dependency = dependenciesToVisit.popLast() {
             guard let accumulatedCondition = dependencyConditions[dependency] else { continue }
 
-            for childDependency in graph.dependencies[dependency, default: []] {
+            for childDependency in graph.dependencies[dependency.graphKey, default: []] {
                 let condition = intersection(
                     accumulatedCondition,
-                    with: graph.dependencyConditions[(dependency, childDependency)]
+                    with: graph.dependencyConditions[(dependency.graphKey, childDependency)]
                 )
                 guard condition != .incompatible else { continue }
 
@@ -1426,7 +1426,7 @@ public class GraphTraverser: GraphTraversing {
                 continue
             }
 
-            graph.dependencies[node]?.forEach { nodeDependency in
+            graph.dependencies[node.graphKey]?.forEach { nodeDependency in
                 if !visited.contains(nodeDependency) {
                     stack.push(nodeDependency)
                 }
@@ -1460,19 +1460,19 @@ public class GraphTraverser: GraphTraversing {
         }
 
         // if we're at a leaf dependency, there is nothing else to traverse.
-        guard let dependencies = graph.dependencies[rootDependency] else { return .incompatible }
+        guard let dependencies = graph.dependencies[rootDependency.graphKey] else { return .incompatible }
 
         let result: PlatformCondition.CombinationResult
 
         // We've reached our destination, return a condition for the leaf relationship (`nil` or a `PlatformFilters` set)
         if dependencies.contains(transitiveDependency) {
-            result = .condition(graph.dependencyConditions[(rootDependency, transitiveDependency)])
+            result = .condition(graph.dependencyConditions[(rootDependency.graphKey, transitiveDependency)])
         } else {
             // Capture the filters that could be applied to intermediate dependencies
             // A --> (.ios) B --> C : C should have the .ios filter applied due to B
             let filters = dependencies.map { node -> PlatformCondition.CombinationResult in
                 let transitive = combinedCondition(to: transitiveDependency, from: node)
-                let currentCondition = graph.dependencyConditions[(rootDependency, node)]
+                let currentCondition = graph.dependencyConditions[(rootDependency.graphKey, node)]
                 switch transitive {
                 case .incompatible:
                     return .incompatible

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Graph/GraphDependency.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Graph/GraphDependency.swift
@@ -152,6 +152,23 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         }
     }
 
+    /// The dependency in the form graphs use as a key.
+    ///
+    /// A linking status describes the edge that points at a target rather than the target itself, so both
+    /// `Graph.dependencies` and the `from` side of `Graph.dependencyConditions` key targets without one,
+    /// while the values they hold carry the status declared for their edge. Lookups have to normalize
+    /// first: the status is left out of `hash(into:)` but still compared by `==`, so feeding a value back
+    /// in as a key finds the right bucket and then misses. Normalize the key only — the `to` side of
+    /// `Graph.dependencyConditions` is stored with its status and has to be matched as it is.
+    public var graphKey: GraphDependency {
+        switch self {
+        case let .target(name, path, status) where status != .required:
+            return .target(name: name, path: path)
+        case .target, .macro, .foreignBuildOutput, .xcframework, .framework, .library, .bundle, .packageProduct, .sdk:
+            return self
+        }
+    }
+
     public var isTarget: Bool {
         switch self {
         case .macro: return false

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -46,6 +46,235 @@ struct GraphTraverserPackageProductTests {
     }
 }
 
+/// A non-default linking status describes the edge that points at a target, not the target itself. It must
+/// not change what is reachable behind that edge, nor the platform conditions along the way; the only thing
+/// it may change is whether, and how, the target it points at is linked.
+struct GraphTraverserLinkingStatusTests {
+    private func graph(
+        status: LinkingStatus,
+        intermediateProduct: Product = .framework
+    ) -> (Graph, Project) {
+        let app = Target.test(name: "App", product: .app)
+        let intermediate = Target.test(name: "MyFramework", product: intermediateProduct)
+        let deep = Target.test(name: "DeepFramework", product: .framework)
+        let project = Project.test(targets: [app, intermediate, deep])
+
+        return (
+            Graph.test(
+                projects: [project.path: project],
+                dependencies: [
+                    .target(name: app.name, path: project.path): [
+                        .target(name: intermediate.name, path: project.path, status: status),
+                    ],
+                    .target(name: intermediate.name, path: project.path): [
+                        .target(name: deep.name, path: project.path),
+                    ],
+                ]
+            ),
+            project
+        )
+    }
+
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func embeddableFrameworksIncludesFrameworksBehindADependencyWithLinkingStatus(
+        status: LinkingStatus
+    ) {
+        // Given
+        let (graph, project) = graph(status: status)
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: project.path, name: "App").sorted()
+
+        // Then
+        #expect(got == [
+            .product(target: "DeepFramework", productName: "DeepFramework.framework"),
+            .product(target: "MyFramework", productName: "MyFramework.framework", status: status),
+        ])
+    }
+
+    /// The same shape with the dependency in a separate project, which is the node a
+    /// `.project(target:path:status:)` declaration resolves to.
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func embeddableFrameworksIncludesFrameworksBehindACrossProjectDependencyWithLinkingStatus(
+        status: LinkingStatus
+    ) {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let intermediate = Target.test(name: "MyFramework", product: .framework)
+        let deep = Target.test(name: "DeepFramework", product: .framework)
+        let appProject = Project.test(path: "/App", targets: [app])
+        let frameworkProject = Project.test(path: "/Frameworks", targets: [intermediate, deep])
+        let graph = Graph.test(
+            projects: [appProject.path: appProject, frameworkProject.path: frameworkProject],
+            dependencies: [
+                .target(name: app.name, path: appProject.path): [
+                    .target(name: intermediate.name, path: frameworkProject.path, status: status),
+                ],
+                .target(name: intermediate.name, path: frameworkProject.path): [
+                    .target(name: deep.name, path: frameworkProject.path),
+                ],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: appProject.path, name: "App").sorted()
+
+        // Then
+        #expect(got == [
+            .product(target: "DeepFramework", productName: "DeepFramework.framework"),
+            .product(target: "MyFramework", productName: "MyFramework.framework", status: status),
+        ])
+    }
+
+    /// Platform conditions are stored per edge, keyed by the target the edge points at. A status further up
+    /// the chain must not lose them, for the edge carrying the condition or for anything beyond it.
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func embeddableFrameworksKeepsThePlatformConditionBehindADependencyWithLinkingStatus(
+        status: LinkingStatus
+    ) throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let intermediate = Target.test(name: "MyFramework", product: .framework)
+        let deep = Target.test(name: "DeepFramework", product: .framework)
+        let leaf = Target.test(name: "LeafFramework", product: .framework)
+        let project = Project.test(targets: [app, intermediate, deep, leaf])
+        let iOSOnly = try #require(PlatformCondition.when([.ios]))
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: app.name, path: project.path): [
+                    .target(name: intermediate.name, path: project.path, status: status),
+                ],
+                .target(name: intermediate.name, path: project.path): [
+                    .target(name: deep.name, path: project.path),
+                ],
+                .target(name: deep.name, path: project.path): [
+                    .target(name: leaf.name, path: project.path),
+                ],
+            ],
+            dependencyConditions: [
+                GraphEdge(
+                    from: .target(name: intermediate.name, path: project.path),
+                    to: .target(name: deep.name, path: project.path)
+                ): iOSOnly,
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: project.path, name: "App").sorted()
+
+        // Then
+        #expect(got == [
+            .product(target: "DeepFramework", productName: "DeepFramework.framework", condition: iOSOnly),
+            .product(target: "LeafFramework", productName: "LeafFramework.framework", condition: iOSOnly),
+            .product(target: "MyFramework", productName: "MyFramework.framework", status: status),
+        ])
+    }
+
+    /// When the status and the condition sit on the same edge, everything beyond that edge is only reachable
+    /// by walking through a node that carries the status.
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func embeddableFrameworksKeepsThePlatformConditionOfAnEdgeCarryingALinkingStatus(
+        status: LinkingStatus
+    ) throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let intermediate = Target.test(name: "MyFramework", product: .framework)
+        let deep = Target.test(name: "DeepFramework", product: .framework)
+        let leaf = Target.test(name: "LeafFramework", product: .framework)
+        let project = Project.test(targets: [app, intermediate, deep, leaf])
+        let iOSOnly = try #require(PlatformCondition.when([.ios]))
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: app.name, path: project.path): [
+                    .target(name: intermediate.name, path: project.path),
+                ],
+                .target(name: intermediate.name, path: project.path): [
+                    .target(name: deep.name, path: project.path, status: status),
+                ],
+                .target(name: deep.name, path: project.path): [
+                    .target(name: leaf.name, path: project.path),
+                ],
+            ],
+            dependencyConditions: [
+                GraphEdge(
+                    from: .target(name: intermediate.name, path: project.path),
+                    to: .target(name: deep.name, path: project.path, status: status)
+                ): iOSOnly,
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: project.path, name: "App").sorted()
+
+        // Then
+        #expect(got == [
+            .product(target: "DeepFramework", productName: "DeepFramework.framework", status: status, condition: iOSOnly),
+            .product(target: "LeafFramework", productName: "LeafFramework.framework", condition: iOSOnly),
+            .product(target: "MyFramework", productName: "MyFramework.framework"),
+        ])
+    }
+
+    /// `packageProductsLinkedThroughStaticTargets` walks the graph itself, so it needs the same treatment.
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func packageProductsLinkedThroughStaticTargetsIncludesProductsBehindADependencyWithLinkingStatus(
+        status: LinkingStatus
+    ) throws {
+        // Given
+        let feature = Target.test(name: "Feature", product: .staticFramework)
+        let featureCore = Target.test(name: "FeatureCore", product: .staticFramework)
+        let project = Project.test(targets: [feature, featureCore])
+        let packageProduct = GraphDependency.packageProduct(
+            path: "/path/package",
+            product: "SwiftProtobuf",
+            type: .runtime
+        )
+        let iOSOnly = try #require(PlatformCondition.when([.ios]))
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: feature.name, path: project.path): [
+                    .target(name: featureCore.name, path: project.path, status: status),
+                ],
+                .target(name: featureCore.name, path: project.path): [packageProduct],
+            ],
+            dependencyConditions: [
+                GraphEdge(
+                    from: .target(name: featureCore.name, path: project.path),
+                    to: packageProduct
+                ): iOSOnly,
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.packageProductsLinkedThroughStaticTargets(path: project.path, name: feature.name)
+
+        // Then
+        #expect(got == [.packageProduct(product: "SwiftProtobuf", condition: iOSOnly)])
+    }
+
+    @Test(arguments: [LinkingStatus.required, .optional, .none])
+    func linkableDependenciesIncludesFrameworksBehindAStaticDependencyWithLinkingStatus(
+        status: LinkingStatus
+    ) throws {
+        // Given
+        let (graph, project) = graph(status: status, intermediateProduct: .staticFramework)
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.linkableDependencies(path: project.path, name: "App")
+
+        // Then
+        #expect(got.contains(.product(target: "DeepFramework", productName: "DeepFramework.framework")))
+    }
+}
+
 final class GraphTraverserTests: TuistUnitTestCase {
     func test_dependsOnXCTest_when_is_framework() {
         // Given


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12287>

Declaring a dependency with `status: .none` or `.optional` dropped **every transitive dependency behind that edge** from the depending target's Embed Frameworks and Frameworks phases, with no warning at generation time, so an app shipped without frameworks it needs at runtime.

### Root cause

`Graph.dependencies` keys and values disagree about whether a linking status is part of a node's identity. A status describes the edge pointing at a target rather than the target itself, so every graph builder keys target nodes without one (`GraphLoader.swift:108`, `XcodeGraphMapper.swift:257`) while the edge values carry the declared status (`GraphLoader.swift:142`/`:152`). `GraphDependency.hash(into:)` matches that by leaving the status out of a target's hash, but the synthesized `==` still compares it — so a lookup that takes a value out of another node's dependency set lands in the right bucket and then fails equality. `filterDependencies` treated the node as a leaf and pruned everything behind it.

The same asymmetry affects the `from` side of `Graph.dependencyConditions`, where a miss silently dropped platform filters. In `combinedCondition` it was worse: the miss returned `.incompatible`, which makes `dependencyReference` return `nil` and delete the dependency outright.

### The fix

`GraphDependency.graphKey` normalizes a target to the status-free form graphs key it by, and the eleven `GraphTraverser` lookups that can receive a status-bearing node go through it.

Two alternatives were rejected:

- **Make `==` ignore the status for `.target`.** Five lines, fixes every site, and matches `hash(into:)` — but it collapses same-node/different-status values into a single Set member. `formUnionPreferringRequiredStatus` and `test_embeddableFrameworks_when_transitiveXCFrameworkWithDifferentStatuses` rely on both variants surviving so `.required` wins a diamond; collapsing them makes the surviving status depend on Set iteration order, i.e. nondeterministic weak linking in generated projects.
- **Re-key the graph and move the status to edge metadata**, mirroring `dependencyConditions`. Structurally the right shape, but it changes public `XcodeGraph` API, serialization and hashing — too large for a bugfix.

### Impact

Embedding and reachability are now independent of a dependency's status, as documented: `.none` skips linking that one dependency, `.optional` links it weakly, and neither changes what lies behind it. Platform conditions survive such edges too.

### Deliberately out of scope

Three call sites share the root cause but sit outside the traversal: `ForeignBuildGraphMapper.swift:76` (a real output bug for foreign-build targets), plus `GraphImportsLinter.swift:226` and `StaticProductsGraphLinter.swift:258` (under-reported lint warnings). Separately, `GraphTraverser.swift:298` and `:428` are the mirror image — they rebuild the `to` side status-free — and need the opposite fix (thread the real edge value through) plus their own tests. Happy to follow up on these.

### How to test locally

`GraphTraverserLinkingStatusTests` pins the regression: 6 tests parameterized over `.required`/`.optional`/`.none`, with `.required` as an in-band control.

```sh
mise exec -- tuist generate tuist TuistCore TuistCoreTests XcodeGraph XcodeGraphTests ProjectDescription --no-open
mise exec -- xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistCoreTests/GraphTraverserLinkingStatusTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

Each of the eleven normalizations was verified by reverting it individually and confirming a distinct failure — the dependency going absent, or surviving with its platform filter lost.

End to end with the reproducer from the issue, Embed Frameworks is now identical for all three statuses while linking still differs correctly:

| `status` | Frameworks (link) | Embed Frameworks |
| --- | --- | --- |
| `.required` | `MyFramework.framework` | `DeepFramework.framework`, `MyFramework.framework` |
| `.none` | *(empty)* | `DeepFramework.framework`, `MyFramework.framework` |
| `.optional` | `MyFramework.framework` (weak) | `DeepFramework.framework`, `MyFramework.framework` |

Regression suites green: `TuistCoreTests`, `XcodeGraphTests`, `TuistGeneratorTests` (378 tests), `TuistHasherTests`. `mise run cli:lint` and `swiftformat --lint` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
