### PR TITLE
fix(cli): honor SwiftPM's netrc options when resolving with SwifterPM

### DIFF
--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -56,6 +56,8 @@ mise x github:tuist/swifterpm@latest -- swifterpm --package-path . --force-resol
 
 Useful SwiftPM-shaped flags are supported, including `--package-path`, `--cache-path`, `--scratch-path`, `--build-path`, `--config-path`, `--default-registry-url`, `--skip-update`, `--force-resolved-versions`, `--disable-automatic-resolution`, and `--only-use-versions-from-resolved-file`.
 
+Credentials for registries and binary artifact downloads are read from `~/.netrc`, from the `SWIFTPM_NETRC_DATA` environment variable, or from the file given by `--netrc-file`. Pass `--disable-netrc` to skip all of them. A `--netrc-file` that does not exist is an error rather than a silent fallback to unauthenticated requests.
+
 By default, `swifterpm` copies cached directories into the project scratch directory on CI and symlinks them elsewhere. Pass `--cached-directory-materialization symlink` to preserve global-cache symlinks on CI. The accepted values are `automatic`, `copy`, and `symlink`.
 
 > [!NOTE]

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -36,6 +36,8 @@ struct CLI {
     var buildPath: CLIPath?
     var configPath: CLIPath?
     var securityPath: CLIPath?
+    var netrcFile: CLIPath?
+    var netrc = true
     var disableSandbox = false
     var enableDependencyCache = false
     var disableDependencyCache = false
@@ -152,6 +154,7 @@ public enum SwifterPMCommandParser {
                         cli: cli, paths: paths, packageDir: package, commandScratchDir: options.scratchDir),
                     registryConfigurationPath: paths.resolve(cli.configPath),
                     defaultRegistryURL: cli.defaultRegistryURL,
+                    netrc: CLIRunner.netrcConfiguration(cli: cli, paths: paths),
                     disableSandbox: cli.disableSandbox,
                     disablePackageInfoCache: cli.disablePackageInfoCache,
                     packageInfoCacheDirectory: paths.resolve(cli.packageInfoCachePath),
@@ -181,6 +184,7 @@ public enum SwifterPMCommandParser {
                 cli: cli, paths: paths, packageDir: package, commandScratchDir: nil),
             registryConfigurationPath: paths.resolve(cli.configPath),
             defaultRegistryURL: cli.defaultRegistryURL,
+            netrc: CLIRunner.netrcConfiguration(cli: cli, paths: paths),
             disableSandbox: cli.disableSandbox,
             forceResolvedVersions: cli.forceResolvedVersions || cli.disableAutomaticResolution
                 || cli.onlyUseVersionsFromResolvedFile,
@@ -223,6 +227,12 @@ public struct SwifterPMCommand: AsyncParsableCommand {
 
     @Option(name: .customLong("security-path"))
     var securityPath: String?
+
+    @Option(name: .customLong("netrc-file"))
+    var netrcFile: String?
+
+    @Flag(inversion: .prefixedEnableDisable)
+    var netrc = true
 
     @Flag(name: .customLong("disable-sandbox"))
     var disableSandbox = false
@@ -305,6 +315,8 @@ public struct SwifterPMCommand: AsyncParsableCommand {
             buildPath: CLIPath.optional(buildPath),
             configPath: CLIPath.optional(configPath),
             securityPath: CLIPath.optional(securityPath),
+            netrcFile: CLIPath.optional(netrcFile),
+            netrc: netrc,
             disableSandbox: disableSandbox,
             enableDependencyCache: enableDependencyCache,
             disableDependencyCache: disableDependencyCache,
@@ -354,10 +366,18 @@ enum CLIParser {
 /// subcommand parse, because `.allUnrecognized` on `commandArguments` only
 /// collects arguments that trail the `action` positional, and `tuist install`
 /// forwards passthrough arguments ahead of it.
+///
+/// `--netrc` joins that set because SwiftPM deprecated it once netrc became the
+/// default, so it only restates what `--enable-netrc` already gives.
+/// `--netrc-file` and `--enable-netrc`/`--disable-netrc` still change what
+/// happens, so they are real options instead. `--netrc-optional` is deliberately
+/// absent: Swift 6.3.2 rejects it outright, so tolerating it here would be more
+/// permissive than the tool we are standing in for.
 public enum DeprecatedSwiftPMOptions {
     static let ignored: Set<String> = [
         "--disable-prefetching",
         "--enable-prefetching",
+        "--netrc",
     ]
 
     public static func strip(_ arguments: [String]) -> [String] {
@@ -488,66 +508,79 @@ struct CLIPathResolver {
 }
 
 enum CLIRunner {
+    static func netrcConfiguration(cli: CLI, paths: CLIPathResolver)
+        -> SwifterPMNetrcConfiguration
+    {
+        SwifterPMNetrcConfiguration(isEnabled: cli.netrc, path: paths.resolve(cli.netrcFile))
+    }
+
     static func run(_ cli: CLI) async throws {
         try await Environment.withCachedDirectoryMaterialization(
             cli.cachedDirectoryMaterialization
         ) {
             let paths = try await CLIPathResolver(chdir: cli.chdir)
-
-            switch cli.command {
-            case .resolve(let options):
-                try ensureWholePackageResolution(
-                    packageName: options.packageName,
-                    version: options.version,
-                    branch: options.branch,
-                    revision: options.revision
-                )
-                try await runResolutionCommand(
-                    cli: cli,
-                    paths: paths,
-                    packageDir: options.packageDir,
-                    cacheDir: options.cacheDir,
-                    preferResolvedFile: true,
-                    write: options.write,
-                    restore: options.restore,
-                    printOnly: options.printOnly
-                )
-            case .update(let options):
-                if !options.packageNames.isEmpty {
-                    throw ToolError.message("package-specific update is not supported yet")
-                }
-                try await runResolutionCommand(
-                    cli: cli,
-                    paths: paths,
-                    packageDir: options.packageDir,
-                    cacheDir: options.cacheDir,
-                    preferResolvedFile: false,
-                    write: options.write,
-                    restore: options.restore,
-                    printOnly: options.printOnly
-                )
-            case .restore(let options):
-                let cache = try await Cache(
-                    root: cliCacheDir(cli: cli, paths: paths, commandCacheDir: options.cacheDir))
-                let package = canonicalPackageDir(
-                    commandPackageDir(
-                        cli: cli, paths: paths, commandPackageDir: options.packageDir))
-                let scratch = commandScratchDir(
-                    cli: cli, paths: paths, packageDir: package, commandScratchDir: options.scratchDir)
-                let registryConfig = try await cliRegistryConfig(
-                    cli: cli, paths: paths, package: package)
-                let resolved = try await ResolvedFile.read(packageDir: package)
-                try await WorkspaceRestorer.restorePackage(
-                    scratchDir: scratch, packageDir: package, cache: cache, registryConfig: registryConfig,
-                    resolved: resolved,
-                    progress: cli.quiet ? nil : RestoreProgressReporter(),
-                    disableSandbox: cli.disableSandbox)
-                try await maybeWritePackageInfoCache(
-                    cli: cli, paths: paths, package: package, scratch: scratch, resolved: resolved)
-                try await WorkspaceRestorer.writeWorkspaceState(
-                    packageDir: package, scratchDir: scratch, resolved: resolved,
-                    disableSandbox: cli.disableSandbox)
+            let netrc = netrcConfiguration(cli: cli, paths: paths)
+            try await Netrc.validate(netrc)
+            try await Environment.withNetrc(netrc) {
+                try await runCommand(cli: cli, paths: paths)
             }
+        }
+    }
+
+    private static func runCommand(cli: CLI, paths: CLIPathResolver) async throws {
+        switch cli.command {
+        case .resolve(let options):
+            try ensureWholePackageResolution(
+                packageName: options.packageName,
+                version: options.version,
+                branch: options.branch,
+                revision: options.revision
+            )
+            try await runResolutionCommand(
+                cli: cli,
+                paths: paths,
+                packageDir: options.packageDir,
+                cacheDir: options.cacheDir,
+                preferResolvedFile: true,
+                write: options.write,
+                restore: options.restore,
+                printOnly: options.printOnly
+            )
+        case .update(let options):
+            if !options.packageNames.isEmpty {
+                throw ToolError.message("package-specific update is not supported yet")
+            }
+            try await runResolutionCommand(
+                cli: cli,
+                paths: paths,
+                packageDir: options.packageDir,
+                cacheDir: options.cacheDir,
+                preferResolvedFile: false,
+                write: options.write,
+                restore: options.restore,
+                printOnly: options.printOnly
+            )
+        case .restore(let options):
+            let cache = try await Cache(
+                root: cliCacheDir(cli: cli, paths: paths, commandCacheDir: options.cacheDir))
+            let package = canonicalPackageDir(
+                commandPackageDir(
+                    cli: cli, paths: paths, commandPackageDir: options.packageDir))
+            let scratch = commandScratchDir(
+                cli: cli, paths: paths, packageDir: package, commandScratchDir: options.scratchDir)
+            let registryConfig = try await cliRegistryConfig(
+                cli: cli, paths: paths, package: package)
+            let resolved = try await ResolvedFile.read(packageDir: package)
+            try await WorkspaceRestorer.restorePackage(
+                scratchDir: scratch, packageDir: package, cache: cache, registryConfig: registryConfig,
+                resolved: resolved,
+                progress: cli.quiet ? nil : RestoreProgressReporter(),
+                disableSandbox: cli.disableSandbox)
+            try await maybeWritePackageInfoCache(
+                cli: cli, paths: paths, package: package, scratch: scratch, resolved: resolved)
+            try await WorkspaceRestorer.writeWorkspaceState(
+                packageDir: package, scratchDir: scratch, resolved: resolved,
+                disableSandbox: cli.disableSandbox)
         }
     }
 

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -38,6 +38,7 @@ struct CLI {
     var securityPath: CLIPath?
     var netrcFile: CLIPath?
     var netrc = true
+    var forceNetrc = false
     var disableSandbox = false
     var enableDependencyCache = false
     var disableDependencyCache = false
@@ -234,6 +235,9 @@ public struct SwifterPMCommand: AsyncParsableCommand {
     @Flag(inversion: .prefixedEnableDisable)
     var netrc = true
 
+    @Flag(name: .customLong("netrc"))
+    var forceNetrc = false
+
     @Flag(name: .customLong("disable-sandbox"))
     var disableSandbox = false
 
@@ -317,6 +321,7 @@ public struct SwifterPMCommand: AsyncParsableCommand {
             securityPath: CLIPath.optional(securityPath),
             netrcFile: CLIPath.optional(netrcFile),
             netrc: netrc,
+            forceNetrc: forceNetrc,
             disableSandbox: disableSandbox,
             enableDependencyCache: enableDependencyCache,
             disableDependencyCache: disableDependencyCache,
@@ -367,17 +372,16 @@ enum CLIParser {
 /// collects arguments that trail the `action` positional, and `tuist install`
 /// forwards passthrough arguments ahead of it.
 ///
-/// `--netrc` joins that set because SwiftPM deprecated it once netrc became the
-/// default, so it only restates what `--enable-netrc` already gives.
-/// `--netrc-file` and `--enable-netrc`/`--disable-netrc` still change what
-/// happens, so they are real options instead. `--netrc-optional` is deliberately
-/// absent: Swift 6.3.2 rejects it outright, so tolerating it here would be more
-/// permissive than the tool we are standing in for.
+/// No netrc option belongs in this set. `--netrc` looks like a deprecated spelling
+/// of `--enable-netrc` and is not: SwiftPM's `SecurityOptions.forceNetrc` is a
+/// separate, undeprecated flag that disables the keychain for registry requests, so
+/// swallowing it would quietly invert registry precedence. `--netrc-optional` is
+/// absent for the opposite reason: Swift 6.3.2 rejects it outright, and tolerating
+/// it would make us more permissive than the tool we are standing in for.
 public enum DeprecatedSwiftPMOptions {
     static let ignored: Set<String> = [
         "--disable-prefetching",
         "--enable-prefetching",
-        "--netrc",
     ]
 
     public static func strip(_ arguments: [String]) -> [String] {
@@ -511,7 +515,11 @@ enum CLIRunner {
     static func netrcConfiguration(cli: CLI, paths: CLIPathResolver)
         -> SwifterPMNetrcConfiguration
     {
-        SwifterPMNetrcConfiguration(isEnabled: cli.netrc, path: paths.resolve(cli.netrcFile))
+        SwifterPMNetrcConfiguration(
+            isEnabled: cli.netrc,
+            path: paths.resolve(cli.netrcFile),
+            forcesNetrc: cli.forceNetrc
+        )
     }
 
     static func run(_ cli: CLI) async throws {

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -519,8 +519,8 @@ enum CLIRunner {
             cli.cachedDirectoryMaterialization
         ) {
             let paths = try await CLIPathResolver(chdir: cli.chdir)
-            let netrc = netrcConfiguration(cli: cli, paths: paths)
-            try await Netrc.validate(netrc)
+            let netrc = try await Netrc.resolve(
+                netrcConfiguration(cli: cli, paths: paths), environment: Environment.current)
             try await Environment.withNetrc(netrc) {
                 try await runCommand(cli: cli, paths: paths)
             }

--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -7,21 +7,17 @@ enum Environment {
     @TaskLocal
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
+    /// The netrc every download authenticates against. Entry points install it once
+    /// per resolution, so the unbound value means no netrc source was configured.
     @TaskLocal
-    static var netrc: ResolvedNetrc?
+    static var netrc: Netrc = .empty
 
     static var isCI: Bool {
         ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
     }
 
-    /// The netrc every download authenticates against. Entry points install it once
-    /// per resolution, so an unset task local means no netrc source was configured.
-    static var resolvedNetrc: ResolvedNetrc {
-        netrc ?? .none
-    }
-
     static func withNetrc<T>(
-        _ netrc: ResolvedNetrc,
+        _ netrc: Netrc,
         operation: () async throws -> T
     ) async throws -> T {
         try await Environment.$netrc.withValue(netrc) {

--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -7,8 +7,24 @@ enum Environment {
     @TaskLocal
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
+    @TaskLocal
+    static var netrc: SwifterPMNetrcConfiguration?
+
     static var isCI: Bool {
         ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
+    }
+
+    static var netrcConfiguration: SwifterPMNetrcConfiguration {
+        netrc ?? .default
+    }
+
+    static func withNetrc<T>(
+        _ configuration: SwifterPMNetrcConfiguration,
+        operation: () async throws -> T
+    ) async throws -> T {
+        try await Environment.$netrc.withValue(configuration) {
+            try await operation()
+        }
     }
 
     static func cachedDirectoryMaterializationMode()

--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -8,21 +8,23 @@ enum Environment {
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
     @TaskLocal
-    static var netrc: SwifterPMNetrcConfiguration?
+    static var netrc: ResolvedNetrc?
 
     static var isCI: Bool {
         ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
     }
 
-    static var netrcConfiguration: SwifterPMNetrcConfiguration {
-        netrc ?? .default
+    /// The netrc every download authenticates against. Entry points install it once
+    /// per resolution, so an unset task local means no netrc source was configured.
+    static var resolvedNetrc: ResolvedNetrc {
+        netrc ?? .none
     }
 
     static func withNetrc<T>(
-        _ configuration: SwifterPMNetrcConfiguration,
+        _ netrc: ResolvedNetrc,
         operation: () async throws -> T
     ) async throws -> T {
-        try await Environment.$netrc.withValue(configuration) {
+        try await Environment.$netrc.withValue(netrc) {
             try await operation()
         }
     }

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -63,7 +63,9 @@ struct Netrc: Sendable {
     func credential(for url: URL) -> RegistryCredential? {
         guard let host = url.host?.lowercased() else { return nil }
         for machines in sources {
-            if let machine = machines.last(where: { $0.name == host })
+            // First match rather than last: SwiftPM and curl both resolve a duplicated
+            // host to the entry that appears first.
+            if let machine = machines.first(where: { $0.name == host })
                 ?? machines.first(where: \.isDefault)
             {
                 return RegistryCredential(user: machine.login, password: machine.password)

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -16,67 +16,89 @@ public struct SwifterPMNetrcConfiguration: Equatable, Sendable {
     public static let `default` = SwifterPMNetrcConfiguration()
 }
 
-enum Netrc {
-    /// SwiftPM refuses to run when `--netrc-file` points at a file that isn't there rather than
-    /// downgrading to unauthenticated requests, which would otherwise surface much later as an
-    /// opaque 401 or 404 from a private registry.
-    static func validate(_ configuration: SwifterPMNetrcConfiguration) async throws {
-        guard configuration.isEnabled, let path = configuration.path else { return }
-        guard try await fileSystem.exists(path.absolutePath, isDirectory: false) else {
-            throw ToolError.message("did not find netrc file at \(path.path)")
-        }
-    }
+/// The netrc credentials a resolution runs with, read and parsed once up front so
+/// every later lookup is a search over `machines` rather than another file read.
+struct ResolvedNetrc: Sendable {
+    static let none = ResolvedNetrc(sources: [])
 
-    static func credential(
-        for url: URL,
-        environment: [String: String]
-    ) async -> RegistryCredential? {
-        let configuration = Environment.netrcConfiguration
-        guard configuration.isEnabled else { return nil }
+    /// Parsed sources in priority order. `SWIFTPM_NETRC_DATA` and `~/.netrc` are
+    /// both consulted, the environment first, because a host missing from one has
+    /// always fallen through to the other.
+    private let sources: [[NetrcMachine]]
 
-        if let path = configuration.path {
-            return await credential(for: url, atPath: path)
-        }
-
-        if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty,
-           let credential = RegistryNetrc(content: data).credential(for: url)
-        {
-            return credential
-        }
-
-        guard let home = environment["HOME"] else { return nil }
-        return await credential(
-            for: url,
-            atPath: URL(fileURLWithPath: home).appendingPathComponent(".netrc")
-        )
-    }
-
-    private static func credential(for url: URL, atPath path: URL) async -> RegistryCredential? {
-        guard let data = try? await fileSystem.readFile(at: path.absolutePath),
-              let content = String(data: data, encoding: .utf8)
-        else {
-            return nil
-        }
-        return RegistryNetrc(content: content).credential(for: url)
-    }
-}
-
-struct RegistryNetrc {
-    private let machines: [Machine]
-
-    init(content: String) {
-        machines = Self.parse(content: content)
+    init(sources: [[NetrcMachine]]) {
+        self.sources = sources
     }
 
     func credential(for url: URL) -> RegistryCredential? {
         guard let host = url.host?.lowercased() else { return nil }
-        let machine = machines.last(where: { $0.name == host }) ?? machines.first(where: \.isDefault)
-        return machine.map { RegistryCredential(user: $0.login, password: $0.password) }
+        for machines in sources {
+            if let machine = machines.last(where: { $0.name == host })
+                ?? machines.first(where: \.isDefault)
+            {
+                return RegistryCredential(user: machine.login, password: machine.password)
+            }
+        }
+        return nil
+    }
+}
+
+enum Netrc {
+    static func resolve(
+        _ configuration: SwifterPMNetrcConfiguration,
+        environment: [String: String]
+    ) async throws -> ResolvedNetrc {
+        guard configuration.isEnabled else { return .none }
+
+        // An explicit `--netrc-file` is the only source when it is given, and it has
+        // to be there. SwiftPM refuses to run on a missing one rather than downgrading
+        // to unauthenticated requests, which would surface much later as an opaque 401
+        // or 404 from a private registry.
+        if let path = configuration.path {
+            guard try await fileSystem.exists(path.absolutePath, isDirectory: false) else {
+                throw ToolError.message("did not find netrc file at \(path.path)")
+            }
+            return ResolvedNetrc(sources: [NetrcParser.machines(in: try await contents(of: path))])
+        }
+
+        var sources: [[NetrcMachine]] = []
+        if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty {
+            sources.append(NetrcParser.machines(in: data))
+        }
+        if let home = environment["HOME"] {
+            let path = URL(fileURLWithPath: home).appendingPathComponent(".netrc")
+            if let content = try? await contents(of: path) {
+                sources.append(NetrcParser.machines(in: content))
+            }
+        }
+        return ResolvedNetrc(sources: sources)
     }
 
-    private static func parse(content: String) -> [Machine] {
+    private static func contents(of path: URL) async throws -> String {
+        let data = try await fileSystem.readFile(at: path.absolutePath)
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw ToolError.message("netrc file at \(path.path) is not valid UTF-8")
+        }
+        return content
+    }
+}
+
+struct NetrcMachine: Equatable, Sendable {
+    let name: String
+    let login: String
+    let password: String
+
+    var isDefault: Bool { name == "default" }
+}
+
+enum NetrcParser {
+    /// netrc is a token stream rather than a line-oriented format, so the content is
+    /// flattened into tokens first and then scanned for the two keywords that open an
+    /// entry. Anything else at that level is skipped, which is what lets `macdef`
+    /// blocks and unknown fields pass through without derailing the scan.
+    static func machines(in content: String) -> [NetrcMachine] {
         var tokens = tokenize(content)
-        var machines: [Machine] = []
+        var machines: [NetrcMachine] = []
         while let token = tokens.first {
             switch token {
             case "machine":
@@ -97,7 +119,7 @@ struct RegistryNetrc {
         return machines
     }
 
-    private static func parseMachine(name: String, tokens: inout [String]) -> Machine? {
+    private static func parseMachine(name: String, tokens: inout [String]) -> NetrcMachine? {
         var login: String?
         var password: String?
         while let key = tokens.first {
@@ -119,7 +141,7 @@ struct RegistryNetrc {
             }
         }
         guard let login, let password else { return nil }
-        return Machine(name: name, login: login, password: password)
+        return NetrcMachine(name: name, login: login, password: password)
     }
 
     private static func tokenize(_ content: String) -> [String] {
@@ -160,14 +182,6 @@ struct RegistryNetrc {
             tokens.append(token)
         }
         return tokens
-    }
-
-    private struct Machine {
-        let name: String
-        let login: String
-        let password: String
-
-        var isDefault: Bool { name == "default" }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -17,9 +17,9 @@ public struct SwifterPMNetrcConfiguration: Equatable, Sendable {
 }
 
 /// The netrc credentials a resolution runs with, read and parsed once up front so
-/// every later lookup is a search over `machines` rather than another file read.
-struct ResolvedNetrc: Sendable {
-    static let none = ResolvedNetrc(sources: [])
+/// every later lookup is a search over `sources` rather than another file read.
+struct Netrc: Sendable {
+    static let empty = Netrc(sources: [])
 
     /// Parsed sources in priority order. `SWIFTPM_NETRC_DATA` and `~/.netrc` are
     /// both consulted, the environment first, because a host missing from one has
@@ -30,25 +30,11 @@ struct ResolvedNetrc: Sendable {
         self.sources = sources
     }
 
-    func credential(for url: URL) -> RegistryCredential? {
-        guard let host = url.host?.lowercased() else { return nil }
-        for machines in sources {
-            if let machine = machines.last(where: { $0.name == host })
-                ?? machines.first(where: \.isDefault)
-            {
-                return RegistryCredential(user: machine.login, password: machine.password)
-            }
-        }
-        return nil
-    }
-}
-
-enum Netrc {
     static func resolve(
         _ configuration: SwifterPMNetrcConfiguration,
         environment: [String: String]
-    ) async throws -> ResolvedNetrc {
-        guard configuration.isEnabled else { return .none }
+    ) async throws -> Netrc {
+        guard configuration.isEnabled else { return .empty }
 
         // An explicit `--netrc-file` is the only source when it is given, and it has
         // to be there. SwiftPM refuses to run on a missing one rather than downgrading
@@ -58,7 +44,7 @@ enum Netrc {
             guard try await fileSystem.exists(path.absolutePath, isDirectory: false) else {
                 throw ToolError.message("did not find netrc file at \(path.path)")
             }
-            return ResolvedNetrc(sources: [NetrcParser.machines(in: try await contents(of: path))])
+            return Netrc(sources: [NetrcParser.machines(in: try await contents(of: path))])
         }
 
         var sources: [[NetrcMachine]] = []
@@ -71,7 +57,19 @@ enum Netrc {
                 sources.append(NetrcParser.machines(in: content))
             }
         }
-        return ResolvedNetrc(sources: sources)
+        return Netrc(sources: sources)
+    }
+
+    func credential(for url: URL) -> RegistryCredential? {
+        guard let host = url.host?.lowercased() else { return nil }
+        for machines in sources {
+            if let machine = machines.last(where: { $0.name == host })
+                ?? machines.first(where: \.isDefault)
+            {
+                return RegistryCredential(user: machine.login, password: machine.password)
+            }
+        }
+        return nil
     }
 
     private static func contents(of path: URL) async throws -> String {

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// Where netrc credentials are read from when authenticating registry and HTTP downloads.
+public struct SwifterPMNetrcConfiguration: Equatable, Sendable {
+    /// When false, no netrc source is consulted at all.
+    public var isEnabled: Bool
+    /// An explicit netrc file, as passed through `--netrc-file`. When nil the
+    /// `SWIFTPM_NETRC_DATA` environment variable and `~/.netrc` are used.
+    public var path: URL?
+
+    public init(isEnabled: Bool = true, path: URL? = nil) {
+        self.isEnabled = isEnabled
+        self.path = path
+    }
+
+    public static let `default` = SwifterPMNetrcConfiguration()
+}
+
+enum Netrc {
+    /// SwiftPM refuses to run when `--netrc-file` points at a file that isn't there rather than
+    /// downgrading to unauthenticated requests, which would otherwise surface much later as an
+    /// opaque 401 or 404 from a private registry.
+    static func validate(_ configuration: SwifterPMNetrcConfiguration) async throws {
+        guard configuration.isEnabled, let path = configuration.path else { return }
+        guard try await fileSystem.exists(path.absolutePath, isDirectory: false) else {
+            throw ToolError.message("did not find netrc file at \(path.path)")
+        }
+    }
+
+    static func credential(
+        for url: URL,
+        environment: [String: String]
+    ) async -> RegistryCredential? {
+        let configuration = Environment.netrcConfiguration
+        guard configuration.isEnabled else { return nil }
+
+        if let path = configuration.path {
+            return await credential(for: url, atPath: path)
+        }
+
+        if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty,
+           let credential = RegistryNetrc(content: data).credential(for: url)
+        {
+            return credential
+        }
+
+        guard let home = environment["HOME"] else { return nil }
+        return await credential(
+            for: url,
+            atPath: URL(fileURLWithPath: home).appendingPathComponent(".netrc")
+        )
+    }
+
+    private static func credential(for url: URL, atPath path: URL) async -> RegistryCredential? {
+        guard let data = try? await fileSystem.readFile(at: path.absolutePath),
+              let content = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        return RegistryNetrc(content: content).credential(for: url)
+    }
+}
+
+struct RegistryNetrc {
+    private let machines: [Machine]
+
+    init(content: String) {
+        machines = Self.parse(content: content)
+    }
+
+    func credential(for url: URL) -> RegistryCredential? {
+        guard let host = url.host?.lowercased() else { return nil }
+        let machine = machines.last(where: { $0.name == host }) ?? machines.first(where: \.isDefault)
+        return machine.map { RegistryCredential(user: $0.login, password: $0.password) }
+    }
+
+    private static func parse(content: String) -> [Machine] {
+        var tokens = tokenize(content)
+        var machines: [Machine] = []
+        while let token = tokens.first {
+            switch token {
+            case "machine":
+                tokens.removeFirst()
+                guard let name = tokens.popFirst() else { continue }
+                if let machine = parseMachine(name: name.lowercased(), tokens: &tokens) {
+                    machines.append(machine)
+                }
+            case "default":
+                tokens.removeFirst()
+                if let machine = parseMachine(name: "default", tokens: &tokens) {
+                    machines.append(machine)
+                }
+            default:
+                tokens.removeFirst()
+            }
+        }
+        return machines
+    }
+
+    private static func parseMachine(name: String, tokens: inout [String]) -> Machine? {
+        var login: String?
+        var password: String?
+        while let key = tokens.first {
+            if key == "machine" || key == "default" { break }
+            tokens.removeFirst()
+            switch key {
+            case "login":
+                login = tokens.popFirst()
+            case "password":
+                password = tokens.popFirst()
+            default:
+                _ = tokens.popFirst()
+            }
+            if login != nil, password != nil {
+                while let key = tokens.first, key != "machine", key != "default" {
+                    tokens.removeFirst()
+                }
+                break
+            }
+        }
+        guard let login, let password else { return nil }
+        return Machine(name: name, login: login, password: password)
+    }
+
+    private static func tokenize(_ content: String) -> [String] {
+        var tokens: [String] = []
+        var token = ""
+        var inQuote = false
+        var skippingComment = false
+
+        for character in content {
+            if skippingComment {
+                if character == "\n" {
+                    skippingComment = false
+                }
+                continue
+            }
+            if !inQuote, character == "#" {
+                if !token.isEmpty {
+                    tokens.append(token)
+                    token = ""
+                }
+                skippingComment = true
+                continue
+            }
+            if character == "\"" {
+                inQuote.toggle()
+                continue
+            }
+            if !inQuote, character.isWhitespace {
+                if !token.isEmpty {
+                    tokens.append(token)
+                    token = ""
+                }
+                continue
+            }
+            token.append(character)
+        }
+        if !token.isEmpty {
+            tokens.append(token)
+        }
+        return tokens
+    }
+
+    private struct Machine {
+        let name: String
+        let login: String
+        let password: String
+
+        var isDefault: Bool { name == "default" }
+    }
+}
+
+private extension Array where Element == String {
+    mutating func popFirst() -> String? {
+        isEmpty ? nil : removeFirst()
+    }
+}

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -157,11 +157,10 @@ enum NetrcParser {
                 }
                 continue
             }
-            if !inQuote, character == "#" {
-                if !token.isEmpty {
-                    tokens.append(token)
-                    token = ""
-                }
+            // Only a `#` that opens a token starts a comment. SwiftPM's netrc regex
+            // requires whitespace ahead of it and curl agrees, so `password se#cret`
+            // is a password rather than a truncated one followed by a comment.
+            if !inQuote, character == "#", token.isEmpty {
                 skippingComment = true
                 continue
             }

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -7,10 +7,14 @@ public struct SwifterPMNetrcConfiguration: Equatable, Sendable {
     /// An explicit netrc file, as passed through `--netrc-file`. When nil the
     /// `SWIFTPM_NETRC_DATA` environment variable and `~/.netrc` are used.
     public var path: URL?
+    /// `--netrc`, SwiftPM's `forceNetrc`: skip the OS credential store for registry
+    /// requests so a netrc entry beats a keychain item for the same host.
+    public var forcesNetrc: Bool
 
-    public init(isEnabled: Bool = true, path: URL? = nil) {
+    public init(isEnabled: Bool = true, path: URL? = nil, forcesNetrc: Bool = false) {
         self.isEnabled = isEnabled
         self.path = path
+        self.forcesNetrc = forcesNetrc
     }
 
     public static let `default` = SwifterPMNetrcConfiguration()
@@ -33,21 +37,49 @@ struct NetrcSource: Sendable {
 /// The netrc credentials a resolution runs with, read and parsed once up front so
 /// every later lookup is a search over `sources` rather than another file read.
 struct Netrc: Sendable {
-    static let empty = Netrc(sources: [])
+    static let empty = Netrc(configuration: .default, sources: [])
 
+    /// What was asked for, kept so a child `swift package` invocation can be given
+    /// the same flags this process resolved from.
+    let configuration: SwifterPMNetrcConfiguration
     /// Parsed sources in priority order, the environment ahead of any file, matching
     /// the order SwiftPM appends its netrc providers in.
     private let sources: [NetrcSource]
 
-    init(sources: [NetrcSource]) {
+    init(configuration: SwifterPMNetrcConfiguration = .default, sources: [NetrcSource]) {
+        self.configuration = configuration
         self.sources = sources
+    }
+
+    /// Skips the keychain for registry requests, SwiftPM's `forceNetrc`.
+    var forcesNetrc: Bool { configuration.forcesNetrc }
+
+    /// The netrc flags to hand a child `swift package` invocation so it authenticates
+    /// against the same credentials this process does.
+    var swiftPackageArguments: [String] {
+        guard configuration.isEnabled else { return ["--disable-netrc"] }
+        var arguments: [String] = []
+        if let path = configuration.path {
+            arguments.append(contentsOf: ["--netrc-file", path.path])
+        }
+        if configuration.forcesNetrc {
+            arguments.append("--netrc")
+        }
+        return arguments
     }
 
     static func resolve(
         _ configuration: SwifterPMNetrcConfiguration,
         environment: [String: String]
     ) async throws -> Netrc {
-        guard configuration.isEnabled else { return .empty }
+        // SwiftPM rejects this pair outright rather than letting one win, and this is
+        // the choke point every entry point goes through, embedders included.
+        if !configuration.isEnabled, configuration.path != nil {
+            throw ToolError.message("'--disable-netrc' and '--netrc-file' are mutually exclusive")
+        }
+        guard configuration.isEnabled else {
+            return Netrc(configuration: configuration, sources: [])
+        }
 
         var sources: [NetrcSource] = []
         if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty {
@@ -70,7 +102,7 @@ struct Netrc: Sendable {
                 sources.append(NetrcSource(origin: .file, machines: NetrcParser.machines(in: content)))
             }
         }
-        return Netrc(sources: sources)
+        return Netrc(configuration: configuration, sources: sources)
     }
 
     func credential(for url: URL) -> RegistryCredential? {
@@ -148,11 +180,11 @@ enum NetrcParser {
             tokens.removeFirst()
             switch key {
             case "login":
-                login = tokens.popFirst()
+                login = tokens.popFirstValue()
             case "password":
-                password = tokens.popFirst()
+                password = tokens.popFirstValue()
             default:
-                _ = tokens.popFirst()
+                _ = tokens.popFirstValue()
             }
             if login != nil, password != nil {
                 while let key = tokens.first, key != "machine", key != "default" {
@@ -208,5 +240,14 @@ enum NetrcParser {
 private extension Array where Element == String {
     mutating func popFirst() -> String? {
         isEmpty ? nil : removeFirst()
+    }
+
+    /// Pops a value, refusing one that opens the next entry. A `login` or `password`
+    /// whose value never materialises, from an empty quoted string or a value that
+    /// starts a comment, would otherwise consume the following `machine` keyword and
+    /// take the rest of the file down with it.
+    mutating func popFirstValue() -> String? {
+        guard let first, first != "machine", first != "default" else { return nil }
+        return removeFirst()
     }
 }

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -16,17 +16,30 @@ public struct SwifterPMNetrcConfiguration: Equatable, Sendable {
     public static let `default` = SwifterPMNetrcConfiguration()
 }
 
+/// Where a set of parsed netrc entries came from. SwiftPM interleaves the keychain
+/// between the two for registry requests, so the distinction has to survive parsing.
+enum NetrcOrigin: Equatable, Sendable {
+    /// `SWIFTPM_NETRC_DATA`.
+    case environment
+    /// `--netrc-file`, or `~/.netrc` when no file was given.
+    case file
+}
+
+struct NetrcSource: Sendable {
+    let origin: NetrcOrigin
+    let machines: [NetrcMachine]
+}
+
 /// The netrc credentials a resolution runs with, read and parsed once up front so
 /// every later lookup is a search over `sources` rather than another file read.
 struct Netrc: Sendable {
     static let empty = Netrc(sources: [])
 
-    /// Parsed sources in priority order. `SWIFTPM_NETRC_DATA` and `~/.netrc` are
-    /// both consulted, the environment first, because a host missing from one has
-    /// always fallen through to the other.
-    private let sources: [[NetrcMachine]]
+    /// Parsed sources in priority order, the environment ahead of any file, matching
+    /// the order SwiftPM appends its netrc providers in.
+    private let sources: [NetrcSource]
 
-    init(sources: [[NetrcMachine]]) {
+    init(sources: [NetrcSource]) {
         self.sources = sources
     }
 
@@ -36,37 +49,45 @@ struct Netrc: Sendable {
     ) async throws -> Netrc {
         guard configuration.isEnabled else { return .empty }
 
-        // An explicit `--netrc-file` is the only source when it is given, and it has
-        // to be there. SwiftPM refuses to run on a missing one rather than downgrading
-        // to unauthenticated requests, which would surface much later as an opaque 401
+        var sources: [NetrcSource] = []
+        if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty {
+            sources.append(NetrcSource(origin: .environment, machines: NetrcParser.machines(in: data)))
+        }
+
+        // An explicit `--netrc-file` replaces `~/.netrc`, and it has to be there.
+        // SwiftPM refuses to run on a missing one rather than downgrading to
+        // unauthenticated requests, which would surface much later as an opaque 401
         // or 404 from a private registry.
         if let path = configuration.path {
             guard try await fileSystem.exists(path.absolutePath, isDirectory: false) else {
                 throw ToolError.message("did not find netrc file at \(path.path)")
             }
-            return Netrc(sources: [NetrcParser.machines(in: try await contents(of: path))])
-        }
-
-        var sources: [[NetrcMachine]] = []
-        if let data = environment["SWIFTPM_NETRC_DATA"], !data.isEmpty {
-            sources.append(NetrcParser.machines(in: data))
-        }
-        if let home = environment["HOME"] {
+            sources.append(
+                NetrcSource(origin: .file, machines: NetrcParser.machines(in: try await contents(of: path))))
+        } else if let home = environment["HOME"] {
             let path = URL(fileURLWithPath: home).appendingPathComponent(".netrc")
             if let content = try? await contents(of: path) {
-                sources.append(NetrcParser.machines(in: content))
+                sources.append(NetrcSource(origin: .file, machines: NetrcParser.machines(in: content)))
             }
         }
         return Netrc(sources: sources)
     }
 
     func credential(for url: URL) -> RegistryCredential? {
+        credential(for: url, in: sources)
+    }
+
+    func credential(for url: URL, from origin: NetrcOrigin) -> RegistryCredential? {
+        credential(for: url, in: sources.filter { $0.origin == origin })
+    }
+
+    private func credential(for url: URL, in sources: [NetrcSource]) -> RegistryCredential? {
         guard let host = url.host?.lowercased() else { return nil }
-        for machines in sources {
+        for source in sources {
             // First match rather than last: SwiftPM and curl both resolve a duplicated
             // host to the entry that appears first.
-            if let machine = machines.first(where: { $0.name == host })
-                ?? machines.first(where: \.isDefault)
+            if let machine = source.machines.first(where: { $0.name == host })
+                ?? source.machines.first(where: \.isDefault)
             {
                 return RegistryCredential(user: machine.login, password: machine.password)
             }

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -129,23 +129,38 @@ enum RegistryAuthorization {
             )
         }
 
-        // Inline netrc data, then the keychain, then any netrc file. SwiftPM's
-        // registry provider reads SWIFTPM_NETRC_DATA before anything else and then
-        // orders the rest "OS-specific AuthorizationProvider has higher precedence",
-        // which is the opposite of how it orders its download provider.
-        if let credential = Environment.netrc.credential(for: url, from: .environment) {
-            return header(for: credential, url: url, registryConfig: registryConfig)
-        }
-
-        if let credential = await RegistryKeychain.credential(for: url) {
-            return header(for: credential, url: url, registryConfig: registryConfig)
-        }
-
-        if let credential = Environment.netrc.credential(for: url, from: .file) {
+        let netrc = Environment.netrc
+        if let credential = await prioritizedCredential(
+            environmentNetrc: netrc.credential(for: url, from: .environment),
+            fileNetrc: netrc.credential(for: url, from: .file),
+            forcesNetrc: netrc.forcesNetrc,
+            keychain: { await RegistryKeychain.credential(for: url) }
+        ) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 
         return nil
+    }
+
+    /// Registry credentials in SwiftPM's order: inline netrc data, then the OS
+    /// credential store, then any netrc file. `makeRegistryAuthorizationProvider`
+    /// returns immediately on `SWIFTPM_NETRC_DATA` and otherwise takes
+    /// `providers.first` with the keychain appended ahead of netrc, so this is the
+    /// reverse of how its download provider is composed.
+    ///
+    /// Where it differs on purpose: upstream selects one provider and stops, so a
+    /// host missing from the chosen one gets no credentials, while a miss here falls
+    /// through to the next source. That fall-through is what lets `--netrc-file`
+    /// reach registry auth at all when a keychain item exists.
+    static func prioritizedCredential(
+        environmentNetrc: RegistryCredential?,
+        fileNetrc: RegistryCredential?,
+        forcesNetrc: Bool,
+        keychain: () async -> RegistryCredential?
+    ) async -> RegistryCredential? {
+        if let environmentNetrc { return environmentNetrc }
+        if !forcesNetrc, let credential = await keychain() { return credential }
+        return fileNetrc
     }
 
     static func header(

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -129,15 +129,19 @@ enum RegistryAuthorization {
             )
         }
 
-        // Netrc is resolved ahead of the keychain to match SwiftPM, whose composite
-        // authorization provider asks the netrc provider first: an entry the user
-        // just wrote to the file they pointed us at must not lose to a stale
-        // keychain item for the same host.
-        if let credential = Environment.netrc.credential(for: url) {
+        // Inline netrc data, then the keychain, then any netrc file. SwiftPM's
+        // registry provider reads SWIFTPM_NETRC_DATA before anything else and then
+        // orders the rest "OS-specific AuthorizationProvider has higher precedence",
+        // which is the opposite of how it orders its download provider.
+        if let credential = Environment.netrc.credential(for: url, from: .environment) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 
         if let credential = await RegistryKeychain.credential(for: url) {
+            return header(for: credential, url: url, registryConfig: registryConfig)
+        }
+
+        if let credential = Environment.netrc.credential(for: url, from: .file) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -133,7 +133,7 @@ enum RegistryAuthorization {
         // authorization provider asks the netrc provider first: an entry the user
         // just wrote to the file they pointed us at must not lose to a stale
         // keychain item for the same host.
-        if let credential = await Netrc.credential(for: url, environment: environment) {
+        if let credential = Environment.resolvedNetrc.credential(for: url) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -133,7 +133,7 @@ enum RegistryAuthorization {
         // authorization provider asks the netrc provider first: an entry the user
         // just wrote to the file they pointed us at must not lose to a stale
         // keychain item for the same host.
-        if let credential = Environment.resolvedNetrc.credential(for: url) {
+        if let credential = Environment.netrc.credential(for: url) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -114,11 +114,11 @@ struct RegistryCredential: Sendable {
 
 enum RegistryAuthorization {
     static func header(for url: URL, registryConfig: RegistryConfig) async -> String? {
-        if let token = nonEmpty(ProcessInfo.processInfo.environment["SWIFTPM_REGISTRY_TOKEN"]) {
+        let environment = Environment.current
+        if let token = nonEmpty(environment["SWIFTPM_REGISTRY_TOKEN"]) {
             return bearerHeader(token)
         }
 
-        let environment = ProcessInfo.processInfo.environment
         if let login = nonEmpty(environment["SWIFTPM_REGISTRY_LOGIN"]),
            let password = nonEmpty(environment["SWIFTPM_REGISTRY_PASSWORD"])
         {
@@ -129,24 +129,16 @@ enum RegistryAuthorization {
             )
         }
 
-        if let netrcData = nonEmpty(environment["SWIFTPM_NETRC_DATA"]),
-           let credential = RegistryNetrc(content: netrcData).credential(for: url)
-        {
+        // Netrc is resolved ahead of the keychain to match SwiftPM, whose composite
+        // authorization provider asks the netrc provider first: an entry the user
+        // just wrote to the file they pointed us at must not lose to a stale
+        // keychain item for the same host.
+        if let credential = await Netrc.credential(for: url, environment: environment) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
 
         if let credential = await RegistryKeychain.credential(for: url) {
             return header(for: credential, url: url, registryConfig: registryConfig)
-        }
-
-        if let home = environment["HOME"] {
-            let netrcPath = URL(fileURLWithPath: home).appendingPathComponent(".netrc")
-            if let data = try? await fileSystem.readFile(at: netrcPath.absolutePath),
-               let content = String(data: data, encoding: .utf8),
-               let credential = RegistryNetrc(content: content).credential(for: url)
-            {
-                return header(for: credential, url: url, registryConfig: registryConfig)
-            }
         }
 
         return nil
@@ -182,116 +174,6 @@ enum RegistryAuthorization {
     private static func nonEmpty(_ value: String?) -> String? {
         guard let value, !value.isEmpty else { return nil }
         return value
-    }
-}
-
-struct RegistryNetrc {
-    private let machines: [Machine]
-
-    init(content: String) {
-        machines = Self.parse(content: content)
-    }
-
-    func credential(for url: URL) -> RegistryCredential? {
-        guard let host = url.host?.lowercased() else { return nil }
-        let machine = machines.last(where: { $0.name == host }) ?? machines.first(where: \.isDefault)
-        return machine.map { RegistryCredential(user: $0.login, password: $0.password) }
-    }
-
-    private static func parse(content: String) -> [Machine] {
-        var tokens = tokenize(content)
-        var machines: [Machine] = []
-        while let token = tokens.first {
-            switch token {
-            case "machine":
-                tokens.removeFirst()
-                guard let name = tokens.popFirst() else { continue }
-                if let machine = parseMachine(name: name.lowercased(), tokens: &tokens) {
-                    machines.append(machine)
-                }
-            case "default":
-                tokens.removeFirst()
-                if let machine = parseMachine(name: "default", tokens: &tokens) {
-                    machines.append(machine)
-                }
-            default:
-                tokens.removeFirst()
-            }
-        }
-        return machines
-    }
-
-    private static func parseMachine(name: String, tokens: inout [String]) -> Machine? {
-        var login: String?
-        var password: String?
-        while let key = tokens.first {
-            if key == "machine" || key == "default" { break }
-            tokens.removeFirst()
-            switch key {
-            case "login":
-                login = tokens.popFirst()
-            case "password":
-                password = tokens.popFirst()
-            default:
-                _ = tokens.popFirst()
-            }
-            if login != nil, password != nil {
-                while let key = tokens.first, key != "machine", key != "default" {
-                    tokens.removeFirst()
-                }
-                break
-            }
-        }
-        guard let login, let password else { return nil }
-        return Machine(name: name, login: login, password: password)
-    }
-
-    private static func tokenize(_ content: String) -> [String] {
-        var tokens: [String] = []
-        var token = ""
-        var inQuote = false
-        var skippingComment = false
-
-        for character in content {
-            if skippingComment {
-                if character == "\n" {
-                    skippingComment = false
-                }
-                continue
-            }
-            if !inQuote, character == "#" {
-                if !token.isEmpty {
-                    tokens.append(token)
-                    token = ""
-                }
-                skippingComment = true
-                continue
-            }
-            if character == "\"" {
-                inQuote.toggle()
-                continue
-            }
-            if !inQuote, character.isWhitespace {
-                if !token.isEmpty {
-                    tokens.append(token)
-                    token = ""
-                }
-                continue
-            }
-            token.append(character)
-        }
-        if !token.isEmpty {
-            tokens.append(token)
-        }
-        return tokens
-    }
-
-    private struct Machine {
-        let name: String
-        let login: String
-        let password: String
-
-        var isDefault: Bool { name == "default" }
     }
 }
 
@@ -521,12 +403,6 @@ enum RegistryClient {
         return registryURL.appendingPathComponents(components)
     }
 
-}
-
-private extension Array where Element == String {
-    mutating func popFirst() -> String? {
-        isEmpty ? nil : removeFirst()
-    }
 }
 
 extension URL {

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -159,6 +159,11 @@ enum PackageResolver {
         if disableSandbox {
             arguments.append("--disable-sandbox")
         }
+        // The child solves the graph, which means it fetches availability and
+        // manifests from the same registries this process authenticates against. Its
+        // environment is inherited, so `SWIFTPM_NETRC_DATA` already reaches it, but
+        // the flags are ours alone until they are forwarded.
+        arguments.append(contentsOf: Environment.netrc.swiftPackageArguments)
         switch scmToRegistryTransformation {
         case .disabled:
             arguments.append("--disable-scm-to-registry-transformation")

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -276,7 +276,7 @@ enum HTTPAuthorization {
         // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
         if let header = prioritizedHeader(
             isGitHub: isGitHub(url),
-            netrcCredential: Environment.resolvedNetrc.credential(for: url),
+            netrcCredential: Environment.netrc.credential(for: url),
             gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
         ) {
             return header

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -265,18 +265,18 @@ enum HTTPClient {
 
 enum HTTPAuthorization {
     static func header(for url: URL) async -> String? {
-        let environment = ProcessInfo.processInfo.environment
+        let environment = Environment.current
 
         // Explicit, host-scoped credentials win over an ambient GitHub token. A
-        // `machine api.github.com` entry in ~/.netrc (or SWIFTPM_NETRC_DATA) is a
-        // deliberate per-host credential, so it must beat a generic GITHUB_TOKEN /
+        // `machine api.github.com` entry in a netrc file is a deliberate per-host
+        // credential, so it must beat a generic GITHUB_TOKEN /
         // GH_TOKEN that may be scoped to an unrelated repository — otherwise a
         // repo-scoped CI token shadows the netrc credential that can actually read
         // a private release asset. This mirrors SwiftPM, whose download
         // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
         if let header = prioritizedHeader(
             isGitHub: isGitHub(url),
-            netrcCredential: await netrcCredential(for: url, environment: environment),
+            netrcCredential: await Netrc.credential(for: url, environment: environment),
             gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
         ) {
             return header
@@ -300,29 +300,6 @@ enum HTTPAuthorization {
         if isGitHub, let token = nonEmpty(gitHubEnvToken) {
             return bearerHeader(token)
         }
-        return nil
-    }
-
-    private static func netrcCredential(
-        for url: URL,
-        environment: [String: String]
-    ) async -> RegistryCredential? {
-        if let netrcData = nonEmpty(environment["SWIFTPM_NETRC_DATA"]),
-           let credential = RegistryNetrc(content: netrcData).credential(for: url)
-        {
-            return credential
-        }
-
-        if let home = environment["HOME"] {
-            let netrcPath = URL(fileURLWithPath: home).appendingPathComponent(".netrc")
-            if let data = try? await fileSystem.readFile(at: netrcPath.absolutePath),
-               let content = String(data: data, encoding: .utf8),
-               let credential = RegistryNetrc(content: content).credential(for: url)
-            {
-                return credential
-            }
-        }
-
         return nil
     }
 

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -276,7 +276,7 @@ enum HTTPAuthorization {
         // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
         if let header = prioritizedHeader(
             isGitHub: isGitHub(url),
-            netrcCredential: await Netrc.credential(for: url, environment: environment),
+            netrcCredential: Environment.resolvedNetrc.credential(for: url),
             gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
         ) {
             return header

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -37,6 +37,7 @@ public struct SwifterPMResolutionRequest: Sendable {
     public var scratchDirectory: URL?
     public var registryConfigurationPath: URL?
     public var defaultRegistryURL: String?
+    public var netrc: SwifterPMNetrcConfiguration
     public var disableSandbox: Bool
     public var forceResolvedVersions: Bool
     public var skipUpdate: Bool
@@ -54,6 +55,7 @@ public struct SwifterPMResolutionRequest: Sendable {
         scratchDirectory: URL? = nil,
         registryConfigurationPath: URL? = nil,
         defaultRegistryURL: String? = nil,
+        netrc: SwifterPMNetrcConfiguration = .default,
         disableSandbox: Bool = false,
         forceResolvedVersions: Bool = false,
         skipUpdate: Bool = false,
@@ -70,6 +72,7 @@ public struct SwifterPMResolutionRequest: Sendable {
         self.scratchDirectory = scratchDirectory
         self.registryConfigurationPath = registryConfigurationPath
         self.defaultRegistryURL = defaultRegistryURL
+        self.netrc = netrc
         self.disableSandbox = disableSandbox
         self.forceResolvedVersions = forceResolvedVersions
         self.skipUpdate = skipUpdate
@@ -89,6 +92,7 @@ public struct SwifterPMRestoreRequest: Sendable {
     public var scratchDirectory: URL?
     public var registryConfigurationPath: URL?
     public var defaultRegistryURL: String?
+    public var netrc: SwifterPMNetrcConfiguration
     public var disableSandbox: Bool
     public var disablePackageInfoCache: Bool
     public var packageInfoCacheDirectory: URL?
@@ -101,6 +105,7 @@ public struct SwifterPMRestoreRequest: Sendable {
         scratchDirectory: URL? = nil,
         registryConfigurationPath: URL? = nil,
         defaultRegistryURL: String? = nil,
+        netrc: SwifterPMNetrcConfiguration = .default,
         disableSandbox: Bool = false,
         disablePackageInfoCache: Bool = false,
         packageInfoCacheDirectory: URL? = nil,
@@ -112,6 +117,7 @@ public struct SwifterPMRestoreRequest: Sendable {
         self.scratchDirectory = scratchDirectory
         self.registryConfigurationPath = registryConfigurationPath
         self.defaultRegistryURL = defaultRegistryURL
+        self.netrc = netrc
         self.disableSandbox = disableSandbox
         self.disablePackageInfoCache = disablePackageInfoCache
         self.packageInfoCacheDirectory = packageInfoCacheDirectory
@@ -126,28 +132,37 @@ public struct SwifterPM: Sendable {
     public func resolve(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Environment.withCachedDirectoryMaterialization(
-            request.cachedDirectoryMaterialization
-        ) {
-            try await runResolution(request: request, preferResolvedFile: true)
+        try await Netrc.validate(request.netrc)
+        return try await Environment.withNetrc(request.netrc) {
+            try await Environment.withCachedDirectoryMaterialization(
+                request.cachedDirectoryMaterialization
+            ) {
+                try await runResolution(request: request, preferResolvedFile: true)
+            }
         }
     }
 
     public func update(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Environment.withCachedDirectoryMaterialization(
-            request.cachedDirectoryMaterialization
-        ) {
-            try await runResolution(request: request, preferResolvedFile: false)
+        try await Netrc.validate(request.netrc)
+        return try await Environment.withNetrc(request.netrc) {
+            try await Environment.withCachedDirectoryMaterialization(
+                request.cachedDirectoryMaterialization
+            ) {
+                try await runResolution(request: request, preferResolvedFile: false)
+            }
         }
     }
 
     public func restore(_ request: SwifterPMRestoreRequest) async throws {
-        try await Environment.withCachedDirectoryMaterialization(
-            request.cachedDirectoryMaterialization
-        ) {
-            try await runRestore(request)
+        try await Netrc.validate(request.netrc)
+        try await Environment.withNetrc(request.netrc) {
+            try await Environment.withCachedDirectoryMaterialization(
+                request.cachedDirectoryMaterialization
+            ) {
+                try await runRestore(request)
+            }
         }
     }
 

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -132,7 +132,7 @@ public struct SwifterPM: Sendable {
     public func resolve(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
+        try await Environment.withNetrc(try await loadNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
@@ -144,7 +144,7 @@ public struct SwifterPM: Sendable {
     public func update(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
+        try await Environment.withNetrc(try await loadNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
@@ -154,7 +154,7 @@ public struct SwifterPM: Sendable {
     }
 
     public func restore(_ request: SwifterPMRestoreRequest) async throws {
-        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
+        try await Environment.withNetrc(try await loadNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
@@ -163,9 +163,7 @@ public struct SwifterPM: Sendable {
         }
     }
 
-    private func resolvedNetrc(_ configuration: SwifterPMNetrcConfiguration) async throws
-        -> ResolvedNetrc
-    {
+    private func loadNetrc(_ configuration: SwifterPMNetrcConfiguration) async throws -> Netrc {
         try await Netrc.resolve(configuration, environment: Environment.current)
     }
 

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -132,8 +132,7 @@ public struct SwifterPM: Sendable {
     public func resolve(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Netrc.validate(request.netrc)
-        return try await Environment.withNetrc(request.netrc) {
+        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
@@ -145,8 +144,7 @@ public struct SwifterPM: Sendable {
     public func update(_ request: SwifterPMResolutionRequest) async throws
         -> SwifterPMResolutionResult
     {
-        try await Netrc.validate(request.netrc)
-        return try await Environment.withNetrc(request.netrc) {
+        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
@@ -156,14 +154,19 @@ public struct SwifterPM: Sendable {
     }
 
     public func restore(_ request: SwifterPMRestoreRequest) async throws {
-        try await Netrc.validate(request.netrc)
-        try await Environment.withNetrc(request.netrc) {
+        try await Environment.withNetrc(try await resolvedNetrc(request.netrc)) {
             try await Environment.withCachedDirectoryMaterialization(
                 request.cachedDirectoryMaterialization
             ) {
                 try await runRestore(request)
             }
         }
+    }
+
+    private func resolvedNetrc(_ configuration: SwifterPMNetrcConfiguration) async throws
+        -> ResolvedNetrc
+    {
+        try await Netrc.resolve(configuration, environment: Environment.current)
     }
 
     private func runRestore(_ request: SwifterPMRestoreRequest) async throws {

--- a/swifterpm/Tests/swifterpmTests/CLITests.swift
+++ b/swifterpm/Tests/swifterpmTests/CLITests.swift
@@ -128,14 +128,8 @@ struct CLITests {
 
     @Test
     func resolveParsesNetrcOptions() throws {
-        let cli = try CLIParser.parse([
-            "--netrc-file", "/tmp/netrc",
-            "--disable-netrc",
-            "resolve",
-        ])
-
-        #expect(cli.netrcFile?.path == "/tmp/netrc")
-        #expect(!cli.netrc)
+        #expect(try CLIParser.parse(["--netrc-file", "/tmp/netrc", "resolve"]).netrcFile?.path == "/tmp/netrc")
+        #expect(!(try CLIParser.parse(["--disable-netrc", "resolve"]).netrc))
     }
 
     @Test
@@ -144,7 +138,16 @@ struct CLITests {
         #expect(try CLIParser.parse(["--enable-netrc", "resolve"]).netrc)
     }
 
-    @Test(arguments: ["--disable-prefetching", "--enable-prefetching", "--netrc"])
+    @Test
+    func forceNetrcIsAParsedFlagRatherThanAnIgnoredOne() throws {
+        // `--netrc` is SwiftPM's `forceNetrc`, which disables the keychain for
+        // registry requests. Stripping it as a deprecated spelling of
+        // `--enable-netrc` would silently invert registry precedence.
+        #expect(try CLIParser.parse(["--netrc", "resolve"]).forceNetrc)
+        #expect(!(try CLIParser.parse(["resolve"]).forceNetrc))
+    }
+
+    @Test(arguments: ["--disable-prefetching", "--enable-prefetching"])
     func deprecatedSwiftPackageManagerOptionsAreAccepted(option: String) throws {
         // `tuist install` forwards passthrough arguments verbatim and ahead of the
         // action, and SwiftPM still exits 0 on these, so rejecting them would break

--- a/swifterpm/Tests/swifterpmTests/CLITests.swift
+++ b/swifterpm/Tests/swifterpmTests/CLITests.swift
@@ -126,7 +126,25 @@ struct CLITests {
         }
     }
 
-    @Test(arguments: ["--disable-prefetching", "--enable-prefetching"])
+    @Test
+    func resolveParsesNetrcOptions() throws {
+        let cli = try CLIParser.parse([
+            "--netrc-file", "/tmp/netrc",
+            "--disable-netrc",
+            "resolve",
+        ])
+
+        #expect(cli.netrcFile?.path == "/tmp/netrc")
+        #expect(!cli.netrc)
+    }
+
+    @Test
+    func netrcIsEnabledByDefault() throws {
+        #expect(try CLIParser.parse(["resolve"]).netrc)
+        #expect(try CLIParser.parse(["--enable-netrc", "resolve"]).netrc)
+    }
+
+    @Test(arguments: ["--disable-prefetching", "--enable-prefetching", "--netrc"])
     func deprecatedSwiftPackageManagerOptionsAreAccepted(option: String) throws {
         // `tuist install` forwards passthrough arguments verbatim and ahead of the
         // action, and SwiftPM still exits 0 on these, so rejecting them would break
@@ -155,12 +173,14 @@ struct CLITests {
             let scratch = root.appendingPathComponent("Scratch")
             let config = root.appendingPathComponent("registries.json")
             let packageInfoCache = root.appendingPathComponent("PackageInfo")
+            let netrc = root.appendingPathComponent("netrc")
 
             let command = try await SwifterPMCommandParser.parse([
                 "--package-path", package.path,
                 "--cache-path", cache.path,
                 "--scratch-path", scratch.path,
                 "--config-path", config.path,
+                "--netrc-file", netrc.path,
                 "--default-registry-url", "https://registry.example.com",
                 "--disable-sandbox",
                 "--force-resolved-versions",
@@ -180,6 +200,7 @@ struct CLITests {
             #expect(request.cacheDirectory == cache.standardizedFileURL)
             #expect(request.scratchDirectory == scratch.standardizedFileURL)
             #expect(request.registryConfigurationPath == config.standardizedFileURL)
+            #expect(request.netrc == SwifterPMNetrcConfiguration(path: netrc.standardizedFileURL))
             #expect(request.defaultRegistryURL == "https://registry.example.com")
             #expect(request.disableSandbox)
             #expect(request.forceResolvedVersions)

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+@testable import SwifterPMCore
+
+struct NetrcTests {
+    @Test
+    func credentialReadsTheConfiguredNetrcFile() async throws {
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login example password from-file",
+                to: netrcFile
+            )
+
+            let credential = try await Environment.withNetrc(
+                SwifterPMNetrcConfiguration(path: netrcFile)
+            ) {
+                await Netrc.credential(
+                    for: try #require(URL(string: "https://registry.example.com")),
+                    environment: [:]
+                )
+            }
+
+            #expect(credential?.user == "example")
+            #expect(credential?.password == "from-file")
+        }
+    }
+
+    @Test
+    func configuredNetrcFileBeatsEnvironmentData() async throws {
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login example password from-file",
+                to: netrcFile
+            )
+
+            let credential = try await Environment.withNetrc(
+                SwifterPMNetrcConfiguration(path: netrcFile)
+            ) {
+                await Netrc.credential(
+                    for: try #require(URL(string: "https://registry.example.com")),
+                    environment: [
+                        "SWIFTPM_NETRC_DATA":
+                            "machine registry.example.com login example password from-environment",
+                    ]
+                )
+            }
+
+            #expect(credential?.password == "from-file")
+        }
+    }
+
+    @Test
+    func credentialFallsBackToTheHomeNetrcFile() async throws {
+        try await withTemporaryDirectory { root in
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login example password from-home",
+                to: root.appendingPathComponent(".netrc")
+            )
+
+            let credential = await Netrc.credential(
+                for: try #require(URL(string: "https://registry.example.com")),
+                environment: ["HOME": root.path]
+            )
+
+            #expect(credential?.password == "from-home")
+        }
+    }
+
+    @Test
+    func disabledNetrcIgnoresEveryCredentialSource() async throws {
+        try await withTemporaryDirectory { root in
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login example password from-home",
+                to: root.appendingPathComponent(".netrc")
+            )
+
+            let credential = try await Environment.withNetrc(
+                SwifterPMNetrcConfiguration(isEnabled: false)
+            ) {
+                await Netrc.credential(
+                    for: try #require(URL(string: "https://registry.example.com")),
+                    environment: [
+                        "HOME": root.path,
+                        "SWIFTPM_NETRC_DATA":
+                            "machine registry.example.com login example password from-environment",
+                    ]
+                )
+            }
+
+            #expect(credential == nil)
+        }
+    }
+
+    @Test
+    func validateRejectsAMissingConfiguredNetrcFile() async throws {
+        try await withTemporaryDirectory { root in
+            let missing = root.appendingPathComponent("netrc")
+
+            await #expect(throws: (any Error).self) {
+                try await Netrc.validate(SwifterPMNetrcConfiguration(path: missing))
+            }
+        }
+    }
+
+    @Test
+    func validateAcceptsAnExistingFileAMissingOneWhenDisabledAndNoFileAtAll() async throws {
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite("machine example.com login a password b", to: netrcFile)
+
+            try await Netrc.validate(SwifterPMNetrcConfiguration(path: netrcFile))
+            try await Netrc.validate(
+                SwifterPMNetrcConfiguration(
+                    isEnabled: false, path: root.appendingPathComponent("missing")))
+            try await Netrc.validate(SwifterPMNetrcConfiguration())
+        }
+    }
+
+    @Test
+    func registryAuthorizationUsesTheConfiguredNetrcFile() async throws {
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login user password secret",
+                to: netrcFile
+            )
+            let config = try await RegistryConfig.load(
+                packageDir: root,
+                configPath: nil,
+                defaultRegistryURL: "https://registry.example.com"
+            )
+
+            let header = try await Environment.$values.withValue([:]) {
+                try await Environment.withNetrc(SwifterPMNetrcConfiguration(path: netrcFile)) {
+                    await RegistryAuthorization.header(
+                        for: try #require(URL(string: "https://registry.example.com")),
+                        registryConfig: config
+                    )
+                }
+            }
+
+            #expect(header == "Basic dXNlcjpzZWNyZXQ=")
+        }
+    }
+
+    @Test
+    func httpAuthorizationUsesTheConfiguredNetrcFileOverTheAmbientGitHubToken() async throws {
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite(
+                "machine api.github.com login x-access-token password from-file",
+                to: netrcFile
+            )
+
+            let header = try await Environment.$values.withValue(["GITHUB_TOKEN": "ambient"]) {
+                try await Environment.withNetrc(SwifterPMNetrcConfiguration(path: netrcFile)) {
+                    await HTTPAuthorization.header(
+                        for: try #require(
+                            URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1"))
+                    )
+                }
+            }
+
+            #expect(header == "Basic eC1hY2Nlc3MtdG9rZW46ZnJvbS1maWxl")
+        }
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -40,6 +40,21 @@ struct NetrcTests {
     }
 
     @Test
+    func parserKeepsAHashInsideAValueAndStripsATrailingComment() {
+        // curl and SwiftPM both open a comment only where `#` starts a token, so a
+        // password containing one has to survive whole. Truncating it silently sends
+        // a wrong password, which reads as bad credentials rather than bad parsing.
+        let machines = NetrcParser.machines(
+            in: "machine registry.example.com login user password se#cret # trailing"
+        )
+
+        #expect(
+            machines == [
+                NetrcMachine(name: "registry.example.com", login: "user", password: "se#cret")
+            ])
+    }
+
+    @Test
     func parserSkipsEntriesWithoutBothCredentials() {
         let machines = NetrcParser.machines(
             in: """

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -22,6 +22,24 @@ struct NetrcTests {
     }
 
     @Test
+    func credentialUsesTheFirstEntryForADuplicatedHost() throws {
+        // SwiftPM's own netrc resolves duplicates with `machines.firstIndex(where:)`,
+        // and curl sends the first entry too, so a file that both tools read one way
+        // must not authenticate differently here.
+        let machines = NetrcParser.machines(
+            in: """
+            machine registry.example.com login first password one
+            machine registry.example.com login second password two
+            """
+        )
+        let netrc = Netrc(sources: [machines])
+
+        #expect(
+            netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
+                .password == "one")
+    }
+
+    @Test
     func parserSkipsEntriesWithoutBothCredentials() {
         let machines = NetrcParser.machines(
             in: """

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -11,7 +11,7 @@ struct NetrcTests {
             default login fallback password fallback-secret
             """
         )
-        let netrc = ResolvedNetrc(sources: [machines])
+        let netrc = Netrc(sources: [machines])
 
         #expect(
             netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
@@ -176,7 +176,7 @@ struct NetrcTests {
     }
 
     @Test
-    func registryAuthorizationUsesTheResolvedNetrc() async throws {
+    func registryAuthorizationUsesTheLoadedNetrc() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
@@ -205,7 +205,7 @@ struct NetrcTests {
     }
 
     @Test
-    func httpAuthorizationUsesTheResolvedNetrcOverTheAmbientGitHubToken() async throws {
+    func httpAuthorizationUsesTheLoadedNetrcOverTheAmbientGitHubToken() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -4,7 +4,37 @@ import Testing
 
 struct NetrcTests {
     @Test
-    func credentialReadsTheConfiguredNetrcFile() async throws {
+    func parserMatchesHostAndFallsBackToDefault() throws {
+        let machines = NetrcParser.machines(
+            in: """
+            machine registry.example.com login example password secret
+            default login fallback password fallback-secret
+            """
+        )
+        let netrc = ResolvedNetrc(sources: [machines])
+
+        #expect(
+            netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
+                .password == "secret")
+        #expect(
+            netrc.credential(for: try #require(URL(string: "https://other.example.com")))?
+                .password == "fallback-secret")
+    }
+
+    @Test
+    func parserSkipsEntriesWithoutBothCredentials() {
+        let machines = NetrcParser.machines(
+            in: """
+            machine incomplete.example.com login example
+            machine complete.example.com login example password secret
+            """
+        )
+
+        #expect(machines == [NetrcMachine(name: "complete.example.com", login: "example", password: "secret")])
+    }
+
+    @Test
+    func resolveReadsTheConfiguredNetrcFile() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
@@ -12,14 +42,10 @@ struct NetrcTests {
                 to: netrcFile
             )
 
-            let credential = try await Environment.withNetrc(
-                SwifterPMNetrcConfiguration(path: netrcFile)
-            ) {
-                await Netrc.credential(
-                    for: try #require(URL(string: "https://registry.example.com")),
-                    environment: [:]
-                )
-            }
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(path: netrcFile), environment: [:])
+            let credential = netrc.credential(
+                for: try #require(URL(string: "https://registry.example.com")))
 
             #expect(credential?.user == "example")
             #expect(credential?.password == "from-file")
@@ -27,44 +53,78 @@ struct NetrcTests {
     }
 
     @Test
-    func configuredNetrcFileBeatsEnvironmentData() async throws {
+    func configuredNetrcFileIsTheOnlySource() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
                 "machine registry.example.com login example password from-file",
                 to: netrcFile
             )
+            try await fileSystem.atomicWrite(
+                "machine other.example.com login example password from-home",
+                to: root.appendingPathComponent(".netrc")
+            )
 
-            let credential = try await Environment.withNetrc(
-                SwifterPMNetrcConfiguration(path: netrcFile)
-            ) {
-                await Netrc.credential(
-                    for: try #require(URL(string: "https://registry.example.com")),
-                    environment: [
-                        "SWIFTPM_NETRC_DATA":
-                            "machine registry.example.com login example password from-environment",
-                    ]
-                )
-            }
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(path: netrcFile),
+                environment: [
+                    "HOME": root.path,
+                    "SWIFTPM_NETRC_DATA":
+                        "machine registry.example.com login example password from-environment",
+                ]
+            )
 
-            #expect(credential?.password == "from-file")
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
+                    .password == "from-file")
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://other.example.com"))) == nil)
         }
     }
 
     @Test
-    func credentialFallsBackToTheHomeNetrcFile() async throws {
+    func environmentDataWinsButHomeStillCoversOtherHosts() async throws {
+        try await withTemporaryDirectory { root in
+            try await fileSystem.atomicWrite(
+                """
+                machine registry.example.com login example password from-home
+                machine other.example.com login example password home-only
+                """,
+                to: root.appendingPathComponent(".netrc")
+            )
+
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(),
+                environment: [
+                    "HOME": root.path,
+                    "SWIFTPM_NETRC_DATA":
+                        "machine registry.example.com login example password from-environment",
+                ]
+            )
+
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
+                    .password == "from-environment")
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://other.example.com")))?
+                    .password == "home-only")
+        }
+    }
+
+    @Test
+    func resolveFallsBackToTheHomeNetrcFile() async throws {
         try await withTemporaryDirectory { root in
             try await fileSystem.atomicWrite(
                 "machine registry.example.com login example password from-home",
                 to: root.appendingPathComponent(".netrc")
             )
 
-            let credential = await Netrc.credential(
-                for: try #require(URL(string: "https://registry.example.com")),
-                environment: ["HOME": root.path]
-            )
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(), environment: ["HOME": root.path])
 
-            #expect(credential?.password == "from-home")
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
+                    .password == "from-home")
         }
     }
 
@@ -76,50 +136,47 @@ struct NetrcTests {
                 to: root.appendingPathComponent(".netrc")
             )
 
-            let credential = try await Environment.withNetrc(
-                SwifterPMNetrcConfiguration(isEnabled: false)
-            ) {
-                await Netrc.credential(
-                    for: try #require(URL(string: "https://registry.example.com")),
-                    environment: [
-                        "HOME": root.path,
-                        "SWIFTPM_NETRC_DATA":
-                            "machine registry.example.com login example password from-environment",
-                    ]
-                )
-            }
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(isEnabled: false),
+                environment: [
+                    "HOME": root.path,
+                    "SWIFTPM_NETRC_DATA":
+                        "machine registry.example.com login example password from-environment",
+                ]
+            )
 
-            #expect(credential == nil)
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://registry.example.com")))
+                    == nil)
         }
     }
 
     @Test
-    func validateRejectsAMissingConfiguredNetrcFile() async throws {
+    func resolveRejectsAMissingConfiguredNetrcFile() async throws {
         try await withTemporaryDirectory { root in
             let missing = root.appendingPathComponent("netrc")
 
             await #expect(throws: (any Error).self) {
-                try await Netrc.validate(SwifterPMNetrcConfiguration(path: missing))
+                try await Netrc.resolve(
+                    SwifterPMNetrcConfiguration(path: missing), environment: [:])
             }
         }
     }
 
     @Test
-    func validateAcceptsAnExistingFileAMissingOneWhenDisabledAndNoFileAtAll() async throws {
+    func resolveIgnoresAMissingNetrcFileWhenDisabledOrUnconfigured() async throws {
         try await withTemporaryDirectory { root in
-            let netrcFile = root.appendingPathComponent("netrc")
-            try await fileSystem.atomicWrite("machine example.com login a password b", to: netrcFile)
+            let missing = root.appendingPathComponent("netrc")
 
-            try await Netrc.validate(SwifterPMNetrcConfiguration(path: netrcFile))
-            try await Netrc.validate(
-                SwifterPMNetrcConfiguration(
-                    isEnabled: false, path: root.appendingPathComponent("missing")))
-            try await Netrc.validate(SwifterPMNetrcConfiguration())
+            _ = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(isEnabled: false, path: missing), environment: [:])
+            _ = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(), environment: ["HOME": root.path])
         }
     }
 
     @Test
-    func registryAuthorizationUsesTheConfiguredNetrcFile() async throws {
+    func registryAuthorizationUsesTheResolvedNetrc() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
@@ -131,9 +188,11 @@ struct NetrcTests {
                 configPath: nil,
                 defaultRegistryURL: "https://registry.example.com"
             )
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(path: netrcFile), environment: [:])
 
             let header = try await Environment.$values.withValue([:]) {
-                try await Environment.withNetrc(SwifterPMNetrcConfiguration(path: netrcFile)) {
+                try await Environment.withNetrc(netrc) {
                     await RegistryAuthorization.header(
                         for: try #require(URL(string: "https://registry.example.com")),
                         registryConfig: config
@@ -146,16 +205,18 @@ struct NetrcTests {
     }
 
     @Test
-    func httpAuthorizationUsesTheConfiguredNetrcFileOverTheAmbientGitHubToken() async throws {
+    func httpAuthorizationUsesTheResolvedNetrcOverTheAmbientGitHubToken() async throws {
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
                 "machine api.github.com login x-access-token password from-file",
                 to: netrcFile
             )
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(path: netrcFile), environment: [:])
 
             let header = try await Environment.$values.withValue(["GITHUB_TOKEN": "ambient"]) {
-                try await Environment.withNetrc(SwifterPMNetrcConfiguration(path: netrcFile)) {
+                try await Environment.withNetrc(netrc) {
                     await HTTPAuthorization.header(
                         for: try #require(
                             URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1"))

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -55,6 +55,22 @@ struct NetrcTests {
     }
 
     @Test
+    func parserContainsAMissingValueToItsOwnEntry() {
+        // A value that never materialises must not swallow the next `machine`
+        // keyword: the damage belongs to the malformed entry, not to the rest of
+        // the file, which would drop credentials silently.
+        let machines = NetrcParser.machines(
+            in: """
+            machine first.example.com  login user  password ""
+            machine second.example.com login u2    password p2
+            """
+        )
+
+        #expect(
+            machines == [NetrcMachine(name: "second.example.com", login: "u2", password: "p2")])
+    }
+
+    @Test
     func parserSkipsEntriesWithoutBothCredentials() {
         let machines = NetrcParser.machines(
             in: """
@@ -233,15 +249,79 @@ struct NetrcTests {
     }
 
     @Test
-    func resolveIgnoresAMissingNetrcFileWhenDisabledOrUnconfigured() async throws {
+    func resolveIgnoresAMissingHomeNetrcFile() async throws {
         try await withTemporaryDirectory { root in
-            let missing = root.appendingPathComponent("netrc")
-
-            _ = try await Netrc.resolve(
-                SwifterPMNetrcConfiguration(isEnabled: false, path: missing), environment: [:])
             _ = try await Netrc.resolve(
                 SwifterPMNetrcConfiguration(), environment: ["HOME": root.path])
         }
+    }
+
+    @Test
+    func resolveRejectsDisabledNetrcCombinedWithAnExplicitFile() async throws {
+        // SwiftPM fails the command outright here rather than letting one win:
+        // "error: '--disable-netrc' and '--netrc-file' are mutually exclusive".
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite("machine example.com login a password b", to: netrcFile)
+
+            await #expect(throws: (any Error).self) {
+                try await Netrc.resolve(
+                    SwifterPMNetrcConfiguration(isEnabled: false, path: netrcFile), environment: [:])
+            }
+        }
+    }
+
+    @Test
+    func swiftPackageArgumentsCarryTheConfigurationToTheChildProcess() async throws {
+        // The child `swift package resolve` solves the graph, so it hits the same
+        // registries. Its environment is inherited, but flags are not.
+        try await withTemporaryDirectory { root in
+            let netrcFile = root.appendingPathComponent("netrc")
+            try await fileSystem.atomicWrite("machine example.com login a password b", to: netrcFile)
+
+            let file = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(path: netrcFile, forcesNetrc: true), environment: [:])
+            #expect(file.swiftPackageArguments == ["--netrc-file", netrcFile.path, "--netrc"])
+
+            let disabled = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(isEnabled: false), environment: [:])
+            #expect(disabled.swiftPackageArguments == ["--disable-netrc"])
+
+            let defaults = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(), environment: [:])
+            #expect(defaults.swiftPackageArguments.isEmpty)
+        }
+    }
+
+    @Test
+    func registryPrecedenceIsEnvironmentThenKeychainThenFile() async throws {
+        let environmentNetrc = RegistryCredential(user: "u", password: "environment")
+        let fileNetrc = RegistryCredential(user: "u", password: "file")
+        let keychain = RegistryCredential(user: "u", password: "keychain")
+
+        let environmentWins = await RegistryAuthorization.prioritizedCredential(
+            environmentNetrc: environmentNetrc,
+            fileNetrc: fileNetrc,
+            forcesNetrc: false,
+            keychain: { Issue.record("keychain consulted despite inline netrc data"); return keychain }
+        )
+        #expect(environmentWins?.password == "environment")
+
+        let keychainWins = await RegistryAuthorization.prioritizedCredential(
+            environmentNetrc: nil, fileNetrc: fileNetrc, forcesNetrc: false, keychain: { keychain })
+        #expect(keychainWins?.password == "keychain")
+
+        let forced = await RegistryAuthorization.prioritizedCredential(
+            environmentNetrc: nil,
+            fileNetrc: fileNetrc,
+            forcesNetrc: true,
+            keychain: { Issue.record("keychain consulted despite --netrc"); return keychain }
+        )
+        #expect(forced?.password == "file")
+
+        let fileFallback = await RegistryAuthorization.prioritizedCredential(
+            environmentNetrc: nil, fileNetrc: fileNetrc, forcesNetrc: false, keychain: { nil })
+        #expect(fileFallback?.password == "file")
     }
 
     @Test

--- a/swifterpm/Tests/swifterpmTests/NetrcTests.swift
+++ b/swifterpm/Tests/swifterpmTests/NetrcTests.swift
@@ -11,7 +11,7 @@ struct NetrcTests {
             default login fallback password fallback-secret
             """
         )
-        let netrc = Netrc(sources: [machines])
+        let netrc = Netrc(sources: [NetrcSource(origin: .file, machines: machines)])
 
         #expect(
             netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
@@ -32,7 +32,7 @@ struct NetrcTests {
             machine registry.example.com login second password two
             """
         )
-        let netrc = Netrc(sources: [machines])
+        let netrc = Netrc(sources: [NetrcSource(origin: .file, machines: machines)])
 
         #expect(
             netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
@@ -86,15 +86,20 @@ struct NetrcTests {
     }
 
     @Test
-    func configuredNetrcFileIsTheOnlySource() async throws {
+    func configuredNetrcFileReplacesHomeButNotEnvironmentData() async throws {
+        // SwiftPM reads SWIFTPM_NETRC_DATA before it switches on which file to use, so
+        // an explicit `--netrc-file` displaces `~/.netrc` and nothing else.
         try await withTemporaryDirectory { root in
             let netrcFile = root.appendingPathComponent("netrc")
             try await fileSystem.atomicWrite(
-                "machine registry.example.com login example password from-file",
+                """
+                machine registry.example.com login example password from-file
+                machine other.example.com login example password file-only
+                """,
                 to: netrcFile
             )
             try await fileSystem.atomicWrite(
-                "machine other.example.com login example password from-home",
+                "machine home.example.com login example password from-home",
                 to: root.appendingPathComponent(".netrc")
             )
 
@@ -109,9 +114,12 @@ struct NetrcTests {
 
             #expect(
                 netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
-                    .password == "from-file")
+                    .password == "from-environment")
             #expect(
-                netrc.credential(for: try #require(URL(string: "https://other.example.com"))) == nil)
+                netrc.credential(for: try #require(URL(string: "https://other.example.com")))?
+                    .password == "file-only")
+            #expect(
+                netrc.credential(for: try #require(URL(string: "https://home.example.com"))) == nil)
         }
     }
 
@@ -141,6 +149,34 @@ struct NetrcTests {
             #expect(
                 netrc.credential(for: try #require(URL(string: "https://other.example.com")))?
                     .password == "home-only")
+        }
+    }
+
+    @Test
+    func credentialFromAnOriginIgnoresTheOtherSources() async throws {
+        // The registry path asks for each origin separately so it can consult the
+        // keychain between them, the way SwiftPM's registry provider does.
+        try await withTemporaryDirectory { root in
+            try await fileSystem.atomicWrite(
+                "machine registry.example.com login example password from-home",
+                to: root.appendingPathComponent(".netrc")
+            )
+
+            let netrc = try await Netrc.resolve(
+                SwifterPMNetrcConfiguration(),
+                environment: [
+                    "HOME": root.path,
+                    "SWIFTPM_NETRC_DATA":
+                        "machine other.example.com login example password from-environment",
+                ]
+            )
+            let registry = try #require(URL(string: "https://registry.example.com"))
+            let other = try #require(URL(string: "https://other.example.com"))
+
+            #expect(netrc.credential(for: registry, from: .environment) == nil)
+            #expect(netrc.credential(for: registry, from: .file)?.password == "from-home")
+            #expect(netrc.credential(for: other, from: .environment)?.password == "from-environment")
+            #expect(netrc.credential(for: other, from: .file) == nil)
         }
     }
 

--- a/swifterpm/Tests/swifterpmTests/RegistryTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RegistryTests.swift
@@ -103,23 +103,6 @@ struct RegistryTests {
         }
     }
 
-    @Test
-    func netrcAuthorizationMatchesHostAndDefault() throws {
-        let netrc = RegistryNetrc(
-            content: """
-            machine registry.example.com login example password secret
-            default login fallback password fallback-secret
-            """
-        )
-
-        #expect(
-            netrc.credential(for: try #require(URL(string: "https://registry.example.com")))?
-                .password == "secret")
-        #expect(
-            netrc.credential(for: try #require(URL(string: "https://other.example.com")))?
-                .password == "fallback-secret")
-    }
-
     private func uniqueRegistryIdentity() -> String {
         "\(uniqueRegistryScope()).package"
     }


### PR DESCRIPTION
### What

Gives SwifterPM the netrc surface SwiftPM exposes: `--netrc-file <path>` selects the file, `--enable-netrc` / `--disable-netrc` toggle netrc lookups, and `--netrc` disables the OS credential store for registry requests. It also consolidates two copies of the netrc lookup into one type, forwards the configuration to the child solve, and fixes three parser and validation behaviours that disagreed with every other tool reading the same file.

### Why

`tuist install` forwards its passthrough arguments to SwifterPM verbatim, and SwifterPM defined no netrc options at all. A pipeline that authenticated a private registry with `swift package resolve --netrc-file <path>` therefore broke the moment SwifterPM became the default resolver. A customer hit this while upgrading the CLI and worked around it with `SWIFTPM_NETRC_DATA="$(<"$HOME/.netrc")" tuist install`.

The failure was worse than a clean rejection. ArgumentParser discards the unrecognized `--netrc-file` and then tries its value as the `action` positional, so the actual message was:

```
Error: The value '/path/to/.netrc' is invalid for '<action>'
```

which says nothing about netrc. `Unknown option` appears only for the valueless forms:

```
Error: Unknown option '--disable-netrc'
```

### Root cause

No netrc options existed, and `DeprecatedSwiftPMOptions` is deliberately an exact allowlist rather than a blanket "ignore anything unrecognized", so nothing absorbed them.

The environment variable workaround covering more ground than the flag would have is not a coincidence. The version solve is delegated to a child `swift package resolve`, and the child inherits the environment but not our flags, so `SWIFTPM_NETRC_DATA` was the only mechanism that reached both halves. That gap is closed here.

### Solution, and what was rejected

Netrc configuration travels on the resolution and restore requests and is installed as a task local, matching how `cachedDirectoryMaterialization` is already threaded. Plumbing an extra parameter down to the two authorization helpers would have touched far more code for the same result.

A missing `--netrc-file` fails the command up front instead of silently downgrading to unauthenticated requests. Falling back quietly is the tempting option, and it is the one that produces the bug report a week later: an opaque 401 or 404 from a private registry with no hint that the credentials were never read. SwiftPM errors here too, in both of its authorization factories.

`--netrc-optional` is deliberately not tolerated. Swift 6.3.2 rejects it outright, so swallowing it would make SwifterPM more permissive than SwiftPM, which is the failure mode the allowlist exists to prevent in the other direction. The same reasoning now rejects `--netrc-file` combined with `--disable-netrc`, which upstream fails with "'--disable-netrc' and '--netrc-file' are mutually exclusive". That check lives in `Netrc.resolve` rather than in the CLI so embedders building a configuration directly hit it too.

### Why SwifterPM parses netrc itself

The obvious question on a hand-written parser is why it is not a dependency. Every off-the-shelf option was checked:

- `TSCUtility.Netrc` in swift-tools-support-core is marked `@available(*, deprecated, message: "moved to SwiftPM")`, dated 2/2022, and is gated at macOS 10.13.
- `Basics.Netrc` in swift-package-manager is where it moved and is the real reference implementation, but it lives inside SwiftPM. Depending on it pulls llbuild, swift-driver, TSC and swift-collections into a tool whose whole premise is being the lean alternative, and it would have to resolve under Bazel and Buck2 as well as SwiftPM. `Basics` is not among the products SwiftPM exports either.
- `ggruen/SwiftNetrc` is the only standalone package. Last pushed March 2018, `swiftLanguageVersions: [3, 4]`, a `final class` with `open` members that modern Swift rejects, its own `FileManager` I/O, a hard requirement that the file be `0o600`, comment stripping commented out in the source, and `[String: NetrcMachine]` storage that collapses duplicate hosts by accident.
- The Swift CLI has no netrc dump to shell out to. `swift package config` offers only the mirror subcommands and `swift package-registry` only set, unset, login, logout and publish. Printing credentials on a subprocess's stdout would be a poor idea regardless, since SwifterPM captures subprocess output for diagnostics.

So the parser stays. It is a tokenizer over a frozen file format, about ninety lines, and the dependency cost across three build systems exceeds its maintenance cost. It is not a port of SwiftPM's, which strips comments with one regex and matches whole entries with a second, while this one walks characters into a token stream and scans it. Reading them side by side is what produced the corrections below.

### Behaviours corrected against `main`

**A duplicated host resolved to the last entry, not the first.** SwiftPM uses `machines.firstIndex(where: { $0.name == url.host })`, and curl pointed at a file with two `machine 127.0.0.1` entries sends the first one, confirmed against a local server that decodes the header it receives. Appending a corrected entry therefore changed which credential SwifterPM sent while every other tool kept using the original.

**An unquoted `#` truncated the value it appeared in.** `password se#cret` parsed as the password `se`. SwiftPM's comment pattern is `("[^"]*"|\s#.*$)`, which requires whitespace ahead of the `#`, and curl sends `se#cret` whole. A `#` that opens a token still starts a comment, so whole-line and trailing comments are unaffected.

**A missing value took the rest of the file with it.** `login` and `password` accepted whatever token followed, and since tokenizing has already erased line boundaries, a value that never materialises consumed the next entry's `machine` keyword. Given two entries where the first ends `password ""`, the parser returned one machine whose password was the literal `machine`, and the second entry was gone; `login ""` returned nothing at all for the whole file. Values now refuse a token that opens an entry, so the damage stays inside the malformed entry. This is the same silent credential downgrade the missing-file error exists to prevent, reachable by a typo rather than by configuration.

**`--netrc` was swallowed as a deprecated no-op, and it is not one.** SwiftPM's `SecurityOptions.forceNetrc` is undeprecated, and `getRegistryAuthorizationProvider` consumes it as `authorization.keychain = forceNetrc ? .disabled : .enabled` under the comment "Don't use OS credential store if user wants netrc". Ignoring it left no way to prefer a fresh netrc entry over a stale keychain item from an old `swift package-registry login`, which is exactly the situation someone passes it for. It is now a real flag.

**The netrc configuration never reached the child solve.** `swift package resolve` performs the version solve, which fetches availability and manifests from the same registries, and it was invoked without `--netrc-file`, `--netrc` or `--disable-netrc`. Forwarding them covers `assertResolvedFileUpToDate` as well, since it builds on the same argument function. Verified with a PATH shim, the child now receives `--netrc-file <path> --netrc`.

### Divergences kept on purpose

- Registry lookups fall through on a miss; upstream selects at most one provider and stops. Falling through is what lets `--netrc-file` reach registry auth when the keychain holds an unrelated item, which is the point of the change. It does mean a host absent from the chosen source gets credentials here where SwiftPM would send none.
- `--disable-netrc` switches off registry netrc here. Upstream documents the enable/disable pair as having "no effects on registry communications", and `getRegistryAuthorizationProvider` never reads it.
- Host matching folds case on both sides, where SwiftPM compares the raw URL host. netrc machine names are DNS names, so folding is the more correct reading, and it can only widen what matches rather than change which entry wins.
- `GITHUB_TOKEN` / `GH_TOKEN` still act as a fallback for github.com downloads, behind netrc. SwiftPM has no such fallback; this was added deliberately in #11528.
- A `default` entry is accepted anywhere in the file. SwiftPM throws `invalidDefaultMachinePosition` unless it is last, which discards the whole file.
- Downloads do not consult the keychain, which SwiftPM does. Pre-existing, and left for a separate change.

### Impact

`tuist install -- --netrc-file <path>` works again, as do `--enable-netrc`, `--disable-netrc` and `--netrc`, and they now apply to the child solve as well as to SwifterPM's own requests. Nobody needs the `SWIFTPM_NETRC_DATA` wrapper anymore, though it keeps working. Registry precedence is `SWIFTPM_REGISTRY_TOKEN`, then `SWIFTPM_REGISTRY_LOGIN` and `SWIFTPM_REGISTRY_PASSWORD`, then inline netrc data, then the keychain unless `--netrc` was passed, then the netrc file. Downloads ask netrc in source order, then fall back to an ambient GitHub token.

### Validation

Red first, against the parent commit built in a scratch worktree. A test asserting the four options parse fails there:

```
✘ netrcFileOptionIsAccepted: unableToParseValue(... "/tmp/netrc", forKey: action)
✘ netrcToggleOptionsAreAccepted: unknownOption("disable-netrc")
✘ netrcToggleOptionsAreAccepted: unknownOption("enable-netrc")
✘ netrcToggleOptionsAreAccepted: unknownOption("netrc")
```

and the pre-fix binary reproduces both customer-visible errors quoted above. Each parser correction was written test-first and observed failing, one reporting `password: "se"` and another returning `first.example.com` with the password `machine`.

Green on the fix, same binary and same scratch package: `--netrc-file` with an existing file resolves, `--netrc` resolves, a missing `--netrc-file` exits 1 with `did not find netrc file at ...`, and the flag pair exits 1 with the mutually-exclusive message. Child forwarding was verified with a shim on `PATH` in front of a package with a local git dependency, so a real solve runs without touching the network.

The suite is at 162 tests, including registry precedence as a pure function over its three sources, per-origin lookup, the child argument list, and both authorization headers. `SwifterPMCore` builds in Swift 6 language mode, which bazel does not exercise.

### Note on the branch history

Two things this branch changes were regressions it introduced rather than problems on `main`. The registry ordering was already inline netrc data, then keychain, then netrc file at the merge base, and an intermediate commit here moved netrc ahead of the keychain on a misreading of upstream, citing the download provider's composition for the registry one. The same commit made `--netrc-file` suppress `SWIFTPM_NETRC_DATA`. Both are repaired, and the end state matches the merge base plus the corrections listed above. An early commit message also quotes the pre-fix failure as `Unknown option '--netrc-file'`, which a later commit corrects. This description reflects the end state rather than the route.
