### PR TITLE
fix(server): collapse localized route paths in Phoenix HTTP metrics

### DIFF
--- a/server/lib/tuist/locale.ex
+++ b/server/lib/tuist/locale.ex
@@ -19,6 +19,25 @@ defmodule Tuist.Locale do
                 @all_languages
               end)
 
+  @additional_locales @languages |> Enum.map(& &1.code) |> Enum.reject(&(&1 == "en"))
+
   def languages, do: @languages
   def supported_locales, do: Enum.map(@languages, & &1.code)
+
+  @doc """
+  Rewrites the locale segment of a router path to `:locale`.
+
+  The marketing and docs routes are generated once per locale, so every metric
+  labelled by route path carries one series per locale per page. Folding the
+  localized variants into a single label keeps that cardinality flat as locales
+  are added. English is left alone: its marketing routes carry no prefix, and
+  its traffic is worth reading on its own.
+  """
+  def collapse_locale_path_prefix(path) when is_binary(path) do
+    case String.split(path, "/", parts: 3) do
+      ["", locale] -> if locale in @additional_locales, do: "/:locale", else: path
+      ["", locale, rest] -> if locale in @additional_locales, do: "/:locale/" <> rest, else: path
+      _ -> path
+    end
+  end
 end

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -88,7 +88,10 @@ defmodule Tuist.PromEx do
         plugins ++
           [
             {TuistCommon.PromExPhoenixPlugin,
-             router: TuistWeb.Router, endpoint: TuistWeb.Endpoint, include_controller_action_tags: false}
+             router: TuistWeb.Router,
+             endpoint: TuistWeb.Endpoint,
+             include_controller_action_tags: false,
+             normalize_path: &Tuist.Locale.collapse_locale_path_prefix/1}
           ]
       else
         plugins

--- a/server/lib/tuist/prom_ex/AGENTS.md
+++ b/server/lib/tuist/prom_ex/AGENTS.md
@@ -14,6 +14,8 @@ This context owns PromEx helpers and buckets configuration.
 ## Guardrails
 - If changes add or modify stored customer data, update `server/data-export.md`.
 - Keep `StripedPeep.scrape/1` non-destructive. Counters and distributions have to be cumulative for `rate/1` and `histogram_quantile/2`, and PromEx also calls `scrape/1` from `PromEx.ETSCronFlusher` and discards the result, so anything freed on read never reaches Prometheus. Bound memory through tag cardinality instead.
+- Because scrapes are cumulative, a tag value only has to be seen once to be exported for the life of the pod. Series therefore accumulate up to the full tag cross-product, so treat every new tag as a permanent cost rather than one paid only while traffic flows.
+- The `path` tag on the Phoenix HTTP metrics is the largest such cross-product: one value per router entry, multiplied by method, status and bucket. The router generates marketing and docs routes once per locale, so `Tuist.PromEx` passes `Tuist.Locale.collapse_locale_path_prefix/1` as the plugin's `:normalize_path` to fold those variants into `/:locale/...`. Adding a locale must not add a route label.
 
 ## Related Context
 - Parent business logic: `server/lib/tuist/AGENTS.md`

--- a/server/test/tuist/locale_test.exs
+++ b/server/test/tuist/locale_test.exs
@@ -1,0 +1,47 @@
+defmodule Tuist.LocaleTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Locale
+
+  describe "collapse_locale_path_prefix/1" do
+    # Collapsing relies on Tuist.Locale.languages/0, which is trimmed to "en"
+    # unless TUIST_DEV_ALL_LOCALES=1.
+    @describetag :locale
+
+    test "collapses the locale segment of a localized route" do
+      assert Locale.collapse_locale_path_prefix("/ja/pricing") == "/:locale/pricing"
+
+      assert Locale.collapse_locale_path_prefix("/zh_Hant/customers/:slug") ==
+               "/:locale/customers/:slug"
+
+      assert Locale.collapse_locale_path_prefix("/yue_Hant/docs/*path") == "/:locale/docs/*path"
+    end
+
+    test "collapses a locale home route" do
+      assert Locale.collapse_locale_path_prefix("/ka") == "/:locale"
+    end
+
+    test "leaves English routes alone so they stay separable from the other locales" do
+      assert Locale.collapse_locale_path_prefix("/en/docs") == "/en/docs"
+    end
+  end
+
+  describe "collapse_locale_path_prefix/1 for paths without a locale" do
+    test "leaves unlocalized routes alone" do
+      assert Locale.collapse_locale_path_prefix("/") == "/"
+      assert Locale.collapse_locale_path_prefix("/pricing") == "/pricing"
+
+      assert Locale.collapse_locale_path_prefix("/api/projects/:account_handle") ==
+               "/api/projects/:account_handle"
+    end
+
+    test "leaves an unresolved route label alone" do
+      assert Locale.collapse_locale_path_prefix("Unknown") == "Unknown"
+    end
+
+    test "does not collapse a route whose first segment is a path parameter" do
+      assert Locale.collapse_locale_path_prefix("/:account_handle/:project_handle") ==
+               "/:account_handle/:project_handle"
+    end
+  end
+end

--- a/server/test/tuist/prom_ex_test.exs
+++ b/server/test/tuist/prom_ex_test.exs
@@ -1,0 +1,51 @@
+defmodule Tuist.PromExTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias TuistCommon.PromExPhoenixPlugin
+
+  describe "plugins/0" do
+    # The router generates a route per locale, and Tuist.Locale.languages/0 is
+    # trimmed to "en" unless TUIST_DEV_ALL_LOCALES=1.
+    @describetag :locale
+
+    test "labels every localized variant of a marketing route with one path" do
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+      [duration | _] = phoenix_http_metrics()
+
+      for path <- ["/ja/pricing", "/ko/pricing", "/zh_Hant/pricing"] do
+        assert tag_values(duration, path).path == "/:locale/pricing"
+      end
+    end
+
+    test "keeps unlocalized routes addressable on their own" do
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+      [duration | _] = phoenix_http_metrics()
+
+      assert tag_values(duration, "/pricing").path == "/pricing"
+      assert tag_values(duration, "/api/projects").path == "/api/projects"
+    end
+  end
+
+  defp phoenix_http_metrics do
+    {plugin, opts} =
+      Enum.find(Tuist.PromEx.plugins(), &match?({PromExPhoenixPlugin, _}, &1))
+
+    opts
+    |> Keyword.put(:otp_app, :tuist)
+    |> plugin.event_metrics()
+    |> Enum.find(&(&1.group_name == :phoenix_http_event_metrics))
+    |> Map.fetch!(:metrics)
+  end
+
+  defp tag_values(metric, path) do
+    conn =
+      :get
+      |> Plug.Test.conn(path)
+      |> Map.put(:status, 200)
+
+    metric.tag_values.(%{conn: conn})
+  end
+end

--- a/tuist_common/lib/tuist_common/prom_ex_phoenix_plugin.ex
+++ b/tuist_common/lib/tuist_common/prom_ex_phoenix_plugin.ex
@@ -5,6 +5,11 @@ defmodule TuistCommon.PromExPhoenixPlugin do
   It mirrors `PromEx.Plugins.Phoenix` but excludes the `host` label from HTTP
   metrics by default to avoid high-cardinality series from arbitrary request
   hosts and preview/custom domains.
+
+  The `path` label is one series per router entry, so a router that generates
+  the same page under many prefixes multiplies every HTTP metric by that many.
+  Pass `:normalize_path`, a 1-arity function, to rewrite the resolved route
+  before it becomes a label and fold those variants back together.
   """
 
   use PromEx.Plugin
@@ -136,6 +141,10 @@ defmodule TuistCommon.PromExPhoenixPlugin do
 
     duration_unit = Keyword.get(opts, :duration_unit, :millisecond)
     duration_unit_plural = Utils.make_plural_atom(duration_unit)
+    normalize_path = Keyword.get(opts, :normalize_path, & &1)
+
+    conn_tags =
+      get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag, normalize_path)
 
     Event.build(
       :phoenix_http_event_metrics,
@@ -148,7 +157,7 @@ defmodule TuistCommon.PromExPhoenixPlugin do
           reporter_options: [
             buckets: [10, 100, 500, 1_000, 5_000, 10_000, 30_000]
           ],
-          tag_values: get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag),
+          tag_values: conn_tags,
           tags: http_metrics_tags,
           unit: {:native, duration_unit}
         ),
@@ -165,7 +174,7 @@ defmodule TuistCommon.PromExPhoenixPlugin do
               _ -> :erlang.iolist_size(metadata.conn.resp_body)
             end
           end,
-          tag_values: get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag),
+          tag_values: conn_tags,
           tags: http_metrics_tags,
           unit: :byte
         ),
@@ -173,7 +182,7 @@ defmodule TuistCommon.PromExPhoenixPlugin do
           metric_prefix ++ [:http, :requests, :total],
           event_name: @stop_event,
           description: "The number of requests have been serviced.",
-          tag_values: get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag),
+          tag_values: conn_tags,
           tags: http_metrics_tags
         )
       ]
@@ -252,13 +261,14 @@ defmodule TuistCommon.PromExPhoenixPlugin do
     )
   end
 
-  defp get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag) do
+  defp get_conn_tags(routers, additional_routes, http_metrics_tags, status_tag, normalize_path) do
     fn
       %{conn: %Conn{} = conn} ->
         default_route_tags = default_route_tags(conn, additional_routes)
 
         conn
         |> do_get_router_info(routers, default_route_tags)
+        |> Map.update!(:path, normalize_path)
         |> Map.merge(http_status_tags(conn.status, status_tag))
         |> Map.put(:method, conn.method)
         |> maybe_put_host(conn.host, http_metrics_tags)

--- a/tuist_common/test/tuist_common/prom_ex_phoenix_plugin_test.exs
+++ b/tuist_common/test/tuist_common/prom_ex_phoenix_plugin_test.exs
@@ -17,6 +17,7 @@ defmodule TuistCommon.PromExPhoenixPluginTest do
     use Phoenix.Router
 
     get("/articles", TuistCommon.PromExPhoenixPluginTest.ArticleController, :index)
+    get("/es/articles", TuistCommon.PromExPhoenixPluginTest.ArticleController, :index)
   end
 
   describe "event_metrics/1" do
@@ -99,6 +100,44 @@ defmodule TuistCommon.PromExPhoenixPluginTest do
       assert tag_values.path == "/articles"
       refute Map.has_key?(tag_values, :controller)
       refute Map.has_key?(tag_values, :action)
+    end
+
+    test "can normalize the resolved route path" do
+      http_event =
+        phoenix_http_event(
+          router: Router,
+          endpoint: Endpoint,
+          normalize_path: &String.replace_prefix(&1, "/es", "/:locale")
+        )
+
+      [request_duration, response_size, requests_total] = http_event.metrics
+
+      conn =
+        :get
+        |> Plug.Test.conn("/es/articles")
+        |> Map.put(:status, 200)
+
+      for metric <- [request_duration, response_size, requests_total] do
+        assert metric.tag_values.(%{conn: conn}).path == "/:locale/articles"
+      end
+    end
+
+    test "leaves unresolved routes alone when normalizing paths" do
+      http_event =
+        phoenix_http_event(
+          router: Router,
+          endpoint: Endpoint,
+          normalize_path: &String.replace_prefix(&1, "/es", "/:locale")
+        )
+
+      [request_duration | _] = http_event.metrics
+
+      conn =
+        :get
+        |> Plug.Test.conn("/not-a-route")
+        |> Map.put(:status, 404)
+
+      assert request_duration.tag_values.(%{conn: conn}).path == "Unknown"
     end
   end
 


### PR DESCRIPTION
Follow-up to https://github.com/tuist/tuist/pull/12302. No issue: this came out of a Grafana Cloud "Anomaly: Metrics Usage" alert on the hosted stack.

## What happened

Active series for the stack had been flat at roughly 72k to 77k for two weeks. On 2026-08-13 at around 10:30 UTC they stepped up and then climbed steadily to 109k, dropping back only when pods restarted. The sawtooth is the tell: series were accumulating for the life of each pod rather than tracking traffic.

## Root cause

The step matches the production deploy of https://github.com/tuist/tuist/pull/12302, which made `StripedPeep.scrape/1` non-destructive.

That change was correct and stays. PromEx drives `scrape/1` from `PromEx.ETSCronFlusher` on a timer and throws the result away, so freeing metrics on read deleted them before Prometheus ever saw them, which is what broke `rate/1` on the low-volume Oban panels. Reverting would reintroduce that bug.

What it also removed was the only thing bounding series by time. Now that scrapes are cumulative, a tag value only has to be observed once to be exported for the rest of the pod's life, so series accumulate up to the full tag cross-product.

That made an assumption in the module doc load-bearing, and it turned out to be false for the Phoenix plugin:

> Every metric registered by the plugins in `Tuist.PromEx` tags on a closed set (queue, state, worker, fleet, request host, ...)

`TuistCommon.PromExPhoenixPlugin` tags HTTP metrics on `[status, method, path]`, and `path` is one value per router entry. The router generates marketing and docs routes once per locale, so of the 328 path labels production was exporting, 195 were locale variants of about 32 pages. In production, `tuist_prom_ex_phoenix_http_request_duration_milliseconds_bucket` alone went from roughly 1k to 14.5k series in about 30 hours, and had still not plateaued when the pods restarted. All environments were affected.

## What changed

Fix the cardinality rather than the storage.

`TuistCommon.PromExPhoenixPlugin` gains a `normalize_path` option, a 1-arity function applied to the resolved route before it becomes a label. It defaults to identity, so the cache and registry consumers are unaffected. The tag-values closure is now built once and shared across the three HTTP metrics instead of being constructed three times.

The server passes `Tuist.Locale.collapse_locale_path_prefix/1`, so `/ja/pricing` and `/zh_Hant/pricing` both report as `/:locale/pricing`. English is deliberately left alone: its marketing routes carry no prefix, and its traffic is worth reading on its own. The important property is that adding a locale no longer adds route labels.

The collapsing function lives in `Tuist.Locale` rather than `TuistWeb.Marketing.Localization`, which was the first instinct since that module owns the locale-to-path mapping. The `Boundary` config forbids references from `Tuist` to `TuistWeb` except for the exported `Endpoint` and `Router`, and `Tuist.Locale` already owns the language list, so it is the better home regardless.

Alternatives considered and rejected:

- Reverting to a destructive scrape. Brings back the broken `rate/1` panels.
- Dropping the marketing-path histogram at remote_write via `metricProcessingRules`. Faster to ship, but it hides the cost instead of removing it, and the labels still cost cardinality at the source. Worth keeping in reserve if more reduction is needed.
- Reducing the bucket count. Cuts every path equally, including the API routes whose latency we actually read.

## Impact

Measured against the paths production is currently exporting, path labels go from 328 to 165. That roughly halves the Phoenix HTTP metric family, which was the single largest contributor to the growth.

This does not by itself return the stack to the 80k baseline. Cumulative-scrape accumulation still applies to the API and dashboard routes and to the Oban histograms. That growth is bounded by the router rather than unbounded, but it is real, and the remote_write rule is the next lever if the p95 is still uncomfortable.

The Phoenix `path` label changes value for localized routes, so any saved query or dashboard filtering on a specific locale path will need updating. Nothing in `infra/grafana-dashboards/` does.

`server/lib/tuist/prom_ex/AGENTS.md` picks up the reasoning so the next person changing this does not have to rediscover why cumulative storage makes every new tag a permanent cost.

### How to test locally

The locale-dependent tests are tagged `:locale`, because `Tuist.Locale.languages/0` is trimmed to English unless `TUIST_DEV_ALL_LOCALES=1`. CI sets that. `dev_all_locales` is a compile-time key, so the build has to be recompiled when toggling it:

```
cd server
MIX_ENV=test TUIST_DEV_ALL_LOCALES=1 mix compile --force
TUIST_DEV_ALL_LOCALES=1 mix test test/tuist/locale_test.exs test/tuist/prom_ex_test.exs
```

`test/tuist/prom_ex_test.exs` is the one worth reading: it drives `Tuist.PromEx.plugins/0` end to end and asserts that real router paths collapse while unlocalized routes stay distinct. The unit tests alone would still pass if the wiring in `prom_ex.ex` were dropped.

For the shared plugin:

```
cd tuist_common
mix test test/tuist_common/prom_ex_phoenix_plugin_test.exs
```

To reset the build afterwards:

```
cd server
MIX_ENV=test mix compile --force
```

## Validation

- New unit tests for the collapsing, covering localized routes, locale home routes, English routes, unlocalized routes, the `Unknown` label for unresolved routes, and paths whose first segment is a route parameter rather than a locale.
- New end-to-end test through `Tuist.PromEx.plugins/0` against the real router.
- New plugin tests for `normalize_path`, including that an unresolved route still reports `Unknown`.
- Full `tuist_common` suite. Two failures in `TuistCommon.GitHubTest` are pre-existing Mimic ownership flakes, confirmed failing identically on a clean tree.
- Server locale and PromEx suites in both locale modes.
- `mix format` and `mix credo` clean on the changed files.
- Reduction figures above were measured by applying the collapsing function to the path label set pulled from the production Prometheus, not estimated.
