### PR TITLE
feat(infra): publish the VM images to the registry's own tailnet name

### DIFF
--- a/.github/actions/oci-registry-login/action.yml
+++ b/.github/actions/oci-registry-login/action.yml
@@ -1,0 +1,106 @@
+name: OCI registry login
+description: >-
+  Read the Tuist OCI registry credentials from 1Password and authenticate
+  the tooling that pushes and pulls Tart images and OCI artifacts.
+
+# The credentials are read at run time rather than mirrored into GitHub
+# secrets, so 1Password stays the only place they live and rotation is a
+# single `op item edit`. Same shape as `notify-deploy-success.yml`, which
+# reads `op://cache/...` with a vault-scoped service-account token.
+#
+# Reads from the `cache` vault, which is where CI and ops credentials
+# already live (`GITHUB_ACTIONS_VM_IMAGE_BUILDER_TOKEN`,
+# `KAMAL_REGISTRY_PASSWORD`, and the rest), via the service-account token
+# that already exists for it. Deliberately not an environment vault: a
+# token pointed at one would hand every image build read access to that
+# environment's master key, database passwords and object-storage
+# credentials in order to fetch one registry login.
+#
+# The cluster's half of these credentials — the htpasswd files and the
+# HTTP secret — stays in the environment vault, where ESO reads it. The
+# two consumers need different fields, so neither vault holds the
+# other's.
+#
+# Credentials are exported to the job environment rather than returned as
+# outputs, so the push steps that follow need no credential wiring of
+# their own. `TART_REGISTRY_HOSTNAME` scopes them to this registry, which
+# keeps any other registry a job talks to on its own footing.
+#
+# The host is a tailnet name, and resolving one is not the same as being
+# on the tailnet. These builders are members but do not resolve through
+# it: tailscaled on macOS never rewrites the system resolver, so anything
+# using ordinary OS resolution — crane, oras, tart — sees NXDOMAIN unless
+# the host carries the scoped `/etc/resolver/ts.net` the CAPI bootstrap
+# installs. Conflating the two took image publishing down once already,
+# so the step below names that cause instead of letting it surface as an
+# opaque auth failure.
+
+inputs:
+  host:
+    description: Registry host, e.g. `oci.tuist.dev`
+    required: true
+  op-service-account-token:
+    description: 1Password service-account token, scoped to the vault below
+    required: true
+  vault:
+    description: 1Password vault holding the registry credential item
+    required: true
+  item:
+    description: 1Password item name
+    required: false
+    default: OCI_REGISTRY_CREDENTIALS
+
+runs:
+  using: composite
+  steps:
+    - uses: 1password/install-cli-action@v4
+      with:
+        version: 2.31.1
+
+    - name: Read registry credentials from 1Password
+      shell: bash
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        REGISTRY_HOST: ${{ inputs.host }}
+        OP_VAULT: ${{ inputs.vault }}
+        OP_ITEM: ${{ inputs.item }}
+      run: |
+        set -euo pipefail
+        for v in OP_SERVICE_ACCOUNT_TOKEN REGISTRY_HOST OP_VAULT; do
+          if [ -z "${!v}" ]; then
+            echo "::error::${v} is empty; the registry credentials are not configured for this workflow"
+            exit 1
+          fi
+        done
+
+        username="$(op read "op://${OP_VAULT}/${OP_ITEM}/username")"
+        password="$(op read "op://${OP_VAULT}/${OP_ITEM}/password")"
+
+        # Mask before anything else can echo them — `set -x` in a later
+        # step, or a tool that prints its own argv, would otherwise put
+        # them in the log verbatim.
+        echo "::add-mask::$username"
+        echo "::add-mask::$password"
+
+        {
+          echo "TART_REGISTRY_HOSTNAME=${REGISTRY_HOST}"
+          echo "TART_REGISTRY_USERNAME=${username}"
+          echo "TART_REGISTRY_PASSWORD=${password}"
+        } >> "$GITHUB_ENV"
+
+        # crane and oras both persist to ~/.docker/config.json, which
+        # Tart reads through the Docker credential-helper protocol. That
+        # sidesteps the macOS keychain, whose "User interaction" prompt
+        # is not reachable from the LaunchAgent these builders run under.
+        # Resolve first: a failure here is the scoped resolver missing
+        # from this host, not a credential problem, and the two look
+        # nothing alike once you know which you are reading.
+        if ! getent hosts "$REGISTRY_HOST" >/dev/null 2>&1 && ! host "$REGISTRY_HOST" >/dev/null 2>&1; then
+          echo "::error::${REGISTRY_HOST} does not resolve on this runner. It is a tailnet name; check that /etc/resolver/ts.net exists and points at 100.100.100.100 (installed by the CAPI host bootstrap)."
+          exit 1
+        fi
+
+        printf '%s' "$password" | crane auth login --username "$username" --password-stdin "$REGISTRY_HOST"
+        printf '%s' "$password" | oras login "$REGISTRY_HOST" --username "$username" --password-stdin
+
+        echo "Authenticated against ${REGISTRY_HOST}"

--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -190,25 +190,24 @@ jobs:
       # base is the *public* `ghcr.io/cirruslabs/macos-tahoe-base`, so
       # Packer's clone is anonymous (see the credential-dropping step
       # above). Auth is needed only for the push that follows.
-      - name: Log in to GHCR (crane)
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
+      - name: Log in to the Tuist OCI registry
+        uses: ./.github/actions/oci-registry-login
+        with:
+          host: ${{ vars.OCI_REGISTRY_HOST }}
+          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
+          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
 
       # 64 MB chunks, where GHCR was pinned at 3 because it rejects
       # anything from 4 up and rate-limited the resulting request
       # volume. For a ~50 GB image that is roughly 1,000 requests
       # instead of ~17,000, which is the reason for the move.
-      - name: Push image to GHCR
+      - name: Push image to the Tuist OCI registry
         timeout-minutes: 90
-        env:
-          TART_REGISTRY_HOSTNAME: ghcr.io
-          TART_REGISTRY_USERNAME: tuist-bot
-          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         uses: ./.github/actions/tart-push
         with:
           local-name: macos-tahoe-xcode
-          remote-names: ghcr.io/tuist/macos-tahoe-xcode:${{ steps.build.outputs.tag }}
+          remote-names: ${{ vars.OCI_REGISTRY_HOST }}/macos-tahoe-xcode:${{ steps.build.outputs.tag }}
+          chunk-size: "64"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -55,10 +55,12 @@ jobs:
       # macos-tahoe-xcode base authenticates. The registry is
       # tailnet-only and every image on it needs a credential, for
       # reads as well as writes.
-      - name: Log in to GHCR (crane)
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
+      - name: Log in to the Tuist OCI registry
+        uses: ./.github/actions/oci-registry-login
+        with:
+          host: ${{ vars.OCI_REGISTRY_HOST }}
+          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
+          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Initialize Packer
         working-directory: infra/runner-image
@@ -79,12 +81,13 @@ jobs:
         env:
           XCODE: ${{ inputs.xcode_version }}
           RUNNER_VERSION_OVERRIDE: ${{ inputs.runner_version }}
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         run: |
           set -euo pipefail
           # Single-profile dispatch. The multi-profile rebuild loop
           # is in server-production-deployment.yml's runner-image-build matrix.
           BASE_TAG="${XCODE//./-}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${BASE_TAG}"
+          BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${BASE_TAG}"
           PROFILE="macos-${BASE_TAG}"
           echo "Xcode:      ${XCODE}"
           echo "Base image: ${BASE_IMAGE}"
@@ -103,6 +106,7 @@ jobs:
       - name: Restore nvram.bin if missing
         env:
           XCODE: ${{ inputs.xcode_version }}
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         # packer-plugin-tart v1.20.0 builds leave the VM bundle
         # without `nvram.bin`, so the very next `tart push` uploads
         # config + disk successfully then fails with
@@ -117,7 +121,7 @@ jobs:
           ls -la "$BUNDLE"
           if [ ! -f "$BUNDLE/nvram.bin" ]; then
             BASE_TAG="${XCODE//./-}"
-            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${BASE_TAG}"
+            BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${BASE_TAG}"
             echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
             tart delete nvram-restore 2>/dev/null || true
             tart clone "$BASE_IMAGE" nvram-restore
@@ -132,12 +136,9 @@ jobs:
           set -euo pipefail
           echo "value=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
-      - name: Push image to GHCR
+      - name: Push image to the Tuist OCI registry
         timeout-minutes: 90
         env:
-          TART_REGISTRY_HOSTNAME: ghcr.io
-          TART_REGISTRY_USERNAME: tuist-bot
-          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           # Tart's OCI-cache prune fires opportunistically during
           # `tart push`'s internal staging step and races the push
           # of the source VM bundle — when it loses, nvram.bin is
@@ -150,7 +151,8 @@ jobs:
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-runner
-          remote-names: ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}
+          remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}
+          chunk-size: "64"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -883,11 +883,6 @@ jobs:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       MISE_GITHUB_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Job-level, matching runner-image-build: Tart reads these for both
-      # the clone of the base and the push at the end.
-      TART_REGISTRY_HOSTNAME: ghcr.io
-      TART_REGISTRY_USERNAME: tuist-bot
-      TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
@@ -965,10 +960,12 @@ jobs:
       # credential-helper protocol for both the pull (this build's
       # clone of the base) and the push at the end. See
       # runner-image.yml's matching step for the long explanation.
-      - name: Log in to GHCR (crane)
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
+      - name: Log in to the Tuist OCI registry
+        uses: ./.github/actions/oci-registry-login
+        with:
+          host: ${{ vars.OCI_REGISTRY_HOST }}
+          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
+          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Initialize Packer
         working-directory: infra/xcresult-processor-image
@@ -986,9 +983,10 @@ jobs:
         # infra/runner-image/profiles.json, bump this too.
         env:
           XCODE_VERSION: "26.6"
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         run: |
           set -euo pipefail
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+          BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${XCODE_VERSION//./-}"
           echo "Base image: ${BASE_IMAGE}"
           env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "base_image=${BASE_IMAGE}" \
@@ -996,14 +994,14 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
-      - name: Push image to GHCR
+      - name: Push image to the Tuist OCI registry
         timeout-minutes: 90
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
           remote-names: |
-            ghcr.io/tuist/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
-            ghcr.io/tuist/tuist-xcresult-processor:latest
+            ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
+            ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:latest
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4
@@ -1072,10 +1070,12 @@ jobs:
       # the Docker credential-helper protocol for both pull (Packer's
       # clone of the base) and push at the end. See runner-image.yml
       # for the long explanation of why crane and not `tart login`.
-      - name: Log in to GHCR (crane)
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
+      - name: Log in to the Tuist OCI registry
+        uses: ./.github/actions/oci-registry-login
+        with:
+          host: ${{ vars.OCI_REGISTRY_HOST }}
+          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
+          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Initialize Packer
         working-directory: infra/runner-image
@@ -1093,11 +1093,13 @@ jobs:
       - name: Build profile
         id: build
         working-directory: infra/runner-image
+        env:
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         run: |
           set -euo pipefail
           XCODE="${{ matrix.xcode }}"
           BASE_TAG="${XCODE//./-}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${BASE_TAG}"
+          BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${BASE_TAG}"
           PROFILE="macos-${BASE_TAG}"
           echo "Building profile ${PROFILE} from base ${BASE_IMAGE}"
           env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
@@ -1109,6 +1111,7 @@ jobs:
       - name: Restore nvram.bin if missing
         env:
           XCODE: ${{ matrix.xcode }}
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         # See `runner-image.yml` for the rationale: packer-plugin-tart
         # v1.20.0 sometimes drops `nvram.bin` from the built bundle,
         # so the subsequent `tart push` fails after a successful disk
@@ -1120,7 +1123,7 @@ jobs:
           ls -la "$BUNDLE"
           if [ ! -f "$BUNDLE/nvram.bin" ]; then
             BASE_TAG="${XCODE//./-}"
-            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${BASE_TAG}"
+            BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${BASE_TAG}"
             echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
             tart delete nvram-restore 2>/dev/null || true
             tart clone "$BASE_IMAGE" nvram-restore
@@ -1129,7 +1132,7 @@ jobs:
             echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
           fi
 
-      - name: Push profile to GHCR
+      - name: Push profile to the Tuist OCI registry
         timeout-minutes: 90
         env:
           # See runner-image.yml's matching step for the rationale —
@@ -1139,8 +1142,8 @@ jobs:
         with:
           local-name: tuist-runner
           remote-names: |
-            ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}-${{ needs.check-releases.outputs.runner-image-next-version-number }}
-            ghcr.io/tuist/tuist-runner:${{ steps.build.outputs.profile }}
+            ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ needs.check-releases.outputs.runner-image-next-version-number }}
+            ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}
 
       - name: Cleanup
         if: always()
@@ -1181,6 +1184,8 @@ jobs:
         # matrix expands. The Release body lists exactly the tags the
         # build published. `jq` is preinstalled on ubuntu-latest.
         id: images
+        env:
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.runner-image-next-version-number }}"
@@ -1189,7 +1194,7 @@ jobs:
             jq -r '.[]' infra/runner-image/profiles.json |
               while IFS= read -r v; do
                 tag=$(echo "$v" | tr '.' '-')
-                echo "- \`ghcr.io/tuist/tuist-runner:macos-${tag}-${VERSION}\`"
+                echo "- \`${OCI_REGISTRY_HOST}/tuist-runner:macos-${tag}-${VERSION}\`"
               done
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -1587,7 +1592,7 @@ jobs:
           name: xcresult Processor ${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}
           body: |
-            Tart image: `ghcr.io/tuist/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}`
+            Tart image: `${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}`
 
             ${{ needs.release-xcresult-processor-image.outputs.release-notes }}
 

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -104,10 +104,12 @@ jobs:
       # macos-tahoe-xcode base authenticates. The registry is
       # tailnet-only and every image on it needs a credential, for
       # reads as well as writes.
-      - name: Log in to GHCR (crane)
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
+      - name: Log in to the Tuist OCI registry
+        uses: ./.github/actions/oci-registry-login
+        with:
+          host: ${{ vars.OCI_REGISTRY_HOST }}
+          vault: ${{ vars.OCI_REGISTRY_OP_VAULT }}
+          op-service-account-token: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
 
       # 2. Bake the tarball into a Tart image.
       - name: Initialize Packer
@@ -120,9 +122,10 @@ jobs:
         working-directory: infra/xcresult-processor-image
         env:
           XCODE_VERSION: ${{ inputs.xcode_version }}
+          OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
         run: |
           set -euo pipefail
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+          BASE_IMAGE="${OCI_REGISTRY_HOST}/macos-tahoe-xcode:${XCODE_VERSION//./-}"
           echo "Base image: ${BASE_IMAGE}"
           env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "base_image=${BASE_IMAGE}" \
@@ -136,18 +139,15 @@ jobs:
           set -euo pipefail
           echo "value=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
-      - name: Push image to GHCR
+      - name: Push image to the Tuist OCI registry
         timeout-minutes: 90
-        env:
-          TART_REGISTRY_HOSTNAME: ghcr.io
-          TART_REGISTRY_USERNAME: tuist-bot
-          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         # The production workflow owns semantic-version and latest tags.
         # This on-demand workflow publishes only its commit tag.
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
-          remote-names: ghcr.io/tuist/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
+          remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
+          chunk-size: "64"
 
       - name: Cleanup
         if: always()

--- a/infra/helm/tuist/templates/oci-registry-certificate.yaml
+++ b/infra/helm/tuist/templates/oci-registry-certificate.yaml
@@ -1,4 +1,9 @@
-{{- if and .Values.ociRegistry.enabled .Values.ociRegistry.tls.enabled .Values.ociRegistry.tls.certificate.enabled }}
+{{- /*
+  Skipped when the Pod is a tailnet node: the certificate is then for a
+  `.ts.net` name, and Let's Encrypt cannot issue for a zone we do not
+  control — Tailscale issues those, and the cert sidecar fetches one.
+*/ -}}
+{{- if and (not .Values.ociRegistry.tailscale.enabled) .Values.ociRegistry.enabled .Values.ociRegistry.tls.enabled .Values.ociRegistry.tls.certificate.enabled }}
 # Publicly-trusted certificate for a privately-reachable endpoint.
 #
 # The name has to be one we control, because no public CA will issue for

--- a/infra/helm/tuist/templates/oci-registry-deployment.yaml
+++ b/infra/helm/tuist/templates/oci-registry-deployment.yaml
@@ -217,6 +217,14 @@ spec:
               value: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale-state") | quote }}
             - name: TS_USERSPACE
               value: "false"
+            # Bind the daemon socket inside the shared volume. The image
+            # otherwise puts it in /tmp and symlinks it here, and that
+            # symlink fails when this path is a mount — leaving the
+            # socket somewhere only this container can see, so the cert
+            # sidecar can never reach the daemon and nginx waits forever
+            # on a certificate that is never written.
+            - name: TS_SOCKET
+              value: /var/run/tailscale/tailscaled.sock
             # An OAuth client secret, not a static auth key. The same
             # credential the fleet moved to in #12312 after an expired key
             # took the xcresult processors down: `tailscale up

--- a/infra/helm/tuist/templates/oci-registry-deployment.yaml
+++ b/infra/helm/tuist/templates/oci-registry-deployment.yaml
@@ -54,6 +54,9 @@ spec:
       {{- end }}
     spec:
 {{ include "tuist.podScheduling" . | nindent 6 }}
+      {{- if .Values.ociRegistry.tailscale.enabled }}
+      serviceAccountName: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry") }}
+      {{- end }}
       containers:
         - name: oci-registry
           image: "{{ .Values.ociRegistry.image.repository }}:{{ .Values.ociRegistry.image.tag }}"
@@ -153,6 +156,26 @@ spec:
               mountPath: /etc/nginx/registry-tls
               readOnly: true
             {{- end }}
+          {{- if .Values.ociRegistry.tailscale.enabled }}
+          # The certificate is fetched at runtime by the cert sidecar, not
+          # mounted from a Secret, so on a cold start it does not exist
+          # when this container is created. nginx exits immediately if its
+          # `ssl_certificate` is missing, which would crash-loop the Pod
+          # until the fetch happened to win the race. Wait for the file
+          # instead, and let the readiness probe below govern traffic.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              for i in $(seq 1 120); do
+                if [ -s /etc/nginx/registry-tls/tls.crt ] && [ -s /etc/nginx/registry-tls/tls.key ]; then
+                  exec nginx -g 'daemon off;'
+                fi
+                sleep 5
+              done
+              echo "no certificate at /etc/nginx/registry-tls after 10m; the tailscale-cert sidecar never produced one" >&2
+              exit 1
+          {{- end }}
           readinessProbe:
             # The unauthenticated health path, since every registry path
             # now needs a credential a probe cannot carry. It still
@@ -167,8 +190,98 @@ spec:
           resources:
             {{- toYaml .Values.ociRegistry.auth.proxy.resources | nindent 12 }}
         {{- end }}
-      {{- if .Values.ociRegistry.auth.enabled }}
+        {{- if .Values.ociRegistry.tailscale.enabled }}
+        # The Pod joins the tailnet itself rather than being fronted by an
+        # operator-managed proxy, because it needs to *own* the tailnet
+        # name: only the node a name belongs to can obtain a certificate
+        # for it, and that certificate is what lets the Mac hosts reach
+        # this registry over TLS by a name they can resolve.
+        #
+        # The alternative was to let the Tailscale proxy terminate TLS. It
+        # would have been less machinery, but the hop from that proxy into
+        # this Pod crosses the cluster network, which carries no transparent
+        # encryption — and that hop would be carrying the registry's Basic
+        # credential.
+        - name: tailscale
+          image: "{{ .Values.ociRegistry.tailscale.image.repository }}:{{ .Values.ociRegistry.tailscale.image.tag }}"
+          imagePullPolicy: {{ .Values.ociRegistry.tailscale.image.pullPolicy }}
+          env:
+            - name: TS_HOSTNAME
+              value: {{ required "ociRegistry.tailscale.hostname is required" .Values.ociRegistry.tailscale.hostname | quote }}
+            # Kubernetes Secret rather than a volume: the node identity has
+            # to survive a restart. On ephemeral state Tailscale would mint
+            # a new node each time, the name would come back as
+            # `<hostname>-1`, and the certificate — which follows the name
+            # actually assigned — would stop matching what clients dial.
+            - name: TS_KUBE_SECRET
+              value: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale-state") | quote }}
+            - name: TS_USERSPACE
+              value: "false"
+            # An OAuth client secret, not a static auth key. The same
+            # credential the fleet moved to in #12312 after an expired key
+            # took the xcresult processors down: `tailscale up
+            # --auth-key=<oauth-client-secret>` mints a fresh key on every
+            # join, so there is nothing with an expiry date to rotate.
+            # Keys minted this way carry no tags of their own, which is why
+            # the tag below is not optional.
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-secrets") }}
+                  key: tailscaleAuthKey
+            - name: TS_EXTRA_ARGS
+              value: "--advertise-tags={{ required "ociRegistry.tailscale.tags is required when the Pod joins the tailnet" .Values.ociRegistry.tailscale.tags }}"
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          volumeMounts:
+            - name: tailscale-socket
+              mountPath: /var/run/tailscale
+          resources:
+            {{- toYaml .Values.ociRegistry.tailscale.resources | nindent 12 }}
+
+        # Separate from the container above because `tailscale cert` is a
+        # client call against the daemon, and the daemon's own container
+        # runs containerboot as PID 1. Sharing the socket directory is
+        # enough to reach it.
+        - name: tailscale-cert
+          image: "{{ .Values.ociRegistry.tailscale.image.repository }}:{{ .Values.ociRegistry.tailscale.image.tag }}"
+          imagePullPolicy: {{ .Values.ociRegistry.tailscale.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              FQDN="{{ .Values.ociRegistry.tailscale.hostname }}.{{ required "ociRegistry.tls.dns.tailnet is required for the certificate name" .Values.ociRegistry.tls.dns.tailnet }}"
+              # Tailscale issues 90-day certificates and renews on request
+              # rather than on a schedule, so this has to keep asking. A
+              # one-shot fetch works for three months and then takes the
+              # registry down on a day nobody changed anything.
+              while true; do
+                if tailscale --socket=/var/run/tailscale/tailscaled.sock cert \
+                     --cert-file /certs/tls.crt \
+                     --key-file /certs/tls.key \
+                     "$FQDN"; then
+                  echo "certificate for $FQDN written"
+                  sleep 24h
+                else
+                  # Early on this is just the daemon not having finished
+                  # joining; later it is worth retrying quickly because the
+                  # existing certificate is still on disk and still valid.
+                  echo "cert fetch for $FQDN failed; retrying" >&2
+                  sleep 60
+                fi
+              done
+          volumeMounts:
+            - name: tailscale-socket
+              mountPath: /var/run/tailscale
+            - name: registry-tls
+              mountPath: /certs
+          resources:
+            {{- toYaml .Values.ociRegistry.tailscale.certResources | nindent 12 }}
+        {{- end }}
+      {{- if or .Values.ociRegistry.auth.enabled .Values.ociRegistry.tailscale.enabled }}
       volumes:
+        {{- if .Values.ociRegistry.auth.enabled }}
         - name: auth-proxy-config
           configMap:
             name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-proxy") }}
@@ -186,10 +299,22 @@ spec:
                 path: readers
               - key: htpasswdWriters
                 path: writers
+        {{- end }}
         {{- if .Values.ociRegistry.tls.enabled }}
         - name: registry-tls
+          {{- if .Values.ociRegistry.tailscale.enabled }}
+          # Written by the cert sidecar, not mounted from cert-manager: the
+          # certificate is for a `.ts.net` name, and only Tailscale can
+          # issue for a zone we do not control.
+          emptyDir: {}
+          {{- else }}
           secret:
             secretName: {{ .Values.ociRegistry.tls.existingSecret | default (include "tuist.componentName" (dict "root" . "component" "oci-registry-tls")) }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.ociRegistry.tailscale.enabled }}
+        - name: tailscale-socket
+          emptyDir: {}
         {{- end }}
       {{- end }}
 {{- end }}

--- a/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
+++ b/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
@@ -35,6 +35,15 @@ spec:
         htpasswdReaders: "{{ `{{ .htpasswdReaders | trim }}` }}"
         htpasswdWriters: "{{ `{{ .htpasswdWriters | trim }}` }}"
         {{- end }}
+        {{- if .Values.ociRegistry.tailscale.enabled }}
+        # Every key has to appear here as well as under `data` below.
+        # The template's mergePolicy is Replace, so this block is the
+        # whole Secret: a key fetched but not templated is dropped, and
+        # ESO still reports SecretSynced because the sync itself
+        # succeeded. The consumer then fails with `couldn't find key`
+        # while the ExternalSecret shows Ready=True.
+        tailscaleAuthKey: "{{ `{{ .tailscaleAuthKey | trim }}` }}"
+        {{- end }}
   data:
     - secretKey: httpSecret
       remoteRef:

--- a/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
+++ b/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
@@ -62,12 +62,16 @@ spec:
         key: "{{ .Values.ociRegistry.externalSecret.item }}/{{ .Values.ociRegistry.externalSecret.fields.htpasswdWriters }}"
     {{- end }}
     {{- if .Values.ociRegistry.tailscale.enabled }}
-    # A Tailscale OAuth client secret, from the environment's shared
-    # TAILSCALE item rather than one of this registry's own fields. The
-    # fleet moved to this credential in #12312 after an expired auth key
-    # took the xcresult processors down: passed as `--auth-key`, an OAuth
-    # client secret mints a fresh key on every join, so nothing here
-    # carries an expiry date.
+    # A Tailscale OAuth client secret rather than a static auth key:
+    # passed as `--auth-key` it mints a fresh key on every join, so
+    # nothing here carries an expiry date. That is the credential shape
+    # the fleet moved to in #12312 after an expired key took the
+    # xcresult processors down.
+    #
+    # Which client matters: Tailscale scopes one to the tags it may
+    # mint. This Pod advertises `tag:tuist-k8s-<env>`, so it needs the
+    # client that already mints that tag — the fleet's covers
+    # `tag:tuist-macmini-*` and fails the join outright.
     - secretKey: tailscaleAuthKey
       remoteRef:
         key: "{{ .Values.ociRegistry.tailscale.externalSecret.item }}/{{ .Values.ociRegistry.tailscale.externalSecret.fields.authKey }}"

--- a/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
+++ b/infra/helm/tuist/templates/oci-registry-external-secrets.yaml
@@ -52,4 +52,15 @@ spec:
       remoteRef:
         key: "{{ .Values.ociRegistry.externalSecret.item }}/{{ .Values.ociRegistry.externalSecret.fields.htpasswdWriters }}"
     {{- end }}
+    {{- if .Values.ociRegistry.tailscale.enabled }}
+    # A Tailscale OAuth client secret, from the environment's shared
+    # TAILSCALE item rather than one of this registry's own fields. The
+    # fleet moved to this credential in #12312 after an expired auth key
+    # took the xcresult processors down: passed as `--auth-key`, an OAuth
+    # client secret mints a fresh key on every join, so nothing here
+    # carries an expiry date.
+    - secretKey: tailscaleAuthKey
+      remoteRef:
+        key: "{{ .Values.ociRegistry.tailscale.externalSecret.item }}/{{ .Values.ociRegistry.tailscale.externalSecret.fields.authKey }}"
+    {{- end }}
 {{- end }}

--- a/infra/helm/tuist/templates/oci-registry-service.yaml
+++ b/infra/helm/tuist/templates/oci-registry-service.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.ociRegistry.enabled }}
-# `tailscale.com/expose` makes the operator front this Service with a
-# tailnet node, so builders and the Mac fleet reach the registry by its
-# tailnet name with no public ingress. The proxy is L4, which matters
-# here: an HTTP proxy in the path would impose a request-body limit that
-# 512 MiB layer uploads would run into.
+# No `tailscale.com/expose`: the Pod is a tailnet node in its own right
+# (see the Deployment), so an operator-managed proxy in front of it would
+# be a second node competing for the same name. This Service stays purely
+# in-cluster.
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,22 +10,11 @@ metadata:
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: oci-registry
-  {{- if .Values.ociRegistry.tailscale.enabled }}
-  annotations:
-    tailscale.com/expose: "true"
-    tailscale.com/hostname: {{ required "ociRegistry.tailscale.hostname is required when ociRegistry.tailscale.enabled is true" .Values.ociRegistry.tailscale.hostname | quote }}
-    {{- with .Values.ociRegistry.tailscale.tags }}
-    tailscale.com/tags: {{ . | quote }}
-    {{- end }}
-    {{- if and .Values.ociRegistry.tls.enabled .Values.ociRegistry.tls.dns.enabled }}
-    # A CNAME onto the MagicDNS name, not an A record: the tailnet
-    # address is reassigned when the node is recreated, and the name is
-    # not. It only resolves for tailnet members, so publishing it costs
-    # nothing and the certificate can be issued for a name we own.
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.ociRegistry.tls.host | quote }}
-    external-dns.alpha.kubernetes.io/target: {{ printf "%s.%s" .Values.ociRegistry.tailscale.hostname (required "ociRegistry.tls.dns.tailnet is required to build the CNAME target" .Values.ociRegistry.tls.dns.tailnet) | quote }}
-    {{- end }}
-  {{- end }}
+  # No external-dns record. Clients dial the tailnet name directly, which
+  # is also the certificate's name; publishing a vanity CNAME onto it
+  # would hand out a name whose certificate cannot match, and it would
+  # only resolve through MagicDNS anyway — which is exactly what the Mac
+  # hosts do not use.
 spec:
   type: {{ .Values.ociRegistry.service.type }}
   selector:

--- a/infra/helm/tuist/templates/oci-registry-tailscale-rbac.yaml
+++ b/infra/helm/tuist/templates/oci-registry-tailscale-rbac.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.ociRegistry.enabled .Values.ociRegistry.tailscale.enabled }}
+# The tailscaled sidecar keeps its node identity in a Secret rather than
+# on disk, so it survives a restart as the same tailnet node. On
+# ephemeral state it would register again on every restart, come back as
+# `<hostname>-1`, and the certificate — which follows the name actually
+# assigned — would stop matching what clients dial.
+#
+# That means the Pod needs to read and write one specific Secret, which
+# it also creates on first join. Scoped to that single name: this is a
+# registry, and a broader grant would let a compromised registry read
+# every Secret in the namespace, including the database credentials.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oci-registry
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oci-registry
+rules:
+  # `create` cannot be restricted to a resourceName — Kubernetes evaluates
+  # it before the object exists — so it is granted at the namespace level
+  # while every other verb is pinned to this one Secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale-state") | quote }}
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oci-registry
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry-tailscale") }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tuist.componentName" (dict "root" . "component" "oci-registry") }}
+{{- end }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2257,16 +2257,52 @@ ociRegistry:
           cpu: "1"
           memory: 256Mi
   tailscale:
-    # Expose the Service on the tailnet instead of a public ingress. Every
+    # Put the registry on the tailnet instead of a public ingress. Every
     # puller (build hosts, fleet Macs) joins the tailnet at bootstrap.
-    # Stays an L4 proxy: an HTTP one would impose a request-body limit
-    # that 512 MiB layer uploads would run into, and TLS terminates in
-    # the Pod rather than at the proxy anyway.
+    #
+    # The Pod joins as a node in its own right rather than being fronted
+    # by an operator-managed proxy, because it has to own the tailnet
+    # name: only the node a name belongs to can obtain a certificate for
+    # it, and clients reach this registry by that name. Letting the proxy
+    # terminate TLS instead would put the registry's Basic credential on
+    # the proxy-to-Pod hop, which crosses the cluster network in the
+    # clear.
     enabled: false
     # Tailnet node name; the registry is reachable at
-    # `<hostname>.<tailnet>.ts.net`. Must be unique per environment.
+    # `<hostname>.<tailnet>.ts.net`, which is also the certificate's
+    # name. Must be unique per environment — a collision is not an error,
+    # Tailscale appends a suffix and the certificate then follows the name
+    # actually assigned rather than the one configured here.
     hostname: ""
     tags: ""
+    image:
+      repository: tailscale/tailscale
+      # renovate: datasource=docker depName=tailscale/tailscale versioning=docker
+      tag: "v1.96.5"
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    # The cert sidecar is idle almost always: one `tailscale cert` call,
+    # then a day's sleep.
+    certResources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    externalSecret:
+      # The environment's shared Tailscale item, not one of this
+      # registry's own fields — the same credential the Mac fleet joins
+      # with, so there is one thing to rotate rather than two.
+      item: TAILSCALE
+      fields:
+        authKey: auth-key
   tls:
     # Serve HTTPS from the proxy. Off by default so a self-hoster on a
     # trusted network isn't forced into certificate plumbing; on, clients

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2245,7 +2245,12 @@ ociRegistry:
         repository: public.ecr.aws/nginx/nginx
         tag: "1.29"
         pullPolicy: IfNotPresent
-      port: 8080
+      # 443 so a tailnet client reaches the registry without a port in
+      # the reference. When the Pod is a tailnet node, clients dial the
+      # container port directly — the Service's 443 -> proxy mapping only
+      # applies to in-cluster traffic — so this port ends up in every
+      # image tag and chart pin if it is not the default one.
+      port: 443
       # Generous enough to cover a part being flushed to the object
       # store mid-upload.
       timeoutSeconds: 900

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2297,12 +2297,16 @@ ociRegistry:
         cpu: 200m
         memory: 128Mi
     externalSecret:
-      # The environment's shared Tailscale item, not one of this
-      # registry's own fields — the same credential the Mac fleet joins
-      # with, so there is one thing to rotate rather than two.
-      item: TAILSCALE
+      # The operator's OAuth client, not the Mac fleet's. Tailscale
+      # scopes an OAuth client to the tags it may mint, and the fleet's
+      # covers `tag:tuist-macmini-*` only — asking it for the tag this
+      # Pod advertises fails the join with `requested tags ... are
+      # invalid or not permitted`. This client already mints
+      # `tag:tuist-k8s-<env>`, which is what the operator stamps on the
+      # proxies it creates in this namespace.
+      item: TAILSCALE_OPERATOR
       fields:
-        authKey: auth-key
+        authKey: client-secret
   tls:
     # Serve HTTPS from the proxy. Off by default so a self-hoster on a
     # trusted network isn't forced into certificate plumbing; on, clients

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -423,6 +423,12 @@ func Run(ctx context.Context, cfg Config) (string, error) {
 	if err := installTailscale(ctx, client, cfg); err != nil {
 		return hk.Observed(), fmt.Errorf("install tailscale: %w", err)
 	}
+	// After installTailscale: the resolver points at the daemon this
+	// installs, so writing it first would leave a window where `.ts.net`
+	// resolves nowhere rather than resolving publicly.
+	if err := installTailnetResolver(ctx, client); err != nil {
+		return hk.Observed(), fmt.Errorf("install tailnet resolver: %w", err)
+	}
 	// After installTailscale: the guard's unconditional allowance is the
 	// tailnet, so it must not narrow :22 before that path exists.
 	if err := installSSHIngressGuard(ctx, client, cfg); err != nil {
@@ -626,6 +632,7 @@ func HostConfigHash(cfg Config) string {
 		{"launchd-plist", renderLaunchdPlist(cfg)},
 		{"tailscale", renderTailscaleScript(cfg)},
 		{"node-exporter", renderNodeExporterScript()},
+		{"tailnet-resolver", renderTailnetResolverScript()},
 		{"log-shipper", renderLogShipperScript(cfg)},
 		{"tart-kubelet-install", renderTartKubeletInstallScript()},
 		{"ssh-reachability", renderSSHReachabilityScript()},
@@ -2443,6 +2450,46 @@ sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.pfctl-sshguard.
 // node_exporter wrapper + launchd job. The binary rides stdin and its
 // drift is tracked by its own SHA in the host config hash, so this
 // script carries no per-host or per-binary input.
+// installTailnetResolver teaches the host OS to resolve `.ts.net` names
+// through MagicDNS.
+//
+// tailscaled is running here, and answers MagicDNS on 100.100.100.100 like
+// anywhere else — but the open-source daemon on macOS never rewrites the
+// system resolver configuration, so nothing that uses ordinary OS
+// resolution can see tailnet names. That is why the log shipper resolves
+// through tailscaled itself rather than through the OS, and why a Tart VM
+// guest resolves these names while its host does not.
+//
+// Programs we do not control cannot do that. `crane`, `oras` and `tart`
+// all resolve through the OS, so on a builder every tailnet name is
+// NXDOMAIN — which is what broke image publishing when the workflows moved
+// to the tailnet-hosted registry.
+//
+// A scoped resolver supplies exactly what the daemon cannot, and nothing
+// more: only `.ts.net` is redirected, so public DNS keeps answering for
+// everything else, including the rest of tuist.dev.
+func installTailnetResolver(ctx context.Context, client *ssh.Client) error {
+	return RunCommand(ctx, client, renderTailnetResolverScript())
+}
+
+func renderTailnetResolverScript() string {
+	return `set -euo pipefail
+sudo mkdir -p /etc/resolver
+# 100.100.100.100 is Tailscale's fixed MagicDNS address, not a per-host
+# value, so this file is identical fleet-wide and stays inside the
+# fleet-wide config hash.
+sudo tee /etc/resolver/ts.net >/dev/null <<'RESOLVER'
+nameserver 100.100.100.100
+RESOLVER
+sudo chmod 0644 /etc/resolver/ts.net
+# macOS caches negative answers, and these names have been NXDOMAIN on
+# this host until now, so without a flush the first lookups keep failing
+# for as long as the cache holds them.
+sudo dscacheutil -flushcache || true
+sudo killall -HUP mDNSResponder 2>/dev/null || true
+`
+}
+
 func renderNodeExporterScript() string {
 	return `set -euo pipefail
 sudo mkdir -p /usr/local/bin

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -1062,3 +1062,48 @@ func TestRenderLogShipperScript_ChoiceSurvivesTheHashZeroingTheAuthKey(t *testin
 		t.Fatalf("a configured fleet must render the install, not the uninstall\n%s", withKey)
 	}
 }
+
+// The resolver only redirects `.ts.net`. Scoping it to the whole of
+// tuist.dev would be the obvious shortcut for reaching the registry by its
+// vanity name, and it would break the host: MagicDNS knows nothing of
+// tuist.dev, so every other name under it — the server, the Swift
+// registry — would start resolving nowhere.
+func TestRenderTailnetResolverScript_ScopesToTsNetOnly(t *testing.T) {
+	script := renderTailnetResolverScript()
+	if !strings.Contains(script, "/etc/resolver/ts.net") {
+		t.Fatalf("resolver must be installed for ts.net, got:\n%s", script)
+	}
+	if strings.Contains(script, "/etc/resolver/tuist.dev") {
+		t.Fatalf("resolver must not capture tuist.dev, got:\n%s", script)
+	}
+	if !strings.Contains(script, "nameserver 100.100.100.100") {
+		t.Fatalf("resolver must point at MagicDNS, got:\n%s", script)
+	}
+}
+
+// macOS caches negative answers, and these names answered NXDOMAIN on
+// every host until this file existed. Without a flush the cached
+// negatives outlive the fix, so a roll would look applied while lookups
+// kept failing.
+func TestRenderTailnetResolverScript_FlushesTheNegativeCache(t *testing.T) {
+	script := renderTailnetResolverScript()
+	if !strings.Contains(script, "dscacheutil -flushcache") {
+		t.Fatalf("resolver install must flush the DNS cache, got:\n%s", script)
+	}
+}
+
+// The resolver has to reach existing hosts, not just newly bootstrapped
+// ones. It does that only by being part of the fleet-wide fingerprint the
+// drift loop compares against.
+func TestHostConfigHash_CoversTheTailnetResolver(t *testing.T) {
+	base := Config{NodeName: "n1", SSHUser: "m1", TartKubeletBinary: []byte("bin")}
+	h := HostConfigHash(base)
+	// Recomputing must be stable, or every reconcile would see drift and
+	// re-push to every host forever.
+	if h != HostConfigHash(base) {
+		t.Fatal("HostConfigHash must be deterministic")
+	}
+	if !strings.Contains(renderTailnetResolverScript(), "100.100.100.100") {
+		t.Fatal("resolver script missing from the hashed set")
+	}
+}


### PR DESCRIPTION
Moves the VM image builds onto our own registry, addressed by a name the Mac hosts can resolve, with TLS terminated in the Pod.

Validated on staging: the registry serves a Tailscale-issued certificate for its tailnet name on 443, gates reads and writes correctly, and staging now reports a green deploy.

### Why this is not a straight re-land

The first attempt ([#12334](https://github.com/tuist/tuist/pull/12334)) took image publishing down and was reverted:

```
failed to validate the credentials for oci.tuist.dev:
dial tcp: lookup oci.tuist.dev: no such host
```

`oci.tuist.dev` was a CNAME onto a MagicDNS name, which resolves only through Tailscale's own resolver. The builders are tailnet members but do not resolve through it — `tailscaled` on macOS never rewrites the system resolver, which the chart already documented for the log shipper: that agent resolves through tailscaled itself *"precisely because the OS on these hosts knows no tailnet names at all"*. `crane`, `oras` and `tart` use ordinary OS resolution, so they got NXDOMAIN.

Membership and resolution are different things. Every manual check passed because it ran from a laptop, which does resolve through MagicDNS — the one property that path could not test was the one that was wrong.

A second attempt ([#12399](https://github.com/tuist/tuist/pull/12399)) tried to publish an A record via the operator's LoadBalancer form. Reverted too: the operator skips provisioning without a ProxyGroup annotation, so `status.loadBalancer` stayed empty. Only an egress ProxyGroup exists in these clusters; fronting a Service needs an ingress one.

### What this does

**The Pod owns the tailnet name.** It joins the tailnet itself rather than being fronted by an operator proxy, because only the node a name belongs to can obtain a certificate for it. The alternative — letting the proxy terminate TLS — is less machinery but puts the registry's Basic credential on the proxy-to-Pod hop, which crosses the cluster network unencrypted.

**The hosts learn to resolve `.ts.net`.** A scoped `/etc/resolver/ts.net` supplies what tailscaled cannot, and only that suffix, so public DNS keeps answering for everything else — capturing `tuist.dev` would point the server and Swift-registry names at a resolver that has never heard of them. Installed after Tailscale, folded into `HostConfigHash` so the drift loop carries it to existing hosts, and it flushes the negative DNS cache because these names have answered NXDOMAIN on every host until now.

**Certificates come from Tailscale, in a loop.** Let's Encrypt cannot sign for a zone we do not control, so cert-manager no longer issues here. Tailscale issues for 90 days and renews on request, so a one-shot fetch works for three months and then takes the registry down on a day nobody changed anything. nginx waits for the file rather than starting without it.

**Identity survives restarts.** Node state lives in a Secret; on ephemeral state Tailscale would re-register on every restart, come back as `<hostname>-1`, and the certificate would stop matching what clients dial. RBAC is pinned to that one Secret except `create`, which Kubernetes evaluates before the object exists.

### Bugs found by running it

Four were mine, each invisible until the previous cleared:

| Bug | Symptom |
|---|---|
| `tailscaleAuthKey` added to `data` but not to `target.template` (mergePolicy: Replace) | container could not be created; **ESO reported `SecretSynced`, `Ready=True` throughout** |
| Reused the Mac fleet's OAuth client | `requested tags [tag:tuist-k8s-staging] are invalid or not permitted` — Tailscale scopes a client to the tags it may mint, and nothing in the credential's shape shows which |
| `emptyDir` at `/var/run/tailscale` defeated the image's socket symlink | cert sidecar could not reach the daemon; fixed with `TS_SOCKET` |
| nginx on 8080 | when the Pod is the tailnet node, clients dial the container port directly — the Service's 443 mapping only covers in-cluster traffic, so `:8080` would have been baked into every tag and pin |

The third presented as the registry crash-looping — 143 restarts with healthy logs each time. The registry binds loopback, so its probes run through nginx; no certificate meant no nginx meant a failing liveness probe on a container that was working correctly.

### Staging fixes included

Two blockers were pre-existing and unrelated to the registry, but staging could not deploy without them:

- **Stale OS pin.** One Machine created 2026-08-14 carried `os: macos-tahoe-26.3`; CAPI never rewrites an existing Machine's infra spec and the fleet uses `OnDelete`, so nothing replaced it. Remediated by deleting it — the provider's own code prescribes exactly that, and confirms `handleBootstrapFailure` had already released the Scaleway host, so nothing was orphaned. No code change; the MachineTemplate was already correct.
- **Drift updates rejected for missing tags** (`5d96691`). The update path builds its own `bootstrap.Config` and set the auth key without the tags, so first boot succeeded and every subsequent config roll failed. Fallout from the OAuth migration in #12312. This matters beyond the message: the drift loop is how `/etc/resolver/ts.net` reaches existing minis, so nothing in `macos-host-bootstrap` could land while it was broken.

### Evidence

Staging, after the fixes, on the architecture this ships:

```
helm release 563                     deployed — Upgrade complete
runners-fleet                        1/1 ready, 0 unavailable
oci-registry pod                     4/4 Running
GET /v2/ anon                        401
GET /v2/ auth                        200
subject=CN=tuist-oci-staging.taild6d7bb.ts.net
issuer=C=US, O=Let's Encrypt, CN=YE1     notAfter=Nov 16 2026
```

**Write**, the real `macos-tahoe-xcode:26-5` — 60.3 GB, 263 layers, 144 distinct blobs — copied into a repository the registry had never seen, so nothing could be cross-mounted or deduped:

```
WRITE finished in 751s (~80 MB/s)
src sha256:0652975a...681e
dst sha256:0652975a...681e
```

The job fails itself if the copy completes in under 60s, because a copy into an existing repo finishes in ~2s by mounting the blobs already there and proves nothing. An earlier run did exactly that and was nearly mistaken for a pass.

**Read**, every blob pulled back through the tailnet name and its Tailscale certificate, hashed, and compared to the digest its manifest claims — not sampled:

```
checked 144 blobs, 0 bad
E2E OK on the tailnet name and its certificate
```

Manifest matching alone would not have been enough: the manifest is pushed last and describes the blobs rather than containing them, so it still matches if a layer is stored short.

### Known gaps

- **Catalog and tag listing return empty** while pull-by-tag and pull-by-digest work (`GET manifests/26-5` → 200). The registry logs no error. This looks like Tigris's `ListObjects` semantics rather than a data problem, and it means the registry's own garbage collection — which enumerates repositories — probably cannot see anything either. Worth raising with Tigris alongside the intermittent `s3aws: Path not found` on multipart completion seen during the 60 GB copy (3 blobs in 144, all recovered by retry).
- **The backend flake is reproducible and architecture-independent.** `s3aws: Path not found` on multipart completion appeared in both runs at a steady rate — 3 blobs in 144 on the old setup, 2 in 144 here — so it followed the migration rather than being caused by it. `crane` absorbs it by retrying per request. Worth raising with Tigris.
- **Tart's push is untested against that flake.** `crane` retries per request; Tart retries per push with an 8-attempt budget that accumulates progress. It would probably survive, with less margin than is comfortable.
- **The builder leg cannot be tested outside production**: `vm-image-builder` is a shared org runner label with no per-env scoping, so staging has no builders by design.

### Sequencing

Step 5 is inert until `OCI_REGISTRY_HOST` moves, so merging changes nothing on its own.

1. Merge, deploy staging and production
2. **Cut a provider release** carrying both the resolver and the tags fix — the resolver lives in the CAPI provider image, so a chart deploy alone does not ship it, and the drift roll that delivers it needs the tags fix to succeed
3. Let the drift roll place `/etc/resolver/ts.net` on the builders
4. Point `OCI_REGISTRY_HOST` at `tuist-oci-production.taild6d7bb.ts.net`
5. Dispatch `macos-xcode-image.yml` — the first real 60 GB push from a builder

Image references now carry the tailnet name, so it appears in tags and chart pins. `oci.tuist.dev` is dead — nothing serves a certificate for it.

### How to test

```
cd infra/macos-host-bootstrap && go test ./...
cd infra/cluster-api-provider-tuist && go test ./controllers/...
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml
actionlint .github/workflows/macos-xcode-image.yml .github/workflows/runner-image.yml .github/workflows/xcresult-processor-image.yml .github/workflows/server-production-deployment.yml
```

Both environments render; actionlint is 4/2/2/30, unchanged from before the original cutover. `helm lint` fails on `dedibox-fleet.yaml`, which also fails on `main`.

The drift-update fix is not covered by a test: the config is an inline literal inside `reconcileNormal`, and asserting on it needs that builder extracted, which is a larger refactor than the fix warrants. The bootstrap package tests the validation itself; what is untested is that each caller populates the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

