### PR TITLE
fix(server): stop discarding PromEx event metrics before they are scraped

### DIFF
--- a/infra/grafana-dashboards/xcresult-processor.json
+++ b/infra/grafana-dashboards/xcresult-processor.json
@@ -37,7 +37,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "xcresult-processor Pods that are currently being scraped. Mac mini fleet is sized for one Pod per host (Apple's 2-VM SLA + per-Pod resource budget); production runs 2 hosts and so this should sit at 2 in steady state.",
+        "description": "xcresult-processor Pods that are currently being scraped. These are only reachable through the `tuist-macos-pod-metrics` scrape job (tart-kubelet's host-side forwarder on :9091); the in-cluster Linux `tuist` job is the web fleet, which enqueues into :process_xcresult but never consumes it. Mac mini fleet is sized for one Pod per host (Apple's 2-VM SLA + per-Pod resource budget); production runs 2 hosts and so this should sit at 2 in steady state. Minis in the fleet without a Pod scheduled keep a target that stays down, so this counts up == 1 rather than the target list.",
         "fieldConfig": {
           "defaults": {
             "color": {"mode": "thresholds"},
@@ -78,7 +78,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Pending work in the :process_xcresult queue — sum of available + scheduled + retryable. Climbing under steady consumer count means a backlog.",
+        "description": "Pending work in the :process_xcresult queue — sum of available + scheduled + retryable. Climbing under steady consumer count means a backlog. Every PromEx-enabled pod polls the same oban_jobs table, so each state is deduped with max() before the states are summed; summing the raw series instead multiplies the backlog by the replica count.",
         "fieldConfig": {
           "defaults": {
             "color": {"mode": "thresholds"},
@@ -109,7 +109,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "max(sum by (instance) (tuist_oban_queue_length_count{queue=\"process_xcresult\", state=~\"available|scheduled|retryable\"}))",
+            "expr": "sum(max by (state) (tuist_oban_queue_length_count{queue=\"process_xcresult\", state=~\"available|scheduled|retryable\"}))",
             "instant": false,
             "refId": "A"
           }
@@ -576,11 +576,11 @@
         {
           "current": {
             "selected": false,
-            "text": "xcresult-processor",
-            "value": "xcresult-processor"
+            "text": "tuist-macos-pod-metrics",
+            "value": "tuist-macos-pod-metrics"
           },
           "datasource": "$datasource",
-          "definition": "label_values(tuist_oban_queue_length_count{queue=\"process_xcresult\"}, job)",
+          "definition": "label_values(up{job=~\".*macos-pod-metrics\"}, job)",
           "hide": 0,
           "includeAll": false,
           "label": "Job",
@@ -589,7 +589,7 @@
           "options": [],
           "query": {
             "qryType": 1,
-            "query": "label_values(tuist_oban_queue_length_count{queue=\"process_xcresult\"}, job)",
+            "query": "label_values(up{job=~\".*macos-pod-metrics\"}, job)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -841,7 +841,10 @@ config :tuist, Tuist.PromEx,
   manual_metrics_start_delay: :no_delay,
   drop_metrics_groups: [],
   grafana: :disabled,
-  ets_flush_interval: 20_000,
+  # `PromEx.ETSCronFlusher` renders the whole metric set and discards it on
+  # this interval. `Tuist.PromEx.StripedPeep` frees nothing on read, so the
+  # only thing a short interval buys is CPU spent on exports nobody reads.
+  ets_flush_interval: to_timeout(minute: 30),
   metrics_server: [
     port: 9091,
     auth_strategy: :none

--- a/server/lib/tuist/prom_ex/AGENTS.md
+++ b/server/lib/tuist/prom_ex/AGENTS.md
@@ -4,6 +4,7 @@ This context owns PromEx helpers and buckets configuration.
 
 ## Responsibilities
 - Provide custom bucket configuration for PromEx/Peep distributions.
+- Provide the PromEx storage adapter (`Tuist.PromEx.StripedPeep`, wired in `server/config/config.exs`).
 
 ## Boundaries
 - HTTP/API and UI code live in `server/lib/tuist_web`.
@@ -12,6 +13,7 @@ This context owns PromEx helpers and buckets configuration.
 
 ## Guardrails
 - If changes add or modify stored customer data, update `server/data-export.md`.
+- Keep `StripedPeep.scrape/1` non-destructive. Counters and distributions have to be cumulative for `rate/1` and `histogram_quantile/2`, and PromEx also calls `scrape/1` from `PromEx.ETSCronFlusher` and discards the result, so anything freed on read never reaches Prometheus. Bound memory through tag cardinality instead.
 
 ## Related Context
 - Parent business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist/prom_ex/striped_peep.ex
+++ b/server/lib/tuist/prom_ex/striped_peep.ex
@@ -1,38 +1,34 @@
 defmodule Tuist.PromEx.StripedPeep do
   @moduledoc """
-  "Striped" storage based on `PromEx.Storage.Peep`.
+  `PromEx` storage backed by `Peep`'s striped tables, which give each
+  scheduler its own ETS table instead of contending on a shared one.
+
+  Scrapes are non-destructive, so counters and distributions are cumulative
+  across the life of the node. Prometheus requires that: `rate/1` and
+  `histogram_quantile/2` need a sample on every scrape, and a metric whose
+  storage is emptied disappears from the export entirely whenever no event
+  lands between two scrapes. `PromEx` also drives `scrape/1` from
+  `PromEx.ETSCronFlusher` on a timer and throws the result away, so anything
+  freed on read is freed without ever reaching the scraper.
+
+  Memory is therefore bounded by tag cardinality rather than by uptime. Every
+  metric registered by the plugins in `Tuist.PromEx` tags on a closed set
+  (queue, state, worker, fleet, request host, ...), and `Tuist.PromEx.Buckets`
+  gives each distribution a fixed bucket list.
   """
 
   @behaviour PromEx.Storage
 
   @impl true
   def scrape(name) do
-    metrics =
-      name
-      |> Peep.get_all_metrics()
-      |> case do
-        # Handle case when Peep instance doesn't exist
-        nil -> %{}
-        metrics -> metrics
-      end
-
-    flush_storage(name)
-
-    metrics
+    name
+    |> Peep.get_all_metrics()
+    |> case do
+      nil -> %{}
+      metrics -> metrics
+    end
     |> Peep.Prometheus.export()
     |> IO.iodata_to_binary()
-  end
-
-  defp flush_storage(name) do
-    case Peep.Persistent.fetch(name) do
-      %Peep.Persistent{storage: {Peep.Storage.Striped, tids}} ->
-        tids
-        |> Tuple.to_list()
-        |> Enum.each(&:ets.delete_all_objects/1)
-
-      _ ->
-        :ok
-    end
   end
 
   @impl true

--- a/server/test/tuist/prom_ex/striped_peep_test.exs
+++ b/server/test/tuist/prom_ex/striped_peep_test.exs
@@ -6,32 +6,26 @@ defmodule Tuist.PromEx.StripedPeepTest do
   defp unique_id, do: String.replace(UUIDv7.generate(), "-", "_")
 
   describe "scrape/1" do
-    test "clears striped ETS tables after scraping metrics" do
+    test "keeps striped ETS tables intact after scraping metrics" do
       test_id = unique_id()
       name = :"test_peep_#{test_id}"
-      event_name = ["test", test_id, "counter"]
+      event_name = [:test, String.to_atom(test_id), :counter]
 
-      metrics = [Telemetry.Metrics.counter(Enum.join(event_name, "."))]
+      metrics = [Telemetry.Metrics.counter("test.#{test_id}.counter.count", tags: [:test])]
       opts = [name: name, metrics: metrics, storage: :striped]
 
       {:ok, _pid} = Peep.start_link(opts)
-      Process.sleep(50)
 
-      :telemetry.execute(event_name, %{}, %{test: "value1"})
-      :telemetry.execute(event_name, %{}, %{test: "value2"})
+      :telemetry.execute(event_name, %{count: 1}, %{test: "value1"})
+      :telemetry.execute(event_name, %{count: 1}, %{test: "value2"})
 
-      # Wait for Peep to process metrics
-      Process.sleep(50)
-
-      metrics_before = Peep.get_all_metrics(name) || %{}
+      metrics_before = Peep.get_all_metrics(name)
+      assert map_size(metrics_before) > 0
 
       result = StripedPeep.scrape(name)
       assert is_binary(result)
 
-      if map_size(metrics_before) > 0 do
-        metrics_after = Peep.get_all_metrics(name) || %{}
-        assert map_size(metrics_after) == 0
-      end
+      assert Peep.get_all_metrics(name) == metrics_before
 
       GenServer.stop(name)
     end
@@ -68,7 +62,7 @@ defmodule Tuist.PromEx.StripedPeepTest do
       GenServer.stop(name)
     end
 
-    test "handles non-striped storage without clearing" do
+    test "handles non-striped storage" do
       test_id = unique_id()
       name = :"test_peep_default_#{test_id}"
       event_name = ["test", test_id, "counter"]
@@ -102,29 +96,30 @@ defmodule Tuist.PromEx.StripedPeepTest do
       assert String.contains?(result, "# EOF")
     end
 
-    test "memory leak prevention through multiple scrape cycles" do
+    test "accumulates counts across multiple scrape cycles" do
       test_id = unique_id()
-      name = :"test_peep_memory_#{test_id}"
-      event_name = ["test", test_id, "leak_test"]
+      name = :"test_peep_cumulative_#{test_id}"
+      event_name = [:test, String.to_atom(test_id), :cumulative]
 
-      metrics = [Telemetry.Metrics.counter(Enum.join(event_name, "."))]
+      metrics = [Telemetry.Metrics.counter("test.#{test_id}.cumulative.count", tags: [:kind])]
       opts = [name: name, metrics: metrics, storage: :striped]
 
       {:ok, _pid} = Peep.start_link(opts)
-      Process.sleep(50)
 
-      for cycle <- 1..3 do
-        for i <- 1..5 do
-          :telemetry.execute(event_name, %{}, %{cycle: cycle, iteration: i})
+      totals =
+        for _cycle <- 1..3 do
+          for _ <- 1..5, do: :telemetry.execute(event_name, %{count: 1}, %{kind: "test"})
+
+          assert is_binary(StripedPeep.scrape(name))
+
+          name
+          |> Peep.get_all_metrics()
+          |> Map.values()
+          |> Enum.flat_map(&Map.values/1)
+          |> Enum.sum()
         end
 
-        Process.sleep(10)
-
-        result = StripedPeep.scrape(name)
-        assert is_binary(result)
-
-        Process.sleep(10)
-      end
+      assert totals == [5, 10, 15]
 
       GenServer.stop(name)
     end


### PR DESCRIPTION
The Tuist xcresult Processor dashboard shows "No data" on seven panels: Throughput, Terminal failures, Processing Duration, Queue Wait Time, Exception Rate by Error Class, Attempts to Completion, and Terminal Failure Rate.

### What was wrong

Every empty panel is an Oban job **event** metric behind `rate/1` or `histogram_quantile/2`. Every panel that still worked is a polled `last_value` gauge or an externally-produced metric. That split is the tell: the problem was not the scrape target, and not the queries.

`Tuist.PromEx.StripedPeep.scrape/1` cleared the Peep ETS tables after every read. PromEx drives `scrape/1` from two places:

1. the `/metrics` endpoint, where the data reaches Prometheus, and
2. `PromEx.ETSCronFlusher` on `ets_flush_interval`, which **discards its result**.

With the flusher at 20s and Alloy scraping at 60s, the flusher fired roughly twice per scrape interval, so most of every event metric was deleted before Prometheus ever read it. Worse, a metric with no activity in the final window vanished from the export entirely, so `rate(...[5m])` had no two points to work with. Polled gauges were unaffected because their poller re-emits every 5s.

Confirmed against production Prometheus: `tuist_oban_job_processing_duration_milliseconds_count`, a counter, oscillates instead of climbing — 99, 62, 75, 91, 200, 64 over the last hour for `DispatchWorker`. High-volume workers always have something in the final window so their panels look plausible; `ProcessXcresultWorker` appears in only a handful of scrapes, so its panels are empty.

The destructive scrape was safe when it was written (cac9d1e11c, "memory leak with Prometheus metrics"): the server ran on Fly.io, which polled `/metrics` every 15s, and the flusher is deferred on each scrape, so it rarely fired. It broke silently when scraping moved to Alloy at 60s.

### What changed

- **`server/lib/tuist/prom_ex/striped_peep.ex`** — scrape is non-destructive, matching upstream `PromEx.Storage.Peep`; the striped storage backend (the actual reason this module exists) is unchanged. Counters and distributions are now cumulative, which is what Prometheus requires.
- **`server/config/runtime.exs`** — `ets_flush_interval` 20s to 30min. The flusher can no longer free anything, so a short interval only spends CPU rendering exports nobody reads. Any future change to the scrape interval has to be checked against this value.
- **`server/lib/tuist/prom_ex/AGENTS.md`** — guardrail recording the non-destructive contract, since the failure mode is silent.
- **`server/test/tuist/prom_ex/striped_peep_test.exs`** — the flush assertion is inverted into an accumulation assertion.
- **`infra/grafana-dashboards/xcresult-processor.json`** — two unrelated query bugs found while verifying, see below.

**Why cumulative rather than retuning the flush interval.** A perfectly-timed destructive scrape still drops a series whenever no event lands between two scrapes, which is precisely the case for a low-volume worker. Delta export cannot produce a continuous series for `:process_xcresult`, so it cannot fix these panels.

**On the memory concern this replaces.** Peep stores one row per (metric, tag-set), so memory is bounded by tag cardinality rather than uptime. Every metric registered by the plugins in `Tuist.PromEx` tags on a closed set (queue, state, worker, fleet, request host, response status), and `Tuist.PromEx.Buckets` gives each distribution an explicit fixed bucket list, so distributions are bounded at buckets x tag-sets. The scrape payload grows from "series active in the last 20s" to "series active since boot", which is the normal shape Prometheus expects.

### Dashboard queries

Two panels reported wrong numbers independently of the above.

- **Pending Jobs** read 49,724 against a real backlog of ~4,640. `max(sum by (instance) (...))` was meant to dedupe replicas, but Grafana Cloud Adaptive Metrics collapses `instance` on `tuist_*` metrics to a single `<aggregated>` series holding the sum, so the expression added up all ~10 pods polling the same `oban_jobs` table. Now `sum(max by (state) (...))`, which dedupes on a label that survives.
- **Active Consumers** read 26 — the Linux web fleet, which enqueues into `:process_xcresult` but never consumes it. The `$job` variable was derived from a metric both fleets report. The processors are only reachable through the `tuist-macos-pod-metrics` scrape job, so the variable now resolves there and the panel reads 2.

### Impact

All Oban, HTTP, storage, and Finch event metrics across every service become correct, not just this dashboard's. Rates and quantiles that previously undercounted by roughly the flusher-to-scrape ratio will step up once this ships; that is the metric becoming accurate, not traffic increasing. Anything alerting on absolute rates of these metrics is worth a look after deploy.

Unrelated to this change but visible once the numbers are honest: the queue is sitting at ~4,600 available jobs against 2 consumers, and one Mac mini in the fleet has had `up == 0` for hours.

### How to test locally

```
mise run install
mix test test/tuist/prom_ex/striped_peep_test.exs
```

The suite asserts that a scrape leaves the striped tables intact and that counts accumulate across scrape cycles (5, 10, 15).

Note for reviewers: the previous tests were vacuous. `Telemetry.Metrics.counter("a.b.c")` listens on event `[:a, :b]` with measurement `:c`, and `:telemetry.execute/3` needs an atom list, but the tests executed `["a", "b", "c"]`. Nothing was ever recorded, and every storage assertion sat behind an `if map_size(metrics_before) > 0` guard that was never true. Both contract tests now record real data and assert unconditionally.

Verification beyond the suite: the corrected dashboard expressions were run against production Prometheus and return 4,640 pending and 2 active consumers. `mix credo` is clean on the changed module and the dashboard JSON parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
