### PR TITLE
fix(server): stop node-level OOMKills of the processor pods

### DIFF
--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -51,12 +51,23 @@ spec:
       # DoNotSchedule for hard separation. nodeTaintsPolicy=Honor excludes a
       # draining node from the topology so a single-node failure under
       # DoNotSchedule doesn't deadlock the replacement pod.
+      #
+      # matchLabelKeys scopes the skew calculation to the ReplicaSet being
+      # rolled out. Without it the constraint counts the outgoing pods too,
+      # and at maxSurge=1/maxUnavailable=0 that lets both new replicas land
+      # on one node: each new pod is admitted while an old pod still holds
+      # the other node's slot (skew stays 1), and once the old pods drain
+      # the survivors sit stacked at skew 2. Nothing rebalances them
+      # afterwards, so the pair stayed co-resident until the next deploy
+      # happened to spread them.
       {{- if .Values.processor.topologySpread.enabled }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: {{ .Values.processor.topologySpread.whenUnsatisfiable | default "ScheduleAnyway" }}
           nodeTaintsPolicy: Honor
+          matchLabelKeys:
+            - pod-template-hash
           labelSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "processor") | nindent 14 }}

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -418,9 +418,11 @@ processor:
   # ~9-10 GiB. A processor therefore could not reach a 24Gi cgroup limit
   # without first exhausting the node - 24 + 10 > 30.6 - so the kernel OOM
   # killer fired at the node level and picked the largest RSS cgroup, which is
-  # always a processor. The container was reported OOMKilled while sitting far
-  # below its own limit, which is why raising the limit would have made the
-  # problem worse rather than better.
+  # always a processor. Measured on the 2026-08-14 07:13Z kill: both replicas
+  # were stacked on ...-g7wzh-qk9kr, that node sat at 27-28 GiB of 30.5 GiB
+  # for half an hour, crossed capacity, and the victim container was killed
+  # holding 10.7 GiB - 45% of its own 24Gi limit. Raising the limit would
+  # therefore have made this worse rather than better.
   #
   # 16Gi is the largest limit a single replica can actually be given here:
   # 16 + ~10 GiB of co-resident platform leaves ~5 GiB of node headroom, so
@@ -438,19 +440,28 @@ processor:
   # node, anything above ~11.7Gi leaves the surge pod Pending and, with
   # maxUnavailable=0, stalls the deploy indefinitely.
   #
-  # Within that ceiling the request is raised 8Gi -> 10Gi because
-  # oom_score_adj for a burstable pod scales with memoryRequest/capacity:
-  # 10Gi moves the processor from ~739 to ~673 while the small platform pods
-  # stay near 1000, so if the node does come under pressure the kernel
-  # reaches for them before it reaches for a live parse.
+  # Within that ceiling the request is raised 8Gi -> 10Gi, which also matches
+  # the measured median daily peak, because oom_score_adj for a burstable pod
+  # scales with memoryRequest/capacity: 10Gi moves the processor from ~739 to
+  # ~673 while the small platform pods stay near 1000, so if the node does
+  # come under pressure the kernel reaches for them before a live parse.
+  #
+  # Sized against 30 days of container_memory_working_set_bytes: the daily
+  # peak sits at 9-12 GiB on 29 of 31 days, with two excursions (14.9 GiB,
+  # and 20.1 GiB on 2026-07-23 when several pods spiked together). So 16Gi
+  # clears normal operation with room and clips only the far tail. That tail
+  # is a deliberate trade: a 20 GiB parse cannot be served on a co-tenanted
+  # node at all, and a contained cgroup kill of the one offending pod is
+  # strictly better than a node-level kill that also destabilises whatever
+  # platform workload happens to share the node.
   #
   # The Swift parser holds ~3-4x the .xcactivitylog file size while building
   # the BuildStep tree and JSON-encoding the result, so 16Gi is ~3.2 GiB per
   # slot at queueConcurrency=5 - the same per-slot budget tmpSizeLimit is
-  # sized against. If this OOMKills again with the container at its own limit
-  # (as opposed to the node-level kills seen here), lower queueConcurrency
-  # before raising memory, or reintroduce a per-archive size cap in
-  # Tuist.Processor.BuildProcessor.
+  # sized against. A future OOMKill with the container at its own limit
+  # (rather than the node-level kills seen here) means the tail got common:
+  # lower queueConcurrency before raising memory, or reintroduce a
+  # per-archive size cap in Tuist.Processor.BuildProcessor.
   #
   # CPU stays burstable at 4/12. The limit at 12 cores lets the BEAM run ~12
   # dirty-CPU schedulers, so all 5 NIF parses get a dedicated dirty scheduler

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -410,25 +410,58 @@ processor:
       value: prod
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
-  # Sized for the dedicated cpx51 processor pool (16 vCPU / 32 GiB shared
-  # vCPU per node). With anti-affinity pinning one replica per node, each
-  # pod owns the whole node minus kube-system overhead; we leave ~4 GiB
-  # and ~4 vCPU as headroom. The Swift parser holds ~3-4x the .xcactivitylog
-  # file size in memory while building the BuildStep tree and JSON-encoding
-  # the result; at queueConcurrency=5 most realistic builds fit comfortably
-  # in 24 GiB. If we ever start seeing OOMKills again the next move is
-  # either to lower queueConcurrency, bump pod memory, or reintroduce a
-  # per-archive size cap in Tuist.Processor.BuildProcessor.
-  # CPU limit at 12 cores lets the BEAM run ~12 dirty-CPU schedulers,
-  # so all 5 NIF parses run on dedicated dirty schedulers without
-  # serializing on scheduler availability the way they did at 4 cores.
+  # The 24Gi ceiling this used to carry assumed each replica owned a whole
+  # cpx51 (16 vCPU / ~30.6 GiB allocatable) minus kube-system overhead. That
+  # assumption never held: the pool is pinned by nodeSelector but not tainted,
+  # so the platform stack (CNPG, ingress-nginx, cert-manager, external-secrets,
+  # Pomerium, Tailscale, Alloy) schedules onto these nodes too and occupies
+  # ~9-10 GiB. A processor therefore could not reach a 24Gi cgroup limit
+  # without first exhausting the node - 24 + 10 > 30.6 - so the kernel OOM
+  # killer fired at the node level and picked the largest RSS cgroup, which is
+  # always a processor. The container was reported OOMKilled while sitting far
+  # below its own limit, which is why raising the limit would have made the
+  # problem worse rather than better.
+  #
+  # 16Gi is the largest limit a single replica can actually be given here:
+  # 16 + ~10 GiB of co-resident platform leaves ~5 GiB of node headroom, so
+  # the cgroup limit is now the thing that binds a runaway parse rather than
+  # a decoration the node can never honor. Net effect is more usable memory,
+  # not less - a stacked replica previously had ~10 GiB of real headroom
+  # before the node died, versus 16 GiB that is honorable now.
+  #
+  # Keeping the replicas off each other is the topology constraint's job
+  # (matchLabelKeys in templates/processor-deployment.yaml), not the
+  # scheduler's: there is no request value that both blocks stacking and
+  # leaves room for the maxSurge=1 pod during a rollout, because the pool
+  # has only two schedulable nodes. Requests are therefore capped by the
+  # rollout, not by the steady state - at ~7-10 GiB of platform requests per
+  # node, anything above ~11.7Gi leaves the surge pod Pending and, with
+  # maxUnavailable=0, stalls the deploy indefinitely.
+  #
+  # Within that ceiling the request is raised 8Gi -> 10Gi because
+  # oom_score_adj for a burstable pod scales with memoryRequest/capacity:
+  # 10Gi moves the processor from ~739 to ~673 while the small platform pods
+  # stay near 1000, so if the node does come under pressure the kernel
+  # reaches for them before it reaches for a live parse.
+  #
+  # The Swift parser holds ~3-4x the .xcactivitylog file size while building
+  # the BuildStep tree and JSON-encoding the result, so 16Gi is ~3.2 GiB per
+  # slot at queueConcurrency=5 - the same per-slot budget tmpSizeLimit is
+  # sized against. If this OOMKills again with the container at its own limit
+  # (as opposed to the node-level kills seen here), lower queueConcurrency
+  # before raising memory, or reintroduce a per-archive size cap in
+  # Tuist.Processor.BuildProcessor.
+  #
+  # CPU stays burstable at 4/12. The limit at 12 cores lets the BEAM run ~12
+  # dirty-CPU schedulers, so all 5 NIF parses get a dedicated dirty scheduler
+  # instead of serializing the way they did at 4 cores.
   resources:
     requests:
       cpu: "4000m"
-      memory: "8Gi"
+      memory: "10Gi"
     limits:
       cpu: "12000m"
-      memory: "24Gi"
+      memory: "16Gi"
 
   # Pin processor pods to the dedicated cpx51 pool provisioned by
   # md-processor in cluster-production.yaml. The label is set on

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -376,6 +376,21 @@ swiftRegistrySync:
       value: stag
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
+  # Unlike canary, staging sets no syncAllowlist, so it walks the same full
+  # catalog production does while inheriting the 512Mi/1Gi common default
+  # that was only ever meant for an allowlisted env. That is the exact
+  # condition production hit after #12136 - idle working set 750-850Mi,
+  # per-release peaks 930-995Mi - and staging reproduces the same OOMKill
+  # loop across every replacement pod. Matching production's sizing rather
+  # than allowlisting staging keeps it a real rehearsal of the production
+  # sync path. See the extended rationale in values-managed-production.yaml.
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "1Gi"
+    limits:
+      cpu: "1000m"
+      memory: "4Gi"
 
 xcresultProcessor:
   # Single replica in staging, matching macosFleet.replicas=1.


### PR DESCRIPTION
## What changed

- `templates/processor-deployment.yaml`: added `matchLabelKeys: [pod-template-hash]` to the processor's topology spread constraint.
- `values-managed-production.yaml`: processor memory `requests` 8Gi → 10Gi, `limits` 24Gi → 16Gi. CPU untouched.
- `values-managed-staging.yaml`: gave `swiftRegistrySync` the 1Gi/4Gi sizing production already uses (was inheriting the 512Mi/1Gi common default).

## Why

The `processor` container dominated pod restarts in `tuist` over the last 7 days (8, 5, 4, 3, 2 restarts across five pods), with `kube_pod_container_status_last_terminated_reason` reporting `OOMKilled`.

### The limit was not too low, it was unreachable

The production sizing assumed each replica owned a whole cpx51 (16 vCPU / ~30.5 GiB allocatable). That premise never held. The pool is pinned via `nodeSelector: node.cluster.x-k8s.io/pool: processor`, but the `tuist-hcloud` ClusterClass exposes no taint variable, so nothing keeps other workloads off. These nodes also carry CNPG, ingress-nginx, cert-manager, external-secrets, Pomerium, Tailscale, Alloy and kube-state-metrics — about 8-10 GiB before a processor starts.

From live `describe node` on `...-g7wzh-zkv8h`: memory **requests** at 84% of allocatable, memory **limits at 262%** (82120 Mi of 31232 Mi).

A single processor at its 24Gi limit needs 24 + ~10 = 33.5 GiB on a 30.5 GiB node. **One replica could not reach its own cgroup limit without exhausting the node first**, let alone two. So the limit never bound anything: the node ran out of physical memory, the kernel OOM killer chose the largest RSS cgroup, and that is always a processor. Raising the limit would have made this worse.

### The 2026-08-14 07:13Z kill, measured

Prometheus confirms the mechanism end to end rather than by inference:

| time (UTC) | node `...-g7wzh-qk9kr` total WSS | victim container `...-6cc95f9568-kxm5r` |
|---|---|---|
| 06:40 | 26.7 GiB | — |
| 06:50 | 28.0 GiB | ~10.1 GiB |
| 07:00 | 27.0 GiB | ~9.8 GiB |
| 07:10 | crossed capacity | **10.7 GiB** |
| 07:15 | 21.4 GiB | 3.5 GiB (restarted) |

The node sat at 27-28 GiB of 30.5 GiB for half an hour, crossed capacity, and the kernel killed a processor **holding 10.7 GiB against a 24 GiB limit — 45% of it**. A cgroup-limit OOM is arithmetically excluded.

`count by (pod)` over `container="processor"` on that node also shows **both replicas were stacked on `qk9kr`** at the time — a different node from where they sit stacked today, so the stacking is recurrent rather than a one-off placement.

### Both replicas keep ending up on one node

`whenUnsatisfiable: DoNotSchedule` was added previously for exactly this, but it does not survive a rollout. Without `matchLabelKeys`, the skew calculation counts the outgoing ReplicaSet's pods too. At `maxSurge: 1` / `maxUnavailable: 0`:

1. Steady: `oldA@X`, `oldB@Y` — X=1, Y=1.
2. `new1` admitted to X — skew 1, allowed. X=2, Y=1.
3. `oldA` drains. X=1, Y=1.
4. `new2` admitted to X — skew 1, allowed. X=2, Y=1.
5. `oldB` drains. **X=2, Y=0.**

Nothing rebalances afterwards, so the pair stays co-resident until a later deploy happens to spread them. With 11 ReplicaSets in 7 days that is a frequent coin flip. `matchLabelKeys: [pod-template-hash]` scopes the skew to the ReplicaSet being rolled out, so step 4 is correctly rejected. The field is GA since 1.30; the cluster is on v1.34.6.

## Why this sizing

30 days of `container_memory_working_set_bytes`, daily peak:

- **9-12 GiB on 29 of 31 days.** Median daily peak ~10.4 GiB.
- Two excursions: 14.9 GiB, and 20.1 GiB on 2026-07-23 when several pods spiked together.
- Last 7 days max: 11.3 GiB — the pods never got near 24Gi because the node killed them first.

Verified against live node numbers:

| request / limit | 1 pod/node fits | stacking blocked | surge pod fits | node @limit, 1 pod |
|---|---|---|---|---|
| 8Gi / 24Gi (current) | yes | no | yes | **33.5 GiB — node OOM** |
| **10Gi / 16Gi (this PR)** | yes | no | yes | 25.5 GiB — OK |
| 16Gi / 16Gi | yes | **yes** | **no** | 25.5 GiB — OK |

16Gi is the largest limit a replica can actually be given: 16 + ~10 leaves ~5 GiB of node headroom, so the cgroup limit finally bounds a runaway parse. It clears normal operation with room and clips only the far tail. That is a deliberate trade — a 20 GiB parse cannot be served on a co-tenanted node at all, and a contained cgroup kill of the one offending pod beats a node-level kill that also destabilises whatever platform workload shares the node. Concurrency is left at 5 rather than lowered, since paying 40% throughput every day to cover a 1-in-30-day excursion is the wrong trade; if that tail becomes common it will now show up as a clean, attributable cgroup OOMKill.

Requests=limits=16Gi was rejected deliberately. It would let the scheduler enforce the spread by itself, but it wedges deploys: `md-processor` is specified at `replicas: 2`, so two schedulable nodes is the steady state and not a degraded one, meaning a third surge pod has nowhere to land and with `maxUnavailable: 0` the rollout stalls indefinitely. There is no request value that both blocks stacking and leaves surge headroom on a 2-node pool, so anti-stacking is left to `matchLabelKeys`, the mechanism built for it. Within the ~11.7Gi surge ceiling the request goes to 10Gi, which also matches the measured median daily peak, and moves burstable `oom_score_adj` from ~739 to ~673 while the small platform pods stay near 1000.

## The staging swift-registry-sync OOMKills are a separate root cause

Not shared with the processor. Canary sets `syncAllowlist: alamofire/alamofire`; staging sets none, so it walks the same full catalog production does while inheriting the 512Mi/1Gi default meant for allowlisted envs. That is precisely the condition production documented after #12136 (idle working set 750-850Mi, per-release peaks 930-995Mi) and fixed by moving to 1Gi/4Gi. This is a genuine cgroup-limit OOM, and this PR applies the same proven sizing rather than allowlisting staging, so staging stays a real rehearsal of the production sync path.

## Impact

Production processors stop being the kernel's OOM victim, and stop losing in-flight `:process_build` jobs to restarts (Oban's Lifeline reclaims them, but the parse work is redone). Co-resident platform workloads stop being collateral in a node-level memory crunch. Staging's swift-registry-sync stops its restart loop.

Nominal ceiling drops 24Gi → 16Gi, but effective memory goes **up**: a stacked replica previously had ~10 GiB of real headroom before the node died, versus 16 GiB that is honorable now.

## Validation

- `helm template` renders both envs correctly; verified `matchLabelKeys` and the resource blocks in the output. Pre-existing unrelated `helm lint` failure in `templates/dedibox-fleet.yaml` (untouched here).
- Scheduling and node-memory arithmetic checked against live `kubectl describe node` / `kubectl top` from `tuist-production`; the sizing table is generated from those numbers.
- Kill mechanism and 30-day working set distribution confirmed against `grafanacloud-prom`, as above.
- Nothing deployed.

## Follow-ups, not in this PR

- **The processor pool is not actually dedicated.** Tainting it is the real structural fix and would let the limit go back up to serve the 20 GiB tail; the `tuist-hcloud` ClusterClass exposes no taint variable, so this needs a ClusterClass change. Until then the 16Gi limit depends on the platform footprint staying near ~10 GiB per node, and this recurs if it grows.
- **The `md-processor` roll has been stuck in `ScalingDown` since 2026-07-31** (`DESIRED=2 CURRENT=3 UP-TO-DATE=2`). Machine `...-7tzhn-qwrzv` has been deleting for two weeks: CAPI runs `nodeDrainTimeoutSeconds: 0` (wait forever, by design) and the drain cannot evict `tuist-ops/tuist-ops-pg-1` or `once-production/once-postgres-1`, both single-instance CNPG clusters whose `-primary` PDB is permanently at zero allowed disruptions. Unrelated to the OOMKills, but it leaves two databases stranded on a node marked for deletion.
- **The alert meant to catch that cannot see it.** `machinedeployment_up_to_date_replicas < machinedeployment_spec_replicas` is `2 < 2`, so it stays quiet, even though `values-management.yaml` claims the series "also covers a drain that cannot finish". The only series that reveals this state is `status.replicas` (CURRENT=3), which kube-state-metrics is not configured to export.
- Alert rule "Pod restarts (possible overload)" (`efsvikd2rq22oa`) is UI-managed and was firing `DatasourceNoData`; `no_data_state` was corrected to `OK` on 2026-08-14. Not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

