### PR TITLE
fix(infra): stop a required MachineTemplate field from wedging fleet scale-up

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -178,10 +178,20 @@ infra/cluster-api-provider-tuist/
 ```
 
 CRDs live in [`infra/helm/tuist/crds/`](../helm/tuist/crds/) so Helm
-installs them automatically on first `helm install` (Helm 3 ignores
-the `crds/` directory on upgrades, which is what we want — CRD
-schema changes go through a deliberate `kubectl apply` rather than
-piggybacking on routine deploys).
+installs them on first `helm install`. Helm 3 skips that directory on
+upgrades, so the deploy workflow re-applies it every run
+(`kubectl apply -f "$HELM_CHART_PATH/crds/"` in
+[`server-deployment.yml`](../../.github/workflows/server-deployment.yml)) —
+schema changes ship with the deploy that carries them, no operator step.
+
+A schema change is therefore a live change to what the apiserver accepts,
+including for the CRs **CAPI clones on its own**. Adding a required field
+to a machine spec makes every MachineTemplate that predates it un-clonable,
+which surfaces as `InfrastructureTemplateCloningFailed` on the next
+MachineSet scale-up rather than at deploy time — and Helm does not backfill
+the field onto a live template (it patches these CRs manifest-to-manifest,
+so a field the live object never received is never added). Prefer an
+optional field with a controller-side default over a required one.
 
 ## Node extended resources
 

--- a/infra/cluster-api-provider-tuist/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-tuist/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -77,11 +77,28 @@ type ScalewayAppleSiliconMachineSpec struct {
 	HostMemoryMB int `json:"hostMemoryMB,omitempty"`
 
 	// AdoptPoolPrefix is the Scaleway-side name prefix the controller
-	// scans when claiming a Mac mini for this Machine. Required:
-	// the controller has no auto-order path. Operators pre-order
-	// capacity in the Scaleway console because Mac mini inventory is
-	// frequently out of stock and Apple's 24h licensing floor makes
-	// speculative ordering expensive.
+	// scans when claiming a Mac mini for this Machine. The controller
+	// has no auto-order path, so a prefix must resolve from somewhere:
+	// this field, or the operator-global `--default-adopt-pool-prefix`
+	// when it is unset. Operators pre-order capacity in the Scaleway
+	// console because Mac mini inventory is frequently out of stock
+	// and Apple's 24h licensing floor makes speculative ordering
+	// expensive.
+	//
+	// Optional on purpose, even though every chart-rendered
+	// MachineTemplate sets it. A required field here is a schema
+	// constraint on a resource CAPI *clones*, so a MachineTemplate
+	// that lacks it fails `InfrastructureTemplateCloningFailed` on
+	// every MachineSet scale-up — and the drift that produces such a
+	// template is invisible until the next scale-up, which is
+	// typically an operator recovering a host by deleting its Machine.
+	// That turned a routine roll into an unrecoverable fleet: the CR
+	// the MachineSet needs to create is the one the apiserver rejects,
+	// and no elevation short of break-glass can repair a
+	// MachineTemplate. Accepting an empty value and resolving the
+	// operator default instead keeps scale-up working on a drifted
+	// template and confines the blast radius to a missing default,
+	// which the controller surfaces as a `NoAdoptPoolPrefix` event.
 	//
 	// Operator workflow:
 	//
@@ -107,8 +124,8 @@ type ScalewayAppleSiliconMachineSpec struct {
 	// scan once Scaleway flips it back to `Delivered + Ready`.
 	// Physical destruction is operator-owned via the Scaleway
 	// console so the 24h billing floor doesn't leak into deploy flows.
-	// +kubebuilder:validation:MinLength=1
-	AdoptPoolPrefix string `json:"adoptPoolPrefix"`
+	// +optional
+	AdoptPoolPrefix string `json:"adoptPoolPrefix,omitempty"`
 }
 
 // GHActionsRunnerConfig tells the reconciler what GitHub Actions

--- a/infra/cluster-api-provider-tuist/cmd/manager/main.go
+++ b/infra/cluster-api-provider-tuist/cmd/manager/main.go
@@ -294,10 +294,10 @@ func main() {
 	flag.StringVar(&defaultAdoptPoolPrefix, "default-adopt-pool-prefix",
 		envOrDefault("CAPI_DEFAULT_ADOPT_POOL_PREFIX", ""),
 		"Pool prefix the controller falls back to when a CR's adoptPoolPrefix is "+
-			"empty (legacy CRs), used both to release such CRs on delete and as the "+
+			"empty, used to adopt and to release such CRs and as the "+
 			"orphan-reclaim sweep's pool prefix. Setting it enables the orphan-reclaim "+
 			"sweep (report-only until --orphan-reclaim-claim-name-prefix is also set). "+
-			"Empty disables both — bare legacy CRs skip release and no sweep runs.")
+			"Empty disables both — bare CRs refuse to adopt, skip release, and no sweep runs.")
 	flag.StringVar(&orphanReclaimClaimNamePrefix, "orphan-reclaim-claim-name-prefix",
 		envOrDefault("CAPI_ORPHAN_RECLAIM_CLAIM_NAME_PREFIX", ""),
 		"Claimed-name namespace this cluster owns within the Scaleway project (e.g. "+

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -221,12 +221,16 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// locking — bumping this only parallelizes across distinct CRs.
 	MaxConcurrentReconciles int
 
-	// DefaultAdoptPoolPrefix is the pool prefix reconcileDelete falls
-	// back to when a CR's Spec.AdoptPoolPrefix is empty. Spec now
-	// requires the field (MinLength=1), so this only covers legacy CRs
-	// created before that contract existed: without a fallback their
-	// delete skips the Scaleway release and strands the host. Empty
-	// preserves the skip behavior (no pool prefix to release into).
+	// DefaultAdoptPoolPrefix is the pool prefix every path falls back
+	// to when a CR's Spec.AdoptPoolPrefix is empty — adoption,
+	// bootstrap-exhaustion release, and delete alike. A CR reaches
+	// that shape either by predating the field or by being cloned
+	// from a MachineTemplate that drifted without it (helm patches
+	// these CRs manifest-to-manifest, so a field the live object
+	// never received is never backfilled). Empty means no prefix
+	// resolves at all: adoption refuses to scan (an unprefixed scan
+	// would claim an arbitrary server) and release skips, leaving the
+	// host running for the orphan-reclaim sweep.
 	DefaultAdoptPoolPrefix string
 
 	// Tailscale egress Service materialisation. When EgressProxyGroup
@@ -668,7 +672,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			}
 		}
 		if err != nil {
-			return handleBootstrapFailure(ctx, machine, err, r.ScalewayClient, r.CredentialsManager, r.Recorder, logger, r.BootstrapRebootAfter, r.BootstrapMaxAttempts), nil
+			return handleBootstrapFailure(ctx, machine, err, r.ScalewayClient, r.CredentialsManager, r.Recorder, logger, r.BootstrapRebootAfter, r.BootstrapMaxAttempts, r.adoptPoolPrefix(machine)), nil
 		}
 
 		conditions.MarkTrue(machine, BootstrappedCondition)
@@ -948,23 +952,17 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	// rename + reinstall — so the host stays alive for the next
 	// adopt. Skip if already released (mid-cleanup retry).
 	//
-	// Legacy CRs predating the required-AdoptPoolPrefix contract may
-	// still exist with the field unset (the older chart only
-	// rendered `adoptPoolPrefix` when the value was non-empty, so
-	// fleets that didn't set it produced bare CRs). For those, fall
-	// back to the controller-level DefaultAdoptPoolPrefix so the host
-	// still returns to the pool. Only when neither the CR nor the
+	// CRs with an unset AdoptPoolPrefix fall back to the
+	// controller-level DefaultAdoptPoolPrefix so the host still
+	// returns to the pool. Only when neither the CR nor the
 	// controller default carries a prefix do we skip the Scaleway
 	// release (the client rejects an empty prefix to avoid orphaning a
 	// host outside the pool namespace), leave the host running, and
 	// let the orphan-reclaim sweep or an operator clean it up. Without
-	// this fallthrough, deleting a bare legacy CR would loop forever on
+	// this fallthrough, deleting a bare CR would loop forever on
 	// a precondition error and block fleet teardown.
 	if machine.Status.ServerID != "" {
-		poolPrefix := machine.Spec.AdoptPoolPrefix
-		if poolPrefix == "" {
-			poolPrefix = r.DefaultAdoptPoolPrefix
-		}
+		poolPrefix := r.adoptPoolPrefix(machine)
 		switch {
 		case poolPrefix == "":
 			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseSkipped",
@@ -1379,6 +1377,7 @@ func handleBootstrapFailure(
 	logger logr.Logger,
 	rebootAfter int32,
 	maxAttempts int32,
+	poolPrefix string,
 ) ctrl.Result {
 	machine.Status.BootstrapAttempts++
 	attempts := machine.Status.BootstrapAttempts
@@ -1388,10 +1387,10 @@ func handleBootstrapFailure(
 	recorder.Eventf(machine, corev1.EventTypeWarning, "BootstrapFailed",
 		"%v (attempt %d, will retry)", err, attempts)
 
-	hostAdoptable := machine.Status.ServerID != "" && machine.Spec.AdoptPoolPrefix != ""
+	hostAdoptable := machine.Status.ServerID != "" && poolPrefix != ""
 	switch {
 	case maxAttempts > 0 && attempts >= maxAttempts && hostAdoptable:
-		if releaseErr := client.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); releaseErr != nil {
+		if releaseErr := client.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, poolPrefix); releaseErr != nil {
 			logger.Error(releaseErr, "release-to-pool after bootstrap exhaustion failed; will retry")
 			recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
 				"Scaleway ReleaseToPool after %d bootstrap failures: %v (will retry)",
@@ -1447,6 +1446,20 @@ func handleBootstrapFailure(
 	return ctrl.Result{RequeueAfter: 60 * time.Second}
 }
 
+// adoptPoolPrefix resolves the pool prefix for a CR: its own spec
+// first, the operator-global default when the spec is empty. Every
+// caller goes through this rather than reading Spec.AdoptPoolPrefix
+// directly, so a CR cloned from a MachineTemplate that never received
+// the field still adopts into, and releases back to, the right pool.
+func (r *ScalewayAppleSiliconMachineReconciler) adoptPoolPrefix(
+	machine *infrav1.ScalewayAppleSiliconMachine,
+) string {
+	if machine.Spec.AdoptPoolPrefix != "" {
+		return machine.Spec.AdoptPoolPrefix
+	}
+	return r.DefaultAdoptPoolPrefix
+}
+
 // acquireServer claims a pre-ordered host from the pool. Returns
 // (nil, requeue, nil) on `ErrNoAvailableHost` — that's a transient
 // "wait for operator pre-order" state, not a failure; surfaces a
@@ -1457,27 +1470,41 @@ func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 	ctx context.Context,
 	machine *infrav1.ScalewayAppleSiliconMachine,
 ) (*scaleway.Server, time.Duration, error) {
+	poolPrefix := r.adoptPoolPrefix(machine)
+	// An unprefixed scan would match every server in the project,
+	// including hosts already claimed by other fleets, so refuse
+	// rather than adopt something arbitrary. Requeue: the operator
+	// fixes this by setting `--default-adopt-pool-prefix` or the
+	// field on the template, and neither needs the CR recreated.
+	if poolPrefix == "" {
+		conditions.MarkFalse(machine, shared.ProvisionedCondition, "NoAdoptPoolPrefix",
+			clusterv1.ConditionSeverityError,
+			"no adoptPoolPrefix on the CR and no operator default; cannot scan the pool")
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "NoAdoptPoolPrefix",
+			"No adoptPoolPrefix on the CR and no --default-adopt-pool-prefix on the operator; refusing to scan for an unprefixed host")
+		return nil, 5 * time.Minute, nil
+	}
 	machine.Status.Phase = "Adopting"
 	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopting",
 		"Searching pool %q for an unclaimed %s Mac mini in zone %s",
-		machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.Zone)
+		poolPrefix, machine.Spec.Type, machine.Spec.Zone)
 	srv, err := r.ScalewayClient.AdoptFromPool(
 		ctx,
 		machine.Name,
 		machine.Spec.Zone,
 		machine.Spec.Type,
 		machine.Spec.OS,
-		machine.Spec.AdoptPoolPrefix,
+		poolPrefix,
 	)
 	if errors.Is(err, scaleway.ErrNoAvailableHost) {
 		conditions.MarkFalse(machine, shared.ProvisionedCondition, "NoAvailableHost",
 			clusterv1.ConditionSeverityWarning,
 			"no server with prefix %q matching %s/%s/%s in zone %s; pre-order more capacity",
-			machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS,
+			poolPrefix, machine.Spec.Type, machine.Spec.OS,
 			"ready", machine.Spec.Zone)
 		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "NoAvailableHost",
 			"No pre-ordered Mac mini matching pool=%q type=%s os=%s zone=%s; waiting for operator to pre-order more capacity",
-			machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS, machine.Spec.Zone)
+			poolPrefix, machine.Spec.Type, machine.Spec.OS, machine.Spec.Zone)
 		return nil, 60 * time.Second, nil
 	}
 	if err != nil {
@@ -1489,7 +1516,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 	}
 	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopted",
 		"Claimed Mac mini %s from pool %q (renamed to %s)",
-		srv.ID, machine.Spec.AdoptPoolPrefix, machine.Name)
+		srv.ID, poolPrefix, machine.Name)
 	return srv, 0, nil
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -732,6 +732,7 @@ func TestReconcileTailscaleEgressService_IdempotentAndPreservesOperatorRewrite(t
 // is loud in test output rather than silently doing nothing.
 type scalewayAPIStub struct {
 	servers        []*applesilicon.Server
+	listCalls      int
 	updateCalls    int
 	updatedNames   []string
 	reinstalledIDs []string
@@ -741,8 +742,15 @@ type scalewayAPIStub struct {
 	rebootError    error
 }
 
+// ListServers returns the whole fixture as one page. AdoptFromPool
+// treats a short page as the end of the listing, so a single call is
+// enough as long as the fixture stays under the client's page size.
 func (f *scalewayAPIStub) ListServers(*applesilicon.ListServersRequest, ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
-	return nil, errors.New("ListServers not implemented in stub")
+	f.listCalls++
+	return &applesilicon.ListServersResponse{
+		Servers:    f.servers,
+		TotalCount: uint32(len(f.servers)),
+	}, nil
 }
 
 func (f *scalewayAPIStub) GetServer(req *applesilicon.GetServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
@@ -846,7 +854,7 @@ func TestReconcileDelete_LegacyCRWithoutPrefixSkipsRelease(t *testing.T) {
 			Finalizers: []string{MachineFinalizer},
 		},
 		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
-			// Empty AdoptPoolPrefix — predates the required-prefix contract.
+			// Empty AdoptPoolPrefix — a drifted MachineTemplate clones this shape.
 			Zone: "fr-par-1",
 		},
 		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-legacy"},
@@ -888,7 +896,7 @@ func TestReconcileDelete_LegacyCRUsesDefaultPrefix(t *testing.T) {
 			Finalizers: []string{MachineFinalizer},
 		},
 		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
-			// Empty AdoptPoolPrefix — predates the required-prefix contract.
+			// Empty AdoptPoolPrefix — a drifted MachineTemplate clones this shape.
 			Zone: "fr-par-1",
 		},
 		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-legacy"},
@@ -913,6 +921,89 @@ func TestReconcileDelete_LegacyCRUsesDefaultPrefix(t *testing.T) {
 
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// --- adopt-pool-prefix resolution ------------------------------------------
+
+// poolServer is a pre-ordered host in the shape AdoptFromPool accepts:
+// delivered, Ready, and matching the requested SKU + OS.
+func poolServer(id, name string) *applesilicon.Server {
+	return &applesilicon.Server{
+		ID:        id,
+		Name:      name,
+		Type:      "M2-L",
+		Delivered: true,
+		Status:    applesilicon.ServerStatusReady,
+		Os:        &applesilicon.OS{Name: "macos-tahoe-26.3"},
+	}
+}
+
+func newAdoptMachine(name string) *infrav1.ScalewayAppleSiliconMachine {
+	return &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			// Empty AdoptPoolPrefix — a drifted MachineTemplate clones this shape.
+			Type: "M2-L",
+			Zone: "fr-par-1",
+			OS:   "macos-tahoe-26.3",
+		},
+	}
+}
+
+// A CR cloned from a MachineTemplate that never received
+// `adoptPoolPrefix` must still adopt, against the operator-global
+// default. This is the path that keeps a MachineSet scale-up working
+// on a drifted template instead of failing the clone outright.
+func TestAcquireServer_FallsBackToControllerDefaultPrefix(t *testing.T) {
+	api := &scalewayAPIStub{servers: []*applesilicon.Server{poolServer("srv-pool-1", "tuist-pool-001")}}
+	machine := newAdoptMachine("macos-fleet-abc12")
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+	r.DefaultAdoptPoolPrefix = "tuist-pool-"
+
+	srv, requeue, err := r.acquireServer(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("acquireServer: %v", err)
+	}
+	if requeue != 0 {
+		t.Fatalf("a successful adopt must not requeue; got %v", requeue)
+	}
+	if srv == nil || srv.ID != "srv-pool-1" {
+		t.Fatalf("expected to claim srv-pool-1; got %+v", srv)
+	}
+	if got := api.servers[0].Name; got != machine.Name {
+		t.Fatalf("claim must promote the server name to the Machine name; got %q", got)
+	}
+}
+
+// With neither a spec prefix nor an operator default there is no pool
+// to scan, and an unprefixed scan would claim a server belonging to
+// another fleet. Refuse and requeue rather than adopting something
+// arbitrary — the operator fixes this by setting either value, neither
+// of which needs the CR recreated.
+func TestAcquireServer_NoPrefixAnywhereRefusesToScan(t *testing.T) {
+	api := &scalewayAPIStub{servers: []*applesilicon.Server{poolServer("srv-pool-1", "tuist-pool-001")}}
+	machine := newAdoptMachine("macos-fleet-abc12")
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+
+	srv, requeue, err := r.acquireServer(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("acquireServer must not return a hard error; got %v", err)
+	}
+	if srv != nil {
+		t.Fatalf("must not claim a host without a pool prefix; got %+v", srv)
+	}
+	if requeue == 0 {
+		t.Fatal("expected a requeue so the fix lands without recreating the CR")
+	}
+	if api.listCalls != 0 {
+		t.Fatalf("must not scan Scaleway at all; got %d ListServers calls", api.listCalls)
+	}
+	cond := conditions.Get(machine, shared.ProvisionedCondition)
+	if cond == nil || cond.Reason != "NoAdoptPoolPrefix" {
+		t.Fatalf("expected a NoAdoptPoolPrefix condition; got %+v", cond)
+	}
 }
 
 // --- handleBootstrapFailure ------------------------------------------------
@@ -996,7 +1087,7 @@ func newBootstrapFailureMachine(serverID, poolPrefix string) *infrav1.ScalewayAp
 func TestHandleBootstrapFailure_IncrementsAttempts(t *testing.T) {
 	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
 	stub := &recoveryStub{}
-	res := handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if machine.Status.BootstrapAttempts != 1 {
 		t.Fatalf("expected attempts=1, got %d", machine.Status.BootstrapAttempts)
@@ -1021,7 +1112,7 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 	machine.Status.BootstrapAttempts = 2 // next call lands at 3
 	stub := &recoveryStub{}
 
-	res := handleBootstrapFailure(context.Background(), machine, errors.New("sudo locked"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("sudo locked"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 	if res.RequeueAfter != 60*time.Second {
 		t.Fatalf("expected 60s requeue, got %v", res.RequeueAfter)
 	}
@@ -1037,7 +1128,7 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 
 	// Drive attempts past the threshold without crossing maxAttempts.
 	// The reboot must not fire again because BootstrapRebootIssued is set.
-	res = handleBootstrapFailure(context.Background(), machine, errors.New("still wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	res = handleBootstrapFailure(context.Background(), machine, errors.New("still wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 	if len(stub.rebootCalls) != 1 {
 		t.Fatalf("reboot must be one-shot per host; got %d calls", len(stub.rebootCalls))
 	}
@@ -1078,7 +1169,7 @@ func TestHandleBootstrapFailure_ReleasesToPoolAtMax(t *testing.T) {
 
 	stub := &recoveryStub{}
 	secrets := &secretCleanerStub{}
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if len(stub.releaseCalls) != 1 {
 		t.Fatalf("expected one release call at max attempts, got %d", len(stub.releaseCalls))
@@ -1123,7 +1214,7 @@ func TestHandleBootstrapFailure_RebootRetriesAfterAPIError(t *testing.T) {
 	machine.Status.BootstrapAttempts = 2 // next call lands at 3
 	stub := &recoveryStub{rebootErr: errors.New("scaleway 503")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 	if len(stub.rebootCalls) != 1 {
 		t.Fatalf("expected one reboot attempt on attempt 3, got %d", len(stub.rebootCalls))
 	}
@@ -1135,7 +1226,7 @@ func TestHandleBootstrapFailure_RebootRetriesAfterAPIError(t *testing.T) {
 	// The reboot tier should fire again — that's the whole point of
 	// not consuming the one-shot flag on the prior error.
 	stub.rebootErr = nil
-	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged again"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged again"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 	if len(stub.rebootCalls) != 2 {
 		t.Fatalf("expected retry-after-error to fire a second reboot at attempt 4, got %d total calls", len(stub.rebootCalls))
 	}
@@ -1158,7 +1249,7 @@ func TestHandleBootstrapFailure_ReleaseSwallowsSecretDeleteError(t *testing.T) {
 	stub := &recoveryStub{}
 	secrets := &secretCleanerStub{deleteErr: errors.New("api server unreachable")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if len(stub.releaseCalls) != 1 {
 		t.Fatalf("Scaleway release must still happen even when Secret delete errors; got %d release calls", len(stub.releaseCalls))
@@ -1178,7 +1269,7 @@ func TestHandleBootstrapFailure_ReleaseAPIErrorKeepsState(t *testing.T) {
 	machine.Status.BootstrapAttempts = 7
 	stub := &recoveryStub{releaseErr: errors.New("scaleway 503")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if machine.Status.ServerID != "srv-1" {
 		t.Fatalf("ServerID must persist when release fails; got %q", machine.Status.ServerID)
@@ -1197,7 +1288,7 @@ func TestHandleBootstrapFailure_RebootAPIErrorDoesNotConsumeOneShot(t *testing.T
 	machine.Status.BootstrapAttempts = 2
 	stub := &recoveryStub{rebootErr: errors.New("scaleway 503")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if len(stub.rebootCalls) != 1 {
 		t.Fatalf("expected one reboot attempt despite error, got %d", len(stub.rebootCalls))
@@ -1218,7 +1309,7 @@ func TestHandleBootstrapFailure_LegacyCRWithoutPoolPrefixNeverReleases(t *testin
 	machine.Status.BootstrapAttempts = 7
 
 	stub := &recoveryStub{}
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8, machine.Spec.AdoptPoolPrefix)
 
 	if len(stub.releaseCalls) != 0 {
 		t.Fatalf("legacy CR (no pool prefix) must not trigger release; got %+v", stub.releaseCalls)
@@ -1236,7 +1327,7 @@ func TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers(t *testing.T) {
 	machine.Status.BootstrapAttempts = 100
 	stub := &recoveryStub{}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("boom"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 0, 0)
+	handleBootstrapFailure(context.Background(), machine, errors.New("boom"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 0, 0, machine.Spec.AdoptPoolPrefix)
 
 	if len(stub.rebootCalls) != 0 || len(stub.releaseCalls) != 0 {
 		t.Fatalf("zero thresholds must skip both tiers; got reboots=%+v releases=%+v",

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -543,6 +543,32 @@ k8s-monitoring:
   #   - Note: exactly one series per machine (recordMachinePhase clears the
   #     prior phase on transition), so a recovered machine stops matching.
   #
+  # Alert to create in Grafana Cloud (PromQL) — fleet short of its replicas.
+  # The gauge above is per-CR, so it cannot see a machine that was never
+  # created: a MachineSet whose infrastructure clone is rejected by the
+  # apiserver (`InfrastructureTemplateCloningFailed`, e.g. a MachineTemplate
+  # missing a field the schema requires) retries forever and emits no series
+  # at all. That is how a fleet ran at half capacity unnoticed — every
+  # remaining machine was Ready, so the Failed alert above stayed green.
+  # Count the fleet instead and compare against its chart replica count:
+  #
+  #   count by (cluster, fleet) (
+  #     capt_scaleway_applesilicon_machine_phase{fleet="tuist-tuist-macos-fleet"}
+  #   ) < 2
+  #
+  # Recommended config:
+  #   - For: 1h    (an adopt legitimately takes ~50 min end to end, and a
+  #                 planned roll deletes a Machine before its replacement
+  #                 finishes bootstrapping)
+  #   - Severity: warning
+  #   - Summary: "Fleet {{ $labels.fleet }} is short of its replicas — check
+  #              `kubectl -n tuist describe machineset` for a cloning error
+  #              before assuming the pool is empty."
+  #   - Note: the threshold is the fleet's `replicas` in
+  #     values-managed-<env>.yaml; bump both together when a fleet grows.
+  #     One alert per fleet whose replicas > 1 — a single-replica fleet is
+  #     already covered by the workload's own availability alerting.
+  #
   # metricsPortName narrows the discovery output to a single target per
   # pod when the pod declares more than one container port. Without it,
   # Kubernetes pod-role discovery emits one target per declared port

--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -181,6 +181,14 @@ rules:
 #   * scalewayapplesiliconmachines (+/status) update/patch — clear the terminal
 #     failure so the drift loop retries. No delete: the CAPI Machine delete
 #     cascades to the infra machine on its own.
+#   * scalewayapplesiliconmachinetemplates update/patch — heal spec drift on the
+#     template a MachineSet clones. Helm patches these CRs manifest-to-manifest,
+#     so a field the live object never received is never backfilled, and an
+#     invalid clone fails every scale-up. Without this verb the `machines` delete
+#     above is a one-way trapdoor: the operator can retire a host but the
+#     MachineSet cannot recreate it, and repairing the template needs
+#     break-glass. Update/patch only — create/delete would change which template
+#     a fleet renders from, which is fleet management.
 #   * nodes update/patch/delete + pods/eviction create — cordon and drain a
 #     live host before recreating it, or remove a confirmed orphaned Node after
 #     its Machine and infrastructure are already gone.
@@ -196,6 +204,9 @@ rules:
     verbs: ["get", "list", "watch", "delete"]
   - apiGroups: ["infrastructure.cluster.x-k8s.io"]
     resources: ["scalewayapplesiliconmachines", "scalewayapplesiliconmachines/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["scalewayapplesiliconmachinetemplates"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]

--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -181,14 +181,6 @@ rules:
 #   * scalewayapplesiliconmachines (+/status) update/patch — clear the terminal
 #     failure so the drift loop retries. No delete: the CAPI Machine delete
 #     cascades to the infra machine on its own.
-#   * scalewayapplesiliconmachinetemplates update/patch — heal spec drift on the
-#     template a MachineSet clones. Helm patches these CRs manifest-to-manifest,
-#     so a field the live object never received is never backfilled, and an
-#     invalid clone fails every scale-up. Without this verb the `machines` delete
-#     above is a one-way trapdoor: the operator can retire a host but the
-#     MachineSet cannot recreate it, and repairing the template needs
-#     break-glass. Update/patch only — create/delete would change which template
-#     a fleet renders from, which is fleet management.
 #   * nodes update/patch/delete + pods/eviction create — cordon and drain a
 #     live host before recreating it, or remove a confirmed orphaned Node after
 #     its Machine and infrastructure are already gone.
@@ -204,9 +196,6 @@ rules:
     verbs: ["get", "list", "watch", "delete"]
   - apiGroups: ["infrastructure.cluster.x-k8s.io"]
     resources: ["scalewayapplesiliconmachines", "scalewayapplesiliconmachines/status"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
-    resources: ["scalewayapplesiliconmachinetemplates"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -61,11 +61,28 @@ spec:
                 adoptPoolPrefix:
                   description: |-
                     AdoptPoolPrefix is the Scaleway-side name prefix the controller
-                    scans when claiming a Mac mini for this Machine. Required:
-                    the controller has no auto-order path. Operators pre-order
-                    capacity in the Scaleway console because Mac mini inventory is
-                    frequently out of stock and Apple's 24h licensing floor makes
-                    speculative ordering expensive.
+                    scans when claiming a Mac mini for this Machine. The controller
+                    has no auto-order path, so a prefix must resolve from somewhere:
+                    this field, or the operator-global `--default-adopt-pool-prefix`
+                    when it is unset. Operators pre-order capacity in the Scaleway
+                    console because Mac mini inventory is frequently out of stock
+                    and Apple's 24h licensing floor makes speculative ordering
+                    expensive.
+
+                    Optional on purpose, even though every chart-rendered
+                    MachineTemplate sets it. A required field here is a schema
+                    constraint on a resource CAPI *clones*, so a MachineTemplate
+                    that lacks it fails `InfrastructureTemplateCloningFailed` on
+                    every MachineSet scale-up — and the drift that produces such a
+                    template is invisible until the next scale-up, which is
+                    typically an operator recovering a host by deleting its Machine.
+                    That turned a routine roll into an unrecoverable fleet: the CR
+                    the MachineSet needs to create is the one the apiserver rejects,
+                    and no elevation short of break-glass can repair a
+                    MachineTemplate. Accepting an empty value and resolving the
+                    operator default instead keeps scale-up working on a drifted
+                    template and confines the blast radius to a missing default,
+                    which the controller surfaces as a `NoAdoptPoolPrefix` event.
 
                     Operator workflow:
 
@@ -91,7 +108,6 @@ spec:
                     scan once Scaleway flips it back to `Delivered + Ready`.
                     Physical destruction is operator-owned via the Scaleway
                     console so the 24h billing floor doesn't leak into deploy flows.
-                  minLength: 1
                   type: string
                 fleetName:
                   description: |-
@@ -221,8 +237,6 @@ spec:
                   default: fr-par-1
                   description: Zone is the Scaleway zone (fr-par-1, fr-par-3, etc.).
                   type: string
-              required:
-                - adoptPoolPrefix
               type: object
             status:
               description: ScalewayAppleSiliconMachineStatus is the observed state of the Machine.

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
@@ -61,11 +61,28 @@ spec:
                         adoptPoolPrefix:
                           description: |-
                             AdoptPoolPrefix is the Scaleway-side name prefix the controller
-                            scans when claiming a Mac mini for this Machine. Required:
-                            the controller has no auto-order path. Operators pre-order
-                            capacity in the Scaleway console because Mac mini inventory is
-                            frequently out of stock and Apple's 24h licensing floor makes
-                            speculative ordering expensive.
+                            scans when claiming a Mac mini for this Machine. The controller
+                            has no auto-order path, so a prefix must resolve from somewhere:
+                            this field, or the operator-global `--default-adopt-pool-prefix`
+                            when it is unset. Operators pre-order capacity in the Scaleway
+                            console because Mac mini inventory is frequently out of stock
+                            and Apple's 24h licensing floor makes speculative ordering
+                            expensive.
+
+                            Optional on purpose, even though every chart-rendered
+                            MachineTemplate sets it. A required field here is a schema
+                            constraint on a resource CAPI *clones*, so a MachineTemplate
+                            that lacks it fails `InfrastructureTemplateCloningFailed` on
+                            every MachineSet scale-up — and the drift that produces such a
+                            template is invisible until the next scale-up, which is
+                            typically an operator recovering a host by deleting its Machine.
+                            That turned a routine roll into an unrecoverable fleet: the CR
+                            the MachineSet needs to create is the one the apiserver rejects,
+                            and no elevation short of break-glass can repair a
+                            MachineTemplate. Accepting an empty value and resolving the
+                            operator default instead keeps scale-up working on a drifted
+                            template and confines the blast radius to a missing default,
+                            which the controller surfaces as a `NoAdoptPoolPrefix` event.
 
                             Operator workflow:
 
@@ -91,7 +108,6 @@ spec:
                             scan once Scaleway flips it back to `Delivered + Ready`.
                             Physical destruction is operator-owned via the Scaleway
                             console so the 24h billing floor doesn't leak into deploy flows.
-                          minLength: 1
                           type: string
                         fleetName:
                           description: |-
@@ -221,8 +237,6 @@ spec:
                           default: fr-par-1
                           description: Zone is the Scaleway zone (fr-par-1, fr-par-3, etc.).
                           type: string
-                      required:
-                        - adoptPoolPrefix
                       type: object
                   required:
                     - spec


### PR DESCRIPTION
## What changed

`ScalewayAppleSiliconMachineSpec.adoptPoolPrefix` becomes optional, and every path that needs a pool prefix — adopt, bootstrap-exhaustion release, delete — resolves it through one helper that falls back to the operator-global `--default-adopt-pool-prefix`. Previously only the delete path had that fallback.

## Why

The production macOS fleet ran at half capacity with no way to recover short of break-glass. `tuist-tuist-macos-fleet` wants 2 replicas; its MachineSet retried forever with:

```
InfrastructureTemplateCloningFailed: ScalewayAppleSiliconMachine
"tuist-tuist-macos-fleet-j8s79-<n>" is invalid: spec.adoptPoolPrefix: Required value
```

### Root cause

Two things had to meet.

**The live template is drifted.** `ScalewayAppleSiliconMachineTemplate/tuist-tuist-macos-fleet` is missing `adoptPoolPrefix`, `hostCPU`, and `hostMemoryMB` even though the rendered chart manifest carries all three. The object is still at `generation: 1` from the day it was created, because Helm patches these CRs manifest-to-manifest rather than against live state — so a patch that was missed once is never retried. `builders-fleet` and `runners-fleet` are not drifted.

**The field was required at the schema level.** That is a schema constraint on a resource CAPI *clones*, so a template lacking it cannot produce a Machine at all.

### Why it stayed hidden

Neither half is visible on its own. An invalid template only matters at scale-up, and the fleet had been at full strength for months, so the drift sat silent until an operator deleted a Machine to recover a host — the roll procedure the chart itself documents. That delete released its Mac mini back to the pool and left the fleet unable to claim a replacement, halving xcresult processing capacity and removing the redundancy the second host existed to provide.

## Why this fix over the alternatives

The requirement bought nothing. The controller already carries `--default-adopt-pool-prefix`, set to `tuist-pool-` in every environment, and already fell back to it on delete. Making the field optional and resolving that default everywhere means scale-up works on a drifted template, and the only remaining failure mode is no prefix anywhere — which the controller now reports as a `NoAdoptPoolPrefix` condition and event rather than scanning unprefixed and claiming an arbitrary server.

**Rejected: patching the live template.** That repairs one object in one cluster and leaves the trapdoor armed in every other environment. It is still worth doing to bring live in line with the manifest, but it is remediation, not a fix.

**Rejected: relaxing the CRD alone.** The deployed operator would then create a CR with an empty prefix, `AdoptFromPool` would hard-error (`poolPrefix is required for adoption`), and the MachineSet would count a Machine that can never produce a host. Strictly worse than the current loud failure. The schema and controller halves must ship together — which they do here.

## Supporting changes

For the parts that let this go unnoticed:

- **A documented Grafana alert for a fleet short of its replicas.** The per-machine `capt_scaleway_applesilicon_machine_phase` gauge cannot see a machine that was never created, so every surviving machine read `Ready` and the existing stuck-`Failed` alert stayed green while the fleet ran at half capacity. Follows the repo's existing convention of PromQL recipes in the monitoring values.
- **`AGENTS.md` correction.** It still claimed CRD schema changes need a deliberate `kubectl apply`. The deploy workflow has re-applied `crds/` on every run for a while, which is precisely what makes adding a required field a live change to what the apiserver accepts.

The `tuist-fleet-unwedge` RBAC grant that makes the live template repairable from a JIT elevation is split into #12303 so it can land first.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` all pass in `infra/cluster-api-provider-tuist`.
- Two new tests: adoption via the controller default on a CR with an empty prefix, and the refuse-to-scan path (no `ListServers` call, `NoAdoptPoolPrefix` condition, requeue) when no prefix resolves anywhere.
- Verified against the live production cluster that `adoptPoolPrefix` is absent from the macos-fleet template while present in `helm get manifest`, and that the other two fleets match.
- Traced CAPI v1.10.4's `OnDelete` rollout (`NewMSNewReplicas`, `reconcileOldMachineSetsOnDelete`) to confirm repairing the template converges over two reconciles to exactly one new machine, leaving the existing healthy host untouched.
- Confirmed the regenerated CRDs no longer list the field as `required` and drop its `minLength`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)