### PR TITLE
revert(infra): front the OCI registry with the expose annotation again

### DIFF
--- a/infra/helm/tuist/templates/oci-registry-service.yaml
+++ b/infra/helm/tuist/templates/oci-registry-service.yaml
@@ -1,15 +1,9 @@
 {{- if .Values.ociRegistry.enabled }}
-# `loadBalancerClass: tailscale` makes the operator front this Service
-# with a tailnet node, so builders and the Mac fleet reach the registry
-# with no public ingress. The proxy is L4, which matters here: an HTTP
-# proxy in the path would impose a request-body limit that 512 MiB layer
-# uploads would run into.
-#
-# LoadBalancer rather than the `tailscale.com/expose` annotation because
-# only this form reports the tailnet address back in the Service status,
-# and that address is what has to reach DNS. The annotation form leaves
-# the status empty, which left external-dns with nothing to publish but
-# the MagicDNS name.
+# `tailscale.com/expose` makes the operator front this Service with a
+# tailnet node, so builders and the Mac fleet reach the registry by its
+# tailnet name with no public ingress. The proxy is L4, which matters
+# here: an HTTP proxy in the path would impose a request-body limit that
+# 512 MiB layer uploads would run into.
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,30 +13,22 @@ metadata:
     app.kubernetes.io/component: oci-registry
   {{- if .Values.ociRegistry.tailscale.enabled }}
   annotations:
+    tailscale.com/expose: "true"
     tailscale.com/hostname: {{ required "ociRegistry.tailscale.hostname is required when ociRegistry.tailscale.enabled is true" .Values.ociRegistry.tailscale.hostname | quote }}
     {{- with .Values.ociRegistry.tailscale.tags }}
     tailscale.com/tags: {{ . | quote }}
     {{- end }}
     {{- if and .Values.ociRegistry.tls.enabled .Values.ociRegistry.tls.dns.enabled }}
-    # An A record onto the tailnet address, which external-dns reads from
-    # the Service status and re-syncs when the operator reassigns it —
-    # so this survives the node being recreated without pinning anything.
-    #
-    # It is deliberately not a CNAME onto the MagicDNS name. That name
-    # resolves only through Tailscale's own resolver, and the Mac hosts
-    # do not resolve through it: `tailscaled` there never reconfigures
-    # system DNS, so anything using ordinary OS resolution — crane, oras,
-    # tart — gets NXDOMAIN. The address answers for them because routing
-    # over the tailnet does not depend on MagicDNS, and publishing it
-    # costs nothing since it is only reachable from the tailnet anyway.
+    # A CNAME onto the MagicDNS name, not an A record: the tailnet
+    # address is reassigned when the node is recreated, and the name is
+    # not. It only resolves for tailnet members, so publishing it costs
+    # nothing and the certificate can be issued for a name we own.
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.ociRegistry.tls.host | quote }}
+    external-dns.alpha.kubernetes.io/target: {{ printf "%s.%s" .Values.ociRegistry.tailscale.hostname (required "ociRegistry.tls.dns.tailnet is required to build the CNAME target" .Values.ociRegistry.tls.dns.tailnet) | quote }}
     {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.ociRegistry.service.type }}
-  {{- if and .Values.ociRegistry.tailscale.enabled (eq .Values.ociRegistry.service.type "LoadBalancer") }}
-  loadBalancerClass: tailscale
-  {{- end }}
   selector:
     {{- include "tuist.componentLabels" (dict "root" . "component" "oci-registry") | nindent 4 }}
   ports:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2133,12 +2133,7 @@ ociRegistry:
     tag: "3"
     pullPolicy: IfNotPresent
   service:
-    # LoadBalancer so the Tailscale operator reports the tailnet address
-    # back in the Service status, which is what external-dns publishes.
-    # `loadBalancerClass: tailscale` is set by the template whenever
-    # `tailscale.enabled` is on, so nothing external is provisioned.
-    # Self-hosters not fronting this with a tailnet want ClusterIP.
-    type: LoadBalancer
+    type: ClusterIP
     port: 5000
   logLevel: info
   s3:


### PR DESCRIPTION
Reverts the Service to the `tailscale.com/expose` form. **Merge before the next production deploy** — the version on `main` will hang the helm step for 70 minutes and fail.

### What happened

The LoadBalancer form in #12399 does not work on this operator version. It skips provisioning entirely without a ProxyGroup annotation:

```
service-pg-reconciler "[unexpected] no ProxyGroup annotation, skipping Tailscale Service provisioning"
Service: tuist-staging/tuist-tuist-oci-registry
```

No tailnet address is assigned, `status.loadBalancer` stays empty, and `helm upgrade --wait` blocks on a Service that can never become ready. The staging deploy ([32017636919](https://github.com/tuist/tuist/actions/runs/32017636919)) timed out after **70 minutes** and rolled back. Staging is healthy — the registry is 1/1 with its original proxy still running.

Only an **egress** ProxyGroup exists in these clusters (`macmini-egress`). Fronting a Service needs an **ingress** one, which is new infrastructure rather than the annotation I assumed it was.

### Why this is urgent

`main` currently carries the broken chart. The canary and production deploys use the same `helm upgrade --wait`, so they will hang the same way — turning a DNS problem that only affected image publishing into one that blocks the server deploy.

### What this keeps

- **The ACL grant for `tcp:443`** — correct however the registry ends up being addressed, and free while unused.
- **The workflows on GHCR** — image publishing is green and stays that way.

### What is still open

The original problem is untouched: the Mac hosts do not resolve MagicDNS names, so `oci.tuist.dev` is unresolvable from a builder. Options that remain, none of which I would land without proving them somewhere first:

1. **An ingress ProxyGroup** plus the LoadBalancer form — gets a self-updating A record, but adds a proxy StatefulSet to run and reason about.
2. **`/etc/resolver/ts.net` on the minis** — makes tailnet names resolvable OS-wide via the host bootstrap. Uncertain: the public resolver returns NXDOMAIN for the whole CNAME chain, and macOS may not re-dispatch the target to the scoped resolver.
3. **A hosts entry** pinning the address — certain to work, but goes stale when the node is recreated, which is the failure this whole exercise has been about.

### How to test

```
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml
```

Renders the Service with `tailscale.com/expose`, no `loadBalancerClass`, and the CNAME target annotation, matching what is deployed and running. Staging renders the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)