### PR TITLE
feat(atlas): presign stored artifacts for the internal Atlas API

### DIFF
--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -53,6 +53,7 @@ defmodule Tuist do
       Cache.Analytics,
       CacheEndpoints,
       Atlas,
+      Atlas.Artifacts,
       AtlasWorkloadIdentity,
       Kubernetes.Client,
       Kura,

--- a/server/lib/tuist/atlas/artifacts.ex
+++ b/server/lib/tuist/atlas/artifacts.ex
@@ -1,0 +1,177 @@
+defmodule Tuist.Atlas.Artifacts do
+  @moduledoc """
+  Resolves a stored artifact to a short-lived presigned download URL for the
+  internal Atlas workload.
+
+  Atlas runs in its own cluster with no credentials for the artifact buckets, so
+  it cannot reach object storage on its own. Support escalations, however, are
+  usually about the artifact rather than the row: the `.xcresult` bundle behind a
+  failed test run, the crash report attached to a test case run, the
+  `.xcactivitylog` behind a slow build. This module maps a record id to the key
+  its artifact lives under and presigns a download for it — the same key builders
+  the product paths use, so a drift in one shows up in both.
+
+  Each kind is looked up before it is presigned, so a caller learns the
+  difference between "no such run" (`:not_found`) and "the run exists but its
+  artifact was never uploaded or has since been pruned" (`:object_not_found`),
+  which is the distinction that usually resolves the escalation.
+  """
+
+  alias Tuist.AppBuilds
+  alias Tuist.Builds
+  alias Tuist.CommandEvents
+  alias Tuist.Projects
+  alias Tuist.Storage
+  alias Tuist.Tests
+
+  @default_expires_in 900
+  @max_expires_in 3600
+
+  @kinds ~w(test_run_result_bundle test_run_session test_case_run_attachment build_archive preview_app_build)
+
+  @doc "The artifact kinds `presign/3` accepts."
+  def kinds, do: @kinds
+
+  @doc """
+  Presigns a download for the artifact of `kind` belonging to the record `id`.
+
+  `:expires_in` is the URL lifetime in seconds, defaulting to
+  #{@default_expires_in} and clamped to #{@max_expires_in}.
+  """
+  def presign(kind, id, opts \\ [])
+
+  def presign(kind, id, opts) when kind in @kinds and is_binary(id) do
+    with {:ok, project, object_key} <- resolve(kind, id),
+         {:ok, byte_size} <- object_size(object_key, project.account) do
+      expires_in = expires_in(Keyword.get(opts, :expires_in))
+
+      {:ok,
+       %{
+         kind: kind,
+         id: id,
+         account_handle: project.account.name,
+         project_handle: project.name,
+         object_key: object_key,
+         byte_size: byte_size,
+         download_url: download_url(object_key, project.account, expires_in),
+         expires_at: DateTime.utc_now() |> DateTime.add(expires_in, :second) |> DateTime.truncate(:second)
+       }}
+    end
+  end
+
+  def presign(kind, _id, _opts) when kind in @kinds, do: {:error, :not_found}
+  def presign(_kind, _id, _opts), do: {:error, :unknown_kind}
+
+  # Both the command-event and run-scoped key builders resolve to
+  # `<account>/<project>/runs/<id>/…`, so the id is the only thing that differs
+  # between a legacy `tuist test` command event and a remote-processed
+  # `tuist inspect test` run. Look the id up as a test run first and fall back to
+  # a command event, then let the shared builder produce the key.
+  defp resolve("test_run_result_bundle", id) do
+    with {:ok, project} <- test_run_project(id) do
+      {:ok, project, CommandEvents.get_result_bundle_key(id, project)}
+    end
+  end
+
+  defp resolve("test_run_session", id) do
+    with {:ok, project} <- test_run_project(id) do
+      {:ok, project, CommandEvents.get_session_key(id, project)}
+    end
+  end
+
+  defp resolve("test_case_run_attachment", id) do
+    with {:ok, uuid} <- cast_uuid(id),
+         {:ok, attachment} <- Tests.get_attachment_by_id(uuid),
+         {:ok, test_case_run} <- Tests.get_test_case_run_by_id(attachment.test_case_run_id),
+         {:ok, project} <- project_with_account(test_case_run.project_id) do
+      object_key =
+        Tests.attachment_storage_key(%{
+          account_handle: project.account.name,
+          project_handle: project.name,
+          test_run_id: attachment.test_run_id,
+          test_case_run_id: attachment.test_case_run_id,
+          attachment_id: attachment.id,
+          file_name: attachment.file_name
+        })
+
+      {:ok, project, object_key}
+    end
+  end
+
+  defp resolve("build_archive", id) do
+    with {:ok, build} <- Builds.get_build(id),
+         {:ok, project} <- project_with_account(build.project_id) do
+      {:ok, project, Builds.build_storage_key(project.account.name, project.name, build.id)}
+    end
+  end
+
+  defp resolve("preview_app_build", id) do
+    with {:ok, app_build} <- app_build(id) do
+      project = app_build.preview.project
+
+      object_key =
+        AppBuilds.storage_key(%{
+          account_handle: project.account.name,
+          project_handle: project.name,
+          app_build: app_build
+        })
+
+      {:ok, project, object_key}
+    end
+  end
+
+  defp test_run_project(id) do
+    case Tests.get_test(id) do
+      {:ok, test} ->
+        project_with_account(test.project_id)
+
+      {:error, :not_found} ->
+        with {:ok, command_event} <- CommandEvents.get_command_event_by_id(id) do
+          CommandEvents.get_project_for_command_event(command_event, preload: :account)
+        end
+    end
+  end
+
+  # `app_build_by_id/2` answers a malformed id with a message rather than
+  # `:not_found`; the caller only cares that nothing was found.
+  defp app_build(id) do
+    case AppBuilds.app_build_by_id(id, preload: [preview: [project: :account]]) do
+      {:ok, %{preview: %{project: %{account: _account}}} = app_build} -> {:ok, app_build}
+      _other -> {:error, :not_found}
+    end
+  end
+
+  # The attachment lookup queries a UUID column directly, which raises on a
+  # malformed value instead of returning nothing.
+  defp cast_uuid(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp project_with_account(project_id) do
+    case Projects.get_project_by_id(project_id) do
+      nil -> {:error, :not_found}
+      project -> {:ok, project}
+    end
+  end
+
+  defp object_size(object_key, account) do
+    case Storage.get_object_size(object_key, account) do
+      {:ok, byte_size} -> {:ok, byte_size}
+      {:error, :not_found} -> {:error, :object_not_found}
+      {:error, _reason} -> {:error, :storage_unavailable}
+    end
+  end
+
+  defp download_url(object_key, account, expires_in) do
+    Storage.generate_download_url(object_key, account,
+      expires_in: expires_in,
+      content_disposition: ~s(attachment; filename="#{Path.basename(object_key)}")
+    )
+  end
+
+  defp expires_in(seconds) when is_integer(seconds) and seconds > 0, do: min(seconds, @max_expires_in)
+  defp expires_in(_seconds), do: @default_expires_in
+end

--- a/server/lib/tuist_web/controllers/internal/atlas_artifacts_controller.ex
+++ b/server/lib/tuist_web/controllers/internal/atlas_artifacts_controller.ex
@@ -1,0 +1,51 @@
+defmodule TuistWeb.Internal.AtlasArtifactsController do
+  @moduledoc """
+  Internal Atlas access to stored artifacts.
+
+  Returns a short-lived presigned download URL for the artifact behind a record
+  (see `Tuist.Atlas.Artifacts`) rather than the bytes themselves, so a large
+  `.xcresult` bundle never travels through this server. The caller is
+  authenticated by `TuistWeb.Plugs.InternalAtlasAuthPlug` (Atlas workload
+  identity), so this endpoint is reachable only by the Atlas service account.
+  """
+
+  use TuistWeb, :controller
+
+  alias Tuist.Atlas.Artifacts
+
+  @doc """
+  Presign a download for `:kind`/`:id`. `expires_in` (seconds, query param)
+  shortens the default lifetime; it is clamped server-side.
+  """
+  def show(conn, %{"kind" => kind, "id" => id} = params) do
+    case Artifacts.presign(kind, id, expires_in: expires_in(params)) do
+      {:ok, artifact} ->
+        json(conn, artifact)
+
+      {:error, :unknown_kind} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "unknown_kind", supported_kinds: Artifacts.kinds()})
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "record_not_found"})
+
+      {:error, :object_not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "artifact_not_stored"})
+
+      {:error, :storage_unavailable} ->
+        conn |> put_status(:bad_gateway) |> json(%{error: "storage_unavailable"})
+    end
+  end
+
+  defp expires_in(%{"expires_in" => expires_in}) when is_integer(expires_in), do: expires_in
+
+  defp expires_in(%{"expires_in" => expires_in}) when is_binary(expires_in) do
+    case Integer.parse(expires_in) do
+      {seconds, ""} -> seconds
+      _ -> nil
+    end
+  end
+
+  defp expires_in(_params), do: nil
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -796,6 +796,8 @@ defmodule TuistWeb.Router do
     post "/atlas/clickhouse/query", AtlasClickHouseController, :query
     get "/atlas/clickhouse/tables", AtlasClickHouseController, :tables
     get "/atlas/clickhouse/tables/:database/:name", AtlasClickHouseController, :describe
+
+    get "/atlas/artifacts/:kind/:id", AtlasArtifactsController, :show
   end
 
   scope "/_internal", TuistWeb.Internal do

--- a/server/test/tuist/atlas/artifacts_test.exs
+++ b/server/test/tuist/atlas/artifacts_test.exs
@@ -1,0 +1,146 @@
+defmodule Tuist.Atlas.ArtifactsTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+  use Mimic
+
+  alias Tuist.Atlas.Artifacts
+  alias Tuist.Storage
+  alias TuistTestSupport.Fixtures.AppBuildsFixtures
+  alias TuistTestSupport.Fixtures.CommandEventsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.RunsFixtures
+
+  setup do
+    project = ProjectsFixtures.project_fixture(name: "acme-app")
+
+    stub(Storage, :get_object_size, fn _object_key, _actor -> {:ok, 1024} end)
+    stub(Storage, :generate_download_url, fn _object_key, _actor, _opts -> "https://storage.test/signed" end)
+
+    %{project: project, handle: project.account.name}
+  end
+
+  describe "presign/3" do
+    test "resolves a remote-processed test run's result bundle", %{project: project, handle: handle} do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      assert {:ok, artifact} = Artifacts.presign("test_run_result_bundle", test_run.id)
+
+      assert artifact.object_key == "#{handle}/acme-app/runs/#{test_run.id}/result_bundle.zip"
+      assert artifact.account_handle == handle
+      assert artifact.project_handle == "acme-app"
+      assert artifact.byte_size == 1024
+      assert artifact.download_url == "https://storage.test/signed"
+    end
+
+    test "resolves a test run's session archive", %{project: project, handle: handle} do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      assert {:ok, artifact} = Artifacts.presign("test_run_session", test_run.id)
+
+      assert artifact.object_key == "#{handle}/acme-app/runs/#{test_run.id}/session.zip"
+    end
+
+    # Older `tuist test` runs have no row in `test_runs`; their bundle is stored
+    # under the command event id instead.
+    test "falls back to a command event when the id is not a test run", %{project: project, handle: handle} do
+      command_event = CommandEventsFixtures.command_event_fixture(project_id: project.id, name: "test")
+
+      assert {:ok, artifact} = Artifacts.presign("test_run_result_bundle", command_event.id)
+
+      assert artifact.object_key == "#{handle}/acme-app/runs/#{command_event.id}/result_bundle.zip"
+    end
+
+    test "resolves a test case run attachment", %{project: project, handle: handle} do
+      test_case_run = RunsFixtures.test_case_run_fixture(project_id: project.id)
+
+      attachment =
+        RunsFixtures.test_case_run_attachment_fixture(
+          test_case_run_id: test_case_run.id,
+          test_run_id: test_case_run.test_run_id,
+          file_name: "crash-report.ips"
+        )
+
+      assert {:ok, artifact} = Artifacts.presign("test_case_run_attachment", attachment.id)
+
+      assert artifact.object_key ==
+               "#{handle}/acme-app/tests/runs/#{test_case_run.test_run_id}/attachments/#{attachment.id}/crash-report.ips"
+    end
+
+    test "resolves a legacy attachment stored without a test run id", %{project: project, handle: handle} do
+      test_case_run = RunsFixtures.test_case_run_fixture(project_id: project.id)
+
+      attachment =
+        RunsFixtures.test_case_run_attachment_fixture(
+          test_case_run_id: test_case_run.id,
+          test_run_id: nil,
+          file_name: "screenshot.png"
+        )
+
+      assert {:ok, artifact} = Artifacts.presign("test_case_run_attachment", attachment.id)
+
+      assert artifact.object_key ==
+               "#{handle}/acme-app/tests/test-case-runs/#{test_case_run.id}/attachments/#{attachment.id}/screenshot.png"
+    end
+
+    test "resolves a build run's archive", %{project: project, handle: handle} do
+      {:ok, build} = RunsFixtures.build_fixture(project_id: project.id)
+
+      assert {:ok, artifact} = Artifacts.presign("build_archive", build.id)
+
+      assert artifact.object_key == "#{handle}/acme-app/builds/#{String.downcase(build.id)}/build.zip"
+    end
+
+    test "resolves a preview app build", %{project: project, handle: handle} do
+      preview = AppBuildsFixtures.preview_fixture(project: project)
+      app_build = AppBuildsFixtures.app_build_fixture(preview: preview)
+
+      assert {:ok, artifact} = Artifacts.presign("preview_app_build", app_build.id)
+
+      assert artifact.object_key == "#{handle}/acme-app/previews/#{app_build.id}.zip"
+    end
+
+    test "signs the URL for the configured lifetime, clamped to an hour", %{project: project} do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      expect(Storage, :generate_download_url, fn _object_key, _actor, opts ->
+        assert Keyword.fetch!(opts, :expires_in) == 3600
+        "https://storage.test/signed"
+      end)
+
+      assert {:ok, artifact} = Artifacts.presign("test_run_result_bundle", test_run.id, expires_in: 86_400)
+
+      assert DateTime.diff(artifact.expires_at, DateTime.utc_now()) in 3595..3600
+    end
+
+    test "reports an unknown kind" do
+      assert {:error, :unknown_kind} = Artifacts.presign("crash_dump", UUIDv7.generate())
+    end
+
+    test "reports a record that does not exist" do
+      assert {:error, :not_found} = Artifacts.presign("test_run_result_bundle", UUIDv7.generate())
+      assert {:error, :not_found} = Artifacts.presign("build_archive", UUIDv7.generate())
+      assert {:error, :not_found} = Artifacts.presign("preview_app_build", UUIDv7.generate())
+    end
+
+    test "reports a malformed attachment id without raising" do
+      assert {:error, :not_found} = Artifacts.presign("test_case_run_attachment", "not-a-uuid")
+    end
+
+    # The row outliving its artifact is the common escalation shape: the run is
+    # in the dashboard but the bundle was never uploaded or has been pruned.
+    test "distinguishes a stored record from a missing object", %{project: project} do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:error, :not_found} end)
+
+      assert {:error, :object_not_found} = Artifacts.presign("test_run_result_bundle", test_run.id)
+    end
+
+    test "reports storage failures separately from a missing object", %{project: project} do
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:error, :timeout} end)
+
+      assert {:error, :storage_unavailable} = Artifacts.presign("test_run_result_bundle", test_run.id)
+    end
+  end
+end

--- a/server/test/tuist_web/controllers/internal/atlas_artifacts_controller_test.exs
+++ b/server/test/tuist_web/controllers/internal/atlas_artifacts_controller_test.exs
@@ -1,0 +1,130 @@
+defmodule TuistWeb.Internal.AtlasArtifactsControllerTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use Mimic
+
+  alias Tuist.AtlasWorkloadIdentity
+  alias Tuist.Storage
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.RunsFixtures
+  alias TuistWeb.RateLimit
+
+  setup :set_mimic_from_context
+
+  setup do
+    stub(RateLimit.Atlas, :hit, fn _conn -> {:allow, 1} end)
+
+    :ok
+  end
+
+  defp ok_workload_identity_stub do
+    stub(AtlasWorkloadIdentity, :verify, fn "valid-token" ->
+      {:ok, %{namespace: "atlas-production", name: "atlas"}}
+    end)
+  end
+
+  defp authorized(conn), do: put_req_header(conn, "authorization", "Bearer valid-token")
+
+  describe "GET /api/internal/atlas/artifacts/:kind/:id" do
+    test "presigns a download for a stored artifact", %{conn: conn} do
+      project = ProjectsFixtures.project_fixture(name: "acme-app")
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:ok, 2048} end)
+      stub(Storage, :generate_download_url, fn _object_key, _actor, _opts -> "https://storage.test/signed" end)
+      ok_workload_identity_stub()
+
+      conn = conn |> authorized() |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{test_run.id}")
+
+      assert %{
+               "kind" => "test_run_result_bundle",
+               "id" => id,
+               "project_handle" => "acme-app",
+               "object_key" => object_key,
+               "byte_size" => 2048,
+               "download_url" => "https://storage.test/signed",
+               "expires_at" => _expires_at
+             } = json_response(conn, 200)
+
+      assert id == test_run.id
+      assert object_key == "#{project.account.name}/acme-app/runs/#{test_run.id}/result_bundle.zip"
+    end
+
+    test "passes a shorter expiry through to the signature", %{conn: conn} do
+      project = ProjectsFixtures.project_fixture(name: "acme-app")
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:ok, 2048} end)
+
+      expect(Storage, :generate_download_url, fn _object_key, _actor, opts ->
+        assert Keyword.fetch!(opts, :expires_in) == 60
+        "https://storage.test/signed"
+      end)
+
+      ok_workload_identity_stub()
+
+      conn =
+        conn
+        |> authorized()
+        |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{test_run.id}?expires_in=60")
+
+      assert json_response(conn, 200)["download_url"] == "https://storage.test/signed"
+    end
+
+    test "returns 400 with the supported kinds for an unknown kind", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authorized() |> get("/api/internal/atlas/artifacts/crash_dump/#{UUIDv7.generate()}")
+
+      assert %{"error" => "unknown_kind", "supported_kinds" => kinds} = json_response(conn, 400)
+      assert "test_run_result_bundle" in kinds
+    end
+
+    test "returns 404 when the record does not exist", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn =
+        conn |> authorized() |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{UUIDv7.generate()}")
+
+      assert %{"error" => "record_not_found"} = json_response(conn, 404)
+    end
+
+    test "returns 404 when the record exists but its artifact was never stored", %{conn: conn} do
+      project = ProjectsFixtures.project_fixture(name: "acme-app")
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:error, :not_found} end)
+      ok_workload_identity_stub()
+
+      conn = conn |> authorized() |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{test_run.id}")
+
+      assert %{"error" => "artifact_not_stored"} = json_response(conn, 404)
+    end
+
+    test "returns 502 when object storage is unreachable", %{conn: conn} do
+      project = ProjectsFixtures.project_fixture(name: "acme-app")
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      stub(Storage, :get_object_size, fn _object_key, _actor -> {:error, :timeout} end)
+      ok_workload_identity_stub()
+
+      conn = conn |> authorized() |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{test_run.id}")
+
+      assert %{"error" => "storage_unavailable"} = json_response(conn, 502)
+    end
+
+    test "returns 401 when bearer token is missing", %{conn: conn} do
+      conn = get(conn, "/api/internal/atlas/artifacts/test_run_result_bundle/#{UUIDv7.generate()}")
+
+      assert json_response(conn, 401)["error"] =~ "bearer"
+    end
+
+    test "returns 401 when workload identity rejects the token", %{conn: conn} do
+      stub(AtlasWorkloadIdentity, :verify, fn _token -> {:error, :invalid_signature} end)
+
+      conn =
+        conn |> authorized() |> get("/api/internal/atlas/artifacts/test_run_result_bundle/#{UUIDv7.generate()}")
+
+      assert json_response(conn, 401)
+    end
+  end
+end


### PR DESCRIPTION
Atlas can already read the rows behind a support escalation — it has read-only access to this database and to ClickHouse — but not the files those rows point at: the `.xcresult` bundle of a failed test run, the `.ips` crash report attached to a test case run, the archive holding a build's `.xcactivitylog`, a preview's IPA. Those live in object storage Atlas has no credentials for, so today they get handed over manually.

This adds `GET /api/internal/atlas/artifacts/:kind/:id` behind `InternalAtlasAuthPlug`, alongside the existing `/atlas/db` and `/atlas/clickhouse` endpoints. It resolves a record to its storage key and signs a short-lived download; only the URL crosses the wire, so a multi-gigabyte bundle never travels through this server.

| `kind` | `id` | resolved through |
| --- | --- | --- |
| `test_run_result_bundle` | test run id, or the command event id of an older `tuist test` run | `Tests.get_test/1`, falling back to `CommandEvents.get_command_event_by_id/1` |
| `test_run_session` | same | same |
| `test_case_run_attachment` | `test_case_run_attachments.id` | attachment → test case run → project; handles the legacy `test-case-runs/` path when `test_run_id` is null |
| `build_archive` | build run id | `Builds.build_storage_key/3` |
| `preview_app_build` | app build id | `AppBuilds.storage_key/1` |

Two things worth a reviewer's attention:

- **The resolver reuses the product's own key builders** rather than restating the path conventions, so a drift in one shows up in both. The command-event and run-scoped builders already produce the same `<account>/<project>/runs/<id>/…` shape, which is why one lookup fallback covers both generations of test run.
- **Each kind is looked up, and its object sized, before it is presigned.** That is what lets the response separate `record_not_found` (404) from `artifact_not_stored` (404) from `storage_unavailable` (502). A row outliving its artifact is the common escalation shape, and it is the distinction that usually resolves the ticket.

URLs default to 15 minutes and are clamped to an hour.

Runner job logs are deliberately not here: they are ClickHouse rows (`Tuist.Runners.JobLogs`), not a stored object, and Atlas's `query_tuist_clickhouse` already reaches them.

The Atlas-side MCP tool that consumes this is tuist/atlas#400. This needs to merge first; until it does, that tool reports the server as unreachable.

### How to test locally

```
mix test test/tuist/atlas/artifacts_test.exs test/tuist_web/controllers/internal/atlas_artifacts_controller_test.exs
```

21 tests cover each kind, the command-event fallback, the legacy attachment path, expiry clamping, and every error branch. `Tuist.Storage` is stubbed, so no bucket is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
