### PR TITLE
feat(cli): add tuist teardown insights command

### DIFF
--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -98,6 +98,11 @@ public protocol Environmenting: Sendable {
     /// proxy serves every project on the machine, multiplexing by instance.
     func casProxyLaunchAgentLabel() -> String
 
+    /// Returns the machine-wide LaunchAgent label for the host metrics sampling
+    /// daemon. Shared between `tuist setup insights` (which registers the LaunchAgent)
+    /// and `tuist teardown insights` (which boots it out).
+    func metricsSamplerLaunchAgentLabel() -> String
+
     /// Returns the current architecture of the machine
     func architecture() async throws -> MacArchitecture
 
@@ -450,6 +455,10 @@ public struct Environment: Environmenting {
 
     public func casProxyLaunchAgentLabel() -> String {
         "tuist.cas-proxy"
+    }
+
+    public func metricsSamplerLaunchAgentLabel() -> String {
+        "tuist.metrics-sampler"
     }
 
     #if os(macOS)

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -98,6 +98,10 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
     public func casProxyLaunchAgentLabel() -> String {
         "tuist.cas-proxy"
     }
+
+    public func metricsSamplerLaunchAgentLabel() -> String {
+        "tuist.metrics-sampler"
+    }
 }
 
 extension Environment {

--- a/cli/Sources/TuistKit/Commands/Teardown/TeardownInsightsCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Teardown/TeardownInsightsCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+
+struct TeardownInsightsCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "insights",
+            _superCommandName: "teardown",
+            abstract: "Stop the insights daemon and remove its LaunchAgent and sampled machine metrics"
+        )
+    }
+
+    func run() async throws {
+        try await TeardownInsightsCommandService().run()
+    }
+}

--- a/cli/Sources/TuistKit/Commands/TeardownCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TeardownCommand.swift
@@ -10,6 +10,7 @@ public struct TeardownCommand: AsyncParsableCommand {
             abstract: "Commands to tear down Tuist services previously set up with `tuist setup`",
             subcommands: [
                 TeardownCacheCommand.self,
+                TeardownInsightsCommand.self,
             ]
         )
     }

--- a/cli/Sources/TuistKit/Services/Setup/SetupInsightsCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupInsightsCommandService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TuistEnvironment
 import TuistLaunchctl
 import TuistLogging
 
@@ -12,9 +13,10 @@ struct SetupInsightsCommandService {
     }
 
     func run() async throws {
+        let label = Environment.current.metricsSamplerLaunchAgentLabel()
         try await launchAgentService.setupLaunchAgent(
-            label: "tuist.metrics-sampler",
-            plistFileName: "tuist.metrics-sampler.plist",
+            label: label,
+            plistFileName: "\(label).plist",
             programArguments: ["sample-host-metrics"],
             environmentVariables: [:]
         )

--- a/cli/Sources/TuistKit/Services/Teardown/TeardownInsightsCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Teardown/TeardownInsightsCommandService.swift
@@ -1,0 +1,45 @@
+import FileSystem
+import Foundation
+import Path
+import TuistEnvironment
+import TuistLaunchctl
+import TuistLogging
+import TuistMachineMetrics
+
+struct TeardownInsightsCommandService {
+    private let launchAgentService: LaunchAgentServicing
+    private let fileSystem: FileSysteming
+
+    init(
+        launchAgentService: LaunchAgentServicing = LaunchAgentService(),
+        fileSystem: FileSysteming = FileSystem()
+    ) {
+        self.launchAgentService = launchAgentService
+        self.fileSystem = fileSystem
+    }
+
+    func run() async throws {
+        let label = Environment.current.metricsSamplerLaunchAgentLabel()
+        try await launchAgentService.teardownLaunchAgent(
+            label: label,
+            plistFileName: "\(label).plist"
+        )
+
+        // The samples are only meaningful to a running daemon, and leaving them behind
+        // means a later `tuist setup insights` appends to a file the daemon never wrote.
+        let metricsFilePath = MachineMetricsReader.metricsFilePath
+        let stateDirectory = Environment.current.stateDirectory
+        let leftovers = [
+            metricsFilePath,
+            metricsFilePath.parentDirectory.appending(component: "\(metricsFilePath.basename).lock"),
+            stateDirectory.appending(component: "\(label).stdout.log"),
+            stateDirectory.appending(component: "\(label).stderr.log"),
+        ]
+        for path in leftovers {
+            guard try await fileSystem.exists(path) else { continue }
+            try await fileSystem.remove(path)
+        }
+
+        Logger.current.info("Insights daemon has been torn down 🧹", metadata: .success)
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupInsightsCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupInsightsCommandServiceTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Mockable
+import Testing
+import TuistEnvironment
+import TuistLaunchctl
+import TuistLoggerTesting
+import TuistTesting
+
+@testable import TuistKit
+
+struct SetupInsightsCommandServiceTests {
+    private let subject: SetupInsightsCommandService
+    private let launchAgentService = MockLaunchAgentServicing()
+
+    init() {
+        subject = SetupInsightsCommandService(
+            launchAgentService: launchAgentService
+        )
+
+        given(launchAgentService)
+            .setupLaunchAgent(
+                label: .any,
+                plistFileName: .any,
+                programArguments: .any,
+                environmentVariables: .any
+            )
+            .willReturn()
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedLogger()) func setupInsights() async throws {
+        // When
+        try await subject.run()
+
+        // Then: the label has to match the one `tuist teardown insights` boots out.
+        verify(launchAgentService)
+            .setupLaunchAgent(
+                label: .value("tuist.metrics-sampler"),
+                plistFileName: .value("tuist.metrics-sampler.plist"),
+                programArguments: .value(["sample-host-metrics"]),
+                environmentVariables: .value([:])
+            )
+            .called(1)
+
+        TuistTest.expectLogs("Metrics sampling daemon has been set up successfully")
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Teardown/TeardownInsightsCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Teardown/TeardownInsightsCommandServiceTests.swift
@@ -1,0 +1,83 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Mockable
+import Path
+import Testing
+import TuistEnvironment
+import TuistLaunchctl
+import TuistLoggerTesting
+import TuistMachineMetrics
+import TuistTesting
+
+@testable import TuistKit
+
+struct TeardownInsightsCommandServiceTests {
+    private let subject: TeardownInsightsCommandService
+    private let launchAgentService = MockLaunchAgentServicing()
+    private let fileSystem = FileSystem()
+
+    init() {
+        subject = TeardownInsightsCommandService(
+            launchAgentService: launchAgentService,
+            fileSystem: FileSystem()
+        )
+
+        given(launchAgentService)
+            .teardownLaunchAgent(label: .any, plistFileName: .any)
+            .willReturn()
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger()) func teardownInsights() async throws {
+        // When
+        try await subject.run()
+
+        // Then
+        verify(launchAgentService)
+            .teardownLaunchAgent(
+                label: .value("tuist.metrics-sampler"),
+                plistFileName: .value("tuist.metrics-sampler.plist")
+            )
+            .called(1)
+
+        TuistTest.expectLogs("Insights daemon has been torn down 🧹")
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func teardownInsights_removesSampledMetricsAndLogsWhenPresent() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        let metricsFilePath = MachineMetricsReader.metricsFilePath
+        let lockPath = metricsFilePath.parentDirectory
+            .appending(component: "\(metricsFilePath.basename).lock")
+        let stdoutLogPath = environment.stateDirectory
+            .appending(component: "tuist.metrics-sampler.stdout.log")
+        let stderrLogPath = environment.stateDirectory
+            .appending(component: "tuist.metrics-sampler.stderr.log")
+        for path in [metricsFilePath, lockPath, stdoutLogPath, stderrLogPath] {
+            try await fileSystem.writeText("", at: path)
+        }
+
+        // When
+        try await subject.run()
+
+        // Then
+        for path in [metricsFilePath, lockPath, stdoutLogPath, stderrLogPath] {
+            let exists = try await fileSystem.exists(path)
+            #expect(exists == false)
+        }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func teardownInsights_succeedsWhenSampledMetricsMissing() async throws {
+        // When / Then
+        try await subject.run()
+
+        verify(launchAgentService)
+            .teardownLaunchAgent(
+                label: .value("tuist.metrics-sampler"),
+                plistFileName: .value("tuist.metrics-sampler.plist")
+            )
+            .called(1)
+    }
+}

--- a/server/priv/docs/en/guides/features/build-insights/generated-projects.md
+++ b/server/priv/docs/en/guides/features/build-insights/generated-projects.md
@@ -88,6 +88,14 @@ This runs a local daemon that samples metrics in the background. The data is pic
 >
 > Run `tuist setup insights` on your CI machines before building to capture machine metrics there as well.
 
+To stop collecting machine metrics, run:
+
+```bash
+tuist teardown insights
+```
+
+This unloads the daemon's LaunchAgent, removes its plist, and deletes the sampled metrics and daemon logs from `~/.local/state`, so nothing is left running in the background.
+
 
 ## Custom metadata {#custom-metadata}
 

--- a/server/priv/docs/en/guides/features/build-insights/xcode.md
+++ b/server/priv/docs/en/guides/features/build-insights/xcode.md
@@ -85,6 +85,14 @@ This runs a local daemon that samples metrics in the background. The data is pic
 >
 > Run `tuist setup insights` on your CI machines before building to capture machine metrics there as well.
 
+To stop collecting machine metrics, run:
+
+```bash
+tuist teardown insights
+```
+
+This unloads the daemon's LaunchAgent, removes its plist, and deletes the sampled metrics and daemon logs from `~/.local/state`, so nothing is left running in the background.
+
 
 ## Custom metadata {#custom-metadata}
 


### PR DESCRIPTION
`tuist setup insights` installs a background daemon and nothing removed it. This adds `tuist teardown insights`, mirroring `tuist teardown cache`.

### What the daemon was, and why there was no way out

`tuist setup insights` registers a `tuist.metrics-sampler` LaunchAgent that runs the hidden `tuist sample-host-metrics` command: an infinite 1 Hz sampling loop, bootstrapped into `gui/<uid>` with `KeepAlive = {SuccessfulExit: false}` so it respawns on a nonzero exit. Bare `tuist setup` installs it too, alongside the cache setup.

Nothing removed it:

- `SetupInsightsCommand` had no flags at all, so there was no `--disable`.
- `TeardownCommand` registered only `TeardownCacheCommand`.
- The only removal behavior anywhere was the idempotency branch inside `setupLaunchAgent`, which boots the agent out and immediately reinstalls it.

So anyone who ran setup once was left with a permanent background process and no supported way to stop it, short of `launchctl bootout` by hand. Beyond the plist, the daemon also accumulates on-disk state in the state directory that nothing cleaned up: `machine_metrics.jsonl`, its `.lock`, and the agent's stdout/stderr logs.

### What changed

`LaunchAgentService.teardownLaunchAgent(label:plistFileName:)` already boots the agent out and deletes its plist, with tests covering it. It was simply never wired to insights, only to cache. This adds the service and subcommand around the existing machinery rather than introducing new teardown plumbing.

Two decisions worth a reviewer's attention:

**Teardown deletes the sampled state, not just the LaunchAgent.** Cache teardown removes only its socket, so this is deliberately a step further. The metrics file is different in kind from a socket: it is meaningless without a running daemon, and leaving it behind means a later `tuist setup insights` starts a daemon that appends to a file the new daemon never wrote. "Teardown" leaving a stale metrics file to be silently resurrected seemed worse than removing it.

**The LaunchAgent label moved into `Environment`.** The label and plist name were hardcoded string literals in the setup service. Duplicating them in a teardown service would let the two drift apart, and drift here is nasty in a specific way: the agent stays loaded while the teardown command that is supposed to name it looks for a label nobody registered, leaving a running daemon no command can address. They now come from `Environment.metricsSamplerLaunchAgentLabel()`, the same pattern `casProxyLaunchAgentLabel()` established for the cache path, and a new setup-service test pins the value from the other side so the two cannot separate silently.

### User impact

Users can stop machine metrics collection with a supported command, and CI machines that ran `tuist setup insights` can be returned to a clean state. Nothing about the setup path changes behaviorally: it registers the same label and plist as before, now resolved rather than literal.

### Not included

Bare `tuist setup` installs both cache and insights, but bare `tuist teardown` still just prints help rather than mirroring it. That asymmetry predates this change and is left alone here, since making bare `tuist teardown` destructive is a separate decision from giving insights a teardown path at all. Happy to close it in a follow-up if reviewers want the symmetry.

### How to test locally

Unit tests (4 tests across the new teardown suite and the new setup suite):

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TeardownInsightsCommandServiceTests -only-testing TuistKitTests/SetupInsightsCommandServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

End to end, on a machine where installing a LaunchAgent is acceptable:

```bash
tuist setup insights && launchctl print gui/$(id -u)/tuist.metrics-sampler | head -5
```

```bash
tuist teardown insights && launchctl print gui/$(id -u)/tuist.metrics-sampler
```

The second `launchctl print` should fail with "Could not find service", `~/Library/LaunchAgents/tuist.metrics-sampler.plist` should be gone, and `~/.local/state` should no longer contain `machine_metrics.jsonl`, its `.lock`, or the two `tuist.metrics-sampler.*.log` files.

### Validation performed

- The 4 unit tests pass via `xcodebuild test`.
- The cleanup assertions were confirmed non-vacuous: removing the deletion loop made all four leftover paths fail the expectation, and restoring it turned them green again.
- `tuist teardown --help` lists the new subcommand with its abstract.
- SwiftFormat reports no changes and SwiftLint is clean on the new files.
- The live setup/teardown round trip was deliberately not run during development, since it installs and removes a real LaunchAgent on the developer machine; it is documented above for reviewers instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
