### PR TITLE
fix(runner-image, app): approve scripted Finder automation and size the iOS archive timeout

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -166,7 +166,12 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
     runs-on: tuist-macos
-    timeout-minutes: 30
+    # Matches release-app. `app:upload-ios` archives before it uploads,
+    # and `tuist generate` runs with --no-binary-cache, so a cold
+    # compilation cache (any runner image roll invalidates it) makes
+    # this a full build of the app. 30 minutes fit only while the
+    # cache was warm; it cancelled mid-`xcodebuild` on run 31618151811.
+    timeout-minutes: 50
     permissions:
       contents: write
       id-token: write

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -37,6 +37,18 @@ handed over explicitly. Two things are:
 When adding tooling to the base, check ownership and login-shell
 reachability from `runner`, not just presence under `admin`.
 
+A related class of gap is anything GitHub-hosted images pre-seed
+that ours do not. TCC is one: scripted Finder automation
+(`create-dmg`, and anything else driving an app through
+`osascript`) needs a standing `kTCCServiceAppleEvents` approval,
+or macOS raises a prompt no one can answer on a headless VM and
+the send fails as `AppleEvent timed out (-1712)`. That reads as
+flakiness and is not. When adding parity features, compare
+against `actions/runner-images` `images/macos/scripts/build/`,
+and pair each one with a check that asserts the behaviour rather
+than the ingredient — every gap so far was found by a release
+failing, not by the image build.
+
 The sanity checks at the end of the Packer template run as `sudo
 -u runner -H`. macOS sudoers keeps `HOME`, so dropping `-H`
 leaves them pointed at `/Users/admin` and they assert against the

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -252,6 +252,51 @@ build {
     ]
   }
 
+  # Pre-approve scripted Finder automation. Tools that style a
+  # window through AppleScript, `create-dmg` being the one that
+  # surfaced this, drive Finder from `osascript`. macOS gates that
+  # behind a TCC approval, and with none recorded it raises an
+  # authorization prompt. Nothing can answer a prompt on a headless
+  # VM, so the send sits until it gives up with "Finder got an
+  # error: AppleEvent timed out. (-1712)". The timeout reads as
+  # flakiness, which is why callers retry it; here it is
+  # deterministic and retrying only multiplies the wait.
+  #
+  # GitHub-hosted images seed the same table
+  # (images/macos/scripts/build/configure-tccdb-macos.sh). Ours
+  # never have, so DMG creation has been impossible on this fleet
+  # since macOS jobs moved here.
+  #
+  # TCC attributes an event to the *responsible* process, which for
+  # a shell pipeline is usually an ancestor rather than `osascript`
+  # itself, so the shells are seeded alongside it.
+  #
+  # Columns are named rather than positional: the `access` schema
+  # gains columns across macOS releases, and the positional tuple
+  # GitHub uses has to be rewritten on every OS bump.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "SYSTEM_DB='/Library/Application Support/com.apple.TCC/TCC.db'",
+      "USER_DB='/Users/runner/Library/Application Support/com.apple.TCC/TCC.db'",
+      "seed() { local db=$1; for client in /usr/bin/osascript /bin/bash /bin/zsh; do sudo sqlite3 \"$db\" \"INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier_type, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAppleEvents', '$client', 1, 2, 4, 1, 0, 'com.apple.finder', 0, strftime('%s','now'));\"; done; }",
+      "echo 'admin' | sudo -S true",
+      "seed \"$SYSTEM_DB\"",
+      # The per-user database only exists once something has
+      # triggered a TCC decision for that account. Creating it here
+      # would leave a schema-less file shadowing the real one and
+      # break TCC for the runner outright, so seed it only if macOS
+      # has already made it.
+      "if sudo test -f \"$USER_DB\" && sudo sqlite3 \"$USER_DB\" 'SELECT 1 FROM access LIMIT 1;' >/dev/null 2>&1; then seed \"$USER_DB\"; sudo chown runner:staff \"$USER_DB\"; else echo 'per-user TCC.db absent; relying on the system database'; fi",
+      # Not decoration. TCC.db is SIP protected, so a base image
+      # shipping with SIP enforced would have the INSERT rejected and
+      # publish an image where Finder automation is still broken.
+      # That is how the reachability-only brew check let a breakage
+      # through; read the row back so it lands on the image build.
+      "sudo sqlite3 \"$SYSTEM_DB\" \"SELECT 1 FROM access WHERE service='kTCCServiceAppleEvents' AND client='/usr/bin/osascript' AND indirect_object_identifier='com.apple.finder' AND auth_value=2;\" | grep -q 1 || { echo 'sanity check: AppleEvents approval for Finder did not persist to TCC.db (SIP enforced?) — scripted Finder automation, and therefore DMG creation, would fail on this image' >&2; exit 1; }"
+    ]
+  }
+
   # The runner auto-login opens a real desktop session so launchd can
   # run the GitHub Actions agent. On fresh macOS images that first
   # desktop can be intercepted by Setup Assistant's "Update Mac


### PR DESCRIPTION
Follow-up to [#12263](https://github.com/tuist/tuist/pull/12263) and [#12294](https://github.com/tuist/tuist/pull/12294). Those unblocked `brew install` on the macOS fleet, which let [run 31618151811](https://github.com/tuist/tuist/actions/runs/31618151811) become the first app release attempt to get past `Install create-dmg`. It then found two more blockers, fixed here.

That run did confirm real progress: `Release Android App` succeeded for the first time, so the SDK bake in [#12262](https://github.com/tuist/tuist/pull/12262) is good, and the macOS job built the app before failing.

## Blocker 1: create-dmg cannot drive Finder

`Bundle macOS app` failed all five create-dmg attempts, identically:

```
execution error: Finder got an error: AppleEvent timed out. (-1712)
Failed running AppleScript
create-dmg failed after 5 attempts
```

create-dmg styles the DMG window by driving Finder from `osascript`. macOS gates that behind a TCC approval, and with none recorded it raises an authorization prompt. Nothing can answer a prompt on a headless VM, so the send sits until it gives up.

The retry loop in `mise/tasks/app/bundle.sh` calls this failure periodic. That was accurate when the job ran on GitHub-hosted runners, where TCC is pre-seeded and timeouts really were intermittent. On our fleet it is deterministic, and retrying only multiplies the wait.

GitHub-hosted images seed these approvals in `images/macos/scripts/build/configure-tccdb-macos.sh`. Grepping our two image templates for `tcc`, `AppleEvent`, `automation`, `osascript`, or `Finder` returns nothing, so DMG creation has been impossible on this fleet since macOS jobs moved here in [#10793](https://github.com/tuist/tuist/pull/10793).

This seeds `kTCCServiceAppleEvents` for `com.apple.finder`, covering `osascript` plus `/bin/bash` and `/bin/zsh`, because TCC attributes an event to the responsible process rather than the immediate caller.

Two deliberate details:

- **Named columns, not positional.** The `access` schema gains columns across macOS releases. The positional tuple GitHub uses has to be rewritten on every OS bump; a named-column insert survives it.
- **The read-back is not decoration.** TCC.db is SIP protected. If a base image ever ships with SIP enforced, the insert is rejected and the image would publish with Finder automation still broken. That is exactly how the reachability-only brew check let a breakage through for months, so the check asserts the row persisted and fails the build otherwise.

The per-user database is only touched when macOS has already created it. Creating it here would leave a schema-less file shadowing the real one and break TCC for the runner outright.

## Blocker 2: iOS job timed out building, not uploading

`Release iOS App` was cancelled at exactly its 30 minute limit, during a step named `Upload iOS App to App Store Connect`. The name is misleading. `mise/tasks/app/upload-ios.sh` runs `bundle-ios.sh` first and only then calls `altool`, and the job never reached the upload: the orphaned processes at cancellation were `xcodebuild` and `SWBBuildService`, and the last output was compile-time `cache miss` notes.

`tuist generate TuistApp` runs with `--no-binary-cache`, so this is a full archive of the app whenever the compilation cache is cold, which any runner image roll causes. The step took about 11 minutes when it last succeeded on Aug 10 with a warm cache. Raised to 50 minutes to match `release-app`, which does comparable work on the same runner.

## Impact

`publish-app` requires all three platform jobs green, so no app release has been published since `app@0.25.4` on 2026-05-06. The Sparkle appcast asset that shipped apps point at through `SUFeedURL` has never been published either, so in-app auto-update is broken for existing users on top of there being no new build.

The TCC fix is not specific to our release. Any customer workflow on `tuist-macos` that builds a styled DMG, or scripts any app through AppleScript, hits the same wall.

## How to test locally

The Packer build needs the bare-metal Mac mini with a live GUI session, since Tart requires Virtualization.framework. What can be checked without it:

```bash
cd infra/runner-image && packer fmt -check -diff . && packer validate -syntax-only .
```

The seed and read-back logic was exercised against a stand-in SQLite database carrying the real `access` column set. Both directions were confirmed: the three rows land with `auth_value=2` against `com.apple.finder`, and when the insert is suppressed to simulate SIP rejecting the write, the check exits non-zero and fails the build.

To smoke-test on the builder before merge:

```bash
gh workflow run runner-image.yml --ref claude/macos-runner-tcc-finder -f xcode_version=26.4.1
```

That build is the real gate. SIP state inside the VM cannot be confirmed from outside it, and if SIP does reject the write, the fallback is to stop depending on Finder at all: pre-bake the styled `.DS_Store` and apply it with `hdiutil`, which needs no GUI and no TCC.

## Note for reviewers

Scoped `fix(...)` rather than `ci(...)` on purpose. `infra/runner-image/cliff.toml` skips `ci` commits, so a `ci`-scoped message would merge without cutting a new image and the fleet would never pick the change up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
