### PR TITLE
fix(server,cli): stop sharded test executions from reporting the build's URL

### DIFF
--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -228,7 +228,7 @@ public class TrackableCommand {
                 await gitHubActionsJobSummaryService.writeJobSummary(
                     testRunReports: testRunReports,
                     buildRunReports: buildRunReports,
-                    runURL: serverCommandEvent.url
+                    runURL: buildRunURL ?? serverCommandEvent.url
                 )
 
                 // Unlike the job summary, this is written even when there's nothing to tabulate:

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -697,17 +697,7 @@ defmodule Tuist.Tests do
         )
       )
 
-    test =
-      if test_run_id do
-        ClickHouseRepo.one(
-          from(test in Test,
-            where: test.project_id == ^project_id,
-            where: test.id == ^test_run_id,
-            order_by: [desc: test.inserted_at],
-            limit: 1
-          )
-        )
-      end
+    test = test_run_id && sharded_test_by_id(project_id, test_run_id)
 
     case test do
       %Test{} = test ->
@@ -719,16 +709,40 @@ defmodule Tuist.Tests do
         # its shard-run row. It avoids FINAL because ordering the physical rows
         # by version returns the same latest test without an in-memory merge.
         # Every later shard takes the prefix-keyed lookup above.
-        ClickHouseRepo.one(
-          from(test in Test,
-            where: test.shard_plan_id == ^shard_plan_id,
-            where: test.project_id == ^project_id,
-            order_by: [desc: test.inserted_at],
-            limit: 1
-          ),
-          settings: @sharded_test_lookup_settings
-        )
+        case sharded_test_id_by_plan(project_id, shard_plan_id) do
+          nil -> nil
+          id -> sharded_test_by_id(project_id, id)
+        end
     end
+  end
+
+  defp sharded_test_by_id(project_id, test_run_id) do
+    ClickHouseRepo.one(
+      from(test in Test,
+        where: test.project_id == ^project_id,
+        where: test.id == ^test_run_id,
+        order_by: [desc: test.inserted_at],
+        limit: 1
+      )
+    )
+  end
+
+  # `shard_plan_id` is not part of the sorting key, so this reads every granule
+  # the project's key prefix leaves. Selecting the id alone keeps that read to a
+  # handful of column streams: with `SELECT *` the per-column read buffers of a
+  # 20+ column table blow past `max_memory_usage` and the whole shard report
+  # 500s, which drops the run's test report entirely.
+  defp sharded_test_id_by_plan(project_id, shard_plan_id) do
+    ClickHouseRepo.one(
+      from(test in Test,
+        where: test.shard_plan_id == ^shard_plan_id,
+        where: test.project_id == ^project_id,
+        order_by: [desc: test.inserted_at],
+        limit: 1,
+        select: test.id
+      ),
+      settings: @sharded_test_lookup_settings
+    )
   end
 
   # Carry forward metadata fields when a later shard report has them and

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -94,10 +94,6 @@ defmodule Tuist.Tests do
     join_algorithm: "grace_hash",
     grace_hash_join_initial_buckets: 16
   ]
-  @sharded_test_lookup_settings [
-    max_threads: 1,
-    max_memory_usage: 128 * 1024 * 1024
-  ]
   @flaky_correction_lookup_settings [
     max_threads: 1,
     max_memory_usage: 128 * 1024 * 1024
@@ -576,14 +572,35 @@ defmodule Tuist.Tests do
     project_id = Map.fetch!(attrs, :project_id)
     test_modules = Map.get(attrs, :test_modules, [])
 
-    existing = existing_sharded_test(project_id, shard_plan_id)
-
     {:ok, shard_plan} = Shards.get_shard_plan(shard_plan_id)
     expected_shard_count = shard_plan.shard_count
 
     shard_index = Map.get(attrs, :shard_index)
     shard_status = Map.get(attrs, :status, "success")
     shard_duration = Map.get(attrs, :duration, 0)
+
+    # `shard_runs` is the only authority on which run a plan's shards report
+    # into. The first shard claims that mapping before its run row exists, so a
+    # report that dies in between leaves a pointer the next shard rebuilds
+    # through, rather than a run no later shard can find.
+    mapped_id = mapped_shard_test_run_id(project_id, shard_plan_id)
+    merged_id = mapped_id || Map.get(attrs, :id) || UUIDv7.generate()
+
+    if is_nil(mapped_id) do
+      insert_shard_run(
+        shard_plan_id,
+        project_id,
+        merged_id,
+        shard_index,
+        shard_status,
+        shard_duration,
+        attrs
+      )
+    end
+
+    existing = sharded_test_by_id(project_id, merged_id)
+
+    attrs = Map.put(attrs, :id, merged_id)
 
     result =
       case existing do
@@ -669,7 +686,9 @@ defmodule Tuist.Tests do
       end
 
     with {:ok, test} <- result do
-      if is_nil(existing) do
+      # Rebuilding a run whose row went missing still owes the mapping this
+      # shard's status; the claim above only covers the plan's first shard.
+      if is_nil(existing) and not is_nil(mapped_id) do
         insert_shard_run(
           shard_plan_id,
           project_id,
@@ -685,37 +704,23 @@ defmodule Tuist.Tests do
     end
   end
 
-  defp existing_sharded_test(project_id, shard_plan_id) do
-    test_run_id =
-      ClickHouseRepo.one(
-        from(shard_run in ShardRun,
-          where: shard_run.project_id == ^project_id,
-          where: shard_run.shard_plan_id == ^shard_plan_id,
-          order_by: [desc: shard_run.inserted_at],
-          limit: 1,
-          select: shard_run.test_run_id
-        )
+  # Keyed on the `(project_id, shard_plan_id, …)` sorting key. Resolving this
+  # against `test_runs` instead would scan the project's whole key range, since
+  # `shard_plan_id` is not part of that table's sorting key.
+  defp mapped_shard_test_run_id(project_id, shard_plan_id) do
+    ClickHouseRepo.one(
+      from(shard_run in ShardRun,
+        where: shard_run.project_id == ^project_id,
+        where: shard_run.shard_plan_id == ^shard_plan_id,
+        order_by: [desc: shard_run.inserted_at],
+        limit: 1,
+        select: shard_run.test_run_id
       )
-
-    test = test_run_id && sharded_test_by_id(project_id, test_run_id)
-
-    case test do
-      %Test{} = test ->
-        test
-
-      _ ->
-        # The first shard has no shard-run row yet. The fallback also repairs a
-        # report interrupted after writing the merged test but before writing
-        # its shard-run row. It avoids FINAL because ordering the physical rows
-        # by version returns the same latest test without an in-memory merge.
-        # Every later shard takes the prefix-keyed lookup above.
-        case sharded_test_id_by_plan(project_id, shard_plan_id) do
-          nil -> nil
-          id -> sharded_test_by_id(project_id, id)
-        end
-    end
+    )
   end
 
+  # Avoids FINAL because ordering the physical rows by version returns the same
+  # latest run without an in-memory merge.
   defp sharded_test_by_id(project_id, test_run_id) do
     ClickHouseRepo.one(
       from(test in Test,
@@ -724,24 +729,6 @@ defmodule Tuist.Tests do
         order_by: [desc: test.inserted_at],
         limit: 1
       )
-    )
-  end
-
-  # `shard_plan_id` is not part of the sorting key, so this reads every granule
-  # the project's key prefix leaves. Selecting the id alone keeps that read to a
-  # handful of column streams: with `SELECT *` the per-column read buffers of a
-  # 20+ column table blow past `max_memory_usage` and the whole shard report
-  # 500s, which drops the run's test report entirely.
-  defp sharded_test_id_by_plan(project_id, shard_plan_id) do
-    ClickHouseRepo.one(
-      from(test in Test,
-        where: test.shard_plan_id == ^shard_plan_id,
-        where: test.project_id == ^project_id,
-        order_by: [desc: test.inserted_at],
-        limit: 1,
-        select: test.id
-      ),
-      settings: @sharded_test_lookup_settings
     )
   end
 

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -545,14 +545,13 @@ defmodule TuistWeb.API.AnalyticsController do
       })
     end
 
-    url =
-      if is_nil(build_run_id) do
-        url(~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{command_event.id}")
-      else
-        url(
-          ~p"/#{selected_project.account.name}/#{selected_project.name}/builds/build-runs/#{String.downcase(build_run_id)}"
-        )
-      end
+    # Always the run page, never the build run's. A `build_run_id` on a command
+    # event says the run relates to that build, not that it produced it: every
+    # `test --without-building` shard reuses the build phase's id to link its
+    # report back. Resolving to the build run therefore sent sharded test
+    # executions to the build's page as their own run report. The build run and
+    # test run have their own URLs, carried separately.
+    url = url(~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{command_event.id}")
 
     test_run_url =
       if is_nil(test_run_id) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2262,6 +2262,48 @@ defmodule Tuist.TestsTest do
       assert updated_test.id == interrupted_test.id
     end
 
+    # `shard_plan_id` is not in the sorting key, so this lookup reads every
+    # granule the project prefix leaves. Reading the whole row allocates a read
+    # buffer per column stream, which on its own exceeds the memory the lookup
+    # is capped at: the shard report then 500s and the run gets no test report
+    # at all. Asserting the shape is the only way to hold that here, since the
+    # test dataset is far too small to reproduce the limit.
+    test "reads only the id when looking a merged run up by shard plan" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      queries =
+        capture_clickhouse_queries(fn ->
+          {:ok, _test} =
+            Tests.create_test(%{
+              id: UUIDv7.generate(),
+              project_id: project.id,
+              account_id: account.id,
+              duration: 500,
+              status: "success",
+              model_identifier: "Mac15,6",
+              macos_version: "14.0",
+              xcode_version: "15.0",
+              git_branch: "main",
+              git_commit_sha: "abc123",
+              ran_at: NaiveDateTime.utc_now(),
+              is_ci: true,
+              shard_plan_id: plan.id,
+              shard_index: 0
+            })
+        end)
+
+      shard_plan_lookups =
+        Enum.filter(queries, &(&1 =~ ~s(FROM "test_runs") and &1 =~ "shard_plan_id"))
+
+      assert shard_plan_lookups != []
+
+      for query <- shard_plan_lookups do
+        assert query =~ ~r/SELECT\s+t0\."id"\s+FROM\s+"test_runs"/
+      end
+    end
+
     test "single shard plan sets status directly (not in_progress)" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account
@@ -10432,6 +10474,34 @@ defmodule Tuist.TestsTest do
       project = ProjectsFixtures.project_fixture(default_branch: "main")
 
       assert Tests.test_case_ids_with_successful_default_branch_run(project.id, [], "main") == []
+    end
+  end
+
+  defp capture_clickhouse_queries(fun) do
+    test_pid = self()
+    handler_id = "clickhouse-queries-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [[:tuist, :click_house_repo, :query], [:tuist, :ingest_repo, :query]],
+      fn _event, _measurements, %{query: query}, _config -> send(test_pid, {:clickhouse_query, query}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    drain_clickhouse_queries([])
+  end
+
+  defp drain_clickhouse_queries(acc) do
+    receive do
+      {:clickhouse_query, query} -> drain_clickhouse_queries([query | acc])
+    after
+      0 -> Enum.reverse(acc)
     end
   end
 end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2209,6 +2209,59 @@ defmodule Tuist.TestsTest do
       refute updated_test.id == conflicting_test_id
     end
 
+    test "recovers the merged run of a plan whose shard-run row was never written" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, interrupted_test} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: account.id,
+          status: "in_progress",
+          test_modules: []
+        )
+
+      interrupted_row =
+        interrupted_test
+        |> Map.from_struct()
+        |> Map.drop([
+          :__meta__,
+          :ran_by_account,
+          :build_run,
+          :gradle_build,
+          :test_case_runs,
+          :shard_plan,
+          :run_destinations
+        ])
+        |> Map.merge(%{
+          shard_plan_id: plan.id,
+          inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), 1, :second)
+        })
+
+      IngestRepo.insert_all(Test, [interrupted_row])
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "success",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.id == interrupted_test.id
+    end
+
     test "single shard plan sets status directly (not in_progress)" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2209,39 +2209,29 @@ defmodule Tuist.TestsTest do
       refute updated_test.id == conflicting_test_id
     end
 
-    test "recovers the merged run of a plan whose shard-run row was never written" do
+    test "rebuilds the merged run under the mapped id when its run row is missing" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account
       plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+      mapped_id = UUIDv7.generate()
 
-      {:ok, interrupted_test} =
-        RunsFixtures.test_fixture(
-          project_id: project.id,
-          account_id: account.id,
-          status: "in_progress",
-          test_modules: []
-        )
-
-      interrupted_row =
-        interrupted_test
-        |> Map.from_struct()
-        |> Map.drop([
-          :__meta__,
-          :ran_by_account,
-          :build_run,
-          :gradle_build,
-          :test_case_runs,
-          :shard_plan,
-          :run_destinations
-        ])
-        |> Map.merge(%{
+      # A report that claimed the mapping and then died before its run row
+      # landed. The mapping is what later shards converge on, so the run has to
+      # be rebuilt under it rather than started again under a fresh id.
+      IngestRepo.insert_all(ShardRun, [
+        %{
           shard_plan_id: plan.id,
-          inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), 1, :second)
-        })
+          project_id: project.id,
+          test_run_id: mapped_id,
+          shard_index: 0,
+          status: "processing",
+          duration: 0,
+          ran_at: NaiveDateTime.utc_now(),
+          inserted_at: NaiveDateTime.utc_now()
+        }
+      ])
 
-      IngestRepo.insert_all(Test, [interrupted_row])
-
-      {:ok, updated_test} =
+      {:ok, rebuilt_test} =
         Tests.create_test(%{
           id: UUIDv7.generate(),
           project_id: project.id,
@@ -2259,16 +2249,10 @@ defmodule Tuist.TestsTest do
           shard_index: 1
         })
 
-      assert updated_test.id == interrupted_test.id
+      assert rebuilt_test.id == mapped_id
     end
 
-    # `shard_plan_id` is not in the sorting key, so this lookup reads every
-    # granule the project prefix leaves. Reading the whole row allocates a read
-    # buffer per column stream, which on its own exceeds the memory the lookup
-    # is capped at: the shard report then 500s and the run gets no test report
-    # at all. Asserting the shape is the only way to hold that here, since the
-    # test dataset is far too small to reproduce the limit.
-    test "reads only the id when looking a merged run up by shard plan" do
+    test "claims the shard mapping before writing the run row" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account
       plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
@@ -2294,14 +2278,52 @@ defmodule Tuist.TestsTest do
             })
         end)
 
-      shard_plan_lookups =
-        Enum.filter(queries, &(&1 =~ ~s(FROM "test_runs") and &1 =~ "shard_plan_id"))
+      # Anything written between the run row and its mapping is unrecoverable:
+      # later shards resolve the run through the mapping alone, so a run row
+      # without one splits the report in two.
+      mapping_insert = Enum.find_index(queries, &(&1 =~ ~s(INSERT INTO "shard_runs")))
+      run_insert = Enum.find_index(queries, &(&1 =~ ~s(INSERT INTO "test_runs")))
 
-      assert shard_plan_lookups != []
+      assert mapping_insert
+      assert run_insert
+      assert mapping_insert < run_insert
+    end
 
-      for query <- shard_plan_lookups do
-        assert query =~ ~r/SELECT\s+t0\."id"\s+FROM\s+"test_runs"/
+    test "never resolves a merged run by scanning test runs for a shard plan" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      shard = fn index ->
+        %{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: index
+        }
       end
+
+      queries =
+        capture_clickhouse_queries(fn ->
+          {:ok, _} = Tests.create_test(shard.(0))
+          {:ok, _} = Tests.create_test(shard.(1))
+        end)
+
+      # `shard_plan_id` is not in `test_runs`' sorting key, so this lookup reads
+      # every granule the project prefix leaves, and the read buffer it
+      # allocates per column stream is what blew the shard report's memory cap.
+      # The mapping in `shard_runs` is keyed for exactly this question.
+      refute Enum.any?(queries, &(&1 =~ ~s(FROM "test_runs") and &1 =~ ~s|"shard_plan_id" = |))
     end
 
     test "single shard plan sets status directly (not in_progress)" do

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -717,6 +717,51 @@ defmodule TuistWeb.AnalyticsControllerTest do
       assert response["url"] == url(~p"/#{account.name}/#{project.name}/runs/#{command_event.id}")
     end
 
+    test "returns command event URL with runs route when build_run_id is provided", %{
+      conn: conn,
+      user: user
+    } do
+      # Given
+      stub(Tuist.VCS, :enqueue_vcs_pull_request_comment, fn _ -> :ok end)
+      conn = Authentication.put_current_user(conn, user)
+
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+      build_run_id = UUIDv7.generate()
+
+      # When a test execution reuses the build phase's build_run_id to link its
+      # report back to the build.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-tuist-cli-version", "4.203.4")
+        |> post(
+          "/api/analytics?project_id=#{account.name}/#{project.name}",
+          %{
+            name: "test",
+            command_arguments: ["test", "--without-building"],
+            duration: 100,
+            tuist_version: "4.203.4",
+            swift_version: "5.0",
+            macos_version: "10.15",
+            params: %{},
+            is_ci: true,
+            client_id: "client-id",
+            build_run_id: build_run_id
+          }
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+
+      Buffer.flush()
+
+      {:ok, command_event} = CommandEvents.get_command_event_by_id(response["id"])
+
+      assert command_event.build_run_id == build_run_id
+      assert response["url"] == url(~p"/#{account.name}/#{project.name}/runs/#{command_event.id}")
+    end
+
     test "returns UUID as id", %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)


### PR DESCRIPTION
Follow-up to [#12255](https://github.com/tuist/tuist/pull/12255), which did not fully close the reported issue.

A customer running a split `--build-only` + sharded `--without-building` pipeline reported that the test job printed the build run's URL as its own run report, so both commands linked to the same build page and nothing linked to a test report. Investigating that turned up a second, larger defect behind it: **sharded test runs have not been created at all since 2026-07-02**.

## Root cause

Two independent defects compounded.

### Sharded test runs were never created

`existing_sharded_test/2` resolves the merged run through the small `shard_runs` table, and falls back to looking it up in `test_runs` by `shard_plan_id`. That column is not part of `test_runs`' sorting key (`ORDER BY (project_id, id)`), and the fallback selected the whole row.

Reading 24 columns allocates a read buffer per column stream, which on its own exceeds the 128 MiB `max_memory_usage` the lookup is capped at — so ClickHouse raised `MEMORY_LIMIT_EXCEEDED` and `POST /tests` returned 500. This is buffer-driven, not row-driven: it failed for a project holding only ~6k rows, and for one holding ~52k rows at almost exactly the same memory.

The failure was total rather than intermittent. The first shard is the one that takes the fallback, so its 500 meant no run row and no shard-run row were ever written, which sent every later shard down the same fallback. Not one shard of a sharded run produced a test report.

Confirmed in production for the reported build: all four `--without-building` shards 500'd on that query, and `test_runs` holds no row for their shard plan. Sentry `TUIST-15M` records ~33k events across 368 accounts.

### The command event's URL resolved to the build run

`url` pointed at the build run page whenever the event carried a `build_run_id`. That field says the run *relates* to a build, not that it produced one: every `test --without-building` shard reuses the build phase's id so its test report links back to the build. With no test run to report (defect one), the CLI fell through to `url` and printed the build page.

This also contradicted the documented run report contract, where `runURL` is the run page and `buildRunURL` carries the build.

## What changed

**Stop the bleeding.** The shard-plan fallback resolves an id and fetches the row by primary key, so the unindexed scan touches a handful of column streams instead of the full row. The memory cap stays as the guard it was meant to be, rather than being raised — a query reading 24 columns to use one of them would grow into whatever ceiling it was given.

**Then remove the fallback entirely.** Narrowing it left an unindexed scan of `test_runs` on the write path, reached once per sharded run. It existed to cover a window: the first shard wrote its run row and only then claimed the plan's mapping in `shard_runs`, so a report dying in between left a run no later shard could resolve — and without the scan, the next shard would start a second run for the same plan and the report would split in two.

That window is closable rather than patchable. Every caller that can carry a `shard_plan_id` already supplies the run id (both controllers default it, the xcresult worker carries it through), so the mapping can be claimed *before* the run row exists. `shard_runs` then answers "which run does this plan report into" on its own sorting key, and a run row that never landed is rebuilt under the mapped id instead of searched for.

The merge path keeps its existing write ordering — only the plan's first shard claims up front, so a shard whose modules fail to write is still not counted as reported.

**The URL.** `url` is always the run page. The build run and test run already have their own URLs, and the CLI prefers those when it has them. Because the CLI's GitHub Actions job summary used `url` to link the build, it now prefers the build run URL it uploaded itself, keeping today's link for build commands.

## Notes for review

- **One documented field changes value.** `url` has exactly one consumer, the CLI's `ServerCommandEvent.url`. The printed log line and the job summary link are unchanged for every command that builds, because both prefer URLs the CLI already holds. The one delta is `RunReport.runURL` for build-producing commands, which moves from the build page to the run page — which is what the run report contract already documents (`runURL` is the run, `buildRunURL` carries the build). Before this change the two were the same value for build commands, contradicting the docs. Nothing outside the CLI reads the field: no app, Android, Gradle, or dashboard consumer, and the server never reads its own response.
- **The old behaviour could emit a dead link.** `build_run_id` is derived from the activity log basename before the upload, while the build run row is created by that upload. A failed upload left the CLI printing a `/builds/build-runs/<id>` link for a run that was never created; it now prints the run page, which exists.
- **A test was deleted, deliberately.** `"recovers the merged run of a plan whose shard-run row was never written"` guarded the fallback's repair path. That state is now unreachable by construction, and the successor test covers the replacement path (mapping present, run row missing). Worth a look to confirm you agree the state is genuinely unreachable.
- **Concurrent first shards still race**, as they do today: both can miss the mapping and claim it. They now converge rather than split, since both write the run under the id they claimed and ReplacingMergeTree keeps the latest version. Not fixed, not made worse.
- **`idx_shard_plan_id`** (added in `20260728140000`) now has no reader — it was added for exactly the query this removes, and never fixed these 500s because pruning granules does not stop the per-column buffers being allocated for the part that does match. It is unmaterialized on historical parts and costs nothing to keep, so dropping it is left as separate cleanup.
- **Rollout:** a sharded run in flight at deploy time that already has a run row but no mapping row would split. One-deploy window, and those runs currently produce nothing at all, so the practical exposure is nil.

## Impact

Sharded test runs get their test report back, along with the flaky detection, PR comment and dashboard rows that all hang off the run row. Affected accounts need no CLI upgrade — every fix is server-side; the CLI change only preserves the existing job summary link.

## How to test locally

```
cd server
mix test test/tuist/tests_test.exs test/tuist_web/controllers/analytics_controller_test.exs
```

Also run: `test/tuist/tests/`, `test/tuist_web/controllers/api/tests_controller_test.exs`, `test/tuist/shards_test.exs`, `test/tuist_web/controllers/api/shards_controller_test.exs`, `test/tuist_web/controllers/api/runs_controller_test.exs`.

Every regression test here was verified red against the implementation it replaces:

| test | fails before with |
|---|---|
| command event with a `build_run_id` resolves to the run page | `.../builds/build-runs/...` — the reported symptom exactly |
| the mapping insert precedes the run insert | mapping at index 5, run at index 3 — the window itself |
| a run whose row is missing is rebuilt under the mapped id | a second run started under a fresh id |
| no query resolves a run by scanning `test_runs` for a shard plan | the 24-column select, verbatim |

Worth flagging: those tests pin the mechanism, not the outcome. Nothing here proves the query fits under the cap against production-sized data; the evidence for that is the production trace (Loki 500s, the Sentry stack at `tests.ex:579`, and the `128.00 MiB` in the error matching `@sharded_test_lookup_settings` exactly). The first real confirmation will be a sharded run producing a test run row after deploy.

CLI changes compiled with `xcodebuild build -scheme tuist` and `build-for-testing -only-testing TuistKitTests`. Note that draft PRs skip the CLI build jobs, so that side wants a real CI pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

