### PR TITLE
fix(server): drop the status label from the Phoenix duration histogram

### DIFF
--- a/infra/grafana-dashboards/registry-service.json
+++ b/infra/grafana-dashboards/registry-service.json
@@ -2067,7 +2067,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "100 * (sum(rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", status_class=\"5xx\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
+                        "expr": "100 * (sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", status_class=\"5xx\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
                         "instant": true,
                         "queryType": "instant",
                         "range": false
@@ -2251,7 +2251,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version\", status_class=\"3xx\"}[$__range])) or vector(0)",
+                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version\", status_class=\"3xx\"}[$__range])) or vector(0)",
                         "instant": true,
                         "range": false
                       },
@@ -2332,7 +2332,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version/Package[.]swift\", status_class=\"2xx\"}[$__range])) or vector(0)",
+                        "expr": "sum(increase(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", method=\"GET\", path=~\"/(api/registry/)?swift/:scope/:name/:version/Package[.]swift\", status_class=\"2xx\"}[$__range])) or vector(0)",
                         "instant": true,
                         "range": false
                       },
@@ -2538,7 +2538,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum by (env, status_class) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_count{env=~\"$environment\", pod=~\"$pod\", status_class=~\"4xx|5xx\"}[$__rate_interval]))",
+                        "expr": "sum by (env, status_class) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", status_class=~\"4xx|5xx\"}[$__rate_interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true

--- a/tuist_common/lib/tuist_common/prom_ex_phoenix_plugin.ex
+++ b/tuist_common/lib/tuist_common/prom_ex_phoenix_plugin.ex
@@ -10,6 +10,13 @@ defmodule TuistCommon.PromExPhoenixPlugin do
   the same page under many prefixes multiplies every HTTP metric by that many.
   Pass `:normalize_path`, a 1-arity function, to rewrite the resolved route
   before it becomes a label and fold those variants back together.
+
+  The request duration histogram also drops the status label. Every label
+  combination it carries is multiplied by the bucket count, and a route keeps
+  minting combinations as it serves statuses it had not served before, so
+  status is the tag that makes the histogram grow the longest. Latency is read
+  per route rather than per status code, and `http_requests_total` still tags
+  on status for rates and error ratios.
   """
 
   use PromEx.Plugin
@@ -139,6 +146,8 @@ defmodule TuistCommon.PromExPhoenixPlugin do
         include_controller_action_tags
       )
 
+    duration_metrics_tags = http_metrics_tags -- [status_tag]
+
     duration_unit = Keyword.get(opts, :duration_unit, :millisecond)
     duration_unit_plural = Utils.make_plural_atom(duration_unit)
     normalize_path = Keyword.get(opts, :normalize_path, & &1)
@@ -158,7 +167,7 @@ defmodule TuistCommon.PromExPhoenixPlugin do
             buckets: [10, 100, 500, 1_000, 5_000, 10_000, 30_000]
           ],
           tag_values: conn_tags,
-          tags: http_metrics_tags,
+          tags: duration_metrics_tags,
           unit: {:native, duration_unit}
         ),
         distribution(

--- a/tuist_common/test/tuist_common/prom_ex_phoenix_plugin_test.exs
+++ b/tuist_common/test/tuist_common/prom_ex_phoenix_plugin_test.exs
@@ -60,11 +60,13 @@ defmodule TuistCommon.PromExPhoenixPluginTest do
           http_status_tag: :status_class
         )
 
-      assert Enum.all?(http_event.metrics, fn metric ->
-               :status_class in metric.tags and :status not in metric.tags
-             end)
+      [request_duration, response_size, requests_total] = http_event.metrics
 
-      [request_duration | _] = http_event.metrics
+      for metric <- [response_size, requests_total] do
+        assert :status_class in metric.tags and :status not in metric.tags
+      end
+
+      assert :status_class not in request_duration.tags
 
       conn =
         Plug.Test.conn(:get, "/articles")
@@ -74,6 +76,18 @@ defmodule TuistCommon.PromExPhoenixPluginTest do
 
       assert tag_values.status_class == "4xx"
       refute Map.has_key?(tag_values, :status)
+    end
+
+    test "keeps the status tag off the request duration histogram" do
+      http_event = phoenix_http_event(router: Router, endpoint: Endpoint)
+
+      [request_duration, _response_size, requests_total] = http_event.metrics
+
+      assert :status not in request_duration.tags
+      assert :path in request_duration.tags
+      assert :method in request_duration.tags
+
+      assert :status in requests_total.tags
     end
 
     test "can drop controller and action labels while keeping path" do


### PR DESCRIPTION
Grafana Cloud's "Anomaly: Metrics Usage" alert fired on 2026-08-18. Active series had stepped from a flat ~73k to ~98k on 2026-08-13 around 11:00 CEST and kept climbing, and `grafanacloud_org_metrics_billable_series` went from a stable ~78.4k to ~106.8k and still rising. That is roughly +28k series, about +$225/mo at list. Billing is p95 over the month, so it had already passed the percentile rather than being a transient.

### Root cause

The trigger was [#12302](https://github.com/tuist/tuist/pull/12302), which made `StripedPeep.scrape/1` non-destructive. The timing lines up exactly: merged 09:39, production around 11:00 to 12:00.

That change is correct and stays. The old `:ets.delete_all_objects` flush broke `rate/1` and `histogram_quantile/2`, and `PromEx.ETSCronFlusher` calls `scrape/1` on a timer and discards the result, so flushed data never reached the scraper at all.

Its side effect is that every label combination a pod has ever observed now stays in that pod's export for its whole lifetime, instead of only the combinations seen since the last scrape. Cardinality therefore climbs toward the full tag ceiling instead of sitting at the working set. The signature is a sawtooth that never plateaus: a monotonic ramp all day, reset only when a deploy restarts the pods. `count({job="tuist"})` went from a flat ~6.5k to ramping up to 34k, with the daily peak still growing (31.5k on Aug 13, 34.3k on Aug 17). Only frequent deploys were containing it.

The request duration histogram dominates: 16,592 series at peak against 1,109 before.

Worth noting two things this is *not*. It is not the usual unbounded-path bug, since `path` is already templated to 159 bounded routes. And it is not a memory leak: BEAM ETS total held its pre-change band of roughly 36 to 46MB, so there is nothing to chase on the server side. The cost is purely cardinality.

### Why this fix over the alternatives

Reverting #12302 would reintroduce the broken `rate/1` and `histogram_quantile/2` semantics, so the right move is to bound the tag set instead.

Status is the tag worth dropping. A route mints a new combination every time it first serves a status it had not served before, and each combination is multiplied by the bucket count. The `path x method` set, by contrast, is small and fixed, so it saturates within minutes. That is the real win here: not just a smaller number, but converting an all-day ramp into a flat line. Latency is read per route rather than per status code, and `http_requests_total` keeps status for rates and error ratios.

Measured against live data: `path x method` sits at 183 distinct combinations and is already effectively saturated, against 245 for `path x method x status` early in a ramp and 562 at yesterday's peak while still climbing. The histogram therefore goes from an unbounded ramp past 562 to a hard ceiling near 183, roughly 16.6k series down to about 5.4k at peak.

That closes the largest single contributor but not the whole +28k. The Oban job histograms (`tuist_oban_job_queue_time_milliseconds_bucket` and `tuist_oban_job_processing_duration_milliseconds_bucket`, 352 to 3,223 each) accumulate the same way and are the next lever if more is needed.

### Dashboard and alert impact

A Telemetry.Metrics `distribution` exports `_bucket`, `_sum` and `_count`, so dropping a tag from the histogram also drops it from `_count`. This plugin is shared with `cache/` and `registry/`. Four panels in `registry-service.json` filtered `..._duration_milliseconds_count` by `status_class` (5xx error rate, 2xx and 3xx counts, and the 4xx|5xx breakdown). Those now read `..._http_requests_total`, which still carries the tag.

Grafana Cloud alerts live in the UI rather than in this repo, so they were audited through the provisioning API. Four rules reference a `duration_milliseconds` metric and none filter on status: `HTTP request endpoint duration` and `HTTP request processing endpoints duration` filter on `path` only, and the two Oban job duration rules are untouched by this change. The one rule that does use status, `High Forbidden (403) Response Ratio - Production`, reads `tuist_prom_ex_phoenix_http_requests_total`, which keeps the tag. No alert breaks.

### How to test locally

```bash
cd tuist_common && mix test test/tuist_common/prom_ex_phoenix_plugin_test.exs
```

Tests were written failing first. They cover the histogram losing the tag and the counter keeping it, including under `http_status_tag: :status_class`.

Also run:

```bash
cd tuist_common && mix test && mix format --check-formatted && mix credo
```

The full suite reports one failure, `TuistCommon.GitHubTest "list_tags/3 works without a token"`. It is a pre-existing Mimic ownership flake, confirmed by reproducing it on a clean tree with these changes stashed, and it passes in isolation.

Every dashboard JSON was checked to still parse.

After deploy, the confirmation is that `count({job="tuist"})` stops ramping and sits flat instead of climbing toward 34k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
