### PR TITLE
fix(app): stop the App workflow from failing on GitHub rate limits

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -33,6 +33,21 @@ env:
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_APP_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: ${{ github.event.pull_request.head.repo.fork != true }}
   MISE_GITHUB_ATTESTATIONS: 0
+  # Skip mise's SLSA provenance verification for github-backend tools only.
+  # The verification resolves the release through
+  # api.github.com/repos/<owner>/<repo>/releases/tags/<tag>, which mise.lock
+  # cannot replace: the lockfile only supplies the download URL, and mise
+  # already prefers that CDN URL over url_api. So this API call is the last
+  # one standing on the install path, and it 403s once the token's hourly
+  # budget is spent across concurrent runs - failing the install of
+  # `github:endevco/aube` and `github:pomerium/cli`. The jobs here install the
+  # full merged root toolset (the Xcode build phases and scheme post-actions
+  # need it, so the install cannot be scoped), so they always pull both.
+  # Aqua-backend SLSA stays ON: mise.lock records slsa provenance for aqua
+  # tools (e.g. getsops/sops) and this setting does not touch them. Same
+  # setting as server.yml, server-deployment.yml and
+  # server-production-deployment.yml.
+  MISE_GITHUB_SLSA: 0
 
 concurrency:
   group: app-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
The `App` workflow fails on `main` with a GitHub API rate limit during tool installation. Example: [run 31818910656](https://github.com/tuist/tuist/actions/runs/31818910656), where `Build` and `Device Build` both died 2 minutes in.

### What was happening

All three macOS jobs fail inside `jdx/mise-action`:

```
mise WARN  GitHub rate limit exceeded. Resets at 2026-08-14 16:24:18 +00:00
mise WARN  GitHub API returned a 403 Forbidden error.
mise ERROR Failed to install tools: github:endevco/aube@1.6.2, github:pomerium/cli@0.32.2

github:endevco/aube@1.6.2: SLSA verification error for github:endevco/aube@1.6.2:
  Failed to get release: HTTP status client error (403 Forbidden) for url
  (https://api.github.com/repos/endevco/aube/releases/tags/v1.6.2)
```

### Root cause

On the pinned mise `2026.5.15`, github-backend tools are already downloaded from the unmetered release CDN using the URL recorded in `mise.lock`, so the binary fetch is not what is being rate limited. The one remaining `api.github.com` request on the install path is SLSA provenance verification, which resolves `repos/<owner>/<repo>/releases/tags/<tag>`. The lockfile cannot serve that: it only stores the download URL and checksum. Once the hourly budget of the token shared by every concurrent run is spent, that lookup 403s and the whole install fails.

This is the same failure that was fixed for the server workflows in #11347, #11477 and #12350. `app.yml` had `MISE_GITHUB_ATTESTATIONS: 0` but never got `MISE_GITHUB_SLSA`.

### Why this fix and not the obvious alternative

The usual mitigation is to scope the install to the tools a job actually needs, which keeps the github-backend tools out of the picture entirely. That is not available here. The `App` jobs run an Xcode build whose build phases and scheme post-actions (`mise activate --shims` plus `tuist inspect build`, protoc, swiftlint, swiftformat) need the full merged root toolset at build time, and that set cannot be enumerated from the workflow. A previous attempt to scope this workflow broke the `TuistApp` build. So these jobs necessarily install everything and always pull `github:endevco/aube` and `github:pomerium/cli`.

That leaves disabling the provenance lookup, which is what `server.yml`, `server-deployment.yml` and `server-production-deployment.yml` already do.

### What changed

`MISE_GITHUB_SLSA: 0` at workflow level in `.github/workflows/app.yml`.

Supply-chain impact is narrow:

- Checksums from `mise.lock` still verify every download.
- The setting only affects the github backend. Aqua-backend SLSA stays on, so the `provenance.slsa` blocks that `mise.lock` records for `getsops/sops` (the only tool that has them) are still honoured and mise's downgrade-attack guard is not tripped.

### How to test locally

Both checks were run against the two tools that actually failed in CI, on mise `2026.5.15`:

```bash
MISE_DATA_DIR=$(mktemp -d) MISE_GITHUB_SLSA=0 MISE_GITHUB_ATTESTATIONS=0 MISE_LOG_LEVEL=debug mise install "github:pomerium/cli@0.32.2" 2>&1 | grep -iE "api.github.com|Using existing URL|GET Downloading"
```

Expect zero `api.github.com` lines, and instead:

```
DEBUG Using existing URL from lockfile for platform macos-arm64: https://github.com/pomerium/cli/releases/download/v0.32.2/pomerium-cli-darwin-arm64.zip
DEBUG GET Downloading https://github.com/pomerium/cli/releases/download/v0.32.2/pomerium-cli-darwin-arm64.zip
```

Then confirm the aqua tool that carries recorded SLSA provenance is unaffected:

```bash
MISE_DATA_DIR=$(mktemp -d) MISE_GITHUB_SLSA=0 MISE_GITHUB_ATTESTATIONS=0 mise install sops@3.9.3
```

Expect a clean `sops@3.9.3 ✓ installed` with the checksum step, and no `Lockfile requires ... provenance` downgrade-attack error.

End to end, the `Build`, `Device Build` and `Test` jobs on this PR should get past `Run jdx/mise-action`, which is where they currently stop.

### Note for the reviewer

This fixes `app.yml` only, matching the reported failure. The following workflows install github-backend tools and still lack `MISE_GITHUB_SLSA`, so they can hit the same 403 on a busy hour: `handbook.yml` and `cache-deploy.yml` (unscoped, full toolset), `noora.yml`, `noora-release.yml`, `status.yml`, `status-deploy.yml` and `search.yml` (scoped but include `aube`), and `gradle-cache-acceptance.yml` (`github:ClickHouse/ClickHouse`). Happy to sweep those in a follow-up if we want them covered now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)