### PR TITLE
fix(cli): stop tuist clean from breaking concurrent commands on the same host

### DIFF
--- a/cli/Sources/TuistCore/Cache/CacheDirectoryLock.swift
+++ b/cli/Sources/TuistCore/Cache/CacheDirectoryLock.swift
@@ -1,0 +1,112 @@
+import FileSystem
+import Foundation
+import Path
+import TuistEnvironment
+import TuistLogging
+
+/// Coordinates access to the global cache directories between the Tuist processes running on one
+/// host.
+///
+/// The directories under the cache root are shared, and `tuist clean` empties them, so a command
+/// that reads or writes one while a clean deletes it observes a path that disappeared underneath
+/// it. Commands that use a cache take shared access and still run concurrently with each other;
+/// a clean takes exclusive access, so it waits for them and they wait for it.
+///
+/// Access is advisory and held through an open descriptor, which the kernel closes when the
+/// process exits. A command killed mid-run therefore cannot wedge the next one, and no cleanup
+/// pass has to reason about locks left behind by a crash.
+///
+/// Only short bursts of cache work belong inside these calls. Access that lasts as long as the
+/// command does, such as a test run writing its result bundle under `Runs`, would leave a clean
+/// waiting for minutes, which is worse than the interleaving it prevents.
+///
+/// These calls do not nest. Each one opens its own descriptor, so a second request for the same
+/// category from inside the first waits on a lock this process is already holding and never
+/// returns. Take access around the work that touches the directory, not around a span that may
+/// reach back into the cache.
+public protocol CacheDirectoryLocking: Sendable {
+    /// Runs `body` while this process is using `category`, alongside other users of it.
+    func whileUsing<T>(_ category: CacheCategory, _ body: () async throws -> T) async throws -> T
+
+    /// Runs `body` while this process is the only one touching `category`.
+    func whileEmptying<T>(_ category: CacheCategory, _ body: () async throws -> T) async throws -> T
+}
+
+public struct CacheDirectoryLock: CacheDirectoryLocking {
+    private let cacheDirectory: AbsolutePath?
+    private let fileSystem: FileSysteming
+
+    /// - Parameter cacheDirectory: The cache root to place lock files under. Defaults to the
+    ///   environment's, which is what every command uses; tests pass their own so a unit test
+    ///   never takes a lock the machine's other Tuist processes wait on.
+    public init(
+        cacheDirectory: AbsolutePath? = nil,
+        fileSystem: FileSysteming = FileSystem()
+    ) {
+        self.cacheDirectory = cacheDirectory
+        self.fileSystem = fileSystem
+    }
+
+    public func whileUsing<T>(_ category: CacheCategory, _ body: () async throws -> T) async throws -> T {
+        try await withAccess(to: category, mode: LOCK_SH, body)
+    }
+
+    public func whileEmptying<T>(_ category: CacheCategory, _ body: () async throws -> T) async throws -> T {
+        try await withAccess(to: category, mode: LOCK_EX, body)
+    }
+
+    /// Falls back to running `body` unguarded when the lock cannot be taken, because a cache that
+    /// cannot be coordinated is still a cache. Refusing to run would turn an unwritable lock
+    /// directory into a failure of every command, which is a worse outcome than the interleaving
+    /// the lock exists to prevent.
+    private func withAccess<T>(
+        to category: CacheCategory,
+        mode: Int32,
+        _ body: () async throws -> T
+    ) async throws -> T {
+        guard let descriptor = await descriptor(for: category, mode: mode) else {
+            return try await body()
+        }
+        defer {
+            flock(descriptor, LOCK_UN)
+            close(descriptor)
+        }
+        return try await body()
+    }
+
+    /// `flock` blocks until the lock is granted, so it is taken off the cooperative pool: a
+    /// command waiting on a clean must not consume a thread other work is scheduled on.
+    private func descriptor(for category: CacheCategory, mode: Int32) async -> Int32? {
+        let lockPath: AbsolutePath
+        do {
+            lockPath = try await lockFile(for: category)
+        } catch {
+            Logger.current.debug("Couldn't prepare the \(category.rawValue) cache lock: \(error)")
+            return nil
+        }
+        let descriptor = await Task.detached {
+            let descriptor = open(lockPath.pathString, O_CREAT | O_RDWR, 0o644)
+            guard descriptor >= 0 else { return Int32?.none }
+            guard flock(descriptor, mode) == 0 else {
+                close(descriptor)
+                return Int32?.none
+            }
+            return descriptor
+        }.value
+        if descriptor == nil {
+            Logger.current.debug("Couldn't take the \(category.rawValue) cache lock at \(lockPath.pathString)")
+        }
+        return descriptor
+    }
+
+    /// Lock files sit beside the directories they guard rather than inside them, so that emptying
+    /// a category leaves its lock in place. A lock file removed by the clean it coordinates would
+    /// hand the next two processes separate files, and each would hold what it takes to be the
+    /// same lock.
+    private func lockFile(for category: CacheCategory) async throws -> AbsolutePath {
+        let root = cacheDirectory ?? Environment.current.cacheDirectory
+        let directory = root.appending(component: "Locks")
+        try await fileSystem.makeDirectory(at: directory, options: [.createTargetParentDirectories])
+        return directory.appending(component: "\(category.directoryName).lock")
+    }
+}

--- a/cli/Sources/TuistCore/Cache/GenerationMetadataStore.swift
+++ b/cli/Sources/TuistCore/Cache/GenerationMetadataStore.swift
@@ -29,41 +29,54 @@ public struct GenerationMetadataStore: GenerationMetadataStoring {
     private let cacheDirectoriesProvider: CacheDirectoriesProviding
     private let contentHasher: ContentHashing
     private let fileSystem: FileSysteming
+    private let cacheDirectoryLock: CacheDirectoryLocking
 
     private static let retention: TimeInterval = 60 * 60 * 24 * 30
 
     public init(
         cacheDirectoriesProvider: CacheDirectoriesProviding = CacheDirectoriesProvider(),
         contentHasher: ContentHashing = ContentHasher(),
-        fileSystem: FileSysteming = FileSystem()
+        fileSystem: FileSysteming = FileSystem(),
+        cacheDirectoryLock: CacheDirectoryLocking = CacheDirectoryLock()
     ) {
         self.cacheDirectoriesProvider = cacheDirectoriesProvider
         self.contentHasher = contentHasher
         self.fileSystem = fileSystem
+        self.cacheDirectoryLock = cacheDirectoryLock
     }
 
     public func store(generationId: String, for projectPath: AbsolutePath) async throws {
         let path = try metadataPath(for: projectPath)
-        let directory = path.parentDirectory
-        if try await !fileSystem.exists(directory) {
-            try await fileSystem.makeDirectory(at: directory)
+        try await cacheDirectoryLock.whileUsing(.generationMetadata) {
+            let directory = path.parentDirectory
+            if try await !fileSystem.exists(directory) {
+                try await fileSystem.makeDirectory(at: directory)
+            }
+            if try await fileSystem.exists(path) {
+                try await fileSystem.remove(path)
+            }
+            let metadata = GenerationMetadata(generationId: generationId, generatedAt: Date())
+            try await fileSystem.writeAsJSON(metadata, at: path)
         }
-        if try await fileSystem.exists(path) {
-            try await fileSystem.remove(path)
-        }
-        let metadata = GenerationMetadata(generationId: generationId, generatedAt: Date())
-        try await fileSystem.writeAsJSON(metadata, at: path)
     }
 
     public func read(for projectPath: AbsolutePath) async throws -> String? {
         let path = try metadataPath(for: projectPath)
-        guard try await fileSystem.exists(path) else { return nil }
-        let metadata: GenerationMetadata = try await fileSystem.readJSONFile(at: path)
-        return metadata.generationId
+        return try await cacheDirectoryLock.whileUsing(.generationMetadata) {
+            guard try await fileSystem.exists(path) else { return String?.none }
+            let metadata: GenerationMetadata = try await fileSystem.readJSONFile(at: path)
+            return metadata.generationId
+        }
     }
 
     public func prune() async throws {
         let directory = try cacheDirectoriesProvider.cacheDirectory(for: .generationMetadata)
+        try await cacheDirectoryLock.whileUsing(.generationMetadata) {
+            try await prune(in: directory)
+        }
+    }
+
+    private func prune(in directory: AbsolutePath) async throws {
         guard try await fileSystem.exists(directory) else { return }
         let cutoff = Date().addingTimeInterval(-Self.retention)
         let files = try await fileSystem.glob(directory: directory, include: ["*.json"]).collect()

--- a/cli/Sources/TuistKit/Services/CleanService.swift
+++ b/cli/Sources/TuistKit/Services/CleanService.swift
@@ -117,18 +117,30 @@ struct CleanService {
         )
 
         for category in categories {
+            let cleaned: Bool
             let directory: AbsolutePath?
             switch category {
             case let .global(category):
-                directory = try cacheDirectoriesProvider.cacheDirectory(for: category)
+                let globalDirectory = try cacheDirectoriesProvider.cacheDirectory(for: category)
+                directory = globalDirectory
+                cleaned = try await emptyShared(globalDirectory)
             case .dependencies:
                 directory = swiftPackageManagerScratchDirectory
+                // Not emptied through `emptyShared`: the scratch directory belongs to a single
+                // checkout, so no other process on the host resolves paths inside it, and the
+                // staging directory that method leaves behind while it deletes would sit in the
+                // user's project rather than in a directory Tuist owns.
+                if let scratchDirectory = swiftPackageManagerScratchDirectory,
+                   try await fileSystem.exists(scratchDirectory)
+                {
+                    try await fileSystem.remove(scratchDirectory)
+                    try await fileSystem.makeDirectory(at: scratchDirectory)
+                    cleaned = true
+                } else {
+                    cleaned = false
+                }
             }
-            if let directory,
-               try await fileSystem.exists(directory)
-            {
-                try await fileSystem.remove(directory)
-                try await fileSystem.makeDirectory(at: directory)
+            if cleaned, let directory {
                 AlertController.current
                     .success(.alert("Successfully cleaned artifacts at path \(directory.pathString)"))
             } else {
@@ -176,6 +188,34 @@ struct CleanService {
 
             Logger.current.notice("Successfully cleaned the remote storage.")
         }
+    }
+
+    /// Empties a cache directory that every Tuist process on the host shares, and reports whether
+    /// there was anything to empty.
+    ///
+    /// The contents are moved aside and the moved copy is deleted, rather than the directory being
+    /// deleted where it stands. Deleting in place leaves the path missing for as long as the
+    /// recursive delete of a warm cache takes, which is long enough that a command running
+    /// alongside this one resolves a path inside it and fails: a manifest write into
+    /// `Manifests` is the one that reaches users, as a rename onto a directory that no longer
+    /// exists. A move is a single rename, so the path is missing only between the move and the
+    /// call that recreates it.
+    ///
+    /// A move that finds nothing to move produces the outcome this method is asked for, so it
+    /// reports nothing cleaned rather than failing. That covers both a cache that was never
+    /// populated and a concurrent `tuist clean` that emptied this directory first, which is the
+    /// interleaving that used to surface as `Path not found` naming a cache directory.
+    private func emptyShared(_ directory: AbsolutePath) async throws -> Bool {
+        let stagingDirectory = directory.parentDirectory
+            .appending(component: "\(directory.basename).\(UUID().uuidString).deleting")
+        do {
+            try await fileSystem.move(from: directory, to: stagingDirectory)
+        } catch FileSystemError.moveNotFound {
+            return false
+        }
+        try await fileSystem.makeDirectory(at: directory, options: [.createTargetParentDirectories])
+        try await fileSystem.remove(stagingDirectory)
+        return true
     }
 
     private func swiftPackageManagerScratchDirectory(

--- a/cli/Sources/TuistKit/Services/CleanService.swift
+++ b/cli/Sources/TuistKit/Services/CleanService.swift
@@ -58,6 +58,7 @@ struct CleanService {
     private let getCacheEndpointsService: GetCacheEndpointsServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator
+    private let cacheDirectoryLock: CacheDirectoryLocking
     private let fileSystem: FileSystem
 
     init(
@@ -72,6 +73,7 @@ struct CleanService {
         serverAuthenticationController: ServerAuthenticationControlling,
         swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator =
             SwiftPackageManagerScratchDirectoryLocator(),
+        cacheDirectoryLock: CacheDirectoryLocking,
         fileSystem: FileSystem
     ) {
         self.rootDirectoryLocator = rootDirectoryLocator
@@ -84,6 +86,7 @@ struct CleanService {
         self.getCacheEndpointsService = getCacheEndpointsService
         self.serverAuthenticationController = serverAuthenticationController
         self.swiftPackageManagerScratchDirectoryLocator = swiftPackageManagerScratchDirectoryLocator
+        self.cacheDirectoryLock = cacheDirectoryLock
         self.fileSystem = fileSystem
     }
 
@@ -99,6 +102,7 @@ struct CleanService {
             getCacheEndpointsService: GetCacheEndpointsService(),
             serverAuthenticationController: ServerAuthenticationController(),
             swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator(),
+            cacheDirectoryLock: CacheDirectoryLock(),
             fileSystem: FileSystem()
         )
     }
@@ -117,35 +121,10 @@ struct CleanService {
         )
 
         for category in categories {
-            let cleaned: Bool
-            let directory: AbsolutePath?
-            switch category {
-            case let .global(category):
-                let globalDirectory = try cacheDirectoriesProvider.cacheDirectory(for: category)
-                directory = globalDirectory
-                cleaned = try await emptyShared(globalDirectory)
-            case .dependencies:
-                directory = swiftPackageManagerScratchDirectory
-                // Not emptied through `emptyShared`: the scratch directory belongs to a single
-                // checkout, so no other process on the host resolves paths inside it, and the
-                // staging directory that method leaves behind while it deletes would sit in the
-                // user's project rather than in a directory Tuist owns.
-                if let scratchDirectory = swiftPackageManagerScratchDirectory,
-                   try await fileSystem.exists(scratchDirectory)
-                {
-                    try await fileSystem.remove(scratchDirectory)
-                    try await fileSystem.makeDirectory(at: scratchDirectory)
-                    cleaned = true
-                } else {
-                    cleaned = false
-                }
-            }
-            if cleaned, let directory {
-                AlertController.current
-                    .success(.alert("Successfully cleaned artifacts at path \(directory.pathString)"))
-            } else {
-                Logger.current.notice("There's nothing to clean for \(category.defaultValueDescription)")
-            }
+            try await clean(
+                category,
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
+            )
         }
 
         if remote {
@@ -187,6 +166,43 @@ struct CleanService {
             }
 
             Logger.current.notice("Successfully cleaned the remote storage.")
+        }
+    }
+
+    private func clean(
+        _ category: TuistCleanCategory,
+        swiftPackageManagerScratchDirectory: AbsolutePath?
+    ) async throws {
+        let cleaned: Bool
+        let directory: AbsolutePath?
+        switch category {
+        case let .global(category):
+            let globalDirectory = try cacheDirectoriesProvider.cacheDirectory(for: category)
+            directory = globalDirectory
+            cleaned = try await cacheDirectoryLock.whileEmptying(category) {
+                try await emptyShared(globalDirectory)
+            }
+        case .dependencies:
+            directory = swiftPackageManagerScratchDirectory
+            // Neither locked nor emptied through `emptyShared`: the scratch directory belongs to a
+            // single checkout, so no other process on the host resolves paths inside it, and the
+            // staging directory `emptyShared` leaves behind while it deletes would sit in the
+            // user's project rather than in a directory Tuist owns.
+            if let scratchDirectory = swiftPackageManagerScratchDirectory,
+               try await fileSystem.exists(scratchDirectory)
+            {
+                try await fileSystem.remove(scratchDirectory)
+                try await fileSystem.makeDirectory(at: scratchDirectory)
+                cleaned = true
+            } else {
+                cleaned = false
+            }
+        }
+        if cleaned, let directory {
+            AlertController.current
+                .success(.alert("Successfully cleaned artifacts at path \(directory.pathString)"))
+        } else {
+            Logger.current.notice("There's nothing to clean for \(category.defaultValueDescription)")
         }
     }
 

--- a/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -291,11 +291,23 @@ public class CachedManifestLoader: ManifestLoading {
         guard let cachedManifestContent = String(data: cachedManifestData, encoding: .utf8) else {
             throw ManifestLoaderError.manifestCachingFailed(manifest, cachedManifestPath)
         }
-        try await fileSystem.makeDirectory(
-            at: cachedManifestPath.parentDirectory,
-            options: [.createTargetParentDirectories]
-        )
-        try await fileSystem.writeText(cachedManifestContent, at: cachedManifestPath)
+        // Storing the entry is best effort. The manifest is loaded by the time we get here, so a
+        // cache that cannot be written costs a reload on the next run and nothing else, while
+        // failing here fails a command that already has everything it needs. The cache directory
+        // is shared by every Tuist process on the host and `tuist clean` empties it, so a
+        // concurrent clean can remove it between the call that creates it and the write, which is
+        // how this surfaced: a `tuist install` reporting a failed rename into `Manifests`.
+        do {
+            try await fileSystem.makeDirectory(
+                at: cachedManifestPath.parentDirectory,
+                options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.writeText(cachedManifestContent, at: cachedManifestPath)
+        } catch {
+            Logger.current.debug(
+                "Couldn't cache the \(manifest) manifest at \(cachedManifestPath.pathString): \(error)"
+            )
+        }
     }
 }
 

--- a/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -22,6 +22,7 @@ public class CachedManifestLoader: ManifestLoading {
     private let helpersDirectoryLocator: HelpersDirectoryLocating
     private let fileSystem: FileSysteming
     private let cacheDirectoriesProvider: CacheDirectoriesProviding
+    private let cacheDirectoryLock: CacheDirectoryLocking
     private let tuistVersion: String
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
@@ -46,13 +47,15 @@ public class CachedManifestLoader: ManifestLoading {
         helpersDirectoryLocator: HelpersDirectoryLocating,
         fileSystem: FileSysteming,
         cacheDirectoriesProvider: CacheDirectoriesProviding,
-        tuistVersion: String
+        tuistVersion: String,
+        cacheDirectoryLock: CacheDirectoryLocking = CacheDirectoryLock()
     ) {
         self.manifestLoader = manifestLoader
         self.projectDescriptionHelpersHasher = projectDescriptionHelpersHasher
         self.helpersDirectoryLocator = helpersDirectoryLocator
         self.fileSystem = fileSystem
         self.cacheDirectoriesProvider = cacheDirectoriesProvider
+        self.cacheDirectoryLock = cacheDirectoryLock
         self.tuistVersion = tuistVersion
         cacheDirectory = ThrowableCaching {
             try cacheDirectoriesProvider.cacheDirectory(for: .manifests)
@@ -253,11 +256,10 @@ public class CachedManifestLoader: ManifestLoading {
         at cachedManifestPath: AbsolutePath,
         hashes: Hashes
     ) async throws -> T? {
-        guard try await fileSystem.exists(cachedManifestPath) else {
-            return nil
-        }
-
-        guard let data = try? await fileSystem.readFile(at: cachedManifestPath) else {
+        guard let data = try await cacheDirectoryLock.whileUsing(.manifests, {
+            guard try await fileSystem.exists(cachedManifestPath) else { return Data?.none }
+            return try? await fileSystem.readFile(at: cachedManifestPath)
+        }) else {
             return nil
         }
 
@@ -298,11 +300,13 @@ public class CachedManifestLoader: ManifestLoading {
         // concurrent clean can remove it between the call that creates it and the write, which is
         // how this surfaced: a `tuist install` reporting a failed rename into `Manifests`.
         do {
-            try await fileSystem.makeDirectory(
-                at: cachedManifestPath.parentDirectory,
-                options: [.createTargetParentDirectories]
-            )
-            try await fileSystem.writeText(cachedManifestContent, at: cachedManifestPath)
+            try await cacheDirectoryLock.whileUsing(.manifests) {
+                try await fileSystem.makeDirectory(
+                    at: cachedManifestPath.parentDirectory,
+                    options: [.createTargetParentDirectories]
+                )
+                try await fileSystem.writeText(cachedManifestContent, at: cachedManifestPath)
+            }
         } catch {
             Logger.current.debug(
                 "Couldn't cache the \(manifest) manifest at \(cachedManifestPath.pathString): \(error)"

--- a/cli/Sources/TuistPlugin/PluginService.swift
+++ b/cli/Sources/TuistPlugin/PluginService.swift
@@ -72,6 +72,7 @@ public struct PluginService: PluginServicing {
     private let fileClient: FileClienting
     private let fileSystem: FileSystem
     private let commandRunner: CommandRunning
+    private let cacheDirectoryLock: CacheDirectoryLocking
 
     /// Creates a `PluginService`.
     /// - Parameters:
@@ -89,7 +90,8 @@ public struct PluginService: PluginServicing {
         fileArchivingFactory: FileArchivingFactorying = FileArchivingFactory(),
         fileClient: FileClienting = FileClient(),
         fileSystem: FileSystem = FileSystem(),
-        commandRunner: CommandRunning = CommandRunner()
+        commandRunner: CommandRunning = CommandRunner(),
+        cacheDirectoryLock: CacheDirectoryLocking = CacheDirectoryLock()
     ) {
         self.manifestLoader = manifestLoader
         self.templatesDirectoryLocator = templatesDirectoryLocator
@@ -98,6 +100,7 @@ public struct PluginService: PluginServicing {
         self.fileArchivingFactory = fileArchivingFactory
         self.fileClient = fileClient
         self.fileSystem = fileSystem
+        self.cacheDirectoryLock = cacheDirectoryLock
         self.commandRunner = commandRunner
     }
 
@@ -222,21 +225,26 @@ public struct PluginService: PluginServicing {
             url: url,
             gitId: gitReference.raw
         )
-        try await fetchGitPluginRepository(
-            pluginCacheDirectory: pluginCacheDirectory,
-            url: url,
-            gitId: gitReference.raw
-        )
-        switch gitReference {
-        case .sha:
-            break
-        case let .tag(tag):
-            try await fetchGitPluginRelease(
+        // A clone writes straight into the plugin cache, so it has to hold the directory for its
+        // whole duration rather than only while the files land. A clean waiting behind a clone is
+        // the cost of not letting it delete a half-written plugin.
+        try await cacheDirectoryLock.whileUsing(.plugins) {
+            try await fetchGitPluginRepository(
                 pluginCacheDirectory: pluginCacheDirectory,
                 url: url,
-                gitTag: tag,
-                releaseUrl: releaseUrl
+                gitId: gitReference.raw
             )
+            switch gitReference {
+            case .sha:
+                break
+            case let .tag(tag):
+                try await fetchGitPluginRelease(
+                    pluginCacheDirectory: pluginCacheDirectory,
+                    url: url,
+                    gitTag: tag,
+                    releaseUrl: releaseUrl
+                )
+            }
         }
     }
 

--- a/cli/Tests/TuistCoreTests/Cache/CacheDirectoryLockTests.swift
+++ b/cli/Tests/TuistCoreTests/Cache/CacheDirectoryLockTests.swift
@@ -1,0 +1,100 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+import TuistCore
+
+struct CacheDirectoryLockTests {
+    /// Commands that use a cache have to keep running concurrently with each other, so shared
+    /// access must not serialize them. Each task waits for the other to be inside its own critical
+    /// section before leaving, which cannot complete unless both are inside at once.
+    @Test(.inTemporaryDirectory) func shared_access_admits_other_shared_access() async throws {
+        // Given
+        let subject = CacheDirectoryLock(cacheDirectory: try #require(FileSystem.temporaryTestDirectory))
+        let first = Signal()
+        let second = Signal()
+
+        // When / Then
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await subject.whileUsing(.manifests) {
+                    first.send()
+                    await second.wait()
+                }
+            }
+            group.addTask {
+                try await subject.whileUsing(.manifests) {
+                    second.send()
+                    await first.wait()
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    /// A clean has to see a cache nobody else is touching, so nothing may enter while it holds the
+    /// directory. The assertion is that the waiting task has not run, which a slow machine can only
+    /// make more true, so there is no timing window in which this passes spuriously.
+    @Test(.inTemporaryDirectory) func exclusive_access_keeps_other_access_out() async throws {
+        // Given
+        let subject = CacheDirectoryLock(cacheDirectory: try #require(FileSystem.temporaryTestDirectory))
+        let holding = Signal()
+        let entered = Signal()
+
+        // When
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await subject.whileEmptying(.manifests) {
+                    holding.send()
+                    // Then: the other task cannot be inside while this one holds the directory.
+                    #expect(await entered.hasFired(within: .milliseconds(200)) == false)
+                }
+            }
+            group.addTask {
+                await holding.wait()
+                try await subject.whileUsing(.manifests) {
+                    entered.send()
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        // Then: and it gets in once the directory is released.
+        #expect(await entered.hasFired(within: .seconds(5)))
+    }
+}
+
+/// A one-shot latch. `Signal` rather than a continuation pair so that a second `send` is harmless,
+/// which keeps a failing expectation from hanging the task group it is checked in.
+private final class Signal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+
+    func send() {
+        lock.lock()
+        fired = true
+        lock.unlock()
+    }
+
+    var isFired: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return fired
+    }
+
+    func wait() async {
+        while !isFired {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    func hasFired(within duration: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while ContinuousClock.now < deadline {
+            if isFired { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return isFired
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -124,6 +124,69 @@ final class CleanServiceTests: TuistUnitTestCase {
         XCTAssertTrue(cachePathsExists[1])
     }
 
+    /// A concurrent `tuist clean` on the same host reaches the directory first, so by the time
+    /// this one deletes it there is nothing there. That interleaving is indistinguishable from a
+    /// cache that was never populated, and neither is a failure of this command.
+    func test_run_with_category_whose_directory_is_absent_does_not_fail() async throws {
+        // Given
+        let rootDirectory = try temporaryPath()
+        let absentCacheDirectory = rootDirectory.appending(components: "tuist", "Manifests")
+
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.manifests))
+            .willReturn(absentCacheDirectory)
+        given(rootDirectoryLocator)
+            .locate(from: .any)
+            .willReturn(rootDirectory)
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(nil)
+
+        // When / Then
+        try await subject.run(
+            categories: [TuistCleanCategory.global(.manifests)],
+            remote: false,
+            path: nil
+        )
+    }
+
+    /// The directory has to survive the clean as an empty directory rather than disappear and come
+    /// back, because concurrent commands resolve these paths and write into them. The staging copy
+    /// the contents are moved to must not outlive the command either.
+    func test_run_with_category_leaves_an_empty_directory_and_no_staging_leftovers() async throws {
+        // Given
+        let rootDirectory = try temporaryPath()
+        let cachePaths = try await createFiles(["tuist/Manifests/manifest.json"])
+        let cacheDirectory = cachePaths[0].parentDirectory
+
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.manifests))
+            .willReturn(cacheDirectory)
+        given(rootDirectoryLocator)
+            .locate(from: .any)
+            .willReturn(rootDirectory)
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(nil)
+
+        // When
+        try await subject.run(
+            categories: [TuistCleanCategory.global(.manifests)],
+            remote: false,
+            path: nil
+        )
+
+        // Then
+        let exists = try await fileSystem.exists(cacheDirectory, isDirectory: true)
+        XCTAssertTrue(exists)
+        let contents = try await fileSystem.glob(directory: cacheDirectory, include: ["*"]).collect()
+        XCTAssertEqual(contents, [])
+        let siblings = try await fileSystem.glob(
+            directory: cacheDirectory.parentDirectory, include: ["*"]
+        ).collect()
+        XCTAssertEqual(siblings, [cacheDirectory])
+    }
+
     func test_run_with_dependencies_cleans_dependencies() async throws {
         // Given
         let rootDirectory = try temporaryPath()

--- a/cli/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -56,6 +56,7 @@ final class CleanServiceTests: TuistUnitTestCase {
             cleanProjectCacheService: cleanProjectCacheService,
             getCacheEndpointsService: getCacheEndpointsService,
             serverAuthenticationController: serverAuthenticationController,
+            cacheDirectoryLock: CacheDirectoryLock(cacheDirectory: try temporaryPath()),
             fileSystem: FileSystem()
         )
     }
@@ -74,7 +75,7 @@ final class CleanServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    private func makeSubject(configLoader: MockConfigLoading? = nil) -> CleanService {
+    private func makeSubject(configLoader: MockConfigLoading? = nil) throws -> CleanService {
         CleanService(
             rootDirectoryLocator: rootDirectoryLocator,
             cacheDirectoriesProvider: cacheDirectoriesProvider,
@@ -85,6 +86,7 @@ final class CleanServiceTests: TuistUnitTestCase {
             cleanProjectCacheService: cleanProjectCacheService,
             getCacheEndpointsService: getCacheEndpointsService,
             serverAuthenticationController: serverAuthenticationController,
+            cacheDirectoryLock: CacheDirectoryLock(cacheDirectory: try temporaryPath()),
             fileSystem: FileSystem()
         )
     }
@@ -295,7 +297,7 @@ final class CleanServiceTests: TuistUnitTestCase {
                     )
                 )
             )
-        let subject = makeSubject(configLoader: customConfigLoader)
+        let subject = try makeSubject(configLoader: customConfigLoader)
 
         // When
         try await subject.run(
@@ -392,7 +394,7 @@ final class CleanServiceTests: TuistUnitTestCase {
                 given(manifestFilesLocator)
                     .locatePackageManifest(at: .any)
                     .willReturn(nil)
-                let subject = makeSubject(configLoader: customConfigLoader)
+                let subject = try makeSubject(configLoader: customConfigLoader)
 
                 // When
                 try await subject.run(
@@ -460,7 +462,7 @@ final class CleanServiceTests: TuistUnitTestCase {
                 given(manifestFilesLocator)
                     .locatePackageManifest(at: .any)
                     .willReturn(nil)
-                let subject = makeSubject(configLoader: customConfigLoader)
+                let subject = try makeSubject(configLoader: customConfigLoader)
 
                 // When
                 try await subject.run(

--- a/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -306,12 +306,15 @@ class CachedManifestLoaderTests {
         })
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func throwing_writeErrors() async throws {
+    /// The manifest is already loaded by the time it is cached, so a cache that cannot be written
+    /// costs a re-load on the next run and nothing else. It must not fail a command that has
+    /// everything it needs, which is what a concurrent `tuist clean` removing the cache directory
+    /// out from under the write used to do.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func tolerates_writeErrors() async throws {
         // Given
-        let expectedError = TestError.writeFailed
         let fileSystem = MockFileSystem()
         fileSystem.writeTextOverride = { _, _, _ in
-            throw expectedError
+            throw TestError.writeFailed
         }
 
         subject = try createSubject(fileSystem: fileSystem)
@@ -320,10 +323,11 @@ class CachedManifestLoaderTests {
         let project = Project.test(name: "App")
         try await stubProject(project, at: path)
 
-        // When/Then
-        await #expect(throws: expectedError, performing: {
-            try await self.subject.loadProject(at: path, disableSandbox: false)
-        })
+        // When
+        let got = try await subject.loadProject(at: path, disableSandbox: false)
+
+        // Then
+        #expect(got.name == "App")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Relates to https://github.com/tuist/tuist/issues/12228

## What changed

`tuist clean` empties the global caches under `~/.cache/tuist`. Every Tuist process on the host shares those directories, and until now clean deleted each one where it stood, with nothing coordinating it against the commands using them. On a machine running several commands at once, which is what CI looks like when shard jobs each start with `tuist clean && tuist install`, that left the path missing for as long as a recursive delete of a warm cache takes. Commands running alongside resolved paths inside it and failed:

```
Path not found: ~/.cache/tuist/{Manifests,Plugins,Projects,GenerationMetadata}
Path not found: ~/.cache/tuist/Manifests/1.<hash>
Rename failed '…/Manifests/.1.<hash>.atomic.<rand>.tmp' → '…/Manifests/1.<hash>': No such file or directory (errno=2)
```

Three changes, in layers.

**Access to the shared caches is coordinated.** `CacheDirectoryLock` guards each category under the cache root with an advisory `flock`. Commands that use a cache take shared access and still run concurrently with each other; clean takes exclusive access, so it waits for them and they wait for it. It is held through an open descriptor, which the kernel closes when the process exits, so a command killed mid-run cannot wedge the next one. Lock files live in a `Locks` directory beside the categories rather than inside them: a lock file removed by the clean it coordinates would hand the next two processes separate files, each holding what it takes to be the same lock. Failing to take a lock logs and proceeds unguarded, because a cache that cannot be coordinated is still a cache, and an unwritable lock directory must not fail every command.

Clean takes it for every global category. The manifest cache, the generation metadata store, and the plugin fetch take it around the work that touches their directories.

**Clean moves aside instead of deleting in place.** `CleanService` moves a shared directory's contents to a uniquely named sibling, recreates the directory, and deletes the moved copy. This is what makes the lock affordable: the exclusive section is a single rename rather than a full recursive delete, so a clean does not stall every other command on the host for seconds.

A move that finds no source produces the outcome the command was asked for, whether the cache was never populated or another clean emptied it first, so it reports nothing cleaned rather than failing. That is the `Path not found` naming a cache directory. It is not clean racing an install, it is clean racing another clean: both `CleanService` and `FileSystem.remove` check existence before deleting, so a process can win its own check and still lose the delete. Routing the lost race and the never populated case through the same missing source branch removes the distinction rather than special casing it.

**Writing a manifest cache entry is best effort.** `CachedManifestLoader` already has the loaded manifest by the time it stores it, so an entry that cannot be written costs a reload on the next run. Failing there failed a command that had everything it needed. With the lock in place this is defence in depth rather than the primary fix, and it is what keeps a cache accessor that does not participate in the lock from turning into a failed build.

## Why this shape

Locking alone would have meant holding a directory for the length of a recursive delete, stalling every concurrent command. Moving aside alone left a window and left every accessor depending on that window staying small. Neither is sufficient on its own, and the combination is what makes each part cheap: the lock is correctness, the move keeps the exclusive section to one rename, and the tolerant write degrades gracefully for anything outside the lock.

Catching a typed error rather than re-checking existence after a failed move matters too. A re-check would race the recreate that follows a concurrent clean's move, so it would still fail intermittently. `FileSystemError.moveNotFound` says exactly what happened with no second look at the filesystem.

## Deliberately not locked

- The project description helpers builder already compiles into a staging sibling and publishes with an atomic rename, handling the lost race explicitly. That is better than a lock, because it never blocks.
- Result bundles under `Runs` and generated projects under `EditProjects` are written for as long as the command runs. A lock there would leave a clean waiting minutes, which is worse than the interleaving it prevents.

These calls also do not nest: each opens its own descriptor, so a second request for the same category from inside the first would wait on a lock the process already holds. That constraint is documented on the protocol.

## Impact

Concurrent Tuist commands on one host stop failing on cache directories they do not own. Most visible in CI that shards a build across jobs on one agent, where every job starts with a clean.

Two behaviour changes worth a reviewer's attention:

- A manifest cache write failure is now logged at debug level rather than raised. Deliberate, and why the existing `throwing_writeErrors` test became `tolerates_writeErrors`.
- A clean now waits for in-flight cache users rather than deleting underneath them, and a plugin clone holds the plugin cache for its duration. A clean concurrent with a slow plugin fetch will take longer than it used to.

`CleanService.run` moved its per-category work into a helper. That function was already over the body length limit before this branch and threading the lock through it made it longer; it is now under.

## Validation

Unit tests: 49 cases across `CacheDirectoryLockTests`, `CleanServiceTests`, `CachedManifestLoaderTests`, and `GenerationMetadataStoreTests`.

The two lock tests are the ones that carry weight. One has two tasks each enter shared access and refuse to leave until the other is also inside, which cannot complete unless shared access really is shared, and deadlocks if someone turns it exclusive. The other asserts that a task cannot get in while exclusive access is held, phrased so that a slow machine only makes the assertion more true.

End to end, using the reproduction harness attached to https://github.com/tuist/tuist/issues/12228, which runs 12 checkouts through `tuist clean && tuist install` in lockstep against shared caches. Same machine, same configuration:

| Build | Failures |
| --- | --- |
| 4.205.0-canary.10 | 6 in 720 installs (`Manifests/<hash>` x3, `Plugins` x2, `Projects` x1) |
| this branch, move aside only | 0 in 720 installs |
| this branch, with locking | 0 in 720 installs, and 0 in a further 360 on the final revision |

Note this is a different defect from the `no Package.swift in <repo root>` failure reported in the same issue, which https://github.com/tuist/tuist/pull/12345 already fixed. Measured on the same harness, that one reproduces on 4.203.4 in roughly one install in twelve and did not reproduce in about 2,600 installs after #12345. The cache races described here survived it, which is why the reproduction kept failing after the upgrade.

The two `CleanServiceTests` cases added here are regression guards rather than red first tests. The only observable difference between deleting in place and moving aside is under real concurrency, and a test that has to win a race to fail is flaky. What makes them meaningful is that the fix routes the lost race and the never populated case through the same branch, so exercising one exercises the other.

### How to test locally

Unit tests:

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination "platform=macOS,arch=arm64" -only-testing TuistCoreTests/CacheDirectoryLockTests -only-testing TuistKitTests/CleanServiceTests -only-testing TuistLoaderTests/CachedManifestLoaderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

The race itself needs concurrency. Copy any project that has a `Tuist/Package.swift` into a dozen sibling checkouts, then run this against a build of this branch and against a released binary:

```
for i in $(seq 1 12); do (cd checkout-$i && rm -rf Tuist/.build && tuist clean >log-$i 2>&1 && tuist install >>log-$i 2>&1) & done; wait; grep -L Success log-*
```

Released binaries print `Path not found` or `Rename failed` naming a path under `~/.cache/tuist` in a fraction of rounds. This branch should list no failing logs.
