### PR TITLE
fix(cache): delete abandoned temporary files in the orphan cleanup scan

### DIFF
--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -166,7 +166,7 @@ defmodule Cache.Config do
     Application.get_env(:cache, :xcode_database_interactions_enabled, true)
   end
 
-  @default_orphan_scan_max_dirs 50
+  @default_orphan_scan_max_dirs 1000
   def orphan_scan_max_dirs, do: Application.get_env(:cache, :orphan_scan_max_dirs, @default_orphan_scan_max_dirs)
 
   def repo_busy_timeout_ms(repo \\ Cache.Repo) do

--- a/cache/lib/cache/orphan_cleanup_worker.ex
+++ b/cache/lib/cache/orphan_cleanup_worker.ex
@@ -17,6 +17,14 @@ defmodule Cache.OrphanCleanupWorker do
   ETS entry for a file older than this window, the file will be correctly
   identified as an orphan and removed — the next cache miss triggers a
   re-upload, so the system is self-healing.
+
+  Partially written temporary files (`.tmp.*` from the S3 read-through
+  download path, `.cache-upload-*` from the streaming upload path) are
+  orphans under the same rule: they are renamed into place on success and
+  removed on failure, so one that outlives `@min_age_seconds` belongs to a
+  process that died mid-write. The age window is not a fixed deadline for a
+  transfer — every written chunk advances the mtime, so an in-flight
+  transfer of any size or duration is never considered stale.
   """
 
   use Oban.Worker, queue: :maintenance, max_attempts: 1
@@ -137,16 +145,11 @@ defmodule Cache.OrphanCleanupWorker do
             {[full | dirs], files, checked}
 
           {:ok, %File.Stat{type: :regular, size: size, mtime: mtime}} ->
-            cond do
-              tmp_file?(entry) ->
-                {dirs, files, checked + 1}
-
-              now - mtime >= @min_age_seconds ->
-                key = Path.relative_to(full, root)
-                {dirs, [{key, size} | files], checked + 1}
-
-              true ->
-                {dirs, files, checked + 1}
+            if now - mtime >= @min_age_seconds do
+              key = Path.relative_to(full, root)
+              {dirs, [{key, size} | files], checked + 1}
+            else
+              {dirs, files, checked + 1}
             end
 
           _ ->
@@ -211,10 +214,6 @@ defmodule Cache.OrphanCleanupWorker do
       :ok -> try_remove_empty_ancestors(Path.dirname(dir), storage_dir)
       {:error, _} -> :ok
     end
-  end
-
-  defp tmp_file?(filename) do
-    String.starts_with?(filename, [".tmp.", ".cache-upload-"])
   end
 
   defp log_summary(%{orphans_deleted: 0, dirs_scanned: dirs}) do

--- a/cache/test/cache/orphan_cleanup_worker_test.exs
+++ b/cache/test/cache/orphan_cleanup_worker_test.exs
@@ -64,18 +64,18 @@ defmodule Cache.OrphanCleanupWorkerTest do
     assert File.exists?(path)
   end
 
-  test "skips .tmp files regardless of age", %{storage_dir: storage_dir} do
-    key = "acct/proj/xcode/AB/CD/.tmp.12345"
+  test "deletes .tmp files abandoned by an interrupted download", %{storage_dir: storage_dir} do
+    key = "acct/proj/xcode/AB/CD/.tmp.abcdef123456.789"
     path = write_artifact_file(storage_dir, key)
 
     set_old_mtime(path)
     stub(Config, :orphan_scan_max_dirs, fn -> 100 end)
 
     assert :ok = OrphanCleanupWorker.perform(%Oban.Job{args: %{}})
-    assert File.exists?(path)
+    refute File.exists?(path)
   end
 
-  test "skips .cache-upload files regardless of age", %{storage_dir: storage_dir} do
+  test "deletes .cache-upload files abandoned by an interrupted upload", %{storage_dir: storage_dir} do
     key = "acct/proj/xcode/AB/CD/.cache-upload-67890"
     path = write_artifact_file(storage_dir, key)
 
@@ -83,7 +83,47 @@ defmodule Cache.OrphanCleanupWorkerTest do
     stub(Config, :orphan_scan_max_dirs, fn -> 100 end)
 
     assert :ok = OrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+    refute File.exists?(path)
+  end
+
+  test "does NOT delete .tmp files still being written to", %{storage_dir: storage_dir} do
+    key = "acct/proj/xcode/AB/CD/.tmp.abcdef123456.789"
+    path = write_artifact_file(storage_dir, key)
+
+    stub(Config, :orphan_scan_max_dirs, fn -> 100 end)
+
+    assert :ok = OrphanCleanupWorker.perform(%Oban.Job{args: %{}})
     assert File.exists?(path)
+  end
+
+  test "does NOT delete .cache-upload files still being written to", %{storage_dir: storage_dir} do
+    key = "acct/proj/xcode/AB/CD/.cache-upload-67890"
+    path = write_artifact_file(storage_dir, key)
+
+    stub(Config, :orphan_scan_max_dirs, fn -> 100 end)
+
+    assert :ok = OrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+    assert File.exists?(path)
+  end
+
+  test "deletes a stale .tmp file without touching the tracked artifact it was named after", %{
+    storage_dir: storage_dir
+  } do
+    artifact_key = "acct/proj/xcode/AB/CD/abcdef123456"
+    artifact_path = write_artifact_file(storage_dir, artifact_key)
+    tmp_path = write_artifact_file(storage_dir, "acct/proj/xcode/AB/CD/.tmp.abcdef123456.789")
+
+    :ok = CacheArtifacts.track_artifact_access(artifact_key)
+    :ok = CacheArtifactsBuffer.flush()
+
+    set_old_mtime(artifact_path)
+    set_old_mtime(tmp_path)
+    stub(Config, :orphan_scan_max_dirs, fn -> 100 end)
+
+    assert :ok = OrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    assert File.exists?(artifact_path)
+    refute File.exists?(tmp_path)
   end
 
   test "persists cursor position after processing", %{storage_dir: storage_dir} do


### PR DESCRIPTION
## What changed

`Cache.OrphanCleanupWorker` now treats partially written temporary files (`.tmp.*`, `.cache-upload-*`) as orphan candidates instead of skipping them by name. The existing age guard (`@min_age_seconds`, 1 hour) decides whether they are deleted, exactly as it does for regular artifacts.

The per-run scan budget also goes from 50 to 1000 directories (`Cache.Config.orphan_scan_max_dirs/0`).

## Why

While cleaning up disk on cache servers we found temporary files more than a week old sitting in the CAS tree, at paths like `/cas/<account>/<project>/<protocol>/<xx>/<yy>/.tmp.<artifact-hash>.<unique-integer>`. They are never read by anything and they are never reclaimed, so the volume grows without bound.

### Root cause

Two paths write a temporary file next to the final artifact and rename it into place:

- `Cache.S3.download/2` writes the S3 read-through download to `.tmp.<key>.<unique-integer>`, then renames it (`cache/lib/cache/s3.ex`).
- `Cache.BodyReader` buffers a streamed upload into `.cache-upload-<unique-integer>` inside the target directory (`cache/lib/cache/body_reader.ex`), for the Xcode and Gradle upload controllers.

Both clean up only from the process that owns the transfer: rename on success, unlink on error. Neither survives a pod restart, a crash, or an OOM kill between those two steps. When that happens the file stays on disk with no owner and no `cache_artifacts` row.

`OrphanCleanupWorker` is the component that reclaims exactly this class of file, but it excluded both prefixes unconditionally:

```elixir
defp tmp_file?(filename) do
  String.starts_with?(filename, [".tmp.", ".cache-upload-"])
end
```

The exclusion was there to protect writes still in flight, which is a real concern — but it had no age component, so it also protected files whose writer had been dead for weeks. Nothing else in the system removes them. The result is an unbounded leak.

## Why this approach

The obvious alternative is a dedicated sweep for temporary files with its own threshold and its own deletion pass. That adds a second traversal and a second policy for the same question the worker already answers, so this instead removes the special case and lets one rule cover both file kinds.

The safety argument for reusing the 1-hour window is that mtime tracks liveness, not transfer start. Every chunk written to a temporary file advances its mtime, both for `ExAws.S3.download_file/3` and for the chunked body reader. So the window is not a deadline on the transfer: a multi-hour download of a very large artifact keeps looking fresh for as long as bytes keep arriving, and a file only becomes eligible after a full hour with no write at all. The upload path has a 60s per-chunk read timeout, so an hour of silence there means the stream is already dead.

Even in the worst case the failure mode is benign. If the worker deleted a file a writer still held open, POSIX unlink semantics keep the writer's descriptor valid; the writer finishes into an unlinked inode and its final `File.rename/2` fails with `:enoent`. The request errors out instead of publishing a partial artifact, and the client retries.

Temporary filenames can never collide with a real artifact key — keys are hashes with no leading dot — so a stale temporary file always classifies as an orphan and a tracked artifact is never at risk, including when the temporary file is named after it.

### Scan budget

At 50 directories per hourly run, a full pass over a large CAS tree takes long enough that an orphan can outlive many scan cycles before the resumable cursor reaches it, which weakens every reclaim path in this worker rather than only the temporary-file one. 1000 directories per run keeps a full pass on a useful cadence.

`CacheArtifacts.existing_keys/1` already chunks its lookups at 500 keys per query, so the wider per-run batch does not approach the SQLite bound-variable limit. The work per directory is one `lstat` per entry, unchanged.

## Impact

Leaked temporary files are reclaimed automatically on the next scan that reaches their directory. No behavior change for live traffic: in-flight downloads and uploads are protected by the mtime guard, and no code path reads a temporary file it did not create.

Operators can reclaim the existing backlog immediately, before this ships, without waiting for the scan:

```
find <storage_dir> -type f -name '.tmp.*' -mmin +60 -delete
find <storage_dir> -type f -name '.cache-upload-*' -mmin +60 -delete
```

## Validation

- `mix test test/cache/orphan_cleanup_worker_test.exs` — 15 passed.
- `mix test test/cache/config_test.exs` — 5 passed.
- `mix credo lib/cache/orphan_cleanup_worker.ex lib/cache/config.ex` — no issues.
- `mix format` on all three changed files.

Test coverage added, replacing the two tests that asserted the old skip:

- a stale `.tmp.*` file is deleted;
- a stale `.cache-upload-*` file is deleted;
- a fresh `.tmp.*` file is kept (in-flight download);
- a fresh `.cache-upload-*` file is kept (in-flight upload);
- a stale `.tmp.<hash>.<n>` file is deleted while the tracked artifact `<hash>` in the same directory is untouched.

## Note for the reviewer

Out of scope here, but found while tracing the temporary-file writers: `CacheWeb.XcodeModuleController` buffers multipart parts as `cache-part-<unique>` under `<storage_dir>/tmp`. That name matches neither prefix, so those files were already treated as ordinary orphans and deleted after an hour. Worth confirming separately that no multipart session legitimately keeps a buffered part idle for longer than that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
