### PR TITLE
feat(server): add a Microsoft Entra ID preset to single sign-on

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -2164,6 +2164,10 @@ defmodule Tuist.Accounts do
   @okta_token_path "/oauth2/v1/token"
   @okta_userinfo_path "/oauth2/v1/userinfo"
 
+  @entra_authority "https://login.microsoftonline.com"
+  @entra_user_info_url "https://graph.microsoft.com/oidc/userinfo"
+  @entra_tenant_regex ~r/\A[a-zA-Z0-9][a-zA-Z0-9._-]*\z/
+
   def oauth2_config_for_organization(%Organization{
         sso_provider: provider,
         sso_organization_id: sso_organization_id,
@@ -2197,6 +2201,55 @@ defmodule Tuist.Accounts do
   def okta_authorize_url(domain), do: "https://#{domain}#{@okta_authorize_path}"
   def okta_token_url(domain), do: "https://#{domain}#{@okta_token_path}"
   def okta_userinfo_url(domain), do: "https://#{domain}#{@okta_userinfo_path}"
+
+  @doc """
+  Microsoft Entra ID is a standards-compliant OpenID Connect provider, so it is
+  stored as a `:oauth2` organization. These helpers derive the endpoints from
+  the directory (tenant) identifier so administrators enter one value instead
+  of three URLs. The site is the `iss` value Entra puts in its v2.0 tokens.
+  """
+  def entra_site_url(tenant), do: "#{@entra_authority}/#{tenant}/v2.0"
+  def entra_authorize_url(tenant), do: "#{@entra_authority}/#{tenant}/oauth2/v2.0/authorize"
+  def entra_token_url(tenant), do: "#{@entra_authority}/#{tenant}/oauth2/v2.0/token"
+  def entra_userinfo_url, do: @entra_user_info_url
+
+  def valid_entra_tenant?(tenant) when is_binary(tenant), do: Regex.match?(@entra_tenant_regex, tenant)
+  def valid_entra_tenant?(_tenant), do: false
+
+  @doc """
+  Returns the directory (tenant) identifier when the organization's stored
+  configuration is exactly what `entra_*_url/1` would generate, and `nil`
+  otherwise.
+
+  The match has to be exact. An organization that points at Entra through
+  hand-entered endpoints keeps the generic form, because rewriting its stored
+  URLs would change `sso_organization_id` — the issuer that linked identities
+  are keyed on — and strand every existing member.
+  """
+  def entra_tenant(%Organization{sso_provider: :oauth2} = organization) do
+    with tenant when is_binary(tenant) <- entra_tenant_from_site(organization.sso_organization_id),
+         true <- organization.oauth2_authorize_url == entra_authorize_url(tenant),
+         true <- organization.oauth2_token_url == entra_token_url(tenant),
+         true <- organization.oauth2_user_info_url == entra_userinfo_url() do
+      tenant
+    else
+      _ -> nil
+    end
+  end
+
+  def entra_tenant(_organization), do: nil
+
+  defp entra_tenant_from_site(site) when is_binary(site) do
+    case String.split(site, "/") do
+      ["https:", "", "login.microsoftonline.com", tenant, "v2.0"] ->
+        if valid_entra_tenant?(tenant), do: tenant
+
+      _ ->
+        nil
+    end
+  end
+
+  defp entra_tenant_from_site(_site), do: nil
 
   def sso_organization_for_user_email(email) do
     with {:ok, user} <- get_user_by_email(email),

--- a/server/lib/tuist_web/live/authentication_settings_live.ex
+++ b/server/lib/tuist_web/live/authentication_settings_live.ex
@@ -10,6 +10,13 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   alias Tuist.Environment
   alias Tuist.SCIM
 
+  # Form-level providers. "entra" is a preset over the generic `:oauth2`
+  # provider: it derives Entra's endpoints from a directory (tenant)
+  # identifier and persists as `:oauth2`, so no new `sso_provider` value,
+  # callback route, or identity migration is involved.
+  @oauth2_form_providers ["okta", "oauth2", "entra"]
+  @form_providers ["google" | @oauth2_form_providers]
+
   @impl true
   def mount(_params, _uri, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
     if Authorization.authorize(:account_update, current_user, selected_account) != :ok do
@@ -107,7 +114,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
     end
   end
 
-  def handle_event("select_provider", %{"value" => [provider]}, socket) when provider in ["google", "okta", "oauth2"] do
+  def handle_event("select_provider", %{"value" => [provider]}, socket) when provider in @form_providers do
     form_params = Map.put(socket.assigns.current_form_params, "provider", provider)
 
     verified_domain? =
@@ -164,7 +171,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
       )
 
     custom_provider_without_verified_domain? =
-      socket.assigns.selected_provider in ["okta", "oauth2"] and not verified_domain?
+      socket.assigns.selected_provider in @oauth2_form_providers and not verified_domain?
 
     legacy_enforcement? =
       legacy_sso_enforcement?(
@@ -210,7 +217,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
       :ok ->
         case socket.assigns.selected_provider do
           "google" -> save_google_sso(socket, params)
-          provider when provider in ["okta", "oauth2"] -> save_oauth2_sso(socket, params)
+          provider when provider in @oauth2_form_providers -> save_oauth2_sso(socket, params)
         end
 
       {:error, message} ->
@@ -391,7 +398,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
 
   defp save_oauth2_sso(%{assigns: %{organization: organization, selected_provider: selected_provider}} = socket, params) do
     form_params = params["sso"] || %{}
-    sso_provider = String.to_existing_atom(selected_provider)
+    sso_provider = provider_atom(selected_provider)
 
     attrs =
       build_oauth2_attrs(
@@ -428,7 +435,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   end
 
   @changeset_to_form_field %{
-    sso_organization_id: %{"okta" => "okta_domain", "oauth2" => "oauth2_site"},
+    sso_organization_id: %{"okta" => "okta_domain", "oauth2" => "oauth2_site", "entra" => "entra_tenant_id"},
     sso_login_domain: "sso_login_domain",
     oauth2_authorize_url: "oauth2_authorize_url",
     oauth2_token_url: "oauth2_token_url",
@@ -480,9 +487,20 @@ defmodule TuistWeb.AuthenticationSettingsLive do
     {domain, Accounts.okta_authorize_url(domain), Accounts.okta_token_url(domain), Accounts.okta_userinfo_url(domain)}
   end
 
+  defp extract_oauth2_urls("entra", form) do
+    tenant = entra_tenant_from_form(form)
+
+    {Accounts.entra_site_url(tenant), Accounts.entra_authorize_url(tenant), Accounts.entra_token_url(tenant),
+     Accounts.entra_userinfo_url()}
+  end
+
   defp extract_oauth2_urls("oauth2", form) do
     {String.trim(form["oauth2_site"] || ""), String.trim(form["oauth2_authorize_url"] || ""),
      String.trim(form["oauth2_token_url"] || ""), String.trim(form["oauth2_user_info_url"] || "")}
+  end
+
+  defp entra_tenant_from_form(form) do
+    (form["entra_tenant_id"] || "") |> String.trim() |> String.trim("/")
   end
 
   defp validate_sso_enforcement(%{assigns: %{sso_enforced: false}}), do: :ok
@@ -495,6 +513,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
         "google" -> String.trim(socket.assigns.current_form_params["google_domain"] || "")
         "okta" -> String.trim(socket.assigns.current_form_params["okta_domain"] || "")
         "oauth2" -> String.trim(socket.assigns.current_form_params["oauth2_site"] || "")
+        "entra" -> Accounts.entra_site_url(entra_tenant_from_form(socket.assigns.current_form_params))
       end
 
     has_identity =
@@ -518,6 +537,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   defp provider_atom("google"), do: :google
   defp provider_atom("okta"), do: :okta
   defp provider_atom("oauth2"), do: :oauth2
+  defp provider_atom("entra"), do: :oauth2
 
   defp validate_google_sso(domain, current_user) do
     if is_nil(
@@ -536,7 +556,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   end
 
   defp assign_form_from_organization(socket, organization) do
-    provider = if organization.sso_provider, do: Atom.to_string(organization.sso_provider), else: "google"
+    provider = form_provider(organization)
     form_data = build_form_data(provider, organization)
 
     socket
@@ -594,6 +614,11 @@ defmodule TuistWeb.AuthenticationSettingsLive do
       ])
   end
 
+  defp form_fields_valid?("entra", params, organization) do
+    Accounts.valid_entra_tenant?(entra_tenant_from_form(params)) and
+      oauth2_credentials_valid?(params, organization)
+  end
+
   defp form_fields_valid?(_provider, _params, _organization), do: true
 
   defp oauth2_credentials_valid?(params, organization) do
@@ -641,6 +666,16 @@ defmodule TuistWeb.AuthenticationSettingsLive do
     })
   end
 
+  defp build_form_data("entra", organization) do
+    Map.merge(default_form_data(), %{
+      "provider" => "entra",
+      "entra_tenant_id" => Accounts.entra_tenant(organization) || "",
+      "oauth2_client_id" => organization.oauth2_client_id || "",
+      "oauth2_client_secret" => "",
+      "sso_login_domain" => organization.sso_login_domain || ""
+    })
+  end
+
   defp build_form_data("oauth2", organization) do
     Map.merge(default_form_data(), %{
       "provider" => "oauth2",
@@ -663,6 +698,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
       "provider" => "google",
       "google_domain" => "",
       "okta_domain" => "",
+      "entra_tenant_id" => "",
       "oauth2_client_id" => "",
       "oauth2_client_secret" => "",
       "oauth2_site" => "",
@@ -691,7 +727,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   end
 
   defp automatic_enrollment_toggle_disabled?(selected_provider, organization, form_params, automatic_enrollment) do
-    selected_provider in ["okta", "oauth2"] and
+    selected_provider in @oauth2_form_providers and
       not verified_login_domain_selected?(selected_provider, organization, form_params) and
       not automatic_enrollment
   end
@@ -699,27 +735,27 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   defp sso_enforcement_toggle_disabled?(selected_provider, organization, form_params, enforced) do
     legacy_enforcement? = legacy_sso_enforcement?(selected_provider, organization)
 
-    selected_provider in ["okta", "oauth2"] and
+    selected_provider in @oauth2_form_providers and
       not verified_login_domain_selected?(selected_provider, organization, form_params) and
       not legacy_enforcement? and
       not enforced
   end
 
   defp verified_login_domain_selected?(selected_provider, organization, form_params) do
-    selected_provider in ["okta", "oauth2"] and
+    selected_provider in @oauth2_form_providers and
       not is_nil(organization.sso_login_domain_verified_at) and
       normalize_domain(form_params["sso_login_domain"]) == organization.sso_login_domain
   end
 
   defp legacy_sso_enforcement?(selected_provider, organization) do
     organization.sso_legacy_email_domain_fallback and
-      selected_provider == provider_name(organization.sso_provider)
+      selected_provider == form_provider(organization)
   end
 
   defp legacy_sso_automatic_enrollment?(selected_provider, organization) do
     organization.sso_legacy_email_domain_fallback and
       organization.sso_automatic_enrollment and
-      selected_provider == provider_name(organization.sso_provider)
+      selected_provider == form_provider(organization)
   end
 
   defp automatic_enrollment_for_provider_selection(
@@ -732,7 +768,7 @@ defmodule TuistWeb.AuthenticationSettingsLive do
        when previous_provider != "google", do: true
 
   defp automatic_enrollment_for_provider_selection(provider, _previous_provider, false, false, _automatic_enrollment)
-       when provider in ["okta", "oauth2"], do: false
+       when provider in @oauth2_form_providers, do: false
 
   defp automatic_enrollment_for_provider_selection(
          _provider,
@@ -742,11 +778,21 @@ defmodule TuistWeb.AuthenticationSettingsLive do
          automatic_enrollment
        ), do: automatic_enrollment
 
-  defp enforcement_for_provider_selection(provider, false, false, _enforced) when provider in ["okta", "oauth2"],
+  defp enforcement_for_provider_selection(provider, false, false, _enforced) when provider in @oauth2_form_providers,
     do: false
 
   defp enforcement_for_provider_selection(_provider, _verified_domain?, _legacy_enforcement?, enforced), do: enforced
 
-  defp provider_name(nil), do: nil
-  defp provider_name(provider), do: Atom.to_string(provider)
+  # The form provider is not always the stored `sso_provider`: an organization
+  # whose `:oauth2` configuration matches the Entra preset exactly is shown as
+  # "entra" so it gets the tenant field instead of four URL fields.
+  defp form_provider(%{sso_provider: nil}), do: "google"
+
+  defp form_provider(%{sso_provider: :oauth2} = organization) do
+    if Accounts.entra_tenant(organization), do: "entra", else: "oauth2"
+  end
+
+  defp form_provider(%{sso_provider: provider}), do: Atom.to_string(provider)
+
+  defp oauth2_form_provider?(provider), do: provider in @oauth2_form_providers
 end

--- a/server/lib/tuist_web/live/authentication_settings_live.html.heex
+++ b/server/lib/tuist_web/live/authentication_settings_live.html.heex
@@ -71,6 +71,7 @@
           >
             <:item value="google" label="Google" />
             <:item value="okta" label="Okta" />
+            <:item value="entra" label="Microsoft Entra ID" />
             <:item value="oauth2" label={dgettext("dashboard_account", "OAuth2")} />
           </.select>
         </div>
@@ -148,6 +149,72 @@
         </div>
       </div>
 
+      <%!-- Microsoft Entra ID setup instructions --%>
+      <div :if={@sso_enabled and @selected_provider == "entra"} data-part="section">
+        <div data-part="label">
+          <span data-part="title">
+            {dgettext("dashboard_account", "Setup instructions")}
+          </span>
+          <span data-part="description">
+            {dgettext(
+              "dashboard_account",
+              "Register an application in your Microsoft Entra admin center before configuring the fields below."
+            )}
+          </span>
+        </div>
+        <div data-part="field">
+          <div data-part="setup-steps">
+            <ol>
+              <li>
+                {dgettext(
+                  "dashboard_account",
+                  "Go to Identity > Applications > App registrations > New registration"
+                )}
+              </li>
+              <li>
+                {dgettext(
+                  "dashboard_account",
+                  "Select the \"Web\" platform and set the redirect URI to:"
+                )}
+                <div data-part="read-only-value">
+                  <code>
+                    {Tuist.Environment.app_url(path: "/users/auth/oauth2/callback")}
+                  </code>
+                </div>
+              </li>
+              <li>
+                {dgettext(
+                  "dashboard_account",
+                  "Copy the Directory (tenant) ID and Application (client) ID from the application overview"
+                )}
+              </li>
+              <li>
+                {dgettext(
+                  "dashboard_account",
+                  "Create a client secret under Certificates & secrets and copy its value"
+                )}
+              </li>
+              <li>
+                {dgettext(
+                  "dashboard_account",
+                  "Under API permissions, grant the delegated openid, profile, and email permissions"
+                )}
+              </li>
+              <li>
+                {dgettext("dashboard_account", "Set the home page URL to:")}
+                <div data-part="read-only-value">
+                  <code>
+                    {Tuist.Environment.app_url(
+                      path: "/users/auth/oauth2?organization_id=#{@organization.id}"
+                    )}
+                  </code>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+
       <%!-- Custom OAuth2 setup instructions --%>
       <div :if={@sso_enabled and @selected_provider == "oauth2"} data-part="section">
         <div data-part="label">
@@ -199,7 +266,7 @@
         </div>
       </div>
 
-      <div :if={@sso_enabled and @selected_provider in ["okta", "oauth2"]} data-part="section">
+      <div :if={@sso_enabled and oauth2_form_provider?(@selected_provider)} data-part="section">
         <div data-part="label">
           <span data-part="title">
             {dgettext("dashboard_account", "Login email domain")}
@@ -287,6 +354,29 @@
             type="basic"
             placeholder="your-company.okta.com"
             error={@field_errors["okta_domain"]}
+          />
+        </div>
+      </div>
+
+      <%!-- Microsoft Entra ID directory (tenant) ID --%>
+      <div :if={@sso_enabled and @selected_provider == "entra"} data-part="section">
+        <div data-part="label">
+          <span data-part="title">
+            {dgettext("dashboard_account", "Directory (tenant) ID")}
+          </span>
+          <span data-part="description">
+            {dgettext(
+              "dashboard_account",
+              "The directory (tenant) ID of your Entra application. Tuist derives the authorize, token, and user info endpoints from it."
+            )}
+          </span>
+        </div>
+        <div data-part="field">
+          <.text_input
+            field={@form[:entra_tenant_id]}
+            type="basic"
+            placeholder="00000000-0000-0000-0000-000000000000"
+            error={@field_errors["entra_tenant_id"]}
           />
         </div>
       </div>
@@ -380,7 +470,7 @@
         </div>
       </div>
 
-      <div :if={@sso_enabled and @selected_provider in ["okta", "oauth2"]} data-part="section">
+      <div :if={@sso_enabled and oauth2_form_provider?(@selected_provider)} data-part="section">
         <div data-part="label">
           <span data-part="title">
             {dgettext("dashboard_account", "Client ID")}
@@ -399,7 +489,7 @@
         </div>
       </div>
 
-      <div :if={@sso_enabled and @selected_provider in ["okta", "oauth2"]} data-part="section">
+      <div :if={@sso_enabled and oauth2_form_provider?(@selected_provider)} data-part="section">
         <div data-part="label">
           <span data-part="title">
             {dgettext("dashboard_account", "Client secret")}
@@ -497,7 +587,7 @@
               {dgettext("dashboard_account", "Enforce SSO")}
             </span>
             <span data-part="description">
-              <%= if @selected_provider in ["okta", "oauth2"] and
+              <%= if oauth2_form_provider?(@selected_provider) and
                        is_nil(@organization.sso_login_domain_verified_at) and
                        not @organization.sso_legacy_email_domain_fallback do %>
                 {dgettext(

--- a/server/priv/docs/en/guides/integrations/authentication/scim.md
+++ b/server/priv/docs/en/guides/integrations/authentication/scim.md
@@ -2,7 +2,7 @@
 {
   "title": "SCIM provisioning",
   "titleTemplate": ":title | Authentication | Integrations | Guides | Tuist",
-  "description": "Learn how to configure SCIM provisioning with Okta."
+  "description": "Learn how to configure SCIM provisioning with Okta or Microsoft Entra ID."
 }
 ---
 # SCIM provisioning {#scim-provisioning}
@@ -70,17 +70,68 @@ Configure <.localized_link href="/guides/integrations/authentication/sso#okta">O
 
 To test deprovisioning, unassign or deactivate a user in Okta and verify that they disappear from the Tuist organization's **Members** tab.
 
+## Microsoft Entra ID {#microsoft-entra-id}
+
+Entra ID provisions Tuist through a non-gallery enterprise application. Configure <.localized_link href="/guides/integrations/authentication/sso#microsoft-entra-id">Microsoft Entra ID SSO</.localized_link> first if users should also sign in with Entra ID.
+
+The application you register for single sign-on and the enterprise application you use for provisioning can be the same one. Provisioning is configured on the enterprise application entry.
+
+### Step 1: Generate a Tuist SCIM token {#entra-step-1}
+
+1. In Tuist, navigate to your organization's **Authentication** settings tab.
+2. In the **SCIM provisioning** section, copy the **SCIM endpoint URL**. It should end in `/scim/v2`.
+3. Click **Generate token**.
+4. Name the token (for example, `Entra ID`).
+5. Copy the generated token. Tuist shows the token only once.
+
+### Step 2: Configure provisioning {#entra-step-2}
+
+1. In the Microsoft Entra admin center, go to **Identity > Applications > Enterprise applications** and open the Tuist application.
+2. Open **Provisioning** and set **Provisioning Mode** to **Automatic**.
+3. Set **Tenant URL** to the Tuist SCIM endpoint URL.
+4. Set **Secret Token** to the Tuist SCIM token. Enter the token on its own, without a `Bearer ` prefix; Entra ID adds the scheme itself.
+5. Click **Test Connection**. Entra ID should report that the supplied credentials are authorized.
+6. Save the configuration.
+
+### Step 3: Set the matching attribute {#entra-step-3}
+
+1. Under **Mappings**, open **Provision Microsoft Entra ID Users**.
+2. Confirm that `userPrincipalName` or `mail` maps to the SCIM `userName` attribute, and that this attribute is the one used for **Matching precedence 1**.
+3. Remove `externalId` from the matching attributes if it is present.
+
+Tuist matches provisioned users by `userName`. It does not store the directory object identifier that Entra ID sends as `externalId`, so a filter on that attribute does not find an existing member and provisioning cycles can behave unpredictably.
+
+### Step 4: Disable group provisioning {#entra-step-4}
+
+Under **Mappings**, set **Provision Microsoft Entra ID Groups** to disabled.
+
+Tuist's SCIM groups are two fixed groups that represent organization roles rather than directory groups you can create, so an attempt to provision a directory group fails. Assign roles as described below instead.
+
+### Step 5: Assign users and start provisioning {#entra-step-5}
+
+1. Open the application's **Users and groups** tab and assign the users or groups that should be provisioned into Tuist.
+2. Return to **Provisioning** and start it.
+3. Check Tuist's **Members** tab to verify that assigned users appear in the organization.
+
+Entra ID provisions on its own schedule, which is typically every 40 minutes, so members do not appear instantly. Use **Provision on demand** to test a single user immediately.
+
+To test deprovisioning, unassign or disable a user in Entra ID and verify that they disappear from the Tuist organization's **Members** tab.
+
+### Assigning administrators {#entra-assigning-administrators}
+
+Tuist has two access levels, `admin` and `user`. Define them as app roles on the Entra application, then map the role to the SCIM `roles` attribute so that assignment in Entra ID sets the member's Tuist role. Users provisioned without a role become regular members.
+
 ## Lifecycle behavior {#lifecycle-behavior}
 
-When Okta assigns a user to the SCIM app, Tuist creates the user if the email is not already known to Tuist, then adds them to the organization. If the email already belongs to an existing Tuist user outside the organization, Tuist rejects the request to prevent an IdP from claiming a user that it does not already manage in that organization.
+When your identity provider assigns a user to the provisioning application, Tuist creates the user if the email is not already known to Tuist, then adds them to the organization. If the email already belongs to an existing Tuist user outside the organization, Tuist rejects the request to prevent an IdP from claiming a user that it does not already manage in that organization.
 
-When Okta unassigns or deactivates the user, Tuist removes their organization role while preserving the user record and any work they own. Deprovisioning does not disable the user globally, because the same Tuist user can belong to other organizations.
+When your identity provider unassigns or deactivates the user, Tuist removes their organization role while preserving the user record and any work they own. Deprovisioning does not disable the user globally, because the same Tuist user can belong to other organizations.
 
-Tuist exposes two synthetic SCIM groups: `Admins` and `Users`. Group membership changes from Okta map to organization roles in Tuist.
+Tuist exposes two synthetic SCIM groups: `Admins` and `Users`. Group membership changes from your identity provider map to organization roles in Tuist.
 
 ## Supported SCIM features {#supported-scim-features}
 
-Tuist supports the SCIM 2.0 endpoints Okta needs for lifecycle management:
+Tuist supports the SCIM 2.0 endpoints identity providers need for lifecycle management:
 
 - `POST`, `GET`, `PUT`, `PATCH`, and `DELETE` for `/Users`.
 - `GET` and `PATCH` for `/Groups`.

--- a/server/priv/docs/en/guides/integrations/authentication/sso.md
+++ b/server/priv/docs/en/guides/integrations/authentication/sso.md
@@ -9,7 +9,9 @@
 
 Tuist offers single sign-on as a login option to provide additional account security for your organization.
 
-Single sign-on is configured from the **Authentication** tab in your organization settings. Google Workspace, Okta, and custom [OAuth 2.0](https://oauth.net/2/) providers are supported.
+Single sign-on is configured from the **Authentication** tab in your organization settings. Google Workspace, Okta, Microsoft Entra ID, and custom [OAuth 2.0](https://oauth.net/2/) providers are supported.
+
+Microsoft Entra ID is an OpenID Connect provider that Tuist configures for you from your directory identifier. Everything this guide describes for custom providers, including login email domain verification and enrollment, applies to it as well.
 
 > [!NOTE]
 > Single sign-on controls how members authenticate and whether authenticated users may join automatically. <.localized_link href="/guides/integrations/authentication/scim">System for Cross-domain Identity Management provisioning</.localized_link> controls whether an identity provider can create, update, and deprovision organization members. For Okta, most organizations configure both.
@@ -18,7 +20,7 @@ Single sign-on is configured from the **Authentication** tab in your organizatio
 
 Provider identity, login discovery, and organization enrollment are separate concerns:
 
-- **Provider issuer:** The provider organization or authorization server that authenticated the user. Tuist combines the provider, issuer, and stable provider user identifier when looking up a linked identity. For Okta, the issuer is represented by the Okta domain. For a custom provider, it is represented by the provider URL.
+- **Provider issuer:** The provider organization or authorization server that authenticated the user. Tuist combines the provider, issuer, and stable provider user identifier when looking up a linked identity. For Okta, the issuer is represented by the Okta domain. For Microsoft Entra ID, it is derived from the directory (tenant) identifier. For a custom provider, it is represented by the provider URL.
 - **Login email domain:** The email domain that Tuist uses to discover an Okta or custom provider from the general login page. Once verified, it also establishes which email addresses may be trusted for new account linking and automatic enrollment.
 - **Enrollment policy:** Determines whether a user from the trusted domain needs an invitation or may join automatically.
 - **Provisioning:** Creates and manages organization membership independently of the login flow.
@@ -115,6 +117,50 @@ Assign the users or groups that should be allowed to authenticate through the Ok
 
 Assignment grants access to the login flow, but organization membership still follows the enrollment policy. If the same users are provisioned through System for Cross-domain Identity Management, Tuist links the Okta identity to the existing organization member the first time the user signs in with the same email address.
 
+## Microsoft Entra ID {#microsoft-entra-id}
+
+Microsoft Entra ID authenticates members over [OpenID Connect](https://openid.net/developers/how-connect-works/). Tuist derives the authorization, token, and user information endpoints from your directory (tenant) identifier, so you only enter that value along with the application credentials.
+
+If you also want Entra ID to create, update, or deprovision members automatically, configure <.localized_link href="/guides/integrations/authentication/scim#microsoft-entra-id">Microsoft Entra ID System for Cross-domain Identity Management provisioning</.localized_link> after single sign-on is working.
+
+### Step 1: Register an Entra application {#entra-step-1}
+
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com), go to **Identity > Applications > App registrations > New registration**.
+2. Set the application name, such as `Tuist`.
+3. Under **Redirect URI**, select the **Web** platform and enter the value shown on the Authentication settings page, such as `https://tuist.dev/users/auth/oauth2/callback`.
+4. Register the application, then copy the **Directory (tenant) ID** and the **Application (client) ID** from its overview page.
+5. Go to **Certificates & secrets > New client secret**, create a secret, and copy its **Value**. Microsoft shows the value only once, and every client secret has an expiry date, so record when it needs to be rotated.
+6. Go to **API permissions** and confirm that the delegated Microsoft Graph permissions `openid`, `profile`, and `email` are granted.
+7. Optionally, to let members start the sign-in flow from the My Apps portal, set the **Home page URL** under **Branding & properties** to the value shown on the Authentication settings page.
+
+### Step 2: Configure Tuist {#entra-step-2}
+
+1. Navigate to your organization's **Authentication** settings tab.
+2. Enable single sign-on.
+3. Select **Microsoft Entra ID** as the provider.
+4. Enter the **Directory (tenant) ID**, **Client ID**, and **Client Secret**.
+5. Enter the employee email domain under **Login email domain**. For example, a directory whose users sign in as `first.last@example.com` has a login email domain of `example.com`.
+6. Click **Save changes**.
+7. Add the text record shown by Tuist to the login email domain, then click **Verify domain**.
+8. Choose whether users need an invitation or may enroll automatically, then save the configuration again.
+9. Optionally enable **Enforce single sign-on** after testing the login flow.
+
+### Step 3: Assign users to the Entra application {#entra-step-3}
+
+Assign the users or groups that should be allowed to authenticate. If the application is configured to require assignment, only assigned users can sign in.
+
+Assignment grants access to the login flow, but organization membership still follows the enrollment policy. If the same users are provisioned through System for Cross-domain Identity Management, Tuist links the Entra identity to the existing organization member the first time the user signs in with the same email address.
+
+### Requirements for the email claim {#entra-email-claim}
+
+Tuist reads the authenticated user's profile from the Microsoft Graph user information endpoint, which returns an email address only when the user has one available. A directory user whose `mail` attribute is empty cannot sign in, because Tuist has no address to match against the login email domain.
+
+Confirm that the members you assign have an email address populated in the directory before rolling single sign-on out. Users synchronized from on-premises Active Directory without a mailbox are the most common case where this attribute is missing.
+
+### Conditional Access and multifactor authentication {#entra-conditional-access}
+
+Conditional Access policies, multifactor authentication, and sign-in risk policies apply to the Tuist application the same way they apply to any other Entra application, because they are evaluated during the authorization request. No additional Tuist configuration is required.
+
 ## Custom OAuth 2.0 provider {#custom-oauth-2-provider}
 
 A custom OAuth 2.0 provider allows an organization to use an identity service other than Google Workspace or Okta. The provider's user information endpoint must return a stable user identifier and an email address.
@@ -140,6 +186,8 @@ tuist organization update sso example \
   --organization-id your-company.okta.com \
   --enrollment-policy invitation-only
 ```
+
+Microsoft Entra ID and custom providers are configured from the organization's Authentication settings rather than the command line.
 
 The `--organization-id` value identifies the provider organization. It is not the login email domain. New configurations must add and verify the login email domain from the organization's Authentication settings before enrolling new Okta users. Existing configurations retain their previous enrollment behavior until their provider configuration changes.
 

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -103,7 +103,7 @@ msgstr ""
 #: lib/tuist_web/live/account_settings_live.html.heex:319
 #: lib/tuist_web/live/account_token_live.html.heex:49
 #: lib/tuist_web/live/account_tokens_live.html.heex:250
-#: lib/tuist_web/live/authentication_settings_live.html.heex:657
+#: lib/tuist_web/live/authentication_settings_live.html.heex:747
 #: lib/tuist_web/live/cache_live.ex:600
 #: lib/tuist_web/live/cache_live.ex:688
 #: lib/tuist_web/live/cache_live.ex:866
@@ -232,72 +232,72 @@ msgstr ""
 msgid "Delete account"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:396
+#: lib/tuist_web/live/authentication_settings_live.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "OAuth2 application client ID"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:158
+#: lib/tuist_web/live/authentication_settings_live.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Configure your OAuth2 provider to redirect users back to Tuist after authentication."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:168
+#: lib/tuist_web/live/authentication_settings_live.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth2 application in your identity provider."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:182
+#: lib/tuist_web/live/authentication_settings_live.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Copy the provider URL, authorize URL, token URL, user info URL, client ID, and client secret into the fields below."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:298
+#: lib/tuist_web/live/authentication_settings_live.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "Provider URL"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:301
+#: lib/tuist_web/live/authentication_settings_live.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "The base URL of your identity provider, for example https://auth.example.com."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:320
+#: lib/tuist_web/live/authentication_settings_live.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Authorize URL"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:323
+#: lib/tuist_web/live/authentication_settings_live.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "The full authorization endpoint URL used to start the OAuth2 flow."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:342
+#: lib/tuist_web/live/authentication_settings_live.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Token URL"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:345
+#: lib/tuist_web/live/authentication_settings_live.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "The full token endpoint URL used to exchange the authorization code."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:364
+#: lib/tuist_web/live/authentication_settings_live.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "User info URL"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:367
+#: lib/tuist_web/live/authentication_settings_live.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "The full user info endpoint URL that returns the authenticated user profile."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:389
+#: lib/tuist_web/live/authentication_settings_live.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "The client ID from your OAuth2 application."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:408
+#: lib/tuist_web/live/authentication_settings_live.html.heex:498
 #, elixir-autogen, elixir-format
 msgid "The client secret from your OAuth2 application."
 msgstr ""
@@ -505,7 +505,7 @@ msgstr ""
 
 #: lib/tuist_web/live/account_token_live.html.heex:74
 #: lib/tuist_web/live/account_tokens_live.html.heex:277
-#: lib/tuist_web/live/authentication_settings_live.html.heex:677
+#: lib/tuist_web/live/authentication_settings_live.html.heex:767
 #: lib/tuist_web/live/cache_live.ex:844
 #: lib/tuist_web/live/cache_live.ex:885
 #: lib/tuist_web/live/create_organization_live.ex:66
@@ -921,7 +921,7 @@ msgstr ""
 #: lib/tuist_web/live/account_settings_live.ex:23
 #: lib/tuist_web/live/account_token_live.ex:19
 #: lib/tuist_web/live/account_tokens_live.ex:27
-#: lib/tuist_web/live/authentication_settings_live.ex:17
+#: lib/tuist_web/live/authentication_settings_live.ex:24
 #: lib/tuist_web/live/billing_live.ex:13
 #: lib/tuist_web/live/cache_live.ex:23
 #: lib/tuist_web/live/members_live.ex:16
@@ -1052,35 +1052,35 @@ msgstr ""
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:386
+#: lib/tuist_web/live/authentication_settings_live.html.heex:476
 #: lib/tuist_web/live/cache_live.ex:798
 #: lib/tuist_web/live/cache_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:405
+#: lib/tuist_web/live/authentication_settings_live.html.heex:495
 #: lib/tuist_web/live/cache_live.ex:818
 #, elixir-autogen, elixir-format
 msgid "Client secret"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:131
+#: lib/tuist_web/live/authentication_settings_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Copy the Client ID and Client Secret from the application settings"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:113
+#: lib/tuist_web/live/authentication_settings_live.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Go to Applications > Applications > Create App Integration"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:82
+#: lib/tuist_web/live/authentication_settings_live.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Google Workspace domain"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:275
+#: lib/tuist_web/live/authentication_settings_live.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Okta domain"
 msgstr ""
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:119
+#: lib/tuist_web/live/authentication_settings_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Select \"OIDC - OpenID Connect\" and \"Web Application\""
 msgstr ""
@@ -1100,12 +1100,12 @@ msgstr ""
 msgid "Single Sign-On"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:529
+#: lib/tuist_web/live/authentication_settings_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated with Google using an email tied to this domain. Please sign in with Google first."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:103
+#: lib/tuist_web/live/authentication_settings_live.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Create an OIDC Web Application in your Okta admin dashboard before configuring the fields below."
 msgstr ""
@@ -1115,24 +1115,25 @@ msgstr ""
 msgid "SSO provider"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:521
+#: lib/tuist_web/live/authentication_settings_live.html.heex:611
 #: lib/tuist_web/live/webhook_live.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:100
-#: lib/tuist_web/live/authentication_settings_live.html.heex:155
+#: lib/tuist_web/live/authentication_settings_live.html.heex:101
+#: lib/tuist_web/live/authentication_settings_live.html.heex:156
+#: lib/tuist_web/live/authentication_settings_live.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Setup instructions"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:85
+#: lib/tuist_web/live/authentication_settings_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Users signing in with a Google account from this domain will be automatically added to this organization."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:278
+#: lib/tuist_web/live/authentication_settings_live.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Your Okta organization URL without the https:// prefix."
 msgstr ""
@@ -1147,29 +1148,29 @@ msgstr ""
 msgid "Enable and configure SSO for your organization."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:137
-#: lib/tuist_web/live/authentication_settings_live.html.heex:188
+#: lib/tuist_web/live/authentication_settings_live.html.heex:138
+#: lib/tuist_web/live/authentication_settings_live.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Set the initiate login URI to:"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:125
-#: lib/tuist_web/live/authentication_settings_live.html.heex:174
+#: lib/tuist_web/live/authentication_settings_live.html.heex:126
+#: lib/tuist_web/live/authentication_settings_live.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Set the sign-in redirect URI to:"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:497
+#: lib/tuist_web/live/authentication_settings_live.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Enforce SSO"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:508
+#: lib/tuist_web/live/authentication_settings_live.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "When enabled, organization members will not be able to log in with email and password. They must use SSO instead."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:511
+#: lib/tuist_web/live/authentication_settings_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "You must authenticate with the SSO provider before enforcing SSO. Please sign in with your SSO provider first."
 msgstr ""
@@ -1210,7 +1211,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:74
+#: lib/tuist_web/live/authentication_settings_live.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "OAuth2"
 msgstr ""
@@ -1235,36 +1236,36 @@ msgstr ""
 msgid "Allow members to sign in to Tuist through your identity provider."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:44
+#: lib/tuist_web/live/authentication_settings_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Authentication"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:22
+#: lib/tuist_web/live/authentication_settings_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Authentication settings are only available for organizations."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:549
+#: lib/tuist_web/live/authentication_settings_live.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "SCIM endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:597
+#: lib/tuist_web/live/authentication_settings_live.html.heex:687
 #: lib/tuist_web/live/webhook_live.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Copy it now — it will not be shown again after you close this dialog."
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:79
-#: lib/tuist_web/live/authentication_settings_live.html.heex:613
+#: lib/tuist_web/live/authentication_settings_live.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "Copy token"
 msgstr ""
 
 #: lib/tuist_web/live/account_token_live.html.heex:92
 #: lib/tuist_web/live/account_tokens_live.html.heex:286
-#: lib/tuist_web/live/authentication_settings_live.html.heex:680
+#: lib/tuist_web/live/authentication_settings_live.html.heex:770
 #: lib/tuist_web/live/webhook_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Created"
@@ -1276,7 +1277,7 @@ msgid "Dashboard"
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:244
-#: lib/tuist_web/live/authentication_settings_live.html.heex:651
+#: lib/tuist_web/live/authentication_settings_live.html.heex:741
 #: lib/tuist_web/live/cache_live.ex:858
 #: lib/tuist_web/live/members_live.ex:433
 #: lib/tuist_web/live/webhook_live.html.heex:404
@@ -1286,24 +1287,24 @@ msgid "Done"
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:255
-#: lib/tuist_web/live/authentication_settings_live.html.heex:662
+#: lib/tuist_web/live/authentication_settings_live.html.heex:752
 #: lib/tuist_web/live/cache_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Generate"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:574
+#: lib/tuist_web/live/authentication_settings_live.html.heex:664
 #, elixir-autogen, elixir-format
 msgid "Generate SCIM token"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:716
+#: lib/tuist_web/live/authentication_settings_live.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Generate one above to start provisioning from your IdP."
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:47
-#: lib/tuist_web/live/authentication_settings_live.html.heex:580
+#: lib/tuist_web/live/authentication_settings_live.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "Generate token"
 msgstr ""
@@ -1318,81 +1319,81 @@ msgstr ""
 msgid "Invitation rejected"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:565
+#: lib/tuist_web/live/authentication_settings_live.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Issue one bearer token per IdP. Revoke a token if it leaks or is no longer needed."
 msgstr ""
 
 #: lib/tuist_web/live/account_token_live.html.heex:88
 #: lib/tuist_web/live/account_tokens_live.html.heex:283
-#: lib/tuist_web/live/authentication_settings_live.html.heex:683
+#: lib/tuist_web/live/authentication_settings_live.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:539
+#: lib/tuist_web/live/authentication_settings_live.html.heex:629
 #, elixir-autogen, elixir-format
 msgid "Let your IdP (Okta, Azure AD/Entra, JumpCloud, etc.) provision users into this organization at the SCIM endpoint URL below using a bearer token."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:631
+#: lib/tuist_web/live/authentication_settings_live.html.heex:721
 #, elixir-autogen, elixir-format
 msgid "Name this token so you can identify it later (for example: \"Okta\")."
 msgstr ""
 
 #: lib/tuist_web/live/account_token_helpers.ex:84
 #: lib/tuist_web/live/account_token_helpers.ex:88
-#: lib/tuist_web/live/authentication_settings_live.html.heex:687
+#: lib/tuist_web/live/authentication_settings_live.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:714
+#: lib/tuist_web/live/authentication_settings_live.html.heex:804
 #, elixir-autogen, elixir-format
 msgid "No SCIM tokens yet"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:701
+#: lib/tuist_web/live/authentication_settings_live.html.heex:791
 #, elixir-autogen, elixir-format
 msgid "Revoke this token? This action cannot be undone."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:536
+#: lib/tuist_web/live/authentication_settings_live.html.heex:626
 #, elixir-autogen, elixir-format
 msgid "SCIM provisioning"
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:60
-#: lib/tuist_web/live/authentication_settings_live.html.heex:594
+#: lib/tuist_web/live/authentication_settings_live.html.heex:684
 #, elixir-autogen, elixir-format
 msgid "Token created"
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:95
-#: lib/tuist_web/live/authentication_settings_live.html.heex:629
+#: lib/tuist_web/live/authentication_settings_live.html.heex:719
 #, elixir-autogen, elixir-format
 msgid "Token name"
 msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.ex:156
-#: lib/tuist_web/live/authentication_settings_live.ex:285
+#: lib/tuist_web/live/authentication_settings_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Token name is required."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:332
+#: lib/tuist_web/live/authentication_settings_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Token not found."
 msgstr ""
 
 #: lib/tuist_web/live/account_token_live.ex:33
 #: lib/tuist_web/live/account_tokens_live.ex:47
-#: lib/tuist_web/live/authentication_settings_live.html.heex:562
+#: lib/tuist_web/live/authentication_settings_live.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:678
+#: lib/tuist_web/live/authentication_settings_live.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Unnamed"
 msgstr ""
@@ -1417,12 +1418,12 @@ msgstr ""
 msgid "You won’t be able to access this organization unless invited again."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:636
+#: lib/tuist_web/live/authentication_settings_live.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "e.g. Okta"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:699
+#: lib/tuist_web/live/authentication_settings_live.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "Revoke token"
 msgstr ""
@@ -2592,42 +2593,42 @@ msgstr ""
 msgid "Update the company name, billing address, tax number, and email shown on your invoices."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:238
+#: lib/tuist_web/live/authentication_settings_live.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Add the following text record to your domain, then verify it."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:447
+#: lib/tuist_web/live/authentication_settings_live.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "Automatic enrollment"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:253
+#: lib/tuist_web/live/authentication_settings_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Configure and save a login domain first."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:205
+#: lib/tuist_web/live/authentication_settings_live.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "Login email domain"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:235
+#: lib/tuist_web/live/authentication_settings_live.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Pending verification"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:245
+#: lib/tuist_web/live/authentication_settings_live.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Record name"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:253
+#: lib/tuist_web/live/authentication_settings_live.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Record value"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:270
+#: lib/tuist_web/live/authentication_settings_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Save the login domain before verifying it."
 msgstr ""
@@ -2637,52 +2638,52 @@ msgstr ""
 msgid "Select the identity provider that authenticates your organization members."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:233
+#: lib/tuist_web/live/authentication_settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "The login domain has been verified."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:242
+#: lib/tuist_web/live/authentication_settings_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "The verification text record was not found. Domain record changes can take time to become available."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:231
+#: lib/tuist_web/live/authentication_settings_live.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Verified"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:261
+#: lib/tuist_web/live/authentication_settings_live.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Verify domain"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:457
+#: lib/tuist_web/live/authentication_settings_live.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "When enabled, users from the verified login email domain can join this organization automatically. Other users need an invitation."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:452
+#: lib/tuist_web/live/authentication_settings_live.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "When enabled, users whose Google Workspace domain matches can join this organization automatically. Other users need an invitation."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:208
+#: lib/tuist_web/live/authentication_settings_live.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "Once verified, this domain is used to find the provider and determines which email addresses can be trusted for automatic enrollment and identity linking. It is independent of the provider URL."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:462
+#: lib/tuist_web/live/authentication_settings_live.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "This existing configuration allows any email address reported by the provider to join automatically. Add and verify a login email domain to restrict enrollment."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:503
+#: lib/tuist_web/live/authentication_settings_live.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "Verify a login email domain before enforcing single sign-on for this provider."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.html.heex:467
+#: lib/tuist_web/live/authentication_settings_live.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "Add and verify a login email domain before enabling automatic enrollment. Until then, the provider cannot create or link accounts, including for invited users. Existing linked users can continue signing in."
 msgstr ""
@@ -2736,4 +2737,49 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Cache servers are not enabled for this account yet."
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:186
+#, elixir-autogen, elixir-format
+msgid "Copy the Directory (tenant) ID and Application (client) ID from the application overview"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:192
+#, elixir-autogen, elixir-format
+msgid "Create a client secret under Certificates & secrets and copy its value"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:365
+#, elixir-autogen, elixir-format
+msgid "Directory (tenant) ID"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Go to Identity > Applications > App registrations > New registration"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:159
+#, elixir-autogen, elixir-format
+msgid "Register an application in your Microsoft Entra admin center before configuring the fields below."
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:175
+#, elixir-autogen, elixir-format
+msgid "Select the \"Web\" platform and set the redirect URI to:"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:204
+#, elixir-autogen, elixir-format
+msgid "Set the home page URL to:"
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:368
+#, elixir-autogen, elixir-format
+msgid "The directory (tenant) ID of your Entra application. Tuist derives the authorize, token, and user info endpoints from it."
+msgstr ""
+
+#: lib/tuist_web/live/authentication_settings_live.html.heex:198
+#, elixir-autogen, elixir-format
+msgid "Under API permissions, grant the delegated openid, profile, and email permissions"
 msgstr ""

--- a/server/test/tuist_web/live/authentication_settings_live_test.exs
+++ b/server/test/tuist_web/live/authentication_settings_live_test.exs
@@ -169,6 +169,122 @@ defmodule TuistWeb.AuthenticationSettingsLiveTest do
     end
   end
 
+  describe "Microsoft Entra ID SSO" do
+    test "disables save button when the tenant is empty", %{conn: conn, account: account} do
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      render_hook(lv, "toggle_sso")
+      html = render_hook(lv, "select_provider", %{"value" => ["entra"]})
+
+      assert html =~ "disabled"
+      assert html =~ "Directory (tenant) ID"
+    end
+
+    test "derives the endpoints from the directory (tenant) ID", %{
+      conn: conn,
+      account: account,
+      organization: organization
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      render_hook(lv, "toggle_sso")
+      render_hook(lv, "select_provider", %{"value" => ["entra"]})
+
+      lv
+      |> form("#sso-form", %{
+        "sso" => %{
+          "entra_tenant_id" => "11111111-2222-3333-4444-555555555555",
+          "sso_login_domain" => "example.com",
+          "oauth2_client_id" => "test_client_id",
+          "oauth2_client_secret" => "test_client_secret"
+        }
+      })
+      |> render_submit()
+
+      {:ok, updated_organization} = Accounts.get_organization_by_id(organization.id)
+
+      assert updated_organization.sso_provider == :oauth2
+
+      assert updated_organization.sso_organization_id ==
+               "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0"
+
+      assert updated_organization.oauth2_authorize_url ==
+               "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/oauth2/v2.0/authorize"
+
+      assert updated_organization.oauth2_token_url ==
+               "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/oauth2/v2.0/token"
+
+      assert updated_organization.oauth2_user_info_url == "https://graph.microsoft.com/oidc/userinfo"
+    end
+
+    test "reopens a saved configuration on the Entra form with its tenant", %{conn: conn, account: account} do
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      render_hook(lv, "toggle_sso")
+      render_hook(lv, "select_provider", %{"value" => ["entra"]})
+
+      lv
+      |> form("#sso-form", %{
+        "sso" => %{
+          "entra_tenant_id" => "contoso.onmicrosoft.com",
+          "oauth2_client_id" => "test_client_id",
+          "oauth2_client_secret" => "test_client_secret"
+        }
+      })
+      |> render_submit()
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      document = Floki.parse_fragment!(html)
+      assert Floki.attribute(document, "#sso_entra_tenant_id", "value") == ["contoso.onmicrosoft.com"]
+    end
+
+    test "keeps a hand-configured Entra organization on the generic OAuth2 form", %{
+      conn: conn,
+      account: account,
+      organization: organization
+    } do
+      {:ok, _organization} =
+        Accounts.update_sso_configuration(organization.id, :oauth2, %{
+          sso_organization_id: "https://sts.windows.net/11111111-2222-3333-4444-555555555555/",
+          oauth2_client_id: "test_client_id",
+          oauth2_client_secret: "test_client_secret",
+          oauth2_authorize_url:
+            "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/oauth2/v2.0/authorize",
+          oauth2_token_url: "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/oauth2/v2.0/token",
+          oauth2_user_info_url: "https://graph.microsoft.com/oidc/userinfo"
+        })
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      document = Floki.parse_fragment!(html)
+
+      assert Floki.attribute(document, "#sso_oauth2_site", "value") == [
+               "https://sts.windows.net/11111111-2222-3333-4444-555555555555"
+             ]
+    end
+
+    test "rejects a tenant that is not a single path segment", %{conn: conn, account: account} do
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      render_hook(lv, "toggle_sso")
+      render_hook(lv, "select_provider", %{"value" => ["entra"]})
+
+      html =
+        lv
+        |> form("#sso-form", %{
+          "sso" => %{
+            "entra_tenant_id" => "https://login.microsoftonline.com/tenant/v2.0",
+            "oauth2_client_id" => "test_client_id",
+            "oauth2_client_secret" => "test_client_secret"
+          }
+        })
+        |> render_change()
+
+      assert html =~ "disabled"
+    end
+  end
+
   describe "Custom OAuth2 SSO" do
     test "disables save button when required fields are empty", %{conn: conn, account: account} do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")


### PR DESCRIPTION
Adds a Microsoft Entra ID preset to single sign-on, plus documentation for using Entra ID with both SSO and SCIM provisioning.

### What changed

Entra ID already worked through the generic OAuth 2.0 provider, but an administrator had to hand-enter the provider URL and three endpoints. That is where onboarding breaks: every typo becomes a failed sign-in that surfaces only at the end of the flow, and neither the product nor the docs told an identity team that Entra ID was supported at all.

The provider picker now offers "Microsoft Entra ID". It asks for the directory (tenant) ID and derives the authorization, token, and user information endpoints from it, with setup instructions matching the Entra admin center.

### Why it is a preset and not a first-party provider

The preset persists as `sso_provider: :oauth2` rather than introducing an `:entra` enum value the way Okta has one.

A new provider atom would have to be threaded through `oauth2_identities.provider` as well as `organizations.sso_provider`, and through the 27 places across 6 files that enumerate `[:okta, :oauth2]` (accounts.ex, organization.ex, oauth2_identity.ex, auth_controller.ex, and the settings LiveView and template). Each of those is a spot where missing the new value produces a silent authentication or enrollment bug rather than a compile error. It would also mean that any organization already configured against Entra through the generic provider needs a data migration, since linked identities are keyed on the provider.

Since the March migration folded Okta's credentials onto the shared `oauth2_*` columns, Okta is no longer a separate authentication path either. Its remaining first-party status is an artifact of having existed before the generic provider, not a design chosen on the merits, so recreating that shape for Entra did not seem worth the regression surface. Promoting the preset to a real enum value later stays possible if per-provider behavior (claim mapping, issuer restriction, per-provider reporting) is ever actually needed.

### Reopening a saved configuration

The form provider is decoupled from the stored one through `form_provider/1`. `Accounts.entra_tenant/1` re-detects the preset when a configuration is reopened, and requires the stored URLs to match exactly what the preset would generate.

That exactness is the point. An organization that reached Entra through hand-entered endpoints keeps the generic form, because rewriting its `sso_organization_id` on the next save would change the issuer its members' identities are keyed on and strand every one of them. There is a test pinning that case.

### Documentation

Entra ID sections were added to the SSO and SCIM guides, carrying two provider-specific requirements found while verifying the flow:

- Users must have the directory `mail` attribute populated. The Microsoft Graph user information endpoint returns the email claim only when one is available, and Tuist rejects a sign-in it cannot match against the login email domain. Users synchronized from on-premises Active Directory without a mailbox are the common case.
- Provisioning must match on `userName`. Tuist does not store the object identifier Entra sends as `externalId`, so a filter on that attribute does not find an existing member.

The SCIM guide also notes that group provisioning should stay disabled, since Tuist's SCIM groups are two fixed role groups rather than directory groups, and that roles should be driven through Entra app roles mapped to the SCIM `roles` attribute. Shared lifecycle prose in that guide was generalized away from Okta. Entra remains dashboard-only, as the CLI `SSOProvider` enum still accepts google and okta.

### Validation

Two protocol-level unknowns were verified before writing any code, and both came back clean, which is why the SSO client and the SSRF guard are untouched:

- Entra honors the HTTP Basic client authentication the token exchange already uses. Its discovery document lists `client_secret_basic`, and a live probe confirmed it: a `client_credentials` request with Basic-only credentials got past credential parsing, while the same request with no credentials failed at `AADSTS7000216` demanding a client secret.
- Pinned-IP TLS with SNI to `login.microsoftonline.com` and `graph.microsoft.com` passes certificate verification, so `SSRFGuard.pin/1` handles Microsoft's anycast endpoints.

Not verified: an end-to-end sign-in against a real Entra tenant, which needs a directory we do not have. The first real sign-in should be paired with a `Provision on demand` run before enabling enforcement.

### How to test locally

1. Run the suite: `mix test test/tuist_web/live/authentication_settings_live_test.exs`. It covers endpoint derivation, the tenant round-trip when reopening a saved configuration, the hand-configured organization staying on the generic form, and rejection of a tenant that is not a single path segment.
2. In the dashboard, open an organization's Settings, then Authentication. Enable single sign-on and select Microsoft Entra ID.
3. Enter any directory (tenant) ID with a client ID and secret, and save. Confirm the organization stores `https://login.microsoftonline.com/TENANT/v2.0` as the provider, the two derived `login.microsoftonline.com` endpoints, and `https://graph.microsoft.com/oidc/userinfo` for user information.
4. Reload the page and confirm the form reopens on Microsoft Entra ID with the tenant field populated rather than on the generic OAuth2 form.
5. Confirm the guides render at `/guides/integrations/authentication/sso` and `/guides/integrations/authentication/scim`.
