### PR TITLE
feat(app): add search bar to filter previews

### DIFF
--- a/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
+++ b/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
@@ -9,7 +9,6 @@ public struct PreviewsView: View {
     @EnvironmentObject var errorHandling: ErrorHandling
     @EnvironmentObject private var authenticationService: AuthenticationService
     @State var viewModel = PreviewsViewModel()
-    @State private var searchText = ""
     @State private var navigationPath = NavigationPath()
     @State private var pressedPreviewId: String?
     private let imagePrefetcher = ImagePrefetcher()
@@ -76,8 +75,12 @@ public struct PreviewsView: View {
                                     try await viewModel.refreshPreviews()
                                 }
                             }
+                        } else if viewModel.filteredPreviews.isEmpty {
+                            ContentUnavailableView.search(text: viewModel.searchText)
+                                .listRowSeparator(.hidden)
+                                .listRowBackground(Noora.Colors.surfaceBackgroundPrimary)
                         } else {
-                            ForEach(viewModel.previews) { preview in
+                            ForEach(viewModel.filteredPreviews) { preview in
                                 PreviewRowView(
                                     preview: preview,
                                     navigationPath: $navigationPath,
@@ -93,7 +96,7 @@ public struct PreviewsView: View {
                                     )
                                 )
                                 .onAppear {
-                                    if preview.id == viewModel.previews.last?.id {
+                                    if preview.id == viewModel.filteredPreviews.last?.id {
                                         errorHandling.fireAndHandleError {
                                             try await viewModel.loadMorePreviews()
                                         }
@@ -123,6 +126,7 @@ public struct PreviewsView: View {
                     }
                 }
             }
+            .searchable(text: Bindable(viewModel).searchText, prompt: "Name, branch, or commit")
             .onAppear {
                 // When deleting an account, there's a bug when onAppear is called even when already logged out.
                 // This should never happen due to the check in TuistApp.swift, but it seems there's a race condition in the
@@ -165,14 +169,15 @@ public struct PreviewsView: View {
     }
 
     private func preloadUpcomingImages(for currentPreview: ServerPreview) {
-        guard let currentIndex = viewModel.previews.firstIndex(where: { $0.id == currentPreview.id }) else { return }
+        let previews = viewModel.filteredPreviews
+        guard let currentIndex = previews.firstIndex(where: { $0.id == currentPreview.id }) else { return }
 
         let preloadRange = 5
         let startIndex = currentIndex + 1
-        let endIndex = min(startIndex + preloadRange, viewModel.previews.count)
+        let endIndex = min(startIndex + preloadRange, previews.count)
 
         imagePrefetcher.startPrefetching(
-            with: viewModel.previews[startIndex ..< endIndex].map(\.iconURL)
+            with: previews[startIndex ..< endIndex].map(\.iconURL)
         )
     }
 }

--- a/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
+++ b/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
@@ -16,6 +16,7 @@ public struct PreviewsView: View {
     public init() {}
 
     public var body: some View {
+        @Bindable var viewModel = viewModel
         NavigationStack(path: $navigationPath) {
             Group {
                 if viewModel.isInitialLoading {
@@ -126,7 +127,7 @@ public struct PreviewsView: View {
                     }
                 }
             }
-            .searchable(text: Bindable(viewModel).searchText, prompt: "Name, branch, or commit")
+            .searchable(text: $viewModel.searchText, prompt: "Name, branch, or commit")
             .onAppear {
                 // When deleting an account, there's a bug when onAppear is called even when already logged out.
                 // This should never happen due to the check in TuistApp.swift, but it seems there's a race condition in the

--- a/app/Sources/TuistPreviews/PreviewsView/PreviewsViewModel.swift
+++ b/app/Sources/TuistPreviews/PreviewsView/PreviewsViewModel.swift
@@ -18,6 +18,7 @@ final class PreviewsViewModel: Sendable {
     private(set) var projects: [ServerProject] = []
     private(set) var previews: [ServerPreview] = []
     private(set) var selectedProject: ServerProject?
+    var searchText = ""
 
     private var currentPage = 1
     private(set) var isLoadingMore = false
@@ -25,6 +26,24 @@ final class PreviewsViewModel: Sendable {
     private(set) var isRefreshingPreviews = false
     private(set) var isRefreshingProjects = false
     private(set) var isInitialLoading = true
+
+    var filteredPreviews: [ServerPreview] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return previews }
+
+        return previews.filter { preview in
+            if let displayName = preview.displayName, displayName.localizedCaseInsensitiveContains(query) {
+                return true
+            }
+            if let branch = preview.gitBranch, branch.localizedCaseInsensitiveContains(query) {
+                return true
+            }
+            if let commitSHA = preview.gitCommitSHA, commitSHA.localizedCaseInsensitiveContains(query) {
+                return true
+            }
+            return false
+        }
+    }
 
     init(
         listProjectsService: ListProjectsServicing = ListProjectsService(),
@@ -50,6 +69,7 @@ final class PreviewsViewModel: Sendable {
 
     func selectProject(_ project: ServerProject) async throws {
         selectedProject = project
+        searchText = ""
         try? appStorage.set(SelectedProjectFullHandleKey.self, value: selectedProject?.fullName)
         try await loadPreviews(for: project)
     }


### PR DESCRIPTION
Resolves <!-- link issue if any -->

Add a search bar on the iOS Previews screen to filter by name, branch, or commit.

### Demo

<!-- Upload your video here -->



### How to test locally

1. Open the Tuist iOS app → Previews
2. Search by app name, branch, or commit SHA
3. Clear search / switch project and confirm the filter resets