### PR TITLE
fix(server): stop replayed inserts from 500ing preview uploads

### DIFF
--- a/server/lib/tuist/app_builds.ex
+++ b/server/lib/tuist/app_builds.ex
@@ -9,10 +9,18 @@ defmodule Tuist.AppBuilds do
   alias Tuist.Projects.Project
   alias Tuist.Repo
 
+  # Postgrex replays a statement on a fresh connection when the socket drops
+  # mid-flight (`:disconnect_and_retry`), re-sending the client-generated
+  # UUIDv7 primary key of an attempt that may already have committed. Previews
+  # and app builds both generate their primary key in Elixir, so a conflict on
+  # `id` is only ever that replay. Business unique indexes are not arbitrated
+  # here and still surface as changeset errors.
+  @replay_safe_insert [on_conflict: :nothing, conflict_target: :id]
+
   def create_preview(attrs) do
     %Preview{}
     |> Preview.create_changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert(@replay_safe_insert)
   end
 
   @doc """
@@ -149,7 +157,7 @@ defmodule Tuist.AppBuilds do
   def create_app_build(attrs) do
     %AppBuild{}
     |> AppBuild.create_changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert(@replay_safe_insert)
   end
 
   def update_preview_with_app_build(preview_id, app_build) do

--- a/server/test/tuist/app_builds_test.exs
+++ b/server/test/tuist/app_builds_test.exs
@@ -1,5 +1,6 @@
 defmodule Tuist.AppBuildsTest do
   use TuistTestSupport.Cases.DataCase, async: true
+  use Mimic
 
   alias Tuist.AppBuilds
   alias Tuist.AppBuilds.Preview
@@ -120,6 +121,23 @@ defmodule Tuist.AppBuildsTest do
       assert first_preview.track == "beta"
       assert second_preview.track == "beta"
       assert length(Repo.all(Preview)) == 2
+    end
+
+    test "succeeds when the insert is replayed with an already-committed primary key" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      {:ok, preview} = AppBuilds.create_preview(%{project_id: project.id})
+
+      expect(Repo, :insert, fn changeset, opts ->
+        Mimic.call_original(Repo, :insert, [put_change(changeset, :id, preview.id), opts])
+      end)
+
+      # When
+      {:ok, replayed_preview} = AppBuilds.create_preview(%{project_id: project.id})
+
+      # Then
+      assert replayed_preview.id == preview.id
+      assert length(Repo.all(Preview)) == 1
     end
   end
 
@@ -1587,6 +1605,30 @@ defmodule Tuist.AppBuildsTest do
       # Then
       assert {:error, changeset} = result
       assert Keyword.has_key?(changeset.errors, :binary_id)
+    end
+
+    test "succeeds when the insert is replayed with an already-committed primary key" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      preview = AppBuildsFixtures.preview_fixture(project: project)
+
+      attrs = %{
+        preview_id: preview.id,
+        type: :app_bundle,
+        supported_platforms: [:ios]
+      }
+
+      {:ok, app_build} = AppBuilds.create_app_build(attrs)
+
+      expect(Repo, :insert, fn changeset, opts ->
+        Mimic.call_original(Repo, :insert, [put_change(changeset, :id, app_build.id), opts])
+      end)
+
+      # When
+      {:ok, replayed_app_build} = AppBuilds.create_app_build(attrs)
+
+      # Then
+      assert replayed_app_build.id == app_build.id
     end
 
     test "allows creating app build with same binary_id but different build_version" do


### PR DESCRIPTION
Fixes TUIST-4G8

## What changed

`Tuist.AppBuilds.create_preview/1` and `create_app_build/1` now pass `on_conflict: :nothing, conflict_target: :id` to `Repo.insert/2`, so an insert that is replayed with a primary key that already committed is a no-op instead of a 500.

## Why

`POST /api/projects/:account/:project/previews/start` returned a 500 with:

```
Ecto.ConstraintError: constraint error when attempting to insert struct:
    * "previews_pkey1" (unique_constraint)
```

That is a duplicate **primary key** on a table whose PK is a client-generated UUIDv7, which should be impossible.

## Root cause

Neither Ecto nor Sentry records the conflicting key, but Postgres does. From the CNPG logs in Loki for the failing request:

```
duplicate key value violates unique constraint "previews_pkey1"
detail: Key (id)=(019ffa42-f4a6-7fc6-8256-0a4735573f03) already exists.
session_start_time: 2026-08-13 08:35:34 UTC
```

That id belongs to the preview row committed 22 seconds earlier (`inserted_at` 08:35:19, and the UUIDv7's own embedded millisecond timestamp agrees). So the same INSERT ran twice, with the same bound parameters, on two different Postgres sessions.

The replay comes from Postgrex. `bind_execute/4` pipes both `msg_send` and `recv_bind` through `handle_disconnect_retry/1`, which converts a `%DBConnection.ConnectionError{reason: :closed}` into `{:disconnect_and_retry, ...}`. `DBConnection.run_with_retries/5` (`:checkout_retries`, default 3) then re-runs the operation with identical params on a fresh connection. The retry is safe under Postgrex's assumption that a socket closed at bind time means the statement never executed — but here the socket dropped *after* Postgres had already run and committed the INSERT. Ecto generates the UUIDv7 in Elixir and sends it as a bind param, so the replay re-sent an id that was by then in the table.

The trigger was a fleet-wide database stall: between 08:35:34 and 08:35:38 every server pod logged `Postgrex.Protocol ... disconnected: ... timed out because it queued and checked out the connection for longer than 15000ms`. This is the same class of CNPG blip investigated in tuist/tuist#11940 — this PR does not address that trigger, only the fact that a request loses its write to it.

Things that were ruled out along the way, since they are the obvious first guesses:

- **A UUID collision.** `UUIDv7.bingenerate/1` is a 48-bit millisecond prefix plus 74 bits from `:crypto.strong_rand_bytes`. A collision would also have to reproduce the millisecond, and the conflicting id's timestamp was 22 seconds stale. Across 12,582 preview rows in the previous 30 days, every id is a valid v7 whose embedded timestamp matches its `inserted_at`.
- **A client retry of the HTTP request.** A retried request builds a new changeset with a new id, and `find_or_create_preview/1` would have found the committed row and reused it. Neither is consistent with a duplicate on an old id.
- **A pooler mixing up prepared statements.** Server pods connect to Postgres directly (`TUIST_DATABASE_POOLED` is unset for them) with `prepare: :named`, and Postgrex's `cached_query/2` compares the statement text before reusing a cached name.

## Why this fix over the alternatives

Arbitrating on `id` alone is what makes the change safe. Both tables generate their primary key in Elixir, so a conflict on `id` can only ever be this replay; there is no legitimate caller that inserts a duplicate id. Conflicts on business unique indexes are not arbitrated by `conflict_target: :id` and continue to surface as changeset errors — `create_app_build/1` still returns `{:error, changeset}` for a duplicate `binary_id`/`build_version` (existing test covers this), which the controller turns into a 409.

Two broader fixes were considered and rejected:

- **`checkout_retries: 0`**, globally or per call, would disable the retry entirely. The same retry legitimately rescues the common benign case of the pool handing out a connection the server has already closed, so this would convert stale-connection reads into user-visible errors.
- **`Tuist.Repo.default_options/1` returning the same on-conflict options** would apply them to every insert in the application, including schemas with bigserial primary keys, where `on_conflict: :nothing` would mask genuine conflicts.

Any other schema with an Elixir-generated UUID primary key carries the same latent exposure; this PR fixes the two on the reported endpoint rather than changing behaviour repo-wide.

## Impact

A preview or app-build upload that hits a database blip mid-insert now succeeds instead of returning a 500 to the CLI. In production this endpoint recorded two occurrences from one user, whose upload only went through on a retry 27 seconds later.

### How to test locally

```bash
mix test test/tuist/app_builds_test.exs
```

Two new tests simulate the replay by forcing an already-committed id onto the insert, one for `create_preview/1` and one for `create_app_build/1`. Both fail without the change with exactly the production `Ecto.ConstraintError` — verified by reverting `@replay_safe_insert` to `[]` and re-running.

Validation run:

- `mix test test/tuist/app_builds_test.exs` — 92 passed
- `mix test test/tuist_web/controllers/api/previews_controller_test.exs` — 50 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

