### PR TITLE
fix(infra): strip the legacy pf anchor block so a re-push cannot break the whole ruleset

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1405,12 +1405,33 @@ block drop out quick from <vm_sources> to <blocked_dst>
 block drop out quick from <vm_sources> to 169.254.169.254
 PFCONF
 
-# Manage the anchor block in /etc/pf.conf via begin/end markers.
-# Strip-and-append between markers is idempotent and convergent:
-# any number of pre-existing marker-delimited blocks (duplicates
-# from a stuttering reconcile, partial writes from a prior crashed
-# run) get removed before the canonical block is written.
-sudo sed -i.bak '/^# BEGIN tuist.runners$/,/^# END tuist.runners$/d' /etc/pf.conf
+# Manage the anchor block in /etc/pf.conf. Strip-and-append is
+# idempotent and convergent, but it has to strip EVERY historical
+# form of the block, not just the marker-delimited one.
+#
+# Hosts provisioned before the markers existed carry a bare,
+# un-delimited anchor/load-anchor pair. A marker-only strip left
+# that in place and appended a second copy, so loading /etc/pf.conf
+# hit "cannot define table vm_sources: Resource busy"
+# and rejected the WHOLE ruleset. pf kept serving whatever it had
+# loaded before, which no longer carried the stock
+# nat-anchor "com.apple/*" line, so the com.apple/tuist.vmnat sub-anchor
+# holding the VM NAT rules was never evaluated: cache traffic left
+# un-NAT'd with its 192.168.64.x source, the per-instance kura
+# NetworkPolicy dropped it at ingress with no RST, and every cache
+# request hung until its client timeout. The rules looked perfect in
+# the anchor the whole time; nothing consulted them.
+#
+# Deleting the bare lines as well is safe because the canonical
+# block is re-appended immediately below, and this script is folded
+# into the host config hash, so editing it re-pushes the filter to
+# every host and converges the ones already carrying a duplicate.
+sudo sed -i.bak \
+  -e '/^# BEGIN tuist.runners$/,/^# END tuist.runners$/d' \
+  -e '/^# Tuist runner VM egress filter/d' \
+  -e '/^anchor "tuist.runners"$/d' \
+  -e '\#^load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"$#d' \
+  /etc/pf.conf
 sudo rm -f /etc/pf.conf.bak
 sudo tee -a /etc/pf.conf >/dev/null <<'PFCONFENTRY'
 # BEGIN tuist.runners

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -628,3 +628,80 @@ func TestRenderSSHIngressGuardScript_IsValidSh(t *testing.T) {
 		t.Fatalf("guard script is not valid sh: %v\n%s", err, combined)
 	}
 }
+
+// Hosts provisioned before the begin/end markers existed carry a bare,
+// un-delimited anchor/load-anchor pair in /etc/pf.conf. A marker-only strip
+// leaves it in place and appends a second copy, so loading /etc/pf.conf hits
+// "cannot define table vm_sources: Resource busy" and rejects the WHOLE
+// ruleset. pf then keeps serving whatever it loaded previously, which no longer
+// carries the stock nat-anchor "com.apple/*" line, so the
+// com.apple/tuist.vmnat sub-anchor holding the VM NAT rules is never evaluated:
+// cache traffic leaves un-NAT'd with its 192.168.64.x source, the per-instance
+// kura NetworkPolicy drops it at ingress with no RST, and every cache request
+// hangs until its client timeout. Observed on a live production host whose
+// anchor held perfectly correct rules that nothing ever consulted.
+func TestRenderVMEgressFirewallScript_StripsLegacyUndelimitedAnchorBlock(t *testing.T) {
+	script, err := renderVMEgressFirewallScript(Config{VMCachePNCIDR: "172.16.0.0/22"})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	// The command may be split across continuation lines; collect it whole.
+	var sedLine string
+	lines := strings.Split(script, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "sudo sed ") {
+			continue
+		}
+		parts := []string{}
+		for _, l := range lines[i:] {
+			parts = append(parts, strings.TrimSuffix(strings.TrimSpace(l), `\`))
+			if !strings.HasSuffix(strings.TrimSpace(l), `\`) {
+				break
+			}
+		}
+		sedLine = strings.Join(parts, " ")
+		break
+	}
+	if sedLine == "" || !strings.Contains(sedLine, "/etc/pf.conf") {
+		t.Fatalf("no pf.conf strip command in rendered script\n%s", script)
+	}
+
+	// A host that has been re-pushed once: the legacy block the old bootstrap
+	// appended, then the canonical marker-delimited block.
+	const legacy = `# Tuist runner VM egress filter — see /etc/pf.anchors/tuist.runners
+anchor "tuist.runners"
+load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
+`
+	fixture := `scrub-anchor "com.apple/*"
+nat-anchor "com.apple/*"
+rdr-anchor "com.apple/*"
+anchor "com.apple/*"
+load anchor "com.apple" from "/etc/pf.anchors/com.apple"
+` + legacy + "# BEGIN tuist.runners\n" + legacy + "# END tuist.runners\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pf.conf")
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Run the very expressions the host runs, with the in-place flag removed so
+	// the result lands on stdout.
+	cmd := strings.Replace(sedLine, "sudo ", "", 1)
+	cmd = strings.Replace(cmd, "-i.bak ", "", 1)
+	cmd = strings.Replace(cmd, "/etc/pf.conf", path, 1)
+	out, err := exec.Command("sh", "-c", cmd).Output()
+	if err != nil {
+		t.Fatalf("run %q: %v", cmd, err)
+	}
+
+	if n := strings.Count(string(out), `anchor "tuist.runners"`); n != 0 {
+		t.Fatalf("strip left %d tuist.runners anchor line(s); a re-push would duplicate them and break the whole pf load\n%s", n, out)
+	}
+	// The stock Apple hooks must survive: losing nat-anchor "com.apple/*" is
+	// precisely the failure this guards against.
+	if !strings.Contains(string(out), `nat-anchor "com.apple/*"`) {
+		t.Fatalf("strip removed the stock Apple nat-anchor\n%s", out)
+	}
+}


### PR DESCRIPTION
## What changed

The macOS host bootstrap manages a `tuist.runners` anchor block in `/etc/pf.conf` with a strip-and-append. The strip now removes **every historical form** of that block, not just the marker-delimited one, before re-appending the canonical version.

## Why

A production runner host (`tuist-tuist-runners-fleet-mndbc-c22td`) was silently serving no VM cache NAT at all. Every module-cache download and Xcode CAS request from its VMs hung until the client timed out, turning minutes-long CI jobs into multi-hour ones. It surfaced as the "Kura Cache Rejecting Runner Traffic" alert: a steady ~0.9 packets/s of `Policy denied` ingress drops on the co-located kura cache node.

## Root cause

The strip only deleted blocks between the `# BEGIN tuist.runners` / `# END tuist.runners` markers introduced in #10875. Hosts provisioned before those markers existed carry a **bare, un-delimited** `anchor` / `load anchor` pair, which the marker-only strip never matched. Every config re-push therefore appended a second copy.

Loading a `pf.conf` with the block twice defines `table vm_sources` twice, and pfctl fails the **entire** ruleset rather than just the duplicate:

```
/etc/pf.anchors/tuist.runners:11: cannot define table vm_sources: Resource busy
pfctl: Syntax error in config file: pf rules not loaded
```

pf keeps serving whatever it loaded previously, which no longer carries the stock `nat-anchor "com.apple/*"` line. That line is the only thing that evaluates the `com.apple/tuist.vmnat` sub-anchor holding the VM NAT rules, so those rules sit in the anchor looking perfectly correct while nothing consults them. VM cache traffic then egresses the PN VLAN with its raw `192.168.64.x` source, and the per-instance kura NetworkPolicy (which admits `http` only from `172.16.0.0/22`) drops it at ingress with no RST. The client never sees a refusal, so it hangs.

**This is why #12257 did not fix it.** That change corrected the *contents* of the vmnat anchor; the anchor is never evaluated.

## Why this fix over the alternatives

Deleting the bare `anchor` / `load anchor` lines outright is safe because the canonical block is re-appended immediately afterwards. Because `renderVMEgressFirewallScript` is folded into the host config hash, editing it re-pushes the filter to every host on the next reconcile and converges the hosts already carrying a duplicate, so no manual per-host intervention or machine replacement is needed.

Making pfctl failures fatal to the bootstrap was considered and rejected for this PR: it would have surfaced the problem but would also have wedged reconciles on hosts that are otherwise healthy.

## Impact

Everything that looked healthy on the broken host stayed healthy-looking, which is what made this expensive to find: `pfctl -s info` reported "Enabled for 28 days", the vmnat anchor held the right rules, `vlan0` was UP with a valid `inet 172.16.0.12/22` and a live DHCP lease, and from the host itself the kura NodePort answered in 2 ms. Only the drop counter fired.

A fleet sweep of all 9 runner hosts found the duplicate on 2:

| host | anchor lines | `nat-anchor "com.apple/*"` loaded | pf load failures | state |
|---|---|---|---|---|
| c22td | 4 | no | 49 | broken |
| m42wr | 4 | yes | 45 | latent, tips at next reboot |
| other 7 | 2 | yes | 0 | ok |

`m42wr` still holds a good ruleset from an earlier successful load but can never reload, so it would have become a second silent outage at its next reboot. Node age does not predict it: both affected hosts are 86 days old while 7 younger hosts are clean, so it depends on whether a host ever received the legacy form.

## Validation

- New test `TestRenderVMEgressFirewallScript_StripsLegacyUndelimitedAnchorBlock` builds a `pf.conf` fixture in the state a re-pushed legacy host is actually in (legacy block followed by the marker-delimited block), runs the exact `sed` expressions the host runs, and asserts no `tuist.runners` anchor line survives while the stock Apple `nat-anchor` does. Verified red before the fix (`strip left 2 tuist.runners anchor line(s)`) and green after.
- Full `go test ./...` and `go vet ./...` pass for `infra/macos-host-bootstrap`; `gofmt` clean.
- Diagnosis confirmed on the live host by packet capture on `vlan0` showing un-NAT'd `192.168.64.2 > <kuraPN>.<nodePort>` SYN retransmits, `pfctl -s state | grep -c 172.16` = 0, and a loaded top-level NAT ruleset containing only Apple's internet-sharing entry.

No production state was changed; the two affected hosts converge via the host-config-hash re-push once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)