### PR TITLE
fix(swifterpm): fail local packages that hold no manifest

### DIFF
--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -61,6 +61,7 @@ enum ManifestLoader {
     }
 
     static func dumpPackage(packageDir: URL, disableSandbox: Bool) async throws -> Any {
+        try await requireManifest(packageDir: packageDir)
         do {
             let data = try await loadPackageJSON(
                 packageDir: packageDir, disableSandbox: disableSandbox
@@ -72,12 +73,29 @@ enum ManifestLoader {
     }
 
     static func dumpPackageJSON(packageDir: URL, disableSandbox: Bool) async throws -> Data {
+        try await requireManifest(packageDir: packageDir)
         do {
             return try await loadPackageJSON(
                 packageDir: packageDir, disableSandbox: disableSandbox
             )
         } catch {
             throw await dumpFailure(packageDir: packageDir, underlying: error)
+        }
+    }
+
+    /// `swift package dump-package` resolves the package root by walking up from its working
+    /// directory, and `--package-path` walks up as well, so a directory that holds no manifest
+    /// does not fail the dump: it produces the nearest ancestor package instead, which swifterpm
+    /// would then cache and resolve under the identity of the package the caller asked for. A
+    /// checkout that lives inside another Swift package is enough to turn a broken local
+    /// dependency into a silently wrong graph, so refuse the dump before it starts.
+    ///
+    /// Only the directory-exists-without-a-manifest case is decided here. A directory that is
+    /// absent or unreadable cannot adopt an ancestor either way, and letting the subprocess fail
+    /// keeps the diagnosis of those states in `dumpFailure`, next to the error they produce.
+    private static func requireManifest(packageDir: URL) async throws {
+        if case .absent = await manifestPresence(packageDir: packageDir) {
+            throw ToolError.message("no Package.swift in \(packageDir.path)")
         }
     }
 
@@ -221,7 +239,8 @@ enum ManifestFileSystemDependencyGraph {
                 throw ToolError.message(
                     """
                     failed to load the manifest for the local package \
-                    \(item.dependency.identity), declared as "\(item.dependency.path)" by \
+                    \(item.dependency.identity), declared as "\(item.dependency.path)"\
+                    \(redirect(declared: item.dependency.path, canonical: canonicalPath)) by \
                     \(item.parentPackageDir.path): \(error)
                     """
                 )
@@ -239,6 +258,14 @@ enum ManifestFileSystemDependencyGraph {
         }
 
         return result
+    }
+
+    /// The failure above names the directory the dump was attempted in, which is the declared
+    /// path only when nothing along the way is a symlink. When the two differ, that sentence
+    /// names a directory nobody declared and reads like a typo, while the redirect is the whole
+    /// diagnosis: a local dependency whose path lands somewhere other than the package.
+    private static func redirect(declared: String, canonical: URL) -> String {
+        canonical.path == declared ? "" : ", which resolves to \(canonical.path),"
     }
 
     static func packagePathForFileSystemDependency(

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -507,16 +507,24 @@ enum PathCanonicalizer {
         #if os(Windows)
             url.standardizedFileURL
         #else
+            // The pointer `realpath` returns is only guaranteed for as long as the buffer is
+            // borrowed, so the string has to be built inside the borrow rather than from the
+            // returned pointer afterwards.
             var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-            #if canImport(Glibc)
-                let resolved = Glibc.realpath(url.path, &buffer)
-            #elseif canImport(Musl)
-                let resolved = Musl.realpath(url.path, &buffer)
-            #else
-                let resolved = Darwin.realpath(url.path, &buffer)
-            #endif
-            if let resolved, let path = String(validatingCString: resolved) {
-                return URL(fileURLWithPath: path)
+            let resolved = buffer.withUnsafeMutableBufferPointer { buffer -> String? in
+                guard let base = buffer.baseAddress else { return nil }
+                #if canImport(Glibc)
+                    let resolved = Glibc.realpath(url.path, base)
+                #elseif canImport(Musl)
+                    let resolved = Musl.realpath(url.path, base)
+                #else
+                    let resolved = Darwin.realpath(url.path, base)
+                #endif
+                guard let resolved else { return nil }
+                return String(validatingCString: resolved)
+            }
+            if let resolved {
+                return URL(fileURLWithPath: resolved)
             }
             return url.standardizedFileURL
         #endif

--- a/swifterpm/Tests/swifterpmTests/ManifestTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestTests.swift
@@ -415,6 +415,35 @@ struct ManifestTests {
     }
 
     @Test
+    func dumpingASubdirectoryOfAPackageDoesNotStandInForTheEnclosingPackage() async throws {
+        try await withTemporaryDirectory { directory in
+            // Root resolution runs through the same dump and defaults to the working
+            // directory, so the walk-up let a subdirectory stand in for its own package.
+            // It never carried a run to completion (`originHash` reads the manifest at that
+            // same directory a step later, and fails), so what the gate removes is a dump of
+            // one package announced as another, not a working invocation.
+            try await writeMinimalPackageManifest(at: directory, name: "Root")
+            let subdirectory = directory.appendingPathComponent("Sources/Root")
+            try await fileSystem.makeDirectory(
+                at: subdirectory.absolutePath, options: [.createTargetParentDirectories])
+
+            do {
+                let manifest = try await ManifestLoader.dumpPackage(
+                    packageDir: subdirectory, disableSandbox: true
+                )
+                Issue.record(
+                    """
+                    expected the dump to fail, loaded \
+                    \(ManifestParser.packageName(manifest) ?? "an unnamed package") instead
+                    """
+                )
+            } catch {
+                #expect("\(error)" == "no Package.swift in \(subdirectory.path)")
+            }
+        }
+    }
+
+    @Test
     func localPackageManifestFailureNamesWhereTheDeclaredPathResolvesTo() async throws {
         try await withTemporaryDirectory { directory in
             let rootPackageDir = directory.appendingPathComponent("Root")

--- a/swifterpm/Tests/swifterpmTests/ManifestTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestTests.swift
@@ -376,6 +376,87 @@ struct ManifestTests {
     }
 
     @Test
+    func localPackageWithoutAManifestDoesNotAdoptAnAncestorPackage() async throws {
+        try await withTemporaryDirectory { directory in
+            // `swift package dump-package` resolves the package root by walking up from its
+            // working directory, and `--package-path` walks up too, so a local dependency
+            // pointing at a manifest-less directory underneath another package would dump
+            // that ancestor's manifest under this dependency's identity: a silently wrong
+            // graph in place of an error.
+            try await writeMinimalPackageManifest(at: directory, name: "Ancestor")
+            let rootPackageDir = directory.appendingPathComponent("Root")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            let localPackageDir = directory.appendingPathComponent("Packages/Feature")
+            try await fileSystem.makeDirectory(
+                at: localPackageDir.absolutePath, options: [.createTargetParentDirectories])
+
+            let rootManifest: [String: Any] = [
+                "dependencies": [
+                    ["fileSystem": [["identity": "feature", "path": localPackageDir.path]]]
+                ]
+            ]
+
+            do {
+                let packages = try await ManifestFileSystemDependencyGraph.collect(
+                    rootPackageDir: rootPackageDir,
+                    rootManifest: rootManifest,
+                    disableSandbox: true
+                )
+                Issue.record(
+                    """
+                    expected the local package manifest to fail to load, loaded \
+                    \(packages.compactMap { ManifestParser.packageName($0.manifest) }) instead
+                    """
+                )
+            } catch {
+                #expect("\(error)".contains("no Package.swift in"))
+            }
+        }
+    }
+
+    @Test
+    func localPackageManifestFailureNamesWhereTheDeclaredPathResolvesTo() async throws {
+        try await withTemporaryDirectory { directory in
+            let rootPackageDir = directory.appendingPathComponent("Root")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            let resolvedDir = directory.appendingPathComponent("Elsewhere")
+            try await fileSystem.makeDirectory(
+                at: resolvedDir.absolutePath, options: [.createTargetParentDirectories])
+            let declaredDir = directory.appendingPathComponent("Packages/Feature")
+            try await fileSystem.makeDirectory(
+                at: declaredDir.deletingLastPathComponent().absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.createSymbolicLink(
+                from: declaredDir.absolutePath, to: resolvedDir.absolutePath)
+
+            let rootManifest: [String: Any] = [
+                "dependencies": [
+                    ["fileSystem": [["identity": "feature", "path": declaredDir.path]]]
+                ]
+            ]
+
+            do {
+                _ = try await ManifestFileSystemDependencyGraph.collect(
+                    rootPackageDir: rootPackageDir,
+                    rootManifest: rootManifest,
+                    disableSandbox: true
+                )
+                Issue.record("expected the local package manifest to fail to load")
+            } catch {
+                // The declared path and the directory the failure names are different
+                // directories, and only the redirect explains why: without it the sentence
+                // reads as if swifterpm looked in a place nobody declared.
+                let description = "\(error)"
+                #expect(description.contains("declared as \"\(declaredDir.path)\""))
+                #expect(
+                    description.contains(
+                        "resolves to \(PathCanonicalizer.realpath(resolvedDir).path)"))
+            }
+        }
+    }
+
+    @Test
     func versionRangeMatchesExactAndOpenRanges() throws {
         let exact = try #require(ManifestParser.versionRange(for: .exact(SemVer("1.2.3"))))
         #expect(try exact.contains(SemVer("1.2.3")))

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -324,4 +324,23 @@ struct SupportTests {
             ) == nil
         )
     }
+
+    @Test
+    func realpathFollowsSymlinksAndKeepsThePathWhenItCannotResolve() async throws {
+        try await withTemporaryDirectory { directory in
+            let target = directory.appendingPathComponent("Target")
+            try await fileSystem.makeDirectory(
+                at: target.absolutePath, options: [.createTargetParentDirectories])
+            let link = directory.appendingPathComponent("Link")
+            try await fileSystem.createSymbolicLink(from: link.absolutePath, to: target.absolutePath)
+            let absent = directory.appendingPathComponent("Absent/Deep")
+
+            #expect(
+                PathCanonicalizer.realpath(link).path
+                    == PathCanonicalizer.realpath(directory).appendingPathComponent("Target").path)
+            // Nothing to resolve: the caller still needs the path it asked about, not a
+            // truncated prefix of it.
+            #expect(PathCanonicalizer.realpath(absent).path == absent.standardizedFileURL.path)
+        }
+    }
 }


### PR DESCRIPTION
### What changed

Three fixes in swifterpm's local (`path:`) package handling, all found while diagnosing a
user report of `tuist install` failing with `no Package.swift in <repo root>`.

**1. A local package directory without a manifest no longer adopts an ancestor package.**
`swift package dump-package` resolves the package root by walking up from its working
directory, and passing `--package-path` walks up as well (verified against Swift 6.3). So
dumping a directory that holds no manifest does not fail. It returns the nearest ancestor
package instead, and swifterpm cached and resolved that ancestor under the identity of the
local dependency that was declared. Any checkout that lives inside another Swift package
turned a broken `path:` dependency into a silently wrong dependency graph rather than an
error. Reproduced before the fix: a repo whose parent directory holds an unrelated
`Package.swift`, with the local dependency pointing at a manifest-less directory, resolved
successfully and wrote this into the package-info index:

```
{ "identity": "feature", "kind": "fileSystem", "package_path": "<the repo, not the package>" }
feature-<hash>.json -> name: DecoyAncestorPackage | products: ['Decoy']
```

Plain SwiftPM errors on the same tree, so this was a divergence from SwiftPM, not a shared
limitation. `ManifestLoader` now requires the manifest before the dump, which also saves the
process spawn. Only the directory-exists-without-a-manifest case is decided there. An absent
or unreadable directory cannot adopt an ancestor either way, so those keep failing through
the subprocess and stay classified in `dumpFailure` next to the error they produce.

**2. The failure now says where the declared path resolved to.** swifterpm canonicalizes the
declared path with `realpath` before dumping, so the directory it names is the declared path
only when nothing along the way is a symlink. When the two differ, the old sentence named a
directory nobody declared and read like a typo, while the redirect is the whole diagnosis:

```
before: failed to load the manifest for the local package foo, declared as "<repo>/Frameworks/Foundation/Foo" by <repo>/Tuist: no Package.swift in <repo>
after:  failed to load the manifest for the local package foo, declared as "<repo>/Frameworks/Foundation/Foo", which resolves to <repo>, by <repo>/Tuist: no Package.swift in <repo>
```

The note is omitted when the paths match, so the common case is unchanged.

**3. `PathCanonicalizer.realpath` builds its string inside the buffer borrow.** It previously
built the string from the pointer `realpath` returned after the `&buffer` borrow had ended.
The pointer is only guaranteed for the borrow. I could not make it misbehave (a 320k-iteration
concurrent stress run produced zero wrong results), so this is hygiene, not a fix for an
observed failure.

### Why

The user report was a self-hosted CI runner where a local package path resolved, through a
symlink, to the repository root. That tree is genuinely broken and plain
`swift package resolve` fails on it too, so the report is not a swifterpm bug. But comparing
the two resolvers surfaced the opposite failure: on the same shape of broken tree, swifterpm
can succeed where SwiftPM errors. That is worse than the reported error, because a wrong graph
surfaces much later than a failed install.

The error-message change comes from the same investigation. Reading the reported message, the
declared path and the named directory being different directories was the single fact that
identified the cause, and nothing in the sentence said the two were related.

### Alternatives considered

Passing `--package-path` to the dump instead of checking for the manifest. It does not work:
SwiftPM walks up from `--package-path` too, so the ancestor is still found. An explicit
existence check is the only thing that stops it.

### Impact

A broken local dependency that previously resolved to an ancestor package now fails with a
clear message. Healthy packages are unaffected, including local packages reached through
symlinks, which keep working (covered by the manual check below).

The gate also applies to root resolution, which runs through the same dump and defaults to
the working directory, so a subdirectory of a package no longer dumps the enclosing package.
That invocation did not work before either: the dump walked up, and then `originHash` read
the manifest at the directory the caller actually named and failed a step later. So the
change there is which error you get, not whether it fails:

```
before: Error: Path not found: <package>/Sources/Root/Package.swift
after:  Error: no Package.swift in <package>/Sources/Root
```

`restore` is unchanged, since it already failed on `Package.resolved` before reaching a dump.
The Tuist call sites pass the package path explicitly and never relied on the walk-up.
A test pins the refusal so it stays a stated contract rather than a side effect.

### How to test locally

Unit tests:

```bash
swift test --package-path swifterpm --filter "ManifestTests|SupportTests"
```

Both new tests fail on `main` for the right reasons: the ancestor test reports
`expected the local package manifest to fail to load, loaded ["Ancestor"] instead`, and the
redirect test shows the message without the redirect.

End to end, against the built binary:

```bash
swift build --package-path swifterpm --product swifterpm
```

Then, in a scratch directory, create a package at the top level, a `Tuist/Package.swift`
under it declaring `.package(path: "../Frameworks/Foundation/Foo")`, and make that path a
symlink to a directory holding no manifest. Before this change
`swifterpm --package-path <dir>/Tuist resolve` succeeded with the top-level package bound to
`foo`. After it, the resolve fails and names both the declared path and where it resolves to.

Full swifterpm suite passes locally (145 tests), and `mise run lint` is clean.

