### PR TITLE
fix(kura): compile the connect-timeout warning's variable names

### DIFF
--- a/kura/src/auth/config.rs
+++ b/kura/src/auth/config.rs
@@ -44,9 +44,9 @@ fn reachable_connect_timeout_ms(connect_timeout_ms: u64, request_timeout_ms: u64
 
     warn!(
         "{} ({}ms) is not below {} ({}ms), which spans it; using {}ms for the connect.",
-        CONNECT_TIMEOUT_MS[0],
+        CONNECT_TIMEOUT_MS,
         connect_timeout_ms,
-        REQUEST_TIMEOUT_MS[0],
+        REQUEST_TIMEOUT_MS,
         request_timeout_ms,
         request_timeout_ms
     );


### PR DESCRIPTION
## What changed

`reachable_connect_timeout_ms` in [kura/src/auth/config.rs](kura/src/auth/config.rs:45) interpolated `CONNECT_TIMEOUT_MS[0]` and `REQUEST_TIMEOUT_MS[0]` into its warning. Both are now `&str` constants holding a single env-var name, so indexing them is `E0277: the type str cannot be indexed by {integer}`. The two indexes are dropped so the message interpolates the constants themselves.

## Why

`kura_lib` does not compile on `main`, which fails the Bazel Compile job for every run against it (https://github.com/tuist/tuist/actions/runs/32008069743/job/95321595774).

## Root cause

A semantic conflict between two PRs that were each green on their own base.

- https://github.com/tuist/tuist/pull/12365 added the warning. At that point `CONNECT_TIMEOUT_MS` and `REQUEST_TIMEOUT_MS` were `&[&str]` slices holding two aliases each, the `KURA_AUTH_*` name plus a `KURA_EXTENSION_HTTP_CLIENT_*` one, so `[0]` was a valid index picking the primary name.
- https://github.com/tuist/tuist/pull/12297 deleted the Lua hook and with it the `KURA_EXTENSION_*` aliases, collapsing both constants to a plain `&str`. Its branch predates the new warning, so nothing in that diff indexed them.

Neither branch contained both halves, so the combination first compiled once both were on `main`. Since the constants are single names again, the message wants the constants themselves.

## Impact

`main` compiles again. No behavior change beyond the warning now naming the variables instead of failing to build; the timeout fallback it warns about is untouched.

## Validation

Run from `kura/`:

- `mise run compile` — build completed successfully (1200 actions)
- `mise run clippy` — clean, warnings as errors
- `mise run format -- --check` — clean
- `bazel test //:kura_lib_test --test_arg=auth::config` — passes, covering `a_connect_budget_the_request_budget_spans_is_brought_back_within_it`, the test that exercises the branch containing the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)