### PR TITLE
fix(server): narrow the runners overview cards to work that actually ran

### DIFF
--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -636,6 +636,8 @@ defmodule Tuist.Runners.Jobs do
     * `:status` — restrict to one of `"queued" | "claimed" | "running" | "completed"`
     * `:conclusion` — restrict completed jobs to a conclusion
       (e.g. `"success" | "failure" | "cancelled" | "skipped"`)
+    * `:exclude_conclusions` — list of conclusions to drop from the
+      result
     * `:repository` — substring match on `repository`
     * `:workflow_name` — substring match on `workflow_name`
     * `:job_name` — substring match on `job_name`
@@ -657,6 +659,7 @@ defmodule Tuist.Runners.Jobs do
     from(j in subquery(sub), select: j)
     |> maybe_filter_status(Keyword.get(opts, :status))
     |> maybe_filter_conclusion(Keyword.get(opts, :conclusion))
+    |> maybe_exclude_conclusions(Keyword.get(opts, :exclude_conclusions))
     |> jobs_order_by(sort_by, sort_order)
     |> limit(^limit)
     |> offset(^offset)
@@ -729,6 +732,7 @@ defmodule Tuist.Runners.Jobs do
       from(j in subquery(sub), select: %{count: count(j.workflow_job_id)})
       |> maybe_filter_status(Keyword.get(opts, :status))
       |> maybe_filter_conclusion(Keyword.get(opts, :conclusion))
+      |> maybe_exclude_conclusions(Keyword.get(opts, :exclude_conclusions))
       |> ClickHouseRepo.all()
       |> case do
         [] -> [%{count: 0}]
@@ -881,6 +885,13 @@ defmodule Tuist.Runners.Jobs do
 
   defp maybe_filter_conclusion(query, conclusion) when is_binary(conclusion) do
     where(query, [j], j.conclusion == ^conclusion)
+  end
+
+  defp maybe_exclude_conclusions(query, nil), do: query
+  defp maybe_exclude_conclusions(query, []), do: query
+
+  defp maybe_exclude_conclusions(query, conclusions) when is_list(conclusions) do
+    where(query, [j], j.conclusion not in ^conclusions)
   end
 
   defp maybe_filter_like(query, _field, nil), do: query

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -635,9 +635,8 @@ defmodule Tuist.Runners.Jobs do
     * `:offset` — number of rows to skip (page-based pagination)
     * `:status` — restrict to one of `"queued" | "claimed" | "running" | "completed"`
     * `:conclusion` — restrict completed jobs to a conclusion
-      (e.g. `"success" | "failure" | "cancelled" | "skipped"`)
-    * `:exclude_conclusions` — list of conclusions to drop from the
-      result
+      (e.g. `"success" | "failure" | "cancelled" | "skipped"`), or to
+      a list of them
     * `:repository` — substring match on `repository`
     * `:workflow_name` — substring match on `workflow_name`
     * `:job_name` — substring match on `job_name`
@@ -659,7 +658,6 @@ defmodule Tuist.Runners.Jobs do
     from(j in subquery(sub), select: j)
     |> maybe_filter_status(Keyword.get(opts, :status))
     |> maybe_filter_conclusion(Keyword.get(opts, :conclusion))
-    |> maybe_exclude_conclusions(Keyword.get(opts, :exclude_conclusions))
     |> jobs_order_by(sort_by, sort_order)
     |> limit(^limit)
     |> offset(^offset)
@@ -732,7 +730,6 @@ defmodule Tuist.Runners.Jobs do
       from(j in subquery(sub), select: %{count: count(j.workflow_job_id)})
       |> maybe_filter_status(Keyword.get(opts, :status))
       |> maybe_filter_conclusion(Keyword.get(opts, :conclusion))
-      |> maybe_exclude_conclusions(Keyword.get(opts, :exclude_conclusions))
       |> ClickHouseRepo.all()
       |> case do
         [] -> [%{count: 0}]
@@ -887,11 +884,10 @@ defmodule Tuist.Runners.Jobs do
     where(query, [j], j.conclusion == ^conclusion)
   end
 
-  defp maybe_exclude_conclusions(query, nil), do: query
-  defp maybe_exclude_conclusions(query, []), do: query
+  defp maybe_filter_conclusion(query, []), do: query
 
-  defp maybe_exclude_conclusions(query, conclusions) when is_list(conclusions) do
-    where(query, [j], j.conclusion not in ^conclusions)
+  defp maybe_filter_conclusion(query, conclusions) when is_list(conclusions) do
+    where(query, [j], j.conclusion in ^conclusions)
   end
 
   defp maybe_filter_like(query, _field, nil), do: query

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -1152,6 +1152,9 @@ defmodule Tuist.Runners.Jobs do
     * `:limit` — page size, default 5
     * `:repository` — exact match on `repository`
     * `:workflow_name` — exact match on `workflow_name`
+    * `:conclusion` — restrict to a rollup conclusion, or to a list of
+      them. Applied after the rollup, so the limit counts only the
+      runs that survive it.
   """
   def list_recent_workflow_runs_for_account(account_id, opts \\ []) when is_integer(account_id) do
     limit = Keyword.get(opts, :limit, 5)
@@ -1185,7 +1188,7 @@ defmodule Tuist.Runners.Jobs do
         updated_at: max(j.updated_at)
       })
 
-    ClickHouseRepo.all(
+    rollup =
       from(j in subquery(inner),
         group_by: j.workflow_run_id,
         having: fragment("countIf(? != 'completed')", j.status) == 0,
@@ -1211,11 +1214,17 @@ defmodule Tuist.Runners.Jobs do
               j.conclusion
             ),
           updated_at: max(j.updated_at)
-        },
-        order_by: [desc: max(j.updated_at)],
-        limit: ^limit
+        }
       )
-    )
+
+    # The conclusion filter has to sit outside the rollup: it reads the
+    # column the rollup computes, and running it here rather than as a
+    # `having` keeps the limit counting surviving runs only.
+    from(run in subquery(rollup), select: run)
+    |> maybe_filter_conclusion(Keyword.get(opts, :conclusion))
+    |> order_by([run], desc: run.updated_at)
+    |> limit(^limit)
+    |> ClickHouseRepo.all()
   end
 
   defp maybe_eq_workflow(query, nil, nil), do: query

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -192,8 +192,11 @@ defmodule TuistWeb.RunnersLive do
   end
 
   defp assign_recent_workflow_runs(socket, account_id, repository, platform) do
+    # Same contract as the Recent jobs card above: a run rolls up to
+    # `cancelled` or `skipped` when none of its jobs ran, so it carries
+    # no duration for the table and nothing for the bars or legends.
     opts =
-      [limit: @chart_limit]
+      [conclusion: @duration_conclusions, limit: @chart_limit]
       |> maybe_repository(repository)
       |> maybe_platform(platform)
 
@@ -223,7 +226,6 @@ defmodule TuistWeb.RunnersLive do
   # just don't carry a navigate target.
   defp recent_workflow_runs_chart_data(recent_workflow_runs, account_name) do
     recent_workflow_runs
-    |> Enum.filter(&(&1.conclusion in @duration_conclusions))
     |> Enum.reverse()
     |> Enum.map(fn run ->
       %{
@@ -336,10 +338,11 @@ defmodule TuistWeb.RunnersLive do
   def platforms, do: @platforms
 
   @doc """
-  Conclusion label for the Recent workflow_runs table — the rollup
-  in `list_recent_workflow_runs_for_account/2` may return `success`,
-  `failure`, `cancelled`, or `skipped`. Anything outside that set
-  collapses to "Unknown" so a stray value renders cleanly.
+  Conclusion label for the Recent workflow_runs table. The card asks
+  `list_recent_workflow_runs_for_account/2` for `@duration_conclusions`
+  only, but the rollup can also return `cancelled` or `skipped`, so
+  those keep a label; anything outside the set collapses to "Unknown"
+  so a stray value renders cleanly.
   """
   def conclusion_label("success"), do: dgettext("dashboard_runners", "Success")
   def conclusion_label("failure"), do: dgettext("dashboard_runners", "Failure")

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -19,16 +19,14 @@ defmodule TuistWeb.RunnersLive do
 
   @table_limit 5
   @chart_limit 30
-  # Only runs that reached a success/failure conclusion carry a real
+  # Only work that reached a success/failure conclusion carries a real
   # duration. Running, cancelled and skipped runs would draw as
-  # zero-height bars that scatter the real ones, so they are kept out of
-  # the chart trail (and are not counted by the success/failure legends).
-  @chart_conclusions ["success", "failure"]
-  # A job gated out by an `if:` condition is reported as
-  # completed/skipped without a runner ever claiming it. It represents
-  # no work, so it stays out of the card entirely rather than filling
-  # the table with 0ms rows.
-  @excluded_recent_conclusions ["skipped"]
+  # zero-height bars that scatter the real ones, and count for nothing
+  # in the success/failure legends. The Recent jobs card narrows to
+  # these at the query so its table, bars and legends all describe the
+  # same set of jobs; the workflow-run chart drops the rest before
+  # plotting.
+  @duration_conclusions ["success", "failure"]
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
@@ -171,14 +169,15 @@ defmodule TuistWeb.RunnersLive do
 
   defp assign_recent_jobs(socket, account_id, repository, platform) do
     # The Recent jobs card mirrors the Recent Test Runs card on the
-    # Tests page — it's a chronicle of finished work, not a live
-    # status board. Filter to completed runs only so the bars carry
-    # a real duration and the success/failure legends count
-    # something other than zero. The chart spans up to
-    # `@chart_limit` so the bar trail conveys a trend, while the
-    # table below shows only the freshest `@table_limit` rows.
+    # Tests page — it's a chronicle of work that ran, not a live
+    # status board. Filter to jobs that completed with a
+    # `@duration_conclusions` conclusion so the bars carry a real
+    # duration and the success/failure legends count something other
+    # than zero. The chart spans up to `@chart_limit` so the bar trail
+    # conveys a trend, while the table below shows only the freshest
+    # `@table_limit` rows.
     opts =
-      [status: "completed", exclude_conclusions: @excluded_recent_conclusions, limit: @chart_limit]
+      [status: "completed", conclusion: @duration_conclusions, limit: @chart_limit]
       |> maybe_repository(repository)
       |> maybe_platform(platform)
 
@@ -224,7 +223,7 @@ defmodule TuistWeb.RunnersLive do
   # just don't carry a navigate target.
   defp recent_workflow_runs_chart_data(recent_workflow_runs, account_name) do
     recent_workflow_runs
-    |> Enum.filter(&(&1.conclusion in @chart_conclusions))
+    |> Enum.filter(&(&1.conclusion in @duration_conclusions))
     |> Enum.reverse()
     |> Enum.map(fn run ->
       %{
@@ -257,12 +256,12 @@ defmodule TuistWeb.RunnersLive do
 
   defp workflow_run_detail_url(_account_name, _row), do: nil
 
-  # Bars represent each succeeded/failed job. Y is the duration in
-  # seconds, the bar colour mirrors the row's status badge so the chart
-  # reads at the same glance as the table.
+  # One bar per job, all of them succeeded or failed since the query
+  # narrows to `@duration_conclusions`. Y is the duration in seconds,
+  # the bar colour mirrors the row's status badge so the chart reads at
+  # the same glance as the table.
   defp recent_jobs_chart_data(recent_jobs, account_name) do
     recent_jobs
-    |> Enum.filter(&(&1.conclusion in @chart_conclusions))
     |> Enum.reverse()
     |> Enum.map(fn job ->
       seconds = duration_seconds(job)

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -22,10 +22,9 @@ defmodule TuistWeb.RunnersLive do
   # Only work that reached a success/failure conclusion carries a real
   # duration. Running, cancelled and skipped runs would draw as
   # zero-height bars that scatter the real ones, and count for nothing
-  # in the success/failure legends. The Recent jobs card narrows to
-  # these at the query so its table, bars and legends all describe the
-  # same set of jobs; the workflow-run chart drops the rest before
-  # plotting.
+  # in the success/failure legends. Both Recent cards narrow to these
+  # at the query, so each one's table, bars and legends describe the
+  # same set of rows.
   @duration_conclusions ["success", "failure"]
 
   @impl true
@@ -186,10 +185,27 @@ defmodule TuistWeb.RunnersLive do
 
     socket
     |> assign(:recent_jobs, recent_jobs_table)
+    |> assign(:recent_jobs_hidden, hidden_recent_jobs?(recent_jobs_chart, account_id, repository, platform))
     |> assign(:recent_jobs_chart_data, recent_jobs_chart_data(recent_jobs_chart, socket.assigns.selected_account.name))
     |> assign(:recent_jobs_successful_count, Enum.count(recent_jobs_chart, &(&1.conclusion == "success")))
     |> assign(:recent_jobs_failed_count, Enum.count(recent_jobs_chart, &(&1.conclusion == "failure")))
   end
+
+  # An empty card no longer means "this account has never run a job" —
+  # it also happens when everything recent was skipped or cancelled.
+  # The distinction picks the empty state's copy and keeps `View more`
+  # live so those rows stay one click away on the Jobs page. Only worth
+  # a second query in the empty case, which is the only one that asks.
+  defp hidden_recent_jobs?([], account_id, repository, platform) do
+    opts =
+      [limit: 1]
+      |> maybe_repository(repository)
+      |> maybe_platform(platform)
+
+    Jobs.list_for_account(account_id, opts) != []
+  end
+
+  defp hidden_recent_jobs?(_rows, _account_id, _repository, _platform), do: false
 
   defp assign_recent_workflow_runs(socket, account_id, repository, platform) do
     # Same contract as the Recent jobs card above: a run rolls up to
@@ -206,6 +222,10 @@ defmodule TuistWeb.RunnersLive do
     socket
     |> assign(:recent_workflow_runs, recent_workflow_runs_table)
     |> assign(
+      :recent_workflow_runs_hidden,
+      hidden_recent_workflow_runs?(recent_workflow_runs_chart, account_id, repository, platform)
+    )
+    |> assign(
       :recent_workflow_runs_chart_data,
       recent_workflow_runs_chart_data(recent_workflow_runs_chart, socket.assigns.selected_account.name)
     )
@@ -218,6 +238,17 @@ defmodule TuistWeb.RunnersLive do
       Enum.count(recent_workflow_runs_chart, &(&1.conclusion == "failure"))
     )
   end
+
+  defp hidden_recent_workflow_runs?([], account_id, repository, platform) do
+    opts =
+      [limit: 1]
+      |> maybe_repository(repository)
+      |> maybe_platform(platform)
+
+    Jobs.list_recent_workflow_runs_for_account(account_id, opts) != []
+  end
+
+  defp hidden_recent_workflow_runs?(_rows, _account_id, _repository, _platform), do: false
 
   # Workflow-run bars mirror the recent-jobs chart: one bar per
   # succeeded/failed run, height in seconds, colour from the run-level
@@ -240,6 +271,9 @@ defmodule TuistWeb.RunnersLive do
   defp run_duration_seconds(%{duration_ms: ms}) when is_integer(ms) and ms > 0, do: div(ms, 1000)
   defp run_duration_seconds(_), do: 0
 
+  # The card only ever plots `@duration_conclusions`; the rest are kept
+  # as defensive clauses so a colour is defined for every conclusion
+  # the rollup can produce.
   defp workflow_run_chart_color("success"), do: "var:noora-chart-primary"
   defp workflow_run_chart_color("failure"), do: "var:noora-chart-destructive"
   defp workflow_run_chart_color("cancelled"), do: "var:noora-chart-warning"
@@ -293,6 +327,8 @@ defmodule TuistWeb.RunnersLive do
 
   defp duration_seconds(_), do: 0
 
+  # As with `workflow_run_chart_color/1`, the card only ever plots
+  # `@duration_conclusions`; the other clauses stay defensive.
   defp chart_color_for(%{status: "completed", conclusion: "success"}), do: "var:noora-chart-primary"
   defp chart_color_for(%{status: "completed", conclusion: "failure"}), do: "var:noora-chart-destructive"
   defp chart_color_for(%{status: "completed", conclusion: "cancelled"}), do: "var:noora-chart-warning"

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -24,6 +24,11 @@ defmodule TuistWeb.RunnersLive do
   # zero-height bars that scatter the real ones, so they are kept out of
   # the chart trail (and are not counted by the success/failure legends).
   @chart_conclusions ["success", "failure"]
+  # A job gated out by an `if:` condition is reported as
+  # completed/skipped without a runner ever claiming it. It represents
+  # no work, so it stays out of the card entirely rather than filling
+  # the table with 0ms rows.
+  @excluded_recent_conclusions ["skipped"]
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
@@ -173,7 +178,7 @@ defmodule TuistWeb.RunnersLive do
     # `@chart_limit` so the bar trail conveys a trend, while the
     # table below shows only the freshest `@table_limit` rows.
     opts =
-      [status: "completed", limit: @chart_limit]
+      [status: "completed", exclude_conclusions: @excluded_recent_conclusions, limit: @chart_limit]
       |> maybe_repository(repository)
       |> maybe_platform(platform)
 

--- a/server/lib/tuist_web/live/runners_live.html.heex
+++ b/server/lib/tuist_web/live/runners_live.html.heex
@@ -378,7 +378,7 @@
         size="medium"
         label={dgettext("dashboard_runners", "View more")}
         navigate={~p"/#{@selected_account.name}/runners/workflows"}
-        disabled={Enum.empty?(@recent_workflow_runs)}
+        disabled={Enum.empty?(@recent_workflow_runs) and not @recent_workflow_runs_hidden}
       />
     </:actions>
     <.card_section
@@ -494,8 +494,18 @@
       </div>
       <div :if={Enum.empty?(@recent_workflow_runs)} data-part="empty-recent-workflows">
         <.empty_card_section
-          title={TuistWeb.RunnersLive.widget_empty_label()}
-          get_started_href="https://tuist.dev/en/docs"
+          title={
+            if @recent_workflow_runs_hidden,
+              do:
+                dgettext(
+                  "dashboard_runners",
+                  "Every recent workflow run was skipped or cancelled"
+                ),
+              else: TuistWeb.RunnersLive.widget_empty_label()
+          }
+          get_started_href={
+            if @recent_workflow_runs_hidden, do: nil, else: "https://tuist.dev/en/docs"
+          }
         >
           <:image>
             <img
@@ -527,7 +537,7 @@
         size="medium"
         label={dgettext("dashboard_runners", "View more")}
         navigate={~p"/#{@selected_account.name}/runners/jobs"}
-        disabled={Enum.empty?(@recent_jobs)}
+        disabled={Enum.empty?(@recent_jobs) and not @recent_jobs_hidden}
       />
     </:actions>
     <.card_section
@@ -661,8 +671,12 @@
       </div>
       <div :if={Enum.empty?(@recent_jobs)} data-part="empty-recent-jobs">
         <.empty_card_section
-          title={TuistWeb.RunnersLive.widget_empty_label()}
-          get_started_href="https://tuist.dev/en/docs"
+          title={
+            if @recent_jobs_hidden,
+              do: dgettext("dashboard_runners", "Every recent job was skipped or cancelled"),
+              else: TuistWeb.RunnersLive.widget_empty_label()
+          }
+          get_started_href={if @recent_jobs_hidden, do: nil, else: "https://tuist.dev/en/docs"}
         >
           <:image>
             <img

--- a/server/priv/gettext/dashboard_runners.pot
+++ b/server/priv/gettext/dashboard_runners.pot
@@ -53,7 +53,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:187
 #: lib/tuist_web/live/runner_workflow_live.html.heex:339
 #: lib/tuist_web/live/runners_live.html.heex:474
-#: lib/tuist_web/live/runners_live.html.heex:639
+#: lib/tuist_web/live/runners_live.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "Branch"
 msgstr ""
@@ -73,8 +73,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:524
 #: lib/tuist_web/live/runner_workflow_live.ex:178
 #: lib/tuist_web/live/runner_workflow_live.ex:316
-#: lib/tuist_web/live/runners_live.ex:342
-#: lib/tuist_web/live/runners_live.ex:673
+#: lib/tuist_web/live/runners_live.ex:385
+#: lib/tuist_web/live/runners_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:517
 #: lib/tuist_web/live/runner_workflow_live.ex:174
 #: lib/tuist_web/live/runner_workflow_live.ex:309
-#: lib/tuist_web/live/runners_live.ex:666
+#: lib/tuist_web/live/runners_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Claimed"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:519
 #: lib/tuist_web/live/runner_workflow_live.ex:311
-#: lib/tuist_web/live/runners_live.ex:668
+#: lib/tuist_web/live/runners_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -122,7 +122,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.html.heex:295
 #: lib/tuist_web/live/runner_workflow_live.html.heex:355
 #: lib/tuist_web/live/runners_live.html.heex:485
-#: lib/tuist_web/live/runners_live.html.heex:650
+#: lib/tuist_web/live/runners_live.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "Duration"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:193
 #: lib/tuist_web/live/runner_workflow_live.html.heex:218
 #: lib/tuist_web/live/runners_live.html.heex:396
-#: lib/tuist_web/live/runners_live.html.heex:545
+#: lib/tuist_web/live/runners_live.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -150,8 +150,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:523
 #: lib/tuist_web/live/runner_workflow_live.ex:177
 #: lib/tuist_web/live/runner_workflow_live.ex:315
-#: lib/tuist_web/live/runners_live.ex:341
-#: lib/tuist_web/live/runners_live.ex:672
+#: lib/tuist_web/live/runners_live.ex:384
+#: lib/tuist_web/live/runners_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Failure"
 msgstr ""
@@ -170,8 +170,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:266
 #: lib/tuist_web/live/runner_workflow_live.html.heex:287
 #: lib/tuist_web/live/runner_workflow_live.html.heex:322
-#: lib/tuist_web/live/runners_live.html.heex:583
-#: lib/tuist_web/live/runners_live.html.heex:609
+#: lib/tuist_web/live/runners_live.html.heex:593
+#: lib/tuist_web/live/runners_live.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Job"
 msgstr ""
@@ -257,7 +257,7 @@ msgid "No jobs match the current filters"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.html.heex:684
-#: lib/tuist_web/live/runners_live.ex:688
+#: lib/tuist_web/live/runners_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "No jobs yet"
 msgstr ""
@@ -285,12 +285,12 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:489
 #: lib/tuist_web/live/runner_workflow_live.ex:173
 #: lib/tuist_web/live/runner_workflow_live.ex:308
-#: lib/tuist_web/live/runners_live.ex:665
+#: lib/tuist_web/live/runners_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Queued"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.html.heex:520
+#: lib/tuist_web/live/runners_live.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "Recent jobs"
 msgstr ""
@@ -300,12 +300,12 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:597
 #: lib/tuist_web/live/runner_workflows_live.html.heex:365
 #: lib/tuist_web/live/runners_live.html.heex:465
-#: lib/tuist_web/live/runners_live.html.heex:620
+#: lib/tuist_web/live/runners_live.html.heex:630
 #, elixir-autogen, elixir-format
 msgid "Repository"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:44
+#: lib/tuist_web/live/runners_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Runners"
 msgstr ""
@@ -316,7 +316,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:472
 #: lib/tuist_web/live/runner_workflow_live.ex:175
 #: lib/tuist_web/live/runner_workflow_live.ex:310
-#: lib/tuist_web/live/runners_live.ex:667
+#: lib/tuist_web/live/runners_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -328,8 +328,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:525
 #: lib/tuist_web/live/runner_workflow_live.ex:179
 #: lib/tuist_web/live/runner_workflow_live.ex:317
-#: lib/tuist_web/live/runners_live.ex:343
-#: lib/tuist_web/live/runners_live.ex:674
+#: lib/tuist_web/live/runners_live.ex:386
+#: lib/tuist_web/live/runners_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.ex:169
 #: lib/tuist_web/live/runner_workflow_live.html.heex:328
 #: lib/tuist_web/live/runners_live.html.heex:468
-#: lib/tuist_web/live/runners_live.html.heex:628
+#: lib/tuist_web/live/runners_live.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -353,8 +353,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:522
 #: lib/tuist_web/live/runner_workflow_live.ex:176
 #: lib/tuist_web/live/runner_workflow_live.ex:314
-#: lib/tuist_web/live/runners_live.ex:340
-#: lib/tuist_web/live/runners_live.ex:671
+#: lib/tuist_web/live/runners_live.ex:383
+#: lib/tuist_web/live/runners_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Success"
 msgstr ""
@@ -367,7 +367,7 @@ msgid "Success rate"
 msgstr ""
 
 #: lib/tuist_web/live/runners_live.html.heex:391
-#: lib/tuist_web/live/runners_live.html.heex:540
+#: lib/tuist_web/live/runners_live.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "Successful"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_profiles_live.ex:26
 #: lib/tuist_web/live/runner_workflow_live.ex:30
 #: lib/tuist_web/live/runner_workflows_live.ex:25
-#: lib/tuist_web/live/runners_live.ex:33
+#: lib/tuist_web/live/runners_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
@@ -431,20 +431,20 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.html.heex:344
 #: lib/tuist_web/live/runner_workflows_live.html.heex:360
 #: lib/tuist_web/live/runner_workflows_live.html.heex:368
-#: lib/tuist_web/live/runners_live.ex:344
-#: lib/tuist_web/live/runners_live.ex:669
+#: lib/tuist_web/live/runners_live.ex:387
+#: lib/tuist_web/live/runners_live.ex:712
 #: lib/tuist_web/live/runners_live.html.heex:460
 #: lib/tuist_web/live/runners_live.html.heex:479
-#: lib/tuist_web/live/runners_live.html.heex:615
-#: lib/tuist_web/live/runners_live.html.heex:623
-#: lib/tuist_web/live/runners_live.html.heex:644
+#: lib/tuist_web/live/runners_live.html.heex:625
+#: lib/tuist_web/live/runners_live.html.heex:633
+#: lib/tuist_web/live/runners_live.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
 #: lib/tuist_web/components/runs/ci_context_card.ex:26
 #: lib/tuist_web/live/runners_live.html.heex:379
-#: lib/tuist_web/live/runners_live.html.heex:528
+#: lib/tuist_web/live/runners_live.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "View more"
 msgstr ""
@@ -459,7 +459,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflows_live.html.heex:311
 #: lib/tuist_web/live/runner_workflows_live.html.heex:354
 #: lib/tuist_web/live/runners_live.html.heex:457
-#: lib/tuist_web/live/runners_live.html.heex:612
+#: lib/tuist_web/live/runners_live.html.heex:622
 #, elixir-autogen, elixir-format
 msgid "Workflow"
 msgstr ""
@@ -527,35 +527,35 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.html.heex:115
 #: lib/tuist_web/live/runner_workflow_live.html.heex:160
 #: lib/tuist_web/live/runner_workflows_live.ex:283
-#: lib/tuist_web/live/runners_live.ex:367
+#: lib/tuist_web/live/runners_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "since last month"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:257
 #: lib/tuist_web/live/runner_workflows_live.ex:282
-#: lib/tuist_web/live/runners_live.ex:366
+#: lib/tuist_web/live/runners_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "since last period"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:255
 #: lib/tuist_web/live/runner_workflows_live.ex:280
-#: lib/tuist_web/live/runners_live.ex:364
+#: lib/tuist_web/live/runners_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "since last week"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:256
 #: lib/tuist_web/live/runner_workflows_live.ex:281
-#: lib/tuist_web/live/runners_live.ex:365
+#: lib/tuist_web/live/runners_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "since last year"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:254
 #: lib/tuist_web/live/runner_workflows_live.ex:279
-#: lib/tuist_web/live/runners_live.ex:363
+#: lib/tuist_web/live/runners_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
 msgstr ""
@@ -624,8 +624,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflows_live.ex:242
 #: lib/tuist_web/live/runner_workflows_live.html.heex:10
 #: lib/tuist_web/live/runner_workflows_live.html.heex:40
-#: lib/tuist_web/live/runners_live.ex:308
-#: lib/tuist_web/live/runners_live.ex:329
+#: lib/tuist_web/live/runners_live.ex:350
+#: lib/tuist_web/live/runners_live.ex:371
 #: lib/tuist_web/live/runners_live.html.heex:10
 #: lib/tuist_web/live/runners_live.html.heex:40
 #, elixir-autogen, elixir-format
@@ -720,8 +720,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_profiles_live.ex:331
 #: lib/tuist_web/live/runner_profiles_live.ex:348
 #: lib/tuist_web/live/runner_workflows_live.ex:241
-#: lib/tuist_web/live/runners_live.ex:326
-#: lib/tuist_web/live/runners_live.ex:328
+#: lib/tuist_web/live/runners_live.ex:368
+#: lib/tuist_web/live/runners_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Linux"
 msgstr ""
@@ -748,8 +748,8 @@ msgstr ""
 #: lib/tuist_web/live/runner_profiles_live.ex:332
 #: lib/tuist_web/live/runner_profiles_live.ex:349
 #: lib/tuist_web/live/runner_workflows_live.ex:240
-#: lib/tuist_web/live/runners_live.ex:325
-#: lib/tuist_web/live/runners_live.ex:327
+#: lib/tuist_web/live/runners_live.ex:367
+#: lib/tuist_web/live/runners_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "macOS"
 msgstr ""
@@ -1349,37 +1349,47 @@ msgstr ""
 msgid "Concurrency"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:497
+#: lib/tuist_web/live/runners_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "%{limit} GB limit"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:493
+#: lib/tuist_web/live/runners_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "%{limit} vCPU limit"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:518
+#: lib/tuist_web/live/runners_live.ex:561
 #, elixir-autogen, elixir-format
 msgid "Limit"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:466
+#: lib/tuist_web/live/runners_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "%{platform} memory"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:459
+#: lib/tuist_web/live/runners_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "%{platform} vCPU"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:500
+#: lib/tuist_web/live/runners_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "Peak CPU"
 msgstr ""
 
-#: lib/tuist_web/live/runners_live.ex:501
+#: lib/tuist_web/live/runners_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Peak memory"
+msgstr ""
+
+#: lib/tuist_web/live/runners_live.html.heex:676
+#, elixir-autogen, elixir-format
+msgid "Every recent job was skipped or cancelled"
+msgstr ""
+
+#: lib/tuist_web/live/runners_live.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Every recent workflow run was skipped or cancelled"
 msgstr ""

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -782,7 +782,7 @@ defmodule Tuist.Runners.JobsTest do
       assert bottom.workflow_job_id == 8501
     end
 
-    test "drops the conclusions listed in :exclude_conclusions" do
+    test "narrows to any of the conclusions when :conclusion is a list" do
       account = account_fixture()
       base = ~U[2026-05-01 10:00:00.000000Z]
 
@@ -793,14 +793,16 @@ defmodule Tuist.Runners.JobsTest do
           completed_at: DateTime.add(base, 30, :second)
         )
 
-      :ok = completed_job_fixture(account, 8702, conclusion: "skipped", completed_at: base)
-      :ok = completed_job_fixture(account, 8703, conclusion: "cancelled", completed_at: base)
+      :ok = completed_job_fixture(account, 8702, conclusion: "failure", completed_at: base)
+      :ok = completed_job_fixture(account, 8703, conclusion: "skipped", completed_at: base)
+      :ok = completed_job_fixture(account, 8704, conclusion: "cancelled", completed_at: base)
 
-      jobs = Jobs.list_for_account(account.id, status: "completed", exclude_conclusions: ["skipped"])
+      opts = [status: "completed", conclusion: ["success", "failure"]]
 
-      assert jobs |> Enum.map(& &1.workflow_job_id) |> Enum.sort() == [8701, 8703]
+      assert account.id |> Jobs.list_for_account(opts) |> Enum.map(& &1.workflow_job_id) |> Enum.sort() ==
+               [8701, 8702]
 
-      assert Jobs.count_for_account(account.id, status: "completed", exclude_conclusions: ["skipped"]) == 2
+      assert Jobs.count_for_account(account.id, opts) == 2
     end
 
     test "filters by :search via job_name ILIKE substring" do

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -782,6 +782,27 @@ defmodule Tuist.Runners.JobsTest do
       assert bottom.workflow_job_id == 8501
     end
 
+    test "drops the conclusions listed in :exclude_conclusions" do
+      account = account_fixture()
+      base = ~U[2026-05-01 10:00:00.000000Z]
+
+      :ok =
+        completed_job_fixture(account, 8701,
+          conclusion: "success",
+          started_at: base,
+          completed_at: DateTime.add(base, 30, :second)
+        )
+
+      :ok = completed_job_fixture(account, 8702, conclusion: "skipped", completed_at: base)
+      :ok = completed_job_fixture(account, 8703, conclusion: "cancelled", completed_at: base)
+
+      jobs = Jobs.list_for_account(account.id, status: "completed", exclude_conclusions: ["skipped"])
+
+      assert jobs |> Enum.map(& &1.workflow_job_id) |> Enum.sort() == [8701, 8703]
+
+      assert Jobs.count_for_account(account.id, status: "completed", exclude_conclusions: ["skipped"]) == 2
+    end
+
     test "filters by :search via job_name ILIKE substring" do
       account = account_fixture()
 

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -1028,6 +1028,37 @@ defmodule Tuist.Runners.JobsTest do
       assert Enum.map(runs, & &1.workflow_run_id) == [7_401]
     end
 
+    test "drops a run whose jobs mostly succeeded but one was cancelled" do
+      account = account_fixture()
+      base = ~U[2026-05-01 10:00:00.000000Z]
+
+      :ok =
+        completed_job_fixture(account, 64_101,
+          workflow_run_id: 7_501,
+          conclusion: "success",
+          started_at: base,
+          completed_at: DateTime.add(base, 60, :second)
+        )
+
+      :ok =
+        completed_job_fixture(account, 64_102,
+          workflow_run_id: 7_501,
+          conclusion: "cancelled",
+          started_at: base,
+          completed_at: DateTime.add(base, 90, :second)
+        )
+
+      # The rollup ladder ranks cancelled above success, so this run
+      # reads `cancelled` even though most of it ran and it carries a
+      # real duration. The card asks for success/failure only, so it
+      # stays out — deliberate, and the Workflows page still lists it.
+      assert Jobs.list_recent_workflow_runs_for_account(account.id, conclusion: ["success", "failure"]) == []
+
+      assert account.id
+             |> Jobs.list_recent_workflow_runs_for_account()
+             |> Enum.map(& &1.conclusion) == ["cancelled"]
+    end
+
     test "scopes results to the given account" do
       mine = account_fixture()
       other = account_fixture()

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -991,6 +991,43 @@ defmodule Tuist.Runners.JobsTest do
       assert run.duration_ms >= 0
     end
 
+    test "narrows to the given conclusions, applying the limit after the filter" do
+      account = account_fixture()
+      base = ~U[2026-05-01 10:00:00.000000Z]
+
+      :ok =
+        completed_job_fixture(account, 64_001,
+          workflow_run_id: 7_401,
+          conclusion: "success",
+          started_at: base,
+          completed_at: DateTime.add(base, 60, :second)
+        )
+
+      # Both land after the succeeded run, so an unfiltered limit of 1
+      # would return one of these instead of it.
+      :ok =
+        completed_job_fixture(account, 64_002,
+          workflow_run_id: 7_402,
+          conclusion: "skipped",
+          completed_at: DateTime.add(base, 120, :second)
+        )
+
+      :ok =
+        completed_job_fixture(account, 64_003,
+          workflow_run_id: 7_403,
+          conclusion: "cancelled",
+          completed_at: DateTime.add(base, 180, :second)
+        )
+
+      runs =
+        Jobs.list_recent_workflow_runs_for_account(account.id,
+          conclusion: ["success", "failure"],
+          limit: 1
+        )
+
+      assert Enum.map(runs, & &1.workflow_run_id) == [7_401]
+    end
+
     test "scopes results to the given account" do
       mine = account_fixture()
       other = account_fixture()

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -128,6 +128,26 @@ defmodule TuistWeb.RunnersLiveTest do
     assert html =~ "Concurrency"
     assert html =~ "Recent jobs"
     assert html =~ "No jobs yet"
+    assert html =~ "Get started"
+    assert Enum.all?(view_more_buttons(html), &disabled?/1)
+  end
+
+  test "tells an account whose recent work was all filtered out from one with no jobs", %{
+    conn: conn,
+    account: account
+  } do
+    skip_run(account, 70_010, 700_028)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
+    html = render_async(lv, @render_async_timeout)
+
+    assert html =~ "Every recent job was skipped or cancelled"
+    assert html =~ "Every recent workflow run was skipped or cancelled"
+    refute html =~ "No jobs yet"
+    # The rows exist behind the Jobs and Workflows pages' own filters,
+    # so the way there must stay open and the onboarding link away.
+    refute html =~ "Get started"
+    assert Enum.all?(view_more_buttons(html), &(not disabled?(&1)))
   end
 
   test "shows only the selected concurrency platform", %{conn: conn, account: account} do
@@ -218,6 +238,23 @@ defmodule TuistWeb.RunnersLiveTest do
         "skipped"
       )
   end
+
+  # Noora renders an enabled button with a `navigate` as a link, and a
+  # disabled one as a plain `<button disabled>`. Both cards carry one,
+  # so anything other than two means the lookup, not the page, changed.
+  defp view_more_buttons(html) do
+    buttons =
+      html
+      |> Floki.parse_document!()
+      |> Floki.find("a, button")
+      |> Enum.filter(&(&1 |> Floki.text() |> String.contains?("View more")))
+
+    assert length(buttons) == 2
+    buttons
+  end
+
+  defp disabled?({"button", attrs, _}), do: Enum.any?(attrs, fn {name, _} -> name == "disabled" end)
+  defp disabled?({"a", _attrs, _}), do: false
 
   defp recent_jobs_table(html), do: table_text(html, "recent-jobs-table")
 

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -106,6 +106,20 @@ defmodule TuistWeb.RunnersLiveTest do
     refute table =~ "Cancelled"
   end
 
+  test "lists only succeeded and failed runs in the recent workflows card", %{conn: conn, account: account} do
+    complete_run(account, 70_007, 700_025, "success")
+    complete_run(account, 70_008, 700_026, "cancelled")
+    skip_run(account, 70_009, 700_027)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
+    html = render_async(lv, @render_async_timeout)
+    table = recent_workflows_table(html)
+
+    assert table =~ "Success"
+    refute table =~ "Skipped"
+    refute table =~ "Cancelled"
+  end
+
   test "shows empty state when the account has no jobs", %{conn: conn, account: account} do
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
     html = render_async(lv, @render_async_timeout)
@@ -205,10 +219,14 @@ defmodule TuistWeb.RunnersLiveTest do
       )
   end
 
-  defp recent_jobs_table(html) do
+  defp recent_jobs_table(html), do: table_text(html, "recent-jobs-table")
+
+  defp recent_workflows_table(html), do: table_text(html, "recent-workflows-table")
+
+  defp table_text(html, part) do
     html
     |> Floki.parse_document!()
-    |> Floki.find("[data-part='recent-jobs-table']")
+    |> Floki.find("[data-part='#{part}']")
     |> Floki.text()
   end
 

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -91,6 +91,19 @@ defmodule TuistWeb.RunnersLiveTest do
     end
   end
 
+  test "keeps skipped jobs out of the recent jobs card", %{conn: conn, account: account} do
+    complete_run(account, 70_004, 700_022, "success")
+    skip_run(account, 70_005, 700_023)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
+    html = render_async(lv, @render_async_timeout)
+    table = recent_jobs_table(html)
+
+    assert table =~ "Docker build"
+    refute table =~ "Gated job"
+    refute table =~ "Skipped"
+  end
+
   test "shows empty state when the account has no jobs", %{conn: conn, account: account} do
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
     html = render_async(lv, @render_async_timeout)
@@ -167,6 +180,34 @@ defmodule TuistWeb.RunnersLiveTest do
     :ok = Jobs.record_claimed(candidate, "pod-#{workflow_job_id}", DateTime.utc_now())
     :ok = Jobs.record_running(workflow_job_id, "runner-#{workflow_job_id}")
     {:ok, _} = Jobs.complete(workflow_job_id, conclusion)
+  end
+
+  # A job gated out by an `if:` condition never reaches a runner, so
+  # GitHub delivers `completed`/`skipped` with no preceding `queued`.
+  defp skip_run(account, workflow_job_id, workflow_run_id) do
+    :ok =
+      Jobs.record_completed(
+        %{
+          workflow_job_id: workflow_job_id,
+          account_id: account.id,
+          fleet_name: "fleet-x",
+          repository: "tuist/tuist",
+          workflow_run_id: workflow_run_id,
+          workflow_name: "Server",
+          run_attempt: 1,
+          job_name: "Gated job",
+          head_branch: "main",
+          head_sha: "abcdef#{workflow_job_id}"
+        },
+        "skipped"
+      )
+  end
+
+  defp recent_jobs_table(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-part='recent-jobs-table']")
+    |> Floki.text()
   end
 
   defp chart_series_data(html, chart_id) do

--- a/server/test/tuist_web/live/runners_live_test.exs
+++ b/server/test/tuist_web/live/runners_live_test.exs
@@ -91,8 +91,9 @@ defmodule TuistWeb.RunnersLiveTest do
     end
   end
 
-  test "keeps skipped jobs out of the recent jobs card", %{conn: conn, account: account} do
+  test "lists only succeeded and failed jobs in the recent jobs card", %{conn: conn, account: account} do
     complete_run(account, 70_004, 700_022, "success")
+    complete_run(account, 70_006, 700_024, "cancelled")
     skip_run(account, 70_005, 700_023)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/runners")
@@ -102,6 +103,7 @@ defmodule TuistWeb.RunnersLiveTest do
     assert table =~ "Docker build"
     refute table =~ "Gated job"
     refute table =~ "Skipped"
+    refute table =~ "Cancelled"
   end
 
   test "shows empty state when the account has no jobs", %{conn: conn, account: account} do


### PR DESCRIPTION
The Recent jobs card on the runners overview was showing nothing but skipped jobs, every row reading 0ms, while the Successful and Failed legends both showed 0. The Recent workflows card above it had the same problem, listing Skipped and Cancelled runs with a `None` duration.

### What changed

Both cards queried for completed work without constraining the conclusion. GitHub reports a job gated out by an `if:` condition as completed with conclusion `skipped`, without a runner ever claiming it, and a workflow run rolls up to `skipped` when every job in it was gated out. None of that work has a duration.

Meanwhile the charts and the Successful/Failed legends on both cards already ignored every conclusion outside success/failure. So each card described two different sets of work: rows that no bar and no legend accounted for, sitting in tables that hold only five entries. On an account whose recent activity is mostly gated preview workflows, that is the whole card.

Both cards now narrow to `["success", "failure"]` at the query, so the table, the bars and the legends describe the same runs.

`cancelled` goes with `skipped`, and that part is a deliberate call rather than a consequence: the rollup ranks `cancelled` above `success`, so a run where nine jobs succeeded and the tenth was cancelled reads `cancelled` and carries a real duration, and it is excluded all the same. Including it would put rows on the card that neither legend counts, and the Jobs and Workflows pages already list them behind their status chips. A test pins that mixed shape so the choice is not silently revisited.

Because the filter is total rather than advisory, an empty card no longer implies the account never ran anything. Each card asks, only when it comes back empty, whether the account has anything at all in the same repository/platform scope. If it does, the copy says the recent work was skipped or cancelled, the onboarding link drops, and `View more` stays enabled so the pages listing those rows remain one click away.

Supporting changes in `Tuist.Runners.Jobs`:

- `list_for_account/2` could only pin a single conclusion, so `:conclusion` now also accepts a list. That is a smaller surface than a second, opposite-signed option beside it, and the only other caller, the conclusion filter chip on the Jobs page, passes a binary and is unaffected. `count_for_account/2` shares the filter and keeps its documented promise of matching `list_for_account/2`.
- `list_recent_workflow_runs_for_account/2` gains the same option. Its filter has to sit outside the rollup rather than in the `having` clause, because the run-level conclusion is a column the rollup computes: filtering in the `having` would mean restating that nested `if(countIf(...))` expression.

Filtering in the query rather than after the fetch matters for both: the limit is applied by ClickHouse, so dropping rows afterwards would shrink each card below its intended size, down to empty for an account whose recent completed work was all gated, which is exactly the state that surfaced this.

With the queries as the single gate, the now-redundant in-memory filters in `recent_jobs_chart_data/2` and `recent_workflow_runs_chart_data/2` are removed.

### Impact

Both cards on the runners overview list work that actually ran. The Jobs and Workflows pages, where the Skipped and Cancelled filter chips are deliberate features, are unchanged.

### How to test locally

Open the runners overview for an account whose recent activity includes gated workflows, for example `/tuist/runners?analytics-date-range=last-24-hours`, and confirm both cards list work with real durations instead of 0ms and `None` rows.

```
mix test test/tuist/runners/jobs_test.exs test/tuist_web/live/runners_live_test.exs test/tuist_web/live/runner_jobs_live_test.exs test/tuist_web/live/runner_workflow_live_test.exs
```

- `narrows to any of the conclusions when :conclusion is a list` covers the jobs query, including the mirrored `count_for_account/2`.
- `narrows to the given conclusions, applying the limit after the filter` covers the workflow-run rollup, and pins the limit-after-filter ordering by asking for one row while the two most recent runs are skipped and cancelled.
- `lists only succeeded and failed jobs in the recent jobs card` seeds a skipped job through `Jobs.record_completed/2`, the real webhook path for a gated job with no preceding queued row, plus a cancelled one, and asserts neither reaches the rendered table. `lists only succeeded and failed runs in the recent workflows card` does the same for the card above.
- `drops a run whose jobs mostly succeeded but one was cancelled` pins the deliberate exclusion described above.
- `tells an account whose recent work was all filtered out from one with no jobs` covers the empty state: the filtered copy, no onboarding link, and both `View more` buttons still enabled.
- Every refutation was confirmed to fail without its filter, so none of them pass vacuously. The pre-existing `charts only succeeded and failed runs` now covers the removal of the in-memory chart filters: it fails if either query-level filter is dropped.

