### PR TITLE
fix(infra): let runner VMs egress on :22 through the SSH ingress guard

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -2311,6 +2311,18 @@ func installSSHIngressGuard(ctx context.Context, client *ssh.Client, cfg Config)
 // 127.0.0.1 probe reads as permanently wedged and reloads ssh every
 // minute.
 //
+// Being interface-agnostic is also what makes the VM carve-out
+// mandatory. A Tart VM's egress arrives inbound on the vmnet bridge with
+// its 192.168.64.x source before it is routed and NAT'd out, so a bare
+// `block drop in quick proto tcp to any port 22` matches it and drops
+// every SSH the customer workload makes — private git dependencies,
+// ssh:// submodules, deploy steps — silently, as a connect timeout
+// rather than a refusal. The `tuist.runners` anchor cannot compensate:
+// its VM rules are all `out`, and `com.apple/*` is evaluated ahead of
+// anything appended to the end of /etc/pf.conf. So the VM sources get an
+// explicit pass, preceded by a block that still denies them the host's
+// and a sibling's :22.
+//
 // The live session's own source address is folded into the table on the
 // host at render time, so a roll can never sever the connection
 // carrying it. That also makes the guard self-correcting: if the
@@ -2366,11 +2378,21 @@ sudo tee /etc/pf.anchors/tuist.sshguard >/dev/null <<PFCONF
 # MUST stay above the block.
 
 table <ssh_allowed> persist { 100.64.0.0/10${SESSION_ENTRY}%s }
+table <vm_ssh_sources> persist { 192.168.64.0/22 }
 
 # The reachability watchdog probes 127.0.0.1:22 every minute; a
 # blocked loopback reads as a permanent wedge to it.
 pass in quick on lo0 proto tcp to any port 22 keep state
 pass in quick proto tcp from <ssh_allowed> to any port 22 keep state
+
+# A Tart VM's egress arrives inbound on the vmnet bridge before it is
+# routed and NAT'd out, so the catch-all block below also swallows every
+# SSH the customer workload makes. The guard protects the host's own
+# listener, not the workload's outbound reach: VMs keep :22 to the
+# internet, but not to the host or a sibling VM.
+block drop in quick proto tcp from <vm_ssh_sources> to <vm_ssh_sources> port 22
+pass in quick proto tcp from <vm_ssh_sources> to any port 22 keep state
+
 block drop in quick proto tcp to any port 22
 PFCONF
 

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -630,6 +630,38 @@ func TestRenderSSHIngressGuardScript(t *testing.T) {
 	}
 }
 
+// A Tart VM's egress arrives inbound on the vmnet bridge before it is routed
+// and NAT'd out, so a bare `to any port 22` block also drops every SSH the
+// customer workload makes — private git dependencies, ssh:// submodules, deploy
+// steps — as a silent timeout rather than a refusal. The guard exists to keep
+// scan traffic off the host's own listener, so it must pass VM egress while
+// still denying a VM the host's and a sibling's :22.
+func TestRenderSSHIngressGuardScript_PassesVMEgress(t *testing.T) {
+	s, err := renderSSHIngressGuardScript(Config{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		"table <vm_ssh_sources> persist { 192.168.64.0/22 }",
+		"pass in quick proto tcp from <vm_ssh_sources> to any port 22 keep state",
+		"block drop in quick proto tcp from <vm_ssh_sources> to <vm_ssh_sources> port 22",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("renderSSHIngressGuardScript missing %q", want)
+		}
+	}
+	// pf is first-match-wins across `quick` rules. The VM pass has to render
+	// above the catch-all block or VM egress stays dropped, and the VM→VM block
+	// has to render above that pass or a VM reaches the host's :22.
+	vmPass := strings.Index(s, "pass in quick proto tcp from <vm_ssh_sources> to any port 22")
+	if strings.Index(s, "block drop in quick proto tcp to any port 22") < vmPass {
+		t.Error("catch-all block renders before the VM pass; VM egress to :22 stays dropped")
+	}
+	if vmPass < strings.Index(s, "block drop in quick proto tcp from <vm_ssh_sources> to <vm_ssh_sources> port 22") {
+		t.Error("VM pass renders before the VM→VM block; a VM could reach the host's :22")
+	}
+}
+
 // A malformed allow CIDR must fail closed rather than render a creative
 // ruleset onto a host we can only reach through the port it governs.
 func TestRenderSSHIngressGuardScript_RejectsBadCIDR(t *testing.T) {


### PR DESCRIPTION
## What changed

The macOS host SSH ingress guard now passes Tart VM sources (`192.168.64.0/22`) on port 22, behind a block that still denies a VM the host's and a sibling VM's `:22`.

## Why

A customer's `tuist install` on a macOS runner failed with every git fetch candidate timing out:

```
ssh: connect to host github.com port 22: Operation timed out
```

`Operation timed out`, not `Connection refused`, so the packets were being dropped, not rejected.

## Root cause

`renderSSHIngressGuardScript` writes this into the `com.apple/tuist.sshguard` anchor:

```
pass in quick on lo0 proto tcp to any port 22 keep state
pass in quick proto tcp from <ssh_allowed> to any port 22 keep state
block drop in quick proto tcp to any port 22
```

The block is deliberately source-based rather than interface-based, because public interface names vary across hosts. That is exactly what breaks VM egress. A Tart VM's outbound packet arrives **inbound on the vmnet bridge** with its `192.168.64.x` source before it is routed and NAT'd out, and that source is in neither `<ssh_allowed>` (tailnet CGNAT, the operator's egress, the live session) nor on `lo0`. The catch-all matches and drops it.

The `tuist.runners` anchor cannot compensate: its VM rules are all `out`, and `com.apple/*` is evaluated ahead of anything appended to the end of `/etc/pf.conf`.

Introduced in #12283 (`4e23a2c9a4`), shipped in `capi-scaleway@0.19.1`. Production runs `0.22.2`, so the entire macOS fleet has carried it since 2026-08-13.

## Impact

Every SSH a runner workload makes has been dead fleet-wide since then, to any destination: private SPM and CocoaPods dependencies, `ssh://` submodules, scp/rsync deploy steps, SSH to a device farm. Because it is a silent drop rather than a refusal, it surfaces as a slow or flaky network rather than a policy denial, which is what made it hard to spot. The identical job on a GitHub-hosted machine passes.

## Why this shape

Scoping the block to an interface was the obvious alternative, and it is the one the original rule explicitly rejected: interface names are not stable across hosts, which is why the guard is source-based to begin with. Keeping it source-based and carving out the one source range we control preserves that property. The VM range is already a fixed constant elsewhere in this file (`renderVMEgressFirewallScript`, `renderVMNATScript`), since vmnet places VMs on Apple's documented `192.168.64.0/22`.

The carve-out is deliberately not a bare pass. `to any port 22` would include the host's own vmnet gateway address, handing a customer workload a path to the host's SSH listener, so the VM-to-VM-range block renders above it. Ordering matters because pf is first-match-wins across `quick` rules, and the tests pin it in both directions.

The table is named `vm_ssh_sources` rather than reusing `vm_sources` from the `tuist.runners` anchor. Tables are anchor-scoped, but a name collision across a single ruleset load is what produced the `cannot define table vm_sources: Resource busy` failure that once rejected the whole ruleset, so the distinct name keeps that hazard off the table entirely.

## Validation

- New test `TestRenderSSHIngressGuardScript_PassesVMEgress` asserts the pass and both orderings. Confirmed red before the fix (three missing-rule failures), green after.
- Full package: `go test ./...` passes, `gofmt -l` clean, `go vet` clean.
- The rendered script is folded into `HostConfigHash`, so merging rolls the corrected anchor to every mini on the next reconcile with no VM downtime.

To confirm on a host once this ships: `sudo pfctl -a com.apple/tuist.sshguard -vsr` and watch the catch-all block's packet counter stay flat while a VM runs `nc -vz github.com 22`, which should now connect. Port 443 to the same host worked throughout.

## Note for affected users

swifterpm offers an HTTPS fallback for SSH-declared dependencies, but it is inert for anyone whose job installs a global `url.git@github.com:.insteadOf https://github.com/` rewrite (what `webfactory/ssh-agent` sets up), because all candidates get forced back onto port 22. Flipping that rewrite to the token-HTTPS direction is a workaround that does not depend on this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
