### PR TITLE
fix(infra): let a write elevation repair a drifted fleet MachineTemplate

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -181,6 +181,14 @@ rules:
 #   * scalewayapplesiliconmachines (+/status) update/patch — clear the terminal
 #     failure so the drift loop retries. No delete: the CAPI Machine delete
 #     cascades to the infra machine on its own.
+#   * scalewayapplesiliconmachinetemplates update/patch — heal spec drift on the
+#     template a MachineSet clones. Helm patches these CRs manifest-to-manifest,
+#     so a field the live object never received is never backfilled, and an
+#     invalid clone fails every scale-up. Without this verb the `machines` delete
+#     above is a one-way trapdoor: the operator can retire a host but the
+#     MachineSet cannot recreate it, and repairing the template needs
+#     break-glass. Update/patch only — create/delete would change which template
+#     a fleet renders from, which is fleet management.
 #   * nodes update/patch/delete + pods/eviction create — cordon and drain a
 #     live host before recreating it, or remove a confirmed orphaned Node after
 #     its Machine and infrastructure are already gone.
@@ -196,6 +204,9 @@ rules:
     verbs: ["get", "list", "watch", "delete"]
   - apiGroups: ["infrastructure.cluster.x-k8s.io"]
     resources: ["scalewayapplesiliconmachines", "scalewayapplesiliconmachines/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["scalewayapplesiliconmachinetemplates"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]


### PR DESCRIPTION
## What changed

`tuist-fleet-unwedge` gains `update`/`patch` on `scalewayapplesiliconmachinetemplates`, matching the shape already used for `scalewayapplesiliconmachines`.

## Why

The role already grants `machines: delete` — the host-recovery step the macos-fleet chart documents as the way to roll a Mac mini. It grants no write on the MachineTemplate the MachineSet clones the replacement from, which makes that delete a **one-way trapdoor** whenever the template has drifted.

That is not hypothetical. Production's `tuist-tuist-macos-fleet` template is missing `adoptPoolPrefix`, which the rendered chart manifest carries, because Helm patches these CRs manifest-to-manifest rather than against live state — so a patch missed once is never retried and the live object sits at `generation: 1` indefinitely. The drift is invisible until a scale-up, at which point every clone attempt fails:

```
InfrastructureTemplateCloningFailed: ScalewayAppleSiliconMachine
"tuist-tuist-macos-fleet-j8s79-<n>" is invalid: spec.adoptPoolPrefix: Required value
```

The fleet then cannot recreate the host that was just retired, and the only identity able to fix the template is break-glass — for a one-field patch, on one object, during exactly the incident this elevation exists to handle.

## Why this scope

`update`/`patch` only. `create`/`delete` would change *which* template a fleet renders from, which is fleet management and stays break-glass, consistent with `machinesets` and `machinedeployments` being withheld from this role.

This is the same reasoning as `tuist-edit-runners-write`, whose comment already documents healing spec drift the deploy pipeline cannot see.

Split out of the broader provider fix (which makes `adoptPoolPrefix` optional with a controller-side default so the trapdoor cannot arm again) so the recovery capability can land on its own, ahead of the schema and controller change.

## User impact

None by itself — it widens no tier. The rule is bound directly to `tuist-<env>-write`, so it is reachable only from an active, TTL-bounded, audited JIT elevation and never rides along on the generic `edit` role.

## Validation

- `helm template infra/helm/pomerium --set tuistEnv=production` renders the ClusterRole with the added rule and the unchanged binding to `tuist-production-write`.
- Confirmed against the live production cluster that `kubectl auth can-i patch scalewayapplesiliconmachinetemplates` is currently `no` under an active production-write elevation, while `patch scalewayapplesiliconmachines` is `yes`.

## Note on merging

Merging this triggers `pomerium-deployment.yml` for all three environments (it watches `infra/helm/pomerium/**`). That is the intended path — the `server-k8s-production` GitHub Environment restricts deploys to protected branches, so this cannot be shipped from a topic branch via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)