### PR TITLE
fix(cli): preserve package access in cached dependencies

### DIFF
--- a/cli/Sources/TuistLoader/AGENTS.md
+++ b/cli/Sources/TuistLoader/AGENTS.md
@@ -6,6 +6,7 @@ This module loads and evaluates Tuist manifests (e.g., `Project.swift`, `Workspa
 - Discover manifest files and validate root manifests exist.
 - Load manifests via `ManifestLoader`, handling sandboxing and caching.
 - Build `ProjectDescription` helpers and decode JSON manifest output.
+- Translate Swift Package Manager metadata into external dependency projects.
 
 ## Related Context
 - Core domain models: `cli/Sources/TuistCore/AGENTS.md`
@@ -14,3 +15,4 @@ This module loads and evaluates Tuist manifests (e.g., `Project.swift`, `Workspa
 ## Invariants
 - Manifest loading emits clear `FatalError` types for missing or malformed manifests.
 - `ManifestLoader` uses start/end tokens to parse manifest output and caches results.
+- Swift package targets using tools version 5.9 or newer carry their package name compiler argument in target settings so graph transformations preserve package access.

--- a/cli/Sources/TuistLoader/Models/DependenciesGraph.swift
+++ b/cli/Sources/TuistLoader/Models/DependenciesGraph.swift
@@ -170,7 +170,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "tuist",
                             baseSettings: .settings(
                                 base: [
                                     "GCC_C_LANGUAGE_STANDARD": "c99",
@@ -254,7 +253,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "a-dependency",
                             baseSettings: .settings(
                                 configurations: [
                                     .debug(name: .debug),
@@ -312,7 +310,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "another-dependency",
                             baseSettings: .settings(
                                 configurations: [
                                     .debug(name: .debug),
@@ -378,7 +375,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "Alamofire",
                             baseSettings: .settings(base: ["SWIFT_VERSION": "5.0.0"])
                         ),
                         targets: targets,
@@ -512,7 +508,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "GoogleAppMeasurement",
                             baseSettings: .settings(
                                 base: [
                                     "GCC_C_LANGUAGE_STANDARD": "c99",
@@ -634,7 +629,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "GoogleUtilities",
                             baseSettings: .settings(
                                 configurations: [
                                     .debug(name: .debug),
@@ -692,7 +686,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
                         settings: Self.swiftpmProjectSettings(
-                            packageName: "nanopb",
                             baseSettings: .settings(
                                 configurations: [
                                     .debug(name: .debug),
@@ -716,7 +709,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
         }
 
         public static func swiftpmProjectSettings(
-            packageName: String,
             baseSettings: Settings = .settings(),
             with customSettings: SettingsDictionary = [:]
         ) -> Settings {
@@ -730,7 +722,6 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
                 "FRAMEWORK_SEARCH_PATHS": ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"],
                 "GCC_NO_COMMON_BLOCKS": "NO",
                 "USE_HEADERMAP": "NO",
-                "OTHER_SWIFT_FLAGS": ["-package-name", packageName.quotedIfContainsSpaces],
             ]
             var settingsDictionary = defaultSpmSettings.combine(with: customSettings)
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1028,6 +1028,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
             target: target,
             productName: productName,
             moduleName: moduleName,
+            packageName: packageInfo.name,
+            swiftToolsVersion: Version(stringLiteral: packageInfo.toolsVersion.description),
             packageFolder: packageFolder,
             settings: target.settings,
             moduleMap: moduleMap,
@@ -2229,6 +2231,8 @@ extension ProjectDescription.Settings {
         target: PackageInfo.Target,
         productName: String,
         moduleName: String,
+        packageName: String,
+        swiftToolsVersion: XcodeGraph.Version,
         packageFolder: AbsolutePath,
         settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
         moduleMap: ModuleMap?,
@@ -2431,6 +2435,15 @@ extension ProjectDescription.Settings {
             )
         }
 
+        if swiftToolsVersion >= Version(5, 9, 0) {
+            result.base.ensurePackageName(packageName)
+            for index in result.configurations.indices
+                where result.configurations[index].settings["OTHER_SWIFT_FLAGS"] != nil
+            {
+                result.configurations[index].settings.ensurePackageName(packageName)
+            }
+        }
+
         return result
     }
 
@@ -2518,6 +2531,28 @@ extension ProjectDescription.SettingsDictionary {
                 return ProjectDescription.SettingValue.array(arrayValue)
             }
         }
+    }
+
+    fileprivate mutating func ensurePackageName(_ packageName: String) {
+        let packageName = packageName.quotedIfContainsSpaces
+        var swiftFlags: [String] = switch self["OTHER_SWIFT_FLAGS"] {
+        case let .array(values):
+            values
+        case let .string(value):
+            value.split(separator: " ").map(String.init)
+        case nil:
+            ["$(inherited)"]
+        @unknown default:
+            ["$(inherited)"]
+        }
+
+        let containsPackageName = swiftFlags.indices.dropLast().contains { index in
+            swiftFlags[index] == "-package-name" && swiftFlags[index + 1] == packageName
+        }
+        guard !containsPackageName else { return }
+
+        swiftFlags.append(contentsOf: ["-package-name", packageName])
+        self["OTHER_SWIFT_FLAGS"] = .array(swiftFlags)
     }
 }
 
@@ -2648,18 +2683,6 @@ extension PackageInfo {
         ]
 
         settingsDictionary.merge(.from(settingsDictionary: baseSettings.base), uniquingKeysWith: { $1 })
-
-        if toolsVersion >= Version(5, 9, 0) {
-            let packageNameValues = ["$(inherited)", "-package-name", name.quotedIfContainsSpaces]
-            settingsDictionary["OTHER_SWIFT_FLAGS"] = switch settingsDictionary["OTHER_SWIFT_FLAGS"] {
-            case let .array(swiftFlags):
-                .array(swiftFlags + packageNameValues)
-            case let .string(swiftFlags):
-                .array(swiftFlags.split(separator: " ").map(String.init) + packageNameValues)
-            case .none:
-                .array(packageNameValues)
-            }
-        }
 
         if let cLanguageStandard {
             settingsDictionary["GCC_C_LANGUAGE_STANDARD"] = .string(cLanguageStandard)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4017,7 +4017,10 @@ struct PackageInfoMapperTests {
             base: ["CUSTOM_SETTING": .string("CUSTOM_VALUE")],
             configurations: [
                 .init(name: "Custom Debug", variant: .debug): .init(
-                    settings: ["CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1")],
+                    settings: [
+                        "CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1"),
+                        "OTHER_SWIFT_FLAGS": .array(["-DDEBUG"]),
+                    ],
                     xcconfig: sourcesPath.appending(component: "Config.xcconfig")
                 ),
                 .init(name: "Custom Release", variant: .release): .init(
@@ -4074,7 +4077,14 @@ struct PackageInfoMapperTests {
                                 configurations: [
                                     .debug(
                                         name: "Custom Debug",
-                                        settings: ["CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1")],
+                                        settings: [
+                                            "CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1"),
+                                            "OTHER_SWIFT_FLAGS": .array([
+                                                "-DDEBUG",
+                                                "-package-name",
+                                                "Package",
+                                            ]),
+                                        ],
                                         xcconfig: "Sources/Target1/Config.xcconfig"
                                     ),
                                     .release(
@@ -6294,8 +6304,57 @@ struct PackageInfoMapperTests {
 
         // Then
         #expect(
-            project?.settings?.base["OTHER_SWIFT_FLAGS"] ==
+            project?.targets.first?.settings?.base["OTHER_SWIFT_FLAGS"] ==
                 .array(["$(inherited)", "-package-name", "Package"])
+        )
+        #expect(project?.settings?.base["OTHER_SWIFT_FLAGS"] == nil)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenPackageUsesPackageAccessAndCustomSwiftSettings_addsPackageNameToTargetFlags() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "SwiftProtobuf/Sources/SwiftProtobuf"))
+        )
+
+        let project = try await subject.map(
+            package: "SwiftProtobuf",
+            basePath: basePath,
+            packageInfos: [
+                "SwiftProtobuf": .test(
+                    name: "SwiftProtobuf",
+                    products: [
+                        .init(name: "SwiftProtobuf", type: .library(.automatic), targets: ["SwiftProtobuf"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "SwiftProtobuf",
+                            settings: [
+                                .init(
+                                    tool: .swift,
+                                    name: .enableUpcomingFeature,
+                                    condition: nil,
+                                    value: ["ExistentialAny"]
+                                ),
+                            ]
+                        ),
+                    ],
+                    platforms: [.ios],
+                    toolsVersion: Version(5, 9, 0)
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(
+            target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
+                "$(inherited)",
+                "-enable-upcoming-feature \"ExistentialAny\"",
+                "-package-name",
+                "SwiftProtobuf",
+            ])
         )
     }
 
@@ -7875,6 +7934,7 @@ struct PackageInfoMapperTests {
                     targets: [
                         .test(
                             "Singular",
+                            swiftPackageName: "Singular",
                             basePath: basePath,
                             customProductName: "SingularWrapper",
                             headers: .spmTarget(headersPath.parentDirectory),
@@ -8039,6 +8099,8 @@ struct PackageInfoMapperTests {
                 prebuiltPath.appending(component: "Modules").pathString,
                 "-I",
                 checkoutPath.appending(try RelativePath(validating: "Sources/_SwiftSyntaxCShims/include")).pathString,
+                "-package-name",
+                "Package",
             ])
         )
         #expect(
@@ -8109,10 +8171,21 @@ struct PackageInfoMapperTests {
             target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
                 "$(inherited)",
                 "-enable-experimental-feature \"Lifetimes\"",
+                "-package-name",
+                "Package",
             ])
         )
-        guard case let .array(projectFlags) = project?.settings?.base["OTHER_SWIFT_FLAGS"] else {
-            Issue.record("Expected project-level OTHER_SWIFT_FLAGS to be an array")
+        let projectFlags: [String]
+        switch project?.settings?.base["OTHER_SWIFT_FLAGS"] {
+        case let .array(flags):
+            projectFlags = flags
+        case let .string(flags):
+            projectFlags = flags.split(separator: " ").map(String.init)
+        case nil:
+            Issue.record("Expected project-level OTHER_SWIFT_FLAGS to be a string or an array")
+            return
+        @unknown default:
+            Issue.record("Expected project-level OTHER_SWIFT_FLAGS to be a string or an array")
             return
         }
         #expect(projectFlags.filter { $0 == "-DSTAGING" }.count == 1)
@@ -8166,6 +8239,8 @@ struct PackageInfoMapperTests {
                 "$(inherited)",
                 "-enable-experimental-feature \"Lifetimes\"",
                 "-DSTAGING",
+                "-package-name",
+                "Package",
             ])
         )
     }
@@ -8303,7 +8378,13 @@ struct PackageInfoMapperTests {
 
         let target = try #require(project?.targets.first)
         #expect(target.dependencies == [.external(name: "SwiftSyntax", condition: nil)])
-        #expect(target.settings?.base["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)"]))
+        #expect(
+            target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
+                "$(inherited)",
+                "-package-name",
+                "Package",
+            ])
+        )
         #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
         #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
     }
@@ -8371,6 +8452,8 @@ struct PackageInfoMapperTests {
                 prebuiltPath.appending(component: "Modules").pathString,
                 "-I",
                 prebuiltPath.appending(components: "include", "_SwiftSyntaxCShims").pathString,
+                "-package-name",
+                "Package",
             ])
         )
         #expect(
@@ -8500,7 +8583,13 @@ struct PackageInfoMapperTests {
 
         let target = try #require(project?.targets.first(where: { $0.name == "MyMacro" }))
         #expect(target.dependencies.isEmpty)
-        #expect(target.settings?.base["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)"]))
+        #expect(
+            target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
+                "$(inherited)",
+                "-package-name",
+                "Package",
+            ])
+        )
         #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
         #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
     }
@@ -8732,7 +8821,6 @@ extension ProjectDescription.Project {
             name: name,
             options: options,
             settings: DependenciesGraph.swiftpmProjectSettings(
-                packageName: name,
                 baseSettings: settings,
                 with: customSettings
             ),
@@ -8750,6 +8838,7 @@ extension ProjectDescription.Target {
     fileprivate static func test(
         _ name: String,
         packageName: String = "Package",
+        swiftPackageName: String? = nil,
         basePath: AbsolutePath = "/",
         destinations: ProjectDescription.Destinations = Set(Destination.allCases),
         product: ProjectDescription.Product = .staticFramework,
@@ -8773,6 +8862,7 @@ extension ProjectDescription.Target {
         moduleMap: String? = nil
     ) -> Self {
         let sources: SourceFilesList?
+        var customSettings = customSettings
 
         switch customSources {
         case let .custom(list):
@@ -8784,6 +8874,20 @@ extension ProjectDescription.Target {
                     basePath.appending(defaultSourcesPath).pathString,
                 ])
         }
+
+        let swiftFlags: [String] = switch customSettings["OTHER_SWIFT_FLAGS"] {
+        case let .array(values):
+            values
+        case let .string(value):
+            value.split(separator: " ").map(String.init)
+        case nil:
+            ["$(inherited)"]
+        @unknown default:
+            ["$(inherited)"]
+        }
+        customSettings["OTHER_SWIFT_FLAGS"] = .array(
+            swiftFlags + ["-package-name", (swiftPackageName ?? packageName).quotedIfContainsSpaces]
+        )
 
         return ProjectDescription.Target.target(
             name: name,


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11863>

## What changed

Swift package targets using tools version 5.9 or newer now carry their `-package-name` compiler argument directly in target settings. The mapper preserves existing Swift flags, applies the package name to configuration-specific overrides, and avoids adding a duplicate pair.

The project-level package name setting and its test helper inputs have been removed. Regression coverage models SwiftProtobuf's custom upcoming-feature setting and verifies both the tools-version boundary and configuration-specific flags.

## Why

Running `tuist cache` with SwiftProtobuf could fail because declarations using package access were compiled without a package name. Swift then reported that the package access level required the `-package-name` compiler argument.

## Root cause

The dependency mapper attached `-package-name` only to the generated package project. Cached dependency graph transformations retain target settings, but the compiler argument required by package-access declarations did not travel with the target that needed it.

Targets with custom Swift settings, such as SwiftProtobuf's upcoming feature flag, therefore reached compilation with their target-specific arguments but without the package identity inherited from the original project.

## Approach

The mapper now adds the package name after target base and configuration settings have been merged. This keeps custom arguments intact and guarantees that any configuration overriding `OTHER_SWIFT_FLAGS` still carries the required package identity.

The tools version gate remains at 5.9, where package access became available. Moving the argument instead of copying it keeps the effective compiler invocation free of duplicate package-name arguments.

## Impact

Swift packages that use package access can be compiled as cached dependencies even when their targets define custom Swift settings. Packages using older tools versions retain their previous settings, and no migration or manifest change is required.

## Validation

- Passed the complete `PackageInfoMapperTests` suite with Xcode and code signing disabled.
- Passed focused tests for the tools-version boundary and the SwiftProtobuf-style custom setting.
- Ran `mise run cli:lint --fix` successfully.
- Ran `git diff --check` successfully.
- Completed an adversarial Claude review with no actionable findings.

The reproduction repository linked from the issue is no longer available, so the regression is validated at the dependency project mapping layer with the same SwiftProtobuf settings shape.

### How to test locally

```sh
tuist generate TuistLoader TuistLoaderTests ProjectDescription --no-open --no-binary-cache
xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme TuistUnitTests \
  -only-testing:TuistLoaderTests/PackageInfoMapperTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
  COMPILATION_CACHE_ENABLE_CACHING=NO SDK_STAT_CACHE_ENABLE=NO
```
