### PR TITLE
fix(server): make cache hit rate alert windows comparable

### DIFF
--- a/server/lib/tuist/alerts.ex
+++ b/server/lib/tuist/alerts.ex
@@ -130,14 +130,18 @@ defmodule Tuist.Alerts do
       |> maybe_add_environment(alert_rule.environment)
       |> maybe_add_git_branch(alert_rule.git_branch)
 
-    current = CacheAnalytics.cache_hit_rate_metric_by_count(alert_rule.project_id, alert_rule.metric, current_opts)
-
     previous_opts =
       [limit: alert_rule.rolling_window_size, offset: alert_rule.rolling_window_size]
       |> maybe_add_environment(alert_rule.environment)
       |> maybe_add_git_branch(alert_rule.git_branch)
 
-    previous = CacheAnalytics.cache_hit_rate_metric_by_count(alert_rule.project_id, alert_rule.metric, previous_opts)
+    {current, previous} =
+      CacheAnalytics.cache_hit_rate_metric_window_comparison(
+        alert_rule.project_id,
+        alert_rule.metric,
+        current_opts,
+        previous_opts
+      )
 
     check_decrease_regression(alert_rule, current, previous)
   end

--- a/server/lib/tuist/alerts/AGENTS.md
+++ b/server/lib/tuist/alerts/AGENTS.md
@@ -17,6 +17,7 @@ This context owns alert rules and triggered alert records for projects.
 ## Guardrails
 
 - Alert rules and alerts are customer data; update `server/data-export.md` on schema changes.
+- The `:cache_hit_rate` category averages two sources, module cache and Xcode cache. The current and previous windows must be built from the same set of sources and from equally sized samples, otherwise the comparison measures window composition rather than a regression. `Tuist.Cache.Analytics.cache_hit_rate_metric_window_comparison/4` owns that rule; go through it rather than querying either source per window.
 
 ## Related Context
 

--- a/server/lib/tuist/alerts/alert_rule.ex
+++ b/server/lib/tuist/alerts/alert_rule.ex
@@ -58,6 +58,9 @@ defmodule Tuist.Alerts.AlertRule do
       :bundle_name,
       :environment
     ])
+    |> update_change(:git_branch, &trim/1)
+    |> update_change(:scheme, &trim/1)
+    |> update_change(:bundle_name, &trim/1)
     |> validate_required([
       :project_id,
       :name,
@@ -71,6 +74,9 @@ defmodule Tuist.Alerts.AlertRule do
     |> validate_category_fields()
     |> foreign_key_constraint(:project_id)
   end
+
+  defp trim(value) when is_binary(value), do: String.trim(value)
+  defp trim(value), do: value
 
   defp validate_category_fields(changeset) do
     category = get_field(changeset, :category)

--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -2418,6 +2418,11 @@ defmodule Tuist.Builds.Analytics do
       * `:offset` - Number of builds to skip (default: 0)
       * `:git_branch` - Only consider builds run on the given branch
       * `:is_ci` - Only consider CI (`true`) or local (`false`) builds
+      * `:min_sample_size` - Return `nil` unless the window matched at least this
+        many builds. The reversed percentiles degenerate to `min(values)` on
+        short windows (the p90 index floors to 0 below 10 rows, p99 below 100),
+        so callers comparing two windows can use this to reject a window that
+        did not fill up.
 
   ## Returns
     The calculated metric value (as a ratio 0.0-1.0), or `nil` if no data available.
@@ -2461,8 +2466,15 @@ defmodule Tuist.Builds.Analytics do
 
     hit_rates = ClickHouseRepo.all(query)
 
-    calculate_hit_rate_metric_from_values(hit_rates, metric)
+    if below_min_sample_size?(hit_rates, Keyword.get(opts, :min_sample_size)) do
+      nil
+    else
+      calculate_hit_rate_metric_from_values(hit_rates, metric)
+    end
   end
+
+  defp below_min_sample_size?(_values, nil), do: false
+  defp below_min_sample_size?(values, min_sample_size), do: length(values) < min_sample_size
 
   defp calculate_metric_from_values([], _metric), do: nil
 

--- a/server/lib/tuist/cache/analytics.ex
+++ b/server/lib/tuist/cache/analytics.ex
@@ -159,34 +159,53 @@ defmodule Tuist.Cache.Analytics do
   defp average_hit_rates(rate1, rate2), do: (rate1 + rate2) / 2
 
   @doc """
-  Gets combined cache hit rate metric for the last N runs by averaging
-  module cache (Events) and Xcode cache (Builds) hit rates.
+  Compares the combined cache hit rate metric across two windows of runs.
+
+  The combined rate averages two sources, module cache (Events) and Xcode cache
+  (Builds). A source is only averaged in when both of its windows produced a
+  value, so the two returned numbers always describe the same set of sources. A
+  source that has runs in one window but not the other is dropped from both
+  sides instead of shifting the average under the comparison.
+
+  Each window also requires as many rows as its `:limit`, so a partially filled
+  window is reported as no data rather than as a metric computed off a handful
+  of runs.
 
   ## Parameters
     * `project_id` - The project ID
     * `metric` - The metric to calculate: `:p50`, `:p90`, `:p99`, or `:average`
-    * `opts` - Options:
-      * `:limit` - Number of runs to consider (default: 100)
-      * `:offset` - Number of runs to skip (default: 0)
-      * `:git_branch` - Only consider runs on the given branch
-      * `:is_ci` - Only consider CI (`true`) or local (`false`) runs
+    * `current_opts` - Options for the current window, see below
+    * `previous_opts` - Options for the window preceding it
+
+  Both option lists take:
+    * `:limit` - Number of runs the window holds (default: 100)
+    * `:offset` - Number of runs to skip (default: 0)
+    * `:git_branch` - Only consider runs on the given branch
+    * `:is_ci` - Only consider CI (`true`) or local (`false`) runs
 
   ## Returns
-    The averaged metric value (0.0-1.0), or `nil` if no data available.
+    `{current, previous}` averaged metric values (0.0-1.0), or `{nil, nil}` when
+    no source produced a comparable pair.
   """
-  def cache_hit_rate_metric_by_count(project_id, metric, opts \\ []) do
-    module_hit_rate = CommandEvents.cache_hit_rate_metric_by_count(project_id, metric, opts)
-
-    xcode_hit_rate =
-      Analytics.build_cache_hit_rate_metric_by_count(project_id, metric, opts)
-
-    average_or_nil(module_hit_rate, xcode_hit_rate)
+  def cache_hit_rate_metric_window_comparison(project_id, metric, current_opts, previous_opts) do
+    [
+      &CommandEvents.cache_hit_rate_metric_by_count/3,
+      &Analytics.build_cache_hit_rate_metric_by_count/3
+    ]
+    |> Enum.map(fn source ->
+      {source.(project_id, metric, require_full_window(current_opts)),
+       source.(project_id, metric, require_full_window(previous_opts))}
+    end)
+    |> Enum.reject(fn {current, previous} -> is_nil(current) or is_nil(previous) end)
+    |> case do
+      [] -> {nil, nil}
+      pairs -> {average(Enum.map(pairs, &elem(&1, 0))), average(Enum.map(pairs, &elem(&1, 1)))}
+    end
   end
 
-  defp average_or_nil(nil, nil), do: nil
-  defp average_or_nil(rate1, nil), do: rate1
-  defp average_or_nil(nil, rate2), do: rate2
-  defp average_or_nil(rate1, rate2), do: (rate1 + rate2) / 2
+  defp require_full_window(opts), do: Keyword.put(opts, :min_sample_size, Keyword.get(opts, :limit, 100))
+
+  defp average(values), do: Enum.sum(values) / length(values)
 
   defp date_period(opts) do
     start_datetime = Keyword.get(opts, :start_datetime)

--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -746,6 +746,11 @@ defmodule Tuist.CommandEvents do
       * `:offset` - Number of events to skip (default: 0)
       * `:git_branch` - Only consider events run on the given branch
       * `:is_ci` - Only consider CI (`true`) or local (`false`) events
+      * `:min_sample_size` - Return `nil` unless the window matched at least this
+        many events. The reversed percentiles degenerate to `min(values)` on
+        short windows (the p90 index floors to 0 below 10 rows, p99 below 100),
+        so callers comparing two windows can use this to reject a window that
+        did not fill up.
 
   ## Returns
     The calculated metric value (0.0-1.0), or `nil` if no data available.
@@ -789,8 +794,15 @@ defmodule Tuist.CommandEvents do
 
     hit_rates = ClickHouseRepo.all(query)
 
-    calculate_metric_from_values(hit_rates, metric)
+    if below_min_sample_size?(hit_rates, Keyword.get(opts, :min_sample_size)) do
+      nil
+    else
+      calculate_metric_from_values(hit_rates, metric)
+    end
   end
+
+  defp below_min_sample_size?(_values, nil), do: false
+  defp below_min_sample_size?(values, min_sample_size), do: length(values) < min_sample_size
 
   defp calculate_metric_from_values([], _metric), do: nil
 

--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -508,7 +508,7 @@ defmodule Tuist.Slack do
   defp format_alert_message(%Alert{alert_rule: %{category: :build_run_duration, metric: metric, scheme: scheme}} = alert) do
     deviation = calculate_increase_deviation(alert)
 
-    "*#{scheme} build time #{alert_metric_label(metric)} increased by #{deviation}%*\n" <>
+    "*#{escape_mrkdwn(scheme)} build time #{alert_metric_label(metric)} increased by #{deviation}%*\n" <>
       "Previous: #{format_alert_duration(alert.previous_value)}\n" <>
       "Current: #{format_alert_duration(alert.current_value)}"
   end
@@ -524,7 +524,7 @@ defmodule Tuist.Slack do
   defp format_alert_message(%Alert{alert_rule: %{category: :test_run_duration, metric: metric, scheme: scheme}} = alert) do
     deviation = calculate_increase_deviation(alert)
 
-    "*#{scheme} test time #{alert_metric_label(metric)} increased by #{deviation}%*\n" <>
+    "*#{escape_mrkdwn(scheme)} test time #{alert_metric_label(metric)} increased by #{deviation}%*\n" <>
       "Previous: #{format_alert_duration(alert.previous_value)}\n" <>
       "Current: #{format_alert_duration(alert.current_value)}"
   end
@@ -534,7 +534,7 @@ defmodule Tuist.Slack do
        ) do
     deviation = calculate_decrease_deviation(alert)
 
-    branch_suffix = if is_binary(git_branch) and git_branch != "", do: " on `#{git_branch}`", else: ""
+    branch_suffix = if is_binary(git_branch) and git_branch != "", do: " on #{escape_mrkdwn(git_branch)}", else: ""
 
     "*Cache hit rate #{alert_metric_label(metric)} decreased by #{deviation}%#{branch_suffix}*\n" <>
       "Previous: #{format_alert_percentage(alert.previous_value)}\n" <>
@@ -554,9 +554,19 @@ defmodule Tuist.Slack do
        ) do
     deviation = calculate_increase_deviation(alert)
 
-    "*#{bundle_name} bundle #{bundle_size_metric_label(metric)} increased by #{deviation}%*\n" <>
+    "*#{escape_mrkdwn(bundle_name)} bundle #{bundle_size_metric_label(metric)} increased by #{deviation}%*\n" <>
       "Previous: #{format_alert_bytes(alert.previous_value)}\n" <>
       "Current: #{format_alert_bytes(alert.current_value)}"
+  end
+
+  # Slack parses `<url|label>` inside mrkdwn section text, so a rule-authored
+  # scheme, branch or bundle name could otherwise place an arbitrary link in an
+  # alert going to the whole channel.
+  defp escape_mrkdwn(value) do
+    value
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 
   defp calculate_increase_deviation(%Alert{current_value: current, previous_value: previous}) do

--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -638,11 +638,21 @@ defmodule TuistWeb.ProjectNotificationsLive do
   defp metric_label(:average), do: dgettext("dashboard_projects", "Average")
   defp metric_label(nil), do: ""
 
+  # The description sentence carries its own <strong> markup and is handed to
+  # raw/1, and Gettext bindings are plain string substitution. Rule-authored
+  # values have to be escaped before they reach the template.
+  defp escape_binding(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+
   defp alert_rule_description(category, metric, deviation, rolling_window_size, opts) do
     case category do
       :bundle_size ->
-        git_branch = Keyword.get(opts, :git_branch, "")
-        bundle_name = Keyword.get(opts, :bundle_name, "")
+        git_branch = escape_binding(Keyword.get(opts, :git_branch, ""))
+        bundle_name = escape_binding(Keyword.get(opts, :bundle_name, ""))
         size_label = bundle_size_metric_label(metric)
 
         text =
@@ -670,14 +680,14 @@ defmodule TuistWeb.ProjectNotificationsLive do
       _ ->
         metric_category = alert_metric_category_label(category, metric)
         unit = alert_unit_label(category)
-        scheme = Keyword.get(opts, :scheme, "")
+        scheme = escape_binding(Keyword.get(opts, :scheme, ""))
         environment = Keyword.get(opts, :environment, "any")
         current_unit = qualified_unit_label(scheme, environment, unit)
 
         text =
           case category do
             :cache_hit_rate ->
-              git_branch = Keyword.get(opts, :git_branch, "")
+              git_branch = escape_binding(Keyword.get(opts, :git_branch, ""))
 
               if git_branch == "" do
                 dgettext(

--- a/server/priv/docs/en/guides/integrations/slack.md
+++ b/server/priv/docs/en/guides/integrations/slack.md
@@ -56,6 +56,8 @@ For example, you might create an alert that triggers when the p90 build duration
 
 Scoping a cache hit rate alert to your default branch is useful when only that branch populates the cache. Pull request branches that touch a low-level module legitimately miss the cache, and including them would make the alert fire on expected regressions.
 
+A cache hit rate alert only compares windows it can compare fairly. Both windows have to hold as many runs as the rolling window size, and a source of cache data that only appears in one of the two windows is left out of both. A branch that hasn't accumulated twice the rolling window size in runs yet, or a branch name that matches nothing, therefore never triggers the rule. If you scope a rule to a low-traffic branch, keep the rolling window small enough that the branch fills it.
+
 When an alert triggers, you'll receive a message like this in your Slack channel:
 
 <img src="/images/guides/integrations/slack/alert.png" alt="An image that shows a Slack alert message" style="max-width: 500px;" />

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -47,8 +47,8 @@ msgstr ""
 msgid "Analytics"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:744
-#: lib/tuist_web/live/project_notifications_live.ex:747
+#: lib/tuist_web/live/project_notifications_live.ex:754
+#: lib/tuist_web/live/project_notifications_live.ex:757
 #: lib/tuist_web/live/xcode_overview_live.ex:249
 #: lib/tuist_web/live/xcode_overview_live.html.heex:15
 #: lib/tuist_web/live/xcode_overview_live.html.heex:795
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Bundles"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:746
+#: lib/tuist_web/live/project_notifications_live.ex:756
 #: lib/tuist_web/live/xcode_overview_live.ex:251
 #: lib/tuist_web/live/xcode_overview_live.html.heex:23
 #: lib/tuist_web/live/xcode_overview_live.html.heex:803
@@ -235,7 +235,7 @@ msgid "General access"
 msgstr ""
 
 #: lib/tuist_web/live/project_bundle_settings_live.ex:213
-#: lib/tuist_web/live/project_notifications_live.ex:771
+#: lib/tuist_web/live/project_notifications_live.ex:781
 #: lib/tuist_web/live/xcode_overview_live.html.heex:701
 #, elixir-autogen, elixir-format
 msgid "Install size"
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Latest app previews"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:745
+#: lib/tuist_web/live/project_notifications_live.ex:755
 #: lib/tuist_web/live/xcode_overview_live.ex:250
 #: lib/tuist_web/live/xcode_overview_live.html.heex:31
 #: lib/tuist_web/live/xcode_overview_live.html.heex:811
@@ -722,33 +722,33 @@ msgstr ""
 msgid "Slack channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:768
+#: lib/tuist_web/live/project_notifications_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "average"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:753
+#: lib/tuist_web/live/project_notifications_live.ex:763
 #, elixir-autogen, elixir-format
 msgid "build time"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:761
-#: lib/tuist_web/live/project_notifications_live.ex:763
+#: lib/tuist_web/live/project_notifications_live.ex:771
+#: lib/tuist_web/live/project_notifications_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "builds"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:759
+#: lib/tuist_web/live/project_notifications_live.ex:769
 #, elixir-autogen, elixir-format
 msgid "cache hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:756
+#: lib/tuist_web/live/project_notifications_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "test time"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:762
+#: lib/tuist_web/live/project_notifications_live.ex:772
 #, elixir-autogen, elixir-format
 msgid "tests"
 msgstr ""
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Select build system"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:650
+#: lib/tuist_web/live/project_notifications_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Alert when the <strong>%{size_label}</strong> of the latest bundle on branch <strong>%{git_branch}</strong> has increased by <strong>%{deviation}%</strong> compared to the previous bundle."
 msgstr ""
@@ -841,7 +841,7 @@ msgid "Bundle size"
 msgstr ""
 
 #: lib/tuist_web/live/project_bundle_settings_live.ex:214
-#: lib/tuist_web/live/project_notifications_live.ex:772
+#: lib/tuist_web/live/project_notifications_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "Download size"
 msgstr ""
@@ -857,22 +857,22 @@ msgstr ""
 msgid "e.g. main"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:731
+#: lib/tuist_web/live/project_notifications_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "%{scheme} %{unit}"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:683
+#: lib/tuist_web/live/project_notifications_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Alert when the <strong>%{metric_category}</strong> of the last <strong>%{rolling_window_size} %{current_unit}</strong> has decreased by <strong>%{deviation}%</strong> compared to the previous <strong>%{rolling_window_size} %{unit}</strong>."
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:706
+#: lib/tuist_web/live/project_notifications_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Alert when the <strong>%{metric_category}</strong> of the last <strong>%{rolling_window_size} %{current_unit}</strong> has increased by <strong>%{deviation}%</strong> compared to the previous <strong>%{rolling_window_size} %{unit}</strong>."
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:658
+#: lib/tuist_web/live/project_notifications_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Alert when the <strong>%{size_label}</strong> of the latest <strong>%{bundle_name}</strong> bundle on branch <strong>%{git_branch}</strong> has increased by <strong>%{deviation}%</strong> compared to the previous bundle."
 msgstr ""
@@ -892,12 +892,12 @@ msgstr ""
 msgid "e.g. MyApp (optional)"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:734
+#: lib/tuist_web/live/project_notifications_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "%{environment} %{unit}"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:724
+#: lib/tuist_web/live/project_notifications_live.ex:734
 #, elixir-autogen, elixir-format
 msgid "%{scheme} %{environment} %{unit}"
 msgstr ""
@@ -908,7 +908,7 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:749
+#: lib/tuist_web/live/project_notifications_live.ex:759
 #, elixir-autogen, elixir-format
 msgid "local"
 msgstr ""
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Only apply to tests in these states"
 msgstr ""
 
-#: lib/tuist_web/live/project_notifications_live.ex:693
+#: lib/tuist_web/live/project_notifications_live.ex:703
 #, elixir-autogen, elixir-format
 msgid "Alert when the <strong>%{metric_category}</strong> of the last <strong>%{rolling_window_size} %{current_unit}</strong> on branch <strong>%{git_branch}</strong> has decreased by <strong>%{deviation}%</strong> compared to the previous <strong>%{rolling_window_size} %{unit}</strong>."
 msgstr ""

--- a/server/test/tuist/alerts/alert_rule_test.exs
+++ b/server/test/tuist/alerts/alert_rule_test.exs
@@ -522,5 +522,54 @@ defmodule Tuist.Alerts.AlertRuleTest do
       assert changeset.valid? == false
       assert "is invalid" in errors_on(changeset).environment
     end
+
+    test "trims whitespace around the scoping fields" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      # When
+      changeset =
+        AlertRule.changeset(%AlertRule{}, %{
+          project_id: project.id,
+          name: "Test Alert",
+          category: :cache_hit_rate,
+          metric: :p90,
+          deviation_percentage: 20.0,
+          rolling_window_size: 100,
+          git_branch: "  main\n",
+          scheme: " App ",
+          bundle_name: " App.ipa ",
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel"
+        })
+
+      # Then
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :git_branch) == "main"
+      assert Ecto.Changeset.get_field(changeset, :scheme) == "App"
+      assert Ecto.Changeset.get_field(changeset, :bundle_name) == "App.ipa"
+    end
+
+    test "is invalid when a bundle_size branch is only whitespace" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      # When
+      changeset =
+        AlertRule.changeset(%AlertRule{}, %{
+          project_id: project.id,
+          name: "Test Alert",
+          category: :bundle_size,
+          metric: :install_size,
+          deviation_percentage: 20.0,
+          git_branch: "   ",
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel"
+        })
+
+      # Then
+      assert changeset.valid? == false
+      assert "can't be blank" in errors_on(changeset).git_branch
+    end
   end
 end

--- a/server/test/tuist/alerts/alerts_test.exs
+++ b/server/test/tuist/alerts/alerts_test.exs
@@ -5,6 +5,7 @@ defmodule Tuist.AlertsTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.AlertsFixtures
   alias TuistTestSupport.Fixtures.BundlesFixtures
+  alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
 
@@ -696,6 +697,43 @@ defmodule Tuist.AlertsTest do
           )
       end
 
+      # Create 5 "current" CI module cache events with 50% hit rate
+      for i <- 1..5 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          is_ci: true,
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+        )
+      end
+
+      # Create 5 "previous" CI module cache events with 60% hit rate
+      for i <- 6..10 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          is_ci: true,
+          cacheable_targets: ["A", "B", "C", "D", "E"],
+          local_cache_target_hits: ["A", "B", "C"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+        )
+      end
+
+      # Local module cache events with 100% hit rate, newer than every CI event
+      # so they would take over both windows if the environment scope leaked
+      for i <- 1..10 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          is_ci: false,
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A", "B"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :second)
+        )
+      end
+
       alert_rule =
         AlertsFixtures.alert_rule_fixture(
           project: project,
@@ -709,10 +747,11 @@ defmodule Tuist.AlertsTest do
       # When
       result = Alerts.evaluate(alert_rule)
 
-      # Then - only CI builds are considered; local builds with 100% hit rate are ignored
+      # Then - only CI runs are considered on both sources; the 100% local runs
+      # are ignored by the Xcode cache and the module cache alike
       assert {:triggered, data} = result
-      assert data.current == 0.7
-      assert data.previous == 0.8
+      assert_in_delta data.current, 0.6, 0.0001
+      assert_in_delta data.previous, 0.7, 0.0001
     end
 
     test "filters to local builds only when environment is local" do
@@ -834,6 +873,147 @@ defmodule Tuist.AlertsTest do
           )
       end
 
+      # Create 5 "current" main module cache events with 50% hit rate
+      for i <- 1..5 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          git_branch: "main",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+        )
+      end
+
+      # Create 5 "previous" main module cache events with 60% hit rate
+      for i <- 6..10 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          git_branch: "main",
+          cacheable_targets: ["A", "B", "C", "D", "E"],
+          local_cache_target_hits: ["A", "B", "C"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+        )
+      end
+
+      # Feature branch module cache events with 0% hit rate, newer than every
+      # main event so they would take over both windows if the scope leaked
+      for i <- 1..10 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          git_branch: "feature",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: [],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :second)
+        )
+      end
+
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          category: :cache_hit_rate,
+          metric: :average,
+          deviation_percentage: 10.0,
+          rolling_window_size: 5,
+          git_branch: "main"
+        )
+
+      # When
+      result = Alerts.evaluate(alert_rule)
+
+      # Then - both the Xcode cache and the module cache are scoped to main
+      assert {:triggered, data} = result
+      assert_in_delta data.current, 0.6, 0.0001
+      assert_in_delta data.previous, 0.7, 0.0001
+    end
+
+    test "ignores a source that only has runs in one of the two windows" do
+      # Given
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      # Xcode cache: a steady 80% hit rate across both windows
+      for i <- 1..10 do
+        {:ok, _} =
+          RunsFixtures.build_fixture(
+            project_id: project.id,
+            user_id: user.account.id,
+            duration: 1000,
+            git_branch: "main",
+            cacheable_tasks_count: 100,
+            cacheable_task_local_hits_count: 60,
+            cacheable_task_remote_hits_count: 20,
+            inserted_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+          )
+      end
+
+      # Module cache: only enough events on main to fill the current window
+      for i <- 1..5 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "generate",
+          git_branch: "main",
+          cacheable_targets: ["A", "B", "C", "D"],
+          local_cache_target_hits: ["A"],
+          ran_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+        )
+      end
+
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          category: :cache_hit_rate,
+          metric: :average,
+          deviation_percentage: 10.0,
+          rolling_window_size: 5,
+          git_branch: "main"
+        )
+
+      # When
+      result = Alerts.evaluate(alert_rule)
+
+      # Then - the module cache is missing from the previous window, so it is
+      # left out of the current one too instead of comparing 0.525 against 0.8
+      assert result == :ok
+    end
+
+    test "returns :ok when a window did not fill up" do
+      # Given
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      # 5 "current" builds with a 10% hit rate
+      for i <- 1..5 do
+        {:ok, _} =
+          RunsFixtures.build_fixture(
+            project_id: project.id,
+            user_id: user.account.id,
+            duration: 1000,
+            git_branch: "main",
+            cacheable_tasks_count: 100,
+            cacheable_task_local_hits_count: 10,
+            cacheable_task_remote_hits_count: 0,
+            inserted_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+          )
+      end
+
+      # Only 2 "previous" builds, so the older window is short of the window size
+      for i <- 6..7 do
+        {:ok, _} =
+          RunsFixtures.build_fixture(
+            project_id: project.id,
+            user_id: user.account.id,
+            duration: 1000,
+            git_branch: "main",
+            cacheable_tasks_count: 100,
+            cacheable_task_local_hits_count: 90,
+            cacheable_task_remote_hits_count: 0,
+            inserted_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+          )
+      end
+
       alert_rule =
         AlertsFixtures.alert_rule_fixture(
           project: project,
@@ -848,9 +1028,7 @@ defmodule Tuist.AlertsTest do
       result = Alerts.evaluate(alert_rule)
 
       # Then
-      assert {:triggered, data} = result
-      assert data.current == 0.7
-      assert data.previous == 0.8
+      assert result == :ok
     end
 
     test "considers every branch when git_branch is empty" do

--- a/server/test/tuist/builds/analytics_test.exs
+++ b/server/test/tuist/builds/analytics_test.exs
@@ -2515,6 +2515,52 @@ defmodule Tuist.Builds.AnalyticsTest do
       # Then
       assert_in_delta result, 0.8, 0.001
     end
+
+    test "returns nil when the window holds fewer builds than min_sample_size" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      for i <- 1..2 do
+        {:ok, _} =
+          RunsFixtures.build_fixture(
+            project_id: project.id,
+            duration: 1000,
+            cacheable_tasks_count: 100,
+            cacheable_task_local_hits_count: 80,
+            cacheable_task_remote_hits_count: 0,
+            inserted_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+          )
+      end
+
+      # When
+      result = Analytics.build_cache_hit_rate_metric_by_count(project.id, :average, limit: 3, min_sample_size: 3)
+
+      # Then
+      assert result == nil
+    end
+
+    test "returns the metric when the window fills min_sample_size" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      for i <- 1..3 do
+        {:ok, _} =
+          RunsFixtures.build_fixture(
+            project_id: project.id,
+            duration: 1000,
+            cacheable_tasks_count: 100,
+            cacheable_task_local_hits_count: 80,
+            cacheable_task_remote_hits_count: 0,
+            inserted_at: DateTime.add(DateTime.utc_now(), -i, :minute)
+          )
+      end
+
+      # When
+      result = Analytics.build_cache_hit_rate_metric_by_count(project.id, :average, limit: 3, min_sample_size: 3)
+
+      # Then
+      assert_in_delta result, 0.8, 0.001
+    end
   end
 
   describe "build_duration_scatter_data/2" do

--- a/server/test/tuist/cache/analytics_test.exs
+++ b/server/test/tuist/cache/analytics_test.exs
@@ -779,194 +779,234 @@ defmodule Tuist.Cache.AnalyticsTest do
     end
   end
 
-  describe "cache_hit_rate_metric_by_count/3" do
-    test "averages module cache and Xcode cache hit rates by count" do
+  describe "cache_hit_rate_metric_window_comparison/4" do
+    test "averages module cache and Xcode cache hit rates across both windows" do
       project = ProjectsFixtures.project_fixture()
 
-      # Module cache: 50% hit rate (1 hit out of 2 cacheable)
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["A", "B"],
-        local_cache_target_hits: ["A"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-30 10:00:00Z]
-      )
+      # Module cache: 50% hit rate in both windows
+      for offset <- 1..4 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
 
-      # Xcode cache: 100% hit rate (2 hits out of 2 cacheable)
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-30 10:00:00Z],
-        cacheable_tasks: [
-          %{key: "task1_key", type: :swift, status: :hit_local},
-          %{key: "task2_key", type: :swift, status: :hit_remote}
-        ]
-      )
+      # Xcode cache: 100% hit rate in both windows
+      for offset <- 1..4 do
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          cacheable_tasks_count: 2,
+          cacheable_task_local_hits_count: 2,
+          cacheable_task_remote_hits_count: 0,
+          inserted_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
 
       # When
-      got = Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 10)
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0],
+          limit: 2,
+          offset: 2
+        )
 
-      # Then - Average of [0.5 (module), 1.0 (xcode)] = 0.75
-      assert got == 0.75
+      # Then - Average of [0.5 (module), 1.0 (xcode)] on both sides
+      assert got == {0.75, 0.75}
     end
 
-    test "returns nil when no data exists" do
+    test "returns nil for both windows when no data exists" do
       project = ProjectsFixtures.project_fixture()
 
       # When
-      got = Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 10)
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0],
+          limit: 2,
+          offset: 2
+        )
 
       # Then
-      assert got == nil
+      assert got == {nil, nil}
     end
 
-    test "returns only module hit rate when no Xcode builds exist" do
+    test "uses the module cache alone when the Xcode cache has no runs at all" do
       project = ProjectsFixtures.project_fixture()
 
-      # Module cache: 50% hit rate
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["A", "B"],
-        local_cache_target_hits: ["A"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-30 10:00:00Z]
-      )
+      # Newest two events: 100% hit rate
+      for offset <- 1..2 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A", "B"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
+
+      # Oldest two events: 50% hit rate
+      for offset <- 3..4 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
 
       # When
-      got = Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 10)
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0],
+          limit: 2,
+          offset: 2
+        )
 
-      # Then - Only module cache: 0.5
-      assert got == 0.5
+      # Then
+      assert got == {1.0, 0.5}
     end
 
-    test "returns only Xcode hit rate when no module cache events exist" do
+    test "drops a source that only fills one of the two windows" do
       project = ProjectsFixtures.project_fixture()
 
-      # Xcode cache: 75% hit rate (3 hits out of 4 cacheable)
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-30 10:00:00Z],
-        cacheable_tasks: [
-          %{key: "task1_key", type: :swift, status: :hit_local},
-          %{key: "task2_key", type: :swift, status: :hit_remote},
-          %{key: "task3_key", type: :swift, status: :hit_local},
-          %{key: "task4_key", type: :clang, status: :miss}
-        ]
-      )
+      # Module cache: 50% hit rate, but only enough events for the current window
+      for offset <- 1..2 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
+
+      # Xcode cache: 100% hit rate across both windows
+      for offset <- 1..4 do
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          cacheable_tasks_count: 2,
+          cacheable_task_local_hits_count: 2,
+          cacheable_task_remote_hits_count: 0,
+          inserted_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
 
       # When
-      got = Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 10)
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0],
+          limit: 2,
+          offset: 2
+        )
 
-      # Then - Only Xcode cache: 0.75
-      assert got == 0.75
+      # Then - the module cache is absent from the previous window, so it is
+      # excluded from the current one too rather than dragging it down
+      assert got == {1.0, 1.0}
     end
 
-    test "respects limit and offset parameters" do
+    test "returns nil for both windows when a window did not fill up" do
       project = ProjectsFixtures.project_fixture()
 
-      # Oldest event: 25% hit rate
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["A", "B", "C", "D"],
-        local_cache_target_hits: ["A"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-29 10:00:00Z]
-      )
-
-      # Newest event: 100% hit rate
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["E", "F"],
-        local_cache_target_hits: ["E", "F"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-30 10:00:00Z]
-      )
-
-      # Oldest build: 50% hit rate
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-29 10:00:00Z],
-        cacheable_tasks: [
-          %{key: "task1_key", type: :swift, status: :hit_local},
-          %{key: "task2_key", type: :swift, status: :miss}
-        ]
-      )
-
-      # Newest build: 100% hit rate
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-30 10:00:00Z],
-        cacheable_tasks: [
-          %{key: "task3_key", type: :swift, status: :hit_local},
-          %{key: "task4_key", type: :swift, status: :hit_remote}
-        ]
-      )
-
-      # When - get newest 1 item
-      current =
-        Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 1, offset: 0)
-
-      # Then - Average of [1.0 (module), 1.0 (xcode)] = 1.0
-      assert current == 1.0
-
-      # When - skip newest, get older item
-      previous =
-        Analytics.cache_hit_rate_metric_by_count(project.id, :average, limit: 1, offset: 1)
-
-      # Then - Average of [0.25 (module), 0.5 (xcode)] = 0.375
-      assert previous == 0.375
-    end
-
-    test "works with p50 metric" do
-      project = ProjectsFixtures.project_fixture()
-
-      # Create multiple events with varying hit rates
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["A", "B"],
-        local_cache_target_hits: ["A"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-30 09:00:00Z]
-      )
-
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "build",
-        cacheable_targets: ["C", "D"],
-        local_cache_target_hits: ["C", "D"],
-        remote_cache_target_hits: [],
-        ran_at: ~U[2024-04-30 10:00:00Z]
-      )
-
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-30 09:00:00Z],
-        cacheable_tasks: [
-          %{key: "task1_key", type: :swift, status: :miss},
-          %{key: "task2_key", type: :swift, status: :miss}
-        ]
-      )
-
-      RunsFixtures.build_fixture(
-        project_id: project.id,
-        inserted_at: ~U[2024-04-30 10:00:00Z],
-        cacheable_tasks: [
-          %{key: "task3_key", type: :swift, status: :hit_local},
-          %{key: "task4_key", type: :swift, status: :hit_remote}
-        ]
-      )
+      # Only three builds for a window that holds two, so the previous window is short
+      for offset <- 1..3 do
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          cacheable_tasks_count: 2,
+          cacheable_task_local_hits_count: 2,
+          cacheable_task_remote_hits_count: 0,
+          inserted_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
 
       # When
-      got = Analytics.cache_hit_rate_metric_by_count(project.id, :p50, limit: 10)
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0],
+          limit: 2,
+          offset: 2
+        )
 
-      # Then - Module p50 of sorted [0.5, 1.0] at index trunc(2*0.5)=1 = 1.0
-      # Xcode p50 of sorted [0.0, 1.0] at index trunc(2*0.5)=1 = 1.0
-      # Average of [1.0, 1.0] = 1.0
-      assert got == 1.0
+      # Then
+      assert got == {nil, nil}
+    end
+
+    test "scopes both windows and both sources to the given branch" do
+      project = ProjectsFixtures.project_fixture()
+
+      # main: 50% module hit rate, 100% Xcode hit rate, across both windows
+      for offset <- 1..4 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          git_branch: "main",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          git_branch: "main",
+          cacheable_tasks_count: 2,
+          cacheable_task_local_hits_count: 2,
+          cacheable_task_remote_hits_count: 0,
+          inserted_at: DateTime.add(~U[2024-04-30 10:00:00Z], -offset, :minute)
+        )
+      end
+
+      # feature: 0% on both sources, newer than everything on main
+      for offset <- 1..4 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          git_branch: "feature",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: [],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.add(~U[2024-04-30 11:00:00Z], -offset, :minute)
+        )
+
+        RunsFixtures.build_fixture(
+          project_id: project.id,
+          git_branch: "feature",
+          cacheable_tasks_count: 2,
+          cacheable_task_local_hits_count: 0,
+          cacheable_task_remote_hits_count: 0,
+          inserted_at: DateTime.add(~U[2024-04-30 11:00:00Z], -offset, :minute)
+        )
+      end
+
+      # When
+      got =
+        Analytics.cache_hit_rate_metric_window_comparison(
+          project.id,
+          :average,
+          [limit: 2, offset: 0, git_branch: "main"],
+          limit: 2,
+          offset: 2,
+          git_branch: "main"
+        )
+
+      # Then - only main is considered: average of [0.5, 1.0]
+      assert got == {0.75, 0.75}
     end
   end
 end

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1965,6 +1965,50 @@ defmodule Tuist.CommandEventsTest do
       # Then
       assert got == 0.5
     end
+
+    test "returns nil when the window holds fewer events than min_sample_size" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      for hour <- 10..11 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.new!(~D[2024-04-30], Time.new!(hour, 0, 0))
+        )
+      end
+
+      # When
+      got = CommandEvents.cache_hit_rate_metric_by_count(project.id, :average, limit: 3, min_sample_size: 3)
+
+      # Then
+      assert got == nil
+    end
+
+    test "returns the metric when the window fills min_sample_size" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      for hour <- 10..12 do
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "build",
+          cacheable_targets: ["A", "B"],
+          local_cache_target_hits: ["A"],
+          remote_cache_target_hits: [],
+          ran_at: DateTime.new!(~D[2024-04-30], Time.new!(hour, 0, 0))
+        )
+      end
+
+      # When
+      got = CommandEvents.cache_hit_rate_metric_by_count(project.id, :average, limit: 3, min_sample_size: 3)
+
+      # Then
+      assert got == 0.5
+    end
   end
 
   describe "get_project_last_interaction_data/1" do

--- a/server/test/tuist/slack_test.exs
+++ b/server/test/tuist/slack_test.exs
@@ -745,7 +745,39 @@ defmodule Tuist.SlackTest do
         header_text = Enum.at(blocks, 0).text.text
         metric_text = Enum.at(blocks, 3).text.text
         assert header_text =~ "Decreased on main"
-        assert metric_text =~ "on `main`"
+        assert metric_text =~ "on main"
+        :ok
+      end)
+
+      # When/Then
+      assert Slack.send_alert(alert) == :ok
+    end
+
+    test "escapes mrkdwn control characters in a branch name" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      _installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      stub(Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          category: :cache_hit_rate,
+          metric: :average,
+          git_branch: "<https://evil.example|click me>",
+          slack_channel_id: "C12345",
+          slack_channel_name: "alerts"
+        )
+
+      alert =
+        AlertsFixtures.alert_fixture(alert_rule: alert_rule, current_value: 0.6, previous_value: 0.8)
+
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
+        metric_text = Enum.at(blocks, 3).text.text
+        refute metric_text =~ "<https://evil.example"
+        assert metric_text =~ "&lt;https://evil.example|click me&gt;"
         :ok
       end)
 

--- a/server/test/tuist_web/live/project_notifications_live_test.exs
+++ b/server/test/tuist_web/live/project_notifications_live_test.exs
@@ -346,6 +346,26 @@ defmodule TuistWeb.ProjectNotificationsLiveTest do
       assert html =~ "main"
     end
 
+    test "escapes markup in the branch rendered in the description", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      # Given
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/settings/notifications")
+
+      render_hook(lv, "update_create_alert_form_category", %{"category" => "cache_hit_rate"})
+
+      # When
+      html =
+        render_hook(lv, "update_create_alert_form_git_branch", %{"value" => ~s(main"><xss-probe>)})
+
+      # Then
+      refute html =~ "<xss-probe"
+      assert html =~ "&lt;xss-probe&gt;"
+    end
+
     test "updates the branch of an existing cache_hit_rate alert rule", %{
       conn: conn,
       organization: organization,


### PR DESCRIPTION
Addresses the review comments on https://github.com/tuist/tuist/pull/12356, which landed after that PR was merged.

### Window composition (the blocking-ish one)

The combined cache hit rate averages two sources, module cache (`CommandEvents`) and Xcode cache (`Builds.Analytics`). `evaluate/1` computed each window independently and folded each with a nil-tolerant average, so when a source had rows in one window but not the other, the two numbers being compared did not describe the same set of sources. A rule could fire with every measured run identical in both windows, and the mirror case hid a real regression the same way.

That asymmetry was on `main` already, but it used to require the whole project to sit near the window boundary. Branch scoping divides both source counts independently and by different factors, which moves it from a corner case to something teams hit, and it is the same alert noise the original PR set out to remove.

Evaluation now goes through `Cache.Analytics.cache_hit_rate_metric_window_comparison/4`, which computes each source's current and previous window and only lets a source into the average when both of its windows produced a value. A source present in one window only is dropped from both sides rather than shifting the average under the comparison.

### Short windows

Both hit rate reducers use a reversed nearest-rank percentile, which is the right idea for a higher-is-better metric, but the index floors to 0 when the window holds fewer than 10 rows for p90 or fewer than 100 for p99. Nothing required a window to actually contain `limit` rows, so the metric silently became `min(values)` and a single cold-cache run could report a large decrease. Applying the branch filter before LIMIT/OFFSET made short windows routine.

Both reducers now take a `:min_sample_size` option, and the window comparison sets it to the rolling window size, so a window that did not fill up is reported as no data. `check_decrease_regression/3` already treats nil as `:ok`, so nothing else changed.

The trade-off is deliberate: a rule scoped to a branch that has not accumulated twice the rolling window size in runs will not fire. That is documented in the Slack integration guide, since scoping to a low-traffic branch is exactly the config that runs a source out.

### Markup and mrkdwn escaping

The alert rule description is built by Gettext interpolation and handed to `raw/1`. Gettext bindings are plain string substitution with no HTML awareness, and `git_branch` has no format validation, so a rule-authored branch, scheme, or bundle name reached the markup verbatim. The edit modal renders the persisted value and Noora portals the modal body into the DOM at page load, so a stored value reached other project admins without anyone opening the modal.

Two things bounded the impact and neither is a reason to leave it: the page's CSP has no `unsafe-inline`, so this was markup injection rather than script execution, and `:project`/`:update` is admin-only. Escaping the bindings is cheap and means the property does not rest on the CSP header staying exactly as it is. The same escape covers `scheme` and `bundle_name`, which flow into the sibling sentences.

On the Slack side, the branch went into a code span inside a `mrkdwn` section. A backtick is a legal git ref character and broke the span, and more importantly Slack parses `<url|label>` in section text, so a crafted name could drop an arbitrary hyperlink into an alert going to a whole channel, a wider audience than the admins who can set the field. The three rule-authored values are escaped with Slack's required escapes (`&`, `<`, `>`) and the code span is dropped for a plain suffix. The title clause is unchanged; it is emitted as `plain_text`, so nothing is interpreted there.

### Whitespace in the scoping fields

`maybe_add_git_branch/2` strips exactly nil and `""`, and the changeset neither trimmed nor validated the field. A pasted `" main "` made both queries return `[]`, both windows nil, and the rule returned `:ok` forever with no error in the UI or the logs, while the user's mental model was that regressions on `main` were monitored.

`git_branch`, `scheme`, and `bundle_name` are now trimmed in the changeset. A whitespace-only branch on a bundle size rule fails `validate_required` rather than being stored. The typo half of that failure mode wants a UI signal ("no runs matched this branch yet") and is left as a follow-up, since a legitimately quiet branch looks identical today.

### The test gap that let this happen

The `evaluate/1 for cache_hit_rate` block built all of its data with `RunsFixtures.build_fixture` and never called `CommandEventsFixtures`, so the module cache half was nil in every test and the combined average collapsed to the builds value. Deleting the branch filter from `CommandEvents.cache_hit_rate_metric_by_count/3`, or the `:is_ci` filter that the original PR added there, left those tests passing. That is the same shape as the bug the original PR fixed: the old `:is_ci` bug survived because the CI test seeded only builds.

The branch and environment cases now seed both sources, with the excluded runs (feature branch, local environment) newer than every included run so they would take over both windows if a filter leaked. Both were verified to fail with the filters removed and pass with them in place. New cases also cover the source-symmetry and short-window behaviour at both the query level and through `evaluate/1`.

### Validation

```bash
mix test test/tuist/alerts test/tuist/slack_test.exs test/tuist_web/live/project_notifications_live_test.exs test/tuist/builds/analytics_test.exs test/tuist/command_events_test.exs test/tuist/cache/analytics_test.exs
```

318 passing. Each new escaping and filtering test was also run against the un-fixed code to confirm it goes red; the first version of the description escaping test passed either way because `Phoenix.LiveViewTest` normalizes the rendered HTML through Floki, so the probe was changed to a tag Floki does not rewrite.

The wider `test/tuist_web/live/` suite was run as well and is green apart from two locale tests that fail on `main` in this worktree (the test env compiles only the `en` locale unless `TUIST_DEV_ALL_LOCALES=1`).

### Notes for the reviewer

- `Cache.Analytics.cache_hit_rate_metric_by_count/3` is removed. It had exactly one caller, the alert evaluation, and its tests are migrated to the window comparison rather than left behind on a dead function.
- No migration and no schema change, so `server/data-export.md` needs no update.
- The leaky-selector CSS follow-up noted in the original PR (`project_bundle_settings.css`, `account.css`, `project_settings.css`) is still open and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)