### PR TITLE
fix(infra): request a permitted tailnet tag for canary's Postgres pooler proxy

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -262,17 +262,22 @@ postgresql:
     # infra/cnpg/README.md.
     pooler:
       enabled: true
-      # See values-managed-production.yaml for the rationale. Canary's
-      # only Mac mini is on the production tailnet (single shared
-      # tailnet across canary + production), so the proxy needs to land
-      # on the same tag as production's `tag:tuist-k8s-production`
-      # — the canary's tag (`tag:tuist-k8s-canary`) is not permitted
-      # by the operator's OAuth client. Hostname is env-scoped to
-      # keep production's stable.
+      # See values-managed-production.yaml for the rationale. Canary
+      # shares a tailnet with production but not a tag: the canary Mac
+      # mini fleet joins as `tag:tuist-macmini-canary` (macosFleet
+      # .tailscale.tags below) and the canary operator runs its own
+      # OAuth client, which can only mint `tag:tuist-k8s-canary`.
+      # Requesting production's tag here left the Service stuck on
+      # `requested tags [tag:tuist-k8s-production] are invalid or not
+      # permitted`, so no proxy node existed, the hostname below
+      # resolved to nothing, and the Tart VM could not reach Postgres.
+      # infra/tailscale/acls.json already grants
+      # tag:tuist-macmini-canary -> tag:tuist-k8s-canary on tcp:5432.
+      # Hostname stays env-scoped to keep production's stable.
       tailscale:
         enabled: true
         hostname: tuist-pg-pooler-canary
-        tags: tag:tuist-k8s-production
+        tags: tag:tuist-k8s-canary
     storage:
       size: "10Gi"
     resources:


### PR DESCRIPTION
## What changed

`infra/helm/tuist/values-managed-canary.yaml` now requests
`tag:tuist-k8s-canary` for the CNPG pooler's Tailscale proxy instead of
`tag:tuist-k8s-production`, and the comment above it is rewritten to
state the actual constraint.

## Root cause

Canary's pooler Service carried the exposure annotations, and the pooler
itself was healthy, but no proxy node was ever created for it. The
Service had been sitting on this condition since 2026-06-08:

```
failed to provision: failed to create or get API key secret:
Status: 400, Message: "requested tags [tag:tuist-k8s-production]
are invalid or not permitted"
```

Each environment's Tailscale operator runs its own OAuth client scoped
to its own tag, which is the whole point of the per-env tag split
documented in `infra/tailscale/acls.json`: a leaked staging credential
cannot enroll a device under a production tag. The canary operator
therefore cannot mint `tag:tuist-k8s-production`, and the reconcile
failed on every pass.

Because the proxy never existed, `tuist-pg-pooler-canary` resolved to
nothing on the tailnet. Canary sets
`xcresultProcessor.databaseUrlSecretKey: xcresult-processor-database-url`,
so the Tart VM (whose only network interface is Tailscale) dials exactly
that hostname. Postgrex hung, and the Oban producer for
`process_xcresult` raised on every poll rather than picking up work.

The comment that justified the production tag had both of its premises
backwards. Canary shares a *tailnet* with production, not a *tag*: the
canary Mac mini fleet joins as `tag:tuist-macmini-canary`
(`macosFleet.tailscale.tags`), and `tag:tuist-k8s-canary` is precisely
the tag the canary operator is permitted to mint. Two other Services in
that cluster already use it and are Ready: the Alloy receiver and the
tuist-ops egress. Canary was the only environment affected; staging and
production each request their own matching tag and both have a live
pooler device.

## Why this fix over the alternatives

Widening the canary operator's OAuth client to include the production
tag would let a canary credential enroll production-tagged devices,
which inverts the isolation the tag-per-env split exists to provide. A
dedicated `tag:tuist-pg-pooler-canary` would also work but needs a new
OAuth scope, a `tagOwners` entry, and a new grant, none of which buy
anything today. The env-matching tag is already provisioned, already
permitted, and is already the destination of the load-bearing ACL grant
for this exact path:

```
tag:tuist-macmini-canary -> tag:tuist-k8s-canary on tcp:5432
```

So no change to `infra/tailscale/acls.json` is needed, and the proxy
stays reachable by the canary Mac mini once the wide-open catch-all
grant in that file is eventually removed.

## Impact

Canary's `process_xcresult` queue has not drained since 2026-06-04
08:27 UTC. At the time of writing it holds 3,178 jobs in `available`
with the oldest runnable for 74.1 days, and the canary VM's PromEx
reports 43 producer exceptions at roughly 21s each (the Postgrex connect
timeout) and no successful producer polls at all. Note the queue was
already stalled four days before the proxy annotations landed, so
[#11134](https://github.com/tuist/tuist/pull/11134) was an attempted fix
for an existing outage that succeeded on staging and production and
silently failed on canary. This PR does not by itself replay the
backlog; the jobs are still `available` and a working consumer will pick
them up.

Production and staging are unaffected by this change.

## Validation

`helm template` against the canary values now renders
`tailscale.com/tags: "tag:tuist-k8s-canary"` on the Pooler's
`serviceTemplate`, with the hostname unchanged so the rendered
`xcresult-processor-database-url` still points at
`tuist-pg-pooler-canary`.

Post-deploy this should show `tuist-pg-pooler-canary` present in
`tailscale status`, and the canary VM's PromEx on port 9091 reporting a
climbing `tuist_oban_producer_duration_milliseconds_count` for
`process_xcresult` with `tuist_oban_producer_exception_duration_milliseconds_count`
flat.

## Follow-up, not in this PR

Nothing paged for this. The queue-has-no-consumer rule from
[#12304](https://github.com/tuist/tuist/pull/12304) shipped the metric
and the documentation in `infra/helm/k8s-monitoring/alerts.md`, but the
rule itself is created by hand in the Grafana console and is not in the
repo, so nothing enforces that the deployed rule matches the documented
expression. Canary is emitting
`tuist_oban_queue_oldest_available_age_seconds` at 6.4M seconds from a
correctly scrape-annotated pod, which is far over the documented 900s
threshold, so the gap is in the deployed rule or its routing rather than
in the metric or the environment's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)