### PR TITLE
feat(infra): give the macOS host log shipper a health signal on :9100

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -72,7 +72,10 @@ straight to Grafana Cloud keeps every ingest credential off nine
 internet-facing minis — the tailnet ACL is the access control and Alloy
 forwards with the token it already holds. Installed and drift-rolled by
 `macos-host-bootstrap` exactly like `node_exporter`. Per-env gate:
-`macosFleet.hostLogs.enabled`. See
+`macosFleet.hostLogs.enabled`. Its own health goes the other way — out through
+node_exporter's textfile collector as `tuist_log_shipper_*` on `:9100` — because
+an agent that pushes is invisible when it fails, being the thing that reports.
+See
 [`macos-log-shipper/AGENTS.md`](macos-log-shipper/AGENTS.md).
 
 ### `registry-router/` — Cloudflare Worker for the Tuist registry path

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -148,6 +148,19 @@ Both are gated on Tailscale being wired, for mirrored reasons: without a
 tailnet, the pull agent would have to listen somewhere public, and the push
 agent has no route to its target at all.
 
+The push agent's own health rides the pull agent. `node_exporter` runs with
+`--collector.textfile` over `/var/lib/node_exporter/textfile`
+(`nodeExporterTextfileDir`), and the log shipper publishes
+`tuist_log_shipper_*` there on every poll outcome. The reason is the asymmetry
+above turned against us: an agent that pushes is invisible when it fails,
+because it is the thing that reports. Two multi-day outages came out of that,
+and through both of them SSH to the minis hung and production `kubectl` never
+returned while `:9100` answered every time. Changing the wrapper script moves
+`HostConfigHash`, so enabling the collector rolls the whole fleet — intended.
+`installLogShipper` still runs LAST in both `Run` and `UpdateTartKubelet`, so a
+failure in the observability path cannot block the tart-kubelet roll it travels
+with; keep that ordering.
+
 ### SSH ingress guard
 
 Both dial paths land on the same listener, so both fail together. A Scaleway

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1407,7 +1407,7 @@ sum by (cluster) (
 ### Runner host log shipper not delivering
 
 ```promql
-max by (cluster, env, instance, job) (
+max by (cluster, env, instance, source_job) (
   tuist_log_shipper_consecutive_failures
 ) > 10
 ```
@@ -1416,7 +1416,14 @@ max by (cluster, env, instance, job) (
 - Severity: warning
 - Summary: `Host log shipper on {{ $labels.instance }} has failed
   {{ $value | printf "%.0f" }} consecutive attempts for
-  {{ $labels.job }}; host logs from that mini are not reaching Loki`
+  {{ $labels.source_job }}; host logs from that mini are not reaching Loki`
+
+The label is `source_job`, not `job`. The agent deliberately avoids `job` in its
+exposition: it is a reserved target label, and with `honor_labels=false` (the
+default, which this scrape does not override) it would be overwritten with
+`tuist-macos-node-exporter` and the agent's value pushed to `exported_job`.
+Grouping by `job` would then collapse every tailed source into one series and
+label it with the scrape job.
 
 The agent is the thing that reports host logs, so when it breaks nothing
 reports and no absence of log lines distinguishes "installed but failing"
@@ -1467,7 +1474,58 @@ the basename — verified against node_exporter 1.8.2 on a production mini.
 
 The series disappears rather than freezing when host logging is turned off,
 because the uninstall removes the `.prom` file. That is deliberate: a rule that
-kept firing for a host carrying no agent would train everyone to ignore it.
+kept firing for a host carrying no agent would train everyone to ignore it. It
+also means this rule cannot see an agent that never wrote a file at all, which
+is what the next one is for.
+
+### Runner host log shipper absent
+
+```promql
+count by (cluster, env, instance) (
+  up{job="tuist-macos-node-exporter"} == 1
+)
+unless
+count by (cluster, env, instance) (
+  node_textfile_mtime_seconds{
+    file="/var/lib/node_exporter/textfile/tuist-log-shipper.prom"
+  }
+)
+```
+
+- Pending period: 20 minutes
+- Severity: warning
+- Summary: `Mac mini {{ $labels.instance }} is scrapeable but publishes no log
+  shipper health file; the agent is not installed or never started`
+
+The gap both rules above leave open, and the one that matters most given the
+history: an agent that fails *before its first write* produces no series for
+either of them. `node_textfile_mtime_seconds` exists only for files the collector
+successfully read, and `tuist_log_shipper_*` only once the agent has written, so
+a failed install, a launchd job that never loaded, or a binary the kernel refuses
+(`OS_REASON_CODESIGNING` after an in-place overwrite) is invisible to a threshold
+rule. Per **How to create these rules** item 6, threshold rules run with
+**No Data: Normal**, so "no series" reads as healthy.
+
+The `unless` form is what makes this work under that convention rather than
+needing `No Data: Alerting`: the healthy case is an empty result, while the
+unhealthy case produces a real series from the left-hand side, so the rule has
+data exactly when something is wrong. It anchors on node_exporter's own `up`,
+which exists for every mini from the moment the CAPI provider creates its egress
+Service, whether or not anything else on that host works.
+
+Two scoping notes:
+
+- It reports every host in an environment where `macosFleet.hostLogs.enabled` is
+  false, because the uninstall removes the file by design. All three managed
+  environments are on; pause the rule for an environment that is turned off.
+- 20 minutes is deliberate. `installNodeExporter` runs several steps before
+  `installLogShipper` (which is last on purpose, so the logging path cannot block
+  a tart-kubelet roll), so a freshly bootstrapped host legitimately serves
+  `:9100` for minutes before the agent's first write.
+
+Seeding a placeholder file at install time was the alternative. It was rejected
+because it cannot cover a host the install step never reached at all, which is
+one of the states this is meant to catch.
 
 ### Runner host textfile metrics unparseable
 
@@ -1479,15 +1537,27 @@ max by (cluster, env, instance) (
 
 - Pending period: 5 minutes
 - Severity: warning
-- Summary: `A metrics textfile on {{ $labels.instance }} failed to parse;
-  that host's node_* series are incomplete`
+- Summary: `A metrics textfile on {{ $labels.instance }} failed to parse; some
+  host-agent health is missing from this scrape`
 
-node_exporter parses the whole collector directory on every scrape, so one
-malformed file is a parse error for the DIRECTORY — it takes the host's
-`node_*` series with it rather than costing one metric. The writers rename
-a fully written temp file into place specifically so a scrape can never land
+Measured against node_exporter 1.8.2 on a production mini: a parse failure is
+isolated to the file it happened in. That file's metrics are dropped and no
+`node_textfile_mtime_seconds` is emitted for it, while every other file and
+collector is unaffected (`node_scrape_collector_success{collector="textfile"}`
+even stays 1). So this is not a host-wide outage, but it does mean a host agent's
+health is absent from the scrape, which is the state those agents exist to make
+visible.
+
+The writers rename a fully written temp file into place so a scrape cannot land
 mid-write, so this firing means something is writing into
 `/var/lib/node_exporter/textfile` without that discipline.
+
+Worth knowing about the case this rule *cannot* see: two files holding the same
+series with different values produce no error at all. The collector serves
+whichever the directory walk reaches first, silently drops the other, and leaves
+`node_textfile_scrape_error` at 0. A stale duplicate can therefore pin an agent's
+health at a healthy-looking value indefinitely. Writers keep their pre-rename
+files out of the `.prom` namespace precisely so they cannot become one.
 
 ## Useful investigation queries
 

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1404,6 +1404,91 @@ sum by (cluster) (
 - Pending period: 2 minutes
 - Summary: `Stable outbound controller reconciliation is failing in {{ $labels.cluster }}`
 
+### Runner host log shipper not delivering
+
+```promql
+max by (cluster, env, instance, job) (
+  tuist_log_shipper_consecutive_failures
+) > 10
+```
+
+- Pending period: 15 minutes
+- Severity: warning
+- Summary: `Host log shipper on {{ $labels.instance }} has failed
+  {{ $value | printf "%.0f" }} consecutive attempts for
+  {{ $labels.job }}; host logs from that mini are not reaching Loki`
+
+The agent is the thing that reports host logs, so when it breaks nothing
+reports and no absence of log lines distinguishes "installed but failing"
+from "not installed". This is the counter that does: it is incremented per
+push attempt from inside the retry loop, which retries a retryable failure
+forever, so an unreachable receiver climbs steadily rather than freezing.
+Ten attempts with the capped backoff is several minutes of real failure,
+past any single receiver restart.
+
+Read it together with `tuist_log_shipper_last_success_timestamp_seconds`:
+`0` means the agent has never delivered a line since it was installed,
+which is the shape both host-logging outages had. `tuist_log_shipper_build_info`
+carries a `binary_sha256` label, so hosts running different builds are
+distinguishable without reaching `HostConfigHash` through the kubectl
+gateway — which is the channel that did not answer during those
+investigations, while `:9100` answered every time.
+
+### Runner host log shipper stalled
+
+```promql
+(
+  time()
+  -
+  max by (cluster, env, instance, file) (
+    node_textfile_mtime_seconds{
+      file="/var/lib/node_exporter/textfile/tuist-log-shipper.prom"
+    }
+  )
+) > 900
+```
+
+- Pending period: 10 minutes
+- Severity: warning
+- Summary: `Host log shipper on {{ $labels.instance }} has stopped
+  publishing its own health`
+
+The companion to the rule above, covering the case it cannot see: a process
+that is gone, wedged, or blocked somewhere that records no outcome at all.
+The agent rewrites its textfile on every poll outcome, so the file's mtime
+is a heartbeat that costs no metric of its own. A launchd job with
+`KeepAlive` that keeps dying also shows here, because each restart's first
+write is followed by silence.
+
+Note the `file` label rather than a metric of ours: `node_textfile_mtime_seconds`
+comes from node_exporter's own collector, so it is published even when the
+agent has written nothing since boot. The label carries the **full path**, not
+the basename — verified against node_exporter 1.8.2 on a production mini.
+
+The series disappears rather than freezing when host logging is turned off,
+because the uninstall removes the `.prom` file. That is deliberate: a rule that
+kept firing for a host carrying no agent would train everyone to ignore it.
+
+### Runner host textfile metrics unparseable
+
+```promql
+max by (cluster, env, instance) (
+  node_textfile_scrape_error
+) > 0
+```
+
+- Pending period: 5 minutes
+- Severity: warning
+- Summary: `A metrics textfile on {{ $labels.instance }} failed to parse;
+  that host's node_* series are incomplete`
+
+node_exporter parses the whole collector directory on every scrape, so one
+malformed file is a parse error for the DIRECTORY — it takes the host's
+`node_*` series with it rather than costing one metric. The writers rename
+a fully written temp file into place specifically so a scrape can never land
+mid-write, so this firing means something is writing into
+`/var/lib/node_exporter/textfile` without that discipline.
+
 ## Useful investigation queries
 
 Current Kubernetes requests in flight:

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -993,10 +993,28 @@ k8s-monitoring:
           }
         }
 
+        // The keep-list is also what admits the host-side agents' own health.
+        // They publish through node_exporter's textfile collector (see
+        // macos-host-bootstrap's nodeExporterTextfileDir), so their series arrive
+        // on this scrape and are dropped here unless named:
+        //
+        //   - tuist_log_shipper_.* — the log shipper's last successful push,
+        //     consecutive failed attempts, offset and source size. The agent is
+        //     the thing that reports host logs, so when it breaks nothing
+        //     reports; these are what make "installed but failing" different
+        //     from "not installed" when SSH hangs and kubectl does not return.
+        //   - node_textfile_mtime_seconds — the collector's view of each .prom
+        //     file's mtime. The agents rewrite theirs on every poll, so this is
+        //     liveness for free: an agent that died stops advancing it, and no
+        //     agent needs a heartbeat metric of its own.
+        //   - node_textfile_scrape_error — 1 when a file in the directory failed
+        //     to parse. A half-written file is a parse error for the whole
+        //     DIRECTORY, so this is the signal that an agent is taking the
+        //     host's node_* series down with it.
         prometheus.relabel "tuist_macos_node_exporter" {
           rule {
             source_labels = ["__name__"]
-            regex = "up|scrape_samples_scraped|node_exporter_build_info|node_cpu_seconds_total|node_memory_.*|node_filesystem_.*|node_disk_(read|written)_bytes_total|node_filefd_(allocated|maximum)|node_load.*|node_network_(receive|transmit)_bytes_total|node_pressure_.*|node_sockstat_(TCP_alloc|TCP_inuse|TCP_tw|sockets_used)|node_vmstat_oom_kill|process_cpu_seconds_total|process_resident_memory_bytes"
+            regex = "up|scrape_samples_scraped|node_exporter_build_info|node_cpu_seconds_total|node_memory_.*|node_filesystem_.*|node_disk_(read|written)_bytes_total|node_filefd_(allocated|maximum)|node_load.*|node_network_(receive|transmit)_bytes_total|node_pressure_.*|node_sockstat_(TCP_alloc|TCP_inuse|TCP_tw|sockets_used)|node_vmstat_oom_kill|node_textfile_(mtime_seconds|scrape_error)|tuist_log_shipper_.*|process_cpu_seconds_total|process_resident_memory_bytes"
             action = "keep"
           }
           // Top-level extraConfig sits OUTSIDE the chart's `declare`

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -1006,11 +1006,13 @@ k8s-monitoring:
         //   - node_textfile_mtime_seconds — the collector's view of each .prom
         //     file's mtime. The agents rewrite theirs on every poll, so this is
         //     liveness for free: an agent that died stops advancing it, and no
-        //     agent needs a heartbeat metric of its own.
+        //     agent needs a heartbeat metric of its own. Not emitted for a file
+        //     that failed to parse, so a corrupt file trips the absence rule
+        //     rather than only stalling the heartbeat one.
         //   - node_textfile_scrape_error — 1 when a file in the directory failed
-        //     to parse. A half-written file is a parse error for the whole
-        //     DIRECTORY, so this is the signal that an agent is taking the
-        //     host's node_* series down with it.
+        //     to parse. The failure is isolated to that file (measured against
+        //     node_exporter 1.8.2), so this says an agent's health is missing
+        //     from the scrape, not that the host's node_* series are down.
         prometheus.relabel "tuist_macos_node_exporter" {
           rule {
             source_labels = ["__name__"]

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -2417,6 +2417,25 @@ sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.pfctl-sshguard.
 `, allow), nil
 }
 
+// nodeExporterTextfileDir is the directory node_exporter's textfile collector
+// reads on every scrape, and where host-side agents publish their own health.
+//
+// It is mirrored in the log shipper's shipper.DefaultHealthPath. They are
+// separate Go modules, so the two sides agree by convention rather than through
+// a shared constant: changing one alone leaves a file written on every poll that
+// nothing scrapes, or a collector reading an empty directory.
+//
+// /var/lib rather than /var/log because the contents are the current state of a
+// gauge, not an append-only record — the file is replaced wholesale on every
+// write and nothing accumulates.
+const nodeExporterTextfileDir = "/var/lib/node_exporter/textfile"
+
+// logShipperTextfilePath is the log shipper's file inside that directory. The
+// bootstrap names it only to remove it on uninstall: node_exporter keeps reading
+// the directory after the agent is gone, so a left-behind file would publish a
+// frozen last_success forever — a phantom agent on a host carrying none.
+const logShipperTextfilePath = nodeExporterTextfileDir + "/tuist-log-shipper.prom"
+
 // renderNodeExporterScript is the static SSH script that installs the
 // node_exporter wrapper + launchd job. The binary rides stdin and its
 // drift is tracked by its own SHA in the host config hash, so this
@@ -2426,6 +2445,14 @@ func renderNodeExporterScript() string {
 sudo mkdir -p /usr/local/bin
 sudo tee /usr/local/bin/node_exporter >/dev/null
 sudo chmod 0755 /usr/local/bin/node_exporter
+# The textfile collector reads this directory on every scrape and reports a
+# scrape error if it is missing, so it is created here rather than left to
+# whichever agent writes into it first. Traversable and readable by anyone: the
+# writers are root launchd daemons while node_exporter runs from its own job, and
+# a file the collector cannot read is indistinguishable from an agent that is not
+# running.
+sudo mkdir -p ` + nodeExporterTextfileDir + `
+sudo chmod 0755 /var/lib/node_exporter ` + nodeExporterTextfileDir + `
 sudo tee /usr/local/bin/tuist-node-exporter-wrapper >/dev/null <<'WRAPPER'
 #!/bin/sh
 # Resolve the Mac mini's tailnet IPv4 fresh on every (re)start so
@@ -2441,6 +2468,11 @@ if [ -z "$TAILSCALE_IP" ]; then
   echo "tailscale ip -4 returned empty; node_exporter cannot bind safely" >&2
   exit 1
 fi
+# --collector.disable-defaults means every collector below is opt-in, textfile
+# included. It carries the health of the host-side agents that have no scrapeable
+# surface of their own — the log shipper is the first, and its failures were
+# invisible for days precisely because :9100 was the one channel still answering
+# while SSH and kubectl were not.
 exec /usr/local/bin/node_exporter \
   --web.listen-address="${TAILSCALE_IP}:9100" \
   --collector.disable-defaults \
@@ -2451,6 +2483,8 @@ exec /usr/local/bin/node_exporter \
   --collector.meminfo \
   --collector.netdev \
   --collector.os \
+  --collector.textfile \
+  --collector.textfile.directory=` + nodeExporterTextfileDir + ` \
   --collector.time \
   --collector.uname
 WRAPPER
@@ -2514,6 +2548,13 @@ func renderLogShipperScript(cfg Config) string {
 // as too old. Dropping it makes a re-enable start at the end of the file, the
 // same as a first install.
 //
+// The health textfile goes too, and for a sharper reason: node_exporter keeps
+// reading its collector directory whether or not the agent exists, so a
+// left-behind .prom would keep publishing the last values the agent wrote. A
+// frozen last_success and a frozen failure count is exactly the shape of a
+// broken agent, so the file would alert forever about a host carrying no agent
+// at all.
+//
 // /var/log/tuist-log-shipper.log is left in place: it holds the agent's own
 // diagnostics, which are the first thing anyone reads when asking why host
 // logging was turned off.
@@ -2524,6 +2565,7 @@ sudo launchctl bootout system "$PLIST" 2>/dev/null || true
 sudo rm -f "$PLIST"
 sudo rm -f /usr/local/bin/tuist-log-shipper
 sudo rm -rf /var/lib/tuist-log-shipper
+sudo rm -f ` + logShipperTextfilePath + `
 `
 }
 

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -734,6 +734,82 @@ func TestRenderSSHIngressGuardScript_IsValidSh(t *testing.T) {
 	}
 }
 
+// The log shipper's health signal is only reachable if node_exporter is told to
+// read the directory it writes into. Without the collector flags the .prom file
+// is written on every poll and scraped by nobody, which is the same blind spot
+// the agent's own failures had.
+func TestRenderNodeExporterScript_ReadsTheTextfileCollectorDirectory(t *testing.T) {
+	out := renderNodeExporterScript()
+	for _, want := range []string{
+		"--collector.textfile \\",
+		"--collector.textfile.directory=" + nodeExporterTextfileDir + " \\",
+		// --collector.disable-defaults means textfile is off unless named, and the
+		// directory has to exist before node_exporter starts or the collector
+		// reports a scrape error rather than an empty set.
+		"mkdir -p " + nodeExporterTextfileDir,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("node_exporter wrapper missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The wrapper rides a heredoc inside the install script, so a syntax error in
+// either is invisible until node_exporter stops coming up — which takes :9100
+// with it, the one channel that stayed answerable through both host-logging
+// outages.
+func TestRenderNodeExporterScript_IsValidSh(t *testing.T) {
+	body := renderNodeExporterScript()
+	script := filepath.Join(t.TempDir(), "install-node-exporter")
+	if err := os.WriteFile(script, []byte(body), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if combined, err := exec.Command("sh", "-n", script).CombinedOutput(); err != nil {
+		t.Fatalf("node_exporter script is not valid sh: %v\n%s", err, combined)
+	}
+
+	const open = "<<'WRAPPER'\n"
+	start := strings.Index(body, open)
+	if start < 0 {
+		t.Fatalf("no WRAPPER heredoc in rendered script\n%s", body)
+	}
+	wrapper := body[start+len(open):]
+	end := strings.Index(wrapper, "\nWRAPPER\n")
+	if end < 0 {
+		t.Fatalf("unterminated WRAPPER heredoc\n%s", body)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "tuist-node-exporter-wrapper")
+	if err := os.WriteFile(wrapperPath, []byte(wrapper[:end]), 0o600); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	if combined, err := exec.Command("sh", "-n", wrapperPath).CombinedOutput(); err != nil {
+		t.Fatalf("wrapper is not valid sh: %v\n%s\n---\n%s", err, combined, wrapper[:end])
+	}
+}
+
+// The shipper writes the file as root under launchd; node_exporter reads it from
+// its own job. A directory only the writer can traverse is a file the collector
+// silently skips, which looks exactly like an agent that is not running.
+func TestRenderNodeExporterScript_MakesTheTextfileDirectoryTraversable(t *testing.T) {
+	out := renderNodeExporterScript()
+	// Both levels: mkdir -p creates /var/lib/node_exporter with the process
+	// umask, so chmod'ing only the leaf leaves the collector unable to traverse
+	// into it.
+	if !strings.Contains(out, "chmod 0755 "+filepath.Dir(nodeExporterTextfileDir)+" "+nodeExporterTextfileDir) {
+		t.Fatalf("textfile directory is not made traversable by the collector\n%s", out)
+	}
+}
+
+// The two sides agree on the path by convention, not by a shared constant — they
+// are separate Go modules. The uninstall is the one place the bootstrap names the
+// file itself, so it has to sit inside the directory the wrapper hands the
+// collector.
+func TestLogShipperTextfileLivesInTheCollectorDirectory(t *testing.T) {
+	if !strings.HasPrefix(logShipperTextfilePath, nodeExporterTextfileDir+"/") {
+		t.Fatalf("%s is not inside the collector directory %s", logShipperTextfilePath, nodeExporterTextfileDir)
+	}
+}
+
 func TestRenderLogShipperScript_TailsTartKubeletLogWithHostIdentity(t *testing.T) {
 	out := renderLogShipperInstallScript(Config{
 		NodeName:   "tuist-tuist-runners-fleet-abc12",
@@ -831,6 +907,10 @@ func TestRenderLogShipperScript_UninstallsWhenDisabled(t *testing.T) {
 		// growing while the agent was off, so resuming from it would replay the
 		// whole disabled window — the exact cost the flag was flipped to avoid.
 		"rm -rf /var/lib/tuist-log-shipper",
+		// And the health textfile: node_exporter keeps reading the directory, so
+		// a left-behind .prom would report a frozen last_success forever — a
+		// phantom agent that alerts on a host carrying no agent at all.
+		"rm -f " + logShipperTextfilePath,
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("disabled render missing %q\n%s", want, out)
@@ -865,7 +945,7 @@ func TestRenderLogShipperUninstallScript_IsIdempotentAndValidSh(t *testing.T) {
 	if !strings.Contains(body, "2>/dev/null || true") {
 		t.Fatalf("bootout of an absent job must not fail the script\n%s", body)
 	}
-	for _, removal := range []string{"rm -f \"$PLIST\"", "rm -f /usr/local/bin/tuist-log-shipper", "rm -rf /var/lib/tuist-log-shipper"} {
+	for _, removal := range []string{"rm -f \"$PLIST\"", "rm -f /usr/local/bin/tuist-log-shipper", "rm -rf /var/lib/tuist-log-shipper", "rm -f " + logShipperTextfilePath} {
 		if !strings.Contains(body, removal) {
 			t.Fatalf("missing %q\n%s", removal, body)
 		}

--- a/infra/macos-log-shipper/AGENTS.md
+++ b/infra/macos-log-shipper/AGENTS.md
@@ -87,7 +87,8 @@ while `:9100` answered instantly, every time. So the health signal rides `:9100`
 It goes out as a Prometheus textfile at
 `/var/lib/node_exporter/textfile/tuist-log-shipper.prom`
 (`shipper.DefaultHealthPath`, `--metrics` to override), which node_exporter's
-textfile collector reads on every scrape. Per tailed source (`job` label):
+textfile collector reads on every scrape. Per tailed source, labelled
+`source_job` and **not** `job` (see below):
 
 | Metric | What it answers |
 | --- | --- |
@@ -97,12 +98,25 @@ textfile collector reads on every scrape. Per tailed source (`job` label):
 | `tuist_log_shipper_source_size_bytes` | The source file's size right now. The gap to the offset is the lag. |
 | `tuist_log_shipper_build_info` | `binary_sha256` of the on-host executable and the Go version. Which binary a host carries was itself an open question during the last incident, and the place that answers it (`HostConfigHash` on the Machine) sits behind the kubectl gateway that did not answer. |
 
-Four things about the implementation are load-bearing:
+Six things about the implementation are load-bearing:
 
-- **The write is atomic** — temp file in the same directory, then `os.Rename`.
-  node_exporter parses the whole directory on every scrape, so a partially
-  written file is a parse error for the DIRECTORY. Getting this wrong would take
-  the host's `node_*` series down with it and make the change a net loss.
+- **The source label is `source_job`, not `job`.** `job` is a reserved target
+  label. The scrape runs with `honor_labels=false` (the default; the fleet's
+  scrape does not override it), so a `job` in the exposition collides with the
+  scrape's own `job_name`: the sample would arrive carrying
+  `job="tuist-macos-node-exporter"` with our value silently moved to
+  `exported_job`, and every query grouping by `job` would collapse all sources
+  into one and label them with the scrape job. The *value* is still the Loki
+  `job` label the source's lines carry, so it joins straight against
+  `{job="tuist-macos-tart-kubelet"}` in Loki.
+- **The write is atomic** — temp file in the same directory, then `os.Rename` —
+  so a scrape landing mid-write reads the previous complete document instead of a
+  half-written one. What that protects is narrower than it first appears: see the
+  measurements below.
+- **The temp file must not end in `.prom`** (it is `.tmp`). node_exporter selects
+  files by that suffix, so a `.prom` temp is parsed too and the rename stops
+  being atomic from the collector's point of view. Stale temps from an earlier
+  crash are swept at construction.
 - **The count comes from inside the push retry loop, not from poll boundaries.**
   `push` retries a retryable failure forever, so during a receiver outage `poll`
   never returns. A poll-boundary-only writer would publish nothing for the
@@ -114,6 +128,27 @@ Four things about the implementation are load-bearing:
   Losing the logs to keep the metric would be strictly worse than not having the
   metric.
 
+### What the collector actually does with a bad file
+
+Measured against node_exporter 1.8.2 on a production mini, because the intuitive
+answers are wrong in both directions:
+
+| Situation | What happens |
+| --- | --- |
+| A file fails to parse (a partial write) | Only that file is lost. `node_textfile_scrape_error` goes to 1, no `node_textfile_mtime_seconds` is emitted for it, the parse error is logged per file, and **every other file and collector is unaffected** — `node_scrape_collector_success{collector="textfile"}` even stays 1. |
+| Two files hold the same series with **different** values | The collector serves whichever the directory walk reaches first and **silently drops the other**, with `node_textfile_scrape_error` staying **0**. |
+
+So a malformed file does *not* take the host's `node_*` series down with it, which
+is a claim worth not repeating. The severe case is the second row: a `.prom` temp
+abandoned by a crash is a complete document with stale values, so a leftover
+sorting before the real file pins this agent's health at whatever it said —
+including a healthy-looking zero — with no error metric anywhere. A lost scrape is
+a gap; a leftover is a lie. That is why the suffix matters more than the
+atomicity, and why the sweep exists.
+
+One useful consequence: a permanently corrupt `.prom` emits no mtime series, so
+it does not merely stall the heartbeat rule, it trips the absence rule instead.
+
 Two node_exporter metrics complete the picture without costing us anything:
 `node_textfile_mtime_seconds` is a heartbeat (the file is rewritten on every poll
 outcome, so a dead agent stops advancing it), and `node_textfile_scrape_error`
@@ -121,7 +156,9 @@ catches a malformed file. Both, plus `tuist_log_shipper_.*`, are in the Alloy
 keep-list in [`infra/helm/k8s-monitoring`](../helm/k8s-monitoring)'s
 `values.yaml` — a series not named there is dropped before Grafana Cloud, so
 adding a metric here means adding it there. Recommended alert rules are in that
-chart's `alerts.md` under *Runner host log shipper*.
+chart's `alerts.md` under *Runner host log shipper*; note that neither the
+failure-count rule nor the heartbeat rule can see an agent that died before its
+first write, which is what *Runner host log shipper absent* is for.
 
 The uninstall removes the `.prom` file along with the binary. node_exporter keeps
 reading the directory whether or not the agent exists, so a left-behind file

--- a/infra/macos-log-shipper/AGENTS.md
+++ b/infra/macos-log-shipper/AGENTS.md
@@ -73,6 +73,69 @@ path the xcresult processor's Tart guests already use for their own logs.
   `/var/log/tuist-log-shipper.log`). Shipping push failures through the shipper
   turns an outage into a loop.
 
+## The agent publishes its own health through node_exporter
+
+The agent is the thing that reports, so when it breaks nothing reports.
+"Installed but failing" and "not installed" look identical from off-host, and
+that produced two multi-day outages: the agent shipped and never delivered a
+line, while `launchctl print` reported the job `running` with correct arguments
+throughout; the first fix landed on a misread test and production kept failing
+for another day at attempt 494 per host. Through both investigations SSH to the
+minis hung and production `kubectl` through the Pomerium gateway never returned,
+while `:9100` answered instantly, every time. So the health signal rides `:9100`.
+
+It goes out as a Prometheus textfile at
+`/var/lib/node_exporter/textfile/tuist-log-shipper.prom`
+(`shipper.DefaultHealthPath`, `--metrics` to override), which node_exporter's
+textfile collector reads on every scrape. Per tailed source (`job` label):
+
+| Metric | What it answers |
+| --- | --- |
+| `tuist_log_shipper_last_success_timestamp_seconds` | When a push last returned 2xx. **`0` means this source has never delivered a line** — the state both outages were in. |
+| `tuist_log_shipper_consecutive_failures` | Failed read or push attempts since the last accepted push. Counted per attempt from inside the retry loop, so it matches the `attempt N` in the agent's log. |
+| `tuist_log_shipper_position_offset_bytes` | How far the agent has read **and** pushed. |
+| `tuist_log_shipper_source_size_bytes` | The source file's size right now. The gap to the offset is the lag. |
+| `tuist_log_shipper_build_info` | `binary_sha256` of the on-host executable and the Go version. Which binary a host carries was itself an open question during the last incident, and the place that answers it (`HostConfigHash` on the Machine) sits behind the kubectl gateway that did not answer. |
+
+Four things about the implementation are load-bearing:
+
+- **The write is atomic** — temp file in the same directory, then `os.Rename`.
+  node_exporter parses the whole directory on every scrape, so a partially
+  written file is a parse error for the DIRECTORY. Getting this wrong would take
+  the host's `node_*` series down with it and make the change a net loss.
+- **The count comes from inside the push retry loop, not from poll boundaries.**
+  `push` retries a retryable failure forever, so during a receiver outage `poll`
+  never returns. A poll-boundary-only writer would publish nothing for the
+  duration of the exact failure this exists to expose.
+- **The published size is re-stat'd on every failed attempt** (`Shipper.observe`),
+  for the same reason: a size captured when the blocked poll started would report
+  a constant lag through an outage of any length.
+- **A failure to write the textfile does not stop shipping**, and is logged once.
+  Losing the logs to keep the metric would be strictly worse than not having the
+  metric.
+
+Two node_exporter metrics complete the picture without costing us anything:
+`node_textfile_mtime_seconds` is a heartbeat (the file is rewritten on every poll
+outcome, so a dead agent stops advancing it), and `node_textfile_scrape_error`
+catches a malformed file. Both, plus `tuist_log_shipper_.*`, are in the Alloy
+keep-list in [`infra/helm/k8s-monitoring`](../helm/k8s-monitoring)'s
+`values.yaml` — a series not named there is dropped before Grafana Cloud, so
+adding a metric here means adding it there. Recommended alert rules are in that
+chart's `alerts.md` under *Runner host log shipper*.
+
+The uninstall removes the `.prom` file along with the binary. node_exporter keeps
+reading the directory whether or not the agent exists, so a left-behind file
+would publish a frozen `last_success` forever — a phantom agent alerting about a
+host that carries none.
+
+**A positions offset that equals the file size proves nothing shipped.** `poll`
+on first sight of a file calls `ReadNew` with `exists=false`, which returns the
+end-of-file position and zero lines, persists it, and returns without pushing —
+no network call happens. That is what a "successful push" was read from once. The
+test that exercises the network appends a line *after* first sight and checks the
+offset advances past the first-sight mark; confirm any new metric the same way,
+by asserting `last_success_timestamp` moves after an append.
+
 ## Labels
 
 Every line carries `job`, `instance`, `env` and `level`. Nothing else, and

--- a/infra/macos-log-shipper/cmd/tuist-log-shipper/main.go
+++ b/infra/macos-log-shipper/cmd/tuist-log-shipper/main.go
@@ -47,6 +47,7 @@ func main() {
 		instance  string
 		env       string
 		positions string
+		metrics   string
 	)
 	flag.Var(&files, "file",
 		"Log file to tail, as <job>=<path>. Repeatable. The job name becomes the "+
@@ -65,6 +66,12 @@ func main() {
 	flag.StringVar(&positions, "positions", "/var/lib/tuist-log-shipper/positions.json",
 		"Where read offsets are persisted so a restart resumes instead of "+
 			"re-shipping or skipping.")
+	flag.StringVar(&metrics, "metrics", shipper.DefaultHealthPath,
+		"Where the agent publishes its own health, in Prometheus text format. The "+
+			"default is inside node_exporter's textfile collector directory, so the "+
+			"metrics ride the :9100 scrape that answers when SSH and kubectl do not. "+
+			"Point it elsewhere to validate a binary on a host without clobbering the "+
+			"installed agent's file.")
 	flag.Parse()
 
 	if url == "" {
@@ -90,6 +97,10 @@ func main() {
 		Sources:    files,
 		BaseLabels: labels,
 		Positions:  shipper.LoadPositions(positions),
+		// The agent is the thing that reports, so when it breaks nothing reports.
+		// This is the one channel that stays answerable off-host while it is
+		// broken.
+		Health: shipper.NewHealth(metrics, log.Printf),
 		Client: &shipper.Client{
 			URL: url,
 			// Resolves through tailscaled rather than /etc/resolv.conf, which is

--- a/infra/macos-log-shipper/internal/shipper/health.go
+++ b/infra/macos-log-shipper/internal/shipper/health.go
@@ -61,13 +61,55 @@ type Health struct {
 	logged bool
 }
 
+// tempPattern is the name os.CreateTemp gives the pre-rename file.
+//
+// The suffix is NOT .prom, and that is the whole point: node_exporter selects
+// the files it parses by that suffix, so a .prom temp is parsed too and the
+// rename stops being atomic from the collector's point of view. Both outcomes
+// were measured against node_exporter 1.8.2 on a production mini:
+//
+//   - Read mid-write, the partial file fails to parse. Only that file is lost
+//     (node_textfile_scrape_error goes to 1 and no mtime series is emitted for
+//     it); other files and other collectors are unaffected.
+//   - Left behind by a crash between create and rename, it parses fine and
+//     holds a COMPLETE copy of every series, with stale values. The collector
+//     then serves whichever file the directory walk reaches first and silently
+//     drops the duplicate from the other, with node_textfile_scrape_error
+//     staying 0. A leftover sorting before the real file therefore pins this
+//     agent's health at whatever it said — including a healthy-looking zero —
+//     for as long as it exists, with no error metric anywhere.
+//
+// The second case is why the suffix matters more than the atomicity: a lost
+// scrape is a gap, while a leftover is a lie that defeats the whole signal.
+const tempPattern = ".tuist-log-shipper-*.tmp"
+
 // NewHealth returns a writer publishing to path.
 func NewHealth(path string, logf func(format string, args ...any)) *Health {
-	return &Health{
+	h := &Health{
 		path:     path,
 		build:    buildInfoLine(),
 		bySource: map[string]*sourceHealth{},
 		logf:     logf,
+	}
+	h.removeStaleTemps()
+	return h
+}
+
+// removeStaleTemps clears temp files an earlier run died holding.
+//
+// They are invisible to the collector, so this is about the disk rather than
+// correctness: a launchd job with KeepAlive that crashes in that window on every
+// start would otherwise accumulate them on hosts whose free space already
+// warrants a golden-image GC. Construction is the safe moment for it, because
+// this process has not opened one yet, and only one agent ever owns a given
+// path.
+func (h *Health) removeStaleTemps() {
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(h.path), tempPattern))
+	if err != nil {
+		return
+	}
+	for _, match := range matches {
+		_ = os.Remove(match)
 	}
 }
 
@@ -129,17 +171,18 @@ func (h *Health) record(job string, mutate func(*sourceHealth)) {
 
 // write renders every source and publishes the document atomically.
 //
-// The temp file goes in the target's own directory and is renamed into place.
-// node_exporter reads the whole directory on every scrape, and a partially
-// written file is a parse error for the DIRECTORY, not a missing metric — it
-// would take the host's node_* series down with it, breaking more observability
-// than it adds. Callers hold h.mu.
+// The temp file goes in the target's own directory and is renamed into place, so
+// a scrape landing mid-write reads the previous complete document rather than a
+// half-written one. node_exporter isolates a parse failure to the file it
+// happened in (measured, 1.8.2), so the cost of getting this wrong is not the
+// host's other metrics: it is this agent's own health disappearing from the
+// scrape exactly while something is wrong with it. Callers hold h.mu.
 func (h *Health) write() error {
 	dir := filepath.Dir(h.path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir textfile dir: %w", err)
 	}
-	tmp, err := os.CreateTemp(dir, ".tuist-log-shipper-*.prom")
+	tmp, err := os.CreateTemp(dir, tempPattern)
 	if err != nil {
 		return fmt.Errorf("create textfile temp: %w", err)
 	}
@@ -170,13 +213,24 @@ func (h *Health) write() error {
 	return nil
 }
 
+// sourceLabel names the tailed source a sample belongs to.
+//
+// Deliberately NOT `job`, even though the value IS the Loki `job` label the
+// source's lines carry. `job` is a reserved target label: Prometheus scrapes
+// with honor_labels=false (the default, and the macOS fleet's scrape does not
+// override it), so a `job` in the exposition collides with the scrape's own
+// job_name. The sample would arrive carrying job="tuist-macos-node-exporter"
+// with our value silently moved to `exported_job`, and every query grouping by
+// `job` would collapse all sources into one and label them with the scrape job.
+const sourceLabel = "source_job"
+
 // render builds the exposition document. Callers hold h.mu.
 func (h *Health) render() string {
-	jobs := make([]string, 0, len(h.bySource))
-	for job := range h.bySource {
-		jobs = append(jobs, job)
+	sources := make([]string, 0, len(h.bySource))
+	for source := range h.bySource {
+		sources = append(sources, source)
 	}
-	sort.Strings(jobs)
+	sort.Strings(sources)
 
 	var b strings.Builder
 	if h.build != "" {
@@ -212,9 +266,10 @@ func (h *Health) render() string {
 		},
 	} {
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n", family.name, family.help, family.name)
-		for _, job := range jobs {
-			fmt.Fprintf(&b, "%s{job=\"%s\"} %s\n",
-				family.name, escapeLabelValue(job), strconv.FormatInt(family.value(h.bySource[job]), 10))
+		for _, source := range sources {
+			fmt.Fprintf(&b, "%s{%s=\"%s\"} %s\n",
+				family.name, sourceLabel, escapeLabelValue(source),
+				strconv.FormatInt(family.value(h.bySource[source]), 10))
 		}
 	}
 	return b.String()

--- a/infra/macos-log-shipper/internal/shipper/health.go
+++ b/infra/macos-log-shipper/internal/shipper/health.go
@@ -1,0 +1,269 @@
+package shipper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultHealthPath is where the agent publishes its own health for
+// node_exporter's textfile collector to pick up.
+//
+// This is the whole point of the file: the agent is the thing that reports, so
+// when it breaks nothing reports, and "installed but failing" is
+// indistinguishable from "not installed" from off-host. Twice that produced a
+// multi-day outage while `launchctl print` cheerfully reported the job
+// `running` with correct arguments. Through both investigations SSH to the minis
+// hung and production kubectl never returned, while node_exporter's :9100
+// answered instantly every time — so :9100 is the channel this signal rides.
+//
+// The directory is mirrored in macos-host-bootstrap's nodeExporterTextfileDir,
+// which creates it and passes it to node_exporter as
+// --collector.textfile.directory. They are separate Go modules, so the two
+// sides agree by convention; changing one without the other publishes a file
+// nothing reads.
+const DefaultHealthPath = "/var/lib/node_exporter/textfile/tuist-log-shipper.prom"
+
+// sourceHealth is one tailed source's health as the agent last observed it.
+type sourceHealth struct {
+	// lastSuccess is when a push last returned 2xx. Zero means never, which is
+	// the state a freshly installed agent that has never delivered a line stays
+	// in — the distinction the whole file exists to expose.
+	lastSuccess int64
+	failures    int64
+	offset      int64
+	size        int64
+}
+
+// Health publishes the agent's own health as a Prometheus textfile.
+//
+// A nil *Health is valid and does nothing, so a construction path that wants no
+// health signal needs no branch on the hot path.
+type Health struct {
+	mu       sync.Mutex
+	path     string
+	build    string
+	bySource map[string]*sourceHealth
+	logf     func(format string, args ...any)
+	// Only the first write failure is logged, for the same reason tail logs only
+	// the first of a run of identical failures: a line per poll is tens of
+	// thousands a day onto a disk whose free space already warrants a golden-image
+	// GC.
+	logged bool
+}
+
+// NewHealth returns a writer publishing to path.
+func NewHealth(path string, logf func(format string, args ...any)) *Health {
+	return &Health{
+		path:     path,
+		build:    buildInfoLine(),
+		bySource: map[string]*sourceHealth{},
+		logf:     logf,
+	}
+}
+
+// Success records a push the receiver accepted.
+func (h *Health) Success(job string, at time.Time) {
+	h.record(job, func(state *sourceHealth) {
+		state.lastSuccess = at.Unix()
+		state.failures = 0
+	})
+}
+
+// Failure records one failed attempt: a poll that could not read the file, or a
+// single push attempt that did not land.
+//
+// Counting individual push attempts rather than poll outcomes is deliberate.
+// push retries a retryable failure forever, so during a receiver outage poll
+// never returns and a poll-boundary-only counter would publish nothing for the
+// whole outage — the metric would freeze at whatever it read before the failure
+// started, which is the same silence this file is meant to break. Counted per
+// attempt, the number climbs and matches the `attempt N` the agent's own log
+// carries.
+func (h *Health) Failure(job string) {
+	h.record(job, func(state *sourceHealth) { state.failures++ })
+}
+
+// Progress records how far the persisted position has got relative to the
+// file's current size. Both are needed: the difference is the lag, and during an
+// outage the offset stays put while the file grows.
+func (h *Health) Progress(job string, offset, size int64) {
+	h.record(job, func(state *sourceHealth) {
+		state.offset = offset
+		state.size = size
+	})
+}
+
+// record mutates one source's state and republishes the whole document.
+//
+// Republishing on every outcome rather than on change is what makes the file's
+// own mtime a liveness signal: node_exporter exposes it as
+// node_textfile_mtime_seconds, so an agent that has died stops advancing it
+// without needing a heartbeat metric of its own.
+func (h *Health) record(job string, mutate func(*sourceHealth)) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	state, ok := h.bySource[job]
+	if !ok {
+		state = &sourceHealth{}
+		h.bySource[job] = state
+	}
+	mutate(state)
+	if err := h.write(); err != nil && !h.logged {
+		h.logged = true
+		h.logf("publish health metrics to %s: %v", h.path, err)
+	}
+}
+
+// write renders every source and publishes the document atomically.
+//
+// The temp file goes in the target's own directory and is renamed into place.
+// node_exporter reads the whole directory on every scrape, and a partially
+// written file is a parse error for the DIRECTORY, not a missing metric — it
+// would take the host's node_* series down with it, breaking more observability
+// than it adds. Callers hold h.mu.
+func (h *Health) write() error {
+	dir := filepath.Dir(h.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir textfile dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tuist-log-shipper-*.prom")
+	if err != nil {
+		return fmt.Errorf("create textfile temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func(err error) error {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if _, err := tmp.WriteString(h.render()); err != nil {
+		return cleanup(fmt.Errorf("write textfile temp: %w", err))
+	}
+	// CreateTemp makes the file 0600. The agent runs as root under launchd and
+	// node_exporter runs from its own job, so a file only the writer can read is
+	// a file the collector skips — which reads exactly like an agent that is not
+	// running.
+	if err := tmp.Chmod(0o644); err != nil {
+		return cleanup(fmt.Errorf("chmod textfile temp: %w", err))
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close textfile temp: %w", err)
+	}
+	if err := os.Rename(tmpName, h.path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename textfile: %w", err)
+	}
+	return nil
+}
+
+// render builds the exposition document. Callers hold h.mu.
+func (h *Health) render() string {
+	jobs := make([]string, 0, len(h.bySource))
+	for job := range h.bySource {
+		jobs = append(jobs, job)
+	}
+	sort.Strings(jobs)
+
+	var b strings.Builder
+	if h.build != "" {
+		b.WriteString("# HELP tuist_log_shipper_build_info Which log shipper binary this host is carrying.\n")
+		b.WriteString("# TYPE tuist_log_shipper_build_info gauge\n")
+		b.WriteString(h.build)
+	}
+	// Samples of one metric family have to be contiguous, so this writes family
+	// by family rather than source by source.
+	for _, family := range []struct {
+		name, help string
+		value      func(*sourceHealth) int64
+	}{
+		{
+			"tuist_log_shipper_last_success_timestamp_seconds",
+			"Unix time of the last push the receiver accepted. 0 means this source has never delivered a line.",
+			func(s *sourceHealth) int64 { return s.lastSuccess },
+		},
+		{
+			"tuist_log_shipper_consecutive_failures",
+			"Failed read or push attempts since the last accepted push.",
+			func(s *sourceHealth) int64 { return s.failures },
+		},
+		{
+			"tuist_log_shipper_position_offset_bytes",
+			"How far into the source file the agent has read AND successfully pushed.",
+			func(s *sourceHealth) int64 { return s.offset },
+		},
+		{
+			"tuist_log_shipper_source_size_bytes",
+			"Current size of the source file. The gap to the offset is the shipping lag.",
+			func(s *sourceHealth) int64 { return s.size },
+		},
+	} {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n", family.name, family.help, family.name)
+		for _, job := range jobs {
+			fmt.Fprintf(&b, "%s{job=\"%s\"} %s\n",
+				family.name, escapeLabelValue(job), strconv.FormatInt(family.value(h.bySource[job]), 10))
+		}
+	}
+	return b.String()
+}
+
+// escapeLabelValue applies the exposition format's escaping. Job names come from
+// the operator's --file flags, so this is not defence against a hostile value;
+// it is defence against publishing a document node_exporter cannot parse, which
+// is the one failure this file must never cause.
+func escapeLabelValue(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`).Replace(value)
+}
+
+// buildInfoLine identifies the binary that is running.
+//
+// Which binary a host was carrying was itself an open question during the last
+// incident, and the place that answers it — HostConfigHash on the Machine — sits
+// behind the kubectl gateway that never returned. binary_sha256 hashes the
+// executable on disk, so it is the on-host bytes AFTER the bootstrap's ad-hoc
+// re-sign rather than the operator's embedded SHA: it does not join against the
+// image, but two hosts running the same build report the same value, which is
+// what "did this roll actually reach this host?" needs.
+//
+// Returning "" is fine: an unhashable executable costs one series, not the file.
+func buildInfoLine() string {
+	fingerprint := executableSHA256()
+	if fingerprint == "" {
+		return ""
+	}
+	return fmt.Sprintf("tuist_log_shipper_build_info{binary_sha256=\"%s\",go_version=\"%s\"} 1\n",
+		fingerprint, escapeLabelValue(runtime.Version()))
+}
+
+func executableSHA256() string {
+	path, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sum := sha256.New()
+	if _, err := io.Copy(sum, f); err != nil {
+		return ""
+	}
+	// Twelve hex characters, the same length git and container tooling use for a
+	// human-comparable digest, because the value is read by eye across a fleet
+	// table rather than joined against anything.
+	return hex.EncodeToString(sum.Sum(nil))[:12]
+}

--- a/infra/macos-log-shipper/internal/shipper/health_test.go
+++ b/infra/macos-log-shipper/internal/shipper/health_test.go
@@ -1,0 +1,268 @@
+package shipper
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// readMetrics parses the textfile the way node_exporter's textfile collector
+// does: every non-comment line is `<name>{<labels>} <value>`. The returned map
+// is keyed by the whole series identifier so a test can assert on one label set.
+func readMetrics(t *testing.T, path string) map[string]float64 {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return parseMetrics(t, string(raw))
+}
+
+func parseMetrics(t *testing.T, raw string) map[string]float64 {
+	t.Helper()
+	out := map[string]float64{}
+	for _, line := range strings.Split(raw, "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		series, value, ok := strings.Cut(line, " ")
+		if !ok {
+			t.Fatalf("line %q is not <series> <value>", line)
+		}
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			t.Fatalf("line %q has an unparseable value: %v", line, err)
+		}
+		if _, dup := out[series]; dup {
+			t.Fatalf("series %q appears twice; node_exporter rejects a duplicate", series)
+		}
+		out[series] = parsed
+	}
+	return out
+}
+
+func newTestHealth(t *testing.T) *Health {
+	t.Helper()
+	return NewHealth(filepath.Join(t.TempDir(), "tuist-log-shipper.prom"), func(string, ...any) {})
+}
+
+func TestHealthRecordsLastSuccessAndResetsConsecutiveFailures(t *testing.T) {
+	health := newTestHealth(t)
+
+	health.Failure("tuist-macos-tart-kubelet")
+	health.Failure("tuist-macos-tart-kubelet")
+	metrics := readMetrics(t, health.path)
+	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 2 {
+		t.Fatalf("consecutive_failures = %v, want 2", got)
+	}
+	// A stale last_success next to a growing failure count is the whole signal:
+	// an agent that has never delivered a line reports 0 here, and "installed
+	// but failing" stops looking like "not installed".
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+		t.Fatalf("last_success_timestamp_seconds = %v, want 0 before any push landed", got)
+	}
+
+	health.Success("tuist-macos-tart-kubelet", time.Unix(1_770_000_000, 0))
+	metrics = readMetrics(t, health.path)
+	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+		t.Fatalf("consecutive_failures = %v, want 0 after a success", got)
+	}
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
+		t.Fatalf("last_success_timestamp_seconds = %v, want 1770000000", got)
+	}
+}
+
+// Lag is the difference between the two, so both have to be published, and the
+// offset has to be the one that was persisted rather than the one the tail is
+// about to attempt — during a receiver outage the offset stays put while the
+// file grows, and that gap is the lag.
+func TestHealthPublishesOffsetAndSourceSize(t *testing.T) {
+	health := newTestHealth(t)
+	health.Progress("job", 4096, 65536)
+
+	metrics := readMetrics(t, health.path)
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="job"}`]; got != 4096 {
+		t.Fatalf("position_offset_bytes = %v, want 4096", got)
+	}
+	if got := metrics[`tuist_log_shipper_source_size_bytes{job="job"}`]; got != 65536 {
+		t.Fatalf("source_size_bytes = %v, want 65536", got)
+	}
+}
+
+// Which binary a host is carrying was itself a question during the outage, and
+// kubectl (where HostConfigHash is stamped) was the channel that did not answer.
+func TestHealthPublishesBuildInfo(t *testing.T) {
+	health := newTestHealth(t)
+	health.Failure("job")
+
+	raw, err := os.ReadFile(health.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(raw), "tuist_log_shipper_build_info{") {
+		t.Fatalf("no build_info series\n%s", raw)
+	}
+	for series, value := range parseMetrics(t, string(raw)) {
+		if strings.HasPrefix(series, "tuist_log_shipper_build_info{") && value != 1 {
+			t.Fatalf("%s = %v, want 1", series, value)
+		}
+	}
+}
+
+// One file carries every source, so a per-source update has to republish the
+// whole set. Dropping the other sources' series would make a second tailed file
+// read as "never succeeded" every time the first one polled.
+func TestHealthKeepsEverySourceOnAPerSourceUpdate(t *testing.T) {
+	health := newTestHealth(t)
+	health.Success("first", time.Unix(1_770_000_000, 0))
+	health.Success("second", time.Unix(1_770_000_001, 0))
+	health.Failure("first")
+
+	metrics := readMetrics(t, health.path)
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="second"}`]; got != 1_770_000_001 {
+		t.Fatalf("second source's last success = %v, want 1770000001", got)
+	}
+	if got := metrics[`tuist_log_shipper_consecutive_failures{job="first"}`]; got != 1 {
+		t.Fatalf("first source's failures = %v, want 1", got)
+	}
+}
+
+// node_exporter reads the whole directory on every scrape, so a reader can land
+// mid-write. A partially written file is a parse error for the WHOLE directory,
+// not a missing metric — it takes the host's node_* series down with it.
+func TestHealthWritesAtomically(t *testing.T) {
+	health := newTestHealth(t)
+	health.Success("job", time.Unix(1_770_000_000, 0))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			health.Progress("job", int64(i), int64(i)*4096)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			raw, err := os.ReadFile(health.path)
+			if err != nil {
+				t.Errorf("read during write: %v", err)
+				return
+			}
+			// Every rename publishes a complete document, so the last byte is
+			// always the newline that ends the last sample.
+			if !strings.HasSuffix(string(raw), "\n") {
+				t.Errorf("read a partially written document (%d bytes, no trailing newline)", len(raw))
+				return
+			}
+			if strings.Count(string(raw), "tuist_log_shipper_source_size_bytes{job=\"job\"}") != 1 {
+				t.Errorf("read an incomplete document:\n%s", raw)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	// The temp file has to be created in the target's own directory, or the
+	// rename crosses devices and stops being atomic. Nothing may be left behind.
+	entries, err := os.ReadDir(filepath.Dir(health.path))
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(health.path) {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("expected only %s in the collector directory, got %v", filepath.Base(health.path), names)
+	}
+}
+
+// node_exporter may not be running as the same user as the shipper (which is
+// root under launchd). A file only the writer can read is a file the collector
+// silently skips.
+func TestHealthFileIsReadableByTheCollector(t *testing.T) {
+	health := newTestHealth(t)
+	health.Failure("job")
+
+	info, err := os.Stat(health.path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("mode = %v, want 0644 so node_exporter can read it", perm)
+	}
+	dir, err := os.Stat(filepath.Dir(health.path))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dir.Mode().Perm(); perm&0o055 != 0o055 {
+		t.Fatalf("directory mode = %v, want it traversable and readable by the collector", perm)
+	}
+}
+
+// The directory is created by the node_exporter install step, which runs before
+// the shipper's — but the agent must not depend on that ordering, or a host
+// carrying the shipper without node_exporter publishes nothing.
+func TestHealthCreatesTheCollectorDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "node_exporter", "textfile", "tuist-log-shipper.prom")
+	health := NewHealth(path, func(string, ...any) {})
+	health.Failure("job")
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected the collector directory to be created: %v", err)
+	}
+}
+
+// A textfile that cannot be written is a lost health signal, not a reason to
+// stop shipping logs. It is logged once, for the same reason tail logs a
+// repeating failure once: a line per poll fills a disk that is already watched.
+func TestHealthLogsAWriteFailureOnce(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "textfile")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	var logged []string
+	health := NewHealth(filepath.Join(blocker, "tuist-log-shipper.prom"), func(format string, _ ...any) {
+		logged = append(logged, format)
+	})
+	for i := 0; i < 5; i++ {
+		health.Failure("job")
+	}
+	if len(logged) != 1 {
+		t.Fatalf("expected one log line for a repeating write failure, got %d: %v", len(logged), logged)
+	}
+}
+
+// A job label with a quote in it would close the label value early and make the
+// whole directory unparseable — the failure mode this file exists to avoid.
+func TestHealthEscapesLabelValues(t *testing.T) {
+	health := newTestHealth(t)
+	health.Failure(`job"\` + "\n")
+
+	raw, err := os.ReadFile(health.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(raw), `{job="job\"\\\n"}`) {
+		t.Fatalf("label value is not escaped\n%s", raw)
+	}
+	parseMetrics(t, string(raw))
+}
+
+// A nil writer is how every construction path that does not want a health
+// signal (tests, a run with the textfile disabled) stays valid. It must not
+// panic on the hot path.
+func TestHealthIsNilSafe(t *testing.T) {
+	var health *Health
+	health.Failure("job")
+	health.Success("job", time.Unix(1, 0))
+	health.Progress("job", 1, 2)
+}

--- a/infra/macos-log-shipper/internal/shipper/health_test.go
+++ b/infra/macos-log-shipper/internal/shipper/health_test.go
@@ -56,22 +56,22 @@ func TestHealthRecordsLastSuccessAndResetsConsecutiveFailures(t *testing.T) {
 	health.Failure("tuist-macos-tart-kubelet")
 	health.Failure("tuist-macos-tart-kubelet")
 	metrics := readMetrics(t, health.path)
-	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 2 {
+	if got := metrics[`tuist_log_shipper_consecutive_failures{source_job="tuist-macos-tart-kubelet"}`]; got != 2 {
 		t.Fatalf("consecutive_failures = %v, want 2", got)
 	}
 	// A stale last_success next to a growing failure count is the whole signal:
 	// an agent that has never delivered a line reports 0 here, and "installed
 	// but failing" stops looking like "not installed".
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="tuist-macos-tart-kubelet"}`]; got != 0 {
 		t.Fatalf("last_success_timestamp_seconds = %v, want 0 before any push landed", got)
 	}
 
 	health.Success("tuist-macos-tart-kubelet", time.Unix(1_770_000_000, 0))
 	metrics = readMetrics(t, health.path)
-	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+	if got := metrics[`tuist_log_shipper_consecutive_failures{source_job="tuist-macos-tart-kubelet"}`]; got != 0 {
 		t.Fatalf("consecutive_failures = %v, want 0 after a success", got)
 	}
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
 		t.Fatalf("last_success_timestamp_seconds = %v, want 1770000000", got)
 	}
 }
@@ -85,10 +85,10 @@ func TestHealthPublishesOffsetAndSourceSize(t *testing.T) {
 	health.Progress("job", 4096, 65536)
 
 	metrics := readMetrics(t, health.path)
-	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="job"}`]; got != 4096 {
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{source_job="job"}`]; got != 4096 {
 		t.Fatalf("position_offset_bytes = %v, want 4096", got)
 	}
-	if got := metrics[`tuist_log_shipper_source_size_bytes{job="job"}`]; got != 65536 {
+	if got := metrics[`tuist_log_shipper_source_size_bytes{source_job="job"}`]; got != 65536 {
 		t.Fatalf("source_size_bytes = %v, want 65536", got)
 	}
 }
@@ -123,17 +123,18 @@ func TestHealthKeepsEverySourceOnAPerSourceUpdate(t *testing.T) {
 	health.Failure("first")
 
 	metrics := readMetrics(t, health.path)
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="second"}`]; got != 1_770_000_001 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="second"}`]; got != 1_770_000_001 {
 		t.Fatalf("second source's last success = %v, want 1770000001", got)
 	}
-	if got := metrics[`tuist_log_shipper_consecutive_failures{job="first"}`]; got != 1 {
+	if got := metrics[`tuist_log_shipper_consecutive_failures{source_job="first"}`]; got != 1 {
 		t.Fatalf("first source's failures = %v, want 1", got)
 	}
 }
 
-// node_exporter reads the whole directory on every scrape, so a reader can land
-// mid-write. A partially written file is a parse error for the WHOLE directory,
-// not a missing metric — it takes the host's node_* series down with it.
+// node_exporter reads the directory on every scrape, so a reader can land
+// mid-write. A partial document fails to parse, and node_exporter isolates that
+// to the file it happened in: the cost is this agent's own health vanishing from
+// the scrape exactly while something is wrong with it.
 func TestHealthWritesAtomically(t *testing.T) {
 	health := newTestHealth(t)
 	health.Success("job", time.Unix(1_770_000_000, 0))
@@ -160,7 +161,7 @@ func TestHealthWritesAtomically(t *testing.T) {
 				t.Errorf("read a partially written document (%d bytes, no trailing newline)", len(raw))
 				return
 			}
-			if strings.Count(string(raw), "tuist_log_shipper_source_size_bytes{job=\"job\"}") != 1 {
+			if strings.Count(string(raw), "tuist_log_shipper_source_size_bytes{source_job=\"job\"}") != 1 {
 				t.Errorf("read an incomplete document:\n%s", raw)
 				return
 			}
@@ -180,6 +181,102 @@ func TestHealthWritesAtomically(t *testing.T) {
 			names = append(names, entry.Name())
 		}
 		t.Fatalf("expected only %s in the collector directory, got %v", filepath.Base(health.path), names)
+	}
+}
+
+// node_exporter selects the files it parses by their .prom suffix, so a temp
+// file carrying that suffix is read too and the rename stops being atomic from
+// the collector's point of view.
+//
+// The dangerous half is not the mid-write read (a parse failure, isolated to that
+// file) but the crash leftover: it is a COMPLETE document with stale values, and
+// two files holding the same series with different values make node_exporter
+// serve whichever the directory walk reaches first and silently drop the other,
+// with node_textfile_scrape_error staying 0. Both measured against 1.8.2 on a
+// production mini.
+func TestHealthTempFileIsInvisibleToTheCollector(t *testing.T) {
+	health := newTestHealth(t)
+	dir := filepath.Dir(health.path)
+	// filepath.Glob matches leading dots, exactly as node_exporter's suffix
+	// selection does, so a dot prefix alone hides nothing.
+	collectorGlob := filepath.Join(dir, "*.prom")
+	// Publish once up front so the target exists: the assertion below is about
+	// what the collector sees ALONGSIDE it, not about the moment before the
+	// agent's first write.
+	health.Progress("tuist-macos-tart-kubelet", 0, 0)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 400; i++ {
+			health.Progress("tuist-macos-tart-kubelet", int64(i), int64(i)*4096)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 400; i++ {
+			matches, err := filepath.Glob(collectorGlob)
+			if err != nil {
+				t.Errorf("glob: %v", err)
+				return
+			}
+			if len(matches) != 1 || matches[0] != health.path {
+				t.Errorf("node_exporter would parse %d files, want only %s: %v", len(matches), health.path, matches)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+// A crash in the window between create and rename leaves a temp file behind.
+// It is invisible to the collector once it is not a .prom, but a launchd job
+// with KeepAlive that crashes there on every start would still accumulate them
+// on a disk these hosts already watch closely enough to run a golden-image GC.
+func TestHealthRemovesTempFilesLeftBehindByAnEarlierCrash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tuist-log-shipper.prom")
+	stale := filepath.Join(dir, ".tuist-log-shipper-123456.tmp")
+	if err := os.WriteFile(stale, []byte("half a document"), 0o600); err != nil {
+		t.Fatalf("write stale temp: %v", err)
+	}
+	// A file that is not ours must survive: the directory is shared with any
+	// other host agent that publishes through the same collector.
+	foreign := filepath.Join(dir, "someone-else.prom")
+	if err := os.WriteFile(foreign, []byte("# HELP other_metric x\n"), 0o644); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+
+	NewHealth(path, func(string, ...any) {}).Failure("job")
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("expected the stale temp to be removed, stat returned %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("another agent's file was removed: %v", err)
+	}
+}
+
+// `job` is a reserved target label. Prometheus scrapes with honor_labels=false
+// (the Alloy default, and the macOS fleet's scrape does not set it), so a `job`
+// in the exposition collides with the scrape's own job_name: the series arrives
+// carrying job="tuist-macos-node-exporter" with our value moved to
+// `exported_job`. Every query grouping by `job` would then collapse all sources
+// into one and label them with the scrape job.
+func TestHealthDoesNotEmitTheReservedJobLabel(t *testing.T) {
+	health := newTestHealth(t)
+	health.Success("tuist-macos-tart-kubelet", time.Unix(1_770_000_000, 0))
+
+	raw, err := os.ReadFile(health.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(raw), `{job=`) || strings.Contains(string(raw), `,job=`) {
+		t.Fatalf("exposition carries the reserved `job` label; it would be renamed to exported_job at scrape time\n%s", raw)
+	}
+	if got := readMetrics(t, health.path)[`tuist_log_shipper_last_success_timestamp_seconds{source_job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
+		t.Fatalf("expected the source to be labelled source_job, got:\n%s", raw)
 	}
 }
 
@@ -251,7 +348,7 @@ func TestHealthEscapesLabelValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if !strings.Contains(string(raw), `{job="job\"\\\n"}`) {
+	if !strings.Contains(string(raw), `{source_job="job\"\\\n"}`) {
 		t.Fatalf("label value is not escaped\n%s", raw)
 	}
 	parseMetrics(t, string(raw))

--- a/infra/macos-log-shipper/internal/shipper/shipper.go
+++ b/infra/macos-log-shipper/internal/shipper/shipper.go
@@ -45,6 +45,11 @@ type Options struct {
 	BaseLabels map[string]string
 	Positions  *Positions
 	Client     *Client
+	// Health publishes the agent's own health where node_exporter's textfile
+	// collector picks it up. Nil disables it, which is the right shape here: the
+	// agent's job is shipping logs, and a host that cannot publish its health
+	// must still ship.
+	Health *Health
 	// PollInterval is how long to wait after a poll that found nothing.
 	PollInterval time.Duration
 	// Backoff paces retries of a push that failed for a retryable reason.
@@ -147,6 +152,7 @@ func (s *Shipper) poll(ctx context.Context, source Source, labels map[string]str
 	stored, known := s.opts.Positions.Get(source.Path)
 	res, err := ReadNew(source.Path, stored, known)
 	if err != nil {
+		s.opts.Health.Failure(source.Job)
 		return false, err
 	}
 	if res.Restarted {
@@ -156,11 +162,17 @@ func (s *Shipper) poll(ctx context.Context, source Source, labels map[string]str
 		// Still record the position: first sight of a file has to persist its
 		// end-of-file start point, or a restart before the first line arrives
 		// would skip to the new end and lose whatever landed in between.
+		//
+		// This branch pushes NOTHING, which is why the health signal reports the
+		// offset and the last successful push separately: an offset that equals
+		// the file size proves only that the agent saw the file.
 		if !known || res.Next != stored {
 			if err := s.opts.Positions.Set(source.Path, res.Next); err != nil {
+				s.opts.Health.Failure(source.Job)
 				return false, err
 			}
 		}
+		s.observe(source)
 		return false, nil
 	}
 
@@ -169,30 +181,66 @@ func (s *Shipper) poll(ctx context.Context, source Source, labels map[string]str
 	for _, line := range res.Lines {
 		entries = append(entries, ParseEntry(line, now))
 	}
-	if err := s.push(ctx, labels, entries); err != nil {
+	if err := s.push(ctx, source, labels, entries); err != nil {
+		// push already recorded every attempt it made.
 		return false, err
 	}
 	if err := s.opts.Positions.Set(source.Path, res.Next); err != nil {
+		s.opts.Health.Failure(source.Job)
 		return true, err
 	}
+	s.observe(source)
 	return true, nil
+}
+
+// observe publishes one source's lag: the offset that has actually landed
+// against the file's size right now.
+//
+// Both halves are read fresh rather than taken from the poll that just ran. The
+// persisted offset is the only one that means "shipped", and a fresh stat is the
+// only size that keeps growing while a push retries — push blocks inside a single
+// poll for as long as the receiver is unreachable, so a size captured when that
+// poll started would report a constant lag through an outage of any length.
+//
+// A stat that fails is not recorded: the failure it represents has already been
+// counted by the caller, and publishing a zero size would read as an empty file.
+func (s *Shipper) observe(source Source) {
+	if s.opts.Health == nil {
+		return
+	}
+	_, size, err := statFile(source.Path)
+	if err != nil {
+		return
+	}
+	stored, _ := s.opts.Positions.Get(source.Path)
+	s.opts.Health.Progress(source.Job, stored.Offset, size)
 }
 
 // push retries a batch until it lands, Loki rejects it outright, or the
 // context ends. It never gives up on a retryable failure: the unread remainder
 // of the file is durable on disk, so waiting costs lag, while skipping ahead
 // would cost exactly the lines someone is looking for.
-func (s *Shipper) push(ctx context.Context, labels map[string]string, entries []Entry) error {
+func (s *Shipper) push(ctx context.Context, source Source, labels map[string]string, entries []Entry) error {
 	for attempt := 0; ctx.Err() == nil; attempt++ {
 		err := s.opts.Client.Push(ctx, labels, entries)
 		if err == nil {
+			s.opts.Health.Success(source.Job, s.opts.Now())
 			return nil
 		}
 		if errors.Is(err, ErrRejected) {
-			s.opts.Logf("dropping %d lines for %s: %v", len(entries), labels["job"], err)
+			// Neither a success nor a transport failure: the receiver answered and
+			// refused the batch, and the agent advances past it. Moving
+			// last_success would claim lines landed that did not; counting it as a
+			// failure would grow a number that is documented to reset on success
+			// while the offset keeps advancing. A batch stream that is entirely
+			// rejected shows up as exactly what it is — the offset climbing while
+			// last_success stays frozen.
+			s.opts.Logf("dropping %d lines for %s: %v", len(entries), source.Job, err)
 			return nil
 		}
-		s.opts.Logf("push %d lines for %s failed (attempt %d): %v", len(entries), labels["job"], attempt+1, err)
+		s.opts.Health.Failure(source.Job)
+		s.observe(source)
+		s.opts.Logf("push %d lines for %s failed (attempt %d): %v", len(entries), source.Job, attempt+1, err)
 		if !sleep(ctx, s.opts.Backoff.Next(attempt)) {
 			break
 		}

--- a/infra/macos-log-shipper/internal/shipper/shipper_test.go
+++ b/infra/macos-log-shipper/internal/shipper/shipper_test.go
@@ -144,10 +144,10 @@ func TestFirstSightTakesAPositionWithoutPushingAndOnlyAnAppendReportsSuccess(t *
 		t.Fatal("first sight must not push; an offset that equals the file size is not evidence of a push")
 	}
 	metrics := readMetrics(t, agent.opts.Health.path)
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="tuist-macos-tart-kubelet"}`]; got != 0 {
 		t.Fatalf("last_success_timestamp_seconds = %v after first sight, want 0 — nothing was pushed", got)
 	}
-	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="tuist-macos-tart-kubelet"}`]; got != float64(firstSight.Offset) {
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{source_job="tuist-macos-tart-kubelet"}`]; got != float64(firstSight.Offset) {
 		t.Fatalf("position_offset_bytes = %v, want the persisted first-sight offset %d", got, firstSight.Offset)
 	}
 
@@ -164,13 +164,13 @@ func TestFirstSightTakesAPositionWithoutPushingAndOnlyAnAppendReportsSuccess(t *
 		t.Fatalf("expected exactly one push, got %d", len(loki.all()))
 	}
 	metrics = readMetrics(t, agent.opts.Health.path)
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
 		t.Fatalf("last_success_timestamp_seconds = %v, want the push time 1770000000", got)
 	}
-	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+	if got := metrics[`tuist_log_shipper_consecutive_failures{source_job="tuist-macos-tart-kubelet"}`]; got != 0 {
 		t.Fatalf("consecutive_failures = %v after a successful push, want 0", got)
 	}
-	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="tuist-macos-tart-kubelet"}`]; got != float64(after.Offset) {
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{source_job="tuist-macos-tart-kubelet"}`]; got != float64(after.Offset) {
 		t.Fatalf("position_offset_bytes = %v, want %d", got, after.Offset)
 	}
 }
@@ -213,16 +213,16 @@ func TestHealthCountsPushAttemptsWhileTheOffsetStaysPut(t *testing.T) {
 	<-done
 
 	metrics := readMetrics(t, health.path)
-	if got := metrics[`tuist_log_shipper_consecutive_failures{job="job"}`]; got < 3 {
+	if got := metrics[`tuist_log_shipper_consecutive_failures{source_job="job"}`]; got < 3 {
 		t.Fatalf("consecutive_failures = %v, want the retry loop's attempts to be visible", got)
 	}
-	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="job"}`]; got != 0 {
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{source_job="job"}`]; got != 0 {
 		t.Fatalf("last_success_timestamp_seconds = %v, want 0 — nothing ever landed", got)
 	}
 	// Lag is visible because the offset is frozen at first sight while the file
 	// grew past it.
-	offset := metrics[`tuist_log_shipper_position_offset_bytes{job="job"}`]
-	size := metrics[`tuist_log_shipper_source_size_bytes{job="job"}`]
+	offset := metrics[`tuist_log_shipper_position_offset_bytes{source_job="job"}`]
+	size := metrics[`tuist_log_shipper_source_size_bytes{source_job="job"}`]
 	if offset != float64(firstSight.Offset) || size <= offset {
 		t.Fatalf("offset = %v, size = %v; want the offset frozen at %d with the file grown past it", offset, size, firstSight.Offset)
 	}

--- a/infra/macos-log-shipper/internal/shipper/shipper_test.go
+++ b/infra/macos-log-shipper/internal/shipper/shipper_test.go
@@ -61,6 +61,7 @@ func newTestShipper(t *testing.T, path, url string) (*Shipper, *Positions) {
 		BaseLabels:   map[string]string{"instance": "tuist-runners-fleet-abc", "env": "staging"},
 		Positions:    positions,
 		Client:       &Client{URL: url},
+		Health:       NewHealth(filepath.Join(t.TempDir(), "tuist-log-shipper.prom"), func(string, ...any) {}),
 		PollInterval: time.Millisecond,
 		Backoff:      Backoff{Initial: time.Millisecond, Max: 2 * time.Millisecond},
 		Now:          func() time.Time { return time.Unix(1_770_000_000, 0) },
@@ -111,6 +112,160 @@ func TestPollShipsWithJobInstanceAndLevelLabels(t *testing.T) {
 	}
 	if got := pushes[0].Streams[1].Stream["level"]; got != "info" {
 		t.Fatalf("second stream level = %q, want info (levels are sorted)", got)
+	}
+}
+
+// The first sight of a file takes its end as the start position and returns
+// WITHOUT pushing anything, so an offset that equals the file size proves only
+// that the agent saw the file — no network call happened. Reading it as proof of
+// a successful push is what shipped a broken fix once.
+//
+// The health signal has to draw the same distinction: after first sight
+// last_success is still 0, and only an append that actually lands moves it.
+func TestFirstSightTakesAPositionWithoutPushingAndOnlyAnAppendReportsSuccess(t *testing.T) {
+	loki := &recorder{}
+	server := httptest.NewServer(loki.handler())
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "tart-kubelet.log")
+	// A long-lived host's log is not empty when the agent is installed.
+	writeFile(t, path, "months of history nobody asked for\n")
+	agent, positions := newTestShipper(t, path, server.URL)
+	labels := map[string]string{"job": "tuist-macos-tart-kubelet"}
+
+	if _, err := agent.poll(context.Background(), agent.opts.Sources[0], labels); err != nil {
+		t.Fatalf("first-sight poll: %v", err)
+	}
+	firstSight, ok := positions.Get(path)
+	if !ok {
+		t.Fatal("expected first sight to persist a position")
+	}
+	if len(loki.all()) != 0 {
+		t.Fatal("first sight must not push; an offset that equals the file size is not evidence of a push")
+	}
+	metrics := readMetrics(t, agent.opts.Health.path)
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+		t.Fatalf("last_success_timestamp_seconds = %v after first sight, want 0 — nothing was pushed", got)
+	}
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="tuist-macos-tart-kubelet"}`]; got != float64(firstSight.Offset) {
+		t.Fatalf("position_offset_bytes = %v, want the persisted first-sight offset %d", got, firstSight.Offset)
+	}
+
+	appendFile(t, path, `{"level":"info","ts":1770000000,"msg":"the line that proves the network works"}`+"\n")
+	if _, err := agent.poll(context.Background(), agent.opts.Sources[0], labels); err != nil {
+		t.Fatalf("poll after append: %v", err)
+	}
+
+	after, _ := positions.Get(path)
+	if after.Offset <= firstSight.Offset {
+		t.Fatalf("offset did not advance past the first-sight mark: %d -> %d", firstSight.Offset, after.Offset)
+	}
+	if len(loki.all()) != 1 {
+		t.Fatalf("expected exactly one push, got %d", len(loki.all()))
+	}
+	metrics = readMetrics(t, agent.opts.Health.path)
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="tuist-macos-tart-kubelet"}`]; got != 1_770_000_000 {
+		t.Fatalf("last_success_timestamp_seconds = %v, want the push time 1770000000", got)
+	}
+	if got := metrics[`tuist_log_shipper_consecutive_failures{job="tuist-macos-tart-kubelet"}`]; got != 0 {
+		t.Fatalf("consecutive_failures = %v after a successful push, want 0", got)
+	}
+	if got := metrics[`tuist_log_shipper_position_offset_bytes{job="tuist-macos-tart-kubelet"}`]; got != float64(after.Offset) {
+		t.Fatalf("position_offset_bytes = %v, want %d", got, after.Offset)
+	}
+}
+
+// The failure mode that was invisible for days: the job is `running`, its
+// arguments are correct, and every push fails. push() retries a retryable
+// failure forever, so poll() never returns and a poll-boundary-only writer would
+// publish nothing at all for the duration. The count has to come from inside the
+// retry loop.
+func TestHealthCountsPushAttemptsWhileTheOffsetStaysPut(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tart-kubelet.log")
+	writeFile(t, path, "")
+	health := NewHealth(filepath.Join(t.TempDir(), "tuist-log-shipper.prom"), func(string, ...any) {})
+	positions := LoadPositions(filepath.Join(t.TempDir(), "positions.json"))
+	agent, err := New(Options{
+		Sources:      []Source{{Job: "job", Path: path}},
+		Positions:    positions,
+		Client:       &Client{URL: "http://127.0.0.1:1/loki/api/v1/push"},
+		Health:       health,
+		PollInterval: time.Millisecond,
+		Backoff:      Backoff{Initial: time.Millisecond, Max: time.Millisecond},
+		Now:          func() time.Time { return time.Unix(1_770_000_000, 0) },
+		Logf:         func(string, ...any) {},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := agent.poll(context.Background(), agent.opts.Sources[0], map[string]string{"job": "job"}); err != nil {
+		t.Fatalf("first-sight poll: %v", err)
+	}
+	firstSight, _ := positions.Get(path)
+	appendFile(t, path, "a line that can never land\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); agent.tail(ctx, agent.opts.Sources[0]) }()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+
+	metrics := readMetrics(t, health.path)
+	if got := metrics[`tuist_log_shipper_consecutive_failures{job="job"}`]; got < 3 {
+		t.Fatalf("consecutive_failures = %v, want the retry loop's attempts to be visible", got)
+	}
+	if got := metrics[`tuist_log_shipper_last_success_timestamp_seconds{job="job"}`]; got != 0 {
+		t.Fatalf("last_success_timestamp_seconds = %v, want 0 — nothing ever landed", got)
+	}
+	// Lag is visible because the offset is frozen at first sight while the file
+	// grew past it.
+	offset := metrics[`tuist_log_shipper_position_offset_bytes{job="job"}`]
+	size := metrics[`tuist_log_shipper_source_size_bytes{job="job"}`]
+	if offset != float64(firstSight.Offset) || size <= offset {
+		t.Fatalf("offset = %v, size = %v; want the offset frozen at %d with the file grown past it", offset, size, firstSight.Offset)
+	}
+}
+
+// A textfile the agent cannot write is a lost health signal. Losing the logs too
+// would make the observability change strictly worse than not having it.
+func TestAFailingHealthWriteDoesNotStopShipping(t *testing.T) {
+	loki := &recorder{}
+	server := httptest.NewServer(loki.handler())
+	defer server.Close()
+
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "textfile")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	path := filepath.Join(dir, "tart-kubelet.log")
+	writeFile(t, path, "")
+	var logged []string
+	agent, positions := newTestShipper(t, path, server.URL)
+	agent.opts.Health = NewHealth(filepath.Join(blocker, "tuist-log-shipper.prom"), func(format string, _ ...any) {
+		logged = append(logged, format)
+	})
+	labels := map[string]string{"job": "tuist-macos-tart-kubelet"}
+
+	if _, err := agent.poll(context.Background(), agent.opts.Sources[0], labels); err != nil {
+		t.Fatalf("first-sight poll: %v", err)
+	}
+	appendFile(t, path, "a line\n")
+	if _, err := agent.poll(context.Background(), agent.opts.Sources[0], labels); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if len(loki.all()) != 1 {
+		t.Fatalf("expected the line to ship despite the unwritable textfile, got %d pushes", len(loki.all()))
+	}
+	if _, ok := positions.Get(path); !ok {
+		t.Fatal("expected the position to advance despite the unwritable textfile")
+	}
+	if len(logged) != 1 {
+		t.Fatalf("expected the write failure to be logged once, got %d: %v", len(logged), logged)
 	}
 }
 


### PR DESCRIPTION
Follow-up to [tuist/tuist#12343](https://github.com/tuist/tuist/pull/12343), [tuist/tuist#12374](https://github.com/tuist/tuist/pull/12374) and [tuist/tuist#12376](https://github.com/tuist/tuist/pull/12376).

## Why

`tuist-log-shipper`'s failures are invisible for exactly the reason the agent exists: it is the thing that reports host logs, so when it breaks nothing reports. "Installed but failing" and "not installed" are indistinguishable from off-host, and that has now produced two multi-day outages:

- [#12343](https://github.com/tuist/tuist/pull/12343) shipped the agent. It never delivered a line. `launchctl print` reported the job `running` with correct arguments the whole time.
- [#12374](https://github.com/tuist/tuist/pull/12374) fixed half the cause and shipped on a misread test. Production kept failing for another day, at attempt 494 per host.
- [#12376](https://github.com/tuist/tuist/pull/12376) fixed the other half (fully qualified receiver URL).

Throughout both investigations, SSH to the minis hung on most hosts and production `kubectl` through the Pomerium gateway never returned, while `:9100` (node_exporter) answered instantly, every single time. That is the channel this builds on.

## What changed

**The agent publishes its own health as a Prometheus textfile.** New `internal/shipper/health.go`, written to `/var/lib/node_exporter/textfile/tuist-log-shipper.prom` (`shipper.DefaultHealthPath`). Per tailed source, labelled `source_job`:

| Metric | What it answers |
| --- | --- |
| `tuist_log_shipper_last_success_timestamp_seconds` | When a push last returned 2xx. **`0` means this source has never delivered a line**, which is the state both outages were in. |
| `tuist_log_shipper_consecutive_failures` | Failed read or push attempts since the last accepted push. Resets to 0 on success. |
| `tuist_log_shipper_position_offset_bytes` | How far the agent has read *and* pushed. |
| `tuist_log_shipper_source_size_bytes` | The source file's size right now. The gap to the offset is the lag. |
| `tuist_log_shipper_build_info` | `binary_sha256` of the on-host executable plus the Go version. |

**node_exporter is told to read it.** `renderNodeExporterScript` runs with `--collector.disable-defaults`, so the textfile collector is off unless named: the wrapper now passes `--collector.textfile` and `--collector.textfile.directory`, and the install script creates the directory `0755` (both levels) since `mkdir -p` would otherwise leave the parent at the process umask.

**The Alloy keep-list admits the new series.** The macOS fleet's scrape passes through a `prometheus.relabel` block in `infra/helm/k8s-monitoring/values.yaml` whose regex is a `keep` action, so a series not named there is dropped before the Grafana Cloud remote_write. Added `tuist_log_shipper_.*`, plus `node_textfile_mtime_seconds` (a heartbeat, since the agent rewrites its file on every poll outcome) and `node_textfile_scrape_error`.

**Four recommended alert rules** are documented in that chart's `alerts.md`, under *Runner host log shipper* (not delivering, stalled, absent, and textfile metrics unparseable).

## Design decisions worth reviewing

Six things are load-bearing rather than incidental, and each has a test:

1. **The source label is `source_job`, not `job`.** `job` is a reserved target label and this scrape does not set `honor_labels`, so the default `false` applies: a `job` in the exposition would arrive as `job="tuist-macos-node-exporter"` with the agent's value moved to `exported_job`, and any query grouping by `job` would collapse every tailed source into one series labelled with the scrape job. The value is still the Loki `job` label the source's lines carry, so it joins against Loki unchanged.

2. **The pre-rename temp file must not end in `.prom`.** node_exporter selects the files it parses by that suffix, and Go's glob matches leading dots, so a `.prom` temp is parsed too and the rename is not atomic from the collector's point of view at all. The mid-write read is the milder half. The severe half is the crash leftover: it is a *complete* document holding every series with stale values, and two files holding the same series with different values make the collector serve whichever the directory walk reaches first and **silently drop the other, with `node_textfile_scrape_error` staying 0**. A leftover sorting before the real file pins the agent's health at whatever it said, including a healthy-looking zero, indefinitely and with no error metric anywhere. A lost scrape is a gap; a leftover is a lie. Stale temps are swept at construction so a job crashing in that window on every restart cannot accumulate them.

3. **The write is atomic** (temp in the same directory, then `os.Rename`), so a scrape landing mid-write reads the previous complete document. See the correction below for what this does and does not protect.

4. **The failure count is incremented from inside the push retry loop, not at poll boundaries.** `push` retries a retryable failure forever, so during a receiver outage `poll` never returns. A poll-boundary-only writer would publish nothing at all for the duration of the exact failure this exists to expose: the metric would freeze at whatever it last read. Counted per attempt, it climbs in step with the `attempt N` the agent's own log already carries.

5. **The published size is re-stat'd on every failed attempt** (`Shipper.observe`), for the same reason. A size captured when the blocked poll started would report a constant lag through an outage of any length. `observe` reads the persisted offset (the only one that means "shipped") against a fresh stat, so lag stays truthful.

6. **A failure to write the textfile does not stop shipping**, and is logged once, matching the existing first-failure-only pattern in `tail`. Losing the logs in order to keep the metric would be worse than having no metric.

An agent that dies *before its first write* is invisible to a threshold rule: `node_textfile_mtime_seconds` exists only for files the collector read, and `tuist_log_shipper_*` only once the agent has written. `alerts.md`'s own convention runs threshold rules with **No Data: Normal**, so "no series" reads as healthy. *Runner host log shipper absent* closes that with an `unless` against node_exporter's own `up`, which exists from the moment the provider creates a mini's egress Service. The `unless` form keeps working under No Data: Normal because the healthy case is an empty result while the unhealthy case produces a real series. Seeding a placeholder at install time was the alternative and was rejected: it cannot cover a host the install step never reached.

A permanent rejection (`ErrRejected`) deliberately moves neither counter: the receiver answered and refused the batch, so claiming a success would be false, while counting a failure would grow a number documented to reset on success while the offset keeps advancing. A fully rejected stream instead shows up as what it is: the offset climbing while `last_success` stays frozen.

The uninstall removes the `.prom` file along with the binary. node_exporter keeps reading the directory whether or not the agent exists, so a left-behind file would publish a frozen `last_success` forever: a phantom agent alerting about a host that carries none.

`--metrics` exists as a flag rather than a hardcoded constant for one concrete reason, not speculation: it is how you validate a binary on a host without clobbering the installed agent's file. The bootstrap does not pass it, so no new config surface lands in the launchd plist.

## Correction: a malformed textfile does not take down the host's other metrics

An earlier revision of this branch asserted, in code comments and in all three documents, that a partially written file is "a parse error for the DIRECTORY" that "takes the host's `node_*` series down with it". That is wrong, and it is now corrected everywhere.

Measured against node_exporter 1.8.2 on a production mini: a parse failure is isolated to the file it happened in. That file's metrics are dropped, `node_textfile_scrape_error` goes to 1, no `node_textfile_mtime_seconds` is emitted for it, and every other file and collector is unaffected, with `node_scrape_collector_success{collector="textfile"}` still 1. The atomic write is still correct, but for the narrower reason that a mid-write scrape loses this agent's own health precisely while something is wrong with it.

One useful consequence: a permanently corrupt `.prom` emits no mtime series, so it trips the absence rule rather than only stalling the heartbeat rule.

## Impact

Changing the node_exporter wrapper moves `HostConfigHash`, so **this rolls to every Mac mini**. That is intended and is how the collector flags reach already-bootstrapped hosts. `installLogShipper` still runs last in both `Run` and `UpdateTartKubelet`, so a failure in the observability path cannot block the tart-kubelet and firewall config the same roll carries.

No customer data is involved: the series carry only `source_job` plus the `instance`/`env` labels Alloy already adds, so `server/data-export.md` needs no change.

## How to test locally

```bash
cd infra/macos-log-shipper && go test ./... -race
GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/tuist-log-shipper
cd ../macos-host-bootstrap && go test ./...
```

The bootstrap tests assert the rendered scripts and shell validity (the wrapper is extracted from its heredoc and run through `sh -n`, since a syntax error there takes `:9100` down, which is the one channel that stayed answerable through both outages).

## Validation on a production host

Run against `tuist-tuist-runners-fleet-mndbc-m42wr`, which is **still carrying the pre-[#12376](https://github.com/tuist/tuist/pull/12376) binary at attempt 1177**, with a positions file untouched since Aug 14: a live instance of the invisible failure this makes visible.

Guarding against the specific misread that shipped [#12374](https://github.com/tuist/tuist/pull/12374) broken: `poll` on first sight of a file calls `ReadNew` with `exists=false`, persists an end-of-file position, and returns **without** pushing, so an offset equal to the file size proves only that the agent saw the file and means no network call happened.

- **First sight:** offset `44` == size `44`, and `last_success_timestamp_seconds` = `0`. The metric correctly refuses to call that a delivery.
- **After appending one line:** offset advanced `44` to `115` (past the first-sight mark), `last_success_timestamp_seconds` set, `consecutive_failures` `0`, no push errors. A real push landed against the production receiver through MagicDNS.
- **Pointed at a receiver name that does not resolve:** `consecutive_failures` climbed in step with the log's `attempt N`, `last_success` stayed `0`, and `source_size_bytes` grew `40` to `64` while the offset stayed frozen at first sight. This is the case item 5 above exists for.
- **node_exporter 1.8.2 on that host**, run on a throwaway loopback port with the new flags, exposed all five series with `node_scrape_collector_success{collector="textfile"} 1` and `node_textfile_scrape_error 0`.

The review fixes were validated on the same host:

- **The temp file is no longer selectable.** Across 500 samples taken while the agent wrote continuously, the collector's file selection returned exactly one file every time (0 samples with two or more) and no `.tmp` was left behind. The same probe run before the fix caught the temp.
- **The served exposition carries `source_job`.**
- **The malformed-file and stale-duplicate behaviours above were each reproduced directly** against a throwaway node_exporter, which is where the correction came from. In the duplicate case the stale value was served and the real one dropped, with `node_textfile_scrape_error` at 0.

One earlier correction also came out of this: `node_textfile_mtime_seconds` labels `file` with the **full path**, not the basename. The alert query reflects the verified form.

The installed agent, its positions file and its launchd job were not touched, and the temporary binaries, directories and processes were removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
