### PR TITLE
fix(server): stop mise's SLSA lookup from failing the deployment on a spent API budget

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -62,6 +62,19 @@ env:
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
   MISE_GITHUB_ATTESTATIONS: 0
+  # Skip mise's SLSA provenance verification for github-backend tools only.
+  # The verification resolves the release through
+  # api.github.com/repos/<owner>/<repo>/releases/tags/<tag>, which mise.lock
+  # cannot replace: the lockfile only supplies the download URL, and mise
+  # already prefers that CDN URL over url_api. So this API call is the last
+  # one standing on the install path, and it 403s once the shared deploy
+  # token's 5000/hr budget is spent across a fan-out - failing the install of
+  # `github:endevco/aube` and `github:pomerium/cli`, which every job here
+  # picks up from the merged root toolset. Aqua-backend SLSA stays ON:
+  # mise.lock records slsa provenance for aqua tools (e.g. getsops/sops), and
+  # disabling it trips mise's downgrade-attack guard. Same setting as
+  # server.yml and server-deployment.yml.
+  MISE_GITHUB_SLSA: 0
   # Used by the production deploy cascade's build job.
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist


### PR DESCRIPTION
## What changed

Added `MISE_GITHUB_SLSA: 0` to the workflow-level env of `server-production-deployment.yml`, alongside the `MISE_GITHUB_ATTESTATIONS: 0` that was already there.

## Why

The `Acceptance Tests` job in the production deployment failed 43 seconds in, before it built anything:

```
mise ERROR Failed to install tools: github:endevco/aube@1.6.2, github:pomerium/cli@0.32.2
github:endevco/aube@1.6.2: SLSA verification error … Failed to get release: 403 Forbidden
  for url (https://api.github.com/repos/endevco/aube/releases/tags/v1.6.2)
github rate limit: 0/5000 (core)
```

## Root cause

The 403 is not a download failure. mise's SLSA provenance verification resolves the release through `api.github.com/repos/<owner>/<repo>/releases/tags/<tag>`, and the lockfile cannot stand in for that call — `mise.lock` records only the download URL and checksum.

That distinction matters because the download side is already covered. A local probe of the exact unlocked path this job takes shows mise reading the CDN URL straight out of the lockfile:

```
DEBUG Using existing URL from lockfile for platform macos-arm64:
      https://github.com/jdx/aube/releases/download/v1.6.2/aube-v1.6.2-aarch64-apple-darwin.tar.gz
DEBUG GET https://github.com/…/aube-v1.6.2-aarch64-apple-darwin.tar.gz 200 OK
```

So provenance is the last remaining API call on the install path. Every job in this workflow hits it: the acceptance job runs a bare `jdx/mise-action` with no `install_args`, and mise merges the root `mise.toml` into every directory, so the whole root toolset — including the two `github:` backend tools — gets installed. Once a deployment fan-out spends the shared deploy token's 5000/hr budget, that call 403s and takes the install with it.

## Why this fix over the alternatives

`server.yml` and `server-deployment.yml` already carry this setting for the same class of failure; this workflow was simply never given it.

Scoping the install with `install_args` was the other option and was rejected: the acceptance job runs `tuist test`, whose Xcode build phases and scheme post-actions need the full toolset at runtime, and the tool list cannot be enumerated from the workflow. That is the same hazard that forced `app.yml` back to a full-toolset install.

The setting is deliberately narrow. It governs github-backend tools only, so the `provenance.slsa` entries `mise.lock` records for aqua tools such as `getsops/sops` still verify — leaving those on also avoids tripping mise's downgrade-attack guard. GitHub artifact attestations are unaffected.

## Impact

Removes the last API call on the install path for this workflow's github-backend tools, so a spent token budget no longer fails the deployment before it starts. Version resolution for fuzzy specs (for example `gradle = "8.12"` against a lockfile pinned to `8.12.1`) still consults the API, but those failures are warnings and do not fail the install.

## Validation

- Reproduced the exact failing call and confirmed the download path is already lockfile-backed via `MISE_LOG_LEVEL=debug mise install aube@1.6.2` against a scratch `MISE_DATA_DIR`, on the same mise 2026.5.15 the workflow pins.
- Confirmed the workflow still parses and the value lands where intended (`yq '.env.MISE_GITHUB_SLSA'` → `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)