### PR TITLE
fix(server): let self-hosted cache clients through token introspection

### DIFF
--- a/server/lib/tuist/kura/self_hosted_clients.ex
+++ b/server/lib/tuist/kura/self_hosted_clients.ex
@@ -20,6 +20,17 @@ defmodule Tuist.Kura.SelfHostedClients do
 
   @client_id_prefix "cache"
 
+  @doc """
+  Whether a client id has the self-hosted credential shape. These ids are not
+  UUIDs, so callers routing between OAuth clients and self-hosted credentials
+  branch on this before UUID-validating request parsing.
+  """
+  def self_hosted_client_id?(client_id) when is_binary(client_id) do
+    String.starts_with?(client_id, @client_id_prefix <> "_")
+  end
+
+  def self_hosted_client_id?(_client_id), do: false
+
   @doc "Lists the self-hosted credentials issued for an account."
   def list_self_hosted_clients(%Account{} = account) do
     Repo.all(

--- a/server/lib/tuist_web/controllers/oauth/introspect_controller.ex
+++ b/server/lib/tuist_web/controllers/oauth/introspect_controller.ex
@@ -8,17 +8,29 @@ defmodule TuistWeb.Oauth.IntrospectController do
   alias Tuist.Kura.SelfHostedClients
   alias Tuist.OAuth.Introspection
 
-  def introspect(%Plug.Conn{} = conn, _params) do
-    case Request.introspect_request(conn) do
-      {:ok, request} ->
-        if dedicated_kura_client?(request.client_id) do
-          introspect_control_plane(conn, request)
-        else
-          introspect_self_hosted(conn, request)
-        end
+  def introspect(%Plug.Conn{} = conn, params) do
+    # Self-hosted credentials (`cache_…`) are not UUIDs, which Boruta's request
+    # parsing requires of a client id, so they are answered before it — through
+    # it they could only ever 400.
+    if SelfHostedClients.self_hosted_client_id?(params["client_id"]) do
+      introspect_self_hosted(conn, params["client_id"], params["client_secret"], params["token"])
+    else
+      case Request.introspect_request(conn) do
+        {:ok, request} ->
+          if dedicated_kura_client?(request.client_id) do
+            introspect_control_plane(conn, request)
+          else
+            introspect_self_hosted(
+              conn,
+              request.client_id,
+              conn.params["client_secret"],
+              request.token
+            )
+          end
 
-      {:error, %Error{} = error} ->
-        respond_error(conn, error)
+        {:error, %Error{} = error} ->
+          respond_error(conn, error)
+      end
     end
   end
 
@@ -40,15 +52,17 @@ defmodule TuistWeb.Oauth.IntrospectController do
   # Customer self-hosted node: verify the tenant-scoped credential and constrain
   # the response to the credential's account, so a node can only introspect its
   # own tenant's tokens.
-  defp introspect_self_hosted(conn, request) do
-    case SelfHostedClients.verify(request.client_id, conn.params["client_secret"]) do
+  defp introspect_self_hosted(conn, client_id, client_secret, token) when is_binary(token) do
+    case SelfHostedClients.verify(client_id, client_secret) do
       {:ok, account} ->
-        respond_introspection(conn, Introspection.token_response(request.token, account))
+        respond_introspection(conn, Introspection.token_response(token, account))
 
       :error ->
         invalid_client(conn)
     end
   end
+
+  defp introspect_self_hosted(conn, _client_id, _client_secret, _token), do: invalid_client(conn)
 
   defp respond_introspection(conn, response) do
     conn

--- a/server/test/tuist_web/controllers/oauth/introspect_controller_test.exs
+++ b/server/test/tuist_web/controllers/oauth/introspect_controller_test.exs
@@ -5,8 +5,10 @@ defmodule TuistWeb.Oauth.IntrospectControllerTest do
   alias Boruta.Oauth.Client
   alias Tuist.Accounts
   alias Tuist.Environment
+  alias Tuist.Kura.SelfHostedClients
   alias Tuist.OAuth.Clients
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.BillingFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   setup :set_mimic_from_context
@@ -144,6 +146,91 @@ defmodule TuistWeb.Oauth.IntrospectControllerTest do
         })
 
       assert json_response(conn, 200) == %{"active" => false}
+    end
+
+    test "introspects tenant-scoped for a self-hosted cache client", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      organization = AccountsFixtures.organization_fixture(name: "self-hosted-org", creator: user)
+      BillingFixtures.subscription_fixture(account_id: organization.account.id, plan: :enterprise)
+      Accounts.add_user_to_organization(user, organization, role: :admin)
+      project = ProjectsFixtures.project_fixture(account: organization.account)
+
+      {:ok, {client, client_secret}} =
+        SelfHostedClients.create_self_hosted_client(organization.account, %{name: "node"})
+
+      conn =
+        post(conn, "/oauth2/introspect", %{
+          client_id: client.client_id,
+          client_secret: client_secret,
+          token: user.token
+        })
+
+      assert %{
+               "active" => true,
+               "cache_grants" => %{
+                 "account" => %{"read" => account_reads},
+                 "project" => %{"read" => project_reads}
+               }
+             } = json_response(conn, 200)
+
+      assert account_reads == [organization.account.name]
+      assert project_reads == ["#{organization.account.name}/#{project.name}"]
+    end
+
+    test "rejects a self-hosted cache client with a wrong secret", %{conn: conn} do
+      organization = AccountsFixtures.organization_fixture(name: "self-hosted-wrong")
+
+      {:ok, {client, _client_secret}} =
+        SelfHostedClients.create_self_hosted_client(organization.account, %{name: "node"})
+
+      conn =
+        post(conn, "/oauth2/introspect", %{
+          client_id: client.client_id,
+          client_secret: "wrong-secret",
+          token: "any-token"
+        })
+
+      assert json_response(conn, 401) == %{
+               "error" => "invalid_client",
+               "error_description" => "Invalid client_id or client_secret."
+             }
+    end
+
+    test "reports a foreign tenant's token inactive to a self-hosted cache client", %{conn: conn} do
+      organization = AccountsFixtures.organization_fixture(name: "self-hosted-tenant")
+      BillingFixtures.subscription_fixture(account_id: organization.account.id, plan: :enterprise)
+
+      {:ok, {client, client_secret}} =
+        SelfHostedClients.create_self_hosted_client(organization.account, %{name: "node"})
+
+      foreign_user = AccountsFixtures.user_fixture(preload: [:account])
+
+      conn =
+        post(conn, "/oauth2/introspect", %{
+          client_id: client.client_id,
+          client_secret: client_secret,
+          token: foreign_user.token
+        })
+
+      assert json_response(conn, 200) == %{"active" => false}
+    end
+
+    test "rejects a self-hosted cache client that sends no token", %{conn: conn} do
+      organization = AccountsFixtures.organization_fixture(name: "self-hosted-notoken")
+
+      {:ok, {client, client_secret}} =
+        SelfHostedClients.create_self_hosted_client(organization.account, %{name: "node"})
+
+      conn =
+        post(conn, "/oauth2/introspect", %{
+          client_id: client.client_id,
+          client_secret: client_secret
+        })
+
+      assert json_response(conn, 401) == %{
+               "error" => "invalid_client",
+               "error_description" => "Invalid client_id or client_secret."
+             }
     end
 
     test "rejects invalid introspection clients", %{conn: conn} do


### PR DESCRIPTION
# Self-hosted cache clients could never introspect a token

## What changed

`POST /oauth2/introspect` now dispatches on the client-id shape before handing the request to Boruta: ids with the self-hosted `cache_` prefix go straight to `SelfHostedClients.verify/2` and tenant-scoped `Introspection.token_response/2`, everything else keeps the existing path (the dedicated Kura control-plane client, then self-hosted verification for unknown UUID clients). `SelfHostedClients.self_hosted_client_id?/1` is the new single place that knows the prefix.

## Root cause

Self-hosted Kura credentials are minted as `cache_<token>` (`SelfHostedClients.generate_client_id/0`), but the controller parsed every request with `Boruta.Oauth.Request.introspect_request/1` first, and Boruta's introspect JSON schema requires `client_id` to match a UUID pattern. The result: the `introspect_self_hosted` branch added in #11294 was unreachable by construction. Every introspection call from a self-hosted node returned `400 invalid_request` before the controller's own dispatch ever ran.

The existing controller tests all used UUID client ids, so the endpoint was never exercised with the credential shape self-hosted nodes actually hold — which is how this survived. The new tests go through the real HTTP endpoint with a real `cache_` credential.

## Impact

A self-hosted Kura node maps a non-200 introspection answer to "authentication backend unavailable". With the 400, every request the node could not settle from a locally verified JWT — opaque account tokens, tokens whose grants do not cover the target, invalid tokens — failed with 503 instead of getting a real answer, and each such failure also armed the node's per-credential outage backoff. Opaque (scoped) account tokens were effectively unusable against self-hosted nodes. With the fix, those paths resolve to their correct answers (200 with tenant-scoped grants, 403 refusals, 401 for invalid tokens), and server-side token revocation propagates to the node.

## Why this shape

The alternative was changing Boruta's schema (a fork of the dependency) or re-minting self-hosted ids as UUIDs (a breaking migration for every existing self-hosted credential plus the secret-distribution machinery around them). Branching on the id shape before UUID-validated parsing is contained to the controller, keeps both existing client families' behavior byte-identical, and fails closed: a `cache_` request without a token or with a wrong secret gets `401 invalid_client`.

## Validation

- `mix test test/tuist_web/controllers/oauth/introspect_controller_test.exs` — 10 passed (4 new: tenant-scoped introspection for a `cache_` client, wrong secret rejected, foreign tenant's token reported inactive, missing token rejected).
- Verified live against a self-hosted deployment (k01): the same `cache_` credential that previously got `400 {"error":"invalid_request"}` now gets `200 {"active":true,...}` with grants correctly scoped to the owning account, and a Kura node running the #12365 auth engine resolves all previously-503 paths — garbage token → 401, uncovered project → 403, opaque restricted token → 200 via introspection then cache hits, and deleting an account token server-side voids the node's cached access immediately (cold target 401 plants the revocation marker; a still-warm sibling entry answers 401 on the next request).

Found while live-testing #12365 on a self-hosted node. One adjacent pre-existing issue was observed and deliberately left out of scope: the legacy `/api/cache/access` route lists accessible handles with no read/write split, so a `project:cache:read` account token can get a write allowed through the legacy fallback (both the old and new Kura auth engines behave this way). That needs its own fix on the server side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
