### PR TITLE
fix(infra): stop the kura policy-drop alert paging on controller rollouts

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -377,14 +377,14 @@ sum by (cluster, node) (
   rate(cilium_drop_count_total{
     direction="INGRESS",
     reason="Policy denied"
-  }[10m])
+  }[5m])
   * on (cluster, pod) group_left(node)
   kube_pod_info{
     namespace="kube-system",
     pod=~"cilium-.*",
     node=~".*-kura-fleet-.*"
   }
-) > 0
+) > 0.5
 ```
 
 - Pending period: 10 minutes
@@ -395,8 +395,8 @@ sum by (cluster, node) (
   at the cache.
 - The metric carries no `node` label, hence the `kube_pod_info` join on the
   Cilium agent pod. The `node=~".*-kura-fleet-.*"` matcher restricts this to the
-  co-located runner-cache nodes, whose steady-state rate is exactly zero; other
-  pools carry background policy drops and would make it noisy.
+  co-located runner-cache nodes; other pools carry far heavier background policy
+  drops (one dedibox node holds a flat ~0.42/s indefinitely) and would swamp it.
 - Summary: `Kura cache on {{ $labels.node }} is dropping runner traffic at the
   NetworkPolicy ({{ $labels.cluster }}) — builds on the affected runner will
   hang until their client timeouts`
@@ -405,6 +405,31 @@ sum by (cluster, node) (
   traffic never reaches the kura node and this counter stays at zero while the
   build hangs identically.
 
+**The threshold is `> 0.5`, not `> 0`, and the window is `[5m]`, not `[10m]`.**
+Both matter, and an earlier version of this rule had neither:
+
+- These nodes do **not** sit at exactly zero. Over any given week the production
+  node logs dozens of Policy-denied episodes, and roughly a fifth of all 30-minute
+  buckets are non-zero. A `> 0` threshold treats every one of them as a critical
+  page.
+- A **kura-controller rollout** produces a small burst of Policy-denied ingress on
+  *all four* kura-hosting nodes at once, within seconds of the new ReplicaSet
+  appearing. Roughly half of rollouts do it, and since every merge to `main` rolls
+  the controller, that is a recurring false page. Observed magnitudes are 0.02 to
+  0.10 packets/s, an order of magnitude below the ~1-2/s of a genuinely stuck job,
+  so a 0.5 floor separates them cleanly. The mechanism is unproven: the policy
+  object is patched, never recreated (`reconcileNetworkPolicy` uses
+  `controllerutil.CreateOrUpdate`), so the suspect is transient identity resolution
+  on the `PodSelector` rules rather than a default-deny gap.
+- `rate(...[10m])` stays non-zero for a full 10 minutes after the *last* dropped
+  packet. Paired with a 10-minute pending period that let a ~4-minute burst hold the
+  condition for ~14 minutes and page as critical. `[5m]` keeps the pending period
+  meaning "still dropping" rather than "dropped recently".
+
+Before concluding a Mac mini is mis-sourced, check that the drops are confined to
+**one** node. A runner VM talks to a single regional cache, so simultaneous drops
+across regions are never a mis-sourced host.
+
 A per-instance kura NetworkPolicy admits `http` only from `namespaceSelector: {}`
 and `ipBlock 172.16.0.0/22` (the Private Network). A macOS runner VM whose egress
 is not masqueraded to its host's PN VLAN address arrives from outside that block,
@@ -412,14 +437,32 @@ so Cilium drops it at ingress — silently, with no RST. The client sees no
 connection at all and every cache request hangs until its own timeout, which has
 turned 8-minute CI jobs into 6-hour ones while every dashboard showed kura
 healthy and idle. The drop counter is the only signal that fires, and it tracks
-the stuck job almost exactly: zero before it starts, a steady ~2/s SYN-retransmit
-trickle for its whole life, zero again within a scrape of it being cancelled.
+the stuck job closely: a steady ~1-2/s SYN-retransmit trickle for its whole life,
+falling back to baseline within a scrape of it being cancelled. Note that baseline
+is low but not zero, which is why the rule needs a magnitude floor rather than a
+bare `> 0`.
 
 Note the counter carries no source address, so it says *that* a host is
 mis-sourced but not *which* one. Correlating it back to a Mac mini currently
 needs Hubble flow metrics with source labels on the cache node, or catching the
 job live (`kubectl get pod -o wide`) and checking
 `pfctl -a com.apple/tuist.vmnat -s nat` plus `ifconfig vlan0` on that host.
+
+A mis-sourced host can also be found from metrics alone, because none of its cache
+traffic completes and its PN VLAN goes nearly silent:
+
+```promql
+sort_desc(max_over_time((sum by (instance) (rate(
+  node_network_receive_bytes_total{job="tuist-macos-node-exporter",
+  device="vlan0"}[30m])))[7d:30m]))
+```
+
+Healthy runner hosts peak in the hundreds of kB/s; the mis-sourced host in the
+August 2026 incident sat ~1600x below its peers. Use a **7-day peak**: a shorter
+window makes a merely idle host look broken, and a floor or minimum does not
+separate them because every host, healthy or not, has quiet stretches. Scope this
+to the runner fleet: `macos-fleet` and `builders-fleet` hosts sit at a couple of
+hundred B/s legitimately, since they run no cache-using VMs.
 
 ### Runner host PN VLAN missing
 

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -438,9 +438,23 @@ an earlier version of this note claimed. Two distinct populations show up:
   through a NodePort/LoadBalancer. Note the `peer` rule already had to open
   `0.0.0.0/0` for exactly that reason, while `http` has no equivalent escape hatch
   beyond per-instance `ClientCIDRs`.
-- **Sustained episodes, 0.8 to 5 packets/s, lasting 30 to 90 minutes.** These are
-  the real thing and the rule *should* page on them. The production node logs them
-  regularly. Treat a firing alert as a genuine mis-sourced host, not as noise.
+- **Sustained episodes, 0.8 to 5 packets/s, lasting 30 minutes to 6 hours.** These
+  are the real thing and the rule *should* page on them. Treat a firing alert as a
+  genuine mis-sourced host, not as noise. The impact is now measured rather than
+  assumed: across 2026-08-10 to 2026-08-14 the production node had 20 such
+  episodes, and **every one of the 17 macOS runner sessions that exceeded 40
+  minutes in that window started inside one of them**, 17 for 17. Outside those
+  episodes not a single macOS session passed 40 minutes (max 30.2 min over 650
+  sessions). Linux pools show no effect either way, which is the control: they do
+  not use the PN/pf NAT path. Three sessions hit exactly 361 minutes, the 6-hour
+  ceiling. Total burned wall-clock was ~34 hours across two accounts.
+
+  Those episodes stopped on 2026-08-14 once `b4ce0dba49` fixed the duplicated
+  `/etc/pf.conf` anchor block that made `pfctl` reject the whole ruleset (see
+  "Runner host PN VLAN missing" below for the companion failure). In the three days
+  after, 255 macOS sessions ran with **zero** over 40 minutes and a 27-minute max,
+  and the node logged no sustained episode at all. If this class reappears, the pf
+  anchor is the first thing to check.
 
 Before concluding a Mac mini is mis-sourced, check that the drops are confined to
 **one** node. A runner VM talks to a single regional cache, so simultaneous drops

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -384,7 +384,7 @@ sum by (cluster, node) (
     pod=~"cilium-.*",
     node=~".*-kura-fleet-.*"
   }
-) > 0.5
+) > 0
 ```
 
 - Pending period: 10 minutes
@@ -405,33 +405,42 @@ sum by (cluster, node) (
   traffic never reaches the kura node and this counter stays at zero while the
   build hangs identically.
 
-**The threshold is `> 0.5`, not `> 0`, and the window is `[5m]`, not `[10m]`.**
-Both matter, and an earlier version of this rule had neither:
+**The window is `[5m]`, not `[10m]`. The threshold stays `> 0` deliberately.**
 
-- These nodes do **not** sit at exactly zero. Over any given week the production
-  node logs dozens of Policy-denied episodes, and roughly a fifth of all 30-minute
-  buckets are non-zero. A `> 0` threshold treats every one of them as a critical
-  page.
-- A **kura-controller rollout** produces a small burst of Policy-denied ingress on
-  *all four* kura-hosting nodes at once, within seconds of the new ReplicaSet
-  appearing. Roughly half of rollouts do it, and since every merge to `main` rolls
-  the controller, that is a recurring false page. Observed magnitudes are 0.02 to
-  0.10 packets/s, an order of magnitude below the ~1-2/s of a genuinely stuck job,
-  so a 0.5 floor separates them cleanly. The mechanism is not yet proven, but the
-  obvious suspects are ruled out: the policy object is patched, never recreated
-  (`reconcileNetworkPolicy` uses `controllerutil.CreateOrUpdate`, and the live
-  objects are still `generation: 1`), no Cilium agent restarts, and a rolling
-  update reuses the same pod labels so no new security identity has to propagate.
-  Cilium runs `routing-mode: tunnel`, which carries the source identity in the
-  VXLAN header, so ordinary in-cluster pod-to-pod traffic is matched by
-  `namespaceSelector: {}` and allowed. That leaves a path where the pod identity
-  is *lost*: from outside the cluster, or SNATed through a NodePort/LoadBalancer.
-  Note the `peer` rule already had to open `0.0.0.0/0` for exactly that reason,
-  while `http` has no equivalent escape hatch beyond per-instance `ClientCIDRs`.
-- `rate(...[10m])` stays non-zero for a full 10 minutes after the *last* dropped
-  packet. Paired with a 10-minute pending period that let a ~4-minute burst hold the
-  condition for ~14 minutes and page as critical. `[5m]` keeps the pending period
-  meaning "still dropping" rather than "dropped recently".
+The rule is meant to catch *any* sustained denial, so a magnitude floor was
+rejected: it would have to be tuned, and it would silently hide a low-rate variant
+of the same fault. The discrimination belongs on duration instead, which is what
+the pending period already expresses. `[10m]` broke that: a rate over a 10-minute
+window stays non-zero for a full 10 minutes after the *last* dropped packet, so a
+4-minute burst held the condition for ~14 minutes and cleared a 10-minute pending
+period. Any burst of roughly a minute could page. With `[5m]` the same burst holds
+the condition for about 7 minutes and never reaches the pending period, while a
+genuinely stuck job, which drips for hours, still fires after 10 minutes exactly as
+before. The pending period now means "still dropping" rather than "dropped
+recently".
+
+That matters because these nodes do **not** sit at exactly zero, contrary to what
+an earlier version of this note claimed. Two distinct populations show up:
+
+- **Transient bursts, 0.02 to 0.10 packets/s, a few minutes long.** A
+  **kura-controller rollout** produces one on *all four* kura-hosting nodes at
+  once, within seconds of the new ReplicaSet appearing, on roughly half of
+  rollouts. Since every merge to `main` rolls the controller, a rule that pages on
+  these pages constantly. The `[5m]` window is what suppresses them. The mechanism
+  is not yet proven, but the obvious suspects are ruled out: the policy object is
+  patched, never recreated (`reconcileNetworkPolicy` uses
+  `controllerutil.CreateOrUpdate`, and the live objects are still `generation: 1`),
+  no Cilium agent restarts, and a rolling update reuses the same pod labels so no
+  new security identity has to propagate. Cilium runs `routing-mode: tunnel`, which
+  carries the source identity in the VXLAN header, so ordinary in-cluster
+  pod-to-pod traffic is matched by `namespaceSelector: {}` and allowed. That leaves
+  a path where the pod identity is *lost*: from outside the cluster, or SNATed
+  through a NodePort/LoadBalancer. Note the `peer` rule already had to open
+  `0.0.0.0/0` for exactly that reason, while `http` has no equivalent escape hatch
+  beyond per-instance `ClientCIDRs`.
+- **Sustained episodes, 0.8 to 5 packets/s, lasting 30 to 90 minutes.** These are
+  the real thing and the rule *should* page on them. The production node logs them
+  regularly. Treat a firing alert as a genuine mis-sourced host, not as noise.
 
 Before concluding a Mac mini is mis-sourced, check that the drops are confined to
 **one** node. A runner VM talks to a single regional cache, so simultaneous drops
@@ -445,9 +454,9 @@ connection at all and every cache request hangs until its own timeout, which has
 turned 8-minute CI jobs into 6-hour ones while every dashboard showed kura
 healthy and idle. The drop counter is the only signal that fires, and it tracks
 the stuck job closely: a steady ~1-2/s SYN-retransmit trickle for its whole life,
-falling back to baseline within a scrape of it being cancelled. Note that baseline
-is low but not zero, which is why the rule needs a magnitude floor rather than a
-bare `> 0`.
+falling back to baseline within a scrape of it being cancelled. What makes it
+detectable is that it *persists*, which is why the rule discriminates on duration
+rather than on magnitude.
 
 Note `cilium_drop_count_total` carries no source address, so on its own it says
 *that* a host is mis-sourced but not *which* one. Use `hubble_drop_total`, which

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -417,10 +417,17 @@ Both matter, and an earlier version of this rule had neither:
   appearing. Roughly half of rollouts do it, and since every merge to `main` rolls
   the controller, that is a recurring false page. Observed magnitudes are 0.02 to
   0.10 packets/s, an order of magnitude below the ~1-2/s of a genuinely stuck job,
-  so a 0.5 floor separates them cleanly. The mechanism is unproven: the policy
-  object is patched, never recreated (`reconcileNetworkPolicy` uses
-  `controllerutil.CreateOrUpdate`), so the suspect is transient identity resolution
-  on the `PodSelector` rules rather than a default-deny gap.
+  so a 0.5 floor separates them cleanly. The mechanism is not yet proven, but the
+  obvious suspects are ruled out: the policy object is patched, never recreated
+  (`reconcileNetworkPolicy` uses `controllerutil.CreateOrUpdate`, and the live
+  objects are still `generation: 1`), no Cilium agent restarts, and a rolling
+  update reuses the same pod labels so no new security identity has to propagate.
+  Cilium runs `routing-mode: tunnel`, which carries the source identity in the
+  VXLAN header, so ordinary in-cluster pod-to-pod traffic is matched by
+  `namespaceSelector: {}` and allowed. That leaves a path where the pod identity
+  is *lost*: from outside the cluster, or SNATed through a NodePort/LoadBalancer.
+  Note the `peer` rule already had to open `0.0.0.0/0` for exactly that reason,
+  while `http` has no equivalent escape hatch beyond per-instance `ClientCIDRs`.
 - `rate(...[10m])` stays non-zero for a full 10 minutes after the *last* dropped
   packet. Paired with a 10-minute pending period that let a ~4-minute burst hold the
   condition for ~14 minutes and page as critical. `[5m]` keeps the pending period
@@ -442,11 +449,24 @@ falling back to baseline within a scrape of it being cancelled. Note that baseli
 is low but not zero, which is why the rule needs a magnitude floor rather than a
 bare `> 0`.
 
-Note the counter carries no source address, so it says *that* a host is
-mis-sourced but not *which* one. Correlating it back to a Mac mini currently
-needs Hubble flow metrics with source labels on the cache node, or catching the
-job live (`kubectl get pod -o wide`) and checking
-`pfctl -a com.apple/tuist.vmnat -s nat` plus `ifconfig vlan0` on that host.
+Note `cilium_drop_count_total` carries no source address, so on its own it says
+*that* a host is mis-sourced but not *which* one. Use `hubble_drop_total`, which
+carries `source` and `destination`:
+
+```promql
+topk(10, sum by (source, destination) (
+  rate(hubble_drop_total{reason="POLICY_DENIED", protocol="TCP"}[5m])
+))
+```
+
+An in-cluster source resolves to a pod name; a mis-sourced runner VM or a SNATed
+path resolves to a bare IP, which is the distinction that matters here. Those
+labels come from `drop:sourceContext=pod|ip;destinationContext=pod` in
+[`cilium-values.yaml`](../../k8s/mgmt/bootstrap/cilium-values.yaml). A cluster
+that has not had that Cilium value applied still reports `hubble_drop_total`
+aggregated to `(protocol, reason)` only, and needs the job caught live
+(`kubectl get pod -o wide`) with `pfctl -a com.apple/tuist.vmnat -s nat` plus
+`ifconfig vlan0` checked on the host instead.
 
 A mis-sourced host can also be found from metrics alone, because none of its cache
 traffic completes and its PN VLAN goes nearly silent:

--- a/infra/k8s/mgmt/bootstrap/cilium-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/cilium-values.yaml
@@ -72,7 +72,18 @@ hubble:
   metrics:
     enabled:
       - dns:query;ignoreAAAA
-      - drop
+      # Context labels on `drop` only. Without them hubble_drop_total is
+      # aggregated cluster-wide to (protocol, reason), which names neither
+      # the source nor the destination. That gap is what leaves a policy-denied
+      # kura cache node unattributable (see
+      # ../../../helm/k8s-monitoring/alerts.md, "Kura cache rejecting runner
+      # traffic"). `pod|ip` falls back to the raw address when the source is
+      # not a known pod, which is exactly the discriminator: an in-cluster pod
+      # source resolves to a pod, a mis-sourced runner VM or a SNATed path
+      # resolves to an IP. Do NOT add contexts to `flow` or `tcp`; those are
+      # high-volume and the cardinality is not worth it. `drop` is inherently
+      # low-volume, so the added series count is bounded.
+      - drop:sourceContext=pod|ip;destinationContext=pod
       - tcp
       - flow
       - icmp


### PR DESCRIPTION
## What changed

Two related changes to the `Kura cache rejecting runner traffic` alert (`ffuscyncueo74d`).

**1. Fixed the rule's rate window** in `infra/helm/k8s-monitoring/alerts.md`: `[10m]` becomes `[5m]`. The `> 0` threshold is deliberately left alone. The runbook section is rewritten alongside it: the premise the rule was built on was wrong, the false-positive mode is now documented, the measured impact of a real episode is recorded, and there is a metrics-only way to find a mis-sourced host that the runbook previously said was impossible without Hubble or catching the job live.

**2. Made the drops attributable** in `infra/k8s/mgmt/bootstrap/cilium-values.yaml`: the Hubble `drop` metric now carries `sourceContext=pod|ip;destinationContext=pod`.

## Why

The rule paged critical on 2026-08-17 at 09:40 UTC and resolved itself five minutes later. It was not the failure the runbook describes.

**The burst was a kura-controller rollout, not a mis-sourced Mac mini.** It ran 09:29:39 to 09:33:39 UTC and appeared on all four kura-hosting nodes at once (scw-fr-par, eu-central, us-east, us-west), starting 17 seconds after the new controller ReplicaSet was created. A mis-sourced runner VM talks to a single regional cache, so it structurally cannot deny in four regions simultaneously. Roughly half of controller rollouts do this, and since every merge to `main` rolls the controller, it was a recurring false page.

**The rate window was the actual defect.** A rate over a 10-minute window stays non-zero for a full 10 minutes after the *last* dropped packet. A 4-minute burst therefore held the condition for ~14 minutes and cleared the 10-minute pending period. Any burst of roughly a minute could page.

**The "steady state is exactly zero" premise was false.** The runbook justified the rule by asserting these nodes sit at exactly zero. They do not, and the note now describes the two distinct populations that actually appear, along with what each one means.

**The rollout burst still has no named source.** `cilium_drop_count_total` carries no source address, and `hubble_drop_total` was aggregated cluster-wide to `(protocol, reason)`. Both the runbook and this investigation dead-end at the same place, which is what the Cilium change is for.

## Why this fix over the alternatives

**A magnitude floor was tried and rejected.** An earlier revision of this branch raised the threshold to `> 0.5`, on the reasoning that rollout blips measure 0.02 to 0.10 packets/s while a stuck job sustains 1 to 2/s. It works, but it is the wrong axis: it has to be tuned, and it would silently hide a low-rate variant of the same fault. The property worth keeping is that any sustained denial is real.

Duration is the right discriminator, and the pending period already expresses it. Measured against both known rollout blips, `[5m]` holds the condition for 7 minutes (2026-08-17) and 5 minutes (2026-08-16), neither of which reaches the 10-minute pending period, so neither pages. A genuinely stuck job drips for hours and still fires after 10 minutes exactly as before. This keeps the rule strictly more sensitive than the `> 0.5` version, since it also catches sustained sub-0.5 denial.

**On the Hubble labels**, context options are added to `drop` only. `flow` and `tcp` are high-volume and adding context there is a real cardinality and cost problem; `drop` is inherently low-volume, so the added series count is bounded. `sourceContext=pod|ip` falls back to the raw address when the source is not a known pod, which is precisely the discriminator needed: an in-cluster pod source resolves to a pod name, while a mis-sourced runner VM or a SNATed path resolves to a bare IP.

## What is still open

The mechanism linking a controller rollout to cross-region ingress denies is **not** established, and the runbook now says so rather than guessing. Ruled out so far:

- Policy churn: the live NetworkPolicy objects are still `generation: 1`, created 2026-07-14. `reconcileNetworkPolicy` uses `controllerutil.CreateOrUpdate`, so it patches and never recreates.
- Cilium agent restarts: none.
- Security-identity propagation: identities are label-derived and a rolling update reuses the same labels, so no new identity appears.
- Ordinary in-cluster pod-to-pod: Cilium runs `routing-mode: tunnel`, which carries the source identity in the VXLAN header, so those sources match `namespaceSelector: {}` and are allowed.

That leaves a path where the pod identity is lost, meaning from outside the cluster or SNATed through a NodePort/LoadBalancer. Worth noting the `peer` rule already had to open `0.0.0.0/0` for exactly that reason, while `http` has no equivalent escape hatch beyond per-instance `ClientCIDRs`. The new labels should name the source on the next rollout that reproduces it, at which point the rejection itself can be fixed rather than tolerated.

## Impact

The recurring false page goes away with no loss of sensitivity: the rule still fires on `> 0` for anything sustained past the pending period.

Separately, the sustained episodes this rule is really for are now measured rather than assumed. Across 2026-08-10 to 2026-08-14 the production node had 20 of them, and every one of the 17 macOS runner sessions that exceeded 40 minutes in that window started inside one, 17 for 17. Outside those episodes not a single macOS session passed 40 minutes (max 30.2 minutes across 650 sessions). Linux pools show no effect either way, which is the control, since they do not use the PN/pf NAT path. Three sessions hit exactly 361 minutes, the 6-hour ceiling, and about 34 hours of runner wall-clock was burned in total across two accounts.

That class stopped on 2026-08-14 once `b4ce0dba49` fixed the duplicated `/etc/pf.conf` anchor block. In the three days since, 255 macOS sessions ran with zero over 40 minutes and a 27-minute max, and the node logged no sustained episode. So the only thing still reaching this alert is the rollout blip that this PR suppresses.

**The Cilium change needs an explicit apply.** `cilium-values.yaml` is consumed by `helm upgrade --install` in `infra/mise/tasks/k8s/bootstrap-workload.sh`, which is not continuously reconciled, so existing clusters keep the old aggregation until that upgrade is run against them.

## Validation

Alert behaviour:

- Replayed the rule at 1-minute resolution across both known rollout blips and confirmed `[5m]` holds the condition for 7 and 5 minutes respectively, short of the 10-minute pending period.
- Confirmed sustained episodes in the 7-day history stay non-zero far longer than 10 minutes, so they still page.

The 2026-08-17 burst:

- Confirmed it spanned all four kura nodes via `cilium_drop_count_total` joined to `kube_pod_info`, and that no Cilium agent restarted.
- Confirmed the kura data plane was never disrupted: container restarts flat at 0 for 6 hours, pod count flat at 35.
- Correlated controller ReplicaSet creation times from `kubectl get rs` against the drop windows across two separate rollouts, and confirmed each ReplicaSet carries a distinct image SHA.
- Read the live NetworkPolicy and Cilium config to rule out policy churn, identity churn, and SNAT on ordinary pod-to-pod traffic.

The sustained-episode impact claim:

- Extracted the 20 episode windows from a 7-day replay, then joined them against `runner_sessions` in production Postgres, restricted to rows with `ended_at IS NOT NULL` so that known session-close leaks cannot inflate durations.
- Split by pool: macOS shows 0 sessions over 40 minutes outside episodes versus 15 inside; Linux, which does not use the PN/pf path, shows no difference either way and serves as the control.
- Checked each of the 17 long sessions individually against the episode list; all 17 overlap one, spread across 16 distinct episodes.
- Re-ran the same query for the post-fix window to confirm the class is gone.
- Verified the vlan0 diagnostic added to the runbook: all 9 production runner hosts peak at 292k to 716k B/s over 7 days, so no host is currently mis-sourced.

Docs:

- Parsed the edited `cilium-values.yaml` to confirm the metrics list still renders as intended, and checked both new relative doc links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)