### PR TITLE
fix(cache): authorize the cache tokens the server now mints

### DIFF
--- a/cache/lib/cache/authentication.ex
+++ b/cache/lib/cache/authentication.ex
@@ -48,7 +48,10 @@ defmodule Cache.Authentication do
   end
 
   defp authorize(auth_header, requested_handle, conn, cache) do
-    cache_key = {generate_cache_key(auth_header), requested_handle}
+    # Keyed by action as well as token and handle: a token can be granted the
+    # read and not the write, so a decision reached for one must never be
+    # replayed for the other.
+    cache_key = {generate_cache_key(auth_header), requested_handle, request_action(conn)}
 
     case Cachex.get(cache, cache_key) do
       {:ok, nil} ->
@@ -68,8 +71,9 @@ defmodule Cache.Authentication do
 
   defp authorize_with_jwt_or_api(auth_header, cache_key, requested_handle, conn, cache) do
     token = extract_token(auth_header)
+    {_token_key, _handle, action} = cache_key
 
-    case verify_jwt(token, requested_handle) do
+    case verify_jwt(token, requested_handle, action) do
       {:ok, ttl} ->
         :telemetry.execute([:cache, :auth, :authorized], %{}, %{method: :jwt})
         cache_result(cache, cache_key, :ok, ttl)
@@ -79,31 +83,52 @@ defmodule Cache.Authentication do
 
       {:error, :project_not_in_jwt} ->
         fetch_and_cache_projects(auth_header, cache_key, conn, cache)
+
+      # A token carrying grants has already had its say, so this is the answer
+      # rather than a reason to ask the server. Asking would also be futile:
+      # the server does not accept a cache token as a credential, so the
+      # fallback turns every ungranted request into a misleading 401.
+      {:error, :not_granted} ->
+        :telemetry.execute([:cache, :auth, :server, :error], %{}, %{reason: :forbidden})
+        cache_result(cache, cache_key, {:error, 403, "You don't have access to this project"}, failure_ttl())
     end
   end
+
+  defp request_action(%Plug.Conn{method: method}) when method in ["GET", "HEAD"], do: :read
+  defp request_action(_conn), do: :write
 
   defp extract_token("Bearer " <> token), do: token
   defp extract_token(token), do: token
 
-  defp verify_jwt(token, requested_handle) do
+  defp verify_jwt(token, requested_handle, action) do
     if Cache.Config.guardian_configured?() do
-      do_verify_jwt(token, requested_handle)
+      do_verify_jwt(token, requested_handle, action)
     else
       {:error, :not_jwt}
     end
   end
 
-  defp do_verify_jwt(token, requested_handle) do
+  defp do_verify_jwt(token, requested_handle, action) do
     case Cache.Guardian.decode_and_verify(token) do
       {:ok, claims} ->
-        verify_project_access(claims, requested_handle)
+        verify_project_access(claims, requested_handle, action)
 
       {:error, _reason} ->
         {:error, :not_jwt}
     end
   end
 
-  defp verify_project_access(claims, requested_handle) do
+  defp verify_project_access(claims, requested_handle, action) do
+    case Map.get(claims, "cache_grants") do
+      nil -> verify_listed_project(claims, requested_handle)
+      grants -> verify_granted_project(grants, claims, requested_handle, action)
+    end
+  end
+
+  # The projects claim lists what the token reaches without saying what it may
+  # do there, and it is capped, so a handle missing from it is inconclusive and
+  # falls through to the server.
+  defp verify_listed_project(claims, requested_handle) do
     projects = Map.get(claims, "projects", [])
     exp = Map.get(claims, "exp")
 
@@ -111,6 +136,54 @@ defmodule Cache.Authentication do
       {:ok, calculate_ttl(exp)}
     else
       {:error, :project_not_in_jwt}
+    end
+  end
+
+  # Grants are complete and say which action they cover, so they are the whole
+  # answer. Tuist's server mints these; the shape is agreed with the cache
+  # nodes that read them back.
+  defp verify_granted_project(grants, claims, requested_handle, action) do
+    if granted?(grants, requested_handle, action) do
+      {:ok, calculate_ttl(Map.get(claims, "exp"))}
+    else
+      {:error, :not_granted}
+    end
+  end
+
+  # A request naming a project is answered by the project bucket alone: an
+  # account grant is access to the account's own cache, not to every project
+  # in it.
+  defp granted?(grants, requested_handle, action) do
+    bucket = grants |> grant_bucket("project") |> granted_handles(action)
+
+    requested_handle in bucket
+  end
+
+  defp grant_bucket(grants, scope) when is_map(grants) do
+    case Map.get(grants, scope) do
+      bucket when is_map(bucket) -> bucket
+      _ -> %{}
+    end
+  end
+
+  defp grant_bucket(_grants, _scope), do: %{}
+
+  # Write implies read, so a writer never has to be granted both.
+  defp granted_handles(bucket, :read), do: handles(bucket, "read") ++ handles(bucket, "write")
+  defp granted_handles(bucket, :write), do: handles(bucket, "write")
+
+  # Handles compare lowercased, and an empty handle counts as absent rather
+  # than as a handle named "".
+  defp handles(bucket, action) do
+    case Map.get(bucket, action) do
+      handles when is_list(handles) ->
+        handles
+        |> Enum.filter(&is_binary/1)
+        |> Enum.map(&(&1 |> String.trim() |> String.downcase()))
+        |> Enum.reject(&(&1 == ""))
+
+      _ ->
+        []
     end
   end
 
@@ -226,7 +299,7 @@ defmodule Cache.Authentication do
     |> Base.encode16(case: :lower)
   end
 
-  defp project_access_result({_auth_key, requested_handle}, projects) do
+  defp project_access_result({_auth_key, requested_handle, _action}, projects) do
     project_handles =
       projects
       |> Enum.map(fn

--- a/cache/test/cache/authentication_test.exs
+++ b/cache/test/cache/authentication_test.exs
@@ -120,7 +120,7 @@ defmodule Cache.AuthenticationTest do
 
       Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(@test_auth_header), "account/project"}
+      cache_key = {generate_cache_key(@test_auth_header), "account/project", :read}
 
       {:ok, :ok} = Cachex.get(cache_name, cache_key)
     end
@@ -168,7 +168,7 @@ defmodule Cache.AuthenticationTest do
 
       Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(@test_auth_header), "account/project"}
+      cache_key = {generate_cache_key(@test_auth_header), "account/project", :read}
       {:ok, cached_result} = Cachex.get(cache_name, cache_key)
 
       assert cached_result == {:error, 401, "Unauthorized"}
@@ -181,7 +181,7 @@ defmodule Cache.AuthenticationTest do
 
       Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(@test_auth_header), "account/project"}
+      cache_key = {generate_cache_key(@test_auth_header), "account/project", :read}
       {:ok, cached_result} = Cachex.get(cache_name, cache_key)
 
       assert cached_result == {:error, 403, "You don't have access to this project"}
@@ -201,8 +201,8 @@ defmodule Cache.AuthenticationTest do
       stub_api_call(200, %{"projects" => projects2})
       {:ok, _} = Authentication.ensure_project_accessible(conn2, "account2", "project2", cache_name: cache_name)
 
-      cache_key1 = {generate_cache_key(@test_auth_header), "account1/project1"}
-      cache_key2 = {generate_cache_key(other_auth_header), "account2/project2"}
+      cache_key1 = {generate_cache_key(@test_auth_header), "account1/project1", :read}
+      cache_key2 = {generate_cache_key(other_auth_header), "account2/project2", :read}
 
       {:ok, :ok} = Cachex.get(cache_name, cache_key1)
       {:ok, :ok} = Cachex.get(cache_name, cache_key2)
@@ -286,7 +286,7 @@ defmodule Cache.AuthenticationTest do
 
       {:ok, _} = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(auth_header), "account/project"}
+      cache_key = {generate_cache_key(auth_header), "account/project", :read}
       {:ok, :ok} = Cachex.get(cache_name, cache_key)
     end
 
@@ -304,7 +304,7 @@ defmodule Cache.AuthenticationTest do
 
       assert result == {:error, 403, "You don't have access to this project"}
 
-      cache_key = {generate_cache_key(auth_header), "nonexistent/project"}
+      cache_key = {generate_cache_key(auth_header), "nonexistent/project", :read}
       {:ok, cached_result} = Cachex.get(cache_name, cache_key)
       assert cached_result == {:error, 403, "You don't have access to this project"}
     end
@@ -369,7 +369,7 @@ defmodule Cache.AuthenticationTest do
 
       Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(auth_header), "account/project"}
+      cache_key = {generate_cache_key(auth_header), "account/project", :read}
       {:ok, ttl} = Cachex.ttl(cache_name, cache_key)
 
       assert ttl > 0
@@ -392,7 +392,7 @@ defmodule Cache.AuthenticationTest do
 
       Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
 
-      cache_key = {generate_cache_key(auth_header), "account/project"}
+      cache_key = {generate_cache_key(auth_header), "account/project", :read}
       {:ok, ttl} = Cachex.ttl(cache_name, cache_key)
 
       assert ttl <= 600_000
@@ -419,6 +419,133 @@ defmodule Cache.AuthenticationTest do
 
       assert {:ok, ^auth_header} = result
     end
+  end
+
+  describe "cache grants" do
+    setup %{cache_name: cache_name} do
+      {:ok, cache_name: cache_name}
+    end
+
+    test "authorizes a read the project bucket grants", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(read: ["account/project"])
+      conn = build_conn([{"authorization", auth_header}], "GET")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:ok, ^auth_header} = result
+    end
+
+    test "authorizes a write the project bucket grants", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(write: ["account/project"])
+      conn = build_conn([{"authorization", auth_header}], "PUT")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:ok, ^auth_header} = result
+    end
+
+    test "a write grant carries the read it implies", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(write: ["account/project"])
+      conn = build_conn([{"authorization", auth_header}], "GET")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:ok, ^auth_header} = result
+    end
+
+    test "compares handles case-insensitively", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(write: ["Account/Project"])
+      conn = build_conn([{"authorization", auth_header}], "PUT")
+
+      result = Authentication.ensure_project_accessible(conn, "ACCOUNT", "PROJECT", cache_name: cache_name)
+
+      assert {:ok, ^auth_header} = result
+    end
+
+    test "denies a write a read grant does not cover, without asking the server", %{cache_name: cache_name} do
+      Req.Test.stub(Authentication, fn _conn ->
+        flunk("a token carrying grants has already had its say")
+      end)
+
+      auth_header = grants_auth_header(read: ["account/project"])
+      conn = build_conn([{"authorization", auth_header}], "PUT")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:error, 403, _message} = result
+    end
+
+    test "denies a project the grants do not name", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(read: ["account/other-project"], write: ["account/other-project"])
+      conn = build_conn([{"authorization", auth_header}], "GET")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:error, 403, _message} = result
+    end
+
+    test "an authorized read does not authorize a write", %{cache_name: cache_name} do
+      auth_header = grants_auth_header(read: ["account/project"])
+
+      assert {:ok, ^auth_header} =
+               Authentication.ensure_project_accessible(
+                 build_conn([{"authorization", auth_header}], "GET"),
+                 "account",
+                 "project",
+                 cache_name: cache_name
+               )
+
+      assert {:error, 403, _message} =
+               Authentication.ensure_project_accessible(
+                 build_conn([{"authorization", auth_header}], "PUT"),
+                 "account",
+                 "project",
+                 cache_name: cache_name
+               )
+    end
+
+    test "an account grant is not access to the projects in it", %{cache_name: cache_name} do
+      claims = %{
+        "cache_grants" => %{
+          "account" => %{"read" => ["account"], "write" => ["account"]},
+          "project" => %{"read" => [], "write" => []}
+        },
+        "exp" => System.system_time(:second) + 3600,
+        "iat" => System.system_time(:second),
+        "sub" => "user-123",
+        "typ" => "cache"
+      }
+
+      {:ok, jwt_token, _claims} = Cache.Guardian.encode_and_sign(%{}, claims)
+      auth_header = "Bearer #{jwt_token}"
+      conn = build_conn([{"authorization", auth_header}], "GET")
+
+      result = Authentication.ensure_project_accessible(conn, "account", "project", cache_name: cache_name)
+
+      assert {:error, 403, _message} = result
+    end
+  end
+
+  defp grants_auth_header(buckets) do
+    claims = %{
+      "cache_grants" => %{
+        "project" => %{
+          "read" => Keyword.get(buckets, :read, []),
+          "write" => Keyword.get(buckets, :write, [])
+        }
+      },
+      "exp" => System.system_time(:second) + 3600,
+      "iat" => System.system_time(:second),
+      "sub" => "user-123",
+      "typ" => "cache"
+    }
+
+    {:ok, jwt_token, _claims} = Cache.Guardian.encode_and_sign(%{}, claims)
+    "Bearer #{jwt_token}"
+  end
+
+  defp build_conn(headers, method) do
+    %{build_conn(headers) | method: method}
   end
 
   defp build_conn(headers) do


### PR DESCRIPTION
## What changed

`Cache.Authentication` now reads the `cache_grants` claim when a token carries it, instead of only understanding the legacy `projects` claim.

## Why

The `Acceptance Tests` job of the production deployment went red on `TuistCacheEECanaryAcceptanceTests.generated_project_with_caching_enabled`. The test builds once cold, then retries clean rebuilds for 180s expecting `cacheable tasks (100%)`. Every attempt came back `0 hits / 124 cacheable tasks (0%)`, on both test iterations. The daemon log says why:

```
[] KeyValue.putValue failed after 0.043s for casID: 0~aEsB6zW…: Unauthorized
```

With no action-cache associations written, nothing can ever resolve, so the hit rate is pinned at zero.

## Root cause

#12264 taught the CLI to exchange its credential for a token a cache node can verify by itself, and taught Kura to verify it natively. The cache service serving the `cache-*.tuist.dev` endpoints was not part of that change, and it only recognises the older `projects` claim.

So a cache token reaches `verify_project_access/2`, finds no `projects` claim, and is treated as inconclusive — which sends it down the fallback that asks the server which projects the bearer can reach. The server does not accept a cache token as a credential, answers 401, and the cache service turns that into `{:error, 401, "Unauthorized"}` — the exact string the CLI reported.

Reproduced directly against canary, which shows it is not specific to the keyvalue route. The same account and project, one token from `tuist auth token` and one from canary's own `POST /api/cache/token`:

```
GET /api/cache/keyvalue/<id>  original token → 404 {"message":"No entries found for CAS ID …"}
GET /api/cache/keyvalue/<id>  cache token    → 401 {"message":"Unauthorized"}
GET /api/cache/cas/<id>       original token → 404 {"message":"Not found"}
GET /api/cache/cas/<id>       cache token    → 401 {"message":"Unauthorized"}
```

The minted token is well-formed — `typ: "cache"`, `iss: "tuist"`, and `cache_grants.project` granting `tuist/tuist` both read and write. The endpoint simply had no code path that reads it.

## The change

Grant matching mirrors Kura's `auth/grants.rs` so both sides answer the same request the same way:

- A request naming a project is answered by the project bucket alone. An account grant is access to the account's own cache, not to every project in it.
- Handles compare lowercased and trimmed; an empty handle counts as absent.
- A write grant carries the read it implies, so a writer never has to be granted both.
- The action comes from the request method, read for `GET`/`HEAD` and write otherwise.

Two decisions worth calling out:

**A token carrying grants is answered from those grants alone**, with no fallback to the server. This matches the note on Kura's `from_principal_attributes`, that a principal built from grants has already had its say. The fallback would also be futile here, since the server rejects a cache token as a credential — that is exactly the path that produced the misleading 401.

**The authorization cache is now keyed by action** as well as by token and handle. Grants can cover the read and not the write, so a decision reached for one must never be replayed for the other. Without this the memoised read would have authorized a subsequent write.

`typ` is deliberately not gated on, because Kura does not gate on it either; a stricter check on one side only would let the two authorizers diverge.

## Impact

Restores Xcode compilation caching for any client on a CLI that exchanges its credential, which is every client once #12264's CLI change ships. Legacy tokens are untouched: an opaque token still takes the server fallback, and a JWT carrying `projects` still takes the existing capped-list path with its fall-through.

## Validation

- Eight new tests covering read grants, write grants, write-implies-read, case-insensitive handles, a write a read grant does not cover, a project the grants do not name, an account grant not reaching into its projects, and an authorized read not authorizing a write. Written first and confirmed failing against the old code — they timed out in the server fallback, which is the reported bug reproduced in a test.
- Full cache suite green afterwards: 543 passed.
- Eight pre-existing caching tests build the authorization cache key by hand and were updated for the added action element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)