### PR TITLE
fix(infra): keep the Xcode .xip mirror on GHCR

### DIFF
--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -79,12 +79,17 @@ jobs:
       # the upload task locally and re-triggers this workflow.
       #
       # This mirror stays on GHCR while the images this job publishes
-      # do not, because its only writer is that laptop task. A laptop
-      # sustains about 1 MB/s to the tailnet-only registry, which
-      # cannot hold one connection open long enough for a 2.3 GB blob.
-      # GHCR's limits were never the problem for a single-blob
-      # artifact; they were the problem for the ~50 GB images, which
-      # are pushed from this builder and go to our registry below.
+      # do not, because its only writer is that laptop task. Measured
+      # from one, with the same 512 MB blob: 136s to GHCR against 481s
+      # to the tailnet-only registry, so the same .xip is a ten-minute
+      # upload one way and closer to forty the other. Worse, Tailscale
+      # starts a session on a DERP relay and only upgrades to a direct
+      # path once NAT traversal succeeds — over the relay these uploads
+      # fail outright rather than merely crawl, which is what a fresh
+      # session gets. GHCR's limits were never the problem for a
+      # single-blob artifact; they were the problem for the ~50 GB
+      # images, which are pushed from this builder over a datacenter
+      # link and go to our registry below.
       - name: Pull Xcode .xip from mirror
         id: xcode_xip
         env:

--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -15,7 +15,7 @@ name: macOS + Xcode Image
 # (`runs-on: tuist-macos-xcode-26-5`, etc.) once that wiring lands.
 # For now, the chart pins one image at a time as the default.
 #
-# .xip source: pulled from `<registry>/xcode-xips:<version>`,
+# .xip source: pulled from `ghcr.io/tuist/xcode-xips:<version>`,
 # our in-house mirror populated by `mise run xcode-mirror:upload`
 # on a maintainer's Mac (Apple's SRP-only signin + `xcodes`'s
 # per-process cookie storage rule out an in-cluster auto-mirror).
@@ -77,35 +77,34 @@ jobs:
       # pre-requirement to SSH into the builder.
       # If the .xip isn't in the mirror yet, the operator runs
       # the upload task locally and re-triggers this workflow.
-      # The .xip lives on the same registry as the images, so this needs
-      # a credential before the pull. The login is repeated before the
-      # push at the end of the job: `Build image` moves
-      # ~/.docker/config.json aside for Packer's anonymous clone of the
-      # public Cirrus base and restores it afterwards, and repeating the
-      # login costs nothing next to depending on that restore.
-      - name: Log in to the Tuist OCI registry
-        uses: ./.github/actions/oci-registry-login
-        with:
-          host: ${{ vars.OCI_REGISTRY_HOST }}
-          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
-          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-
+      #
+      # This mirror stays on GHCR while the images this job publishes
+      # do not, because its only writer is that laptop task. A laptop
+      # sustains about 1 MB/s to the tailnet-only registry, which
+      # cannot hold one connection open long enough for a 2.3 GB blob.
+      # GHCR's limits were never the problem for a single-blob
+      # artifact; they were the problem for the ~50 GB images, which
+      # are pushed from this builder and go to our registry below.
       - name: Pull Xcode .xip from mirror
         id: xcode_xip
         env:
           XCODE_VERSION: ${{ inputs.xcode_version }}
-          REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           XCODE_XIP_DIR="${RUNNER_TEMP:-/tmp}/xcode-xip"
           mkdir -p "$XCODE_XIP_DIR"
-          if ! oras pull "${REGISTRY_HOST}/xcode-xips:${XCODE_VERSION}" --output "$XCODE_XIP_DIR"; then
+          # Explicit oras login here (not at workflow top) because
+          # oras' login persists to ~/.docker/config.json, which
+          # Packer's anonymous-pull dance later toggles back to
+          # anonymous for the public Cirrus base.
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io --username tuist-bot --password-stdin
+          if ! oras pull "ghcr.io/tuist/xcode-xips:${XCODE_VERSION}" --output "$XCODE_XIP_DIR"; then
             {
               echo "Error: Xcode ${XCODE_VERSION} is not in the mirror at"
-              echo "${REGISTRY_HOST}/xcode-xips:${XCODE_VERSION}."
+              echo "ghcr.io/tuist/xcode-xips:${XCODE_VERSION}."
               echo ""
-              echo "Populate the mirror from a maintainer Mac, connected"
-              echo "to the tailnet:"
+              echo "Populate the mirror from a maintainer Mac:"
               echo ""
               echo "  mise run xcode-mirror:upload ${XCODE_VERSION}"
               echo ""

--- a/mise/tasks/xcode-mirror/upload.sh
+++ b/mise/tasks/xcode-mirror/upload.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-#MISE description "Download an Xcode .xip from Apple via xcodes and push it to the Tuist OCI registry."
+#MISE description "Download an Xcode .xip from Apple via xcodes and push it to ghcr.io/tuist/xcode-xips."
 #USAGE arg "<version>" help="Xcode version to publish (e.g. 26.4.1, 26.5)."
 
 # Local maintainer task — populates the in-house Xcode .xip mirror
-# at `<registry>/xcode-xips:<version>` that the
+# at `ghcr.io/tuist/xcode-xips:<version>` that the
 # `.github/workflows/macos-xcode-image.yml` workflow pulls from.
 #
 # Run this when an xcodereleases.com RSS notification lands in
@@ -11,11 +11,12 @@
 # `infra/macos-xcode-image/AGENTS.md` for the architecture and the
 # RSS subscription command.
 #
-# Tools come from the repo-root mise.toml (xcodes, oras, jq).
-# Registry credentials come from the environment (see below).
-# xcodes prompts for Apple ID password + 2FA the first time per
-# ~30-day window and caches the session in the local keychain
-# afterwards.
+# Tools come from the repo-root mise.toml (xcodes, oras, jq, gh).
+# Beyond that the task self-bootstraps: it uses the operator's
+# existing `gh` token to log oras into ghcr.io so they don't have
+# to remember the manual login command. xcodes prompts for Apple
+# ID password + 2FA the first time per ~30-day window and caches
+# the session in the local keychain afterwards.
 
 set -euo pipefail
 
@@ -30,29 +31,62 @@ fi
 # Running this task via `mise run xcode-mirror:upload` auto-installs
 # anything missing.
 
-# === Registry credentials ==================================================
+# === Auto-login to GHCR via gh ============================================
 
-# The mirror now lives on the Tuist OCI registry rather than GHCR, so the
-# `gh`-token bootstrap this task used to do no longer applies: the
-# registry has its own credentials and does not know about GitHub.
-#
-# It is also reachable on the tailnet only, so this task needs the
-# operator connected. That is the usual state on a maintainer Mac, and
-# the failure is legible if not.
-: "${TUIST_OCI_REGISTRY_HOST:?set TUIST_OCI_REGISTRY_HOST (e.g. oci.tuist.dev)}"
-: "${TUIST_OCI_REGISTRY_USERNAME:?set TUIST_OCI_REGISTRY_USERNAME (OCI_REGISTRY_CREDENTIALS in the env vault)}"
-: "${TUIST_OCI_REGISTRY_PASSWORD:?set TUIST_OCI_REGISTRY_PASSWORD (OCI_REGISTRY_CREDENTIALS in the env vault)}"
+# oras has no `whoami` so the cheapest reliable auth check is a
+# manifest fetch. Either outcome — success (image exists) or a
+# "not found" / 404 response — proves we authenticated; only an
+# auth error (401/403) means we need to log in. Capture-then-check
+# instead of piping so `set -o pipefail` doesn't shadow oras's exit.
+needs_login=true
+if probe_output=$(oras manifest fetch ghcr.io/tuist/xcode-xips:__probe__ 2>&1); then
+  needs_login=false
+elif printf '%s' "$probe_output" | grep -qiE "not found|404"; then
+  needs_login=false
+fi
 
-echo "Logging oras into ${TUIST_OCI_REGISTRY_HOST}..."
-if ! printf '%s' "$TUIST_OCI_REGISTRY_PASSWORD" | oras login "$TUIST_OCI_REGISTRY_HOST" \
-    --username "$TUIST_OCI_REGISTRY_USERNAME" --password-stdin >/dev/null; then
-  cat >&2 <<EOF
-Error: could not log in to ${TUIST_OCI_REGISTRY_HOST}.
+if [ "$needs_login" = "true" ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: gh CLI not installed, and oras can't authenticate against
+ghcr.io/tuist. Install gh (`brew install gh && gh auth login`) or
+log oras in manually:
 
-The registry is reachable on the tailnet only. Check that Tailscale is
-up on this machine, then retry.
+  echo $TOKEN | oras login ghcr.io --username <gh-user> --password-stdin
 EOF
-  exit 1
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Signing in to gh (needed for ghcr.io push)..."
+    gh auth login
+  fi
+
+  # GHCR distinguishes login (any token does) from push (needs
+  # write:packages on the org). `gh auth login` defaults to repo +
+  # workflow scopes, so a fresh operator session almost never has
+  # write:packages. Probe `gh auth status` for it now and fail
+  # fast — better than burning a 2 GB upload before the registry
+  # returns "permission_denied: token does not match expected
+  # scopes" on the manifest PUT.
+  #
+  # `gh auth status` quotes each scope (`'write:packages'`),
+  # which a bare substring match handles without us having to
+  # care about gh's quoting changes between releases.
+  if ! gh auth status 2>&1 | grep -q "write:packages"; then
+    cat >&2 <<'EOF'
+Error: your gh token doesn't include the write:packages scope.
+
+Refresh it (this won't force a full re-login):
+  gh auth refresh -s write:packages,read:packages
+
+Then re-run this task.
+EOF
+    exit 1
+  fi
+
+  gh_user=$(gh api user --jq .login 2>/dev/null || echo "tuist-bot")
+  echo "Logging oras into ghcr.io as $gh_user..."
+  gh auth token | oras login ghcr.io --username "$gh_user" --password-stdin >/dev/null
 fi
 
 # === Cache & download ======================================================
@@ -81,7 +115,7 @@ fi
 
 # === Push ================================================================
 
-echo "Pushing $(basename "$XIP") → ${TUIST_OCI_REGISTRY_HOST}/xcode-xips:${VERSION}..."
+echo "Pushing $(basename "$XIP") → ghcr.io/tuist/xcode-xips:${VERSION}..."
 # `--artifact-type` advertises the media type for the manifest so
 # the build workflow (and future tooling) can verify the tag
 # points at a real .xip. The blob's own media type is
@@ -99,12 +133,12 @@ xip_filename="$(basename "$XIP")"
   oras push \
     --artifact-type "application/vnd.tuist.xcode-xip" \
     --annotation "org.opencontainers.image.title=${xip_filename}" \
-    "${TUIST_OCI_REGISTRY_HOST}/xcode-xips:${VERSION}" \
+    "ghcr.io/tuist/xcode-xips:${VERSION}" \
     "${xip_filename}:application/x-pkcs7-mime"
 )
 
 echo
-echo "Published ${TUIST_OCI_REGISTRY_HOST}/xcode-xips:${VERSION}"
+echo "Published ghcr.io/tuist/xcode-xips:${VERSION}"
 echo
 echo "Next:"
 echo "  gh workflow run macos-xcode-image.yml -f xcode_version=${VERSION}"


### PR DESCRIPTION
Reverts the Xcode `.xip` mirror to GHCR. The images stay on our own registry.

### What went wrong

[#12334](https://github.com/tuist/tuist/pull/12334) moved the image builds onto our registry and moved the reads with the writes. For the base image and the runner profiles that was right. For the `.xip` mirror it was not, and I did not separate the two.

The mirror's only writer is `mise run xcode-mirror:upload`, which runs on a maintainer's Mac. Measured with the same 512 MB blob from the same machine:

| Destination | Time | Rate |
|---|---|---|
| GHCR | 136s | ~3.8 MB/s |
| our registry (tailnet-only) | 481s | ~1.1 MB/s |

So the laptop's uplink is fine; it is the tailnet path that costs about 3.5x. For a 2.3 GB `.xip` that is roughly ten minutes against roughly forty.

Worse than the slowdown is the failure mode. Tailscale opens a session on a **DERP relay** and upgrades to a direct path only once NAT traversal succeeds — `tailscale ping` shows exactly this, three relayed replies at 59-155ms followed by a direct one at 32ms. Over the relay these uploads do not merely crawl, they fail: 512 MB, 1 GB and the 2.3 GB `.xip` all died mid-body with the registry logging `client disconnected during blob PUT  contentLength=1073741824  copied=171966347  error="unexpected EOF"`, and 512 MB then succeeded once the peer showed `active; direct`. A fresh session starts relayed, so this is not a size you can design around.

Ruled out along the way: nginx config (`client_max_body_size 0`, `proxy_request_buffering off`, 900s timeouts all correct), nginx OOM (zero restarts, 22Mi of a 256Mi limit), and disk (500 GB free, no ephemeral limits). Auth, TLS, chunking and the Tigris backend are all fine — a 64 MB blob succeeds over either path.

So the move broke the mirror's only write path, and left the read pointed at a repository nothing could reliably populate. `main` has been in that state since #12334 merged: any dispatch of `macos-xcode-image.yml` fails at its first step.

### Why GHCR is right for this artifact

The reason for leaving GHCR never applied here. GHCR's 3 MB chunk ceiling, and the ~17,000 requests it forces for a ~50 GB image, are a problem for the VM images — which are pushed from bare-metal builders on a datacenter link. A 2.3 GB single-blob `.xip` pushed occasionally from a laptop is a case GHCR has served fine for a year.

That gives a boundary worth keeping:

| Artifact | Pushed from | Registry |
|---|---|---|
| `xcode-xips` | maintainer's laptop | GHCR |
| `macos-tahoe-xcode`, `tuist-runner`, `tuist-xcresult-processor` | bare-metal builders | ours |

`macos-xcode-image.yml` now authenticates to both: GHCR to read the `.xip`, our registry to push the image it builds. The push path is untouched.

### Why not migrate instead

The alternative was a workflow that copies the artifacts across from a builder, which I opened as #12392 and am closing in favour of this. It was machinery to work around a move that should not have happened, and it would have needed deleting afterwards. It also would not have fixed the durable problem: the *next* Xcode release still has to be uploaded from a laptop.

### How to test

```
actionlint .github/workflows/macos-xcode-image.yml
```

Four findings, unchanged from the pre-#12334 baseline — all pre-existing custom-runner-label and shellcheck notes. `bash -n` passes on the restored upload task, which is byte-identical to its pre-cutover version.

The real test is that `macos-xcode-image.yml` becomes dispatchable again, since the `.xip`s it needs are already on GHCR:

```
gh workflow run macos-xcode-image.yml -f xcode_version=26.5
```

That run is still the one that answers the ~50 GB question for the image push.

### Not covered

- The `pushtest` repository in the registry (one 64 MB blob) from the threshold testing above is worth deleting.
- Fleet image pins are still on GHCR; they move once a build has published to our registry and the hosts carry the pull credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

