### PR TITLE
fix(infra): install bare-metal hosts from Hetzner's zstd image

### DIFF
--- a/infra/k8s/clusters/bare-metal.yaml
+++ b/infra/k8s/clusters/bare-metal.yaml
@@ -69,22 +69,6 @@ spec:
         # to install. Hetzner mounts an NFS share at /root/.oldroot/nfs
         # inside the rescue system with images for each supported
         # distribution.
-        #
-        # `.tar.zst`, not `.tar.gz`: Hetzner re-compressed the archives
-        # with zstd from 2026-06-12 and removed the gzip variants. The
-        # extension is the whole of the contract. Get it wrong and
-        # installimage fails `Error: Image not found!` about two seconds
-        # in, caph reboots into rescue and retries forever, and the host
-        # never registers. Nothing surfaces it as an image problem: the
-        # HetznerBareMetalHost sits in `registering` with
-        # `StillProvisioning`, and the reason appears only in the caph
-        # controller log's `Reconciler error`.
-        #
-        # It stayed latent for two months because a pinned path is read
-        # only when a host is reinstalled, and nothing reinstalled
-        # between the migration and 2026-08-14, when this pool's roll
-        # deleted a Machine and left the production Linux fleet on one
-        # node for three days.
         image:
           path: /root/.oldroot/nfs/install/../images/Ubuntu-2404-noble-amd64-base.tar.zst
         # Software RAID 1 mirror across both NVMes. caph silently

--- a/infra/k8s/clusters/bare-metal.yaml
+++ b/infra/k8s/clusters/bare-metal.yaml
@@ -69,8 +69,24 @@ spec:
         # to install. Hetzner mounts an NFS share at /root/.oldroot/nfs
         # inside the rescue system with images for each supported
         # distribution.
+        #
+        # `.tar.zst`, not `.tar.gz`: Hetzner re-compressed the archives
+        # with zstd from 2026-06-12 and removed the gzip variants. The
+        # extension is the whole of the contract. Get it wrong and
+        # installimage fails `Error: Image not found!` about two seconds
+        # in, caph reboots into rescue and retries forever, and the host
+        # never registers. Nothing surfaces it as an image problem: the
+        # HetznerBareMetalHost sits in `registering` with
+        # `StillProvisioning`, and the reason appears only in the caph
+        # controller log's `Reconciler error`.
+        #
+        # It stayed latent for two months because a pinned path is read
+        # only when a host is reinstalled, and nothing reinstalled
+        # between the migration and 2026-08-14, when this pool's roll
+        # deleted a Machine and left the production Linux fleet on one
+        # node for three days.
         image:
-          path: /root/.oldroot/nfs/install/../images/Ubuntu-2404-noble-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/install/../images/Ubuntu-2404-noble-amd64-base.tar.zst
         # Software RAID 1 mirror across both NVMes. caph silently
         # rewrites `swraidLevel: 0` → `SWRAIDLEVEL 1` in the
         # installimage wrapper (RAID 0 isn't supported via its API),


### PR DESCRIPTION
## What changed

One line: the `HetznerBareMetalMachineTemplate` install image path moves from
`Ubuntu-2404-noble-amd64-base.tar.gz` to `.tar.zst`.

## Why

Hetzner [re-compressed its installimage archives with zstd starting 2026-06-12](https://status.hetzner.com/incident/a96d2977-baca-4ad5-92e8-7391d4efe91e)
and removed the gzip variants, asking operators of automated installs to update
the `IMAGE` extension. Our path was never updated.

## Root cause

Every bare-metal reprovision since the migration fails about two seconds into
installimage:

```
[19:57:20] # executing installfile ...
[19:57:20] Error: Image not found!
[19:57:20] => FAILED
```

caph reports `did not find marker "POST_INSTALL_SCRIPT_FINISHED"`, reboots the
host into rescue, and retries forever.

The bug was latent for two months because a pinned image path is read only when
a host is reinstalled, and nothing reinstalled in between. It surfaced on
2026-08-14 15:51 UTC, when the production `runners-linux` MachineDeployment
(mid-roll since 2026-06-17) finally scaled a Machine down. The replacement
entered the retry loop and never came back, so the production Linux runner
fleet has been running on one AX162-R instead of two for three days.

That halving is what produced the `Runner queue age` page on
`linux-4vcpu-16gb`. The surviving node sits at 99% memory requests against 56%
CPU, because request == limit == advertised shape means idle `2vcpu-8gb` warm
pollers reserve RAM they never touch. With no 16 GiB hole left, every
`4vcpu-16gb` Pod gets `FailedScheduling: 1 Insufficient memory`, and the
`minWarmPoolFloor: 12` chosen on 2026-08-12 was explicitly sized against a
two-node, ~504 GiB fleet.

Staging (`bm-2986829`) and canary (`bm-2987569`) are wedged identically, on
different hardware, which is what confirms a vendor-side change rather than
anything of ours.

## Why this shape

The path is edited in place rather than version-suffixing the template.
`HetznerBareMetalMachineTemplate.spec` is immutable, so a plain apply is
rejected, but `mgmt-cluster-apply.yml` already falls back to delete + apply for
`bare-metal*.yaml` precisely for this. Renaming the template would also mean
bumping `templateRef.name` in the ClusterClass, which the workflow applies
*before* the template, creating a window where the class points at a name that
does not exist yet.

## Impact

Only `tuist/tuist` runs on this shape (675 jobs over the last two days), so
there is no customer exposure, but it gates the production deploy cascade.
Worst wait this week was 9h10m on 08-15.

Once merged, the roll finishes the replacement it started in June. Expect the
fleet to sit at one node for part of that: `bare-metal-worker` runs
`maxSurge: 0` / `maxUnavailable: 1`, and Pods drain with `WaitCompleted`, so
budget hours rather than minutes.

## Validation

Server-side dry-run against the live management cluster:

```
hetznerbaremetalmachinetemplate.infrastructure.cluster.x-k8s.io/tuist-bare-metal-machinetemplate configured (server dry run)
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/tuist-bare-metal-worker-bootstraptemplate unchanged (server dry run)
```

The real check is post-merge: `bm-3000872` should leave `registering`, and
`installimage is finished.` should be followed by a provisioned host rather
than a `Reconciler error`.

## Follow-ups, not in this PR

- The `Worker node pool stuck mid-rollout` alert documented in
  `infra/helm/k8s-monitoring/alerts.md` is not actually provisioned in Grafana.
  It is the rule written for exactly this failure, and its absence is why a
  three-day node loss went unnoticed.
- Even provisioned it could not evaluate: Adaptive Metrics has aggregated away
  `machinedeployment` and `workload_cluster` from
  `kube_customresource_machinedeployment_*`, so any query preserving those
  labels is rejected.
- `minWarmPoolFloor` is sized for a two-node fleet and starves the heavier
  shapes whenever the fleet is down a node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
