### PR TITLE
fix(kura): build macOS binaries against the host SDK, not Apple's CDN

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -15,7 +15,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 - Peer sync bandwidth shaping: `src/bandwidth.rs`
 - Operational assets: `docker-compose.yml`, `ops/`, `test/e2e/`, `spec/e2e/`
   - See `ops/AGENTS.md` for Helm, rollout helpers, and observability config boundaries
-- Bazel build system: `MODULE.bazel`, `BUILD.bazel`, `bazel/` (toolchains + vendored deps); the crate graph is resolved from `Cargo.toml`/`Cargo.lock` by rules_rs
+- Bazel build system: `MODULE.bazel`, `BUILD.bazel`, `bazel/` (toolchains + vendored deps + `patches/`, applied to rules_rs's pinned rules_rust); the crate graph is resolved from `Cargo.toml`/`Cargo.lock` by rules_rs
 - License and contribution terms: `LICENSE.md`, `CLA.md`, `cla/`
 
 ## Development

--- a/kura/MODULE.bazel
+++ b/kura/MODULE.bazel
@@ -46,6 +46,17 @@ register_toolchains("@default_rust_toolchains//:all")
 # rules_rs already provisions this repo; re-importing its extension only adds it to our repo mapping,
 # it does not create a second copy.
 rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+
+# Every Rust target rules_rs generates defaults its `macos_sdkroot` to @macos_sdk//sysroot, which
+# the @llvm module unpacks from a Command Line Tools .pkg fetched from Apple's software update CDN.
+# Apple retires those URLs (the pinned one now 403s) and the archived fallback is best-effort, so
+# macOS analysis fails outright on a cold repository cache. Our macOS builds use the host Xcode
+# toolchain for the -sys crates' C/C++, so the patch drops that attribute back to empty and lets
+# rustc's linker resolve the same SDK the cc toolchain already targets.
+rules_rust.patch(
+    patches = ["//bazel/patches:rules_rust_host_macos_sdkroot.patch"],
+    strip = 1,
+)
 use_repo(rules_rust, "rules_rust")
 
 crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")

--- a/kura/bazel/patches/BUILD.bazel
+++ b/kura/bazel/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/kura/bazel/patches/rules_rust_host_macos_sdkroot.patch
+++ b/kura/bazel/patches/rules_rust_host_macos_sdkroot.patch
@@ -1,0 +1,25 @@
+Use the host macOS SDK instead of the hermetic @macos_sdk sysroot.
+
+rules_rs's rules_rust fork points every Rust target's `macos_sdkroot` attribute at
+@macos_sdk//sysroot, a sysroot the @llvm module unpacks from a Command Line Tools .pkg
+downloaded straight from Apple's software update CDN. Apple rotates those URLs out from
+under the pin (the currently pinned one 403s), and the archived fallback is best-effort,
+so the macOS release legs fail at analysis time whenever a runner's repository cache is
+cold. Kura's macOS builds compile and link their C/C++ with the host Xcode toolchain
+anyway, so pointing rustc at a differently-versioned minimal sysroot buys no hermeticity;
+leaving SDKROOT unset lets rustc's linker use the same SDK the cc toolchain already uses.
+
+--- a/rust/private/BUILD.bazel
++++ b/rust/private/BUILD.bazel
+@@ -25,10 +25,7 @@ filegroup(
+
+ alias(
+     name = "default_macos_sdkroot",
+-    actual = select({
+-        "@platforms//os:osx": "@macos_sdk//sysroot",
+-        "//conditions:default": ":empty_macos_sdkroot",
+-    }),
++    actual = ":empty_macos_sdkroot",
+     visibility = ["//visibility:public"],
+ )
+

--- a/kura/bazel/patches/rules_rust_host_macos_sdkroot.patch
+++ b/kura/bazel/patches/rules_rust_host_macos_sdkroot.patch
@@ -9,6 +9,13 @@ cold. Kura's macOS builds compile and link their C/C++ with the host Xcode toolc
 anyway, so pointing rustc at a differently-versioned minimal sysroot buys no hermeticity;
 leaving SDKROOT unset lets rustc's linker use the same SDK the cc toolchain already uses.
 
+This is how the Apple-facing rulesets already work: apple_support discovers the SDK through
+`xcrun`, and bazel-contrib/toolchains_llvm defaults its macOS sysroot to
+`xcrun --show-sdk-path`. Upstream tracks the retired URL in
+https://github.com/hermeticbuild/hermetic-llvm/issues/702 and host-discovered SDK support in
+https://github.com/hermeticbuild/hermetic-llvm/issues/68 — drop this patch once the @llvm
+module can resolve the SDK from the host.
+
 --- a/rust/private/BUILD.bazel
 +++ b/rust/private/BUILD.bazel
 @@ -25,10 +25,7 @@ filegroup(


### PR DESCRIPTION
Both macOS legs of the Kura release job have been failing on `main` ([example run](https://github.com/tuist/tuist/actions/runs/32018069563/job/95357683918)). They die during Bazel analysis, before any action runs:

```
ERROR: no such package '@@llvm++osx+macos_sdk//sysroot'
  swcdn.apple.com/.../CLTools_macOSNMOS_SDK.pkg  -> 403 Forbidden
  web.archive.org/.../CLTools_macOSNMOS_SDK.pkg  -> 503
```

### Root cause

rules_rs's rules_rust fork defaults every Rust target's `macos_sdkroot` attribute to `@macos_sdk//sysroot`, a sysroot the `@llvm` module unpacks from a Command Line Tools `.pkg` downloaded straight from Apple's software update CDN. Apple has retired that package — the 403 reproduces from any network, so it is not a runner-network problem — and the only fallback is a Wayback snapshot that is itself unavailable right now.

Every `llvm` version currently on the BCR (through 0.8.17) pins the same dead pair of URLs, so bumping upstream is not a fix. Legs pass only when a runner happens to hold the blob in its Bazel repository cache, which is why one `x86_64-apple-darwin` leg went green earlier in the day while the rest of the day's runs failed.

This is tracked upstream as [hermeticbuild/hermetic-llvm#702](https://github.com/hermeticbuild/hermetic-llvm/issues/702), filed by an unrelated downstream project, which independently confirms the 403 from two networks, confirms v0.8.17 carries the identical dead URL and SHA, and notes the same blast radius we hit: `@macos_sdk` is reachable during analysis of targets that are not building for macOS at all.

### Why this fix over the alternatives

The Apple-facing rulesets do not pin an SDK artifact in the first place. apple_support and rules_apple discover the installed Xcode through `xcrun`/`xcodebuild` and resolve the SDK at action time, and bazel-contrib/toolchains_llvm defaults its macOS sysroot to `xcrun --show-sdk-path`. hermetic-llvm is the outlier in downloading one; letting the SDK come from the host is where upstream is headed too, via the open [#68 Support host discovered macOS SDK](https://github.com/hermeticbuild/hermetic-llvm/issues/68).

The other option was mirroring the 58 MB `.pkg` on infrastructure we control (as we already do for Xcode `.xip`s on GHCR) and overriding `osx.from_archive` in the root module. That is more moving parts for no benefit here: our macOS builds compile and link the `-sys` crates' C/C++ with the host Xcode toolchain, so handing rustc a differently-versioned minimal SDK was a mismatch rather than a hermeticity win, and a root-module override would also pin the SDK against future rules_rs bumps. Notably no project mirrors this package, which is consistent with the SDK not being redistributable — hermetic-llvm's own fallback is a Wayback snapshot rather than a hosted copy.

So the patch drops the attribute back to the empty sdkroot. rules_rust then leaves `SDKROOT` unset and rustc's linker resolves the same SDK the cc toolchain already targets. rules_rs exposes `rules_rust.patch` for exactly this purpose, and a future rules_rs bump that reshapes the patched file fails loudly at fetch time rather than silently reverting the behaviour.

### What changed

- `kura/bazel/patches/rules_rust_host_macos_sdkroot.patch` — makes `//rust/private:default_macos_sdkroot` an unconditional alias for `:empty_macos_sdkroot`, with the upstream issues linked in its header so a reader knows when it can be dropped
- `kura/MODULE.bazel` — applies it through the `rules_rust.patch` tag
- `kura/AGENTS.md` — records the new `bazel/patches/` directory

`MODULE.bazel.lock` needs no update: rules_rs marks that extension `reproducible = True`, so it carries no lockfile entry.

### Impact

Restores the `aarch64-apple-darwin` and `x86_64-apple-darwin` Kura release binaries, unblocking the Kura release (and the Kura Docker image that depends on those artifacts) on production deployments. Linux legs are untouched. Local macOS development also stops depending on a dead Apple URL on a cold repository cache.

### How to test locally

From `kura/`, on macOS:

```
bazel cquery 'deps(//...)' --output=starlark --starlark:expr='target.label' | grep macos_sdk
```

Only `empty_macos_sdkroot` should appear — no `@macos_sdk`, so nothing reaches for Apple's CDN during analysis. Then build both release legs:

```
bazel build //:kura
bazel build //:kura --config=macos-x86_64-cross
```

Both were run on this branch: the first produces a working `Mach-O 64-bit executable arm64` (it starts and exits on missing env vars), the second a `Mach-O 64-bit executable x86_64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
