### PR TITLE
fix(infra): give canary rollouts the memory headroom the deploy cascade needs

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -17,6 +17,18 @@ registry:
   ingress:
     host: registry-canary.tuist.dev
     tlsSecretName: registry-canary-tls
+  # Terminate-then-replace on the two-worker canary pool. The chart default
+  # (maxSurge=1, maxUnavailable=0) asks the scheduler for a second 512Mi Pod
+  # while every other Deployment in the release is surging too, so the extra
+  # Pods queue behind each other on FailedScheduling and whichever waits past
+  # progressDeadlineSeconds fails the whole release. One replica means a surge
+  # buys no availability here anyway: the Service has a single endpoint either
+  # way, and canary registry traffic tolerates the restart gap.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
 
 server:
   replicaCount: 1
@@ -302,6 +314,14 @@ processor:
 swiftRegistrySync:
   enabled: true
   syncAllowlist: alamofire/alamofire
+  # Terminate-then-replace, for the same reason as `registry.strategy` above.
+  # This is a pure Oban consumer, so the gap only defers queue work: the jobs
+  # stay in Postgres and the replacement Pod picks them up.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: can

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -74,12 +74,17 @@ pdcAgent:
     # per-env vault the ClusterSecretStore is bound to.
     item: PDC_AGENT
     tokenField: password
-  # Mirrors upstream's manifest: the agent is a single tunnel process, not a
-  # throughput-scaled workload.
+  # The agent is a single ssh tunnel process, not a throughput-scaled
+  # workload: measured steady state is ~10Mi and ~1m across every env.
+  # Upstream's manifest requests 1 CPU + 1Gi, which the scheduler reserves
+  # in full — on the two-worker canary pool that is a seventh of the node's
+  # memory and a quarter of its CPU held for an idle tunnel, and it is what
+  # left rolling updates without the headroom to place a surge Pod. Requests
+  # track the measured working set; the 1Gi limit stays as the burst ceiling.
   resources:
     requests:
-      cpu: "1"
-      memory: 1Gi
+      cpu: 50m
+      memory: 64Mi
     limits:
       memory: 1Gi
 


### PR DESCRIPTION
Unblocks the production deployment cascade, which has failed on every push since 2026-08-12 at the `canary / Deploy to tuist-canary` job. Latest failure: https://github.com/tuist/tuist/actions/runs/31676777864/job/94376165529

## What was happening

The Helm upgrade fails with:

```
UPGRADE FAILED: release tuist failed, and has been rolled back due to rollback-on-failure being set:
resource Deployment/tuist-canary/tuist-tuist-registry not ready. status: Failed, message: Progress deadline exceeded
resource Deployment/tuist-canary/tuist-tuist-swift-registry-sync not ready. status: Failed, message: Progress deadline exceeded
```

and the pods behind those Deployments spend the whole window on:

```
FailedScheduling  0/13 nodes are available: 11 node(s) had untolerated taint(s), 2 Insufficient memory.
```

Everything downstream (backward-compatibility acceptance, acceptance tests, production) is skipped, so no server change has reached production for over a day.

## Root cause

The canary `md-0` pool is two 4 vCPU / 8 GiB workers, ~7.6 GiB allocatable each. Reading the live cluster:

| node | memory requests | memory actually used |
| --- | --- | --- |
| md-0-...-jchxj | 7136Mi (93%) | 4144Mi (54%) |
| md-0-...-qv752 | 7238Mi (94%) | 6157Mi (80%) |

That leaves roughly 400-500 MiB free per node against the scheduler, which is less than the 512 MiB surge Pod a default RollingUpdate asks for. A Helm release rolls every Deployment at once, so the surge Pods queue behind each other on FailedScheduling, cross the Deployment's progressDeadlineSeconds, and Helm rolls the release back. The surge Pods did eventually schedule, about 20 seconds after Helm had already given up.

The gap between requests and usage is what matters here, and the single largest contributor is the PDC agent. It reserves 1 CPU and 1 GiB because those numbers were carried over from upstream's manifest, but it is one ssh tunnel process: measured steady state is 11Mi / 1m in canary, and 7-9Mi / 1m across the three production replicas. On a canary worker that reservation is a seventh of the node's memory and a quarter of its CPU held for an idle process.

## What changed

Two changes, both closing that gap rather than papering over it:

1. `pdcAgent.resources.requests` drops from 1 CPU / 1Gi to 50m / 64Mi in the chart defaults, tracking the measured working set. The 1Gi limit stays as the burst ceiling. This is a chart-wide change because the reservation is equally wrong in every environment that enables the agent; production is simply large enough to absorb it.

2. Canary's `registry` and `swiftRegistrySync` roll terminate-then-replace (maxSurge 0, maxUnavailable 1), which is exactly what canary's `processor` already does for the same reason. Both are single-replica in canary, so a surge Pod buys no availability at all: the Service has one endpoint either way, and the sync side is a pure Oban consumer whose jobs wait in Postgres until the replacement Pod picks them up.

Together this frees about 960 MiB and 950m CPU of reservation on the PDC agent's worker, and cuts transient rollout demand from roughly 1.8 GiB to roughly 770 MiB, which fits on a single node with room left over.

## Why not the alternatives

- Scaling `md-0` from two workers to three is the durable answer if canary keeps growing, but it is a spend decision and it would not fix the misallocation: the cluster would still hold a full CPU and a full gigabyte for an idle tunnel.
- Lowering the CNPG memory request would free another gigabyte per node, but it restarts the Postgres cluster (switchover) as part of the very deploy that is already failing. Not worth stacking that risk on the unblock.
- Raising progressDeadlineSeconds would hide the queueing rather than remove it, and would make every canary deploy slower to fail when something is genuinely wrong.

There is no ordering hazard on the first deploy after this merges: the workloads that were timing out no longer need a surge Pod at all, so they do not depend on the PDC agent rollout having already freed its memory.

## User and developer impact

No user-facing behaviour changes. Canary registry and registry-sync now have a short gap during a rollout instead of an overlap, which is the point. Developers get the deploy cascade back, so server changes reach production again.

## Validation

- `helm template` against `values-managed-common.yaml` + `values-managed-canary.yaml` renders cleanly; the rendered strategies for `tuist-tuist-registry` and `tuist-tuist-swift-registry-sync` are maxSurge 0 / maxUnavailable 1, and the `tuist-tuist-pdc-agent` container resources are 50m / 64Mi requests with the 1Gi limit intact.
- Live read-only inspection of the canary cluster for the numbers above: node allocatable, allocated requests per node, per-Pod requests, and `kubectl top` for measured usage in canary and production.
- Confirmed the failure signature is the same across the last several failing runs, not a one-off.
- The `helm lint` failure on `templates/dedibox-fleet.yaml` ("invalid Yaml document separator") reproduces on the unmodified tree and is unrelated to this change.

## How to test locally

```bash
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=test --set registry.image.tag=test --set kuraController.image.tag=test --set xcresultProcessor.image.tag=test --set codebaseSearch.image.tag=test --set runnersFleet.runnerImageSemver=1.0.0 --set runnersFleetLinux.shapeRunnerImage=test
```

The real verification is the canary deploy job on merge: it should get past `helm upgrade --install` without FailedScheduling on the registry and registry-sync Pods.

## Follow-up worth considering

Even after this, canary steady-state requests stay around 80% on a two-node pool that carries a 4 GiB Postgres instance pinned to each node. This buys back rollout headroom; it does not make the pool roomy. If canary keeps accreting components, scaling `md-0` to three workers is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
