### PR TITLE
fix(app): link ArgumentParser on macOS, and record what the release pipeline needs from the runner image

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -32,6 +32,12 @@ The app depends on several CLI modules:
 - Use SwiftUI for new UI components.
 - Do not add one-line comments unless truly useful.
 
+## Releasing
+`.github/workflows/app-release.yml` runs on pushes to `main` that touch `app/**`, `mise/tasks/app/**`, or the `cli/Sources/*` modules the app links. Changes to the workflow itself, or to the runner image the release runs on, do not trigger it, so a fix to either one stays unproven until an app path changes.
+
+- Bundling the macOS app shells out to `create-dmg`, which styles the DMG window by driving Finder from AppleScript. macOS gates that behind a `kTCCServiceAppleEvents` approval for Finder, seeded into the runner image in `infra/runner-image/runner.pkr.hcl` and present from `runner-image@0.13.3`. On an image without it the send waits on an authorization prompt no headless VM can answer and gives up with `Finder got an error: AppleEvent timed out. (-1712)`; retrying only multiplies the wait.
+- The macOS and iOS jobs allow 50 minutes because `tuist generate` runs with `--no-binary-cache`, making each release a full archive whenever the compilation cache is cold. Any runner image roll leaves it cold, so the first release after one runs far longer than a warm release.
+
 ## Environment Configuration
 The app supports multiple environments via `TUIST_ENV`:
 - `development` - Local server at localhost:8080

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -139,7 +139,11 @@ let project = Project(
                 .target(name: "TuistOnboarding", condition: .when([.ios])),
                 .target(name: "TuistErrorHandling", condition: .when([.ios])),
                 .target(name: "TuistProfile", condition: .when([.ios])),
-                .external(name: "ArgumentParser", condition: .when([.ios])),
+                // Imported directly only by the iOS sources, but reached on
+                // every platform through TuistSupport -> SwifterPMCore. An
+                // iOS condition here overrides that transitive requirement
+                // and leaves the macOS build unable to resolve the module.
+                .external(name: "ArgumentParser"),
                 .external(name: "TuistSDK"),
             ],
             settings: .settings(


### PR DESCRIPTION
Two commits: a macOS build fix that CI surfaced on this branch, and the documentation change that gives the release pipeline fixes from #12317 their first real run.

## 1. `fix(app)`: ArgumentParser was linked on iOS only

`Test TuistApp` failed on macOS while the iOS jobs in the same run passed:

```
error: unable to resolve module dependency: 'ArgumentParser'
note: a dependency of Swift module 'SwifterPMCore'
note: a dependency of Swift module 'TuistSupport'
note: a dependency of Swift module 'TuistHTTP'
note: a dependency of Swift module 'TuistAuthentication'
note: a dependency of main module 'Tuist'
```

**Root cause.** `app/Project.swift` declared `.external(name: "ArgumentParser", condition: .when([.ios]))`, which was accurate when the only use was the direct `import ArgumentParser` in the iOS branch of `TuistApp.swift`. `TuistSupport` has since gained `SwifterPMCore`, which depends on `ArgumentParser`, so the module is now reached on every platform through the chain in the error. The hand-written condition overrides that transitive requirement: the generated project linked `ArgumentParser.framework` with `platformFilter = ios`, while `ArgumentParserToolInfo.framework`, which arrives transitively and is never declared by hand, carried no filter at all.

The job split confirms it. `Build` targets `generic/platform=iOS Simulator` and passed; `Test` targets `platform=macOS,arch=arm64` and failed. Same commit, same graph, only the platform differs.

**Not introduced here.** The last green run of this job was 2026-08-11 and nothing in the module graph has changed since. What changed is the runner image roll emptying the compilation cache, so `TuistSupport` and `SwifterPMCore` were built from source instead of replayed and the unresolvable module surfaced. The job only runs on app-path changes, which is why it stayed latent.

**Fix.** Drop the platform condition. macOS already needs those symbols at link time through `SwifterPMCore`, so nothing new is pulled in.

## 2. `docs(app)`: what the release pipeline needs from the runner image

A `## Releasing` section in `app/AGENTS.md` covering three things that decide whether an app release succeeds, none of which are discoverable from `app/`:

- what triggers `app-release.yml`, and what does not
- the TCC AppleEvents approval `create-dmg` needs on the runner, and the failure signature when it is missing
- why the macOS and iOS jobs are sized at 50 minutes

The macOS app release has failed repeatedly on conditions outside this directory. `Bundle macOS app` runs `create-dmg`, which styles the DMG window by driving Finder from AppleScript. macOS gates that behind a `kTCCServiceAppleEvents` approval, and with none recorded it raises an authorization prompt that nothing can answer on a headless VM, so the send sits until it gives up with `Finder got an error: AppleEvent timed out. (-1712)`. That reads as flakiness, which is why the caller retries, but on this fleet it is deterministic and the retries only multiply the wait. #12317 seeds the approval; it shipped in `runner-image@0.13.3` and production has been pinned to that image since 2026-08-13.

The iOS job then hit its 30 minute limit. It was not uploading: `app:upload-ios` archives before it uploads, and `tuist generate` runs with `--no-binary-cache`, so the job is a full archive whenever the compilation cache is cold. Any image roll makes it cold, so 30 minutes only ever fit a warm cache. #12317 raised it to 50 to match the macOS job.

## Why this PR exists at all

Both #12317 fixes are on main and live on the fleet, but neither has been exercised. `app-release.yml` triggers only on pushes to main touching `app/**`, `mise/tasks/app/**`, or the `cli/Sources/*` modules the app links, and #12317 touched only `.github/workflows/app-release.yml` and `infra/runner-image/**`. So no release run was queued and none will be.

Re-running the last failed release is not a substitute: a push-event rerun replays the workflow file at that SHA, so it would still carry the 30 minute timeout and prove nothing.

Merging this lands changes on app paths, which gives both fixes their first real release run. The ArgumentParser fix then turns out to be a precondition rather than a detour, since the macOS app could not build from a cold cache at all.

## Impact

`fix(app)` and `docs(app)` are both released scopes in `app/cliff.toml`, so merging cuts `app@0.25.5` and runs the full release: macOS bundle and DMG, Sparkle appcast, iOS upload to App Store Connect, Android publish, and the GitHub Release.

Expect a slow archive. The fleet rolled onto a new image, so the compilation cache is cold, which is exactly the case the 50 minute limit was sized for. A long archive here is expected, not a regression.

## Validation

All app jobs pass on this branch, including the macOS `Test` job that failed before the fix:

| Job | Destination | Before | After |
|---|---|---|---|
| Build | iOS Simulator | pass | pass |
| Test | macOS arm64 | fail | pass |
| Device Build | iOS device | pass | pass |

Regenerating the project after the change confirms the cause structurally: `ArgumentParser.framework` is now linked with no `platformFilter`, matching `ArgumentParserToolInfo.framework`.

`mise run --skip-tools release:check` reports the app component as releasable, so the commits actually trigger a release rather than being filtered out as skipped scopes:

```
component:  app
latest tag: app@0.25.4
next:       app@0.25.5 (number: 0.25.5)
release?    true
```

The runner-image side is already confirmed: the TCC seeding and its read-back check passed on all five Xcode profiles in `runner-image@0.13.3`, so SIP is not rejecting the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)