### PR TITLE
fix(infra): drop the Finder automation approval from the runner image

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -38,16 +38,23 @@ When adding tooling to the base, check ownership and login-shell
 reachability from `runner`, not just presence under `admin`.
 
 A related class of gap is anything GitHub-hosted images pre-seed
-that ours do not. TCC is one: scripted Finder automation
-(`create-dmg`, and anything else driving an app through
-`osascript`) needs a standing `kTCCServiceAppleEvents` approval,
-or macOS raises a prompt no one can answer on a headless VM and
-the send fails as `AppleEvent timed out (-1712)`. That reads as
-flakiness and is not. When adding parity features, compare
-against `actions/runner-images` `images/macos/scripts/build/`,
-and pair each one with a check that asserts the behaviour rather
-than the ingredient — every gap so far was found by a release
-failing, not by the image build.
+that ours do not. When adding parity features, compare against
+`actions/runner-images` `images/macos/scripts/build/`, and pair
+each one with a check that asserts the behaviour rather than the
+ingredient — every gap so far was found by a release failing, not
+by the image build.
+
+TCC looked like one of those gaps and was not. Scripted Finder
+automation here fails as `AppleEvent timed out (-1712)`, which
+reads as a missing `kTCCServiceAppleEvents` approval, and this
+template used to seed one. It changed nothing: seeding the
+approval into the session user's database and reading the row
+back still left every send timing out, because these VMs have no
+Finder that answers rather than one that refuses. Do not re-add
+it. The DMG step that surfaced this no longer drives Finder at
+all (`app/dmg-settings.py`), and if something else needs a GUI
+app here, the question to answer first is whether the auto-login
+session materialises, not whether it is authorised.
 
 The sanity checks at the end of the Packer template run as `sudo
 -u runner -H`. macOS sudoers keeps `HOME`, so dropping `-H`

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -252,51 +252,6 @@ build {
     ]
   }
 
-  # Pre-approve scripted Finder automation. Tools that style a
-  # window through AppleScript, `create-dmg` being the one that
-  # surfaced this, drive Finder from `osascript`. macOS gates that
-  # behind a TCC approval, and with none recorded it raises an
-  # authorization prompt. Nothing can answer a prompt on a headless
-  # VM, so the send sits until it gives up with "Finder got an
-  # error: AppleEvent timed out. (-1712)". The timeout reads as
-  # flakiness, which is why callers retry it; here it is
-  # deterministic and retrying only multiplies the wait.
-  #
-  # GitHub-hosted images seed the same table
-  # (images/macos/scripts/build/configure-tccdb-macos.sh). Ours
-  # never have, so DMG creation has been impossible on this fleet
-  # since macOS jobs moved here.
-  #
-  # TCC attributes an event to the *responsible* process, which for
-  # a shell pipeline is usually an ancestor rather than `osascript`
-  # itself, so the shells are seeded alongside it.
-  #
-  # Columns are named rather than positional: the `access` schema
-  # gains columns across macOS releases, and the positional tuple
-  # GitHub uses has to be rewritten on every OS bump.
-  provisioner "shell" {
-    inline = [
-      "set -euo pipefail",
-      "SYSTEM_DB='/Library/Application Support/com.apple.TCC/TCC.db'",
-      "USER_DB='/Users/runner/Library/Application Support/com.apple.TCC/TCC.db'",
-      "seed() { local db=$1; for client in /usr/bin/osascript /bin/bash /bin/zsh; do sudo sqlite3 \"$db\" \"INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier_type, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAppleEvents', '$client', 1, 2, 4, 1, 0, 'com.apple.finder', 0, strftime('%s','now'));\"; done; }",
-      "echo 'admin' | sudo -S true",
-      "seed \"$SYSTEM_DB\"",
-      # The per-user database only exists once something has
-      # triggered a TCC decision for that account. Creating it here
-      # would leave a schema-less file shadowing the real one and
-      # break TCC for the runner outright, so seed it only if macOS
-      # has already made it.
-      "if sudo test -f \"$USER_DB\" && sudo sqlite3 \"$USER_DB\" 'SELECT 1 FROM access LIMIT 1;' >/dev/null 2>&1; then seed \"$USER_DB\"; sudo chown runner:staff \"$USER_DB\"; else echo 'per-user TCC.db absent; relying on the system database'; fi",
-      # Not decoration. TCC.db is SIP protected, so a base image
-      # shipping with SIP enforced would have the INSERT rejected and
-      # publish an image where Finder automation is still broken.
-      # That is how the reachability-only brew check let a breakage
-      # through; read the row back so it lands on the image build.
-      "sudo sqlite3 \"$SYSTEM_DB\" \"SELECT 1 FROM access WHERE service='kTCCServiceAppleEvents' AND client='/usr/bin/osascript' AND indirect_object_identifier='com.apple.finder' AND auth_value=2;\" | grep -q 1 || { echo 'sanity check: AppleEvents approval for Finder did not persist to TCC.db (SIP enforced?) — scripted Finder automation, and therefore DMG creation, would fail on this image' >&2; exit 1; }"
-    ]
-  }
-
   # The runner auto-login opens a real desktop session so launchd can
   # run the GitHub Actions agent. On fresh macOS images that first
   # desktop can be intercepted by Setup Assistant's "Update Mac


### PR DESCRIPTION
## What changed

Removes the `kTCCServiceAppleEvents` seeding provisioner from `infra/runner-image/runner.pkr.hcl` (45 lines), and rewrites the TCC paragraph in `infra/runner-image/AGENTS.md`.

## Why

The seeding was added in #12317 to unblock DMG creation on the macOS fleet, where `create-dmg` failed with `Finder got an error: AppleEvent timed out. (-1712)`. It did not work, and we now know why it could not.

#12346 seeded the **per-user** TCC database from the release job itself — the session that actually answers the decision, which does not exist at image build time — and read the row back to prove it landed. In run [31784676514](https://github.com/tuist/tuist/actions/runs/31784676514) the read-back passed and all five attempts still timed out. An approval that is present and still ignored means Finder is not refusing the event, it is not answering it. These VMs have no Finder that responds, so no amount of seeding, in either database, changes anything.

## Why remove it rather than leave it

It is not inert. The block ends in a read-back that fails the image build if the `INSERT` does not persist:

```
sanity check: AppleEvents approval for Finder did not persist to TCC.db (SIP enforced?)
```

That check was worth its risk while DMG creation depended on the approval. Now it gates every image build on a SIP-sensitive write to `TCC.db` for a capability nothing uses — so the day macOS enforces SIP on that path, image builds start failing for a feature the fleet does not need.

The DMG step that motivated all of this no longer drives Finder at all: the window layout is written straight into the image's `.DS_Store` (#12348), and the macOS release has shipped that way in `app@0.25.6`, verified down to the icon positions in the published artifact.

## Why the docs note is rewritten, not deleted

The surrounding lesson is sound — GitHub-hosted images pre-seed things ours do not, and parity features should be paired with a check that asserts behaviour rather than presence. But the paragraph cited TCC as a confirmed instance of that gap, which would send the next person straight back to seeding approvals against the same dead end. It now records that this specific one was investigated and ruled out, and that an unanswered AppleEvent here is a question about whether the auto-login session materialises, not about authorisation.

## Validation

`packer fmt -check` and `packer validate -syntax-only` both pass. No TCC references remain anywhere in the template, and nothing else in the repo referenced the seeded rows.

Merging triggers a runner-image build across the Xcode profiles and a fleet roll. It is a pure deletion of a provisioner, with no runtime behaviour depending on it.

## Still open

Why these VMs have no reachable Finder is unexplained. The image configures auto-login and loads the runner as a LaunchAgent specifically so jobs get a real desktop session; if that session is not materialising, it affects anything GUI-dependent on the fleet, not just DMG styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)