### PR TITLE
fix(server): close runner billing sessions the controller never reported stopped

### DIFF
--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -48,6 +48,7 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"* * * * *", Tuist.Runners.Workers.OrphanedRunnersWorker},
     {"* * * * *", Tuist.Runners.Workers.PodClaimReconciliationWorker},
     {"* * * * *", Tuist.Runners.Workers.OrphanedStampedPodsWorker},
+    {"* * * * *", Tuist.Runners.Workers.OrphanedSessionsWorker},
     {"* * * * *", Tuist.Runners.Workers.ExpireInteractiveSessionsWorker},
     {"*/5 * * * *", Tuist.Runners.Workers.WebhookRedeliveryWorker},
     {"*/5 * * * *", Tuist.Runners.Workers.StaleQueuedJobsWorker}

--- a/server/lib/tuist/runners/billing.ex
+++ b/server/lib/tuist/runners/billing.ex
@@ -28,10 +28,15 @@ defmodule Tuist.Runners.Billing do
   upper bound clamps to either `period_end` (so the billing
   query gives a snapshot of "compute consumed so far") or to
   `now()` whenever the caller queries with `period_end` set to
-  the future. An orphaned Pod (controller never tore it down,
-  no completion webhook) keeps billing up to whichever cap
-  applies — operationally the orphan-runners worker should
-  close those sessions out before they run away.
+  the future.
+
+  A session the runners-controller never reported stopped would
+  otherwise bill up to whichever cap applies, forever.
+  `OrphanedSessionsWorker` is what closes those out — at the
+  terminal `completed_at` of the job the Pod actually ran, so the
+  recovered number reflects real work rather than the safety
+  bound. `OrphanedRunnersWorker` does *not* cover this; it
+  recovers `runner_jobs`, never `runner_sessions`.
 
   ## Precision
 
@@ -50,16 +55,26 @@ defmodule Tuist.Runners.Billing do
 
   @default_window_days 30
 
-  # Safety clamp for sessions whose `stopped` event was never
-  # delivered (controller crash + Pod garbage-collected from K8s
-  # before recovery). Without this, an indefinitely-open session
-  # bills against `LEAST(now(), period_end)` for as long as it
-  # stays open, which is exactly the over-bill the
-  # controller-reported-close architecture exists to prevent. 6
-  # hours matches the default `workflow_job` hard timeout on
-  # GitHub-hosted runners, so the clamp never trims a legitimate
-  # session — it only bounds the worst case after the
-  # authoritative signal got lost.
+  # Last-resort bound for sessions whose `stopped` event was never
+  # delivered *and* whose job has not reached a terminal state in
+  # ClickHouse, so `OrphanedSessionsWorker` cannot resolve a real
+  # `ended_at` for them either. Without it, such a session bills
+  # against `LEAST(now(), period_end)` for as long as it stays open.
+  #
+  # 6 hours matches the default `workflow_job` hard timeout on
+  # GitHub-hosted runners, and measured sessions confirm the fit:
+  # real builds on these fleets do reach it (observed 360.6-minute
+  # jobs whose sessions closed at 361.2 minutes), while p99 sits at
+  # 68 minutes. Tightening it would under-bill that tail, because
+  # the clamp sits inside the same `LEAST` as `ended_at` and so
+  # truncates closed sessions too — not just open ones.
+  #
+  # This is deliberately not the mechanism that keeps orphans in
+  # check. It cannot be: it is a constant, and it fires equally on
+  # a Pod that vanished after 90 seconds and one that ran for six
+  # hours. `OrphanedSessionsWorker` closes orphans at their real
+  # completion time; the clamp only covers what that worker cannot
+  # resolve.
   @max_session_lifetime_seconds 6 * 60 * 60
 
   @doc """

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -1324,6 +1324,37 @@ defmodule Tuist.Runners.Jobs do
   end
 
   @doc """
+  Resolves the terminal completion time of each id in
+  `workflow_job_ids`, as `%{workflow_job_id => completed_at}`.
+
+  Only jobs whose latest state is `completed` *and* which carry a
+  non-NULL `completed_at` appear in the result. A job still in
+  flight, or one whose terminal INSERT landed without a timestamp,
+  is absent — callers must treat absence as "no answer yet", never
+  as "finished now".
+
+  `OrphanedSessionsWorker` uses this to close billing sessions the
+  runners-controller never reported stopped: GitHub's terminal
+  timestamp is the closest available proxy for when the Pod stopped
+  doing customer work.
+  """
+  def terminal_completions(workflow_job_ids) when is_list(workflow_job_ids) do
+    case Enum.reject(workflow_job_ids, &is_nil/1) do
+      [] ->
+        %{}
+
+      ids ->
+        Job
+        |> from(hints: ["FINAL"])
+        |> where([j], j.workflow_job_id in ^ids)
+        |> where([j], j.status == "completed" and not is_nil(j.completed_at))
+        |> select([j], {j.workflow_job_id, j.completed_at})
+        |> ClickHouseRepo.all()
+        |> Map.new()
+    end
+  end
+
+  @doc """
   Lists `runner_jobs` rows whose latest state is `queued` and whose
   `enqueued_at` falls in `[enqueued_after, enqueued_before)` —
   candidates for the "queued but never reconciled" recovery path that

--- a/server/lib/tuist/runners/runner_sessions.ex
+++ b/server/lib/tuist/runners/runner_sessions.ex
@@ -162,6 +162,83 @@ defmodule Tuist.Runners.RunnerSessions do
   end
 
   @doc """
+  Lists sessions still open whose `started_at` is older than
+  `threshold` — candidates for the "controller never reported the
+  Pod stopped" recovery path that `OrphanedSessionsWorker` drives.
+
+  The threshold exists so the sweep never races a Pod that is
+  simply still working. Ordering by `started_at` means the oldest
+  (most expensive against the billing clamp) sessions are resolved
+  first when a tick hits `limit`.
+  """
+  def list_open_before(%DateTime{} = threshold, limit) when is_integer(limit) and limit > 0 do
+    RunnerSession
+    |> where([s], is_nil(s.ended_at) and s.started_at < ^threshold)
+    |> order_by([s], asc: s.started_at)
+    |> limit(^limit)
+    |> select([s], %{
+      id: s.id,
+      workflow_job_id: s.workflow_job_id,
+      executed_workflow_job_id: s.executed_workflow_job_id,
+      account_id: s.account_id,
+      pod_name: s.pod_name,
+      fleet_name: s.fleet_name,
+      started_at: s.started_at
+    })
+    |> Repo.all()
+  end
+
+  @doc """
+  Closes the session with `id` at `ended_at`, carrying the same
+  under-bill bias as `close_by_pod_name/2`.
+
+  Addressed by primary key rather than `pod_name` because the
+  recovery sweep already holds the exact row it resolved, and two
+  sessions can share a `pod_name` when a Pod served a re-claim.
+
+  `ended_at` is additionally floored at `started_at`, so a job whose
+  terminal timestamp predates the claim (clock skew between GitHub
+  and us, or a `completed_at` belonging to an earlier attempt on the
+  same runner) closes the session at zero duration instead of
+  writing an inverted interval that the billing query would read as
+  a negative contribution.
+  """
+  def close_by_id(id, %DateTime{} = ended_at) when is_integer(id) do
+    case Repo.get(RunnerSession, id) do
+      nil ->
+        {:ok, :no_open_session}
+
+      %RunnerSession{} = session ->
+        effective_end =
+          session.ended_at
+          |> case do
+            nil -> ended_at
+            %DateTime{} = existing -> earlier(existing, ended_at)
+          end
+          |> later(session.started_at)
+
+        session
+        |> Ecto.Changeset.cast(
+          %{ended_at: effective_end, updated_at: DateTime.truncate(DateTime.utc_now(), :second)},
+          [:ended_at, :updated_at]
+        )
+        |> Repo.update()
+        |> case do
+          {:ok, updated} ->
+            {:ok, updated}
+
+          {:error, changeset} ->
+            Logger.warning("runners: failed to close orphaned billing session",
+              session_id: id,
+              changeset_errors: inspect(changeset.errors)
+            )
+
+            {:error, changeset}
+        end
+    end
+  end
+
+  @doc """
   Counts runner Pods currently occupying capacity, grouped by fleet.
 
   A claim covers the dispatch window before the durable session is
@@ -425,6 +502,10 @@ defmodule Tuist.Runners.RunnerSessions do
 
   defp earlier(%DateTime{} = a, %DateTime{} = b) do
     if DateTime.before?(a, b), do: a, else: b
+  end
+
+  defp later(%DateTime{} = a, %DateTime{} = b) do
+    if DateTime.after?(a, b), do: a, else: b
   end
 
   @doc """

--- a/server/lib/tuist/runners/workers/orphaned_sessions_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_sessions_worker.ex
@@ -1,0 +1,147 @@
+defmodule Tuist.Runners.Workers.OrphanedSessionsWorker do
+  @moduledoc """
+  Closes `runner_sessions` rows the runners-controller never
+  reported stopped, using GitHub's terminal timestamp for the job
+  the Pod actually ran.
+
+  ## The leak this recovers
+
+  A session has exactly one close path: the runners-controller's
+  `PodLifecycleReconciler` POSTs `/api/internal/runners/pods/stopped`
+  when it observes a Pod in a terminal phase. When the Pod leaves
+  the apiserver before that reconcile lands — reap race, controller
+  restart, dropped watch event — the reconciler's `IsNotFound`
+  branch has no `finishedAt` to send and gives up.
+
+  Nothing else ever closed the row. `OrphanedRunnersWorker` recovers
+  `runner_jobs`, `StaleClaimsWorker` recovers `runner_claims`;
+  neither touches `runner_sessions`. The session stayed open
+  forever and `Tuist.Runners.Billing` fell through to its
+  `@max_session_lifetime_seconds` clamp, billing the full safety
+  bound for a Pod that had been gone for weeks — observed at 360
+  billed minutes against jobs that really ran for 1.5.
+
+  ## How it recovers
+
+    1. List open sessions older than `@grace_seconds` (cheap
+       Postgres prefilter; a session younger than the grace period
+       cannot have a job that finished before it).
+    2. Resolve each one's job in ClickHouse via
+       `Jobs.terminal_completions/1`, preferring
+       `executed_workflow_job_id` — the job GitHub proved ran on
+       this runner — over the claim-time `workflow_job_id`.
+    3. Close every session whose job reached `completed` more than
+       `@grace_seconds` ago, at that `completed_at`.
+
+  Sessions whose job is absent from ClickHouse, or still in
+  flight, are left open on purpose. "Still running" is
+  indistinguishable here from "genuinely long build", and real
+  six-hour builds exist on these fleets — closing them on a
+  guess would under-bill live work. Those rows stay covered by the
+  billing clamp, and the job-side recovery workers drive the
+  underlying `runner_jobs` row to a terminal state, at which point
+  the next tick of this worker closes the session properly.
+
+  ## Why a grace period, and why it is generous
+
+  The controller's report is the authoritative close: it carries
+  `containerStatuses[].state.terminated.finishedAt`, the moment the
+  runner process exited, and it accounts for the post-job window
+  where the Pod is still uploading caches and tearing down —
+  occupancy the customer is legitimately billed for.
+
+  This worker's `completed_at` is a proxy that ends at the job
+  boundary and misses that tail. Waiting `@grace_seconds` past the
+  job's completion means the normal path (which lands within
+  seconds) always wins the race, and this only fires once the
+  controller has demonstrably failed to report. On the fleets
+  measured, the tail is worth seconds — closed sessions summed to
+  306.9 minutes against 304.3 minutes of job time over the same
+  window — so resolving to `completed_at` is a rounding error in
+  the under-bill direction, which is the direction this subsystem
+  always errs.
+
+  ## Bounded work per tick
+
+  `@batch_limit` caps one tick's Postgres reads, ClickHouse lookup
+  width, and writes. Oldest sessions are resolved first, so a
+  backlog drains from the most expensive end. At a one-minute
+  cadence the steady state is zero candidates.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Tuist.Runners.Jobs
+  alias Tuist.Runners.RunnerSessions
+  alias Tuist.Runners.Telemetry
+
+  require Logger
+
+  @grace_seconds 600
+  @batch_limit 500
+
+  @impl Oban.Worker
+  def perform(_job) do
+    threshold = DateTime.add(DateTime.utc_now(), -@grace_seconds, :second)
+
+    case RunnerSessions.list_open_before(threshold, @batch_limit) do
+      [] ->
+        :ok
+
+      candidates ->
+        candidates |> resolve(threshold) |> close_all()
+    end
+  end
+
+  # Pairs each candidate session with the terminal `completed_at` of
+  # the job it ran, dropping the ones ClickHouse can't yet answer for.
+  defp resolve(candidates, threshold) do
+    completions =
+      candidates
+      |> Enum.map(&job_id/1)
+      |> Enum.uniq()
+      |> Jobs.terminal_completions()
+
+    candidates
+    |> Enum.flat_map(fn session ->
+      case Map.get(completions, job_id(session)) do
+        %DateTime{} = completed_at -> [{session, completed_at}]
+        _ -> []
+      end
+    end)
+    |> Enum.filter(fn {_session, completed_at} -> DateTime.before?(completed_at, threshold) end)
+  end
+
+  # `executed_workflow_job_id` is GitHub's proof of what this runner
+  # actually ran, learned from the `in_progress` / `completed`
+  # webhook. It only diverges from the claim-time `workflow_job_id`
+  # when the runner picked up a different job than the one it was
+  # dispatched for, and in that case the executed job is the one
+  # whose completion released the Pod.
+  defp job_id(%{executed_workflow_job_id: executed}) when is_integer(executed) and executed > 0, do: executed
+  defp job_id(%{workflow_job_id: workflow_job_id}), do: workflow_job_id
+
+  defp close_all([]), do: :ok
+
+  defp close_all(resolved) do
+    closed =
+      Enum.count(resolved, fn {session, completed_at} ->
+        match?({:ok, %_{}}, RunnerSessions.close_by_id(session.id, completed_at))
+      end)
+
+    if closed > 0 do
+      Logger.warning("runners: closed orphaned billing sessions",
+        count: closed,
+        grace_seconds: @grace_seconds
+      )
+
+      :telemetry.execute(
+        Telemetry.event_name_recovery(),
+        %{count: closed},
+        %{kind: "orphaned_session"}
+      )
+    end
+
+    :ok
+  end
+end

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -1133,6 +1133,63 @@ defmodule Tuist.Runners.JobsTest do
     end
   end
 
+  describe "terminal_completions/1" do
+    test "returns completed_at only for jobs that reached a terminal state" do
+      account = account_fixture()
+
+      :ok = enqueue_fixture(account, 8601, fleet: "fleet-tc")
+      {:ok, done} = Jobs.pick_queued("fleet-tc", [])
+      :ok = Jobs.record_claimed(done, "pod-done", DateTime.utc_now())
+      :ok = Jobs.record_running(8601, "runner-done")
+      {:ok, %{completed_at: completed_at}} = Jobs.complete(8601, "success")
+
+      :ok = enqueue_fixture(account, 8602, fleet: "fleet-tc")
+      {:ok, running} = Jobs.pick_queued("fleet-tc", [])
+      :ok = Jobs.record_claimed(running, "pod-running", DateTime.utc_now())
+      :ok = Jobs.record_running(8602, "runner-running")
+
+      completions = Jobs.terminal_completions([8601, 8602, 8603])
+
+      assert Map.keys(completions) == [8601]
+      assert DateTime.compare(Map.fetch!(completions, 8601), completed_at) == :eq
+    end
+
+    test "returns an empty map for an empty id list without hitting ClickHouse" do
+      assert Jobs.terminal_completions([]) == %{}
+      assert Jobs.terminal_completions([nil]) == %{}
+    end
+
+    test "excludes a row that carries a completed_at but whose latest state is not terminal" do
+      # `not is_nil(completed_at)` alone is not the contract. Today's
+      # writers nil the timestamp when they move a job off `completed`,
+      # so this row is only reachable by writing it directly — but the
+      # predicate is what stops a stale completion from closing a
+      # session that belongs to a live re-claim.
+      account = account_fixture()
+
+      :ok = enqueue_fixture(account, 8611, fleet: "fleet-tc-stale")
+      {:ok, candidate} = Jobs.pick_queued("fleet-tc-stale", [])
+      :ok = Jobs.record_claimed(candidate, "pod-stale", DateTime.utc_now())
+      :ok = Jobs.record_running(8611, "runner-stale")
+      {:ok, completed} = Jobs.complete(8611, "success")
+
+      assert Map.has_key?(Jobs.terminal_completions([8611]), 8611)
+
+      IngestRepo.insert_all(Job, [
+        completed
+        |> Map.from_struct()
+        |> Map.delete(:__meta__)
+        |> Map.merge(%{
+          status: "running",
+          conclusion: "",
+          updated_at: DateTime.add(completed.updated_at, 1, :second)
+        })
+      ])
+
+      assert Jobs.terminal_completions([8611]) == %{}
+    end
+  end
+
   describe "list_stale_queued/2" do
     test "returns queued rows enqueued inside the window" do
       account = account_fixture()

--- a/server/test/tuist/runners/workers/orphaned_sessions_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_sessions_worker_test.exs
@@ -1,0 +1,210 @@
+defmodule Tuist.Runners.Workers.OrphanedSessionsWorkerTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+
+  import Mimic
+  import TuistTestSupport.Fixtures.AccountsFixtures
+
+  alias Tuist.Repo
+  alias Tuist.Runners.Billing
+  alias Tuist.Runners.Jobs
+  alias Tuist.Runners.RunnerSession
+  alias Tuist.Runners.RunnerSessions
+  alias Tuist.Runners.Workers.OrphanedSessionsWorker
+
+  setup :verify_on_exit!
+
+  defp session_fixture(account, attrs) do
+    defaults = %{
+      account_id: account.id,
+      workflow_job_id: System.unique_integer([:positive]),
+      fleet_name: "fleet-orphans",
+      pod_name: "pod-#{System.unique_integer([:positive])}",
+      runner_name: "",
+      # Well past the worker's grace period so the row is a candidate
+      # unless a test deliberately makes it recent.
+      started_at: DateTime.add(DateTime.utc_now(), -3, :hour),
+      ended_at: nil,
+      inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
+      updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+    }
+
+    Repo.insert!(struct(RunnerSession, Map.merge(defaults, Map.new(attrs))))
+  end
+
+  defp reload(session), do: Repo.get!(RunnerSession, session.id)
+
+  describe "perform/1" do
+    test "closes an orphaned session at the terminal completion of its job" do
+      # The controller never reported the Pod stopped, so the row sat
+      # open and billed against the six-hour clamp. GitHub's terminal
+      # timestamp recovers the real window.
+      account = account_fixture()
+      started_at = DateTime.add(DateTime.utc_now(), -3, :hour)
+      completed_at = DateTime.add(started_at, 94, :second)
+
+      session = session_fixture(account, workflow_job_id: 94_218_433_307, started_at: started_at)
+
+      expect(Jobs, :terminal_completions, fn ids ->
+        assert ids == [94_218_433_307]
+        %{94_218_433_307 => completed_at}
+      end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert DateTime.compare(reload(session).ended_at, completed_at) == :eq
+    end
+
+    test "leaves a session open when its job has not reached a terminal state" do
+      # Indistinguishable from a genuinely long build, and real
+      # six-hour builds exist on these fleets. The billing clamp
+      # covers it until the job-side workers drive it terminal.
+      account = account_fixture()
+      session = session_fixture(account, workflow_job_id: 94_245_504_882)
+
+      expect(Jobs, :terminal_completions, fn _ids -> %{} end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert is_nil(reload(session).ended_at)
+    end
+
+    test "leaves a session open when its job completed inside the grace period" do
+      # The controller's report lands within seconds and carries the
+      # post-job cache and teardown tail. Intervening this early would
+      # steal the accurate close and drop that tail.
+      account = account_fixture()
+      session = session_fixture(account, workflow_job_id: 94_284_875_086)
+
+      expect(Jobs, :terminal_completions, fn _ids ->
+        %{94_284_875_086 => DateTime.add(DateTime.utc_now(), -30, :second)}
+      end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert is_nil(reload(session).ended_at)
+    end
+
+    test "ignores sessions younger than the grace period without querying ClickHouse" do
+      account = account_fixture()
+
+      session =
+        session_fixture(account, started_at: DateTime.add(DateTime.utc_now(), -60, :second))
+
+      reject(&Jobs.terminal_completions/1)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert is_nil(reload(session).ended_at)
+    end
+
+    test "resolves against the job GitHub proved ran on the runner" do
+      # `executed_workflow_job_id` is ground truth when the runner
+      # picked up a different job than it was dispatched for; that
+      # job's completion is what released the Pod.
+      account = account_fixture()
+      started_at = DateTime.add(DateTime.utc_now(), -2, :hour)
+      completed_at = DateTime.add(started_at, 12, :minute)
+
+      session =
+        session_fixture(account,
+          workflow_job_id: 111,
+          executed_workflow_job_id: 222,
+          started_at: started_at
+        )
+
+      expect(Jobs, :terminal_completions, fn ids ->
+        assert ids == [222]
+        %{222 => completed_at}
+      end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert DateTime.compare(reload(session).ended_at, completed_at) == :eq
+    end
+
+    test "floors the close at started_at when the job completed before the claim" do
+      # Clock skew against GitHub, or a `completed_at` belonging to an
+      # earlier attempt on the same runner. Writing it verbatim would
+      # invert the interval and bill negative time.
+      account = account_fixture()
+      started_at = DateTime.add(DateTime.utc_now(), -2, :hour)
+
+      session = session_fixture(account, workflow_job_id: 333, started_at: started_at)
+
+      expect(Jobs, :terminal_completions, fn _ids ->
+        %{333 => DateTime.add(started_at, -5, :minute)}
+      end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert DateTime.compare(reload(session).ended_at, started_at) == :eq
+    end
+
+    test "does not reopen or extend an already closed session" do
+      account = account_fixture()
+      started_at = DateTime.add(DateTime.utc_now(), -3, :hour)
+      ended_at = DateTime.add(started_at, 5, :minute)
+
+      session = session_fixture(account, workflow_job_id: 444, started_at: started_at, ended_at: ended_at)
+
+      reject(&Jobs.terminal_completions/1)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert DateTime.compare(reload(session).ended_at, ended_at) == :eq
+    end
+
+    test "is a no-op when nothing is open past the grace period" do
+      reject(&Jobs.terminal_completions/1)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+    end
+  end
+
+  describe "billing recovery" do
+    test "replaces the clamped safety bound with the real billed window" do
+      # The regression this worker exists for. A Pod whose `stopped`
+      # event never arrived billed `@max_session_lifetime_seconds`
+      # against a job that really ran for 94 seconds — observed in
+      # production at 360 billed minutes per orphan, 78% of one
+      # customer's daily total.
+      account = account_fixture()
+      # Older than the clamp, so the open row bills the safety bound
+      # rather than simply `now()`.
+      started_at = DateTime.add(DateTime.utc_now(), -10, :hour)
+      completed_at = DateTime.add(started_at, 94, :second)
+
+      session_fixture(account, workflow_job_id: 94_218_433_307, started_at: started_at)
+
+      period_start = DateTime.add(started_at, -1, :hour)
+      period_end = DateTime.add(DateTime.utc_now(), 1, :hour)
+
+      assert Billing.compute_milliseconds(account.id, period_start, period_end) == 6 * 60 * 60 * 1_000
+
+      expect(Jobs, :terminal_completions, fn _ids -> %{94_218_433_307 => completed_at} end)
+
+      assert :ok = OrphanedSessionsWorker.perform(%Oban.Job{})
+
+      assert Billing.compute_milliseconds(account.id, period_start, period_end) == 94 * 1_000
+    end
+  end
+
+  describe "close_by_id/2" do
+    test "keeps the earlier end when a close races in with a later timestamp" do
+      account = account_fixture()
+      started_at = DateTime.add(DateTime.utc_now(), -3, :hour)
+      ended_at = DateTime.add(started_at, 4, :minute)
+
+      session = session_fixture(account, started_at: started_at, ended_at: ended_at)
+
+      assert {:ok, updated} =
+               RunnerSessions.close_by_id(session.id, DateTime.add(started_at, 90, :minute))
+
+      assert DateTime.compare(updated.ended_at, ended_at) == :eq
+    end
+
+    test "returns :no_open_session for an unknown id" do
+      assert {:ok, :no_open_session} = RunnerSessions.close_by_id(-1, DateTime.utc_now())
+    end
+  end
+end


### PR DESCRIPTION
> Describe here the purpose of your PR.

A customer reported their GitHub Actions API showing roughly 240 runner minutes over 24 hours while the Tuist dashboard showed about 1,500. The dashboard was wrong.

### Root cause

A `runner_sessions` row has exactly one close path: the runners-controller POSTing `/api/internal/runners/pods/stopped` when its `PodLifecycleReconciler` observes a Pod in a terminal phase. When the Pod leaves the apiserver before that reconcile lands (reap race, controller restart, dropped watch event), the reconciler's `IsNotFound` branch has no `finishedAt` to send and deliberately gives up, deferring to the server-side clamp.

Nothing else ever closed the row. `OrphanedRunnersWorker` recovers `runner_jobs` and `StaleClaimsWorker` recovers `runner_claims`; neither touches `runner_sessions`, despite the `Billing` moduledoc asserting that the orphan-runners worker "should close those sessions out". So the session stayed open forever and `Billing.compute_milliseconds/4` fell through to `@max_session_lifetime_seconds`, billing the full six-hour bound for a Pod that had been gone for weeks.

For the reporting account over the 24 hours in question:

| Source | Sessions | Minutes |
|---|---|---|
| Closed normally | 36 | 307 |
| Never closed | 3 | 1,080 |

Those three sessions were 78% of the bill, each pinned at exactly 360.0 minutes. Their real job durations were 1.5, 7.6, and 20.4 minutes. Strip the orphans out and the model is sound: closed sessions summed to 306.9 minutes against 304.3 minutes of completed job time over the same window, so session time tracks job time roughly 1:1 and there is no hidden overhead being counted.

Month to date the same account had 101 of 679 sessions orphaned, contributing 36,360 of 42,409 minutes. Fleet-wide there were 769 orphans in the month.

### What changed

`OrphanedSessionsWorker`, on the same one-minute cadence as the other runner recovery workers. Each tick it lists open sessions past a grace period (cheap Postgres prefilter), resolves their jobs in ClickHouse via the new `Jobs.terminal_completions/1`, and closes each session at the terminal `completed_at` of the job the Pod actually ran.

Three decisions worth reviewing:

- **Sessions whose job is absent from ClickHouse or still in flight are left open on purpose.** "Still running" is indistinguishable here from "genuinely long build", and real six-hour builds exist on these fleets. Closing on a guess would under-bill live work. Those rows stay covered by the clamp, and once the job-side recovery workers drive the underlying row terminal, the next tick closes the session properly.
- **The grace period is measured from job completion, not session start**, so the controller's report (which lands within seconds, carries the real `finishedAt`, and includes the post-job cache and teardown tail the customer is legitimately billed for) always wins the race. This only fires once the controller has demonstrably failed.
- **`executed_workflow_job_id` is preferred** over the claim-time `workflow_job_id`. It is GitHub's proof of what the runner actually ran, and that job's completion is what released the Pod.

Supporting additions: `RunnerSessions.list_open_before/2` and `close_by_id/2`. The latter carries the existing under-bill bias (`MIN` against any existing `ended_at`) and additionally floors at `started_at`, so clock skew against GitHub cannot write an inverted interval that the billing query would read as a negative contribution.

### Why the clamp stays at six hours

The obvious alternative was to tighten `@max_session_lifetime_seconds`. The data rules it out. Comparing session duration against actual job duration separates real long builds from late close signals:

| workflow_job | session | actual job | verdict |
|---|---|---|---|
| 89247178602 | 361.2 min | 360.6 min | real six-hour build |
| 90753631929 | 364.8 min | 360.4 min | real six-hour build |
| 89963764877 | 237.1 min | 236.6 min | real four-hour build |
| 87366189520 | 2219.6 min | 11.2 min | late close signal |
| 90273356576 | 422.3 min | 23.6 min | late close signal |

Legitimate builds do reach the bound, and because the clamp sits inside the same `LEAST` as `ended_at` it truncates closed sessions too, not just open ones. Lowering it would trade over-billing orphans for under-billing the real tail. The clamp is also structurally incapable of being the orphan mechanism: it is a constant, so it fires identically on a Pod that vanished after 90 seconds and one that ran for six hours.

Its comment block claimed it "never trims a legitimate session", which the data contradicts. It now records what it actually covers, why six hours is the right size, and that the worker is what keeps orphans in check. The stale `Billing` moduledoc pointing at `OrphanedRunnersWorker` is corrected too, since that misdirection is how the leak went unnoticed.

### Impact

Billing accuracy. No customer has been invoiced against these numbers yet, and this only affects what the dashboard and future invoices report.

This does not backfill the 769 existing orphaned rows; they keep billing the clamp until closed separately. Also unchanged: `RunnerSessions.live_pod_names/0` is still unbounded, so open sessions shield long-dead Pod names from `OrphanedStampedPodsWorker`. Both are follow-ups.

### How to test locally

```
mix test test/tuist/runners/workers/orphaned_sessions_worker_test.exs test/tuist/runners/jobs_test.exs
```

Full runners suite:

```
mix test test/tuist/runners test/tuist/runners_test.exs test/tuist_web/controllers/runner_pods_controller_test.exs test/tuist/oban
```

565 passing, credo clean.

The tests were written after the implementation, so they were validated retroactively by mutation testing rather than by a red phase. Nine mutations were applied one at a time (worker no-ops, grace period dropped, `executed_workflow_job_id` ignored, `started_at` floor removed, sweep picking up closed sessions, age prefilter dropped, `close_by_id` extending instead of clamping, and both `terminal_completions` predicates). All nine are killed by exactly the test that claims to cover them.

One mutation initially survived and exposed a real gap: dropping the `status == "completed"` check from `terminal_completions/1` went undetected because the fixture's running job had a NULL `completed_at`, so the `not is_nil` predicate alone excluded it. Current writers cannot produce a non-terminal row carrying a `completed_at` (`record_queued` nils it and is guarded by `completion_recorded?`), but that predicate is the function's contract and is what stops a stale completion from closing a session belonging to a live re-claim, so it is now tested directly by writing the row through `IngestRepo`.

Verified against production data: the reporting account's 147 open sessions resolve to 109 terminal jobs totalling 1,401 minutes of real work, replacing the roughly 52,920 phantom minutes they bill today. One of those is a legitimate 360.5-minute build, which the worker closes at its true completion rather than the clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
