### PR TITLE
fix(app): seed the Finder automation approval the DMG step actually reads

### DIFF
--- a/mise/tasks/app/bundle.sh
+++ b/mise/tasks/app/bundle.sh
@@ -59,10 +59,55 @@ mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
 
+# create-dmg styles the DMG window by driving Finder from AppleScript, which
+# macOS gates behind an Automation approval. That consent is answered from the
+# session user's TCC database, so an unseeded one leaves the send waiting on a
+# prompt no headless VM can answer until it gives up with "Finder got an error:
+# AppleEvent timed out. (-1712)".
+#
+# The runner image seeds the system database (infra/runner-image/runner.pkr.hcl),
+# which is not where this decision is read from. It cannot seed the per-user one
+# either: the account is created during the image build and its session first
+# opens when the VM boots, so at build time the database does not exist. GitHub's
+# images carry these same rows in the user database, which is why the step worked
+# before macOS jobs moved to this fleet.
+#
+# Seed it here instead, on the VM that is about to run create-dmg. Guarded to CI
+# so a local bundle never touches a developer's own approvals.
+if [ "${CI:-}" = "true" ]; then
+    print_status "Approving scripted Finder automation..."
+    SYSTEM_TCC_DB='/Library/Application Support/com.apple.TCC/TCC.db'
+    USER_TCC_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+
+    # tccd creates this database on the account's first consent decision, which
+    # on a fresh VM may not have happened yet. An empty file would shadow the
+    # real one, so give it the system database's schema.
+    if [ ! -f "$USER_TCC_DB" ]; then
+        sudo mkdir -p "$(dirname "$USER_TCC_DB")"
+        sudo sqlite3 "$SYSTEM_TCC_DB" .schema | sudo sqlite3 "$USER_TCC_DB"
+    fi
+
+    # TCC attributes an event to the responsible process, which for a shell
+    # pipeline is usually an ancestor rather than osascript itself, so the
+    # shells are seeded alongside it. Columns are named rather than positional
+    # because the access schema gains columns across macOS releases.
+    for client in /usr/bin/osascript /bin/bash /bin/zsh; do
+        sudo sqlite3 "$USER_TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier_type, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAppleEvents', '$client', 1, 2, 0, 1, 0, 'com.apple.finder', 0, strftime('%s','now'));"
+    done
+    sudo chown -R "$(id -un):staff" "$(dirname "$USER_TCC_DB")"
+
+    # tccd holds the database open, so restart it to pick the rows up.
+    killall tccd 2>/dev/null || true
+
+    sqlite3 "$USER_TCC_DB" "SELECT 1 FROM access WHERE service='kTCCServiceAppleEvents' AND client='/usr/bin/osascript' AND indirect_object_identifier='com.apple.finder' AND auth_value=2;" | grep -q 1 || {
+        echo "sanity check: AppleEvents approval for Finder did not persist to the per-user TCC.db, so create-dmg would spend 10 minutes timing out instead" >&2
+        exit 1
+    }
+fi
+
 print_status "Creating DMG..."
-# create-dmg uses Finder via AppleScript to style the DMG window, which
-# periodically fails on CI with "AppleEvent timed out. (-1712)". Retry a few
-# times before giving up.
+# Retries cover the "Can't get disk (-1728)" race create-dmg warns about; the
+# Finder authorization it also needs is seeded above.
 max_attempts=5
 attempt=1
 until create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"; do


### PR DESCRIPTION
## What changed

`mise/tasks/app/bundle.sh` seeds the `kTCCServiceAppleEvents` approval for Finder into the **session user's** TCC database, on the VM that is about to run `create-dmg`, right before it runs. Guarded to CI, followed by a read-back that fails fast.

## Why

`Bundle macOS app` still fails all five `create-dmg` attempts with

```
Finder got an error: AppleEvent timed out. (-1712)
```

on `runner-image@0.13.3`, the image #12317 shipped specifically to fix this. Two release runs hit it this morning, 07:58 and 08:31, ten minutes of timeouts each.

## Root cause

`create-dmg` styles the DMG window by driving Finder from AppleScript. macOS gates that behind an Automation approval, and that decision is answered from the session user's TCC database, not the system one.

#12317 seeded the system database, and its read-back checked the same database it had just written. The check passed on all five Xcode profiles while the row that actually governs the decision was never written anywhere. A guard added to prevent silent breakage validated the wrong thing.

The image cannot fix this at build time. `infra/runner-image/runner.pkr.hcl` creates the account with `sysadminctl -addUser runner`, and auto-login is only configured there, taking effect when the VM boots. At build time the per-user database does not exist, which is why every image build logs `per-user TCC.db absent; relying on the system database`. That branch is always taken, by construction.

## Why it worked on GitHub-hosted runners

GitHub's images carry these same rows in the user database, in `images/macos/scripts/build/configure-tccdb-macos.sh`:

```
'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,…
'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,…
```

seeded by a helper that writes to `$HOME/Library/Application Support/com.apple.TCC/TCC.db` with no schema creation, so it depends on the database already existing. It does on their builders, because the image is built under a logged-in account. That difference is the entire gap between the two images, and why DMG creation worked before macOS jobs moved to this fleet.

## Why here rather than in the image

This is the fast path to confirming the diagnosis on a real release: it ships with the next merge instead of a two-hour image build plus a deploy cascade and fleet roll. The durable fix is the same seeding at first boot in the runner image, so every macOS job gets it rather than this one workflow, and that is worth doing once this is confirmed.

If the approval lands and Finder still times out, the conclusion changes: Finder would be unreachable rather than unauthorized, and the answer becomes dropping the Finder styling entirely (`create-dmg --skip-jenkins`, or a pre-baked `.DS_Store`). The read-back added here distinguishes those two cases instead of leaving them looking identical.

## Notes on the implementation

- The database is created from the system schema when `tccd` has not made it yet. An empty file would shadow the real one and break TCC for the account, so it is never created bare.
- The shells are seeded alongside `osascript` because TCC attributes an event to the responsible process, which for a shell pipeline is usually an ancestor rather than the immediate caller.
- Columns are named rather than positional, so the statement survives the `access` schema gaining columns on a macOS bump.
- Guarded on `CI` so running `mise run app:bundle` locally never touches a developer's own approvals.
- The read-back exits immediately with a clear message rather than letting `create-dmg` burn ten minutes rediscovering it.

## Validation

Shell syntax checks. The seed, the schema-copy path for a missing database, and both directions of the read-back were exercised against a stand-in database carrying the real `access` column set: the rows land, the guard fires when they are absent, and a database created from a copied schema accepts them.

The remaining gate is a release run. Neither the session user's database nor `tccd`'s behaviour can be reproduced off the fleet, which is the same reason #12317's gap survived review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)