### PR TITLE
fix(cli): stop an ambient provider token from overriding git's own credentials

### DIFF
--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -15,6 +15,11 @@ enum Environment {
     @TaskLocal
     static var netrc: Netrc = .empty
 
+    /// Git's own configuration, for deciding whether git can authenticate a location
+    /// unaided. Unbound outside tests, in which case it is read from `git config` once.
+    @TaskLocal
+    static var gitConfiguration: GitConfiguration?
+
     static var isCI: Bool {
         ["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"].contains { current[$0] != nil }
     }

--- a/swifterpm/Sources/swifterpm/GitConfiguration.swift
+++ b/swifterpm/Sources/swifterpm/GitConfiguration.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// The parts of git's configuration that decide whether a plain `git` invocation can find a
+/// credential for a location on its own.
+///
+/// Read once per process rather than per package: every dependency gets the same answer,
+/// and each read is a subprocess. Only the system, global and XDG scopes are read, because
+/// swifterpm fetches into freshly `git init`-ed scratch directories — the local config that
+/// applies to a dependency fetch is empty, so reading the user's project config would apply
+/// rules git itself would not.
+struct GitConfiguration: Sendable {
+    static let empty = GitConfiguration(insteadOfPrefixes: [], hasUnscopedHelper: false, helperURLs: [])
+
+    /// The right-hand side of every `url.<base>.insteadOf`, which is what git matches a
+    /// location against.
+    private let insteadOfPrefixes: [String]
+    /// A `credential.helper` with no URL subsection, which answers for every host.
+    private let hasUnscopedHelper: Bool
+    /// The URL subsection of every `credential.<url>.helper`.
+    private let helperURLs: [String]
+
+    init(insteadOfPrefixes: [String], hasUnscopedHelper: Bool, helperURLs: [String]) {
+        self.insteadOfPrefixes = insteadOfPrefixes
+        self.hasUnscopedHelper = hasUnscopedHelper
+        self.helperURLs = helperURLs
+    }
+
+    /// Whether git would find a credential for `location` without swifterpm injecting one.
+    ///
+    /// Answered fail-safe. `credential.<url>` has matching rules of its own — exact protocol,
+    /// exact host or a leading `*.` wildcard, path only under `credential.useHttpPath` — and
+    /// getting them subtly wrong in the "no match" direction reintroduces the bug this
+    /// ordering exists to fix. So the path is never used to rule a helper out, and anything
+    /// unrecognised counts as a match.
+    func canAuthenticate(_ location: String) -> Bool {
+        if hasUnscopedHelper { return true }
+        // `insteadOf` is a literal longest-prefix string match, with no URL parsing at all.
+        if insteadOfPrefixes.contains(where: { !$0.isEmpty && location.hasPrefix($0) }) { return true }
+        guard let url = URL(string: location), let host = url.host?.lowercased() else {
+            return !helperURLs.isEmpty
+        }
+        return helperURLs.contains { helperURL in
+            guard let configured = URL(string: helperURL),
+                  let configuredHost = configured.host?.lowercased()
+            else {
+                return true
+            }
+            if let scheme = configured.scheme, scheme.lowercased() != (url.scheme ?? "").lowercased() {
+                return false
+            }
+            if configuredHost.hasPrefix("*.") {
+                return host.hasSuffix(String(configuredHost.dropFirst(1)))
+            }
+            return configuredHost == host
+        }
+    }
+
+    static func parse(_ output: String) -> GitConfiguration {
+        var insteadOfPrefixes: [String] = []
+        var hasUnscopedHelper = false
+        var helperURLs: [String] = []
+
+        for record in output.split(separator: "\0", omittingEmptySubsequences: true) {
+            let newline = record.firstIndex(of: "\n")
+            let key = String(newline.map { record[..<$0] } ?? record)
+            let value = newline.map { String(record[record.index(after: $0)...]) } ?? ""
+            let lowercasedKey = key.lowercased()
+
+            if lowercasedKey.hasPrefix("url."), lowercasedKey.hasSuffix(".insteadof") {
+                if !value.isEmpty { insteadOfPrefixes.append(value) }
+                continue
+            }
+            guard lowercasedKey.hasPrefix("credential."), lowercasedKey.hasSuffix(".helper") else {
+                continue
+            }
+            // An empty value resets the helper list rather than configuring one.
+            guard !value.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+            if lowercasedKey == "credential.helper" {
+                hasUnscopedHelper = true
+            } else {
+                let subsection = key.dropFirst("credential.".count).dropLast(".helper".count)
+                helperURLs.append(String(subsection))
+            }
+        }
+
+        return GitConfiguration(
+            insteadOfPrefixes: insteadOfPrefixes,
+            hasUnscopedHelper: hasUnscopedHelper,
+            helperURLs: helperURLs
+        )
+    }
+}
+
+/// Loads the configuration once and hands the same answer to every later caller.
+private actor GitConfigurationCache {
+    private var cached: GitConfiguration?
+
+    func load() async -> GitConfiguration {
+        if let cached { return cached }
+        let configuration = await Self.read()
+        cached = configuration
+        return configuration
+    }
+
+    private static func read() async -> GitConfiguration {
+        // Run outside any working copy so only the system, global and XDG scopes are read.
+        // `git config --system` is not equivalent: on macOS the toolchain's unscoped
+        // `credential.helper = osxkeychain` lives in a gitconfig that scope does not cover.
+        let output = try? await SystemProcess.output(
+            "/usr/bin/git",
+            ["config", "-z", "--get-regexp", #"^(url|credential)\."#],
+            workingDirectory: URL(fileURLWithPath: NSTemporaryDirectory())
+        )
+        return output.map(GitConfiguration.parse) ?? .empty
+    }
+}
+
+private let gitConfigurationCache = GitConfigurationCache()
+
+/// Answers whether git can authenticate a location by itself, which is what decides where
+/// the credential-free attempt goes in the ladder.
+enum GitCredentialDiscovery {
+    static func gitCanAuthenticate(_ location: String) async -> Bool {
+        guard let url = URL(string: location) else { return true }
+
+        // `GIT_ASKPASS` authenticates without netrc, a rewrite or a helper, and being an
+        // environment variable it is invisible to the config parse.
+        let environment = Environment.current
+        if environment["GIT_ASKPASS"] != nil || environment["SSH_ASKPASS"] != nil { return true }
+
+        // Only the netrc git reads for itself counts. A `--netrc-file` or `SWIFTPM_NETRC_DATA`
+        // source is unreachable from curl, so it is a reason to inject rather than to defer.
+        if Environment.netrc.gitVisibleCredential(for: url) != nil { return true }
+
+        if let configuration = Environment.gitConfiguration {
+            return configuration.canAuthenticate(location)
+        }
+        return await gitConfigurationCache.load().canAuthenticate(location)
+    }
+}

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -189,27 +189,38 @@ struct GitFetchAttempt: Sendable {
 /// a working checkout into the same failure as having no credential at all, on machines
 /// where plain git and SwiftPM both succeed.
 ///
-/// So the token goes last. Git resolves the credential itself first, exactly as it did
-/// before swifterpm, then a netrc source only swifterpm can see, then the ambient token.
-/// A setup that has nothing but the token reaches it one failed request later; a setup
-/// that has anything else keeps using it.
+/// So the token stops being an override and becomes a rung. Git resolves the credential
+/// itself, exactly as it did before swifterpm, alongside a netrc source only swifterpm can
+/// see and the ambient token, and whichever the ladder reaches first that works is used.
+///
+/// Which rung goes first is decided by reading git's own configuration once, because both
+/// orderings waste a request in the setup they do not suit. When a rewrite rule, a
+/// credential helper or `~/.netrc` covers the host, git can authenticate unaided and goes
+/// first. When nothing does — a CI runner holding only a token — the injected credential
+/// goes first instead, and the credential-free attempt trails it rather than being dropped:
+/// a public dependency needs no credential at all, so a broken or expired token must never
+/// be the only thing tried.
 enum GitTransportAuth {
     static func attempts(for location: String) async -> [GitFetchAttempt] {
-        var attempts = [
-            GitFetchAttempt(location: location, credential: .gitConfigured, configArguments: []),
-        ]
+        let bare = GitFetchAttempt(
+            location: location, credential: .gitConfigured, configArguments: []
+        )
+        // SSH candidates are always tried bare: ssh-agent is invisible to git's config and
+        // there is no token form for SSH anyway.
         guard location.hasPrefix("https://"),
               let url = URL(string: location),
               let host = url.host
         else {
-            return attempts
+            return [bare]
         }
 
-        // `~/.netrc` is already covered by the attempt above, since git reads it through
+        var injected: [GitFetchAttempt] = []
+
+        // `~/.netrc` is already covered by the bare attempt, since git reads it through
         // curl. This one carries the sources git has no way to know about.
         if let credential = Environment.netrc.credential(for: url) {
             let encoded = basicCredential(user: credential.user, token: credential.password)
-            attempts.append(
+            injected.append(
                 GitFetchAttempt(
                     location: location,
                     credential: .netrc,
@@ -221,7 +232,7 @@ enum GitTransportAuth {
         }
 
         if (try? GitHubRepo(location: location)) != nil, let token = await GitHubAuth.token() {
-            attempts.append(
+            injected.append(
                 GitFetchAttempt(
                     location: location,
                     credential: .gitHubToken,
@@ -231,7 +242,7 @@ enum GitTransportAuth {
         } else if let repo = try? GitLabRepo(location: location),
                   let token = await GitLabAuth.token(host: repo.host)
         {
-            attempts.append(
+            injected.append(
                 GitFetchAttempt(
                     location: location,
                     credential: .gitLabToken,
@@ -239,7 +250,12 @@ enum GitTransportAuth {
                 )
             )
         }
-        return attempts
+
+        guard !injected.isEmpty else { return [bare] }
+        if await GitCredentialDiscovery.gitCanAuthenticate(location) {
+            return [bare] + injected
+        }
+        return injected + [bare]
     }
 
     static func gitHubArguments(token: String) -> [String] {

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -107,6 +107,19 @@ enum SourceControlLocations {
         return attempts
     }
 
+    /// Identifies the package a location points at, collapsing the HTTPS and SSH forms
+    /// `fetchCandidates` produces onto one key so a credential resolved through one form
+    /// is reused for the other.
+    static func packageIdentity(_ location: String) -> String {
+        if let repo = try? GitHubRepo(location: location) {
+            return "github.com/\(repo.owner.lowercased())/\(repo.repo.lowercased())"
+        }
+        if let repo = try? GitLabRepo(location: location) {
+            return "\(repo.host)/\(repo.pathWithNamespace.lowercased())"
+        }
+        return canonicalResolvedFileLocation(location)
+    }
+
     /// Offer both the HTTPS and SSH forms regardless of how the location was originally
     /// declared. The original is tried first, so SSH-declared dependencies keep using
     /// ssh-agent locally while still falling back to HTTPS in environments (typically CI)
@@ -171,6 +184,26 @@ struct GitFetchAttempt: Sendable {
     let location: String
     let credential: GitTransportCredential
     let configArguments: [String]
+}
+
+/// Remembers which credential authenticated a package, so the requests that follow the
+/// first one reuse the answer instead of walking the ladder again.
+///
+/// Keyed by package rather than by host, because access differs per repository — an
+/// enterprise-managed token reads one org's repositories and a `~/.netrc` account reads
+/// another's, both on `github.com`, and a host-keyed answer would poison one with the other.
+actor ResolvedPackageCredentials {
+    static let shared = ResolvedPackageCredentials()
+
+    private var credentials: [String: GitTransportCredential] = [:]
+
+    func record(_ credential: GitTransportCredential, for location: String) {
+        credentials[SourceControlLocations.packageIdentity(location)] = credential
+    }
+
+    func credential(for location: String) -> GitTransportCredential? {
+        credentials[SourceControlLocations.packageIdentity(location)]
+    }
 }
 
 /// Orders the credentials a candidate location is tried with.

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -21,7 +21,9 @@ struct GitHubRepo {
     }
 }
 
-private actor GitHubTokenCache {
+/// Caches only the `gh auth token` subprocess. Reading the environment is free and has to
+/// observe `Environment.current` rather than a value memoized on first use, so it stays out.
+private actor GitHubCLITokenCache {
     private var loaded = false
     private var cachedToken: String?
 
@@ -30,11 +32,6 @@ private actor GitHubTokenCache {
             return cachedToken
         }
         loaded = true
-
-        if let token = GitHubAuth.envToken(from: ProcessInfo.processInfo.environment) {
-            cachedToken = token
-            return token
-        }
 
         guard let output = try? await SystemProcess.output("/usr/bin/env", ["gh", "auth", "token"])
         else {
@@ -46,7 +43,7 @@ private actor GitHubTokenCache {
     }
 }
 
-private let githubTokenCache = GitHubTokenCache()
+private let githubCLITokenCache = GitHubCLITokenCache()
 
 enum GitHubAuth {
     private static let envKeys = ["SWIFTERPM_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"]
@@ -62,7 +59,10 @@ enum GitHubAuth {
     }
 
     static func token() async -> String? {
-        await githubTokenCache.token()
+        if let token = envToken(from: Environment.current) {
+            return token
+        }
+        return await githubCLITokenCache.token()
     }
 
     static func hasSession() async -> Bool {
@@ -95,6 +95,16 @@ enum SourceControlLocations {
         appendGitHubLocations(for: location, to: &locations)
         appendGitLabLocations(for: location, to: &locations)
         return locations
+    }
+
+    /// Every candidate location crossed with the credentials to try it with, flattened
+    /// into the order the fetch loops walk.
+    static func fetchAttempts(_ location: String) async -> [GitFetchAttempt] {
+        var attempts: [GitFetchAttempt] = []
+        for candidate in fetchCandidates(location) {
+            attempts.append(contentsOf: await GitTransportAuth.attempts(for: candidate))
+        }
+        return attempts
     }
 
     /// Offer both the HTTPS and SSH forms regardless of how the location was originally
@@ -133,26 +143,103 @@ enum SourceControlLocations {
     }
 }
 
-/// Authenticates the HTTPS git fallback with the same token swifterpm discovers for the
-/// provider's API. Without this, the HTTPS candidate added by `fetchCandidates` only works
-/// when an ambient credential (a `url.insteadOf` token rewrite, a credential helper, or
-/// ~/.netrc) is configured, so an SSH-declared private dependency keeps failing in CI even
-/// with a usable `SWIFTERPM_GITHUB_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`. Emitting an `http.<base>.extraheader` via `-c`
-/// mirrors what `actions/checkout` does and keeps the token out of the on-disk git config.
-/// SSH candidates return no arguments so ssh-agent stays in charge, and when no token is
-/// available we add nothing so configured ambient credentials keep working unchanged.
+/// How one fetch attempt authenticates. A candidate location is tried with each of these
+/// in turn, most specific first, so an ambient provider token is only ever a last resort.
+enum GitTransportCredential: Equatable, Sendable, CustomStringConvertible {
+    /// Whatever git resolves on its own: ~/.netrc, a credential helper, a
+    /// `url.<...>.insteadOf` rewrite, or ssh-agent on an SSH candidate.
+    case gitConfigured
+    /// A netrc entry git cannot reach by itself, from `--netrc-file` or `SWIFTPM_NETRC_DATA`.
+    case netrc
+    /// `SWIFTERPM_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`.
+    case gitHubToken
+    /// `GITLAB_TOKEN`, `CI_JOB_TOKEN`, and the other GitLab environment tokens.
+    case gitLabToken
+
+    var description: String {
+        switch self {
+        case .gitConfigured: return "git's configured credentials"
+        case .netrc: return "netrc"
+        case .gitHubToken: return "an ambient GitHub token"
+        case .gitLabToken: return "an ambient GitLab token"
+        }
+    }
+}
+
+/// One candidate location paired with the credential to try it with.
+struct GitFetchAttempt: Sendable {
+    let location: String
+    let credential: GitTransportCredential
+    let configArguments: [String]
+}
+
+/// Orders the credentials a candidate location is tried with.
+///
+/// The HTTPS candidate `fetchCandidates` adds is useless in CI without a credential, so
+/// swifterpm injects the provider token it already discovers for the API as an
+/// `http.<base>.extraheader`, the way `actions/checkout` does, which keeps it out of the
+/// on-disk git config.
+///
+/// That header used to go on unconditionally, which made it an override rather than a
+/// fallback. `http.<base>.extraheader` beats every credential git would have found for
+/// itself, and against GitHub it also stops curl consulting ~/.netrc, so the request 401s
+/// and git falls through to a prompt that `nonInteractiveGitEnvironment` has disabled. A
+/// token that cannot read the repository — a `gh` login on a personal account, one not
+/// authorized for a SAML-SSO org, a `GITHUB_TOKEN` exported for unrelated tooling — turned
+/// a working checkout into the same failure as having no credential at all, on machines
+/// where plain git and SwiftPM both succeed.
+///
+/// So the token goes last. Git resolves the credential itself first, exactly as it did
+/// before swifterpm, then a netrc source only swifterpm can see, then the ambient token.
+/// A setup that has nothing but the token reaches it one failed request later; a setup
+/// that has anything else keeps using it.
 enum GitTransportAuth {
-    static func configArguments(for location: String) async -> [String] {
-        guard location.hasPrefix("https://") else { return [] }
-        if (try? GitHubRepo(location: location)) != nil {
-            guard let token = await GitHubAuth.token() else { return [] }
-            return gitHubArguments(token: token)
+    static func attempts(for location: String) async -> [GitFetchAttempt] {
+        var attempts = [
+            GitFetchAttempt(location: location, credential: .gitConfigured, configArguments: []),
+        ]
+        guard location.hasPrefix("https://"),
+              let url = URL(string: location),
+              let host = url.host
+        else {
+            return attempts
         }
-        if let repo = try? GitLabRepo(location: location) {
-            guard let token = await GitLabAuth.token(host: repo.host) else { return [] }
-            return gitLabArguments(host: repo.host, token: token)
+
+        // `~/.netrc` is already covered by the attempt above, since git reads it through
+        // curl. This one carries the sources git has no way to know about.
+        if let credential = Environment.netrc.credential(for: url) {
+            let encoded = basicCredential(user: credential.user, token: credential.password)
+            attempts.append(
+                GitFetchAttempt(
+                    location: location,
+                    credential: .netrc,
+                    configArguments: extraHeaderArguments(
+                        base: "https://\(host)/", authorization: "Basic \(encoded)"
+                    )
+                )
+            )
         }
-        return []
+
+        if (try? GitHubRepo(location: location)) != nil, let token = await GitHubAuth.token() {
+            attempts.append(
+                GitFetchAttempt(
+                    location: location,
+                    credential: .gitHubToken,
+                    configArguments: gitHubArguments(token: token)
+                )
+            )
+        } else if let repo = try? GitLabRepo(location: location),
+                  let token = await GitLabAuth.token(host: repo.host)
+        {
+            attempts.append(
+                GitFetchAttempt(
+                    location: location,
+                    credential: .gitLabToken,
+                    configArguments: gitLabArguments(host: repo.host, token: token)
+                )
+            )
+        }
+        return attempts
     }
 
     static func gitHubArguments(token: String) -> [String] {

--- a/swifterpm/Sources/swifterpm/GitLab.swift
+++ b/swifterpm/Sources/swifterpm/GitLab.swift
@@ -189,44 +189,6 @@ private actor GitLabTokenCache {
 private let gitLabTokenCache = GitLabTokenCache()
 
 enum GitLabAPI {
-    static func remoteVersions(repo: GitLabRepo) async throws -> [RemoteVersion] {
-        struct TagsResponse: Decodable {
-            struct Commit: Decodable { let id: String }
-            let name: String
-            let commit: Commit
-        }
-
-        var versions: [RemoteVersion] = []
-        var page = 1
-        while true {
-            let url = repo.apiBaseURL
-                .appendingGitLabProjectAPIPath(repo.encodedProjectPath, ["repository", "tags"])
-                .appending(queryItems: [
-                    URLQueryItem(name: "per_page", value: "100"),
-                    URLQueryItem(name: "page", value: String(page)),
-                ])
-            let tags = try JSONDecoder().decode(
-                [TagsResponse].self,
-                from: try await HTTPClient.data(url: url, headers: try await headers(for: repo))
-            )
-            if tags.isEmpty {
-                break
-            }
-            for tag in tags {
-                if let version = RemoteMetadata.parseSwiftTagVersion(tag.name) {
-                    versions.append(
-                        RemoteVersion(version: version.description, revision: tag.commit.id)
-                    )
-                }
-            }
-            page += 1
-        }
-        return versions.sorted {
-            ($0.semver ?? SemVer(major: 0, minor: 0, patch: 0))
-                < ($1.semver ?? SemVer(major: 0, minor: 0, patch: 0))
-        }
-    }
-
     static func downloadArchive(repo: GitLabRepo, revision: String, destination: URL) async throws {
         let url = repo.apiBaseURL
             .appendingGitLabProjectAPIPath(

--- a/swifterpm/Sources/swifterpm/Netrc.swift
+++ b/swifterpm/Sources/swifterpm/Netrc.swift
@@ -32,6 +32,15 @@ enum NetrcOrigin: Equatable, Sendable {
 struct NetrcSource: Sendable {
     let origin: NetrcOrigin
     let machines: [NetrcMachine]
+    /// Whether git reads this same source for itself. Only `~/.netrc` qualifies: curl is
+    /// never pointed at another path, and `SWIFTPM_NETRC_DATA` has no on-disk form at all.
+    let isGitVisible: Bool
+
+    init(origin: NetrcOrigin, machines: [NetrcMachine], isGitVisible: Bool = false) {
+        self.origin = origin
+        self.machines = machines
+        self.isGitVisible = isGitVisible
+    }
 }
 
 /// The netrc credentials a resolution runs with, read and parsed once up front so
@@ -99,7 +108,11 @@ struct Netrc: Sendable {
         } else if let home = environment["HOME"] {
             let path = URL(fileURLWithPath: home).appendingPathComponent(".netrc")
             if let content = try? await contents(of: path) {
-                sources.append(NetrcSource(origin: .file, machines: NetrcParser.machines(in: content)))
+                sources.append(
+                    NetrcSource(
+                        origin: .file, machines: NetrcParser.machines(in: content), isGitVisible: true
+                    )
+                )
             }
         }
         return Netrc(configuration: configuration, sources: sources)
@@ -111,6 +124,12 @@ struct Netrc: Sendable {
 
     func credential(for url: URL, from origin: NetrcOrigin) -> RegistryCredential? {
         credential(for: url, in: sources.filter { $0.origin == origin })
+    }
+
+    /// The credential git would find for itself, which is the subset that makes injecting
+    /// one unnecessary.
+    func gitVisibleCredential(for url: URL) -> RegistryCredential? {
+        credential(for: url, in: sources.filter(\.isGitVisible))
     }
 
     private func credential(for url: URL, in sources: [NetrcSource]) -> RegistryCredential? {

--- a/swifterpm/Sources/swifterpm/Remote.swift
+++ b/swifterpm/Sources/swifterpm/Remote.swift
@@ -54,17 +54,17 @@ enum RemoteMetadata {
     }
 
     private static func gitRemoteVersions(location: String) async throws -> [RemoteVersion] {
-        var attempts: [(candidate: String, error: any Error)] = []
-        for candidate in SourceControlLocations.fetchCandidates(location) {
+        var attempts: [(attempt: GitFetchAttempt, error: any Error)] = []
+        for attempt in await SourceControlLocations.fetchAttempts(location) {
             do {
-                let authArguments = await GitTransportAuth.configArguments(for: candidate)
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", authArguments + ["ls-remote", "--tags", candidate],
+                    "/usr/bin/git",
+                    attempt.configArguments + ["ls-remote", "--tags", attempt.location],
                     environment: SystemProcess.nonInteractiveGitEnvironment
                 )
                 return parseGitRemoteVersions(output)
             } catch {
-                attempts.append((candidate, error))
+                attempts.append((attempt, error))
             }
         }
         throw GitFetchFailure.error(location: location, attempts: attempts)
@@ -145,22 +145,22 @@ enum RemoteMetadata {
     }
 
     static func resolveNamedRef(location: String, name: String) async throws -> String {
-        var attempts: [(candidate: String, error: any Error)] = []
-        for candidate in SourceControlLocations.fetchCandidates(location) {
+        var attempts: [(attempt: GitFetchAttempt, error: any Error)] = []
+        for attempt in await SourceControlLocations.fetchAttempts(location) {
             do {
-                let authArguments = await GitTransportAuth.configArguments(for: candidate)
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", authArguments + ["ls-remote", candidate, name],
+                    "/usr/bin/git",
+                    attempt.configArguments + ["ls-remote", attempt.location, name],
                     environment: SystemProcess.nonInteractiveGitEnvironment
                 )
                 guard let line = output.split(separator: "\n").first,
                       let revision = line.split(whereSeparator: \.isWhitespace).first
                 else {
-                    throw ToolError.message("\(name) was not found in \(candidate)")
+                    throw ToolError.message("\(name) was not found in \(attempt.location)")
                 }
                 return String(revision)
             } catch {
-                attempts.append((candidate, error))
+                attempts.append((attempt, error))
             }
         }
         throw GitFetchFailure.error(location: location, attempts: attempts)

--- a/swifterpm/Sources/swifterpm/Remote.swift
+++ b/swifterpm/Sources/swifterpm/Remote.swift
@@ -29,28 +29,17 @@ enum RemoteMetadata {
         return versions
     }
 
+    /// Tag discovery goes through git rather than a provider API.
+    ///
+    /// The provider APIs bought nothing here: `git ls-remote --tags` returns every tag with
+    /// its peeled annotation in one round trip, whereas GitHub's and GitLab's tag endpoints
+    /// page at 100 entries, so on a package with many tags the API path is the slower one.
+    /// What they cost is a second credential system — an API request authenticates only with
+    /// the ambient provider token, so on a machine whose working credential is a `~/.netrc`
+    /// entry or a credential helper it is a guaranteed-404 request per package before git
+    /// runs anyway. Delegating leaves one ladder instead of two.
     private static func fetchRemoteVersions(location: String) async throws -> [RemoteVersion] {
-        let repo = try? GitHubRepo(location: location)
-        if let repo, await GitHubAuth.hasSession() {
-            let apiVersions = (try? await githubRemoteVersions(repo: repo)) ?? []
-            if !apiVersions.isEmpty {
-                return apiVersions
-            }
-        }
-
-        let gitLabRepo = try? GitLabRepo(location: location)
-        if let gitLabRepo, await GitLabAuth.hasSession(host: gitLabRepo.host) {
-            let apiVersions = (try? await GitLabAPI.remoteVersions(repo: gitLabRepo)) ?? []
-            if !apiVersions.isEmpty {
-                return apiVersions
-            }
-        }
-
-        let gitVersions = (try? await gitRemoteVersions(location: location)) ?? []
-        if !gitVersions.isEmpty {
-            return gitVersions
-        }
-        return []
+        (try? await gitRemoteVersions(location: location)) ?? []
     }
 
     private static func gitRemoteVersions(location: String) async throws -> [RemoteVersion] {
@@ -62,6 +51,7 @@ enum RemoteMetadata {
                     attempt.configArguments + ["ls-remote", "--tags", attempt.location],
                     environment: SystemProcess.nonInteractiveGitEnvironment
                 )
+                await ResolvedPackageCredentials.shared.record(attempt.credential, for: location)
                 return parseGitRemoteVersions(output)
             } catch {
                 attempts.append((attempt, error))
@@ -103,47 +93,6 @@ enum RemoteMetadata {
         }
     }
 
-    private static func githubRemoteVersions(repo: GitHubRepo) async throws -> [RemoteVersion] {
-        struct TagsResponse: Decodable {
-            struct Commit: Decodable { let sha: String }
-            let name: String
-            let commit: Commit
-        }
-
-        var versions: [RemoteVersion] = []
-        var page = 1
-        while true {
-            let url = URL(
-                string:
-                "https://api.github.com/repos/\(repo.owner)/\(repo.repo)/tags?per_page=100&page=\(page)"
-            )!
-            var headers = ["User-Agent": "swifterpm/0.1"]
-            if let token = await GitHubAuth.token() {
-                headers["Authorization"] = "Bearer \(token)"
-            }
-            let tags = try JSONDecoder().decode(
-                [TagsResponse].self, from: try await HTTPClient.data(url: url, headers: headers)
-            )
-            if tags.isEmpty {
-                break
-            }
-            for tag in tags {
-                if let version = RemoteMetadata.parseSwiftTagVersion(tag.name) {
-                    versions.append(
-                        RemoteVersion(version: version.description, revision: tag.commit.sha)
-                    )
-                }
-            }
-            page += 1
-        }
-        return versions.sorted {
-            SemVer.ascendingForSort(
-                (try? SemVer($0.version)) ?? SemVer(major: 0, minor: 0, patch: 0),
-                (try? SemVer($1.version)) ?? SemVer(major: 0, minor: 0, patch: 0)
-            )
-        }
-    }
-
     static func resolveNamedRef(location: String, name: String) async throws -> String {
         var attempts: [(attempt: GitFetchAttempt, error: any Error)] = []
         for attempt in await SourceControlLocations.fetchAttempts(location) {
@@ -158,6 +107,7 @@ enum RemoteMetadata {
                 else {
                     throw ToolError.message("\(name) was not found in \(attempt.location)")
                 }
+                await ResolvedPackageCredentials.shared.record(attempt.credential, for: location)
                 return String(revision)
             } catch {
                 attempts.append((attempt, error))

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -851,8 +851,12 @@ enum WorkspaceRestorer {
     private static func downloadSourceArchive(cache: Cache, pin: ResolvedPin, destination: URL)
         async throws
     {
-        if (try? GitHubRepo(location: pin.location)) != nil, await GitHubAuth.hasSession() {
-            try await downloadGitHubArchive(cache: cache, pin: pin, destination: destination)
+        if (try? GitHubRepo(location: pin.location)) != nil,
+           let authorization = await gitHubArchiveAuthorization(location: pin.location)
+        {
+            try await downloadGitHubArchive(
+                cache: cache, pin: pin, destination: destination, authorization: authorization
+            )
             return
         }
         if let repo = try? GitLabRepo(location: pin.location),
@@ -866,9 +870,37 @@ enum WorkspaceRestorer {
         )
     }
 
-    private static func downloadGitHubArchive(cache: Cache, pin: ResolvedPin, destination: URL)
-        async throws
-    {
+    /// The tarball endpoint is the one request git cannot make, so it is the one credential
+    /// swifterpm still has to choose for itself. Choose it by reusing whatever authenticated
+    /// this package's git traffic rather than reaching for the ambient token: picking
+    /// independently is how a token that cannot read the repository ends up shadowing the
+    /// credential that can, and how a machine whose only credential is a `~/.netrc` entry
+    /// never reaches this fast path at all.
+    ///
+    /// A credential git resolved internally cannot be reused — a helper's answer or curl's
+    /// netrc read never surfaces — so those fall back to choosing, the same order
+    /// `HTTPAuthorization` applies to every other download.
+    private static func gitHubArchiveAuthorization(location: String) async -> String? {
+        let netrcAuthorization = URL(string: "https://github.com")
+            .flatMap { Environment.netrc.credential(for: $0) }
+            .map { "Basic \(Data("\($0.user):\($0.password)".utf8).base64EncodedString())" }
+
+        switch await ResolvedPackageCredentials.shared.credential(for: location) {
+        case .netrc:
+            return netrcAuthorization
+        case .gitHubToken:
+            return await GitHubAuth.token().map { "Bearer \($0)" }
+        case .gitLabToken:
+            return nil
+        case .gitConfigured, nil:
+            if let netrcAuthorization { return netrcAuthorization }
+            return await GitHubAuth.token().map { "Bearer \($0)" }
+        }
+    }
+
+    private static func downloadGitHubArchive(
+        cache: Cache, pin: ResolvedPin, destination: URL, authorization: String
+    ) async throws {
         let repo = try GitHubRepo(location: pin.location)
         let revision = try pin.revision()
         let archivePath = cache.archivePath(url: pin.location, revision: revision)
@@ -876,10 +908,10 @@ enum WorkspaceRestorer {
             let lock = try await cache.lock(namespace: "archives", key: archivePath.path)
             _ = lock
             if try !(await fileSystem.exists(archivePath.absolutePath)) {
-                var headers = ["User-Agent": "swifterpm/0.1"]
-                if let token = await GitHubAuth.token() {
-                    headers["Authorization"] = "Bearer \(token)"
-                }
+                let headers = [
+                    "User-Agent": "swifterpm/0.1",
+                    "Authorization": authorization,
+                ]
                 let url = URL(
                     string:
                     "https://api.github.com/repos/\(repo.owner)/\(repo.repo)/tarball/\(revision)"
@@ -951,6 +983,9 @@ enum WorkspaceRestorer {
                 {
                     try await fileSystem.remove(gitDir.absolutePath)
                 }
+                await ResolvedPackageCredentials.shared.record(
+                    attempt.credential, for: pin.location
+                )
                 return
             } catch {
                 attempts.append((attempt, error))

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -922,18 +922,18 @@ enum WorkspaceRestorer {
         let revision = try pin.revision()
         let isLocalSourceControlPackage =
             try await PackageResolver.localSourceControlPackageLocation(pin.location) != nil
-        var attempts: [(candidate: String, error: any Error)] = []
-        for location in SourceControlLocations.fetchCandidates(pin.location) {
+        var attempts: [(attempt: GitFetchAttempt, error: any Error)] = []
+        for attempt in await SourceControlLocations.fetchAttempts(pin.location) {
             do {
                 try await resetDirectory(destination)
                 try await SystemProcess.run("/usr/bin/git", ["init", destination.path])
                 try await SystemProcess.run(
-                    "/usr/bin/git", ["-C", destination.path, "remote", "add", "origin", location]
+                    "/usr/bin/git",
+                    ["-C", destination.path, "remote", "add", "origin", attempt.location]
                 )
-                let authArguments = await GitTransportAuth.configArguments(for: location)
                 try await SystemProcess.run(
                     "/usr/bin/git",
-                    authArguments
+                    attempt.configArguments
                         + ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
                     environment: SystemProcess.nonInteractiveGitEnvironment
                 )
@@ -942,7 +942,7 @@ enum WorkspaceRestorer {
                 )
                 try await updateSubmodulesIfNeeded(
                     in: destination,
-                    gitConfigArguments: authArguments,
+                    gitConfigArguments: attempt.configArguments,
                     allowFileProtocol: isLocalSourceControlPackage
                 )
                 let gitDir = destination.appendingPathComponent(".git")
@@ -953,7 +953,7 @@ enum WorkspaceRestorer {
                 }
                 return
             } catch {
-                attempts.append((location, error))
+                attempts.append((attempt, error))
             }
         }
         throw GitFetchFailure.error(location: pin.location, attempts: attempts)

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -41,18 +41,41 @@ enum ToolError: Error, CustomStringConvertible {
 /// dependency is always the trailing SSH candidate, masking whether the HTTPS fallback was
 /// even attempted and why it failed. Listing each attempt makes the actual cause diagnosable.
 enum GitFetchFailure {
-    static func error(location: String, attempts: [(candidate: String, error: any Error)])
+    static func error(location: String, attempts: [(attempt: GitFetchAttempt, error: any Error)])
         -> ToolError
     {
         guard !attempts.isEmpty else {
             return ToolError.message("no source-control locations available for \(location)")
         }
         let details = attempts
-            .map { "  - \($0.candidate): \($0.error)" }
+            .map { "  - \($0.attempt.location) (\($0.attempt.credential)): \($0.error)" }
             .joined(separator: "\n")
         return ToolError.message(
-            "could not fetch any candidate location for \(location):\n\(details)"
+            "could not fetch any candidate location for \(location):\n\(details)\(hint(for: attempts))"
         )
+    }
+
+    /// git reports a missing credential as `terminal prompts disabled`, which reads like a
+    /// configuration problem with swifterpm rather than what it is. Name the sources that
+    /// were consulted so the reader knows which one to populate.
+    private static func hint(for attempts: [(attempt: GitFetchAttempt, error: any Error)]) -> String {
+        let promptsDisabled = attempts.contains {
+            "\($0.error)".lowercased().contains("terminal prompts disabled")
+        }
+        guard promptsDisabled else { return "" }
+        var tried: [GitTransportCredential] = []
+        for credential in attempts.map(\.attempt.credential) where !tried.contains(credential) {
+            tried.append(credential)
+        }
+        let message = """
+        No credential could authenticate this repository. swifterpm tried \
+        \(tried.map(\.description).joined(separator: ", ")), and prompts are disabled because \
+        fetches run in parallel with their output captured. Configure a credential git can \
+        resolve — a ~/.netrc entry, a credential helper, an ssh-agent key for the SSH \
+        candidate — or set SWIFTERPM_GITHUB_TOKEN/GITHUB_TOKEN/GH_TOKEN to a token that \
+        can read it.
+        """
+        return "\n\(message)"
     }
 }
 

--- a/swifterpm/Tests/swifterpmTests/GitConfigurationTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitConfigurationTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import SwifterPMCore
+
+struct GitConfigurationTests {
+    /// `git config -z` emits one NUL-terminated record per entry, with the key and value
+    /// separated by a newline and the value omitted entirely when the key has none.
+    private func parse(_ records: [String]) -> GitConfiguration {
+        GitConfiguration.parse(records.map { $0 + "\0" }.joined())
+    }
+
+    @Test
+    func readsUnscopedAndScopedHelpers() {
+        let configuration = parse([
+            "credential.helper\nosxkeychain",
+            "credential.https://github.com.helper\n!gh auth git-credential",
+        ])
+
+        #expect(configuration.canAuthenticate("https://anything.example.com/acme/lib.git"))
+    }
+
+    @Test
+    func aValuelessHelperResetsRatherThanConfigures() {
+        // `credential.<url>.helper=` clears the inherited list. Treating it as a configured
+        // helper would claim git can authenticate a host nothing is set up for.
+        let configuration = parse([
+            "credential.https://github.com.helper",
+            "credential.https://github.com.helper\n",
+        ])
+
+        #expect(!configuration.canAuthenticate("https://github.com/acme/lib.git"))
+    }
+
+    @Test
+    func scopedHelpersOnlyAnswerForTheirOwnHostAndProtocol() {
+        let configuration = parse(["credential.https://github.com.helper\n!gh auth git-credential"])
+
+        #expect(configuration.canAuthenticate("https://github.com/acme/lib.git"))
+        #expect(!configuration.canAuthenticate("https://gitlab.com/acme/lib.git"))
+        #expect(!configuration.canAuthenticate("http://github.com/acme/lib.git"))
+    }
+
+    @Test
+    func scopedHelpersHonourTheLeadingWildcard() {
+        let configuration = parse(["credential.https://*.example.com.helper\nstore"])
+
+        #expect(configuration.canAuthenticate("https://git.example.com/acme/lib.git"))
+        #expect(!configuration.canAuthenticate("https://example.org/acme/lib.git"))
+    }
+
+    @Test
+    func scopedHelpersAreNotRuledOutByThePath() {
+        // `credential.<url>` only considers the path under credential.useHttpPath, and
+        // getting that wrong in the "no match" direction would silently demote the attempt
+        // that actually works. Match on host and protocol only.
+        let configuration = parse(["credential.https://github.com/acme.helper\nstore"])
+
+        #expect(configuration.canAuthenticate("https://github.com/other/lib.git"))
+    }
+
+    @Test
+    func insteadOfRulesMatchAsLiteralPrefixes() {
+        // Git performs no URL parsing here at all: the configured value is compared against
+        // the location as a string, longest match winning.
+        let configuration = parse([
+            "url.https://token@github.com/.insteadof\nhttps://github.com/",
+        ])
+
+        #expect(configuration.canAuthenticate("https://github.com/acme/lib.git"))
+        #expect(!configuration.canAuthenticate("https://gitlab.com/acme/lib.git"))
+        #expect(!configuration.canAuthenticate("https://alice:pw@github.com/acme/lib.git"))
+    }
+
+    @Test
+    func anEmptyConfigurationAuthenticatesNothing() {
+        #expect(!GitConfiguration.empty.canAuthenticate("https://github.com/acme/lib.git"))
+    }
+
+    @Test
+    func unrelatedKeysAreIgnored() {
+        let configuration = parse([
+            "credential.usehttppath\ntrue",
+            "url.https://github.com/.pushinsteadof\ngit@github.com:",
+        ])
+
+        #expect(!configuration.canAuthenticate("https://github.com/acme/lib.git"))
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -2,6 +2,47 @@ import Foundation
 import Testing
 @testable import SwifterPMCore
 
+/// Attempt ordering is decided by reading the developer's own git configuration, so every
+/// test that exercises it pins that configuration instead of inheriting the machine's.
+func withGitConfiguration<T: Sendable>(
+    _ configuration: GitConfiguration,
+    environment: [String: String] = [:],
+    operation: () async -> T
+) async -> T {
+    await Environment.$gitConfiguration.withValue(configuration) {
+        await Environment.$values.withValue(environment) {
+            await operation()
+        }
+    }
+}
+
+extension GitConfiguration {
+    /// What Apple's toolchain ships on every developer Mac: an unscoped helper, which
+    /// answers for every host.
+    static let osxkeychain = GitConfiguration(
+        insteadOfPrefixes: [], hasUnscopedHelper: true, helperURLs: []
+    )
+}
+
+extension Netrc {
+    /// `SWIFTPM_NETRC_DATA` or a `--netrc-file`, neither of which curl reads for git.
+    static let invisibleToGit = Netrc(sources: [
+        NetrcSource(
+            origin: .environment,
+            machines: [NetrcMachine(name: "github.com", login: "machine-user", password: "s3cret")]
+        ),
+    ])
+
+    /// `~/.netrc`, the one netrc source git authenticates with by itself.
+    static let visibleToGit = Netrc(sources: [
+        NetrcSource(
+            origin: .file,
+            machines: [NetrcMachine(name: "github.com", login: "machine-user", password: "s3cret")],
+            isGitVisible: true
+        ),
+    ])
+}
+
 struct GitHubTests {
     @Test
     func parsesHTTPSGitHubLocations() throws {
@@ -100,7 +141,9 @@ struct GitHubTests {
 
     @Test
     func gitTransportAuthAddsNoArgumentsForSSHLocations() async {
-        let attempts = await GitTransportAuth.attempts(for: "git@github.com:acme/private-lib.git")
+        let attempts = await withGitConfiguration(.osxkeychain) {
+            await GitTransportAuth.attempts(for: "git@github.com:acme/private-lib.git")
+        }
 
         #expect(attempts.map(\.credential) == [.gitConfigured])
         #expect(attempts.map(\.configArguments) == [[]])
@@ -111,7 +154,9 @@ struct GitHubTests {
         // An `http.<base>.extraheader` overrides every credential git would resolve on its
         // own and stops curl reading ~/.netrc, so a token that cannot read the repository
         // used to fail the fetch outright on a machine where plain git succeeds.
-        let attempts = await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+        let attempts = await withGitConfiguration(
+            .osxkeychain, environment: ["GITHUB_TOKEN": "ghp_secret"]
+        ) {
             await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
         }
 
@@ -129,14 +174,8 @@ struct GitHubTests {
     func gitTransportAuthTriesANetrcSourceGitCannotSeeBeforeAnAmbientToken() async throws {
         // `--netrc-file` and SWIFTPM_NETRC_DATA are invisible to git, so they need to be
         // injected, but they are deliberate per-host credentials and outrank a generic token.
-        let netrc = Netrc(sources: [
-            NetrcSource(
-                origin: .environment,
-                machines: [NetrcMachine(name: "github.com", login: "machine-user", password: "s3cret")]
-            ),
-        ])
-        let attempts = await Environment.$netrc.withValue(netrc) {
-            await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+        let attempts = await Environment.$netrc.withValue(.invisibleToGit) {
+            await withGitConfiguration(.osxkeychain, environment: ["GITHUB_TOKEN": "ghp_secret"]) {
                 await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
             }
         }
@@ -152,7 +191,7 @@ struct GitHubTests {
 
     @Test
     func gitTransportAuthAddsNoTokenAttemptWhenNoneIsAvailable() async {
-        let attempts = await Environment.$values.withValue([:]) {
+        let attempts = await withGitConfiguration(.empty) {
             await GitTransportAuth.attempts(for: "https://source.example.com/acme/private-lib.git")
         }
 
@@ -160,8 +199,64 @@ struct GitHubTests {
     }
 
     @Test
+    func gitTransportAuthTriesAnAmbientTokenFirstWhenGitHasNothingToResolve() async {
+        // A CI runner holding only a token has no rewrite rule, no helper and no ~/.netrc,
+        // so probing without a credential can only ever cost a round trip.
+        let attempts = await withGitConfiguration(
+            .empty, environment: ["GITHUB_TOKEN": "ghp_secret"]
+        ) {
+            await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
+        }
+
+        #expect(attempts.map(\.credential) == [.gitHubToken, .gitConfigured])
+    }
+
+    @Test
+    func gitTransportAuthStillEndsWithACredentialFreeAttemptWhenGitHasNothingToResolve() async {
+        // Dropping it rather than demoting it would break every public dependency the
+        // moment the ambient token is expired or scoped elsewhere: an anonymous fetch is
+        // what reads them, and an injected Authorization header suppresses it.
+        let attempts = await withGitConfiguration(
+            .empty, environment: ["GITHUB_TOKEN": "ghp_secret"]
+        ) {
+            await GitTransportAuth.attempts(for: "https://github.com/acme/public-lib.git")
+        }
+
+        #expect(attempts.last?.credential == .gitConfigured)
+        #expect(attempts.last?.configArguments == [])
+    }
+
+    @Test
+    func gitTransportAuthTriesGitFirstWhenTheHostIsCoveredByHomeNetrc() async {
+        // ~/.netrc is the one netrc source curl reads for git, so it is a reason to let git
+        // go first rather than a reason to inject.
+        let attempts = await Environment.$netrc.withValue(.visibleToGit) {
+            await withGitConfiguration(.empty, environment: ["GITHUB_TOKEN": "ghp_secret"]) {
+                await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
+            }
+        }
+
+        #expect(attempts.first?.credential == .gitConfigured)
+    }
+
+    @Test
+    func gitTransportAuthTriesGitFirstWhenAnAskpassHelperIsConfigured() async {
+        // GIT_ASKPASS authenticates without a rewrite, a helper or a netrc, and being an
+        // environment variable it never shows up in the config parse.
+        let attempts = await withGitConfiguration(
+            .empty, environment: ["GITHUB_TOKEN": "ghp_secret", "GIT_ASKPASS": "/usr/bin/true"]
+        ) {
+            await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
+        }
+
+        #expect(attempts.map(\.credential) == [.gitConfigured, .gitHubToken])
+    }
+
+    @Test
     func fetchAttemptsWalkEveryCandidateWithGitsOwnCredentialsFirst() async {
-        let attempts = await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+        let attempts = await withGitConfiguration(
+            .osxkeychain, environment: ["GITHUB_TOKEN": "ghp_secret"]
+        ) {
             await SourceControlLocations.fetchAttempts("git@github.com:acme/private-lib.git")
         }
 

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -100,7 +100,79 @@ struct GitHubTests {
 
     @Test
     func gitTransportAuthAddsNoArgumentsForSSHLocations() async {
-        #expect(await GitTransportAuth.configArguments(for: "git@github.com:acme/private-lib.git") == [])
+        let attempts = await GitTransportAuth.attempts(for: "git@github.com:acme/private-lib.git")
+
+        #expect(attempts.map(\.credential) == [.gitConfigured])
+        #expect(attempts.map(\.configArguments) == [[]])
+    }
+
+    @Test
+    func gitTransportAuthTriesGitsOwnCredentialsBeforeAnAmbientToken() async throws {
+        // An `http.<base>.extraheader` overrides every credential git would resolve on its
+        // own and stops curl reading ~/.netrc, so a token that cannot read the repository
+        // used to fail the fetch outright on a machine where plain git succeeds.
+        let attempts = await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+            await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
+        }
+
+        #expect(attempts.map(\.credential) == [.gitConfigured, .gitHubToken])
+        #expect(attempts.first?.configArguments == [])
+        let encoded = Data("x-access-token:ghp_secret".utf8).base64EncodedString()
+        #expect(
+            attempts.last?.configArguments == [
+                "-c", "http.https://github.com/.extraheader=Authorization: Basic \(encoded)",
+            ]
+        )
+    }
+
+    @Test
+    func gitTransportAuthTriesANetrcSourceGitCannotSeeBeforeAnAmbientToken() async throws {
+        // `--netrc-file` and SWIFTPM_NETRC_DATA are invisible to git, so they need to be
+        // injected, but they are deliberate per-host credentials and outrank a generic token.
+        let netrc = Netrc(sources: [
+            NetrcSource(
+                origin: .environment,
+                machines: [NetrcMachine(name: "github.com", login: "machine-user", password: "s3cret")]
+            ),
+        ])
+        let attempts = await Environment.$netrc.withValue(netrc) {
+            await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+                await GitTransportAuth.attempts(for: "https://github.com/acme/private-lib.git")
+            }
+        }
+
+        #expect(attempts.map(\.credential) == [.gitConfigured, .netrc, .gitHubToken])
+        let encoded = Data("machine-user:s3cret".utf8).base64EncodedString()
+        #expect(
+            attempts[1].configArguments == [
+                "-c", "http.https://github.com/.extraheader=Authorization: Basic \(encoded)",
+            ]
+        )
+    }
+
+    @Test
+    func gitTransportAuthAddsNoTokenAttemptWhenNoneIsAvailable() async {
+        let attempts = await Environment.$values.withValue([:]) {
+            await GitTransportAuth.attempts(for: "https://source.example.com/acme/private-lib.git")
+        }
+
+        #expect(attempts.map(\.credential) == [.gitConfigured])
+    }
+
+    @Test
+    func fetchAttemptsWalkEveryCandidateWithGitsOwnCredentialsFirst() async {
+        let attempts = await Environment.$values.withValue(["GITHUB_TOKEN": "ghp_secret"]) {
+            await SourceControlLocations.fetchAttempts("git@github.com:acme/private-lib.git")
+        }
+
+        #expect(
+            attempts.map(\.location) == [
+                "git@github.com:acme/private-lib.git",
+                "https://github.com/acme/private-lib.git",
+                "https://github.com/acme/private-lib.git",
+            ]
+        )
+        #expect(attempts.map(\.credential) == [.gitConfigured, .gitConfigured, .gitHubToken])
     }
 
     @Test

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -271,6 +271,15 @@ struct GitHubTests {
     }
 
     @Test
+    func packageIdentityCollapsesTheHTTPSAndSSHFormsOfOneRepository() {
+        let identity = SourceControlLocations.packageIdentity("https://github.com/Acme/Private-Lib.git")
+
+        #expect(SourceControlLocations.packageIdentity("git@github.com:Acme/Private-Lib.git") == identity)
+        #expect(SourceControlLocations.packageIdentity("https://github.com/Acme/Private-Lib") == identity)
+        #expect(SourceControlLocations.packageIdentity("https://github.com/Acme/Other-Lib") != identity)
+    }
+
+    @Test
     func canonicalResolvedFileLocationsStabilizeProviderLocations() {
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(


### PR DESCRIPTION
## What changed

SwifterPM used to make a credential decision at four points, all sourced from the same ambient provider token, and one of them emitted a git config value that git cannot override. This makes git's own credential resolution the primary path and reduces the four decisions to one.

1. **The ambient token is a rung, not an override.** `GitTransportAuth.configArguments` became `attempts(for:)`, returning an ordered `[GitFetchAttempt]`: git's own credentials (no `-c` flags at all), then a netrc source only swifterpm can see, then the token. Failures name which credential each attempt used.
2. **The order is decided by reading git's configuration once per process.** When a rewrite rule, a credential helper, `~/.netrc` or `GIT_ASKPASS` covers the location, the credential-free attempt goes first. When nothing does, the injected credential goes first and the credential-free attempt trails it.
3. **Tag discovery is delegated to git.** The GitHub and GitLab tag endpoints are deleted; `git ls-remote --tags` was already the fallback.
4. **The source archive reuses the credential that authenticated the package**, instead of reaching for the ambient token independently.

## Why

`http.<base>.extraheader` is a *terminal* credential: because curl already holds an `Authorization` header it never issues the unauthenticated probe, so there is no 401, and therefore no challenge for git's credential ladder to react to. SwifterPM set that header unconditionally whenever `GITHUB_TOKEN`, `GH_TOKEN` or `gh auth token` resolved.

The consequence is that a token which cannot read a repository does not merely fail to help — it **displaces** the credential that would have worked, and the resulting failure is indistinguishable from having no credential at all:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Verified locally against a real private repository: an unusable extraheader defeats a working credential helper, a tokenized `url.<...>.insteadOf` rewrite, **and** `~/.netrc`. SwiftPM never emits `extraheader` (zero occurrences in a full clone of `release/6.2`) and never sets `GIT_TERMINAL_PROMPT`, which is why the same machine resolves fine with SwiftPM and fails with SwifterPM.

This is reachable by anyone whose ambient token is scoped to a different set of repositories than the dependency needs — an enterprise-managed `gh` login, a token not authorized for a SAML-SSO organization, a `GITHUB_TOKEN` exported for unrelated tooling. It became widely reachable in 4.203.0, which flipped SwifterPM on by default (`cbaef63401`).

### Why the failure looked machine-dependent

Candidate order is declared → HTTPS → SSH, so a machine with a usable SSH key is rescued by the SSH candidate. Machines with only netrc are not. Same code path, different rescue routes.

### Why CI was never actually protected by `insteadOf`

Verified — the extraheader **beats** the rewrite:

| `insteadOf` | extraheader | result |
|---|---|---|
| good | *(none)* | ✅ |
| good | **bad** | ❌ `Invalid username or token` |
| **bad** | good | ✅ |

The rewrite still fires (`git ls-remote --get-url` shows the credential substituted) and is then discarded, because the header replaces the `Authorization` curl would have derived from the rewritten URL. CI is safe today only because nothing is injected there: GitHub-hosted runners ship `gh` unauthenticated. Adding `env: GITHUB_TOKEN:` to a job for any unrelated reason would break it the same way.

## Why this design over the obvious alternatives

**Why not just stop injecting the header?** The HTTPS candidate that `fetchCandidates` synthesizes has no configured credential on a CI runner, which is exactly what the header was added for. Removing it trades one broken environment for another. Ordering keeps both working.

**Why reorder the credential-free attempt instead of skipping it when git has nothing to find?** Because a public dependency needs no credential at all — the unauthenticated probe simply succeeds. Verified against a public repository with nothing configured:

```
bare git (anonymous)        -> 7a5b4e9e…                        ✅
git + BAD token extraheader -> fatal: could not read Username   ❌
```

Skipping it would relocate this same bug from netrc to anonymous access. Keeping it last also covers anything the config parse fails to model.

**Why parse the config instead of shelling out to `git credential fill` per package?** `fill` is netrc-blind, has approve/reject side effects, and prompts or fails when nothing matches. The parse answers the only question that matters here — *is there anything for git to find* — once, for every package.

**Why only system + global + XDG scope?** SwifterPM fetches into freshly `git init`-ed scratch directories, so the local config that applies to a dependency fetch is empty. Reading the user's project config would apply rules git itself would not. `git config --system` is not a substitute: on macOS the toolchain ships an unscoped `credential.helper = osxkeychain` in a gitconfig that scope does not cover.

**Why is `credential.<url>` matching deliberately loose?** Protocol and host are matched; the path never rules a helper out; anything unrecognised counts as a match. Wrongly concluding "git has nothing here" is precisely what reintroduces this bug, so the fail-safe direction is to assume git can authenticate and let the attempt prove otherwise.

## Impact

- A machine whose working credential is `~/.netrc`, a credential helper or an SSH key resolves private dependencies again, regardless of what token happens to be discoverable.
- `--netrc-file` and `SWIFTPM_NETRC_DATA` authenticate git transport for the first time. #12322 wired them into `HTTPAuthorization` and `RegistryAuthorization`; they never reached the `git fetch` subprocess.
- A netrc-only machine can now use the tarball fast path, which was previously gated behind having a provider token.
- CI holding only a token authenticates on its first attempt rather than after a failed probe.
- No opt-out flag is needed. Every previously-working configuration keeps working; the change is which credential is tried first and that failure now falls through instead of stopping.

## Validation

`swift test` — 174 tests pass, including 15 new ones covering attempt ordering, the config parse, `credential.<url>` matching rules, and package identity.

End to end against a real private repository, `HOME` isolated to a sandbox holding only a working `~/.netrc`, SSH disabled to model an HTTPS-only machine, and a deliberately invalid `GITHUB_TOKEN` exported:

```
=== BEFORE (main) ===
Error: failed to restore … could not fetch any candidate location for https://github.com/…:
  - https://github.com/…: fatal: could not read Username for 'https://github.com':
    terminal prompts disabled
  - git@github.com:…: fatal: Could not read from remote repository.

=== AFTER ===
(fetch succeeds)
```

The reordering path, modelled as a bare CI runner (`GIT_CONFIG_NOSYSTEM=1`, isolated `HOME`, no netrc, no helper, SSH disabled):

| case | before | after |
|---|---|---|
| private repo + valid token | ✅ | ✅ |
| public repo + invalid token | ❌ `could not read Username` | ✅ |

That second row is the regression the trailing credential-free attempt exists to prevent, and it is also a bug the current code has today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)