### PR TITLE
fix(infra): size the production xcresult processor VM for its dedicated host

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -467,6 +467,33 @@ xcresultProcessor:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  # Size the Tart VM for a dedicated host. tart-kubelet derives the VM's
+  # `tart set --cpu/--memory` from the container's resources, preferring
+  # limits (vmResourcesFromPod in infra/tart-kubelet), so these numbers ARE
+  # the VM. The chart default (3 CPU / 4Gi) is sized for a shared or
+  # self-hosted box and left a 10-core / 16 GB Mac mini running a 3-core VM
+  # at load 7+ while the host idled at 3 of 10. The parse path is CPU-bound,
+  # so that capped throughput to roughly a third of the hardware.
+  #
+  # 6 CPU matches the M2 Pro's 6 performance cores and leaves the 4
+  # efficiency cores to the macOS host; 12Gi leaves 4 GB for the host and
+  # the Virtualization.framework reserve (the fleet's runner VMs already run
+  # 14336 MB on identical hardware, so this stays inside proven headroom).
+  # The topology spread pins one replica per host, so a VM never shares.
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "4Gi"
+    limits:
+      cpu: "6000m"
+      memory: "12Gi"
+  # One in-flight parse per performance core. Held at parity with the CPU
+  # count deliberately: at the old 3-core sizing the chart default of 4
+  # oversubscribed the VM 2.4x (load 7.33 on 3 cores), which stretched
+  # per-job latency without adding throughput. 12Gi across 6 workers also
+  # keeps ~2 GB per parse, above the ~1 GB/worker the 4Gi VM ran at
+  # without touching swap.
+  queueConcurrency: 6
   # Opt into the Tailscale-fronted URL the processor's ExternalSecret
   # renders when postgresql.cnpg.pooler.tailscale.enabled is true.
   # Linux processors keep the direct in-cluster URL via the default


### PR DESCRIPTION
## What changed

Production `xcresultProcessor` now sets its own resources and queue concurrency:

- `limits`: `cpu: 3000m / memory: 4Gi` becomes `cpu: 6000m / memory: 12Gi`
- `requests`: `cpu: 1000m / memory: 2Gi` becomes `cpu: 2000m / memory: 4Gi`
- `queueConcurrency`: 4 becomes 6

The chart default is intentionally unchanged.

## Why

`tart-kubelet` derives each Tart VM's `tart set --cpu/--memory` from the pod's container resources, preferring limits (`vmResourcesFromPod`, `infra/tart-kubelet/internal/podagent/reconciler.go`). Those numbers are not a cgroup cap on macOS, they *are* the VM.

`values-managed-production.yaml` never overrode `xcresultProcessor.resources`, so production inherited the chart default and a dedicated 10-core / 16 GB Mac mini was hosting a 3-core / 4 GB guest, using about 30% of the CPU and 25% of the RAM the box provides.

## Root cause context

Found while investigating a production incident in which remote xcresult processing was fully stalled. That outage had a different cause (an expired Tailscale pre-auth key wedged the VM boot chain before `exec tuist start`, so no Oban consumer ever started). Once processing was restored, the recovery rate exposed this sizing problem as a separate, pre-existing issue.

Measurements taken on the live fleet after recovery:

| signal | value |
|---|---|
| VM CPUs / RAM | 3 / 4 GB |
| load average inside VM | 7.33 on 3 CPUs |
| swap used inside VM | 0.00 MB |
| host load | 3.19 of 10 cores |
| throughput | ~2.4 jobs/min |
| arrival rate | ~13 jobs/min |

The guest was starved for cores that sat idle on the host, and zero swap confirmed CPU rather than memory was binding. At those rates the backlog grew rather than drained.

## Why these numbers

6 CPU matches the M2 Pro's 6 performance cores and leaves the 4 efficiency cores to the macOS host. 12Gi leaves 4 GB for the host plus the Virtualization.framework reserve, which stays inside headroom the fleet's runner VMs already prove by running 14336 MB on identical hardware.

Concurrency moves to one in-flight parse per performance core. The previous value was not merely untuned, it was oversubscribed: 4 workers on 3 cores is 2.4x, which stretches per-job latency without adding throughput. At 12Gi across 6 workers each parse gets roughly 2 GB, above the roughly 1 GB per worker the 4Gi VM sustained without touching swap.

## Alternatives considered

- **Raising concurrency alone.** Rejected. The VM was already oversubscribed, so more workers would have added contention, not throughput.
- **Changing the chart default.** Rejected. 3 CPU / 4Gi is a reasonable conservative default for self-hosters who may co-locate the processor with other work. The managed fleet pins one replica per host through the topology spread and can claim the whole box, so the override belongs in the env values file next to `macosFleet.machine`, which already encodes the same host-reserve convention.
- **Going straight to 14336 MB** to match `macosFleet.machine.hostMemoryMB`. Held back one step: the host showed meaningful Virtualization.framework overhead beyond the guest allocation, and CPU is the binding constraint, so the memory increase only needs to keep pace with the extra workers.

## Impact

Roughly doubles per-node parse throughput with no new hardware. This matters immediately because the production fleet is running one node while a second Mac mini is offline, so per-node throughput is the only lever available without new capacity.

Applying it requires a rollout, and with `maxSurge: 0` on a single-node fleet that means a short window at zero throughput while the VM reboots. Worth scheduling deliberately rather than landing during a backlog peak.

## Validation

Rendered the chart against the production values file. The Deployment comes out with `limits: cpu 6000m / memory 12Gi`, `requests: cpu 2000m / memory 4Gi`, and `TUIST_PROCESS_XCRESULT_QUEUE_CONCURRENCY="6"`, which `tart-kubelet` converts to a 6-core / 12288 MB VM. Confirmed the pre-existing local render guards that required extra `--set` values are unrelated to this change by reproducing them against the unmodified file.

## Follow-ups

- Canary still inherits the chart default and should get the same treatment once this is confirmed in production.
- The fleet's second Mac mini is online on the tailnet but registered in no cluster, leaving the deployment at half capacity with the second replica permanently Pending. Tracked separately.
- Nothing alerted during the originating outage. Alerting for a stalled `process_xcresult` queue is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)