### PR TITLE
chore(app): bridge the frozen appcast on main to 0.25.6

### DIFF
--- a/app/appcast.xml
+++ b/app/appcast.xml
@@ -3,6 +3,15 @@
     <channel>
         <title>Tuist</title>
         <item>
+            <title>0.25.6</title>
+            <pubDate>Fri, 14 Aug 2026 17:07:39 +0000</pubDate>
+            <link>https://github.com/tuist/tuist/releases</link>
+            <sparkle:version>1786726964</sparkle:version>
+            <sparkle:shortVersionString>0.25.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.25.6/Tuist.dmg" length="29740645" type="application/octet-stream" sparkle:edSignature="ctKo/lDSr3DttJtaVhBQ8s2OxLFLaSw7ei7ZX746incmB9aV17p00ck251RKiSIY4VLr/cBXZSzPNIm9mRxYAg=="/>
+        </item>
+        <item>
             <title>0.25.3</title>
             <pubDate>Mon, 27 Apr 2026 08:11:23 +0000</pubDate>
             <link>https://github.com/tuist/tuist/releases</link>
@@ -28,15 +37,6 @@
             <sparkle:shortVersionString>0.22.7</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.22.7/Tuist.dmg" length="31713769" type="application/octet-stream" sparkle:edSignature="7dTqY1w4izSmYE/8hv6aBF0/3gzGlheNbLrHJFWUcEYMqj4wRvAN2ZZWy7Jkrto9RLP7k7NOes50RZd6Syo3Aw=="/>
-        </item>
-        <item>
-            <title>0.25.0</title>
-            <pubDate>Tue, 24 Feb 2026 12:33:07 +0000</pubDate>
-            <link>https://github.com/tuist/tuist/releases</link>
-            <sparkle:version>13760</sparkle:version>
-            <sparkle:shortVersionString>0.25.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.25.0/Tuist.dmg" length="27745759" type="application/octet-stream" sparkle:edSignature="mq6G/HktIVb7oZfuWWojydeFsxIphKpsIZrLIr1i7A4xaxRzA08EGFjUJYSNnemfOhXPxkZ7ikPDAbkSYsf/Bg=="/>
         </item>
         <item>
             <title>0.20.2</title>


### PR DESCRIPTION
## The symptom

Installed macOS apps report **"You're up to date! Tuist 0.25.3 is currently the newest version available"**, three days after `app@0.25.6` shipped with a working DMG.

Sparkle is telling the truth. On the feed those builds read, 0.25.3 *is* the newest.

## Why

There are two appcast feeds, and every app in the field reads the dead one.

| Feed | Newest entry | Who reads it |
|---|---|---|
| `raw.githubusercontent.com/tuist/tuist/main/app/appcast.xml` | 0.25.3 | every build ≤ 0.25.3 |
| `releases/download/appcast/appcast.xml` | 0.25.6 | builds after #11160 |

`app/appcast.xml` on `main` used to be kept current by the release flow committing back to `main` — the `[Release] Tuist …` commits, the last being `b0a5fc1b64` for app@0.25.3. #11160 ("tag-resolved deploys, stop committing to main", 2026-06-09) ended that and moved `SUFeedURL` to the appcast release asset.

The trap is the ordering. `0.25.3` shipped in April, before that change, so it points at raw `main`. Nothing shipped between June and 2026-08-14, because the DMG step was broken that whole time. So **no installed copy anywhere is running a build that reads the new feed**, and the file they do read froze the moment the commit-back stopped. Without intervention they stay on 0.25.3 forever, however many releases we cut.

## The fix

Replace the frozen file with the published appcast, which carries the 0.25.6 entry. Old clients see 0.25.6, update, and land on a build whose `SUFeedURL` is the release asset. The bridge retires itself as installs drain, rather than becoming a second feed to keep in sync.

Committed as `chore(app)` so it does not cut a release: the app has not changed, and cutting 0.25.7 would immediately leave this file one version behind again for no gain.

## Validation

The file is the published appcast verbatim, so enclosure URLs are absolute and already point at release assets. It parses as XML.

**Signing key continuity** is what makes it safe to serve this file to a 0.25.3 client. The 0.25.3 item's `sparkle:edSignature` is byte-identical in the frozen file and the published one:

```
frozen:     sparkle:edSignature="/j7raRWITFg98YRskF+vrSodJvTU…
published:  sparkle:edSignature="/j7raRWITFg98YRskF+vrSodJvTU…
```

Both were signed by the key those clients already trust, so the 0.25.6 item signed by that same key validates against the `SUPublicEDKey` they ship with.

The 0.25.6 item declares `minimumSystemVersion 15.0.0`, matching what 0.25.3 itself requires, so no currently-updatable install is excluded.

The diff adds 0.25.6 and drops 0.25.0 — the trim `generate_appcast` applies at 5 versions. Every other item is unchanged byte for byte, which is itself evidence the published feed descends from this file. Historical items are not consulted by clients updating forward.

## Open question this does not answer

Whether the release should keep both feeds in sync going forward, or treat this as a one-shot rescue. #11160 stopped committing to `main` deliberately, so reintroducing that automatically would undo something intentional. A one-shot bridge is the smaller move and is enough to unstick the installed base; if any long-lived installs never take the update, the same copy can be refreshed again by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)