### PR TITLE
fix(cli): ignore embedded macOS products in dependency inspection

### DIFF
--- a/cli/Sources/TuistInspectCommand/Services/GraphImportsLinter.swift
+++ b/cli/Sources/TuistInspectCommand/Services/GraphImportsLinter.swift
@@ -77,7 +77,8 @@
                     target: target,
                     includeExternalDependencies: inspectType == .implicit,
                     excludeAppDependenciesForTests: inspectType == .redundant,
-                    excludeEmbeddableWatchApps: inspectType == .redundant
+                    excludeEmbeddableWatchApps: inspectType == .redundant,
+                    excludeMacOSEmbeddedProducts: inspectType == .redundant
                 )
 
                 let observedImports = switch inspectType {
@@ -99,7 +100,8 @@
             target: GraphTarget,
             includeExternalDependencies: Bool,
             excludeAppDependenciesForTests: Bool,
-            excludeEmbeddableWatchApps: Bool
+            excludeEmbeddableWatchApps: Bool,
+            excludeMacOSEmbeddedProducts: Bool
         ) -> Set<String> {
             let targetDependencies = if includeExternalDependencies {
                 graphTraverser
@@ -115,6 +117,19 @@
                 }
                 .filter { dependency in
                     dependency.target.product != .macro
+                }
+                .filter { dependency in
+                    guard excludeMacOSEmbeddedProducts,
+                          target.target.product == .app,
+                          target.target.supports(.macOS)
+                    else { return true }
+
+                    switch dependency.target.product {
+                    case .app, .commandLineTool, .systemExtension, .xpc:
+                        return false
+                    default:
+                        return true
+                    }
                 }
                 .filter { dependency in
                     switch target.target.product {

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
@@ -497,6 +497,42 @@ struct InspectDependenciesCommandServiceTests {
     // MARK: - Redundant Check: Special Product Types
 
     @Test
+    func runRedundantOnlyDoesntFlagMacOSEmbeddedProductDependencies() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let config = Tuist.test()
+        let mainApp = Target.test(name: "MainApp", destinations: .macOS, product: .app)
+        let innerApp = Target.test(name: "InnerApp", destinations: .macOS, product: .app)
+        let innerCLI = Target.test(name: "InnerCLI", destinations: .macOS, product: .commandLineTool)
+        let innerSystemExtension = Target.test(name: "InnerSystemExtension", destinations: .macOS, product: .systemExtension)
+        let innerXPC = Target.test(name: "InnerXPC", destinations: .macOS, product: .xpc)
+        let project = Project.test(
+            path: path,
+            targets: [mainApp, innerApp, innerCLI, innerSystemExtension, innerXPC]
+        )
+        let graph = Graph.test(path: path, projects: [path: project], dependencies: [
+            .target(name: mainApp.name, path: project.path): [
+                .target(name: innerApp.name, path: project.path),
+                .target(name: innerCLI.name, path: project.path),
+                .target(name: innerSystemExtension.name, path: project.path),
+                .target(name: innerXPC.name, path: project.path),
+            ],
+        ])
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(mainApp), reachableModules: .any).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(innerApp), reachableModules: .any).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(innerCLI), reachableModules: .any).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(innerSystemExtension), reachableModules: .any).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(innerXPC), reachableModules: .any).willReturn(Set([]))
+
+        // When / Then
+        try await subject.run(path: path.pathString, inspectionTypes: [.redundant])
+    }
+
+    @Test
     func runRedundantOnlyDoesntFlagExternalPackageTargets() async throws {
         // Given
         let path = try AbsolutePath(validating: "/project")


### PR DESCRIPTION
## What changed

`tuist inspect dependencies` no longer reports macOS products embedded by a macOS application as redundant dependencies.

During redundant-dependency inspection, a macOS `.app` target now excludes direct dependencies whose products are:

- `.app`
- `.commandLineTool`
- `.systemExtension`
- `.xpc`

Added regression coverage for an app embedding one product of each supported type.

## Why

A macOS application can declare dependencies on helper products in order to build and bundle them into its application bundle. Those products are not necessarily imported by the host application's source code.

[generated_macos_app_with_app_inside](https://github.com/tuist/tuist/tree/4f3f1cbe9047c246dbc424faa6065521b6421e3e/examples/xcode/generated_macos_app_with_app_inside) has `MainApp` which depends on `InnerApp` and `InnerCLI`. Running `tuist inspect dependencies` previously reported:

```text
The following redundant dependencies were found:
 - MainApp redundantly depends on: InnerApp, InnerCLI
```

Both dependencies are required to be bundled, but not used in the code.

## Root cause

The redundant-dependency check infers redundancy from source imports. This is correct for a normal module dependency, but an embedded product is a build-and-bundle dependency rather than an imported module. Its absence from the host app's imports does not mean the declared dependency is redundant.
It could be solved the other way, but #3388 is not planned.

## Validation

- Added `runRedundantOnlyDoesntFlagMacOSEmbeddedProductDependencies`.
- The regression covers a macOS app embedding an app, command-line tool, system extension, and XPC service.
- Ran the focused regression and the full `InspectDependenciesCommandServiceTests` suite through `TuistUnitTests`; both passed.
- Ran `git diff HEAD --check`.

### How to test locally

```sh
tuist generate tuist TuistInspectCommand TuistKitTests ProjectDescription --no-open

xcodebuild test \
  -workspace Tuist.xcworkspace \
  -scheme TuistUnitTests \
  -only-testing:TuistKitTests/InspectDependenciesCommandServiceTests \
  CODE_SIGNING_ALLOWED=NO \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGN_IDENTITY=""
```
```