### PR TITLE
docs(infra): point the Tailscale OAuth client steps at Trust credentials

### DIFF
--- a/infra/helm/tuist/templates/macos-fleet-tailscale-external-secrets.yaml
+++ b/infra/helm/tuist/templates/macos-fleet-tailscale-external-secrets.yaml
@@ -28,7 +28,8 @@
 # tailscale-up.sh and infra/macos-host-bootstrap/bootstrap.go.
 #
 # Provisioning a new env: create an OAuth client in the Tailscale
-# admin console with the `auth_keys` write scope, restricted to that
+# admin console under Settings > Trust credentials (not the Keys
+# page) with the Auth Keys write scope, restricted to that
 # env's `tag:tuist-macmini-<env>` (declared under tagOwners in
 # infra/tailscale/acls.json), and store its secret in the env vault's
 # TAILSCALE item. Rotation, if ever needed, is unchanged: bump the

--- a/infra/k8s/mgmt/tailscale.yaml
+++ b/infra/k8s/mgmt/tailscale.yaml
@@ -32,10 +32,14 @@
 #          "tag:tuist-mgmt": ["autogroup:admin"]
 #        }
 #      (Merge with any existing `tagOwners` block; don't replace.)
-#   3. Settings → OAuth clients → Generate OAuth client.
+#   3. Settings → Trust credentials → Credential → OAuth, then
+#      Generate credential. (Not "Settings → OAuth clients", and not
+#      the Keys page, which holds only auth keys and API tokens.)
+#      https://login.tailscale.com/admin/settings/trust-credentials
 #      - Description: `mgmt-cluster tailscaled (manifest: infra/k8s/mgmt/tailscale.yaml)`
-#      - Scopes: `auth_keys` write (Devices → Auth Keys → Write)
-#      - Tags: `tag:tuist-mgmt` (limits what the client can mint)
+#      - Scopes: Keys → Auth Keys → Write
+#      - Tags: `tag:tuist-mgmt` (required for the write scope, and
+#        limits what the client can mint)
 #      Copy the secret (starts with `tskey-client-`); shown once.
 #   4. Store the secret in 1Password as
 #      `tailscale-mgmt-oauth-client-secret`.

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -211,10 +211,12 @@ Every Mac mini joins the tailnet at bootstrap, and so does every Tart VM the pro
 
 **Store an OAuth client secret here, never a pre-auth key.** Tailscale caps pre-auth keys at 90 days and there is no way to extend one, so a fleet joining with a pre-auth key has an outage on the calendar with nothing but a human remembering the date in the way. On 2026-08-12 that key lapsed and the `:process_xcresult` queue ran with zero consumers for ~13h: the Mac mini hosts were fine (they join once and keep their identity) but every processor Pod roll creates a fresh VM that has to join again, and its launchd chain refuses to start the release without a tailnet identity. OAuth clients don't expire, and `tailscale up` accepts the client secret wherever an auth key goes, minting a fresh key per join.
 
-In the Tailscale admin console, under **Settings → OAuth clients**, create one client per env:
+In the Tailscale admin console, create one client per env under [**Settings → Trust credentials**](https://login.tailscale.com/admin/settings/trust-credentials): select **Credential**, then **OAuth**, then **Generate credential**. Note this is not the **Keys** page, which holds only auth keys and API access tokens; there is no "OAuth clients" page.
 
-- Scope: `auth_keys` (write). Nothing else: this credential only mints join keys.
-- Tags: this env's `tag:tuist-macmini-<env>` only. One client per env means a leaked staging credential can't enroll a device under a production tag, the same isolation the `tuist-k8s-<env>` operator clients get.
+- Scope: **Keys → Auth Keys → Write**, nothing else. This credential only mints join keys.
+- Tags: this env's `tag:tuist-macmini-<env>` only. The write scope requires at least one tag, and it is what the minted key applies to the joining device. One client per env means a leaked staging credential can't enroll a device under a production tag, the same isolation the `tuist-k8s-<env>` operator clients get.
+
+The secret is shown once, and starts with `tskey-client-`. That prefix is load-bearing: both consumers detect it to decide whether to annotate the credential, so a value stored without it is treated as a legacy pre-auth key.
 
 The tag must already exist under `tagOwners` in [`../tailscale/acls.json`](../tailscale/acls.json). Keys minted through an OAuth client are always tagged and carry no default, so the consumers name the tag at join time from `macosFleet.tailscale.tags`. Set that in the env's values file or the fleet cannot join at all (the CAPI operator rejects the config before it pushes anything, and the VM's `tailscale-up.sh` exits before `tailscale up`).
 


### PR DESCRIPTION
Tailscale moved OAuth client creation in the admin console. Every place we document it sends the reader somewhere that no longer exists.

### What was wrong

`Settings → OAuth clients` is gone. The natural guess, `Settings → Keys`, is also wrong: that page holds only auth keys and API access tokens. Clients now live under **Settings → Trust credentials**, created with **Credential → OAuth → Generate credential**.

This was found the hard way while following our own runbook to migrate the macOS fleet credential off pre-auth keys. The documented path dead-ends and the obvious fallback is a second dead end, both at the moment someone is provisioning a fleet and has the least context to recover.

### What changed

- `infra/k8s/onboarding.md` §5c — the fleet credential runbook, the one an operator actually follows. Now links straight to `https://login.tailscale.com/admin/settings/trust-credentials` and names the button sequence, with an explicit note that Keys is not the page, so the same wrong guess isn't repeated.
- `infra/k8s/mgmt/tailscale.yaml` — same path fix for the mgmt-cluster tenant bootstrap. Also corrects the scope path: it said `Devices → Auth Keys → Write`, but the console groups auth-key scopes under **Keys**.
- `infra/helm/tuist/templates/macos-fleet-tailscale-external-secrets.yaml` — the provisioning note beside the Secret that consumes the credential.

Two accuracy fixes came along with it:

**The tag is required, not advisory.** The write scope will not save without at least one tag, and that tag is what the minted key applies to the joining device. The previous wording read as a recommendation.

**The `tskey-client-` prefix is load-bearing.** Both consumers branch on it to decide whether to append `?ephemeral=true&preauthorized=true`. A secret stored without it is silently treated as a legacy pre-auth key, which fails in a way that looks like a network fault rather than a configuration mistake. That was not written down anywhere.

### Validation

Comment and docs only, no behaviour change.

```bash
cd infra/helm/tuist && helm template tuist . -f values-managed-common.yaml -f values-managed-production.yaml --set image.tag=1 --set registry.image.tag=1 --set xcresultProcessor.image.tag=1 --set cache.image.tag=1 --set codebaseSearch.image.tag=1 --set kuraController.image.tag=1 --set kura.image.tag=1 --set runnersFleet.runnerImageSemver=0.0.1 --set runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/x:1
```

```bash
kubectl apply --dry-run=client -f infra/k8s/mgmt/tailscale.yaml
```

Both pass. A repo-wide grep confirms no navigation path still says "OAuth clients" — the remaining matches are prose ("OAuth clients don't expire").

The paths were verified against the live console while creating the three real clients this week, not from documentation alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

