### PR TITLE
fix(infra): fully qualify the host-log receiver URL

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -474,7 +474,7 @@ macosFleet:
   # `instance` (the Machine/Node name) and `level`.
   hostLogs:
     enabled: true
-    url: http://tuist-alloy-receiver-canary:3100/loki/api/v1/push
+    url: http://tuist-alloy-receiver-canary.taild6d7bb.ts.net:3100/loki/api/v1/push
     env: canary
   controlPlane:
     host: api-canary.tuist.dev

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -798,7 +798,7 @@ macosFleet:
   # carries `instance` (the Machine/Node name) and `level`.
   hostLogs:
     enabled: true
-    url: http://tuist-alloy-receiver-production:3100/loki/api/v1/push
+    url: http://tuist-alloy-receiver-production.taild6d7bb.ts.net:3100/loki/api/v1/push
     env: production
   # Claim pre-ordered Mac minis from the shared `tuist-pool-`
   # pool. The CAPI controller has no auto-order path; operators

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -584,7 +584,7 @@ macosFleet:
   # `instance` (the Machine/Node name) and `level`.
   hostLogs:
     enabled: true
-    url: http://tuist-alloy-receiver-staging:3100/loki/api/v1/push
+    url: http://tuist-alloy-receiver-staging.taild6d7bb.ts.net:3100/loki/api/v1/push
     env: staging
   # Firewall half of the runner-cache path: allow VM egress to the
   # staging Service CIDR on the Kura ports + kube-dns on 53. CIDR per

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1407,6 +1407,12 @@ macosFleet:
     # hostname of the Tailscale-operator proxy fronting the k8s-monitoring
     # chart's alloy-receiver — set the matching `tailscale.com/expose` +
     # `tailscale.com/hostname` annotations there, or this resolves nowhere.
+    #
+    # Must be the FULLY QUALIFIED name (<host>.<tailnet>.ts.net). MagicDNS
+    # answers only fully-qualified queries, and a mini has no `search` domain
+    # to complete a short one — the agent resolves through tailscaled rather
+    # than the OS precisely because the OS on these hosts knows no tailnet
+    # names at all. A bare hostname here fails every push with "no such host".
     url: ""
     # `env` stream label on every shipped line, mirroring the label the
     # server's own Loki handler sets. Empty omits it.

--- a/infra/macos-log-shipper/AGENTS.md
+++ b/infra/macos-log-shipper/AGENTS.md
@@ -134,7 +134,12 @@ unreachable — the agent is `RunAtLoad`, so it can start before tailscaled is
 listening, and a `--url` that is a plain address or a public name must still
 work.
 
-Two consequences worth keeping in mind:
+**`--url` must carry the fully qualified name** (`<host>.<tailnet>.ts.net`).
+MagicDNS answers only fully-qualified queries, and these hosts have no `search`
+domain to complete a short one, so a bare hostname `NXDOMAIN`s even when asked
+directly. Both halves are required: the right resolver and the right name.
+
+Three consequences worth keeping in mind:
 
 - **A name that resolves from your laptop says nothing about a mini.** Your Mac
   runs a tailscaled that does configure the OS resolver; these hosts do not.

--- a/infra/macos-log-shipper/internal/shipper/dial.go
+++ b/infra/macos-log-shipper/internal/shipper/dial.go
@@ -2,6 +2,7 @@ package shipper
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -31,11 +32,19 @@ func dialContextVia(resolver *net.Resolver, timeout time.Duration) func(context.
 	primary := &net.Dialer{Timeout: timeout, Resolver: resolver}
 	system := &net.Dialer{Timeout: timeout}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := primary.DialContext(ctx, network, addr)
-		if err == nil {
+		conn, primaryErr := primary.DialContext(ctx, network, addr)
+		if primaryErr == nil {
 			return conn, nil
 		}
-		return system.DialContext(ctx, network, addr)
+		conn, systemErr := system.DialContext(ctx, network, addr)
+		if systemErr == nil {
+			return conn, nil
+		}
+		// Both, not just the fallback's. Returning only the system resolver's
+		// "no such host" hid the fact that MagicDNS was answering and refusing
+		// the name — the push log named the symptom every minute for hours
+		// while saying nothing about the half that mattered.
+		return nil, fmt.Errorf("magicdns: %w; system resolver: %w", primaryErr, systemErr)
 	}
 }
 


### PR DESCRIPTION
Fixes the production host-log outage that #12374 was supposed to fix and did not.

### State before this PR

Every mini, every minute, since the original rollout — now attempt 494 per host **with #12374's fixed binary installed and running**:

```
dial tcp: lookup tuist-alloy-receiver-production: no such host
```

### What #12374 got right and wrong

Right: tailscaled on these minis installs no resolver into macOS, so the OS resolves no tailnet name at all. Asking `100.100.100.100:53` directly is necessary.

Wrong: **MagicDNS answers only fully-qualified queries.** A mini has no `search` domain to complete a short name — `/etc/resolv.conf` carries the Scaleway DHCP nameservers and nothing else — so `tuist-alloy-receiver-production` `NXDOMAIN`s even when asked directly. #12374 routed to the right server and kept asking the wrong question.

Both halves are needed. The resolver landed in #12374; the fully qualified URL lands here.

### Why the bad fix looked validated

This is the part worth internalizing, because the evidence was misread rather than missing.

`poll` on first sight of a file calls `ReadNew` with `exists=false`, which returns `Next = {inode, size}` and **zero lines**. `poll` then persists that position and returns *without ever calling `push`*. So a positions file whose offset equals the file size is the signature of shipping **nothing** — no network call was made at all.

#12374's "validation on a production mini" was exactly that: a fresh file, a fresh positions file, offset landing on file size, read as proof of a successful push. It proved the agent could open a file.

The test that actually exercises the network is: start the agent, let it take its first-sight position, **then append**, and check the offset advances *past* that mark.

### Verified with that test, on production

On `tuist-tuist-runners-fleet-mndbc-c22td`, same binary, only the URL differing:

| URL | first-sight offset | after append | result |
|---|---|---|---|
| bare `tuist-alloy-receiver-production` | 10 | frozen at 10 | pushes failing, `no such host` |
| `…production.taild6d7bb.ts.net` | 5 | **53** (file size 53) | no errors |

The offset only moves past first sight after `push` returns 2xx.

### Also in this PR

`dialContextVia` returned only the system resolver's error, discarding the primary's. That is why the log said `no such host` every minute for hours while never mentioning that MagicDNS had answered and refused the name. It now returns both, so the next failure names which resolver failed and how.

### Testing

```bash
cd infra/macos-log-shipper && go test ./... -race
```

```bash
GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/tuist-log-shipper
```

Plus the on-host append test above, run against the real production receiver. The installed agent, its positions and the launchd job were untouched; probe files removed.

### Still open

The agent has no health signal, so "installed but failing" and "not installed" look identical from off-host. That is what let this run for hours twice. `node_exporter` already runs on every mini with `--collector.disable-defaults`, and `:9100` has been the only channel that answered reliably throughout this investigation — a textfile collector exposing last-successful-push and consecutive-failure-count is the fix. Not in this PR.

Separately, the tailscaled DNS misconfiguration itself is untouched and still affects anything on these hosts wanting a tailnet name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
