### PR TITLE
fix(server): unblock the Security check on the Trivy DB mirror and a new nanoid advisory

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -36,6 +36,12 @@ env:
   MISE_TASK_RUN_AUTO_INSTALL: 0
   MISE_GITHUB_ATTESTATIONS: 0
   MISE_GITHUB_SLSA: 0
+  # Same repositories as Trivy's default, in the opposite order. Trivy only
+  # falls through to the next repository on a temporary status code (408, 429,
+  # 5xx) or a BLOB_UNKNOWN diagnostic. mirror.gcr.io intermittently serves a
+  # bare 404 for the blob redirect target, which is neither, so a mirror.gcr.io
+  # fault is fatal when it is first and recoverable when it is second.
+  TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db:2,mirror.gcr.io/aquasec/trivy-db:2"
 
 defaults:
   run:

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
       "form-data": "4.0.6",
       "@opentelemetry/core": "2.8.0",
       "ts-deepmerge": "8.0.0",
+      "nanoid@^3.0.0": "3.3.18",
       "nanoid@^5.0.0": "5.1.16"
     },
     "allowBuilds": {

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   follow-redirects: 1.16.0
   form-data: 4.0.6
   mdast-util-to-hast: 13.2.1
+  nanoid@^3.0.0: 3.3.18
   nanoid@^5.0.0: 5.1.16
   postcss: 8.5.23
   protobufjs: 7.6.5
@@ -37,7 +38,7 @@ time:
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
-  nanoid@3.3.17: 2026-08-03T10:39:22.487Z
+  nanoid@3.3.18: 2026-08-07T16:41:05.696Z
   nanoid@5.1.16: 2026-06-24T18:37:08.221Z
   postcss@8.5.23: 2026-07-24T17:05:13.876Z
   protobufjs@7.6.5: 2026-07-04T01:13:19.092Z
@@ -1158,8 +1159,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3144,7 +3145,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -3182,7 +3183,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Two independent failures were stacking on the `Security` job of the server workflow, keeping `main` red. This fixes both.

### 1. Trivy vulnerability DB download

[The failing run](https://github.com/tuist/tuist/actions/runs/31737263388/job/94571805323) aborted with:

```
failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2: oci download error:
failed to fetch the layer: GET https://mirror.gcr.io/artifacts-downloads/... unexpected status code 404 Not Found
```

**Root cause.** Trivy's default `--db-repository` already lists `ghcr.io/aquasecurity/trivy-db:2` as a fallback behind `mirror.gcr.io/aquasec/trivy-db:2`, so the real question is why the fallback never ran. In `pkg/oci/artifact.go` at v0.69.3, `Artifacts.Download` advances to the next repository only when `shouldTryOtherRepo` classifies the error as retryable, and that covers just temporary status codes (408, 429, 5xx) or a `BLOB_UNKNOWN` diagnostic. The mirror returns a bare 404 on the blob redirect target, which is neither, so the first repository failing is terminal.

**Fix.** List the same two repositories in the opposite order via `TRIVY_DB_REPOSITORY` in the workflow env block. This makes the built-in fallback reachable in the direction that actually fails: a mirror.gcr.io 404 is now survivable because it is second, while ghcr.io throttling surfaces as 429 or DENIED, which is exactly what `shouldTryOtherRepo` handles.

**Alternatives considered.** Dropping `mirror.gcr.io` outright would give up its rate-limit protection on the fallback path. Retrying the step does not help either, since this fault has been observed persisting for tens of minutes and re-breaking after self-healing. Reordering keeps both sources and costs nothing.

### 2. New nanoid advisory, hidden behind the first failure

Once the DB downloads, `trivy fs` fails on its own. It runs with no ignore file and no severity filter, so any advisory against server dependencies fails the job:

```
nanoid  CVE-2026-67213  HIGH  installed 3.3.17  fixed in 3.3.18, 5.1.6
```

**Root cause.** This is new rather than pre-existing. The last green run on `main` ([31709677781](https://github.com/tuist/tuist/actions/runs/31709677781), 2026-08-13 15:01 UTC) downloaded the DB successfully and reported zero findings, so the advisory range was extended to cover 3.3.17 within the following day. nanoid reaches the graph transitively through `postcss`, whose range is `^3.3.16`, so 3.3.18 satisfies it without touching `postcss` itself.

**Fix.** Pin `nanoid@^3.0.0` to `3.3.18` in the `server/package.json` overrides. The 5.x line of this same advisory is already pinned there as `nanoid@^5.0.0`, so this follows the established pattern rather than adding a `.trivyignore` entry, which would suppress a fix that is available today. Re-resolved with `aube install --fix-lockfile`, so the lockfile diff is only the nanoid version and its integrity hash.

### Impact

`Security` goes green again, and a mirror.gcr.io blob fault degrades to a slower DB fetch instead of a hard job failure. `Docker build` pulls base images through the same mirror and is not addressed here; that path is already covered by the per-image args in `server/Dockerfile`.

### How to test locally

Run the trivy half of the security task from `server/`:

```
cd server
TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db:2,mirror.gcr.io/aquasec/trivy-db:2" trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps,_build" ./
```

It should exit 0. Checking out the parent commit and re-running reproduces the nanoid finding and exit code 1.

### Validation

- Read `shouldTryOtherRepo` in trivy v0.69.3 to confirm it only returns true for `Temporary()` status codes or a `BLOB_UNKNOWN` diagnostic, which is why the default fallback never fired.
- Confirmed `TRIVY_DB_REPOSITORY` parses the comma-separated list and tries `ghcr.io` first, using a throwaway `TRIVY_CACHE_DIR` to force a cold download.
- Reproduced the nanoid finding on the pre-fix lockfile (`trivy fs` exit code 1), then confirmed exit code 0 after the bump with the same flags CI uses.
- Verified the workflow YAML still parses and that the lockfile diff touches nothing but nanoid.

Not validated locally: the `mix sobelow` half of the security task is untouched here and was already passing (it prints findings but exits 0 without an `--exit` threshold, so the job's exit 1 came entirely from trivy). The nanoid bump touches assets, so `esbuild` in CI is the real check on it.
