### PR TITLE
fix(cli): generate package accessors and map conditional settings

### DIFF
--- a/cli/Sources/TuistCore/Graph/TargetTags.swift
+++ b/cli/Sources/TuistCore/Graph/TargetTags.swift
@@ -1,6 +1,9 @@
 /// Shared metadata tags used by graph mappers.
 public enum TargetTags {
-    /// Local path Swift packages loaded through SwiftPM are represented as external projects.
+    /// Targets generated from Swift package manifests.
+    public static let swiftPackage = "tuist:swift-package"
+
+    /// Local path Swift packages loaded through Swift Package Manager are represented as external projects.
     /// This tag allows downstream mappers to preserve only those package test targets.
     public static let localSwiftPackageTest = "tuist:local-swift-package-test"
 }

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -14,7 +14,8 @@ import XcodeGraph
 ///      cannot host their own resources).
 ///   2. Writes a `TuistBundle+<Target>.swift` accessor into the target's Derived directory so
 ///      that user code can call `Bundle.module`.
-///   3. For external Obj-C targets, also emits SwiftPM-shaped C bridging files.
+///   3. For Objective-C targets generated from Swift packages, also emits
+///      Swift Package Manager-shaped C bridging files.
 public struct ResourcesProjectMapper: ProjectMapping {
     private let contentHasher: ContentHashing
     private let buildableFolderChecker: BuildableFolderChecking
@@ -120,7 +121,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
     }
 
     private func targetNeedsObjcAccessor(_ target: Target, project: Project) -> Bool {
-        guard case .external = project.type else { return false }
+        guard projectUsesSwiftPackageBuildSettings(project) else { return false }
         let containsObjc = target.sources.contains {
             $0.path.extension == "m" || $0.path.extension == "mm"
         }
@@ -129,6 +130,21 @@ public struct ResourcesProjectMapper: ProjectMapping {
             .isEmpty
         let needsBundle = !target.supportsResources || target.product == .staticFramework
         return containsObjc && hasBundleResources && needsBundle
+    }
+
+    private func projectUsesSwiftPackageBuildSettings(_ project: Project) -> Bool {
+        if case .external = project.type { return true }
+
+        guard let definitions = project.settings.base["GCC_PREPROCESSOR_DEFINITIONS"] else {
+            return false
+        }
+        let values: [String] = switch definitions {
+        case let .array(values):
+            values
+        case let .string(value):
+            value.split(whereSeparator: \.isWhitespace).map(String.init)
+        }
+        return values.contains { $0 == "SWIFT_PACKAGE" || $0.hasPrefix("SWIFT_PACKAGE=") }
     }
 
     /// Files inside buildable folders that should trip bundle synthesis but aren't caught by

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -82,7 +82,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
             }
         }
 
-        if targetNeedsObjcAccessor(target, project: project) {
+        if targetNeedsObjcAccessor(target) {
             try appendObjcBundleAccessor(
                 to: &modifiedTarget,
                 sideEffects: &sideEffects,
@@ -120,8 +120,8 @@ public struct ResourcesProjectMapper: ProjectMapping {
         return containsSwift || containsSourcesInBuildableFolders
     }
 
-    private func targetNeedsObjcAccessor(_ target: Target, project: Project) -> Bool {
-        guard projectUsesSwiftPackageBuildSettings(project) else { return false }
+    private func targetNeedsObjcAccessor(_ target: Target) -> Bool {
+        guard target.metadata.tags.contains(TargetTags.swiftPackage) else { return false }
         let containsObjc = target.sources.contains {
             $0.path.extension == "m" || $0.path.extension == "mm"
         }
@@ -130,21 +130,6 @@ public struct ResourcesProjectMapper: ProjectMapping {
             .isEmpty
         let needsBundle = !target.supportsResources || target.product == .staticFramework
         return containsObjc && hasBundleResources && needsBundle
-    }
-
-    private func projectUsesSwiftPackageBuildSettings(_ project: Project) -> Bool {
-        if case .external = project.type { return true }
-
-        guard let definitions = project.settings.base["GCC_PREPROCESSOR_DEFINITIONS"] else {
-            return false
-        }
-        let values: [String] = switch definitions {
-        case let .array(values):
-            values
-        case let .string(value):
-            value.split(whereSeparator: \.isWhitespace).map(String.init)
-        }
-        return values.contains { $0 == "SWIFT_PACKAGE" || $0.hasPrefix("SWIFT_PACKAGE=") }
     }
 
     /// Files inside buildable folders that should trip bundle synthesis but aren't caught by

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1039,7 +1039,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             prebuilts: targetPrebuilts
         )
 
-        var metadataTags: [String] = []
+        var metadataTags = [TargetTags.swiftPackage]
         if target.type == .test, packageType.isLocalExternal {
             metadataTags.append(TargetTags.localSwiftPackageTest)
         }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -46,7 +46,7 @@ struct SettingsMapper {
 
         return try map(
             settings: platformSettings,
-            headerSearchPaths: headerSearchPaths
+            headerSearchPaths: platform == nil ? headerSearchPaths : []
         )
     }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -198,18 +198,19 @@ struct SettingsMapper {
         -> [PackageInfo.Target.TargetBuildSettingDescription.Setting]
     {
         settings.filter { setting in
-            if let platformName, setting.hasConditions {
-                let hasMacCatalystPlatform = setting.condition?.platformNames.contains("maccatalyst") == true
-                let platformNames: [String]
-                if hasMacCatalystPlatform {
-                    platformNames = (setting.condition?.platformNames ?? []) + ["ios"]
-                } else {
-                    platformNames = setting.condition?.platformNames ?? []
-                }
-                return platformNames.contains(platformName)
-            } else {
+            guard let platformName else {
                 return !setting.hasConditions
             }
+            guard setting.hasConditions else { return false }
+
+            let hasMacCatalystPlatform = setting.condition?.platformNames.contains("maccatalyst") == true
+            let platformNames: [String]
+            if hasMacCatalystPlatform {
+                platformNames = (setting.condition?.platformNames ?? []) + ["ios"]
+            } else {
+                platformNames = setting.condition?.platformNames ?? []
+            }
+            return platformNames.contains(platformName)
         }
     }
 }

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -137,6 +137,35 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
+    func mapWhenLocalSwiftPackageObjcStaticFrameworkHasResources() async throws {
+        // Given
+        let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let target = Target.test(product: .staticFramework, sources: ["/Absolute/File.m"], resources: .init(resources))
+        let project = Project.test(
+            settings: Settings(
+                base: ["GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "SWIFT_PACKAGE=1"]],
+                configurations: [:]
+            ),
+            targets: [target],
+            type: .local
+        )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
+
+        // When
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
+
+        // Then
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        verifyObjcBundleAccessor(
+            for: target,
+            gotTarget: gotTarget,
+            gotSideEffects: gotSideEffects,
+            project: project
+        )
+    }
+
+    @Test
     func mapWhenDisableBundleAccessorsIsTrueDoesNotGenerateAccessors() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -118,7 +118,12 @@ struct ResourcesProjectMapperTests {
     func mapWhenExternalObjcStaticFrameworkHasResources() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(product: .staticFramework, sources: ["/Absolute/File.m"], resources: .init(resources))
+        let target = Target.test(
+            product: .staticFramework,
+            sources: ["/Absolute/File.m"],
+            resources: .init(resources),
+            metadata: .test(tags: [TargetTags.swiftPackage])
+        )
         let project = Project.test(targets: [target], type: .external(hash: nil))
         given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
         given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
@@ -140,15 +145,13 @@ struct ResourcesProjectMapperTests {
     func mapWhenLocalSwiftPackageObjcStaticFrameworkHasResources() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(product: .staticFramework, sources: ["/Absolute/File.m"], resources: .init(resources))
-        let project = Project.test(
-            settings: Settings(
-                base: ["GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "SWIFT_PACKAGE=1"]],
-                configurations: [:]
-            ),
-            targets: [target],
-            type: .local
+        let target = Target.test(
+            product: .staticFramework,
+            sources: ["/Absolute/File.m"],
+            resources: .init(resources),
+            metadata: .test(tags: [TargetTags.swiftPackage])
         )
+        let project = Project.test(targets: [target], type: .local)
         given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
         given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
@@ -1162,7 +1165,12 @@ struct ResourcesProjectMapperTests {
         // Given
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
-        let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
+        let target = Target.test(
+            product: .staticLibrary,
+            sources: sources,
+            resources: .init(resources),
+            metadata: .test(tags: [TargetTags.swiftPackage])
+        )
         let project = Project.test(
             path: try AbsolutePath(validating: "/AbsolutePath/Project"),
             targets: [target],
@@ -1185,12 +1193,20 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
-    func mapWhenProjectIsNotExternalTargetHasObjcSourceFiles() async throws {
+    func mapWhenRegularProjectHasSwiftPackageDefinitionDoesNotGenerateObjcAccessors() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        let project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
+        let project = Project.test(
+            path: try AbsolutePath(validating: "/AbsolutePath/Project"),
+            settings: Settings(
+                base: ["GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "SWIFT_PACKAGE=0"]],
+                configurations: [:]
+            ),
+            targets: [target],
+            type: .local
+        )
         given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
         given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4264,12 +4264,10 @@ struct PackageInfoMapperTests {
                                 "HEADER_SEARCH_PATHS[sdk=appletvos*]": [
                                     "$(inherited)",
                                     "$(SRCROOT)/Sources/Target1/value",
-                                    "$(SRCROOT)/Sources/Target1/otherValue",
                                 ],
                                 "HEADER_SEARCH_PATHS[sdk=appletvsimulator*]": [
                                     "$(inherited)",
                                     "$(SRCROOT)/Sources/Target1/value",
-                                    "$(SRCROOT)/Sources/Target1/otherValue",
                                 ],
                                 "OTHER_SWIFT_FLAGS": [
                                     "$(inherited)",

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -939,6 +939,7 @@ struct PackageInfoMapperTests {
                     ]
                 )
         )
+        #expect(project?.targets.first?.metadata.tags.contains(TargetTags.swiftPackage) == true)
     }
 
     @Test(
@@ -8799,7 +8800,8 @@ extension ProjectDescription.Target {
                 baseSettings: baseSettings,
                 with: customSettings,
                 moduleMap: moduleMap
-            )
+            ),
+            metadata: .metadata(tags: [TargetTags.swiftPackage])
         )
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -1,5 +1,6 @@
 import Path
 import ProjectDescription
+import Testing
 import TSCUtility
 import TuistCore
 import TuistSupport
@@ -257,114 +258,6 @@ final class SettingsMapperTests: XCTestCase {
         XCTAssertEqual(resolvedSettings["SWIFT_VERSION"], .string("6"))
     }
 
-    func test_set_Combined() throws {
-        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
-            .init(tool: .swift, name: .define, condition: nil, value: ["Define1"]),
-            .init(
-                tool: .swift,
-                name: .define,
-                condition: PackageInfo.PackageConditionDescription(platformNames: ["ios", "tvos"], config: nil),
-                value: ["Define2"]
-            ),
-        ]
-
-        let mapper = SettingsMapper(
-            headerSearchPaths: [],
-            mainRelativePath: try RelativePath(validating: "path"),
-            settings: settings
-        )
-
-        let allPlatformSettings = try mapper.settingsDictionary()
-
-        XCTAssertEqual(
-            allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1"])
-        )
-
-        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
-
-        XCTAssertEqual(
-            iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        let combinedSettings = try mapper.mapSettings()
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=appletvos*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=appletvsimulator*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1"])
-        )
-    }
-
-    func test_set_maccatalyst() throws {
-        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
-            .init(tool: .swift, name: .define, condition: nil, value: ["Define1"]),
-            .init(
-                tool: .swift,
-                name: .define,
-                condition: PackageInfo.PackageConditionDescription(platformNames: ["maccatalyst"], config: nil),
-                value: ["Define2"]
-            ),
-        ]
-
-        let mapper = SettingsMapper(
-            headerSearchPaths: [],
-            mainRelativePath: try RelativePath(validating: "path"),
-            settings: settings
-        )
-
-        let allPlatformSettings = try mapper.settingsDictionary()
-
-        XCTAssertEqual(
-            allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1"])
-        )
-
-        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
-
-        XCTAssertEqual(
-            iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        let combinedSettings = try mapper.mapSettings()
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]"],
-            .array(["$(inherited)", "Define1", "Define2"])
-        )
-
-        XCTAssertEqual(
-            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
-            .array(["$(inherited)", "Define1"])
-        )
-    }
-
     func test_strict_memory_safety_no_arguments() throws {
         let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
             .init(tool: .swift, name: .strictMemorySafety, condition: nil, value: []),
@@ -525,6 +418,137 @@ final class SettingsMapperTests: XCTestCase {
                 "$(inherited)", "-Werror", "-Wno-error",
                 "-Wno-error=unused", "-Werror=deprecated-declarations", "-Wextra",
             ])
+        )
+    }
+}
+
+struct SettingsMapperConditionalTests {
+    @Test
+    func mapSettingsDoesNotRepeatUnconditionalSwiftFlagsInPlatformCondition() throws {
+        let availabilityMacro = "AvailabilityMacro=Repro_v1:iOS 13.0, macOS 13.0"
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .swift, name: .enableExperimentalFeature, condition: nil, value: [availabilityMacro]),
+            .init(
+                tool: .swift,
+                name: .unsafeFlags,
+                condition: PackageInfo.PackageConditionDescription(platformNames: ["macos"], config: nil),
+                value: ["-index-ignore-system-modules"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings
+        )
+
+        let resolvedSettings = try mapper.mapSettings()
+
+        #expect(
+            resolvedSettings["OTHER_SWIFT_FLAGS"] ==
+                .array(["$(inherited)", "-enable-experimental-feature \"\(availabilityMacro)\""])
+        )
+        #expect(
+            resolvedSettings["OTHER_SWIFT_FLAGS[sdk=macosx*]"] ==
+                .array(["$(inherited)", "-index-ignore-system-modules"])
+        )
+    }
+
+    @Test
+    func settingsSeparateUnconditionalAndPlatformConditions() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .swift, name: .define, condition: nil, value: ["Define1"]),
+            .init(
+                tool: .swift,
+                name: .define,
+                condition: PackageInfo.PackageConditionDescription(platformNames: ["ios", "tvos"], config: nil),
+                value: ["Define2"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings
+        )
+
+        let allPlatformSettings = try mapper.settingsDictionary()
+        #expect(
+            allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define1"])
+        )
+
+        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
+        #expect(
+            iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+
+        let combinedSettings = try mapper.mapSettings()
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=appletvos*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=appletvsimulator*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define1"])
+        )
+    }
+
+    @Test
+    func settingsMapMacCatalystConditionToAppleMobilePlatforms() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .swift, name: .define, condition: nil, value: ["Define1"]),
+            .init(
+                tool: .swift,
+                name: .define,
+                condition: PackageInfo.PackageConditionDescription(platformNames: ["maccatalyst"], config: nil),
+                value: ["Define2"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings
+        )
+
+        let allPlatformSettings = try mapper.settingsDictionary()
+        #expect(
+            allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define1"])
+        )
+
+        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
+        #expect(
+            iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+
+        let combinedSettings = try mapper.mapSettings()
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]"] ==
+                .array(["$(inherited)", "Define2"])
+        )
+        #expect(
+            combinedSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] ==
+                .array(["$(inherited)", "Define1"])
         )
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -424,6 +424,40 @@ final class SettingsMapperTests: XCTestCase {
 
 struct SettingsMapperConditionalTests {
     @Test
+    func mapSettingsDoesNotRepeatInjectedHeaderSearchPathsInPlatformCondition() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .c, name: .headerSearchPath, condition: nil, value: ["include"]),
+            .init(
+                tool: .c,
+                name: .headerSearchPath,
+                condition: PackageInfo.PackageConditionDescription(platformNames: ["macos"], config: nil),
+                value: ["macos-include"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: ["$(SRCROOT)/Sources/Target/PublicHeaders"],
+            mainRelativePath: try RelativePath(validating: "Sources/Target"),
+            settings: settings
+        )
+
+        let resolvedSettings = try mapper.mapSettings()
+
+        #expect(
+            resolvedSettings["HEADER_SEARCH_PATHS"] ==
+                .array([
+                    "$(inherited)",
+                    "$(SRCROOT)/Sources/Target/PublicHeaders",
+                    "$(SRCROOT)/Sources/Target/include",
+                ])
+        )
+        #expect(
+            resolvedSettings["HEADER_SEARCH_PATHS[sdk=macosx*]"] ==
+                .array(["$(inherited)", "$(SRCROOT)/Sources/Target/macos-include"])
+        )
+    }
+
+    @Test
     func mapSettingsDoesNotRepeatUnconditionalSwiftFlagsInPlatformCondition() throws {
         let availabilityMacro = "AvailabilityMacro=Repro_v1:iOS 13.0, macOS 13.0"
         let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [


### PR DESCRIPTION
## What changed

Local projects generated from Swift packages now receive the Objective-C bundle accessor when they contain Objective-C sources and resources. Package build settings are also mapped so unconditional Swift flags remain in the base settings instead of being repeated in every platform-specific variant.

Regression tests cover local package resource accessors, separation of unconditional and platform-specific settings, and the existing Mac Catalyst mapping behavior.

## Why

Swift packages at the workspace root could fail to compile when an Objective-C target referenced `Bundle.module`, while unconditional experimental feature flags could be emitted twice after project generation.

Fixes #12375
Fixes #12377

## Root cause

The resource mapper generated Objective-C accessors only for projects marked as external, but root Swift packages are represented as local projects. Separately, the settings mapper included unconditional values while collecting settings for a specific platform, which copied common flags into platform-qualified settings.

## Approach

The resource mapper keeps the existing external-project behavior and recognizes local Swift packages through their package preprocessor definition. The settings mapper now selects either unconditional settings or settings matching the requested platform, while preserving the existing Mac Catalyst compatibility mapping.

## Impact

Objective-C targets in local Swift packages can resolve their generated resource bundles. Unconditional Swift flags are emitted once, avoiding duplicate compiler arguments. Ordinary local Tuist projects and existing external package projects retain their previous behavior.

## Validation

- Ran the complete `ResourcesProjectMapperTests` suite.
- Ran `SettingsMapperTests` and `SettingsMapperConditionalTests`.
- Built the Tuist command-line executable with code signing disabled.
- Generated and built the reproduction attached to #12375 with the locally built Tuist executable.
- Ran `mise run cli:lint`.
- Ran `git diff --check`.
