### PR TITLE
fix(server): cap local ClickHouse dev logs so they cannot fill the disk

### DIFF
--- a/server/mise/tasks/clickhouse/start.sh
+++ b/server/mise/tasks/clickhouse/start.sh
@@ -24,9 +24,11 @@ USER_FILES_DIR="${CLICKHOUSE_RUNTIME_DIR}/user_files"
 FORMAT_SCHEMA_DIR="${CLICKHOUSE_RUNTIME_DIR}/format_schemas"
 LOG_DIR="${CLICKHOUSE_RUNTIME_DIR}/log"
 PID_FILE="${CLICKHOUSE_RUNTIME_DIR}/clickhouse.pid"
+LOCK_FILE="${CLICKHOUSE_RUNTIME_DIR}/start.lock"
 STARTUP_LOG="${LOG_DIR}/startup.log"
 SERVER_LOG="${LOG_DIR}/server.log"
 ERROR_LOG="${LOG_DIR}/error.log"
+STARTUP_LOG_MAX_BYTES=4194304
 
 mkdir -p \
   "${CONFIG_DIR}" \
@@ -38,6 +40,22 @@ mkdir -p \
   "${USER_FILES_DIR}" \
   "${FORMAT_SCHEMA_DIR}" \
   "${LOG_DIR}"
+
+# Bound the server's own log files. The embedded defaults log at `trace` with no
+# rotation, which writes ~8MB/minute and grows server.log until the disk is full.
+# Once a log write fails the Poco channel stays in a permanent error state: every
+# subsequent log call throws, and each throw is reported on stderr, which turns
+# the redirect below into a multi-GB-per-hour firehose that keeps the disk full.
+cat > "${CONFIG_DIR}/logger.xml" << 'EOF'
+<clickhouse>
+    <logger>
+        <level>information</level>
+        <size>50M</size>
+        <count>2</count>
+        <console>0</console>
+    </logger>
+</clickhouse>
+EOF
 
 # Create config.d with query_log enabled (ClickHouse merges this with embedded defaults)
 cat > "${CONFIG_DIR}/query_log.xml" << 'EOF'
@@ -87,6 +105,47 @@ if curl -sf "${CLICKHOUSE_HTTP_URL}/ping" >/dev/null 2>&1; then
   exit 0
 fi
 
+# `enter = { task = "clickhouse:start" }` fires on every shell that enters the
+# directory, so several invocations can reach the checks below at once and each
+# spawn a server against the same data directory. Serialise them: whoever loses
+# the race waits and then takes the "already running" fast path.
+# The lock is published by hard-linking a file that already holds the owner's
+# pid, so it is never observable in a half-written state: a waiter that reads it
+# always sees a pid it can test for liveness, and only reclaims the lock when
+# that pid is gone.
+LOCK_OWNER_FILE="${LOCK_FILE}.$$"
+printf '%s\n' "$$" > "${LOCK_OWNER_FILE}"
+# shellcheck disable=SC2064
+trap "rm -f '${LOCK_OWNER_FILE}'" EXIT
+
+lock_acquired=0
+for _ in $(seq 1 90); do
+  if ln "${LOCK_OWNER_FILE}" "${LOCK_FILE}" 2>/dev/null; then
+    # shellcheck disable=SC2064
+    trap "rm -f '${LOCK_FILE}' '${LOCK_OWNER_FILE}'" EXIT
+    lock_acquired=1
+    break
+  fi
+
+  lock_pid="$(tr -d '[:space:]' < "${LOCK_FILE}" 2>/dev/null || true)"
+  if [[ -n "${lock_pid}" ]] && ! kill -0 "${lock_pid}" >/dev/null 2>&1; then
+    rm -f "${LOCK_FILE}"
+    continue
+  fi
+
+  sleep 1
+done
+
+if [[ "${lock_acquired}" -eq 0 ]]; then
+  echo "Timed out waiting for another ClickHouse start to finish (${LOCK_FILE})." >&2
+  exit 1
+fi
+
+if curl -sf "${CLICKHOUSE_HTTP_URL}/ping" >/dev/null 2>&1; then
+  echo "ClickHouse already running at ${CLICKHOUSE_HTTP_URL}"
+  exit 0
+fi
+
 if [[ -f "${PID_FILE}" ]]; then
   pid="$(tr -d '[:space:]' < "${PID_FILE}")"
   if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
@@ -105,6 +164,15 @@ if [[ -f "${PID_FILE}" ]]; then
   fi
 fi
 
+# stdout/stderr only carries output from before the logger is up (config parse
+# failures, port conflicts), so `head` keeps the first STARTUP_LOG_MAX_BYTES and
+# `cat` drains the rest into /dev/null. Draining rather than closing the pipe is
+# what keeps the cap safe: the server never blocks on a full pipe, and the log
+# cannot grow past the cap no matter how much the server writes. The group's own
+# stdout and stderr go to /dev/null so it holds no descriptor from the caller;
+# otherwise it keeps the task's output pipe open for the server's whole lifetime
+# and whoever reads that pipe never sees EOF.
+#
 # Start ClickHouse in background (--daemon flag doesn't pick up config.d correctly).
 # Set keep_alive_timeout high enough to cover idle gaps in the Elixir connection
 # pool; otherwise the server drops sockets mid-suite and TRUNCATE queries from
@@ -128,7 +196,11 @@ fi
     --mysql_port="${CLICKHOUSE_MYSQL_PORT}" \
     --postgresql_port="${CLICKHOUSE_POSTGRESQL_PORT}" \
     --keep_alive_timeout=300 \
-    >"${STARTUP_LOG}" 2>&1 &
+    2>&1 | (
+      trap '' HUP
+      head -c "${STARTUP_LOG_MAX_BYTES}" > "${STARTUP_LOG}"
+      exec cat
+    ) >/dev/null 2>&1 &
 )
 
 for _ in $(seq 1 60); do


### PR DESCRIPTION
The local dev ClickHouse repeatedly filled the machine's disk (three times in two days). The runtime directory had grown to 36GB, of which 31GB was logs and only 9.3GB was data: `startup.log` alone was 34GB and still growing at roughly 1GB/minute.

## Root cause

This is an amplification loop, not slow drift.

ClickHouse's embedded defaults log at `trace` with no rotation, so `server.log` grows at ~8MB/minute until the disk is full. Once a log write fails, Poco's `FileChannel` is left in a permanent error state: every later log call throws from `LogFileImpl::sizeImpl()` while checking whether to rotate, and ClickHouse reports each throw with a full stack trace on stderr:

```
Cannot log message in OwnAsyncSplitChannel channel: Poco::Exception. Code: 1000,
File access error: .../log/server.log, Stack trace (...)
  0. Poco::FileException::FileException(String const&, int)
  1. Poco::LogFileImpl::sizeImpl() const
  2. Poco::RotateBySizeStrategy::mustRotate(Poco::LogFile*)
  ...
```

stderr was captured by the start task's shell redirection into `startup.log`, so a full disk turned every single log line into kilobytes of stack trace written back to the same disk. The state is sticky: freeing space does not recover it, which is why truncating `startup.log` bought only minutes before the next incident. On the affected machine `error.log` froze at its last real entry, a merge failing with `Available space: 116.46 MiB`, and everything after that was the loop.

Two details worth correcting for anyone who looked at this earlier:

- The several `clickhouse server` processes seen at once are normal. They are ClickHouse's watchdog plus its server child, not stacked servers.
- The redirect was already `>` (truncating), not `>>`. The 34GB→87GB apparent size was a sparse file: the log had been truncated in place while the server still held a descriptor at a large offset. Real usage was ~9GB.

## What changed

Three changes in `server/mise/tasks/clickhouse/start.sh`, each closing one link in the loop:

- **`config.d/logger.xml`** sets `<size>50M</size>` and `<count>2</count>` so `server.log` and `error.log` rotate, and drops the level from `trace` to `information`. A full boot now writes ~100KB instead of ~40MB, so the log files can no longer be what fills the disk in the first place.
- **The startup redirection is bounded.** stdout/stderr only carries output from before the logger is up (config parse failures, port conflicts), so `head` keeps the first 4MiB and `cat` drains the remainder to `/dev/null`. Draining rather than closing the pipe is what makes the cap safe: the server never blocks on a full pipe and is never sent SIGPIPE, so no amount of stderr spam can grow the file past the cap. The drain group's own stdout and stderr go to `/dev/null` so it holds no descriptor belonging to the caller; without that it keeps the task's output pipe open for the server's whole lifetime and anything capturing that output never sees EOF.
- **Starts are serialised.** `enter = { task = "clickhouse:start" }` fires on every shell that enters the directory, so several invocations could reach the readiness checks at once and each launch a server against the same data directory. The lock is published by hard-linking a file that already contains the owner's pid, so it is never observable half-written: a waiter always reads a pid it can test for liveness, and only reclaims the lock when that process is gone. Losers fall through to the existing "already running" path.

### Why these choices

Capping `startup.log` and fixing the logger are both needed, and neither alone is sufficient. Rotation prevents the disk from filling, but if it fills for any other reason (as it did here) the sticky Poco failure still turns stderr into a firehose. Capping the redirect breaks the amplification but leaves `trace`-level logs growing unbounded.

Truncate-on-start was considered and rejected: the redirect was already truncating, and a single run wrote 9GB, so per-start truncation does not bound anything. Dropping the redirect entirely was also rejected because it would leave `ClickHouse failed to start` with no diagnostics for pre-logger failures. `ulimit -f` would apply to data parts too and terminates the process on SIGXFSZ.

The lock is a hard link rather than `mkdir` because `mkdir` plus a separate pid write has a window where the pid file does not yet exist; a waiter that reads it during that window sees no pid, concludes the lock is stale, and removes a live lock.

## Impact

Development environment only. No production or CLI code paths are touched. Contributors get bounded ClickHouse logs and `information`-level output; anyone who needs `trace` back can edit the generated `config.d/logger.xml`. `data/` is untouched, so no re-seeding is required.

## How to test locally

```
mise run clickhouse:start
```

Then:

- `sed -n '/<logger>/,/<\/logger>/p' ~/.local/state/tuist/clickhouse/preprocessed_configs/config.xml` shows `level=information`, `size=50M`, `count=2`.
- `ls -la ~/.local/state/tuist/clickhouse/log/` shows `startup.log` at 0 bytes and `server.log` in the ~100KB range after a boot.
- Running `mise run clickhouse:start` again returns promptly with `ClickHouse already running`.
- Six concurrent cold starts produce exactly one server:

```
mise run clickhouse:stop
for i in 1 2 3 4 5 6; do bash server/mise/tasks/clickhouse/start.sh & done; wait
grep -c "Starting ClickHouse" ~/.local/state/tuist/clickhouse/log/server.log
```

## Validation performed

Run against the real runtime directory on an affected machine:

- Six concurrent cold starts produced exactly one `Starting ClickHouse` line and one server process, with no leftover lock file. Repeated afterwards with three sequential warm starts, all taking the "already running" path.
- The effective config resolved to `level=information`, `size=50M`, `count=2`, confirmed in `preprocessed_configs/config.xml`.
- Rotation was observed producing `server.log.0.gz` at the size boundary.
- A synthetic 27MiB stderr firehose pushed through the same pipeline left the log at exactly 4194304 bytes with the writer still alive, confirming the cap holds and nothing is killed by SIGPIPE.
- `mise run clickhouse:start` returns in 0.7s when already running, verifying the output pipe reaches EOF. An earlier iteration of the drain group did not redirect its own stdio and hung command substitution until the server exited; that is what the `>/dev/null 2>&1` on the group fixes.
- `shellcheck` clean.
- Data intact after the restarts: 16659 tables, 7.18 GiB. The log directory went from 31GB to 136KB and the disk recovered ~60GB.
