### PR TITLE
feat(infra): reap abandoned tagged Tailscale devices

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -11,7 +11,7 @@ Umbrella chart for the server, cache, processor, auxiliary public server-owned w
 
 When editing this chart, anything gated behind `managedSecrets` must stay gated so self-hosters aren't forced into the ESO dependency.
 
-Two grace-period garbage collectors live here, both off or in dry-run by default and both documented at length in their own templates: `released-pv-reaper` (orphaned Hetzner block volumes) and `tailscale-device-reaper` (abandoned tagged tailnet devices). The Tailscale one must be enabled in **exactly one** environment — every env shares a single tailnet, so production owns the sweep and reaps canary's and staging's stale devices too.
+Two grace-period garbage collectors live here, both off or in dry-run by default and both documented at length in their own templates: `released-pv-reaper` (orphaned Hetzner block volumes) and `tailscale-device-reaper` (abandoned tagged tailnet devices). The Tailscale one runs per env and each instance requires `tailscaleDeviceReaper.tags` set to that env's ACL tags — all envs share a single tailnet, and that list is what confines a reaper to its own devices. It must match the tag scope of the env's OAuth client; see §5d of [`k8s/onboarding.md`](k8s/onboarding.md).
 
 ### `helm/noora-storybook/` — standalone Noora Storybook chart
 Dedicated chart for the public `storybook.noora.tuist.dev` release. It deploys independently from the Tuist server so Noora Storybook changes do not have to share the server release boundary.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -11,6 +11,8 @@ Umbrella chart for the server, cache, processor, auxiliary public server-owned w
 
 When editing this chart, anything gated behind `managedSecrets` must stay gated so self-hosters aren't forced into the ESO dependency.
 
+Two grace-period garbage collectors live here, both off or in dry-run by default and both documented at length in their own templates: `released-pv-reaper` (orphaned Hetzner block volumes) and `tailscale-device-reaper` (abandoned tagged tailnet devices). The Tailscale one must be enabled in **exactly one** environment — every env shares a single tailnet, so production owns the sweep and reaps canary's and staging's stale devices too.
+
 ### `helm/noora-storybook/` — standalone Noora Storybook chart
 Dedicated chart for the public `storybook.noora.tuist.dev` release. It deploys independently from the Tuist server so Noora Storybook changes do not have to share the server release boundary.
 

--- a/infra/helm/tuist/templates/tailscale-device-reaper.yaml
+++ b/infra/helm/tuist/templates/tailscale-device-reaper.yaml
@@ -66,7 +66,13 @@ Prometheus Operator (they scrape via Alloy into Grafana Cloud). Alert on the
 reaper's log lines in Grafana Cloud instead.
 */ -}}
 {{- $name := include "tuist.componentName" (dict "root" . "component" "tailscale-device-reaper") }}
-{{- if .Values.tailscaleDeviceReaper.externalSecrets.enabled }}
+{{- /*
+Also gated on oauthSecretName being empty: pointing the CronJob at a
+hand-managed Secret is how you opt out of the chart's 1Password sync, so
+rendering the ExternalSecret anyway would keep syncing an item nothing reads and
+fail the sync outright when that item does not exist in the vault.
+*/ -}}
+{{- if and .Values.tailscaleDeviceReaper.externalSecrets.enabled (not .Values.tailscaleDeviceReaper.oauthSecretName) }}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -190,13 +196,33 @@ data:
     # An empty DISPOSABLE_PATTERN disables the short window entirely rather
     # than matching every device, which is what an unguarded test("") would do.
     #
-    # lastSeen is RFC3339; fromdateiso8601 rejects fractional seconds, so strip
-    # them rather than letting one oddly-formatted device abort the whole run.
+    # lastSeen is RFC3339. Parsing it is the fiddliest part of the predicate and
+    # every failure mode here defaults to skipping the device, never to reaping
+    # it early:
+    #
+    #   * fromdateiso8601 rejects fractional seconds, which the API does emit
+    #     (".1Z" appears on live devices), so strip them first.
+    #   * Anything else it cannot parse -- a numeric offset instead of Z, a
+    #     shape we have not seen -- is caught by `try` and skipped. Without the
+    #     catch a single odd timestamp aborts the entire sweep, which is the
+    #     failure the strip above exists to prevent in the first place.
+    #   * Go's zero time marshals to "0001-01-01T00:00:00Z", which parses fine
+    #     but to a large negative epoch, so it is older than every grace window
+    #     and sorts ahead of genuinely stale devices. `tailscale status --json`
+    #     emits exactly that for peers with no recorded lastSeen, so treat any
+    #     non-positive epoch as "no timestamp" and skip it, the same as an
+    #     absent field. Never assume old.
+    #
+    # Binding the parsed value once also keeps the sort key below honest: it
+    # reuses $seen rather than re-deriving it with a second, separately-escaped
+    # copy of the same expression.
     predicate='
       select(any((.tags // [])[]; IN($allowed[])))
       | select(.lastSeen != null and .lastSeen != "")
+      | (.lastSeen | sub("\\.[0-9]+Z$"; "Z") | try fromdateiso8601 catch null) as $seen
+      | select($seen != null and $seen > 0)
       | select(
-          ((.lastSeen | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601)
+          $seen
           < (now - (if ($pattern != "" and ((.hostname // "") | test($pattern)))
                     then $disposable else $grace end))
         )'
@@ -213,7 +239,7 @@ data:
     # Oldest first, so when the cap bites it reaps the deadest devices and the
     # next run picks up where this one stopped.
     candidates=$(printf '%s' "$devices" | jq -r "${jq_args[@]}" \
-      ".devices[] | ${predicate} | [(.lastSeen | sub(\"\\\\.[0-9]+Z\$\"; \"Z\") | fromdateiso8601), .id, .hostname] | @tsv" \
+      ".devices[] | ${predicate} | [\$seen, .id, .hostname] | @tsv" \
       | sort -n | cut -f2-)
     count=$(printf '%s\n' "$candidates" | grep -c . || true)
     echo "tailscale-device-reaper: ${count} of ${in_scope} in-scope device(s) past their grace window (${total} on the tailnet)"
@@ -222,6 +248,7 @@ data:
     fi
 
     reaped=0
+    failed=0
     while IFS=$'\t' read -r id hostname; do
       [ -z "$id" ] && continue
       if [ "$reaped" -ge "$MAX_DELETIONS" ]; then
@@ -244,16 +271,37 @@ data:
       fi
       last_seen=$(printf '%s' "$current" | jq -r '.lastSeen')
       tags=$(printf '%s' "$current" | jq -r '(.tags // []) | join(",")')
-      if [ "$DRY_RUN" = "true" ]; then
+      # Anything other than the exact string "false" stays in dry-run. Arming is
+      # a hand-edit of a per-env values file, which is where someone writes
+      # `dryRun: "yes"` -- bare True/yes/on coerce to a boolean and render
+      # "true", but the quoted forms reach the container verbatim. Comparing
+      # against "false" means an unrecognised value fails toward not deleting,
+      # which is the direction every other guard here points.
+      if [ "$DRY_RUN" != "false" ]; then
         echo "tailscale-device-reaper: [dry-run] would reap ${hostname} (${id}, ${tags}, last seen ${last_seen})"
       else
         echo "tailscale-device-reaper: reaping ${hostname} (${id}, ${tags}, last seen ${last_seen})"
-        curl -sS -f -X DELETE -H "Authorization: Bearer ${token}" "${api}/device/${id}" >/dev/null
+        # Non-fatal per device. Under `set -e` an unguarded failure here would
+        # abort the run, and because candidates are ordered oldest-first, one
+        # undeletable device would sit at the head of the queue and block every
+        # sweep behind it forever -- a 403 from a tag scope that has drifted out
+        # of agreement with `tags` does exactly that, and so does a transient
+        # 5xx. Record it, move on, and fail the Job at the end so the run is
+        # still loud without being useless.
+        if ! curl -sS -f -X DELETE -H "Authorization: Bearer ${token}" "${api}/device/${id}" >/dev/null; then
+          echo "tailscale-device-reaper: FAILED to delete ${hostname} (${id}, ${tags}); continuing" >&2
+          failed=$(( failed + 1 ))
+          continue
+        fi
       fi
       reaped=$(( reaped + 1 ))
     done <<< "$candidates"
 
-    echo "tailscale-device-reaper: done (${reaped} device(s) $([ "$DRY_RUN" = "true" ] && echo 'would be reaped' || echo reaped))"
+    echo "tailscale-device-reaper: done (${reaped} device(s) $([ "$DRY_RUN" != "false" ] && echo 'would be reaped' || echo reaped), ${failed} failed)"
+    if [ "$failed" -gt 0 ]; then
+      echo "tailscale-device-reaper: ${failed} device(s) could not be deleted; check the tag scope on this env's OAuth client" >&2
+      exit 1
+    fi
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/infra/helm/tuist/templates/tailscale-device-reaper.yaml
+++ b/infra/helm/tuist/templates/tailscale-device-reaper.yaml
@@ -30,11 +30,23 @@ and not the next one. Registrations are an ungarbage-collected resource on a
 shared tailnet, so the sweep is the general answer and the hostname fix is a
 worthwhile narrowing on top of it.
 
+One reaper per environment, each sweeping only its own env's devices. All envs
+share a single tailnet, so `tags` is what keeps three reapers from colliding on
+one device list: a run only ever considers devices carrying one of the tags
+named here, and the OAuth client backing it is scoped to those same tags. Both
+halves matter. Without the predicate a reaper would list devices it has no
+authority over and fail on the first 403; without the client scope the predicate
+would be the only thing standing between a bug and another env's fleet.
+
 Why this is safe:
-  * The OAuth client is tag-scoped (see the ExternalSecret below), so Tailscale
-    itself refuses any write against a device outside our infrastructure tags.
-    User devices are unreachable to this credential no matter what the script
-    does. The `.tags` predicate below is the second, independent check.
+  * Two independent scopes have to agree before anything is deleted. The
+    predicate only selects devices whose tags intersect this env's `tags`, and
+    Tailscale itself refuses a write from a client scoped elsewhere. Neither
+    user devices (which carry no tags at all) nor another env's devices can pass
+    both.
+  * An empty `tags` list is a hard error rather than a silent no-op. A reaper
+    that quietly sweeps nothing is worse than one that fails: the bill keeps
+    growing while the CronJob reports success.
   * `lastSeen` older than graceHours is the liveness test. A device that is up
     reports lastSeen within minutes, so a week-stale device is off by
     definition; and the grace window is the recovery window for a host that is
@@ -48,10 +60,6 @@ Why this is safe:
     re-authenticate from the OAuth client on next boot and simply register
     again.
   * dryRun only logs what it would reap.
-
-Enable in exactly ONE environment. All envs share one tailnet, so a reaper
-running in each would race and triple the API calls; production owns the sweep
-and reaps canary's and staging's stale devices too.
 
 There is intentionally no PrometheusRule here: managed clusters have no
 Prometheus Operator (they scrape via Alloy into Grafana Cloud). Alert on the
@@ -74,28 +82,17 @@ spec:
   target:
     name: {{ $name }}
     creationPolicy: Owner
-  # Provisioning: create an OAuth client in the Tailscale admin console under
-  # Settings > Trust credentials with the `devices:core` WRITE scope -- read
-  # alone lists devices but cannot delete them -- and restrict it to the
-  # infrastructure tags declared in infra/tailscale/acls.json:
+  # Provisioning, once per env: create an OAuth client in the Tailscale admin
+  # console under Settings > Trust credentials with the `devices:core` WRITE
+  # scope -- read alone lists devices but cannot delete them -- restricted to
+  # exactly the tags in this env's `tailscaleDeviceReaper.tags`, which must
+  # already exist under tagOwners in infra/tailscale/acls.json.
   #
-  #   tag:tuist-macmini-production, tag:tuist-macmini-canary,
-  #   tag:tuist-macmini-staging,    tag:tuist-k8s-production,
-  #   tag:tuist-k8s-canary,         tag:tuist-k8s-staging
-  #
-  # It spans every env's tags on purpose: one tailnet, one sweep. The per-env
-  # split the macOS-fleet credential uses exists so a leaked staging credential
-  # cannot reach production; splitting this one would push in the opposite
-  # direction, handing device deletion to the envs that have no such capability
-  # today. So there is a single client, and it lives only in the highest-trust
-  # vault. Note the item name is not production-specific -- the ClusterSecretStore
-  # is bound to `tuist-k8s-<env>` per cluster, so this resolves per env already;
-  # production is simply the only env where the reaper is enabled.
-  #
-  # ADDING AN ENV: extend this client's tag scope to the new env's tags at the
-  # same time. Miss it and the new env's devices are never reaped -- and
-  # depending on whether Tailscale filters the device listing by client scope,
-  # that either fails the Job loudly on a 403 or goes entirely unnoticed.
+  # Same per-env convention, and the same reason, as the macOS-fleet credential:
+  # the client is confined to one env's tags so a leaked staging credential
+  # cannot delete a production device. Note the item title is identical in every
+  # env -- the ClusterSecretStore is bound to `tuist-k8s-<env>` per cluster, so
+  # one name resolves to a different vault and a different client per env.
   #
   # Rotation is a 1Password edit; ESO resyncs within refreshInterval and the
   # next run picks it up.
@@ -126,7 +123,27 @@ data:
     api="https://api.tailscale.com/api/v2"
     grace_seconds=$(( GRACE_HOURS * 3600 ))
     disposable_seconds=$(( DISPOSABLE_GRACE_HOURS * 3600 ))
-    echo "tailscale-device-reaper: tailnet=${TAILNET} graceHours=${GRACE_HOURS} disposableGraceHours=${DISPOSABLE_GRACE_HOURS} disposablePattern='${DISPOSABLE_PATTERN}' maxDeletions=${MAX_DELETIONS} dryRun=${DRY_RUN}"
+
+    # This env's tags, as a JSON array for jq. Validated after parsing rather
+    # than on the raw string, so a value that is technically non-empty but
+    # carries no tags (a stray comma, whitespace) is caught too.
+    #
+    # Refuse to run on an empty list rather than treating it as "match nothing":
+    # a reaper that sweeps nothing looks healthy in every signal we have -- the
+    # Job succeeds, the log reads "0 devices" -- while the tailnet keeps growing,
+    # so the misconfiguration would survive exactly as long as it took someone to
+    # question the bill.
+    # -n with --arg rather than piping: an empty ALLOWED_TAGS would give `jq -R`
+    # no input line at all, which is a usage error rather than the empty list we
+    # want to fall through to the check below.
+    allowed=$(jq -nc --arg s "${ALLOWED_TAGS:-}" \
+      '$s | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+    if [ "$(printf '%s' "$allowed" | jq -r 'length')" -eq 0 ]; then
+      echo "tailscale-device-reaper: tailscaleDeviceReaper.tags names no tags; refusing to run without a tag scope" >&2
+      exit 1
+    fi
+
+    echo "tailscale-device-reaper: tailnet=${TAILNET} tags=${ALLOWED_TAGS} graceHours=${GRACE_HOURS} disposableGraceHours=${DISPOSABLE_GRACE_HOURS} disposablePattern='${DISPOSABLE_PATTERN}' maxDeletions=${MAX_DELETIONS} dryRun=${DRY_RUN}"
 
     # An OAuth client secret is exchanged for a short-lived bearer token; the
     # secret itself is not accepted on the REST endpoints (unlike `tailscale
@@ -140,11 +157,18 @@ data:
       exit 1
     fi
 
-    # A device is reapable only if it carries one of our tags (a user device has
-    # no `tags` key at all) and has not been seen for longer than its grace
-    # window. A device with no lastSeen is skipped, never assumed old. The same
-    # predicate is applied twice: once to pick candidates, once to re-validate
-    # each device immediately before deleting it.
+    # A device is reapable only if one of its tags is in this env's scope and it
+    # has not been seen for longer than its grace window. A device with no
+    # lastSeen is skipped, never assumed old. The same predicate is applied
+    # twice: once to pick candidates, once to re-validate each device
+    # immediately before deleting it.
+    #
+    # The tag intersection is what makes three reapers on one tailnet safe:
+    # `?fields=all` returns the whole tailnet regardless of how the credential is
+    # scoped, so without this filter each env's reaper would walk every other
+    # env's devices and die on the first 403 from a write it was never
+    # authorised to make. It also excludes user devices for free -- they carry no
+    # tags, so the intersection is always empty.
     #
     # Two windows, because the devices are not equally disposable:
     #
@@ -169,17 +193,22 @@ data:
     # lastSeen is RFC3339; fromdateiso8601 rejects fractional seconds, so strip
     # them rather than letting one oddly-formatted device abort the whole run.
     predicate='
-      select((.tags // []) | length > 0)
+      select(any((.tags // [])[]; IN($allowed[])))
       | select(.lastSeen != null and .lastSeen != "")
       | select(
           ((.lastSeen | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601)
           < (now - (if ($pattern != "" and ((.hostname // "") | test($pattern)))
                     then $disposable else $grace end))
         )'
-    jq_args=(--argjson grace "$grace_seconds" --argjson disposable "$disposable_seconds" --arg pattern "$DISPOSABLE_PATTERN")
+    jq_args=(--argjson grace "$grace_seconds" --argjson disposable "$disposable_seconds" --arg pattern "$DISPOSABLE_PATTERN" --argjson allowed "$allowed")
 
     devices=$(curl -sS -f -H "Authorization: Bearer ${token}" "${api}/tailnet/${TAILNET}/devices?fields=all")
     total=$(printf '%s' "$devices" | jq -r '.devices | length')
+    # In-scope count separately from the candidate count, so a run that reaps
+    # nothing still distinguishes "this env has no stale devices" from "the tag
+    # scope matches nothing at all", which is the shape a mistyped tag takes.
+    in_scope=$(printf '%s' "$devices" | jq -r --argjson allowed "$allowed" \
+      '[.devices[] | select(any((.tags // [])[]; IN($allowed[])))] | length')
 
     # Oldest first, so when the cap bites it reaps the deadest devices and the
     # next run picks up where this one stopped.
@@ -187,7 +216,7 @@ data:
       ".devices[] | ${predicate} | [(.lastSeen | sub(\"\\\\.[0-9]+Z\$\"; \"Z\") | fromdateiso8601), .id, .hostname] | @tsv" \
       | sort -n | cut -f2-)
     count=$(printf '%s\n' "$candidates" | grep -c . || true)
-    echo "tailscale-device-reaper: ${count} of ${total} device(s) past their grace window"
+    echo "tailscale-device-reaper: ${count} of ${in_scope} in-scope device(s) past their grace window (${total} on the tailnet)"
     if [ "$count" -eq 0 ]; then
       exit 0
     fi
@@ -262,6 +291,8 @@ spec:
               env:
                 - name: TAILNET
                   value: {{ .Values.tailscaleDeviceReaper.tailnet | quote }}
+                - name: ALLOWED_TAGS
+                  value: {{ join "," .Values.tailscaleDeviceReaper.tags | quote }}
                 - name: GRACE_HOURS
                   value: {{ .Values.tailscaleDeviceReaper.graceHours | quote }}
                 - name: DISPOSABLE_GRACE_HOURS

--- a/infra/helm/tuist/templates/tailscale-device-reaper.yaml
+++ b/infra/helm/tuist/templates/tailscale-device-reaper.yaml
@@ -83,13 +83,22 @@ spec:
   #   tag:tuist-macmini-staging,    tag:tuist-k8s-production,
   #   tag:tuist-k8s-canary,         tag:tuist-k8s-staging
   #
-  # It spans every env's tags on purpose: one tailnet, one sweep. That is also
-  # why this client lives only in the production vault, unlike the per-env
-  # macOS-fleet credential -- there is exactly one consumer.
+  # It spans every env's tags on purpose: one tailnet, one sweep. The per-env
+  # split the macOS-fleet credential uses exists so a leaked staging credential
+  # cannot reach production; splitting this one would push in the opposite
+  # direction, handing device deletion to the envs that have no such capability
+  # today. So there is a single client, and it lives only in the highest-trust
+  # vault. Note the item name is not production-specific -- the ClusterSecretStore
+  # is bound to `tuist-k8s-<env>` per cluster, so this resolves per env already;
+  # production is simply the only env where the reaper is enabled.
   #
-  # Store client id and secret in a TAILSCALE_DEVICE_REAPER item in the
-  # `tuist-k8s-production` vault. Rotation is a 1Password edit; ESO resyncs
-  # within refreshInterval and the next run picks it up.
+  # ADDING AN ENV: extend this client's tag scope to the new env's tags at the
+  # same time. Miss it and the new env's devices are never reaped -- and
+  # depending on whether Tailscale filters the device listing by client scope,
+  # that either fails the Job loudly on a 403 or goes entirely unnoticed.
+  #
+  # Rotation is a 1Password edit; ESO resyncs within refreshInterval and the
+  # next run picks it up.
   data:
     - secretKey: client-id
       remoteRef:

--- a/infra/helm/tuist/templates/tailscale-device-reaper.yaml
+++ b/infra/helm/tuist/templates/tailscale-device-reaper.yaml
@@ -1,0 +1,290 @@
+{{- if .Values.tailscaleDeviceReaper.enabled }}
+{{- /*
+Grace-period garbage collector for abandoned tagged Tailscale devices.
+
+A tailnet device registration has no garbage collector. Tagged devices have key
+expiry disabled by default, so a registration outlives whatever created it until
+something deletes it explicitly, and every producer we run registers a device
+named after a Pod:
+
+  * xcresult-processor Tart VMs join with TAILSCALE_HOSTNAME = the Pod name (see
+    the Deployment template and infra/xcresult-processor-image/tailscale-up.sh),
+    so every image roll mints a brand-new device and abandons the old one. The
+    `ephemeral=true` flag on the minted key only reaps VMs that stay online less
+    than four hours, and these Pods live for days between releases, so they are
+    converted to standard tagged devices and kept.
+  * The Tailscale K8s operator's proxy Pods (macmini-egress-*, the cluster
+    routers, the pg-pooler and OCI egress proxies) re-register when their state
+    Secret is recreated, stranding the previous device under the same hostname.
+
+Measured on 2026-08-17: 67 tagged devices on the tailnet, 44 of them online. Of
+the 23 dead ones, 17 were xcresult-processor rolls from the preceding four days
+and 6 were operator proxies stale for 6-70 days. That is a third of the tailnet
+billed as tagged resources for nothing, and it grows by roughly 10-15 devices a
+week -- the plan's included allowance is 50.
+
+Why a reaper rather than only fixing the hostname: stabilising the
+xcresult-processor identity (a StatefulSet ordinal, or the Node name, which is
+1:1 with the Pod here) would fix the largest producer but not the operator's,
+and not the next one. Registrations are an ungarbage-collected resource on a
+shared tailnet, so the sweep is the general answer and the hostname fix is a
+worthwhile narrowing on top of it.
+
+Why this is safe:
+  * The OAuth client is tag-scoped (see the ExternalSecret below), so Tailscale
+    itself refuses any write against a device outside our infrastructure tags.
+    User devices are unreachable to this credential no matter what the script
+    does. The `.tags` predicate below is the second, independent check.
+  * `lastSeen` older than graceHours is the liveness test. A device that is up
+    reports lastSeen within minutes, so a week-stale device is off by
+    definition; and the grace window is the recovery window for a host that is
+    merely down for maintenance.
+  * A device missing lastSeen is skipped, never assumed old.
+  * Each candidate is re-fetched and re-validated immediately before deletion,
+    so a device that came back between the scan and the delete is left alone.
+  * maxDeletions caps a single run, so a wrong predicate cannot empty the
+    tailnet before anyone reads the logs.
+  * Deletion is not destructive to a live workload even when wrong: our joiners
+    re-authenticate from the OAuth client on next boot and simply register
+    again.
+  * dryRun only logs what it would reap.
+
+Enable in exactly ONE environment. All envs share one tailnet, so a reaper
+running in each would race and triple the API calls; production owns the sweep
+and reaps canary's and staging's stale devices too.
+
+There is intentionally no PrometheusRule here: managed clusters have no
+Prometheus Operator (they scrape via Alloy into Grafana Cloud). Alert on the
+reaper's log lines in Grafana Cloud instead.
+*/ -}}
+{{- $name := include "tuist.componentName" (dict "root" . "component" "tailscale-device-reaper") }}
+{{- if .Values.tailscaleDeviceReaper.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailscale-device-reaper
+spec:
+  refreshInterval: {{ .Values.tailscaleDeviceReaper.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.tailscaleDeviceReaper.externalSecrets.storeRef.name }}
+    kind: {{ .Values.tailscaleDeviceReaper.externalSecrets.storeRef.kind }}
+  target:
+    name: {{ $name }}
+    creationPolicy: Owner
+  # Provisioning: create an OAuth client in the Tailscale admin console under
+  # Settings > Trust credentials with the `devices:core` WRITE scope -- read
+  # alone lists devices but cannot delete them -- and restrict it to the
+  # infrastructure tags declared in infra/tailscale/acls.json:
+  #
+  #   tag:tuist-macmini-production, tag:tuist-macmini-canary,
+  #   tag:tuist-macmini-staging,    tag:tuist-k8s-production,
+  #   tag:tuist-k8s-canary,         tag:tuist-k8s-staging
+  #
+  # It spans every env's tags on purpose: one tailnet, one sweep. That is also
+  # why this client lives only in the production vault, unlike the per-env
+  # macOS-fleet credential -- there is exactly one consumer.
+  #
+  # Store client id and secret in a TAILSCALE_DEVICE_REAPER item in the
+  # `tuist-k8s-production` vault. Rotation is a 1Password edit; ESO resyncs
+  # within refreshInterval and the next run picks it up.
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: "{{ .Values.tailscaleDeviceReaper.externalSecrets.item }}/{{ .Values.tailscaleDeviceReaper.externalSecrets.fields.clientID }}"
+    - secretKey: client-secret
+      remoteRef:
+        key: "{{ .Values.tailscaleDeviceReaper.externalSecrets.item }}/{{ .Values.tailscaleDeviceReaper.externalSecrets.fields.clientSecret }}"
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailscale-device-reaper
+data:
+  reap.sh: |-
+    #!/usr/bin/env bash
+    # pipefail so a failed curl in a pipeline aborts the run instead of feeding
+    # jq empty input and logging a healthy-looking "0 device(s)" -- the logs are
+    # this job's only observability channel.
+    set -euo pipefail
+
+    api="https://api.tailscale.com/api/v2"
+    grace_seconds=$(( GRACE_HOURS * 3600 ))
+    disposable_seconds=$(( DISPOSABLE_GRACE_HOURS * 3600 ))
+    echo "tailscale-device-reaper: tailnet=${TAILNET} graceHours=${GRACE_HOURS} disposableGraceHours=${DISPOSABLE_GRACE_HOURS} disposablePattern='${DISPOSABLE_PATTERN}' maxDeletions=${MAX_DELETIONS} dryRun=${DRY_RUN}"
+
+    # An OAuth client secret is exchanged for a short-lived bearer token; the
+    # secret itself is not accepted on the REST endpoints (unlike `tailscale
+    # up`, which takes it directly and mints a join key behind the scenes).
+    token=$(curl -sS -f -X POST "${api}/oauth/token" \
+      --data-urlencode "client_id=${CLIENT_ID}" \
+      --data-urlencode "client_secret=${CLIENT_SECRET}" \
+      | jq -r '.access_token')
+    if [ -z "$token" ] || [ "$token" = "null" ]; then
+      echo "tailscale-device-reaper: could not exchange the OAuth client secret for a token" >&2
+      exit 1
+    fi
+
+    # A device is reapable only if it carries one of our tags (a user device has
+    # no `tags` key at all) and has not been seen for longer than its grace
+    # window. A device with no lastSeen is skipped, never assumed old. The same
+    # predicate is applied twice: once to pick candidates, once to re-validate
+    # each device immediately before deleting it.
+    #
+    # Two windows, because the devices are not equally disposable:
+    #
+    #   * Devices whose hostname matches DISPOSABLE_PATTERN re-derive their
+    #     identity on every boot. The xcresult-processor Tart VMs are booted
+    #     from an image with no persisted tailscaled state, so each one joins
+    #     with a fresh node key and gets a fresh device; deleting a dead one
+    #     costs nothing, because nothing will ever try to reuse it. These get
+    #     the short window -- long enough to cover a slow rollout many times
+    #     over (progressDeadlineSeconds on the Deployment is 1800s), short
+    #     enough that a week of releases cannot outrun the sweep.
+    #
+    #   * Everything else gets the long window. The Mac mini hosts are the
+    #     reason: unlike the VMs they join once at bootstrap and keep that
+    #     identity for the life of the machine, so reaping one while its host
+    #     is merely down strands the host off the tailnet until it is
+    #     re-bootstrapped. The long window is that recovery margin.
+    #
+    # An empty DISPOSABLE_PATTERN disables the short window entirely rather
+    # than matching every device, which is what an unguarded test("") would do.
+    #
+    # lastSeen is RFC3339; fromdateiso8601 rejects fractional seconds, so strip
+    # them rather than letting one oddly-formatted device abort the whole run.
+    predicate='
+      select((.tags // []) | length > 0)
+      | select(.lastSeen != null and .lastSeen != "")
+      | select(
+          ((.lastSeen | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601)
+          < (now - (if ($pattern != "" and ((.hostname // "") | test($pattern)))
+                    then $disposable else $grace end))
+        )'
+    jq_args=(--argjson grace "$grace_seconds" --argjson disposable "$disposable_seconds" --arg pattern "$DISPOSABLE_PATTERN")
+
+    devices=$(curl -sS -f -H "Authorization: Bearer ${token}" "${api}/tailnet/${TAILNET}/devices?fields=all")
+    total=$(printf '%s' "$devices" | jq -r '.devices | length')
+
+    # Oldest first, so when the cap bites it reaps the deadest devices and the
+    # next run picks up where this one stopped.
+    candidates=$(printf '%s' "$devices" | jq -r "${jq_args[@]}" \
+      ".devices[] | ${predicate} | [(.lastSeen | sub(\"\\\\.[0-9]+Z\$\"; \"Z\") | fromdateiso8601), .id, .hostname] | @tsv" \
+      | sort -n | cut -f2-)
+    count=$(printf '%s\n' "$candidates" | grep -c . || true)
+    echo "tailscale-device-reaper: ${count} of ${total} device(s) past their grace window"
+    if [ "$count" -eq 0 ]; then
+      exit 0
+    fi
+
+    reaped=0
+    while IFS=$'\t' read -r id hostname; do
+      [ -z "$id" ] && continue
+      if [ "$reaped" -ge "$MAX_DELETIONS" ]; then
+        echo "tailscale-device-reaper: hit maxDeletions=${MAX_DELETIONS}; $(( count - reaped )) device(s) left for the next run"
+        break
+      fi
+      # Re-fetch and re-validate right before acting. A device that reconnected
+      # since the scan reports a fresh lastSeen and drops out of the predicate,
+      # so it is skipped rather than deleted out from under a live workload.
+      current=$(curl -sS -f -H "Authorization: Bearer ${token}" "${api}/device/${id}?fields=all" 2>/dev/null || true)
+      if [ -z "$current" ]; then
+        echo "tailscale-device-reaper: skip ${hostname} (${id}, gone since scan)"
+        continue
+      fi
+      still=$(printf '%s' "$current" | jq -r "${jq_args[@]}" \
+        "${predicate} | .id" 2>/dev/null || true)
+      if [ "$still" != "$id" ]; then
+        echo "tailscale-device-reaper: skip ${hostname} (${id}, reconnected since scan)"
+        continue
+      fi
+      last_seen=$(printf '%s' "$current" | jq -r '.lastSeen')
+      tags=$(printf '%s' "$current" | jq -r '(.tags // []) | join(",")')
+      if [ "$DRY_RUN" = "true" ]; then
+        echo "tailscale-device-reaper: [dry-run] would reap ${hostname} (${id}, ${tags}, last seen ${last_seen})"
+      else
+        echo "tailscale-device-reaper: reaping ${hostname} (${id}, ${tags}, last seen ${last_seen})"
+        curl -sS -f -X DELETE -H "Authorization: Bearer ${token}" "${api}/device/${id}" >/dev/null
+      fi
+      reaped=$(( reaped + 1 ))
+    done <<< "$candidates"
+
+    echo "tailscale-device-reaper: done (${reaped} device(s) $([ "$DRY_RUN" = "true" ] && echo 'would be reaped' || echo reaped))"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailscale-device-reaper
+spec:
+  schedule: {{ .Values.tailscaleDeviceReaper.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            {{- include "tuist.labels" . | nindent 12 }}
+            app.kubernetes.io/component: tailscale-device-reaper
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: reaper
+              image: {{ .Values.tailscaleDeviceReaper.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "/scripts/reap.sh"]
+              env:
+                - name: TAILNET
+                  value: {{ .Values.tailscaleDeviceReaper.tailnet | quote }}
+                - name: GRACE_HOURS
+                  value: {{ .Values.tailscaleDeviceReaper.graceHours | quote }}
+                - name: DISPOSABLE_GRACE_HOURS
+                  value: {{ .Values.tailscaleDeviceReaper.disposable.graceHours | quote }}
+                - name: DISPOSABLE_PATTERN
+                  value: {{ .Values.tailscaleDeviceReaper.disposable.hostnamePattern | quote }}
+                - name: MAX_DELETIONS
+                  value: {{ .Values.tailscaleDeviceReaper.maxDeletions | quote }}
+                - name: DRY_RUN
+                  value: {{ .Values.tailscaleDeviceReaper.dryRun | quote }}
+                - name: CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.tailscaleDeviceReaper.oauthSecretName | default $name }}
+                      key: {{ .Values.tailscaleDeviceReaper.oauthSecretClientIDKey }}
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.tailscaleDeviceReaper.oauthSecretName | default $name }}
+                      key: {{ .Values.tailscaleDeviceReaper.oauthSecretClientSecretKey }}
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                {{- toYaml .Values.tailscaleDeviceReaper.resources | nindent 16 }}
+          volumes:
+            - name: script
+              configMap:
+                name: {{ $name }}
+{{- end }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -9,6 +9,14 @@
 #     -f infra/helm/tuist/values-managed-canary.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+# Sweeps this env's abandoned tailnet devices only; production and staging run
+# their own. Starts in dry-run -- read a run's logs, then set dryRun: false.
+tailscaleDeviceReaper:
+  enabled: true
+  tags:
+    - tag:tuist-macmini-canary
+    - tag:tuist-k8s-canary
+
 registry:
   publicHost: registry-canary.tuist.dev
   serverUrl: https://canary.tuist.dev

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -6,11 +6,13 @@
 #     -f infra/helm/tuist/values-managed-production.yaml \
 #     --set server.image.tag=$GIT_SHA
 
-# Production owns the tailnet device sweep. Every env shares one tailnet, so
-# this is enabled here and nowhere else; it reaps canary's and staging's stale
-# devices too. Starts in dry-run -- read a run's logs, then set dryRun: false.
+# Sweeps this env's abandoned tailnet devices only; canary and staging run their
+# own. Starts in dry-run -- read a run's logs, then set dryRun: false.
 tailscaleDeviceReaper:
   enabled: true
+  tags:
+    - tag:tuist-macmini-production
+    - tag:tuist-k8s-production
 
 registry:
   # Clients stay on tuist.dev/api/registry while the Worker forwards requests

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -6,6 +6,12 @@
 #     -f infra/helm/tuist/values-managed-production.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+# Production owns the tailnet device sweep. Every env shares one tailnet, so
+# this is enabled here and nowhere else; it reaps canary's and staging's stale
+# devices too. Starts in dry-run -- read a run's logs, then set dryRun: false.
+tailscaleDeviceReaper:
+  enabled: true
+
 registry:
   # Clients stay on tuist.dev/api/registry while the Worker forwards requests
   # to this dedicated ingress host. The ingress hostname is not advertised as

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -8,6 +8,14 @@
 #     -f infra/helm/tuist/values-managed-staging.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+# Sweeps this env's abandoned tailnet devices only; production and canary run
+# their own. Starts in dry-run -- read a run's logs, then set dryRun: false.
+tailscaleDeviceReaper:
+  enabled: true
+  tags:
+    - tag:tuist-macmini-staging
+    - tag:tuist-k8s-staging
+
 # Grafana Cloud PDC agent — on in staging first. The signing token lives in this
 # env's vault as PDC_AGENT/password; cluster + hostedGrafanaId come from
 # values-managed-common.yaml. Gives Grafana Cloud a tunnel to the in-cluster CNPG

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -34,6 +34,79 @@ pvReaper:
     limits:
       memory: "64Mi"
 
+# Grace-period garbage collector for abandoned tagged Tailscale devices. Tagged
+# devices never expire on their own, and both the xcresult-processor VMs and the
+# Tailscale operator's proxy Pods register a device per Pod, so dead
+# registrations accumulate until something deletes them. See the template for
+# the full failure mode and the safety argument.
+#
+# Off by default, and it must be enabled in exactly ONE environment: every env
+# shares a single tailnet, so production owns the sweep and reaps canary's and
+# staging's stale devices too.
+tailscaleDeviceReaper:
+  enabled: false
+  # dryRun logs the devices it would reap without deleting anything. Flip to
+  # false once a run's logs look right.
+  dryRun: true
+  schedule: "30 3 * * *"
+  # `-` is the default tailnet of the authenticated OAuth client, so the tailnet
+  # name is not pinned in the chart.
+  tailnet: "-"
+  # Default window: only reap devices unseen for longer than this. A live device
+  # reports lastSeen within minutes, so the window is really the recovery margin
+  # for a device that is merely down. Sized for the Mac mini hosts, which join
+  # once at bootstrap and keep that identity for the life of the machine --
+  # reaping one while its host is down strands it off the tailnet until it is
+  # re-bootstrapped (default 7 days).
+  graceHours: 168
+  # Short window for devices that re-derive their tailnet identity on every
+  # boot, so a dead registration can never be reused and is pure garbage. The
+  # xcresult-processor Tart VMs boot from an image with no persisted tailscaled
+  # state: each boot means a new node key, and a new node key always means a new
+  # device -- the hostname has nothing to do with it. Two devices sharing a
+  # hostname AND a tag are visible on the tailnet today, which is what that
+  # looks like in practice.
+  #
+  # This tier is what keeps the tailnet under the plan's included allowance.
+  # Releases add roughly 10-15 devices a week, so parking them behind the 7-day
+  # default would leave a week of debris standing at all times.
+  #
+  # An empty hostnamePattern disables the short window (everything falls back to
+  # graceHours) rather than matching every device.
+  disposable:
+    hostnamePattern: "xcresult-processor"
+    # 12h is ~24x the Deployment's 1800s progressDeadlineSeconds, so a slow
+    # rollout cannot have its own in-flight VM reaped out from under it.
+    graceHours: 12
+  # Ceiling on a single run, so a wrong predicate cannot empty the tailnet
+  # before anyone reads the logs. Candidates are reaped oldest-first and the
+  # remainder rolls into the next run.
+  maxDeletions: 25
+  # curl + jq in one image; same image the PV reaper uses.
+  image: alpine/k8s:1.31.1
+  # Secret holding the tag-scoped OAuth client. Empty falls back to the
+  # ExternalSecret this chart syncs from 1Password; set it to opt out and
+  # manage the Secret by hand.
+  oauthSecretName: ""
+  oauthSecretClientIDKey: client-id
+  oauthSecretClientSecretKey: client-secret
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    storeRef:
+      kind: ClusterSecretStore
+      name: onepassword
+    item: TAILSCALE_DEVICE_REAPER
+    fields:
+      clientID: client-id
+      clientSecret: client-secret
+  resources:
+    requests:
+      cpu: "25m"
+      memory: "32Mi"
+    limits:
+      memory: "64Mi"
+
 # Grafana Cloud Private Data source Connect (PDC) agent. Off by default: it only
 # makes sense on the managed envs whose Grafana Cloud stack has a PDC network,
 # and self-hosters have no Grafana Cloud stack at all.

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -40,11 +40,20 @@ pvReaper:
 # registrations accumulate until something deletes them. See the template for
 # the full failure mode and the safety argument.
 #
-# Off by default, and it must be enabled in exactly ONE environment: every env
-# shares a single tailnet, so production owns the sweep and reaps canary's and
-# staging's stale devices too.
+# One reaper per environment, each sweeping only its own env's devices. Off by
+# default; managed envs enable it and set `tags`.
 tailscaleDeviceReaper:
   enabled: false
+  # ACL tags this env's reaper is allowed to delete, and exactly the tags its
+  # OAuth client must be scoped to. Required: the job refuses to run on an empty
+  # list rather than sweeping nothing while reporting success.
+  #
+  # This is what makes three reapers on one shared tailnet safe. The devices
+  # listing returns the whole tailnet however the credential is scoped, so
+  # without the filter each env's reaper would walk every other env's devices
+  # and die on the first 403. Keep it to the env's own tags: widening it to
+  # another env's would be a credential error, not just a config one.
+  tags: []
   # dryRun logs the devices it would reap without deleting anything. Flip to
   # false once a run's logs look right.
   dryRun: true

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -94,8 +94,9 @@ tailscaleDeviceReaper:
   # curl + jq in one image; same image the PV reaper uses.
   image: alpine/k8s:1.31.1
   # Secret holding the tag-scoped OAuth client. Empty falls back to the
-  # ExternalSecret this chart syncs from 1Password; set it to opt out and
-  # manage the Secret by hand.
+  # ExternalSecret this chart syncs from 1Password. Setting a name opts out of
+  # that sync entirely: the CronJob reads the named Secret and no ExternalSecret
+  # is rendered, so nothing tries to pull a 1Password item you are not using.
   oauthSecretName: ""
   oauthSecretClientIDKey: client-id
   oauthSecretClientSecretKey: client-secret

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -228,6 +228,32 @@ The consumers pin `ephemeral=true&preauthorized=true` on the minted key themselv
 
 > **ESO health is not credential health.** The ExternalSecret reports `SecretSynced` / `Ready=True` whatever the value's validity; it says only that 1Password answered. A fleet that can't join looks identical from the ESO side, so don't use it to rule the credential out. Detection for the failure class lives in [`../helm/k8s-monitoring/alerts.md`](../helm/k8s-monitoring/alerts.md), keyed on queue age.
 
+## 5d. Tailscale device reaper credential (production only)
+
+Unlike 5c, this is **one credential for the whole tailnet, created once** — not one per env. Skip it entirely when onboarding staging, canary or preview.
+
+Nothing garbage-collects a tailnet device. Tagged devices have key expiry disabled, so a registration outlives whatever created it, and both the xcresult-processor VMs and the Tailscale operator's proxy Pods register a device per Pod. Renaming them does not help: identity is the node key, and an image-booted VM has no persisted state to carry one across boots. The `tailscale-device-reaper` CronJob deletes the leftovers; see [`../helm/tuist/templates/tailscale-device-reaper.yaml`](../helm/tuist/templates/tailscale-device-reaper.yaml) for the grace-window design and the safety argument.
+
+Create the client under [**Settings → Trust credentials**](https://login.tailscale.com/admin/settings/trust-credentials) exactly as in 5c: **Credential**, then **OAuth**, then **Generate credential**.
+
+- Scope: **Devices → Core → Write**, nothing else. Read alone lists devices but cannot delete them.
+- Tags: all six env tags at once — `tag:tuist-macmini-{production,canary,staging}` and `tag:tuist-k8s-{production,canary,staging}`. One tailnet means one sweep, and production runs it on every env's behalf.
+
+Scoping the credential is the primary safety boundary: Tailscale itself refuses a write against any device outside these tags, so user devices are unreachable to the reaper whatever the script does.
+
+`tag:tuist-mgmt` is deliberately excluded. It covers a single long-lived device that has never leaked a duplicate, and reaping the mgmt cluster's tailnet identity is the one deletion that could cost you the access you'd need to undo it.
+
+```bash
+op item create --vault tuist-k8s-production --category "API Credential" --title TAILSCALE_DEVICE_REAPER \
+  "client-id[text]=..." "client-secret[password]=tskey-client-..."
+```
+
+Both field labels are load-bearing: the ExternalSecret reads `TAILSCALE_DEVICE_REAPER/client-id` and `/client-secret` by label.
+
+The reaper ships with `dryRun: true`. Read one run's logs in Grafana Cloud, confirm the list is what you expect, then set `tailscaleDeviceReaper.dryRun: false` in [`../helm/tuist/values-managed-production.yaml`](../helm/tuist/values-managed-production.yaml) to arm it.
+
+**Adding an env later:** extend this client's tag scope at the same time, or the new env's devices are never swept.
+
 ## 6. First deploy
 
 ### Manual smoke test

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -228,31 +228,29 @@ The consumers pin `ephemeral=true&preauthorized=true` on the minted key themselv
 
 > **ESO health is not credential health.** The ExternalSecret reports `SecretSynced` / `Ready=True` whatever the value's validity; it says only that 1Password answered. A fleet that can't join looks identical from the ESO side, so don't use it to rule the credential out. Detection for the failure class lives in [`../helm/k8s-monitoring/alerts.md`](../helm/k8s-monitoring/alerts.md), keyed on queue age.
 
-## 5d. Tailscale device reaper credential (production only)
+## 5d. Tailscale device reaper credential
 
-Unlike 5c, this is **one credential for the whole tailnet, created once** — not one per env. Skip it entirely when onboarding staging, canary or preview.
+One client per env, same as 5c, and for the same reason: confined to one env's tags, a leaked staging credential cannot delete a production device.
 
-Nothing garbage-collects a tailnet device. Tagged devices have key expiry disabled, so a registration outlives whatever created it, and both the xcresult-processor VMs and the Tailscale operator's proxy Pods register a device per Pod. Renaming them does not help: identity is the node key, and an image-booted VM has no persisted state to carry one across boots. The `tailscale-device-reaper` CronJob deletes the leftovers; see [`../helm/tuist/templates/tailscale-device-reaper.yaml`](../helm/tuist/templates/tailscale-device-reaper.yaml) for the grace-window design and the safety argument.
+Nothing garbage-collects a tailnet device. Tagged devices have key expiry disabled, so a registration outlives whatever created it, and both the xcresult-processor VMs and the Tailscale operator's proxy Pods register a device per Pod. Renaming them does not help: identity is the node key, and an image-booted VM has no persisted state to carry one across boots. The `tailscale-device-reaper` CronJob deletes the leftovers; see [`../helm/tuist/templates/tailscale-device-reaper.yaml`](../helm/tuist/templates/tailscale-device-reaper.yaml) for the grace-window design and the full safety argument.
 
 Create the client under [**Settings → Trust credentials**](https://login.tailscale.com/admin/settings/trust-credentials) exactly as in 5c: **Credential**, then **OAuth**, then **Generate credential**.
 
 - Scope: **Devices → Core → Write**, nothing else. Read alone lists devices but cannot delete them.
-- Tags: all six env tags at once — `tag:tuist-macmini-{production,canary,staging}` and `tag:tuist-k8s-{production,canary,staging}`. One tailnet means one sweep, and production runs it on every env's behalf.
-
-Scoping the credential is the primary safety boundary: Tailscale itself refuses a write against any device outside these tags, so user devices are unreachable to the reaper whatever the script does.
-
-`tag:tuist-mgmt` is deliberately excluded. It covers a single long-lived device that has never leaked a duplicate, and reaping the mgmt cluster's tailnet identity is the one deletion that could cost you the access you'd need to undo it.
+- Tags: this env's two tags only — `tag:tuist-macmini-<env>` and `tag:tuist-k8s-<env>`. Both must already exist under `tagOwners` in [`../tailscale/acls.json`](../tailscale/acls.json).
 
 ```bash
-op item create --vault tuist-k8s-production --category "API Credential" --title TAILSCALE_DEVICE_REAPER \
+op item create --vault tuist-k8s-<env> --category "API Credential" --title TAILSCALE_DEVICE_REAPER \
   "client-id[text]=..." "client-secret[password]=tskey-client-..."
 ```
 
 Both field labels are load-bearing: the ExternalSecret reads `TAILSCALE_DEVICE_REAPER/client-id` and `/client-secret` by label.
 
-The reaper ships with `dryRun: true`. Read one run's logs in Grafana Cloud, confirm the list is what you expect, then set `tailscaleDeviceReaper.dryRun: false` in [`../helm/tuist/values-managed-production.yaml`](../helm/tuist/values-managed-production.yaml) to arm it.
+**Then set `tailscaleDeviceReaper.tags` in the env's values file to the same two tags.** This is not redundant with the client scope, and it is not optional — the job refuses to start without it. All envs share one tailnet and the devices listing returns every device on it regardless of how the credential is scoped, so the tag list is what stops this env's reaper walking another env's devices and dying on the first 403. The client scope is the second, independent guard: if the two ever disagree, the credential is what prevents a bug in the predicate from deleting someone else's fleet.
 
-**Adding an env later:** extend this client's tag scope at the same time, or the new env's devices are never swept.
+`tag:tuist-mgmt` is swept by no reaper, deliberately. It covers a single long-lived device that has never produced a duplicate, and reaping the mgmt cluster's tailnet identity is the one deletion that could cost you the access you would need to undo it.
+
+Each env ships with `dryRun: true`. Read one run's logs in Grafana Cloud, confirm the list is what you expect, then set `tailscaleDeviceReaper.dryRun: false` in that env's values file to arm it. A run that reports `0 of 0 in-scope device(s)` is the signature of a mistyped tag, not of a clean tailnet — the log line reports in-scope and tailnet-wide counts separately so the two are distinguishable.
 
 ## 6. First deploy
 

--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -188,8 +188,19 @@ inheriting their defaults:
   and Pods normally outlive that between image releases. It reaps only
   short-lived ones; the rest accumulate, and those stale peers stay
   pinned in every VM's `/etc/hosts`, which `tailscale-up.sh` rewrites
-  from `tailscale status` on each boot. Nothing deletes a device today,
-  on this path or the Mac mini one; a reaper is the tracked follow-up.
+  from `tailscale status` on each boot.
+
+  Renaming the device would not help: a device is identified by its node
+  key, not its hostname, and a VM booted from an image has no persisted
+  tailscaled state, so every boot mints a new key and therefore a new
+  device whatever it is called. The tailnet carries pairs of devices
+  sharing a hostname *and* a tag, which is what that looks like from the
+  outside. Deleting the dead ones is the only available fix, and the
+  `tailscale-device-reaper` CronJob in the main chart is it — see
+  `infra/helm/tuist/templates/tailscale-device-reaper.yaml`. Devices on
+  this path match its short `disposable` grace window precisely because
+  their identity is regenerated on every boot; the Mac mini hosts, which
+  join once and keep their identity, sit behind the long one.
 
 Keys minted through an OAuth client are always tagged and carry no
 default tag, so `TAILSCALE_TAGS` must name one (the chart sources it

--- a/infra/xcresult-processor-image/tailscale-up.sh
+++ b/infra/xcresult-processor-image/tailscale-up.sh
@@ -73,7 +73,11 @@ else
   # this only reaps the short-lived ones (crash loops, quick rollbacks)
   # and the rest accumulate regardless. Note those stale peers stay
   # pinned in every VM's /etc/hosts, which the block below rewrites from
-  # `tailscale status` on each boot. A reaper is the tracked follow-up.
+  # `tailscale status` on each boot. Giving the device a stable name
+  # would not change this: identity is the node key, and an image-booted
+  # VM has no persisted state to carry one across boots. The sweep that
+  # deletes the leftovers is the tailscale-device-reaper CronJob in
+  # infra/helm/tuist/templates/tailscale-device-reaper.yaml.
   #
   # An OAuth-minted key is always tagged and carries no default tag, so
   # the join can't work without TAILSCALE_TAGS; refuse here rather than


### PR DESCRIPTION
Adds a grace-period garbage collector for abandoned tagged Tailscale devices, one per environment.

There is no tracked issue; this started from the billing page reporting 63/50 tagged resources and the question of whether we were really using 63.

## What prompted it

We were not. Auditing the tailnet found 67 tagged devices, 44 of them online and 23 dead:

| Stale for | Tag | Devices |
|---|---|---|
| 0 to 4 days | `tag:tuist-macmini-production` | 17 xcresult-processor VMs |
| 24 days | `tag:tuist-k8s-production` | 1 cluster router |
| 6 to 70 days | `tag:tuist-k8s-canary` / `-staging` | 5 operator egress proxies |

A third of the tailnet was billed for nothing, growing by roughly 10 to 15 devices a week against an included allowance of 50. The 17 processor devices are legible as deploy history: eight distinct ReplicaSet hashes over four days, two devices abandoned per roll.

## Root cause

A tailnet device registration has no garbage collector, and tagged devices have key expiry disabled by default, so a registration outlives whatever created it until something deletes it explicitly. Every producer we run registers a device per Pod:

- xcresult-processor Tart VMs join with `TAILSCALE_HOSTNAME` set to the Pod name, so each roll registers a new device.
- The Tailscale operator's proxy Pods re-register when their state Secret is recreated, stranding the previous device.

`ephemeral=true` is already set on the minted key and does not save us: it only reaps VMs that stay online briefly, and these Pods live for days between releases.

## Why a reaper rather than a stable hostname

Stabilising the Pod-derived hostname (a StatefulSet ordinal, or the Node name, which is 1:1 with the Pod here given the hostPort 9091 constraint) was the obvious fix and does not work. A device is identified by its node key, not its hostname, and a Tart VM booted from an image has no persisted tailscaled state, so every boot mints a new key and therefore a new device whatever it is called.

The tailnet already demonstrates this: there are two `macmini-egress-0` devices carrying the same hostname *and* the same `tag:tuist-k8s-canary`, one online and one dead six days. Renaming would have produced colliding names, not fewer devices. Deleting the dead ones is the only fix available.

## What shipped

`tailscale-device-reaper`, modelled on the existing `released-pv-reaper` in the same chart and following its idioms (dry-run default, re-validate before acting, grace window as recovery window, no PrometheusRule because managed clusters scrape via Alloy).

Two design points are worth a reviewer's attention.

**Per-env, not one sweep.** All envs share a single tailnet, so a single production reaper covering every tag was the simpler option and is what the first commits implemented. We chose per-env instead, for failure isolation (a stalled production reaper no longer stops canary and staging being swept) and to confine each credential to one env's tags, matching the confinement the macOS-fleet join credential already has. The cost is three OAuth clients, three 1Password items and three arming decisions.

That choice has a correctness requirement that is easy to miss: `tailscaleDeviceReaper.tags` is load-bearing, not belt-and-braces. The devices listing returns the whole tailnet however the credential is scoped, so without the tag predicate each env's reaper would walk every other env's devices and die on the first 403 from a write it was never authorised to make. The client scope is the second, independent guard, keeping a bug in the predicate from deleting another env's fleet.

**Two grace windows.** A single flat window cannot serve both classes of device:

- 12h for devices matching `disposable.hostnamePattern` (the processor VMs). Their identity regenerates on every boot, so a dead registration can never be reused. 12h is roughly 24x the Deployment's 1800s `progressDeadlineSeconds`, so a slow rollout cannot have its own in-flight VM reaped.
- 7 days for everything else, sized for the Mac mini hosts. Those join once at bootstrap and keep that identity, so reaping one while its host is merely down would strand it off the tailnet until re-bootstrapped.

At a flat 7 days the release debris alone (10 to 15 a week) would sit on top of the 44 live devices and keep the tailnet over its allowance permanently. The split gets steady state to roughly 46.

`tag:tuist-mgmt` is outside every reaper's scope deliberately: one long-lived device that has never produced a duplicate, and the one deletion that could cost the access needed to undo it.

## Safety

- Two independent scopes must agree. The predicate selects only devices whose tags intersect this env's `tags`, and Tailscale itself refuses a write from a client scoped elsewhere. User devices carry no tags and cannot pass either.
- An absent or vacuous tag list is a hard error, not an empty match. A reaper that sweeps nothing is indistinguishable from a healthy one in every signal available (the Job succeeds, the log reads 0 devices), so the misconfiguration would survive until someone questioned the bill. Validation runs on the parsed list, so a stray comma or surrounding whitespace is caught too.
- `lastSeen` older than the window is the liveness test; a live device reports within minutes. A device missing `lastSeen` is skipped, never assumed old.
- Every candidate is re-fetched and re-validated immediately before deletion, so one that reconnected mid-run is skipped without consuming a cap slot.
- `maxDeletions` caps a run at 25, oldest first, remainder rolling into the next run.
- Deletion is recoverable by construction: our joiners re-authenticate from the OAuth client on next boot.
- The run log reports in-scope and tailnet-wide counts separately, so `0 of 0 in-scope (76 on the tailnet)` reads as a mistyped tag rather than a clean tailnet.

## Impact

Nothing changes for self-hosters: `enabled` defaults false and the template renders nothing when off.

All three managed envs ship with `dryRun: true`, so merging this deletes nothing. Arming is a per-env value flip after reading a run's logs. Once armed the reapers clear 21 of the 23 currently-stale devices on their own schedule (the other two are still inside their windows), taking the tailnet from 67 to roughly 46 and stopping the unbounded growth.

The three OAuth clients and 1Password items this depends on already exist, verified as present in each env vault with the `client-id` / `client-secret` labels ESO resolves by, `tskey-client-` prefixes (OAuth clients, not 90-day auth keys) and three distinct client IDs. Provisioning steps for future envs are in section 5d of `infra/k8s/onboarding.md`.

## How to test locally

Render each env overlay and confirm the tag scope reaches the container:

```bash
helm template tuist infra/helm/tuist -n tuist \
  -f infra/helm/tuist/values-managed-common.yaml \
  -f infra/helm/tuist/values-managed-canary.yaml \
  --set server.image.tag=t --set runnersFleet.runnerImageSemver=1.0.0 \
  --set runnersFleetLinux.shapeRunnerImage=i:1 --set registry.image.tag=t \
  --set kuraController.image.tag=t --set cache.image.tag=t \
  --set codebaseSearch.image.tag=t --set ociRegistry.image.tag=t \
  --set xcresultProcessor.image.tag=t --set slack.image.tag=t \
  --show-only templates/tailscale-device-reaper.yaml
```

Confirm the reaper renders nothing when disabled (the self-hoster default):

```bash
helm template tuist infra/helm/tuist -n tuist --set server.image.tag=t \
  --set server.license.key=t --show-only templates/tailscale-device-reaper.yaml
```

The behaviour was verified by extracting `reap.sh` from the rendered ConfigMap and running it against a stub `curl` on PATH serving a fixture built from the live tailnet plus edge cases (untagged-and-ancient, `tag:tuist-mgmt`-and-ancient, never-seen, empty `lastSeen`, one hour inside the window, one hour outside), with the stub recording DELETEs and able to simulate a device reconnecting between scan and delete.

Confirmed across the three env scopes:

- Each env selects only its own devices (production 18, canary 1, staging 2), no env emits a device tagged for another, and the three sets sum to exactly the 21 a single all-tag reaper selected.
- Devices that are online, untagged, `tag:tuist-mgmt`, missing `lastSeen`, carrying an empty `lastSeen`, or one hour inside their window are selected by nobody.
- Empty, unset, comma-only and whitespace-only tag lists all abort non-zero with a clear message.
- A nonexistent tag reports `0 of 0 in-scope` against a 76-device tailnet.
- Fractional-second `lastSeen` values parse (the live API returns some).
- `maxDeletions` stops at its limit and reports the remainder; a mid-run reconnect is skipped without consuming a slot; an API failure exits non-zero.

`helm lint` passes.
