### PR TITLE
feat(server): measure how long jobs sit stranded on a runner that never registered

### DIFF
--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -1334,7 +1334,8 @@ defmodule Tuist.Runners.Jobs do
       repository: j.repository,
       claimed_at: j.claimed_at,
       started_at: j.started_at,
-      pod_name: j.pod_name
+      pod_name: j.pod_name,
+      fleet_name: j.fleet_name
     })
     |> ClickHouseRepo.all()
   end
@@ -1372,6 +1373,7 @@ defmodule Tuist.Runners.Jobs do
         claimed_at: j.claimed_at,
         started_at: j.started_at,
         pod_name: j.pod_name,
+        fleet_name: j.fleet_name,
         status: j.status
       })
       |> ClickHouseRepo.one()

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -247,6 +247,25 @@ defmodule Tuist.Runners.PromExPlugin do
             measurement: :count,
             description: "Stale or orphaned rows recovered by the recovery workers, by kind.",
             tags: [:kind]
+          ),
+          # Only the orphan re-queue carries `stranded_ms`, so this fires
+          # for that recovery alone even though every worker shares the
+          # event — a measurement key absent from the event is skipped.
+          # This is the ONLY series that sees a job dispatched to a runner
+          # that never registered: the row is `running` for the whole
+          # stall, so `queue_length` and `queue_oldest_age_seconds` both
+          # read zero while the customer watches "waiting for a runner".
+          # Its `_count` doubles as the per-fleet strand rate, which is why
+          # the shared counter above is left untagged.
+          distribution(
+            @metric_prefix ++ [:recovery, :stranded, :time, :milliseconds],
+            event_name: Telemetry.event_name_recovery(),
+            measurement: :stranded_ms,
+            description:
+              "Time a workflow_job sat claimed by a runner that never registered with GitHub, until recovery re-queued it.",
+            reporter_options: [buckets: @long_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
           )
         ]
       )

--- a/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
@@ -209,24 +209,18 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     :ok
   end
 
-  defp recover_one(%{
-         workflow_job_id: workflow_job_id,
-         account_id: account_id,
-         repository: repository,
-         claimed_at: claimed_at,
-         pod_name: pod_name
-       }) do
+  defp recover_one(%{workflow_job_id: workflow_job_id, account_id: account_id, repository: repository} = orphan) do
     with {:ok, account} <- Accounts.get_account_by_id(account_id),
          {:ok, installation} <- VCS.get_github_app_installation_for_account(account.id) do
       case GitHubClient.get_workflow_job(installation, repository, workflow_job_id) do
         {:ok, %{status: gh_status, conclusion: conclusion}} ->
-          handle_gh_status(gh_status, conclusion, workflow_job_id, claimed_at, pod_name, account)
+          handle_gh_status(gh_status, conclusion, orphan, account)
 
         {:error, :not_found} ->
           # GH pruned the workflow_job (90-day retention by default).
           # The job can't be live; treat as completed so the PG cap
           # slot doesn't leak forever.
-          handle_gh_status("completed", "", workflow_job_id, claimed_at, pod_name, account)
+          handle_gh_status("completed", "", orphan, account)
 
         {:error, reason} ->
           Logger.warning("runners: orphan worker GH lookup failed; will retry next tick",
@@ -244,7 +238,7 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     end
   end
 
-  defp handle_gh_status("queued", _conclusion, workflow_job_id, claimed_at, pod_name, account) do
+  defp handle_gh_status("queued", _conclusion, %{workflow_job_id: workflow_job_id, pod_name: pod_name} = orphan, account) do
     # GitHub still has this job queued, so the runner minted for it never
     # took it. That does NOT mean the Pod holding the claim is idle: GitHub
     # assigns jobs to any label-eligible runner, so it may be busy executing
@@ -265,13 +259,18 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
 
       false
     else
-      requeue_orphan(workflow_job_id, claimed_at, pod_name, account)
+      requeue_orphan(orphan, account)
     end
   end
 
-  defp handle_gh_status("in_progress", _conclusion, _wfid, _claimed_at, _pod, _account), do: false
+  defp handle_gh_status("in_progress", _conclusion, _orphan, _account), do: false
 
-  defp handle_gh_status("completed", conclusion, workflow_job_id, _claimed_at, pod_name, account) do
+  defp handle_gh_status(
+         "completed",
+         conclusion,
+         %{workflow_job_id: workflow_job_id, pod_name: pod_name, fleet_name: fleet_name},
+         account
+       ) do
     # GH has a terminal status but we never saw the corresponding
     # `workflow_job.completed` webhook (or it was retry-exhausted
     # before reaching us). Without releasing here, the PG claim
@@ -296,13 +295,13 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     :telemetry.execute(
       Telemetry.event_name_recovery(),
       %{count: 1},
-      %{kind: "orphan_completed"}
+      %{kind: "orphan_completed", fleet: fleet_name}
     )
 
     true
   end
 
-  defp handle_gh_status(other, _conclusion, workflow_job_id, _claimed_at, _pod, _account) do
+  defp handle_gh_status(other, _conclusion, %{workflow_job_id: workflow_job_id}, _account) do
     # Unknown / future GH status. Log and skip; if it's actually
     # terminal we'll catch it on a later tick once GitHub-side
     # state settles or the 404 fallback above handles retention.
@@ -314,7 +313,16 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     false
   end
 
-  defp requeue_orphan(workflow_job_id, claimed_at, pod_name, account) do
+  defp requeue_orphan(
+         %{
+           workflow_job_id: workflow_job_id,
+           claimed_at: claimed_at,
+           started_at: started_at,
+           pod_name: pod_name,
+           fleet_name: fleet_name
+         },
+         account
+       ) do
     Logger.warning("runners: orphaned running row — GH still queued, recovering",
       workflow_job_id: workflow_job_id,
       account: account.name,
@@ -325,8 +333,8 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
          :ok <- safe_release(workflow_job_id, claimed_at) do
       :telemetry.execute(
         Telemetry.event_name_recovery(),
-        %{count: 1},
-        %{kind: "orphan_requeued"}
+        %{count: 1, stranded_ms: stranded_ms(started_at)},
+        %{kind: "orphan_requeued", fleet: fleet_name}
       )
 
       true
@@ -334,6 +342,18 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
       _ -> false
     end
   end
+
+  # The customer-visible stall: from the JIT mint that put the row in
+  # `running` to the moment we proved the runner never took the job. No
+  # queue series can express this — the row is `running` throughout, so
+  # queue depth and queue age both read zero while the customer watches
+  # "waiting for a runner". Clamped at 0 so skew between the minting pod's
+  # clock and this one cannot report a negative wait.
+  defp stranded_ms(%DateTime{} = started_at) do
+    DateTime.utc_now() |> DateTime.diff(started_at, :millisecond) |> max(0)
+  end
+
+  defp stranded_ms(_started_at), do: 0
 
   # CH first — see moduledoc. Treat a CH failure as "skip, retry
   # next tick" — the PG claim stays put so we re-see the row.

--- a/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
@@ -6,6 +6,7 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
   alias Tuist.GitHub.Client, as: GitHubClient
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
   alias Tuist.Runners.Workers.OrphanedRunnersWorker
 
   setup :verify_on_exit!
@@ -17,7 +18,8 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
       repository: Keyword.get(opts, :repository, "tuist/tuist"),
       claimed_at: Keyword.get(opts, :claimed_at, ~U[2026-05-16 21:14:06.616167Z]),
       started_at: Keyword.get(opts, :started_at, ~U[2026-05-16 21:14:07.711527Z]),
-      pod_name: Keyword.get(opts, :pod_name, "pod-1")
+      pod_name: Keyword.get(opts, :pod_name, "pod-1"),
+      fleet_name: Keyword.get(opts, :fleet_name, "tuist-tuist-runner-pool-macos-26-6")
     }
   end
 
@@ -58,6 +60,45 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
       end)
 
       assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "recovery telemetry carries the fleet and how long the job sat stranded" do
+      # A stranded job is invisible to every queue signal: its row is
+      # `running`, so queue depth and queue age both read zero while the
+      # customer watches "waiting for a runner". Recovery is the only
+      # point that knows, via the GitHub cross-check, that the wait was
+      # real — so it has to carry both which pool stranded and how long
+      # the customer actually waited.
+      account = account_fixture()
+
+      orphan =
+        candidate(
+          account_id: account.id,
+          fleet_name: "tuist-tuist-runner-pool-macos-26-6",
+          started_at: DateTime.add(DateTime.utc_now(), -90, :second)
+        )
+
+      expect(Jobs, :list_orphaned_running, fn _threshold -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn _id ->
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
+        {:ok, %{status: "queued", conclusion: nil, runner_name: nil}}
+      end)
+
+      expect(Jobs, :record_queued, fn _wfid -> :ok end)
+      expect(Claims, :release, fn _wfid, _handle -> :ok end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_recovery()])
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+
+      assert_receive {[:tuist, :runners, :recovery], ^ref, measurements, metadata}
+      assert metadata.kind == "orphan_requeued"
+      assert metadata.fleet == "tuist-tuist-runner-pool-macos-26-6"
+      assert_in_delta measurements.stranded_ms, 90_000, 5_000
     end
 
     test "leaves real running builds alone when GitHub reports in_progress" do


### PR DESCRIPTION
A customer reported a macOS job sitting on "Waiting for a runner to pick up this job" for ~90 seconds.

Dispatch was not the problem. The job was enqueued at 07:16:35 and dispatched 2.1 seconds later. The runner it was handed to took the JIT config and never registered with GitHub, so GitHub kept the job queued until recovery re-queued it and a second runner picked it up 88 seconds later.

That failure mode is invisible to every signal we have. From the moment the JIT is minted the `runner_jobs` row is `running`, so:

- `tuist_runners_queue_length` correctly reads zero for the whole stall (verified across all 10 server replicas, so it was not a poll-timing miss)
- `tuist_runners_queue_oldest_age_seconds` likewise reads zero, so the "Runner queue age" alert cannot fire
- `tuist_runners_pool_idle_replicas` correctly shows warm runners sitting idle, because the job genuinely is not in the queue for them to take

None of those are wrong. They are blind by construction. The only place that knows the wait was real is the recovery path, which cross-checks the GitHub-side status of the job. Until now it emitted a bare count with no fleet and no duration, so neither the rate nor the customer-visible latency could be measured or alerted on.

## What changed

`stranded_ms` (JIT mint to recovery) and the fleet are added to the orphan re-queue telemetry, exposed as a new distribution:

`tuist_runners_recovery_stranded_time_milliseconds{fleet}`

`fleet_name` is added to the two orphan-recovery selects in `Tuist.Runners.Jobs` so the worker can tag it, and `recover_one/1` now threads the orphan map through `handle_gh_status/4` instead of growing to eight positional arguments.

## Why this shape

**Why not a gauge.** `handle_in_progress` never writes to the ClickHouse row, so nothing in `runner_jobs` distinguishes a stranded `running` row from a genuine multi-hour build. That is precisely why `OrphanedRunnersWorker` has to ask the GitHub API. A polling gauge would need either a schema change plus a write on the dispatch hot path, or a repeat of that API call for every running job every 30 seconds. Riding the call recovery already makes costs zero extra queries and no schema change.

**Why not tag the existing counter.** Nine other call sites emit `Telemetry.event_name_recovery/0` with only `kind`. Adding a `fleet` tag to the shared `recovery_count` counter would degrade all of them. A measurement key absent from an event is skipped by `Telemetry.Metrics`, so keying the distribution on the new `stranded_ms` measurement makes it fire for the orphan re-queue alone. Its `_count` doubles as the per-fleet strand rate, which is why the shared counter is left untagged.

**Why `@long_duration_buckets`.** Its 300s and 900s edges separate the two recovery paths: the pod-stop fast path from [#12395](https://github.com/tuist/tuist/pull/12395) lands under 300s (88s in the reported incident) while the 300s cron sweep lands between 300s and 900s. So this metric also shows what [#12395](https://github.com/tuist/tuist/pull/12395) bought us.

## Impact and limits

This measures the stall; it does not fix it. Root cause of the non-registering runner is still open. Three hypotheses were tested and falsified while investigating: a controller reap race (the VMs ran 3 to 4 minutes and exited on their own, on different hosts, with no controller activity), a JIT label mismatch (every stranded job carries a correct `requested_dispatch_label`), and GitHub having cancelled or superseded the job (the `completed` webhook shows the third runner registered and ran it normally). The remaining untested lead is intermittent VM egress to github.com, the same family as [#12390](https://github.com/tuist/tuist/pull/12390).

Coverage caveat: this counts strands that reach recovery. A job whose runner dies, whose pod never stops, and which GitHub terminates before the 300s sweep would not be counted. Whether that population exists is unknown; this metric is what will tell us.

Observed rate while investigating, from the `GH still queued, recovering` log line: roughly 6 to 20 per 3 hours on Linux pools and 1 to 9 per 3 hours on macOS.

### How to test locally

```
cd server
mix test test/tuist/runners/workers/orphaned_runners_worker_test.exs
```

The added test asserts the fleet and the stranded duration reach the telemetry event. It fails before the change with `key :fleet not found in: %{kind: "orphan_requeued"}`.

Full validation run:

```
cd server
mix test test/tuist/runners/ test/tuist_web/controllers/runner_pods_controller_test.exs
mix credo lib/tuist/runners/workers/orphaned_runners_worker.ex lib/tuist/runners/jobs.ex lib/tuist/runners/prom_ex_plugin.ex
```

508 tests pass, credo reports no issues.

There is no Grafana alert on the new series yet. Worth adding once we have a few days of baseline to pick a threshold.
