### PR TITLE
fix(app): build the DMG without Finder

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -90,8 +90,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - name: Install create-dmg
-        run: brew install create-dmg
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -35,7 +35,7 @@ The app depends on several CLI modules:
 ## Releasing
 `.github/workflows/app-release.yml` runs on pushes to `main` that touch `app/**`, `mise/tasks/app/**`, or the `cli/Sources/*` modules the app links. Changes to the workflow itself, or to the runner image the release runs on, do not trigger it, so a fix to either one stays unproven until an app path changes.
 
-- Bundling the macOS app shells out to `create-dmg`, which styles the DMG window by driving Finder from AppleScript. macOS gates that behind a `kTCCServiceAppleEvents` approval for Finder, seeded into the runner image in `infra/runner-image/runner.pkr.hcl` and present from `runner-image@0.13.3`. On an image without it the send waits on an authorization prompt no headless VM can answer and gives up with `Finder got an error: AppleEvent timed out. (-1712)`; retrying only multiplies the wait.
+- Bundling the macOS app builds the DMG with `dmgbuild`, which writes the window layout into the image's `.DS_Store`. Layout lives in `app/dmg-settings.py`. Nothing in the release drives Finder, and it must stay that way: the fleet's VMs have no Finder that answers, so the previous tool, `create-dmg`, waited out a 120 second AppleEvent timeout on every attempt and no release could produce a DMG. That is an unreachable Finder rather than an unapproved one, so seeding TCC does not help; the approval seeded in `infra/runner-image/runner.pkr.hcl` was an attempt at this and did not fix it.
 - The macOS and iOS jobs allow 50 minutes because `tuist generate` runs with `--no-binary-cache`, making each release a full archive whenever the compilation cache is cold. Any runner image roll leaves it cold, so the first release after one runs far longer than a warm release.
 
 ## Environment Configuration

--- a/app/dmg-settings.py
+++ b/app/dmg-settings.py
@@ -1,0 +1,46 @@
+"""dmgbuild settings for the Tuist macOS app disk image.
+
+Replaces create-dmg, which styled the window by telling Finder where to put
+the icons over AppleScript. The runner fleet's VMs have no Finder that
+answers, so every send waited out the 120 second AppleEvent timeout and the
+release could not produce a DMG at all. dmgbuild writes the same layout
+straight into the image's .DS_Store, so the styling survives without a GUI
+session.
+
+The values below mirror the create-dmg invocation this replaces, including
+the defaults it did not spell out: a 10x60 window origin, 16pt labels, and
+an unarranged icon view with no toolbar or status bar.
+"""
+
+import os
+
+app_path = defines["app"]  # noqa: F821 - injected by dmgbuild
+app_name = os.path.basename(app_path)
+
+files = [app_path]
+symlinks = {"Applications": "/Applications"}
+hide_extensions = [app_name]
+
+icon_locations = {
+    app_name: (139, 161),
+    "Applications": (467, 161),
+}
+
+background = defines["background"]  # noqa: F821 - injected by dmgbuild
+format = "UDZO"
+
+default_view = "icon-view"
+arrange_by = None
+icon_size = 95
+text_size = 16
+label_pos = "bottom"
+window_rect = ((10, 60), (605, 363))
+
+show_status_bar = False
+show_tab_view = False
+show_toolbar = False
+show_pathbar = False
+show_sidebar = False
+
+include_icon_view_settings = True
+include_list_view_settings = False

--- a/mise/tasks/app/bundle.sh
+++ b/mise/tasks/app/bundle.sh
@@ -59,10 +59,55 @@ mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
 
+# create-dmg styles the DMG window by driving Finder from AppleScript, which
+# macOS gates behind an Automation approval. That consent is answered from the
+# session user's TCC database, so an unseeded one leaves the send waiting on a
+# prompt no headless VM can answer until it gives up with "Finder got an error:
+# AppleEvent timed out. (-1712)".
+#
+# The runner image seeds the system database (infra/runner-image/runner.pkr.hcl),
+# which is not where this decision is read from. It cannot seed the per-user one
+# either: the account is created during the image build and its session first
+# opens when the VM boots, so at build time the database does not exist. GitHub's
+# images carry these same rows in the user database, which is why the step worked
+# before macOS jobs moved to this fleet.
+#
+# Seed it here instead, on the VM that is about to run create-dmg. Guarded to CI
+# so a local bundle never touches a developer's own approvals.
+if [ "${CI:-}" = "true" ]; then
+    print_status "Approving scripted Finder automation..."
+    SYSTEM_TCC_DB='/Library/Application Support/com.apple.TCC/TCC.db'
+    USER_TCC_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+
+    # tccd creates this database on the account's first consent decision, which
+    # on a fresh VM may not have happened yet. An empty file would shadow the
+    # real one, so give it the system database's schema.
+    if [ ! -f "$USER_TCC_DB" ]; then
+        sudo mkdir -p "$(dirname "$USER_TCC_DB")"
+        sudo sqlite3 "$SYSTEM_TCC_DB" .schema | sudo sqlite3 "$USER_TCC_DB"
+    fi
+
+    # TCC attributes an event to the responsible process, which for a shell
+    # pipeline is usually an ancestor rather than osascript itself, so the
+    # shells are seeded alongside it. Columns are named rather than positional
+    # because the access schema gains columns across macOS releases.
+    for client in /usr/bin/osascript /bin/bash /bin/zsh; do
+        sudo sqlite3 "$USER_TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier_type, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAppleEvents', '$client', 1, 2, 0, 1, 0, 'com.apple.finder', 0, strftime('%s','now'));"
+    done
+    sudo chown -R "$(id -un):staff" "$(dirname "$USER_TCC_DB")"
+
+    # tccd holds the database open, so restart it to pick the rows up.
+    killall tccd 2>/dev/null || true
+
+    sqlite3 "$USER_TCC_DB" "SELECT 1 FROM access WHERE service='kTCCServiceAppleEvents' AND client='/usr/bin/osascript' AND indirect_object_identifier='com.apple.finder' AND auth_value=2;" | grep -q 1 || {
+        echo "sanity check: AppleEvents approval for Finder did not persist to the per-user TCC.db, so create-dmg would spend 10 minutes timing out instead" >&2
+        exit 1
+    }
+fi
+
 print_status "Creating DMG..."
-# create-dmg uses Finder via AppleScript to style the DMG window, which
-# periodically fails on CI with "AppleEvent timed out. (-1712)". Retry a few
-# times before giving up.
+# Retries cover the "Can't get disk (-1728)" race create-dmg warns about; the
+# Finder authorization it also needs is seeded above.
 max_attempts=5
 attempt=1
 until create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"; do

--- a/mise/tasks/app/bundle.sh
+++ b/mise/tasks/app/bundle.sh
@@ -59,67 +59,21 @@ mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
 
-# create-dmg styles the DMG window by driving Finder from AppleScript, which
-# macOS gates behind an Automation approval. That consent is answered from the
-# session user's TCC database, so an unseeded one leaves the send waiting on a
-# prompt no headless VM can answer until it gives up with "Finder got an error:
-# AppleEvent timed out. (-1712)".
-#
-# The runner image seeds the system database (infra/runner-image/runner.pkr.hcl),
-# which is not where this decision is read from. It cannot seed the per-user one
-# either: the account is created during the image build and its session first
-# opens when the VM boots, so at build time the database does not exist. GitHub's
-# images carry these same rows in the user database, which is why the step worked
-# before macOS jobs moved to this fleet.
-#
-# Seed it here instead, on the VM that is about to run create-dmg. Guarded to CI
-# so a local bundle never touches a developer's own approvals.
-if [ "${CI:-}" = "true" ]; then
-    print_status "Approving scripted Finder automation..."
-    SYSTEM_TCC_DB='/Library/Application Support/com.apple.TCC/TCC.db'
-    USER_TCC_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
-
-    # tccd creates this database on the account's first consent decision, which
-    # on a fresh VM may not have happened yet. An empty file would shadow the
-    # real one, so give it the system database's schema.
-    if [ ! -f "$USER_TCC_DB" ]; then
-        sudo mkdir -p "$(dirname "$USER_TCC_DB")"
-        sudo sqlite3 "$SYSTEM_TCC_DB" .schema | sudo sqlite3 "$USER_TCC_DB"
-    fi
-
-    # TCC attributes an event to the responsible process, which for a shell
-    # pipeline is usually an ancestor rather than osascript itself, so the
-    # shells are seeded alongside it. Columns are named rather than positional
-    # because the access schema gains columns across macOS releases.
-    for client in /usr/bin/osascript /bin/bash /bin/zsh; do
-        sudo sqlite3 "$USER_TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier_type, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAppleEvents', '$client', 1, 2, 0, 1, 0, 'com.apple.finder', 0, strftime('%s','now'));"
-    done
-    sudo chown -R "$(id -un):staff" "$(dirname "$USER_TCC_DB")"
-
-    # tccd holds the database open, so restart it to pick the rows up.
-    killall tccd 2>/dev/null || true
-
-    sqlite3 "$USER_TCC_DB" "SELECT 1 FROM access WHERE service='kTCCServiceAppleEvents' AND client='/usr/bin/osascript' AND indirect_object_identifier='com.apple.finder' AND auth_value=2;" | grep -q 1 || {
-        echo "sanity check: AppleEvents approval for Finder did not persist to the per-user TCC.db, so create-dmg would spend 10 minutes timing out instead" >&2
-        exit 1
-    }
-fi
-
 print_status "Creating DMG..."
-# Retries cover the "Can't get disk (-1728)" race create-dmg warns about; the
-# Finder authorization it also needs is seeded above.
-max_attempts=5
-attempt=1
-until create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"; do
-    if [ $attempt -ge $max_attempts ]; then
-        echo "create-dmg failed after $attempt attempts" >&2
-        exit 1
-    fi
-    echo "create-dmg attempt $attempt failed; retrying..." >&2
-    rm -f "$BUILD_DMG_PATH"
-    attempt=$((attempt + 1))
-    sleep 5
-done
+# The window layout is written straight into the image's .DS_Store. The
+# previous tool, create-dmg, styled it by telling Finder where to put the icons
+# over AppleScript, and the fleet's VMs have no Finder that answers: every send
+# waited out the 120 second AppleEvent timeout, so all five attempts failed
+# with "Finder got an error: AppleEvent timed out. (-1712)" and no release
+# could produce a DMG. Layout lives in app/dmg-settings.py.
+DMGBUILD_VENV=$TMP_DIR/dmgbuild
+python3 -m venv "$DMGBUILD_VENV"
+"$DMGBUILD_VENV/bin/pip" install --quiet --disable-pip-version-check dmgbuild==1.6.7
+"$DMGBUILD_VENV/bin/dmgbuild" \
+    --settings "$MISE_PROJECT_ROOT/app/dmg-settings.py" \
+    -D app="$BUILD_DIRECTORY_BINARY" \
+    -D background="$MISE_PROJECT_ROOT/assets/dmg-background.png" \
+    "Tuist App" "$BUILD_DMG_PATH"
 
 codesign --force --timestamp --options runtime --sign "Developer ID Application: Tuist GmbH (U6LC622NKF)" --identifier "dev.tuist.app.tuist-app-dmg" "$BUILD_DMG_PATH"
 


### PR DESCRIPTION
## What changed

The macOS release builds its DMG with `dmgbuild` instead of `create-dmg`. The window layout moves into `app/dmg-settings.py` and is written directly into the image's `.DS_Store`, so nothing in the release drives Finder.

## Why

The macOS release has not produced a DMG since macOS jobs moved to the Tuist fleet. `create-dmg` styles the window by telling Finder where to put the icons over AppleScript, and every send waited out the 120 second AppleEvent timeout:

```
Finder got an error: AppleEvent timed out. (-1712)
```

Five attempts per run, ten minutes, then the job failed. Five release runs died this way today alone.

## Why the previous two fixes did not work

Both read the timeout as a missing authorization, which was a reasonable first reading: macOS does gate scripted Finder automation behind TCC, and GitHub's images seed exactly that approval.

- #12317 seeded `kTCCServiceAppleEvents` for Finder into the runner image's **system** TCC database. That is not where the decision is read from, and its read-back checked the same database it had just written, so the check passed while the row that governs the decision was absent.
- #12346 seeded the **per-user** database from the release job, where the session actually exists, and read the row back.

That second read-back is what settled it. In run [31784676514](https://github.com/tuist/tuist/actions/runs/31784676514) the log shows `Approving scripted Finder automation...`, no read-back failure, and then five more `-1712` timeouts. The approval is present and Finder still does not answer, so this is an unreachable Finder rather than an unapproved one. There is nothing to approve, and no amount of seeding helps.

## The fix

`dmgbuild` writes the same layout straight into the image's `.DS_Store` rather than asking Finder to arrange the window, so the styling survives without a GUI session. The settings mirror the `create-dmg` invocation, including the defaults it never spelled out: a 10x60 window origin, 16pt labels, and an unarranged icon view with no toolbar or status bar.

It installs into a throwaway venv inside the task rather than through brew, so `mise run app:bundle` behaves the same locally and on a runner, and the workflow's create-dmg install step goes away.

## Why not just drop the styling

`create-dmg --skip-jenkins` skips the AppleScript and would have been a one-line change, but the DMG loses its background and icon placement. Writing the `.DS_Store` keeps the window identical to what shipped before, so nobody downloading the app sees a regression.

## Validation

Built a DMG locally from a stand-in app bundle and read the result back without Finder. The image carries `.DS_Store`, `.background.png`, the `/Applications` symlink and the app, and the `.DS_Store` decodes to the layout create-dmg produced:

```
WindowBounds  {{10, 60}, {605, 363}}
iconSize 95.0, textSize 16.0, arrangeBy none, labelOnBottom True
backgroundType 2 (picture) with a 324 byte alias
Tuist.app (139, 161), Applications (467, 161)
toolbar, status bar, pathbar and sidebar all hidden
```

That read-back caught a real defect before it shipped: dmgbuild's setting is `hide_extensions`, not `hide_extension`, so the first build left the extension visible and the icon would have read "Tuist.app" rather than "Tuist". Fixed and re-verified, the flag is now set.

The output is UDZO, matching create-dmg's format. Signing, notarization and stapling are untouched and still gate the release.

## Follow-ups this leaves open

- The TCC seeding in `infra/runner-image/runner.pkr.hcl` is now dead weight, and its read-back checks the wrong database. Worth removing on the next image change rather than rolling an image for it alone.
- Why the fleet's VMs have no reachable Finder is still unexplained. The image configures auto-login and loads the runner as a LaunchAgent specifically so jobs get a real desktop session. If that session is not materializing, it affects anything GUI-dependent on the fleet, not just this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)