### PR TITLE
fix(infra): let a failed staging upgrade roll back instead of stranding the release

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -791,6 +791,122 @@ jobs:
         # schema changes ship the same way code changes do; no
         # operator-side manual step.
         run: kubectl apply -f "$HELM_CHART_PATH/crds/"
+      - name: Reconcile Mac mini MachineTemplates with the Helm baseline
+        # macos-fleet.yaml names its ScalewayAppleSiliconMachineTemplate
+        # after a hash of its own spec, so an OS or SKU change renders a
+        # new object and the previous one leaves the manifest.
+        #
+        # Helm cannot patch such an object once it is on the cluster but
+        # absent from the manifest it is using as the patch baseline. It
+        # falls back to cluster state as the baseline, and for a custom
+        # resource the patch is a JSON merge from the live object to the
+        # manifest, which nulls `metadata.resourceVersion`; the apiserver
+        # rejects that as an update. Whichever operation hits it fails, so
+        # a failed upgrade cannot roll back and stays half-applied.
+        #
+        # Two things are needed to keep every template on a path Helm can
+        # take, and both are convergence work that no-ops once the fleets
+        # have deployed cleanly once.
+        #
+        # 1. Drop any leftover `helm.sh/resource-policy: keep`. The chart
+        #    no longer renders it, but Helm reads that annotation off the
+        #    *live* object when it deletes resources a new revision no
+        #    longer declares. A template still carrying it survives the
+        #    upgrade that supersedes it and lands outside every recorded
+        #    manifest, which is how these strand in the first place.
+        #
+        # 2. Delete templates the baseline does not name. `helm upgrade`
+        #    baselines on the last *deployed* revision and `helm rollback`
+        #    on the *latest* one, and those diverge precisely when a
+        #    deploy has already failed, so only a template both manifests
+        #    name is safe to leave in place. Helm re-creates from the
+        #    target manifest whatever it needs, on either path. This has
+        #    to run before the recovery step below as well as the upgrade,
+        #    because that step's `helm rollback` hits the same path.
+        #
+        # Deleting a template does not disturb running Machines: the
+        # per-replica ScalewayAppleSiliconMachine is a clone owned by its
+        # Machine, so nothing cascades. It only blocks the MachineSet that
+        # references it from scaling up, which is why a MachineSet still
+        # holding replicas keeps its template even when the baseline has
+        # lost track of it: that MachineSet may need it to replace a
+        # Machine. One at `spec.replicas=0` is a superseded revision that
+        # OnDelete only ever scales further down. Machines are not checked
+        # because a Machine references its own clone, never the template.
+        run: |
+          set -euo pipefail
+
+          templates="$(
+            kubectl -n "$NAMESPACE" get scalewayapplesiliconmachinetemplates \
+              -l app.kubernetes.io/instance="$HELM_RELEASE_NAME",app.kubernetes.io/component=macos-fleet \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
+              sed '/^$/d'
+          )"
+
+          if [ -z "$templates" ]; then
+            echo "No release-owned Mac mini MachineTemplates in $NAMESPACE."
+            exit 0
+          fi
+
+          # One call per template: `kubectl annotate` rejects an annotation
+          # key that precedes the resource names, and xargs appends.
+          printf '%s\n' "$templates" | xargs -r -I{} kubectl -n "$NAMESPACE" \
+            annotate scalewayapplesiliconmachinetemplate {} helm.sh/resource-policy-
+
+          if ! helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+            echo "Release $HELM_RELEASE_NAME is not installed; no baseline to reconcile against."
+            exit 0
+          fi
+
+          latest_manifest="$(helm get manifest "$HELM_RELEASE_NAME" -n "$NAMESPACE")"
+
+          deployed_revision="$(
+            helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
+              awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { revision = $1 } END { print revision }'
+          )"
+
+          if [ -n "$deployed_revision" ]; then
+            deployed_manifest="$(
+              helm get manifest "$HELM_RELEASE_NAME" -n "$NAMESPACE" --revision "$deployed_revision"
+            )"
+          else
+            # With no revision recorded as deployed, helm upgrade baselines
+            # on the latest one instead.
+            echo "No deployed revision recorded; the latest revision is the only baseline."
+            deployed_manifest="$latest_manifest"
+          fi
+
+          # An empty `spec.replicas` reads as non-zero here, which keeps
+          # the template rather than deleting it.
+          scaling_refs="$(
+            kubectl -n "$NAMESPACE" get machinesets \
+              -o jsonpath='{range .items[*]}{.spec.template.spec.infrastructureRef.kind}{"\t"}{.spec.template.spec.infrastructureRef.name}{"\t"}{.spec.replicas}{"\n"}{end}' |
+              awk -F'\t' '$1 == "ScalewayAppleSiliconMachineTemplate" && $3 != "0" { print $2 }' |
+              sort -u
+          )"
+
+          named_by() { printf '%s\n' "$1" | grep -q "^ *name: ${2}\$"; }
+
+          stranded=""
+          while IFS= read -r template; do
+            if named_by "$latest_manifest" "$template" && named_by "$deployed_manifest" "$template"; then
+              echo "Keeping $template: named by every baseline helm can use."
+            elif printf '%s\n' "$scaling_refs" | grep -qxF "$template"; then
+              echo "Keeping $template: a MachineSet holding replicas still clones from it."
+            else
+              stranded="${stranded}${template}"$'\n'
+            fi
+          done <<< "$templates"
+
+          if [ -z "$stranded" ]; then
+            echo "Every Mac mini MachineTemplate is on a path helm can take."
+            exit 0
+          fi
+
+          echo "Deleting Mac mini MachineTemplates outside the baseline:"
+          printf '%s' "$stranded"
+          printf '%s' "$stranded" | xargs -r kubectl -n "$NAMESPACE" \
+            delete scalewayapplesiliconmachinetemplate --ignore-not-found --timeout=2m
       - name: Recover interrupted Helm release
         run: |
           set -euo pipefail

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -262,6 +262,42 @@ the field onto a live template (it patches these CRs manifest-to-manifest,
 so a field the live object never received is never added). Prefer an
 optional field with a controller-side default over a required one.
 
+### MachineTemplate lifecycle
+
+[`macos-fleet.yaml`](../helm/tuist/templates/macos-fleet.yaml) works around
+that manifest-to-manifest patching by naming its
+`ScalewayAppleSiliconMachineTemplate` after a hash of its own spec, so an OS
+or SKU change renders a new object that receives the full spec instead of a
+patch. The other fleets use a stable name and are patched in place.
+
+A hash-named template must never carry `helm.sh/resource-policy: keep`. It
+leaves the rendered manifest the moment the hash moves, so keeping it strands
+an object that is on the cluster but absent from the manifest Helm baselines
+its patches on. Helm answers that by falling back to cluster state as the
+baseline, and for a custom resource the patch is a JSON merge from the live
+object to the manifest, which nulls `metadata.resourceVersion`; the apiserver
+rejects that as an update. Whichever operation hits it fails, and when that
+operation is the `--atomic` rollback of a failed upgrade, the release cannot
+return to its previous revision and stays half-applied.
+
+`helm upgrade` baselines on the last *deployed* revision and `helm rollback`
+on the *latest* one, and those diverge exactly when a deploy has already
+failed, so the deploy workflow reconciles the fleet's templates against both
+before it runs either. It drops leftover `keep` annotations (Helm reads that
+annotation off the live object when deleting resources a new revision no
+longer declares, so a template still carrying one survives the upgrade that
+supersedes it) and deletes templates neither manifest names. Helm re-creates
+from the target manifest whatever it still needs.
+
+Deleting a template does not disturb running Machines: the per-replica
+`ScalewayAppleSiliconMachine` is a clone owned by its Machine, so nothing
+cascades. It only blocks the MachineSet that references it from scaling up,
+reported as `ScalingUp=False` with
+`Scaling up would be blocked because ScalewayAppleSiliconMachineTemplate does not exist`.
+A MachineSet still holding replicas therefore keeps its template even when
+the baseline has lost track of it; one at `spec.replicas=0` is a superseded
+revision that `OnDelete` only ever scales further down.
+
 ## Node extended resources
 
 The Linux machine controllers patch two integer extended resources onto the

--- a/infra/helm/tuist/templates/macos-fleet.yaml
+++ b/infra/helm/tuist/templates/macos-fleet.yaml
@@ -26,9 +26,28 @@ change renders a new object rather than an edit to the existing
 one. Helm's three-way merge only patches fields that differ
 between the previous and current rendered manifest, so a field
 added to a template that already exists in-cluster is never
-applied and the object stays stale indefinitely — every later
+applied and the object stays stale indefinitely: every later
 deploy sees the field as unchanged and emits no patch. Creating
 a new object instead always writes the full spec.
+
+A hash-named object must NOT carry `helm.sh/resource-policy:
+keep`. It leaves the rendered manifest the moment the hash moves,
+so keeping it produces an object that is on the cluster and in
+older revisions' manifests but absent from the current one. Helm
+handles that combination by falling back to cluster state as the
+patch baseline, and for a custom resource the patch is a JSON
+merge from the live object to the manifest, which nulls
+`metadata.resourceVersion`; the apiserver rejects that as an
+update. The rollback itself then fails, so a failed upgrade stays
+half-applied instead of returning to its previous revision.
+Letting Helm delete the superseded object is also what garbage
+collects it, and a rollback recreates it from the target manifest.
+
+Deleting a superseded template does not disturb running Machines:
+the per-replica ScalewayAppleSiliconMachine is a clone owned by
+its Machine, not by the template. It only blocks the MachineSet
+that references it from scaling up, and under OnDelete a
+superseded MachineSet is only ever scaled further down.
 */ -}}
 {{- $machineSpec := dict
       "type" (.Values.macosFleet.machine.type | default "M2-L")
@@ -49,10 +68,6 @@ kind: ScalewayAppleSiliconMachineTemplate
 metadata:
   name: {{ $templateName }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    # A superseded template stays referenced by the MachineSet that
-    # was cloned from it, which outlives the template under OnDelete.
-    helm.sh/resource-policy: keep
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: macos-fleet


### PR DESCRIPTION
A failed `helm upgrade` on the `tuist` release could not roll back. The rollback itself errored, so a failed deploy left the release half-applied instead of returning to its previous revision.

Observed 2026-08-17 in run 32012704348 (`Deploy to tuist-staging`), after the upgrade timed out:

```
level=WARN msg="resource exists on cluster but not in original release, using cluster state as baseline"
  namespace=tuist-staging name=tuist-tuist-macos-fleet-887070e8 kind=ScalewayAppleSiliconMachineTemplate

level=WARN msg="Rollback \"tuist\" failed: cannot patch \"tuist-tuist-macos-fleet-887070e8\"
  ... metadata.resourceVersion: Invalid value: 0: must be specified for an update"

Error: UPGRADE FAILED: an error occurred while rolling back the release.
```

The concrete impact: that upgrade applied `xcresult-processor:0.74.1`, then failed for an unrelated reason, and the broken rollback left the processor back on `0.73.2` while other resources stayed advanced. That combination broke staging's tailnet join during the Tailscale OAuth migration. A failed deploy was worse than a no-op.

### Where the orphan came from

`887070e8` is the pre-#12351 render of the same template. [`a3b45e4c3c`](https://github.com/tuist/tuist/commit/a3b45e4c3c) moved the macOS fleets' OS pin from the image name `macos-tahoe-26.3` to the release family `Tahoe`, which changed the spec hash and therefore the object name. All four live hashes reproduce exactly from the chart, which confirms provenance and rules out a hand-made object:

| inputs | renders | live as |
| --- | --- | --- |
| `os=Tahoe`, `hostCPU`/`hostMemoryMB` set | `5558f1dc` | staging + production current |
| `os=macos-tahoe-26.3`, `hostCPU`/`hostMemoryMB` set | `887070e8` | staging + production orphan |
| `os=Tahoe`, no host overrides | `bad5685f` | canary current |
| `os=macos-tahoe-26.3`, no host overrides | `e91ad5ef` | canary orphan |

Nothing garbage-collected them, so this was systemic rather than a one-off: **every environment carried exactly one orphan**, one per hash change, accumulating forever. Each was a landmine for the next operation whose manifest named it, not just this one.

### Root cause

`macos-fleet.yaml` names its `ScalewayAppleSiliconMachineTemplate` after a hash of its own spec, so a spec change renders a new object that receives the full spec instead of a patch. That part is deliberate and stays: Helm patches these CRs manifest-to-manifest, so a stale live object is never corrected, which is already documented in the provider's `AGENTS.md`.

The defect was pairing that content-derived name with `helm.sh/resource-policy: keep`. Helm's own garbage collection would have deleted the superseded object; the annotation suppressed it. The object then sat on the cluster while older revisions' manifests still named it, and per Helm 4.2.0's `pkg/kube/client.go` that combination takes a cluster-state-baseline path. For a custom resource the patch is `jsonpatch.CreateMergePatch(live, manifest)`, and since the manifest carries no `resourceVersion` the merge patch emits it as `null`, hence `Invalid value: 0`. Unconditional for any CR on that path, so there is no chart-side way to make the patch succeed; the fix has to keep these objects off it.

Two findings cut against the annotation's stated rationale ("a superseded template stays referenced by the MachineSet that was cloned from it"):

- It has never protected anything. In all three environments the MachineSet actually holding the replicas is the rev-1 one referencing the **unsuffixed** `tuist-tuist-macos-fleet`, which the hash rename itself deleted on 2026-08-13. The orphan `keep` does preserve is referenced only by a `spec.replicas=0` MachineSet.
- Deleting a template is safe for running Machines, confirmed from live cluster state: the per-replica `ScalewayAppleSiliconMachine` has `ownerReferences: Machine/...`, never the template, so nothing cascades. CAPI reports the only consequence directly, `ScalingUp=False` with `Scaling up would be blocked because ScalewayAppleSiliconMachineTemplate does not exist`, alongside `Remediating=False` and replicas intact. That has been the live state since 2026-08-13 with no Machine disturbed.

### What changed

`infra/helm/tuist/templates/macos-fleet.yaml` drops the annotation. Helm now deletes a superseded template as part of the upgrade that supersedes it, and a rollback re-creates it from the target manifest via the create path rather than patching a cluster-state baseline. The hash scheme is unchanged; the rendered diff against `main` is the annotation removal and nothing else, hash included, so the next deploy patches the existing object rather than creating a fourth.

`.github/workflows/server-deployment.yml` adds a reconcile step, because the chart change cannot reach the already-stranded objects: they sit outside every recorded manifest, so Helm will never touch them again. It runs before the upgrade and before the recovery step's own `helm rollback`, which hits the identical path. It does two things, both convergence work that no-ops once each fleet has deployed cleanly:

1. Drops leftover `keep` annotations. Helm reads that annotation off the **live** object when deleting resources a new revision no longer declares, so dropping it from the chart alone is not enough; a template still carrying one would survive the upgrade that supersedes it and strand again.
2. Deletes templates that neither baseline manifest names, with a floor that never removes one a MachineSet holding replicas still clones from.

Checking *both* baselines is load-bearing rather than belt-and-braces: `helm upgrade` baselines on the last **deployed** revision and `helm rollback` on the **latest** one, and they diverge exactly when a deploy has already failed. A reference-based predicate would have left `5558f1dc` in place and the next staging deploy would have failed the same way, just on the other hash.

`infra/cluster-api-provider-tuist/AGENTS.md` documents the lifecycle under the existing manifest-to-manifest-patching section.

Canary and production reuse this workflow via `server-production-deployment.yml`, so all three environments converge on their next deploy. No manual cleanup or JIT-elevated cluster write is needed; all investigation here was read-only.

### Scope

Only the rollback path. The upgrade timed out because `tuist-tuist-runners-fleet` has zero available replicas from a stale image-level OS pin; that is tracked separately and the rollback path would be broken regardless of fleet health.

### How to test locally

Rendered output is unchanged apart from the annotation, verified with an isolated harness over the real per-env values (the full chart needs deploy-time secrets):

```bash
helm template tuist infra/helm/tuist -n tuist-staging -f infra/helm/tuist/values-managed-staging.yaml --show-only templates/macos-fleet.yaml
```

The reconcile step's script was extracted from the workflow and exercised against mocked `helm`/`kubectl` across seven scenarios: staging as it stands today, steady state, an upgrade that died mid-`update`, an out-of-baseline template a scaling MachineSet still needs, release-not-installed, no-templates, and no-revision-recorded-as-deployed. All produced the intended keep/delete decisions.

That testing caught a real bug before it shipped: the first `annotate` call put the annotation key before the resource names, which `kubectl` rejects outright with `all resources must be specified before annotation changes`. Confirmed against the live API with `--dry-run=client`, fixed to one call per template, re-verified, and also confirmed that removing an absent annotation exits 0 so the strip is idempotent.

`actionlint` reports the same 5 pre-existing `tuist-linux` self-hosted-label findings on this branch as on `main`, and `shellcheck` is clean on the new script.

The Machine-safety property is confirmed empirically from live cluster state. The rollback property is confirmed against the Helm 4.2.0 source and the fixture tests, but has not been observed end to end, since that needs an actual failing deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
