### PR TITLE
fix(kura): label a completed artifact stream as ok instead of aborted

### DIFF
--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -3594,6 +3594,7 @@ where
     InstrumentedArtifactStream::new(
         state.metrics.clone(),
         manifest.producer,
+        Some(manifest.size),
         stream,
         request_guard,
     )
@@ -3603,6 +3604,7 @@ struct InstrumentedArtifactStream<S> {
     inner: S,
     metrics: Metrics,
     producer: ArtifactProducer,
+    expected_bytes: Option<u64>,
     _request_guard: Option<InflightGuard>,
     started_at: Instant,
     yielded_bytes: u64,
@@ -3613,6 +3615,7 @@ impl<S> InstrumentedArtifactStream<S> {
     fn new(
         metrics: Metrics,
         producer: ArtifactProducer,
+        expected_bytes: Option<u64>,
         stream: S,
         request_guard: Option<InflightGuard>,
     ) -> Self {
@@ -3620,6 +3623,7 @@ impl<S> InstrumentedArtifactStream<S> {
             inner: stream,
             metrics,
             producer,
+            expected_bytes,
             _request_guard: request_guard,
             started_at: Instant::now(),
             yielded_bytes: 0,
@@ -3691,7 +3695,17 @@ where
 
 impl<S> Drop for InstrumentedArtifactStream<S> {
     fn drop(&mut self) {
-        self.record_once("aborted");
+        // Artifact responses declare a Content-Length, and hyper drops a
+        // fixed-length body as soon as the encoder has written that many bytes
+        // instead of polling it to `None`, so a fully delivered stream reaches
+        // this path just like a client abort does. Only the byte count tells
+        // them apart. An unknown expectation stays conservative and counts as
+        // aborted.
+        let result = match self.expected_bytes {
+            Some(expected) if self.yielded_bytes >= expected => "ok",
+            _ => "aborted",
+        };
+        self.record_once(result);
     }
 }
 
@@ -7106,6 +7120,7 @@ mod tests {
         let instrumented = InstrumentedArtifactStream::new(
             context.state.metrics.clone(),
             ArtifactProducer::Xcode,
+            Some(64),
             stream,
             Some(context.state.start_http_request(HttpTrafficClass::Public)),
         );
@@ -7113,6 +7128,131 @@ mod tests {
         assert_eq!(context.state.runtime.public_http_inflight(), 1);
         drop(instrumented);
         assert_eq!(context.state.runtime.public_http_inflight(), 0);
+    }
+
+    fn artifact_egress_completions(metrics: &Metrics, result: &str) -> u64 {
+        metrics
+            .render()
+            .lines()
+            .filter(|line| {
+                line.starts_with("kura_artifact_egress_completions_total")
+                    && line.contains("producer=\"xcode\"")
+                    && line.contains(&format!("result=\"{result}\""))
+            })
+            .filter_map(|line| {
+                line.rsplit(' ')
+                    .next()
+                    .and_then(|value| value.parse::<u64>().ok())
+            })
+            .sum()
+    }
+
+    fn chunked_artifact_stream(
+        chunks: &[&'static [u8]],
+    ) -> impl Stream<Item = Result<Bytes, std::io::Error>> {
+        futures_util::stream::iter(
+            chunks
+                .iter()
+                .map(|chunk| Ok(Bytes::from_static(chunk)))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_stream_dropped_after_the_expected_bytes_records_ok() {
+        let context = test_context(|_| {}).await;
+        let mut instrumented = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Xcode,
+            Some(11),
+            chunked_artifact_stream(&[b"hello", b" world"]),
+            None,
+        );
+
+        // Mirrors hyper dropping a fixed-length body once Content-Length has
+        // been written, without ever polling it to `None`.
+        assert!(instrumented.next().await.is_some());
+        assert!(instrumented.next().await.is_some());
+        drop(instrumented);
+
+        assert_eq!(artifact_egress_completions(&context.state.metrics, "ok"), 1);
+        assert_eq!(
+            artifact_egress_completions(&context.state.metrics, "aborted"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stream_dropped_before_the_expected_bytes_records_aborted() {
+        let context = test_context(|_| {}).await;
+        let mut instrumented = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Xcode,
+            Some(11),
+            chunked_artifact_stream(&[b"hello", b" world"]),
+            None,
+        );
+
+        assert!(instrumented.next().await.is_some());
+        drop(instrumented);
+
+        assert_eq!(
+            artifact_egress_completions(&context.state.metrics, "aborted"),
+            1
+        );
+        assert_eq!(artifact_egress_completions(&context.state.metrics, "ok"), 0);
+    }
+
+    #[tokio::test]
+    async fn a_stream_polled_to_completion_records_ok_once() {
+        let context = test_context(|_| {}).await;
+        let mut instrumented = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Xcode,
+            Some(11),
+            chunked_artifact_stream(&[b"hello", b" world"]),
+            None,
+        );
+
+        while instrumented.next().await.is_some() {}
+        assert_eq!(artifact_egress_completions(&context.state.metrics, "ok"), 1);
+
+        drop(instrumented);
+        assert_eq!(artifact_egress_completions(&context.state.metrics, "ok"), 1);
+        assert_eq!(
+            artifact_egress_completions(&context.state.metrics, "aborted"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failing_stream_records_error_once() {
+        let context = test_context(|_| {}).await;
+        let stream = futures_util::stream::iter(vec![
+            Ok(Bytes::from_static(b"hello")),
+            Err(std::io::Error::other("read failed")),
+        ]);
+        let mut instrumented = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Xcode,
+            Some(11),
+            stream,
+            None,
+        );
+
+        assert!(instrumented.next().await.expect("first chunk").is_ok());
+        assert!(instrumented.next().await.expect("second chunk").is_err());
+        drop(instrumented);
+
+        assert_eq!(
+            artifact_egress_completions(&context.state.metrics, "error"),
+            1
+        );
+        assert_eq!(artifact_egress_completions(&context.state.metrics, "ok"), 0);
+        assert_eq!(
+            artifact_egress_completions(&context.state.metrics, "aborted"),
+            0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`InstrumentedArtifactStream` (`kura/src/http.rs`) now knows how many bytes the response promised, and uses that to decide the `result` label it records on drop:

- `instrument_artifact_stream` passes `Some(manifest.size)` — the same value that becomes the response's `Content-Length` — into the wrapper.
- `Drop` records `result="ok"` when the stream yielded at least the expected bytes and `result="aborted"` only when it yielded fewer.
- `Poll::Ready(None)` still records `ok`, a stream error still records `error`, and `record_once` is still single-shot, so a stream that already reported a terminal outcome is not double-counted on drop.
- When the expected size is unknown (`None`), drop stays conservative and records `aborted`. Every production construction site has a manifest, so this only applies to a caller that cannot state a size; recording `ok` there would let an unverifiable completion silently inflate the success count.

## Why

`kura_artifact_egress_bytes_total` and `kura_artifact_egress_completions_total` labelled almost every successful artifact download as `result="aborted"`. The label was therefore useless: a completed download and a real client abort were indistinguishable, so neither an abort rate nor a "bytes actually delivered" figure could be derived from it.

## Root cause

Three things combined:

1. `InstrumentedArtifactStream` recorded `ok` only on `Poll::Ready(None)` and its `Drop` impl recorded `aborted` for every other termination (`kura/src/http.rs`, `record_once` / `poll_next` / `impl Drop`).
2. Artifact responses always carry a `Content-Length` taken from the manifest size (`apply_artifact_response_headers`, `kura/src/http.rs`).
3. In hyper (1.9.0 is what `kura/Cargo.lock` pins; the same code path exists in 1.10.x), once the fixed-length encoder has written the declared byte count, `Conn::write_body` moves `state.writing` off `Writing::Body` to `Writing::KeepAlive`/`Closed` (`hyper-1.9.0/src/proto/h1/conn.rs:704-727`). On the next dispatcher iteration `can_write_body()` is false, so the dispatcher sets `clear_body = true` and drops the body **without polling it again** (`hyper-1.9.0/src/proto/h1/dispatch.rs:364-371`).

So the terminating `Poll::Ready(None)` never happens for a fully successful streamed download: it always lands in `Drop`, and was recorded as `aborted`.

Production telemetry corroborated this qualitatively: the `ok` share matched the accelerated sendfile serving path exactly — that path records its own result directly (`kura/src/accelerated_file_serving.rs`) and never uses this wrapper — while the `aborted` share matched the streaming path, with near-identical average bytes per read on both. A genuine abort epidemic would not have split cleanly along the serving-path boundary, nor left the two paths with the same average transfer size.

## Why this fix over the alternatives

- **Dropping the `result` label entirely.** That would remove the false signal but also the ability to ever measure client aborts, which is the reason the label exists. The information is recoverable, so discarding it is the wrong trade.
- **Removing `Content-Length` from artifact responses** (so hyper uses a chunked encoder and does poll the body to `None`). This would fix the symptom by changing the wire format of every artifact response — clients would lose the size up front, progress reporting and range/resume behaviour would change, and under a rolling update half the fleet would answer with a length and half without. `kura/AGENTS.md` "Rollout Safety" explicitly rules out node-local behaviour that alters response bytes or headers. Rejected.
- **Recording from the HTTP layer instead of the body** (for example comparing bytes written in middleware). The body stream is the only place that knows how much was actually handed to the transport; the middleware completes when the response head is returned, well before the body finishes.

Comparing yielded bytes against the declared length is the smallest change that restores the label's meaning, touches only the metrics decision, and needs no protocol change.

## Impact

**Users:** none. This is metrics-only. Response bytes, headers and status codes are unchanged — the wrapper's `poll_next` still forwards every chunk and error verbatim, and nothing on the header or admission path was touched. Safe under mixed-version rollout: old and new pods emit the same metric families with the same label names, only the value distribution differs.

**Operators (please note):** the meaning of `result="aborted"` changes at rollout. Before this change it was dominated by successful streamed downloads; after it counts only transfers that ended short of their declared `Content-Length`. Expect `result="aborted"` on `kura_artifact_egress_completions_total` / `kura_artifact_egress_bytes_total` to fall sharply and `result="ok"` to rise correspondingly for the streaming path. Any dashboard panel or alert threshold keyed on `result="aborted"` (or on the `ok` ratio) will shift at the moment of rollout and should be re-baselined; an alert tuned to today's high abort rate will stop firing, and one tuned to a low abort rate could fire during the mixed-version window.

## Tests

Added to the existing `kura/src/http.rs` test module, following the neighbouring convention of asserting on `metrics.render()` output:

- `a_stream_dropped_after_the_expected_bytes_records_ok` — yields exactly the expected bytes, then drops without a terminal poll (mirroring what hyper does), expects `ok` and no `aborted`.
- `a_stream_dropped_before_the_expected_bytes_records_aborted` — yields a short read, then drops; expects `aborted` and no `ok`.
- `a_stream_polled_to_completion_records_ok_once` — polling to `None` records `ok`, and the subsequent drop does not add a second completion.
- `a_failing_stream_records_error_once` — a stream error records `error`, and drop does not reclassify it.

Assertions read the counter values out of the rendered exposition rather than just checking that a label is present, so a regression that flips the label is caught.

## Validation

Run from `kura/`:

- `mise run clippy` (rules_rust clippy aspect over `//...`, warnings as errors) — **passed** (`Build completed successfully, 6 total actions`). It caught one type-inference error in the new test helper on the first run, which was fixed before this commit.
- `mise run test-unit` (`bazel test //...`) — **passed**: `667 passed; 0 failed; 1 ignored`, `//:kura_lib_test PASSED`, `//:kura_bin_test PASSED`. The four new tests were confirmed present and passing in the run output.
- `mise run format` — run before committing; produced no further changes.

The end-to-end shellspec suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
