### PR TITLE
fix(runner-image, infra): unblock the runner image build and its push to GHCR

### DIFF
--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -9,9 +9,12 @@ inputs:
     description: Newline-separated remote image names
     required: true
   attempts:
-    description: Maximum number of push attempts
+    description: >-
+      Maximum number of push attempts. Attempts accumulate rather than
+      start over, so this is a progress budget and not just a way to wait
+      out a bad window.
     required: false
-    default: "5"
+    default: "8"
   concurrency:
     description: Number of concurrent registry uploads within Tart
     required: false
@@ -178,11 +181,24 @@ runs:
             exit 1
           fi
 
+          # The ramp is capped at 5 minutes rather than 10. Sleeping
+          # longer made sense when a retry was assumed to start over,
+          # where the only thing waiting bought was a chance the
+          # condition had cleared. Layers persist between attempts, so
+          # wall clock spent uploading banks progress and wall clock
+          # spent sleeping does not, and 5 minutes already matches what
+          # GitHub asks for after a secondary rate limit.
+          #
+          # The budget is sized against the 90-minute timeout every
+          # caller puts on this step: 8 attempts sleep ~26 minutes plus
+          # jitter, leaving roughly 50 minutes of uploading. Raising
+          # `attempts` past that trades a clear "failed N times" error
+          # for a step killed mid-upload.
           case "$attempt" in
             1) base_delay=60 ;;
             2) base_delay=120 ;;
-            3) base_delay=300 ;;
-            *) base_delay=600 ;;
+            3) base_delay=180 ;;
+            *) base_delay=300 ;;
           esac
           jitter=$((RANDOM % (base_delay / 2 + 1)))
           delay=$((base_delay + jitter))

--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -109,7 +109,18 @@ runs:
             exit 0
           fi
 
+          # GHCR reports its secondary rate limit as a 403 whose OCI
+          # error code is DENIED, which the permissions match below
+          # reads as a credentials problem and fails the push outright.
+          # The throttle clears in minutes and the backoff already
+          # waits longer than that, so classify it first and let the
+          # retry loop ride it out. Ordering is the whole point here:
+          # both patterns match the same log line.
           if grep -Eqi \
+            'secondary rate limit|too many requests|toomanyrequests|code: 429' \
+            "$attempt_log"; then
+            echo "::warning::Tart push hit a registry rate limit; retrying"
+          elif grep -Eqi \
             'unauthorized|authentication required|denied|invalid reference' \
             "$attempt_log"; then
             echo "::error::Tart push failed with a non-retryable error"

--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -128,14 +128,22 @@ runs:
           #   monolithic     one request per blob, no rate limiting seen,
           #                  but every attempt died with "The request
           #                  timed out" partway through the disk (best
-          #                  attempt reached 42%). A single multi-hour
-          #                  request has no way to resume, so a hiccup
-          #                  restarts the whole blob.
+          #                  attempt reached 42%). That error is a
+          #                  URLError raised by Tart's own client, not a
+          #                  registry response.
           #
           # Do not "fix" a rate-limited push by reaching for a larger
           # chunk or for monolithic. The levers that remain are the retry
           # budget below, not pushing several large images concurrently,
           # and the image size itself.
+          #
+          # Retrying is worth more than it looks: Tart splits the disk
+          # into layers of at most 512 MiB, and skips any layer whose
+          # digest the registry already has (DiskV2.push does a
+          # blobExists HEAD per layer). Attempts therefore accumulate
+          # instead of starting over, and a failure costs only the layer
+          # in flight, whose upload session never closes and so never
+          # registers.
           if tart push \
             --concurrency "$TART_PUSH_CONCURRENCY" \
             --chunk-size "$TART_PUSH_CHUNK_SIZE" \

--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -17,9 +17,13 @@ inputs:
     required: false
     default: "1"
   chunk-size:
-    description: Upload chunk size in megabytes
+    description: >-
+      Upload chunk size in megabytes. 0 uploads each blob monolithically,
+      which is what GHCR wants for images this size. GHCR rejects chunks of
+      4 megabytes and up, so chunked mode cannot send fewer than roughly one
+      request per 3 megabytes of image.
     required: false
-    default: "3"
+    default: "0"
 
 runs:
   using: composite
@@ -44,6 +48,15 @@ runs:
           local value="$2"
           if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::${name} must be a positive integer, got '${value}'"
+            exit 1
+          fi
+        }
+
+        require_non_negative_integer() {
+          local name="$1"
+          local value="$2"
+          if [[ ! "$value" =~ ^(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::${name} must be a non-negative integer, got '${value}'"
             exit 1
           fi
         }
@@ -76,7 +89,7 @@ runs:
 
         require_positive_integer "attempts" "$TART_PUSH_ATTEMPTS"
         require_positive_integer "concurrency" "$TART_PUSH_CONCURRENCY"
-        require_positive_integer "chunk-size" "$TART_PUSH_CHUNK_SIZE"
+        require_non_negative_integer "chunk-size" "$TART_PUSH_CHUNK_SIZE"
 
         remote_names=()
         while IFS= read -r remote_name; do
@@ -93,13 +106,25 @@ runs:
         echo "Tart version: $(tart --version)"
         echo "Host macOS version: $(sw_vers -productVersion)"
         echo "Registry concurrency: ${TART_PUSH_CONCURRENCY}"
-        echo "Upload chunk size: ${TART_PUSH_CHUNK_SIZE} megabytes"
+        if [ "$TART_PUSH_CHUNK_SIZE" -eq 0 ]; then
+          echo "Upload mode: monolithic (one request per blob)"
+        else
+          echo "Upload mode: chunked, ${TART_PUSH_CHUNK_SIZE} megabytes per request"
+        fi
         probe_registry_path
 
         for ((attempt = 1; attempt <= TART_PUSH_ATTEMPTS; attempt++)); do
           attempt_log="${RUNNER_TEMP:-/tmp}/tart-push-${GITHUB_RUN_ID:-local}-${attempt}.log"
           echo "Tart push attempt ${attempt}/${TART_PUSH_ATTEMPTS} at $(date -u +%H:%M:%SZ)" >&2
 
+          # `--chunk-size 0` is Tart's monolithic upload. Chunking was
+          # introduced here to make a multi-gigabyte push resumable, but
+          # GHCR caps a chunk below 4 megabytes, so a ~50 gigabyte disk
+          # became on the order of 17,000 requests and started tripping
+          # GHCR's secondary rate limit a few minutes into every attempt.
+          # There is no middle setting to reach for: the ceiling is the
+          # value we were already using. Monolithic trades chunk-level
+          # resumability for one request per blob.
           if tart push \
             --concurrency "$TART_PUSH_CONCURRENCY" \
             --chunk-size "$TART_PUSH_CHUNK_SIZE" \

--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -18,12 +18,12 @@ inputs:
     default: "1"
   chunk-size:
     description: >-
-      Upload chunk size in megabytes. 0 uploads each blob monolithically,
-      which is what GHCR wants for images this size. GHCR rejects chunks of
-      4 megabytes and up, so chunked mode cannot send fewer than roughly one
-      request per 3 megabytes of image.
+      Upload chunk size in megabytes, or 0 for monolithic uploads. GHCR
+      rejects chunks of 4 megabytes and up, so 3 is the largest chunked
+      value it accepts. Monolithic was measured here and does not work at
+      this image size: see the comment on the push call below.
     required: false
-    default: "0"
+    default: "3"
 
 runs:
   using: composite
@@ -117,14 +117,25 @@ runs:
           attempt_log="${RUNNER_TEMP:-/tmp}/tart-push-${GITHUB_RUN_ID:-local}-${attempt}.log"
           echo "Tart push attempt ${attempt}/${TART_PUSH_ATTEMPTS} at $(date -u +%H:%M:%SZ)" >&2
 
-          # `--chunk-size 0` is Tart's monolithic upload. Chunking was
-          # introduced here to make a multi-gigabyte push resumable, but
-          # GHCR caps a chunk below 4 megabytes, so a ~50 gigabyte disk
-          # became on the order of 17,000 requests and started tripping
-          # GHCR's secondary rate limit a few minutes into every attempt.
-          # There is no middle setting to reach for: the ceiling is the
-          # value we were already using. Monolithic trades chunk-level
-          # resumability for one request per blob.
+          # Both upload modes were measured against this image on
+          # 2026-08-12, and 3 megabytes is the least bad of the two:
+          #
+          #   chunked, 3MB   ~17,000 requests for a ~50 gigabyte disk,
+          #                  roughly 120 per minute, which trips GHCR's
+          #                  secondary rate limit under load. GHCR
+          #                  rejects chunks of 4MB and up, so this is
+          #                  already the largest chunk it accepts.
+          #   monolithic     one request per blob, no rate limiting seen,
+          #                  but every attempt died with "The request
+          #                  timed out" partway through the disk (best
+          #                  attempt reached 42%). A single multi-hour
+          #                  request has no way to resume, so a hiccup
+          #                  restarts the whole blob.
+          #
+          # Do not "fix" a rate-limited push by reaching for a larger
+          # chunk or for monolithic. The levers that remain are the retry
+          # budget below, not pushing several large images concurrently,
+          # and the image size itself.
           if tart push \
             --concurrency "$TART_PUSH_CONCURRENCY" \
             --chunk-size "$TART_PUSH_CHUNK_SIZE" \

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -19,16 +19,31 @@ runtime — no service, sudo entry, or auto-login targets it.
 
 Because the base images provision as `admin` and jobs run as
 `runner`, anything the base installs under `admin` has to be
-handed over explicitly. `/opt/homebrew` is the case that bit us:
-the prefix shipped owned by `admin`, so `brew install` from a
-workflow step failed its writability audit while `brew` itself
-resolved fine on `PATH`. GitHub-hosted images build and run under
-one account, so the job user owns the prefix — this image chowns
-it to `runner` to match. When adding tooling to the base, check
-ownership, not just reachability. The `brew install hello`
-sanity check at the end of the Packer template exists because a
-reachability-only check stayed green through months of broken
-installs.
+handed over explicitly. Two things are:
+
+- `/opt/homebrew`. The prefix shipped owned by `admin`, so `brew
+  install` from a workflow step failed its writability audit
+  while `brew` itself resolved fine on `PATH`. GitHub-hosted
+  images build and run under one account, so the job user owns
+  the prefix — this image chowns it to `runner` to match.
+- `~/.zprofile`. The cirruslabs base writes it for `admin` and
+  symlinks `/Users/runner` at `/Users/admin`; this image replaces
+  that symlink with a real `runner` account whose home comes from
+  macOS's user template and has no `.zprofile`, so the file is
+  copied over. Without it the login shell the LaunchAgent (and
+  every step shell under it) runs resolves no brew shellenv, no
+  rbenv, no node.
+
+When adding tooling to the base, check ownership and login-shell
+reachability from `runner`, not just presence under `admin`.
+
+The sanity checks at the end of the Packer template run as `sudo
+-u runner -H`. macOS sudoers keeps `HOME`, so dropping `-H`
+leaves them pointed at `/Users/admin` and they assert against the
+provisioning account's environment instead of the runtime one —
+which is how a reachability check stayed green through months of
+broken `brew install`s, and how the `brew install hello` check
+added to catch that failed on `admin`'s unwritable cache instead.
 
 - `/Users/runner/actions-runner/` — GitHub Actions runner binary
   (no registration; we register at runtime via JIT config minted

--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -21,9 +21,10 @@
   to every step shell. Customer workflows that read $HOME or
   invoke a Homebrew-installed tool break before the first step
   runs. Wrapping the entrypoint in `/bin/zsh -lc` here makes it
-  a login shell, which sources the cirruslabs base's ~/.zprofile
-  (Homebrew shellenv, rbenv init, LANG=en_US.UTF-8, PATH
-  additions for Android SDK + Flutter + openjdk + Node). Step
+  a login shell, which sources ~/.zprofile (Homebrew shellenv,
+  rbenv init, LANG=en_US.UTF-8, node on PATH) — the cirruslabs
+  base builds that file for `admin` and the Packer template
+  copies it into the runner's home, which is created empty. Step
   shells inherit the same environment an interactive SSH session
   on the same VM would see. Supersedes the per-var workarounds
   layered on top of the prior LaunchDaemon (#10797, #10800).

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -69,8 +69,15 @@ packer {
 # That split is the thing to keep in mind when changing this file.
 # Anything the base set up under `admin` is not automatically
 # usable by `runner`: the Homebrew prefix has to be handed over
-# explicitly (see the chown provisioner below), and the sanity
-# checks at the end assert against `runner`, never `admin`.
+# explicitly, `~/.zprofile` has to be copied into the new home
+# (see the two provisioners below), and the sanity checks at the
+# end assert against `runner`, never `admin`.
+#
+# Those checks run as `sudo -u runner -H`. The `-H` is load-
+# bearing: macOS sudoers carries `env_keep += "HOME"`, so a plain
+# `sudo -u runner` leaves `HOME=/Users/admin` and the checks
+# silently exercise `admin`'s login shell and `admin`'s caches
+# while appearing to test the runtime account.
 #
 # Note that the runner is registered with GitHub at *job* time,
 # not image-build time — the image carries the runner binary but
@@ -219,6 +226,29 @@ build {
     inline = [
       "set -euo pipefail",
       "echo 'admin' | sudo -S chown -R runner:admin /opt/homebrew"
+    ]
+  }
+
+  # Hand the login-shell environment to `runner`. The cirruslabs
+  # base builds `~/.zprofile` for `admin` (Homebrew shellenv,
+  # rbenv init, LANG=en_US.UTF-8, node@24 on PATH) and symlinks
+  # `/Users/runner` at `/Users/admin`, so its runner user reads
+  # the same file. Wiping that symlink above gives `runner` a home
+  # created from macOS's user template, which carries no
+  # `.zprofile` at all — every login shell on this image (the
+  # LaunchAgent entrypoint, and therefore every workflow step
+  # shell that inherits its environment) would resolve none of the
+  # base's tooling.
+  #
+  # Copy rather than symlink back into admin's home: the accounts
+  # are separate here (see the header), and a job appending to its
+  # own `~/.zprofile` must not rewrite the provisioning user's.
+  # The file's contents are $HOME-independent, so the copy behaves
+  # identically under the new owner.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "echo 'admin' | sudo -S install -m 0644 -o runner -g staff /Users/admin/.zprofile /Users/runner/.zprofile"
     ]
   }
 
@@ -421,9 +451,11 @@ build {
   # Sanity check: tools customers expect on a GitHub-parity macOS
   # runner have to be reachable from the agent's runtime
   # environment. The agent wraps its entrypoint in `zsh -lc`, so
-  # ~/.zprofile is sourced (Homebrew shellenv, mise, rbenv init,
-  # PATH additions for the macos-tahoe-xcode base's pre-installed
-  # tools). A future base-image bump that moves Homebrew's prefix
+  # the ~/.zprofile copied into the runner's home above is sourced
+  # (Homebrew shellenv, rbenv init, PATH additions for the
+  # macos-tahoe-xcode base's pre-installed tools) — which is why
+  # these run with `-H` and not against `admin`'s copy of the same
+  # file. A future base-image bump that moves Homebrew's prefix
   # or drops a formula would silently make tools unreachable from
   # step shells; resolve each tool against the same login-shell
   # environment so image-build CI fails loudly instead of customer
@@ -436,8 +468,8 @@ build {
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "sudo -u runner /bin/zsh -lc 'for tool in brew mise gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage xcodes xcrun; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in runner login shell — base image regression\" >&2; exit 1; }; done'",
-      "sudo -u runner /bin/zsh -lc '/usr/bin/xcrun xcresulttool version'"
+      "sudo -u runner -H /bin/zsh -lc 'for tool in brew mise gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage xcodes xcrun; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in runner login shell — base image regression\" >&2; exit 1; }; done'",
+      "sudo -u runner -H /bin/zsh -lc '/usr/bin/xcrun xcresulttool version'"
     ]
   }
 
@@ -453,12 +485,14 @@ build {
   # image builds fail on transient GitHub blips. The chown is
   # recursive, so tap writability moves with the prefix; what's
   # actually at risk of regressing, and what this exercises, is
-  # writing into Cellar and the lock/var dirs.
+  # writing into Cellar and the lock/var dirs. `brew` also writes
+  # its download and bootsnap caches under `$HOME`, which is the
+  # other half of why these run with `-H`.
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "sudo -u runner /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew install hello' || { echo 'sanity check: unprivileged brew install failed for the runner user — Homebrew prefix ownership regression' >&2; exit 1; }",
-      "sudo -u runner /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall hello'"
+      "sudo -u runner -H /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew install hello' || { echo 'sanity check: unprivileged brew install failed for the runner user — Homebrew prefix ownership regression' >&2; exit 1; }",
+      "sudo -u runner -H /bin/zsh -lc 'HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall hello'"
     ]
   }
 }


### PR DESCRIPTION
The runner image build has been failing on every Xcode profile since #12263 landed, so no runner image has been published from `main` since ([failing run](https://github.com/tuist/tuist/actions/runs/31580528749/job/94082208068)).

### What was wrong

The `brew install hello` sanity check added in #12263 aborts with:

```
Permission denied @ rb_sysopen - /Users/admin/Library/Caches/Homebrew/bootsnap/...
```

The cache path is the tell. The check runs as `runner`, but brew resolved its caches into *admin's* home. macOS sudoers carries `env_keep += "HOME"`, so a plain `sudo -u runner` leaves `HOME=/Users/admin`, which the runner user cannot write to. The Homebrew prefix handover in #12263 was correct; the check simply never ran with the runner's own `HOME`.

Fixing `HOME` alone would only move the failure, because of a second and older problem that this uncovered: the runner user has no `~/.zprofile` at all. The cirruslabs base builds that file for `admin` and symlinks `/Users/runner` at `/Users/admin` so both accounts read it; #10833 replaced that symlink with a real `runner` account whose home comes from macOS's user template. Since then the runner's login shell has resolved no Homebrew shellenv, no rbenv init, no node on PATH. It stayed invisible because the leaked `HOME` pointed the tool-reachability sanity check at admin's `.zprofile`, so that check was asserting the provisioning account's environment all along rather than the runtime one.

### What changed

- `infra/runner-image/runner.pkr.hcl`: copy `/Users/admin/.zprofile` to `/Users/runner/.zprofile` (owned `runner:staff`) in a new handover provisioner next to the Homebrew chown. Copying rather than symlinking back into admin's home keeps a job that appends to its own profile out of the provisioning user's, and the file's contents are `$HOME`-independent so it behaves identically under the new owner.
- Both sanity-check provisioners now run `sudo -u runner -H`, so they assert against the account and the home that actually run jobs. Without `-H` they are checking `admin`.
- Comments in the Packer template, `launchd.plist`, and `infra/runner-image/AGENTS.md` now record where `~/.zprofile` comes from and why `-H` is load-bearing, so the next change to this file does not reintroduce either half.

### Impact

Image builds pass again. Beyond unblocking CI, workflow steps on the fleet get the login-shell environment the image has always claimed to provide: Homebrew tools on PATH for the runner account, not just for the account that built the image.

### How to test locally

Image builds need the bare-metal Tart builder, so this was validated on CI rather than locally:

```bash
gh workflow run runner-image.yml --ref claude/image-build-failure-b3b3c8 -f xcode_version=26.0.1
```

[Run 31619392575](https://github.com/tuist/tuist/actions/runs/31619392575) is green end to end and published `ghcr.io/tuist/tuist-runner:macos-26-0-1-a963e409`.

The image build is validated four times over, and this run proves the fix rather than just the exit code: the build log shows `Pouring hello--2.12.3.arm64_tahoe.bottle.tar.gz` followed by `Uninstalling`, so an unprivileged `brew install` genuinely works for the `runner` user against the copied `.zprofile` and a real `HOME`. `xcrun xcresulttool version` resolves in the same login shell. On `main` today this step fails.

The push succeeded on attempt 1 in 86 minutes with no rate limit and no timeout, so the registry throttle that reddened the earlier runs had cleared.

One number from that run deserves a reviewer's attention: a clean push takes 86 minutes against the 90-minute timeout every caller puts on the step. The retry budget in this PR is therefore mostly theoretical as things stand, because a second attempt cannot fit in the remaining 4 minutes. Raising those timeouts is a change across all five call sites including the production deployment, so it is deliberately not in this PR.

### Known follow-up, not addressed here

The copied profile's `rbenv init` resolves `RBENV_ROOT=$HOME/.rbenv`, while the base's installed rubies live under `/Users/admin/.rbenv`. A workflow calling `rbenv`/`gem` on this image therefore gets system Ruby. That is a separate gap from this build failure and is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



