### PR TITLE
fix(server): stop the Open Graph renderer outside web mode

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -399,11 +399,12 @@ defmodule Tuist.Application do
     )
     |> Kernel.++(kura_children())
     # Marketing.Stats polls ClickHouse on init. Skip it in test (tables
-    # may not exist) and dev (noisy debug logs every 5 s).
+    # may not exist) and dev (noisy debug logs every 5 s), and outside web
+    # mode — see `RuntimeChildren.marketing_stats/1`.
     |> Kernel.++(
       if Environment.test?() or Environment.dev?(),
         do: [],
-        else: [Tuist.Marketing.Stats]
+        else: RuntimeChildren.marketing_stats(Environment.mode())
     )
   end
 
@@ -422,13 +423,11 @@ defmodule Tuist.Application do
   # Runtime Open Graph image rendering (headless-browser pool + its task
   # supervisor) backs the marketing/docs site, which only the hosted service
   # serves. On-premise instances do not need it, so it is started only when
-  # hosted or in local dev (where the marketing site is developed).
+  # hosted or in local dev (where the marketing site is developed), and only
+  # in web mode — see `RuntimeChildren.open_graph_image_renderer/1`.
   defp open_graph_image_children do
     if Environment.tuist_hosted?() or Environment.dev?() do
-      [
-        {Task.Supervisor, name: Tuist.OpenGraphImageRenderer.TaskSupervisor},
-        Tuist.OpenGraphImageRenderer
-      ]
+      RuntimeChildren.open_graph_image_renderer(Environment.mode())
     else
       []
     end

--- a/server/lib/tuist/application/runtime_children.ex
+++ b/server/lib/tuist/application/runtime_children.ex
@@ -23,4 +23,35 @@ defmodule Tuist.Application.RuntimeChildren do
   """
   def guardian_db_sweeper(:web), do: [{Guardian.DB.Sweeper, [interval: @sweeper_interval_ms]}]
   def guardian_db_sweeper(_), do: []
+
+  @doc """
+  Child specs for the Open Graph image renderer, gated on pod mode.
+
+  Returns the headless-browser pool and its task supervisor for `:web`;
+  empty for every other mode. The renderer is reached only through the
+  `TuistWeb` Open Graph endpoints, and the non-web images run on VMs
+  without Chrome installed — `Browse.Pool.init_worker/1` raises
+  `:chrome_not_found` there, and because the pool is a permanent child
+  the supervisor restarts it in a hot loop (measured at ~120 restarts
+  per second on both xcresult-processor replicas), burning CPU on hosts
+  whose only job is CPU-bound xcresult parsing and flooding Sentry.
+  """
+  def open_graph_image_renderer(:web) do
+    [
+      {Task.Supervisor, name: Tuist.OpenGraphImageRenderer.TaskSupervisor},
+      Tuist.OpenGraphImageRenderer
+    ]
+  end
+
+  def open_graph_image_renderer(_), do: []
+
+  @doc """
+  Child spec for the marketing stats poller, gated on pod mode.
+
+  Returns the poller for `:web`; empty for every other mode. It polls
+  ClickHouse every 5 seconds and broadcasts over PubSub purely to feed
+  the marketing LiveViews, which only the Phoenix endpoint serves.
+  """
+  def marketing_stats(:web), do: [Tuist.Marketing.Stats]
+  def marketing_stats(_), do: []
 end

--- a/server/test/tuist/application/runtime_children_test.exs
+++ b/server/test/tuist/application/runtime_children_test.exs
@@ -20,4 +20,37 @@ defmodule Tuist.Application.RuntimeChildrenTest do
       end
     end
   end
+
+  describe "open_graph_image_renderer/1" do
+    test ":web starts the renderer and its task supervisor" do
+      children = RuntimeChildren.open_graph_image_renderer(:web)
+
+      assert {Task.Supervisor, name: Tuist.OpenGraphImageRenderer.TaskSupervisor} in children
+      assert Tuist.OpenGraphImageRenderer in children
+    end
+
+    test "every non-web mode returns no children" do
+      for mode <- Environment.modes(), mode != :web do
+        assert RuntimeChildren.open_graph_image_renderer(mode) == [],
+               "expected no Tuist.OpenGraphImageRenderer child for #{inspect(mode)} — " <>
+                 "non-web images have no Chrome installed, so Browse.Pool.init_worker/1 " <>
+                 "raises :chrome_not_found and the supervisor restarts the pool in a hot loop"
+      end
+    end
+  end
+
+  describe "marketing_stats/1" do
+    test ":web starts the poller" do
+      assert RuntimeChildren.marketing_stats(:web) == [Tuist.Marketing.Stats]
+    end
+
+    test "every non-web mode returns no children" do
+      for mode <- Environment.modes(), mode != :web do
+        assert RuntimeChildren.marketing_stats(mode) == [],
+               "expected no Tuist.Marketing.Stats child for #{inspect(mode)} — " <>
+                 "it polls ClickHouse every 5 s only to feed the marketing LiveViews, " <>
+                 "which non-web pods never serve"
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Tuist.OpenGraphImageRenderer` started in every hosted mode, including `TUIST_MODE=xcresult_processor`, whose Tart VM image has no Chrome installed. The result was a hot supervisor restart loop on the xcresult processors.

### What changed

`open_graph_image_children/0` gated only on deployment flavor (`Environment.tuist_hosted?() or Environment.dev?()`), not on pod mode. Every hosted mode is `tuist_hosted?`, so the headless-browser pool also started on the xcresult-processor pods. `Browse.Pool.init_worker/1` raises `:chrome_not_found` there, and because the pool is a permanent child the supervisor restarts it immediately:

```
** (RuntimeError) failed to initialize browser: :chrome_not_found
    (browse 0.5.0) lib/browse/pool.ex:25: anonymous fn/4 in Browse.Pool.init_worker/1
    (nimble_pool 1.1.0) lib/nimble_pool.ex:1042: NimblePool.init_worker/5
```

Measured on production 2026-08-12: 50,044 occurrences on one processor VM and 46,994 on the other, each within roughly 7 minutes of VM uptime, so about 120 restarts per second on both replicas simultaneously. Observed by reading `/var/log/xcresult-processor/stdout.log` inside the guest VMs via `tart exec` on the Mac mini hosts, since `kubectl logs` cannot reach kubelet :10250 through the Pomerium gateway.

### Why it matters

* It burned CPU continuously on hosts whose entire purpose is CPU-bound xcresult parsing, on both replicas.
* It flooded Sentry. The logs show events being dropped as duplicates of previously-captured ones.
* It buried real errors. The `process_xcresult` Oban worker lines were drowned out and only findable by grepping past the loop.

### The fix

The renderer is reached only through `TuistWeb.Helpers.OpenGraph` and `TuistWeb.OpenGraphImageController`, both web-only, so `:web` is the correct gate. Verified there is no non-web caller before narrowing it.

### Second instance found while auditing

The original report noted that `open_graph_image_children/0` was found by inspection rather than an exhaustive audit, so the rest of `get_children/0` was checked for the same mode-blindness. One more turned up:

`Tuist.Marketing.Stats` was gated only on `test?/dev?`, so it ran on every hosted non-web pod, polling ClickHouse with five aggregate queries every 5 seconds purely to feed the marketing LiveViews that only the Phoenix endpoint serves. Not a crash loop, but continuous pointless database load on the same CPU-starved processors. Now gated on `:web` too.

The remaining ungated children are fine:

* The docs `NimblePublisher.Cache` is lazy (`ContentCache.get` with fallback functions) and does no work at init.
* `Cluster.Supervisor` is a no-op unless Helm sets `TUIST_CLUSTER_DNS_SERVICE`, and where it is set, joining the cluster for cross-node PubSub is plausibly intentional.
* The MinioServer block is effectively dev-only, since `dev_use_remote_storage?` returns true whenever not in dev.
* `ops_clickhouse_children/0` and `kura_children/0` already gate on `Environment.web?()`.
* The ingestion buffers, Finch, Cachex, PubSub and `API.Pipeline` are genuinely needed by the processors.

### Why the gates live in RuntimeChildren

Both gates went into `Tuist.Application.RuntimeChildren` rather than inline. That module's own moduledoc states it exists so mode gates can be unit-tested against every value of `Environment.modes/0`, expressed as allowlists (`mode == :web`) rather than denylists of known non-web modes, so a future role such as `:scheduler` or `:ingest` is excluded by default and has to opt in. That is exactly the failure mode here, so following the existing `guardian_db_sweeper/1` shape both fixes the bug and makes the next one harder to introduce.

The deployment-flavor and env conditions stay at their original call sites, so this changes nothing for on-premise or dev.

### How to test locally

Run the supervision-tree gate tests, which assert `:web` gets the children and every other mode gets none:

```bash
mix test test/tuist/application/runtime_children_test.exs
```

Confirm web mode still renders OpenGraph images:

```bash
mix test test/tuist/open_graph_image_renderer_test.exs test/tuist_web/controllers/open_graph_image_controller_test.exs test/tuist/open_graph_image_templates_test.exs test/tuist/marketing/stats_test.exs
```

To check the real `TUIST_MODE` to `mode()` to children wiring rather than just the pure functions:

```bash
TUIST_MODE=xcresult_processor mix run --no-start -e 'alias Tuist.Application.RuntimeChildren; alias Tuist.Environment; IO.puts("mode=#{Environment.mode()} og=#{length(RuntimeChildren.open_graph_image_renderer(Environment.mode()))} marketing=#{length(RuntimeChildren.marketing_stats(Environment.mode()))} flavor_gate_open=#{Environment.tuist_hosted?() or Environment.dev?()}")'
```

### Validation that was run

* New `RuntimeChildren` tests for both children, asserting `:web` gets them and every mode in `Environment.modes/0` other than `:web` gets none. 6 tests pass.
* The full `TUIST_MODE` to `mode()` to children wiring verified out of band. Under `TUIST_MODE=xcresult_processor` the flavor gate still opens (`flavor_gate_open=true`) while both child lists come back empty, which confirms the mode gate is what now does the excluding rather than some incidental local condition. `web` and unset both yield the two renderer children plus the poller.
* Existing renderer, controller, templates and marketing stats suites pass. 26 tests.
* `mix compile --warnings-as-errors` clean, `mix credo --strict` reports no issues on both changed modules.

Two limits worth knowing:

* A full release could not be booted under `TUIST_MODE=xcresult_processor` locally, since that needs the macOS xcresult NIF and the processor's database grants. The gate is verified at the child-list composition level, not by a live supervision-tree dump on a real processor pod.
* `TUIST_MODE=swift_registry_sync` cannot run locally at all, because `config/runtime.exs` raises for a missing `TUIST_S3_ENDPOINT`. That is pre-existing and unrelated. The mode is covered by the unit tests via `Environment.modes/0`.
