### PR TITLE
fix(registry): survive rolling deploys without dropping client requests

### DIFF
--- a/infra/helm/tuist/templates/registry-deployment.yaml
+++ b/infra/helm/tuist/templates/registry-deployment.yaml
@@ -158,6 +158,12 @@ spec:
             periodSeconds: {{ .Values.registry.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.registry.probes.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.registry.probes.liveness.failureThreshold }}
+          lifecycle:
+            preStop:
+              exec:
+                # Give the ingress time to stop routing new traffic before the
+                # release shuts down — avoids 502s during a rolling deploy.
+                command: ["sh", "-c", "sleep 10"]
           resources:
             {{- toYaml .Values.registry.resources | nindent 12 }}
           volumeMounts:

--- a/infra/helm/tuist/templates/registry-deployment.yaml
+++ b/infra/helm/tuist/templates/registry-deployment.yaml
@@ -158,12 +158,6 @@ spec:
             periodSeconds: {{ .Values.registry.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.registry.probes.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.registry.probes.liveness.failureThreshold }}
-          lifecycle:
-            preStop:
-              exec:
-                # Give the ingress time to stop routing new traffic before the
-                # release shuts down — avoids 502s during a rolling deploy.
-                command: ["sh", "-c", "sleep 10"]
           resources:
             {{- toYaml .Values.registry.resources | nindent 12 }}
           volumeMounts:

--- a/infra/helm/tuist/templates/registry-pdb.yaml
+++ b/infra/helm/tuist/templates/registry-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.registry.enabled .Values.registry.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "registry") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registry
+spec:
+  minAvailable: {{ .Values.registry.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "tuist.componentLabels" (dict "root" . "component" "registry") | nindent 6 }}
+{{- end }}

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -11,6 +11,10 @@ registry:
   # to this dedicated ingress host. The ingress hostname is not advertised as
   # a separate registry endpoint.
   enabled: true
+  # Two replicas so a rolling deploy or a node loss always leaves another
+  # ready endpoint behind the ingress. With a single replica the ingress has
+  # nowhere to retry a refused connection and clients see 502s.
+  replicaCount: 2
   publicHost: tuist.dev
   serverUrl: https://tuist.dev
   deployEnv: production
@@ -21,6 +25,18 @@ registry:
     tlsSecretName: registry-tls
     annotations:
       external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: registry
+            topologyKey: kubernetes.io/hostname
   resources:
     requests:
       cpu: "500m"

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -829,6 +829,11 @@ registry:
     runAsUser: 990
   extraEnv: []
   extraEnvFrom: []
+  # Off by default so a single-replica self-hosted install can still drain a
+  # node. Enable it wherever replicaCount is raised above 1.
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
   podAnnotations: {}
   podLabels: {}
   affinity: {}

--- a/registry/lib/tuist_registry/application.ex
+++ b/registry/lib/tuist_registry/application.ex
@@ -12,15 +12,18 @@ defmodule TuistRegistry.Application do
     start_loki_logger()
     start_opentelemetry()
 
+    # Supervisors terminate children in reverse start order, so the endpoint
+    # goes last: it stops accepting before Finch and the S3-backed caches it
+    # needs to finish in-flight requests are torn down.
     base_children = [
       {Phoenix.PubSub, name: TuistRegistry.PubSub},
-      TuistRegistry.Swift.Metadata,
-      TuistRegistry.Swift.AlternateManifests,
-      TuistRegistryWeb.Endpoint,
       # Cannot alias TuistRegistry.Finch to Finch or it'll conflict with the top-level library
       # credo:disable-for-next-line Credo.Check.Design.AliasUsage
       {Finch, name: TuistRegistry.Finch, pools: TuistRegistry.Finch.Pools.config()},
-      TuistRegistry.PromEx
+      TuistRegistry.Swift.Metadata,
+      TuistRegistry.Swift.AlternateManifests,
+      TuistRegistry.PromEx,
+      TuistRegistryWeb.Endpoint
     ]
 
     opts = [strategy: :one_for_one, name: TuistRegistry.Supervisor]


### PR DESCRIPTION
## What changed

Two halves of the same problem — surviving a registry roll without failing client requests:

1. **Infra**: the managed production overlay runs **two** registry replicas, with a PodDisruptionBudget (`minAvailable: 1`) and a soft pod anti-affinity term matching the server's. Chart defaults untouched.
2. **App**: the registry's supervision tree shuts the Phoenix endpoint down **before** the Finch pool and caches it drains through, instead of after.

## Why

CI job [95329831553](https://github.com/tuist/tuist/actions/runs/32010833109/job/95329831553) failed on `tuist install --force-resolved-versions` with:

```
HTTP 502 for https://registry.tuist.dev/api/registry/swift/apple/swift-crypto/3.15.1
```

Nothing was wrong with the branch or the package. The 502 came from ingress-nginx, not the registry app:

```
2026/08/17 08:33:52 [error] connect() failed (111: Connection refused) while connecting to upstream,
  server: registry.tuist.dev, request: "GET /api/registry/swift/apple/swift-crypto/3.15.1",
  upstream: "http://192.168.6.6:4000/..."
```

### Root cause

A production deploy started at 08:32:17Z and rolled `tuist-tuist-registry` (ReplicaSet `6985bc6544` to `85f69bd9b9`). Pod deletion starts two independent asynchronous processes: kubelet begins container termination, and separately the EndpointSlice update propagates to ingress-nginx. Kubernetes orders neither. The terminating pod closed its listener on SIGTERM while nginx still had it in the upstream pool, so requests landing in that window were refused.

The registry ran a **single replica**, so there was nothing to fail over to. Every request logged against the registry upstream during the incident went to `192.168.6.6:4000`, which is why nginx's three retries all landed on the same refused address.

Not CI-only: 83 `connect() failed` lines against `registry.tuist.dev` in a 10-minute window.

### Why a second replica

`maxUnavailable: 0` was already in place and did not prevent this, because it guarantees **capacity, not routing**. The deployment controller tracks pod Ready status and knows nothing about nginx's upstream pool; the two diverge precisely during endpoint propagation.

Upstream keepalive is disabled on this ingress (`upstream-keepalive-connections: "0"`, from an earlier Bandit stall fix), so every request opens a fresh connection. A connection refused by a draining pod therefore fails at connect time, before a byte is sent — exactly what ingress-nginx's default `proxy-next-upstream` (`error timeout`, 3 tries, corroborated by the three attempts in the log) retries safely. This is an **ingress-side** retry, invisible to the client; neither SwiftPM nor `tuist install` needs retry logic of its own. The only missing ingredient was a healthy peer to retry against, and a second replica supplies it. It covers node loss and eviction too.

### Why the supervision reorder

Ingress retries cannot cover everything. nginx can retry a connection refused at connect time, but **not** a request it has already begun relaying a response for. A connection accepted and then dropped mid-flight reaches the client as an error no matter how many replicas exist. Only draining covers that case.

The registry does drain: Bandit sits on ThousandIsland, whose `shutdown_timeout` defaults to 15s (verified in the vendored `thousand_island` 1.4.3), and the registry sets no override. But the endpoint sat fourth of six children, and supervisors terminate in reverse start order, so shutdown ran PromEx → Finch → endpoint. The registry reaches S3 through `ExAws` → `TuistCommon.AWS.Client` → `Req(finch: TuistRegistry.Finch)`, and serving a manifest body or the HEAD behind a `.zip` redirect needs that pool. So the drain window existed while the HTTP client those requests depend on was already gone.

Moving the endpoint last restores both halves: it starts last, so it does not accept traffic before its dependencies are up, and terminates first, so the drain runs while they are still alive. Finch also moves ahead of the two S3-backed caches that call through it, fixing the same ordering at boot.

### Considered and rejected

- **A `preStop` sleep on the registry**, mirroring the server's. This was the first version of this PR and was dropped. It narrows the window rather than removing the failure; with a live peer in the pool the retry path already makes a refused connection invisible, and the supervision fix addresses the mid-flight case it was really standing in for.
- **Tuning the rollout strategy.** Already `maxUnavailable: 0`, `maxSurge: 1`. Never a capacity gap.
- **Raising `terminationGracePeriodSeconds`.** The pod exits promptly on its own; 15s of drain fits inside the existing 30s.
- **Failing readiness first, then sleeping.** Terminating pods leave EndpointSlices regardless of readiness, so this buys no ordering.
- **A client-side 5xx retry in `tuist install`.** A CLI change with a wider blast radius that would paper over a real availability gap also affecting plain SwiftPM users.

## Scoping and safety

- Chart defaults unchanged: `replicaCount: 1`, `podDisruptionBudget.enabled: false`, so a single-replica self-hosted install can still drain a node. Only the managed production overlay opts in.
- The registry is not enabled in canary or staging, so no other overlay changed.
- `minAvailable: 1` against 2 replicas leaves drain headroom rather than wedging evictions.
- Anti-affinity is `preferredDuringScheduling` (soft), so it spreads the pair without making pods unschedulable.
- The server Deployment keeps its own `preStop` hook; nothing here changes its behaviour.

## Impact

Rolling deploys and node-level disruption of the registry stop producing 502 windows on `registry.tuist.dev`, for CI jobs running `tuist install` and for users resolving packages. In-flight requests now complete against a live Finch pool instead of racing its teardown. Cost is one additional registry pod in production (requests: 500m CPU / 1Gi memory). Takes effect from the next production deploy.

### How to test locally

Render the production overlay:

```
helm template tuist infra/helm/tuist \
  -f infra/helm/tuist/values-managed-common.yaml \
  -f infra/helm/tuist/values-managed-production.yaml \
  -f infra/helm/tuist/values-ci.yaml \
  | yq eval-all 'select(.metadata.name == "tuist-tuist-registry") | {"kind": .kind, "replicas": .spec.replicas, "minAvailable": .spec.minAvailable}'
```

And from `registry/`: `mise run format --check`, `mise run credo`, `mise run test`.

## Validation run

- Rendered production manifest carries `replicas: 2`, the anti-affinity term, no `lifecycle` block, and a PDB whose selector matches the deployment's pod labels. The preview overlay renders no registry PDB. The server's `preStop` hook renders unchanged.
- `helm lint` passes on all three value stacks CI lints; both render configurations CI checks succeed.
- `registry/`: format check clean, credo clean (no issues over 24 files), 43 tests 0 failures. The suite boots the application, so the new child order is exercised.

## Worth watching after the next deploy

The replica half leans on nginx retrying a refused connect against the second endpoint. That path is sound but has never been exercised here, because the registry has never had more than one endpoint. If `connect() failed` lines against the registry upstream persist after the next production deploy, the retry is not landing on the healthy peer and a `preStop` hook should go back in.

Separately, the graceful-shutdown path is verified in code but not in production: the terminating pod logged nothing during shutdown, which is equally consistent with a clean silent drain and an abrupt exit, since Phoenix and Bandit log no shutdown message by default.

## Note for the reviewer

`helm lint` with the managed-production overlay fails on `templates/dedibox-fleet.yaml` with `invalid Yaml document separator`. Pre-existing and unrelated; reproduced on the unmodified tree. CI does not catch it because the lint step only uses the self-hosted, preview, and k3s overlays, while the production overlay is exercised by `helm template` alone. Worth chasing separately as a gap in the chart's lint coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
