### PR TITLE
fix(infra): advertise the fleet Tailscale tags on the drift-update path

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -854,6 +854,12 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			// carve-out values change lands on existing minis with
 			// the next operator-image roll instead of waiting for
 			// re-provisioning.
+			// The tags are load-bearing, not cosmetic: an OAuth-minted
+			// credential carries no default tag, so a push without them
+			// cannot join the tailnet at all. They also feed
+			// HostConfigHash, so omitting them here stamped hosts as
+			// converged to a hash whose tailscale script they never got.
+			TailscaleTags:         r.TailscaleTags,
 			TailscaleAcceptRoutes: r.TailscaleAcceptRoutes,
 			VMKuraEgressCIDR:      r.VMKuraEgressCIDR,
 			VMClusterDNSIP:        r.VMClusterDNSIP,

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -838,75 +838,10 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		// target on the update path — HostConfigHash strips it and nothing
 		// else reads it — so the fallback re-points it without changing
 		// what we push.
-		updateCfg := bootstrap.Config{
-			IP:                ip,
-			SSHUser:           bootstrapCreds.SSHUsername,
-			SSHPrivateKey:     sshKey,
-			NodeName:          machine.Name,
-			ProviderID:        providerIDOf(machine),
-			Kubeconfig:        kubeconfigYAML,
-			TartKubeletBinary: r.TartKubeletBinary,
-			TailscaleBinaries: r.TailscaleBinaries,
-			TailscaleAuthKey:  tailscaleAuthKey,
-			// Tailscale + firewall config rides the drift loop too —
-			// UpdateTartKubelet re-runs installTailscale and
-			// installVMEgressFirewall, so an accept-routes or
-			// carve-out values change lands on existing minis with
-			// the next operator-image roll instead of waiting for
-			// re-provisioning.
-			// The tags are load-bearing, not cosmetic: an OAuth-minted
-			// credential carries no default tag, so a push without them
-			// cannot join the tailnet at all. They also feed
-			// HostConfigHash, so omitting them here stamped hosts as
-			// converged to a hash whose tailscale script they never got.
-			TailscaleTags:         r.TailscaleTags,
-			TailscaleAcceptRoutes: r.TailscaleAcceptRoutes,
-			VMKuraEgressCIDR:      r.VMKuraEgressCIDR,
-			VMClusterDNSIP:        r.VMClusterDNSIP,
-			VMCachePNCIDR:         r.VMCachePNCIDR,
-			SSHIngressAllowCIDRs:  r.SSHIngressAllowCIDRs,
-			VMCachePNVLAN:         vmCachePNVLAN,
-			// node_exporter is re-installed on every drift-loop run,
-			// not just on first bootstrap, so a chart-driven binary
-			// bump (NODE_EXPORTER_VERSION ARG in the operator
-			// Dockerfile) lands on running minis the next time the
-			// tart-kubelet binary drifts. Forgetting this here made
-			// node_exporter silently skip on every drift update —
-			// installNodeExporter short-circuits when its binary is
-			// empty.
-			NodeExporterBinary: r.NodeExporterBinary,
-			// Same reason node_exporter rides this path: the agent and its push
-			// URL both come from the operator, so an image bump or a values
-			// change has to reach already-bootstrapped minis here or it never
-			// lands on the fleet at all.
-			LogShipperBinary: r.LogShipperBinary,
-			LogShipURL:       r.LogShipURL,
-			LogShipEnv:       r.LogShipEnv,
-			HostCPU:          hostCPUFor(machine, r.TartKubeletHostCPU),
-			HostMemoryMB:     hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
-			MaxPods:          r.TartKubeletMaxPods,
-			// Per-account cache volumes must ride the drift loop
-			// too: the volume flag + provisioning land on already-bootstrapped
-			// minis via UpdateTartKubelet, not first-boot Run. Omitting these
-			// left the plist without --runner-cache-root (tart-kubelet booted
-			// every VM cold) and skipped installRunnerCacheVolume, while the
-			// operator's canonical HostConfigHash still reflected the enabled
-			// config — so the roll looked applied but the feature was off.
-			RunnerCacheVolumeGiB:    r.RunnerCacheVolumeGiB,
-			CacheVolumeMasterCapGiB: r.CacheVolumeMasterCapGiB,
-			CacheVolumeCASGiB:       r.CacheVolumeCASGiB,
-			VNCRelayHost:            vncRelayHost,
-			VNCRelayPort:            vncRelayPort,
-			NodeLabels:              machineNodeLabels(machine),
-			// Builder hosts must keep `--disable-vm-gc` across binary
-			// rolls. This path re-renders the plist but doesn't re-resolve
-			// GHActionsRunner (which renderLaunchdPlist otherwise keys the
-			// flag off), so carry the builder signal explicitly — without
-			// it the roll strips the flag and the orphan-VM GC reaps the
-			// in-flight image-bake VM mid-`tart push`.
-			DisableVMGC:          machine.Spec.GHActionsRunner != nil,
-			KnownHostFingerprint: bootstrapCreds.HostFingerprint,
-		}
+		updateCfg := r.driftUpdateConfig(
+			machine, ip, bootstrapCreds, sshKey, kubeconfigYAML,
+			tailscaleAuthKey, vmCachePNVLAN, vncRelayHost, vncRelayPort,
+		)
 		fingerprint, err := bootstrap.UpdateTartKubelet(ctx, updateCfg)
 		// Tailnet fallback. A running runner mini filters inbound :22 on
 		// its public interface once Internet Sharing / vmnet reconfigures
@@ -1287,6 +1222,100 @@ func shouldClearTerminalFailure(
 		return true
 	}
 	return !now.Before(lastFailure.Time.Add(retryAfter))
+}
+
+// driftUpdateConfig assembles the Config the drift loop pushes to a host that
+// is already bootstrapped. Split out of reconcileNormal so a test can pin the
+// invariant that makes the drift loop honest: every fleet-wide field the
+// canonical HostConfigHash is computed over must be set here too. When one is
+// missing the operator still stamps the host as converged, so the host reports
+// a config it never received and the skew is invisible until something
+// downstream happens to need the dropped field. That has now happened four
+// times — node_exporter, the log shipper, the cache-volume flags, and the
+// Tailscale tags — which is why the invariant is asserted rather than reviewed.
+//
+// Only per-host fields may differ from the canonical config; HostConfigHash
+// zeroes exactly those, so the test compares the two hashes directly.
+func (r *ScalewayAppleSiliconMachineReconciler) driftUpdateConfig(
+	machine *infrav1.ScalewayAppleSiliconMachine,
+	ip string,
+	bootstrapCreds *credentials.MachineBootstrap,
+	sshKey []byte,
+	kubeconfigYAML string,
+	tailscaleAuthKey string,
+	vmCachePNVLAN uint32,
+	vncRelayHost string,
+	vncRelayPort int,
+) bootstrap.Config {
+	return bootstrap.Config{
+		IP:                ip,
+		SSHUser:           bootstrapCreds.SSHUsername,
+		SSHPrivateKey:     sshKey,
+		NodeName:          machine.Name,
+		ProviderID:        providerIDOf(machine),
+		Kubeconfig:        kubeconfigYAML,
+		TartKubeletBinary: r.TartKubeletBinary,
+		TailscaleBinaries: r.TailscaleBinaries,
+		TailscaleAuthKey:  tailscaleAuthKey,
+		// Tailscale + firewall config rides the drift loop too —
+		// UpdateTartKubelet re-runs installTailscale and
+		// installVMEgressFirewall, so an accept-routes or
+		// carve-out values change lands on existing minis with
+		// the next operator-image roll instead of waiting for
+		// re-provisioning.
+		// The tags are load-bearing, not cosmetic: an OAuth-minted
+		// credential carries no default tag, so a push without them
+		// cannot join the tailnet at all. They also feed
+		// HostConfigHash, so omitting them here stamped hosts as
+		// converged to a hash whose tailscale script they never got.
+		TailscaleTags:         r.TailscaleTags,
+		TailscaleAcceptRoutes: r.TailscaleAcceptRoutes,
+		VMKuraEgressCIDR:      r.VMKuraEgressCIDR,
+		VMClusterDNSIP:        r.VMClusterDNSIP,
+		VMCachePNCIDR:         r.VMCachePNCIDR,
+		SSHIngressAllowCIDRs:  r.SSHIngressAllowCIDRs,
+		VMCachePNVLAN:         vmCachePNVLAN,
+		// node_exporter is re-installed on every drift-loop run,
+		// not just on first bootstrap, so a chart-driven binary
+		// bump (NODE_EXPORTER_VERSION ARG in the operator
+		// Dockerfile) lands on running minis the next time the
+		// tart-kubelet binary drifts. Forgetting this here made
+		// node_exporter silently skip on every drift update —
+		// installNodeExporter short-circuits when its binary is
+		// empty.
+		NodeExporterBinary: r.NodeExporterBinary,
+		// Same reason node_exporter rides this path: the agent and its push
+		// URL both come from the operator, so an image bump or a values
+		// change has to reach already-bootstrapped minis here or it never
+		// lands on the fleet at all.
+		LogShipperBinary: r.LogShipperBinary,
+		LogShipURL:       r.LogShipURL,
+		LogShipEnv:       r.LogShipEnv,
+		HostCPU:          hostCPUFor(machine, r.TartKubeletHostCPU),
+		HostMemoryMB:     hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
+		MaxPods:          r.TartKubeletMaxPods,
+		// Per-account cache volumes must ride the drift loop
+		// too: the volume flag + provisioning land on already-bootstrapped
+		// minis via UpdateTartKubelet, not first-boot Run. Omitting these
+		// left the plist without --runner-cache-root (tart-kubelet booted
+		// every VM cold) and skipped installRunnerCacheVolume, while the
+		// operator's canonical HostConfigHash still reflected the enabled
+		// config — so the roll looked applied but the feature was off.
+		RunnerCacheVolumeGiB:    r.RunnerCacheVolumeGiB,
+		CacheVolumeMasterCapGiB: r.CacheVolumeMasterCapGiB,
+		CacheVolumeCASGiB:       r.CacheVolumeCASGiB,
+		VNCRelayHost:            vncRelayHost,
+		VNCRelayPort:            vncRelayPort,
+		NodeLabels:              machineNodeLabels(machine),
+		// Builder hosts must keep `--disable-vm-gc` across binary
+		// rolls. This path re-renders the plist but doesn't re-resolve
+		// GHActionsRunner (which renderLaunchdPlist otherwise keys the
+		// flag off), so carry the builder signal explicitly — without
+		// it the roll strips the flag and the orphan-VM GC reaps the
+		// in-flight image-bake VM mid-`tart push`.
+		DisableVMGC:          machine.Spec.GHActionsRunner != nil,
+		KnownHostFingerprint: bootstrapCreds.HostFingerprint,
+	}
 }
 
 // recordUpdateFailure increments the drift-loop retry counter and,

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
@@ -27,6 +28,7 @@ import (
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/scaleway"
+	bootstrap "github.com/tuist/tuist/infra/macos-host-bootstrap"
 )
 
 // recordUpdateFailure is the safety primitive that bounds the
@@ -1394,5 +1396,92 @@ func TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers(t *testing.T) {
 	if len(stub.rebootCalls) != 0 || len(stub.releaseCalls) != 0 {
 		t.Fatalf("zero thresholds must skip both tiers; got reboots=%+v releases=%+v",
 			stub.rebootCalls, stub.releaseCalls)
+	}
+}
+
+// The drift loop is only honest if what it pushes is what the operator hashed.
+// HostConfigHash is a fleet-wide fingerprint the reconciler stamps on a Machine
+// to mean "this host has the current config"; it is computed in cmd/manager
+// from operator-image + fleet-config inputs, with every per-host field left
+// zero. HostConfigHash zeroes exactly that same set, so a drift config that
+// carries all the fleet-wide fields must hash identically to the canonical one.
+//
+// A field dropped from driftUpdateConfig therefore shows up here as a hash
+// mismatch, which is the failure the fleet cannot otherwise see: the host is
+// marked converged while the dropped field never reached it. node_exporter, the
+// log shipper, the cache-volume flags and the Tailscale tags were each lost this
+// way, the last one freezing the whole production fleet once the credential
+// swap to a Tailscale OAuth client made an untagged join impossible.
+//
+// Every fleet-wide field is set to a distinctive non-zero value, so a field
+// that goes missing can't coincidentally match the canonical config's zero.
+func TestDriftUpdateConfig_HashesEqualToCanonicalFleetConfig(t *testing.T) {
+	fleet := bootstrap.Config{
+		TartKubeletBinary:       []byte("tart-kubelet-binary"),
+		TailscaleBinaries:       []byte("tailscale-binaries"),
+		NodeExporterBinary:      []byte("node-exporter-binary"),
+		LogShipperBinary:        []byte("log-shipper-binary"),
+		LogShipURL:              "http://alloy.example.ts.net:3100/loki/api/v1/push",
+		LogShipEnv:              "production",
+		TailscaleTags:           []string{"tag:tuist-macmini-production"},
+		TailscaleAcceptRoutes:   true,
+		VMKuraEgressCIDR:        "10.128.0.0/12",
+		VMClusterDNSIP:          "10.96.0.10",
+		VMCachePNCIDR:           "172.16.0.0/22",
+		SSHIngressAllowCIDRs:    []string{"116.202.0.10/32"},
+		HostCPU:                 8,
+		HostMemoryMB:            14336,
+		MaxPods:                 3,
+		RunnerCacheVolumeGiB:    80,
+		CacheVolumeMasterCapGiB: 20,
+		CacheVolumeCASGiB:       11,
+		VNCRelayPort:            DashboardVNCRelayPort,
+	}
+
+	r := &ScalewayAppleSiliconMachineReconciler{
+		TartKubeletBinary:       fleet.TartKubeletBinary,
+		TailscaleBinaries:       fleet.TailscaleBinaries,
+		NodeExporterBinary:      fleet.NodeExporterBinary,
+		LogShipperBinary:        fleet.LogShipperBinary,
+		LogShipURL:              fleet.LogShipURL,
+		LogShipEnv:              fleet.LogShipEnv,
+		TailscaleTags:           fleet.TailscaleTags,
+		TailscaleAcceptRoutes:   fleet.TailscaleAcceptRoutes,
+		VMKuraEgressCIDR:        fleet.VMKuraEgressCIDR,
+		VMClusterDNSIP:          fleet.VMClusterDNSIP,
+		VMCachePNCIDR:           fleet.VMCachePNCIDR,
+		SSHIngressAllowCIDRs:    fleet.SSHIngressAllowCIDRs,
+		TartKubeletHostCPU:      fleet.HostCPU,
+		TartKubeletHostMemoryMB: fleet.HostMemoryMB,
+		TartKubeletMaxPods:      fleet.MaxPods,
+		RunnerCacheVolumeGiB:    fleet.RunnerCacheVolumeGiB,
+		CacheVolumeMasterCapGiB: fleet.CacheVolumeMasterCapGiB,
+		CacheVolumeCASGiB:       fleet.CacheVolumeCASGiB,
+	}
+
+	// Per-host values, all distinct from the canonical config's zeroes. If
+	// HostConfigHash ever stops neutralizing one of these the hashes diverge
+	// here too, which is equally worth catching: it would make a fleet-wide
+	// fingerprint differ per host and every drift check fire forever.
+	machine := &infrav1.ScalewayAppleSiliconMachine{}
+	machine.Name = "tuist-tuist-runners-fleet-mndbc-2t7nk"
+	machine.Spec.ProviderID = ptr.To("scw-applesilicon://fr-par-1/c0b4b946")
+
+	got := r.driftUpdateConfig(
+		machine,
+		"51.15.1.1",
+		&credentials.MachineBootstrap{SSHUsername: "m1", HostFingerprint: "SHA256:abc"},
+		[]byte("ssh-private-key"),
+		"apiVersion: v1\nkind: Config\n",
+		"tskey-client-secret",
+		42,
+		"vnc-relay.example",
+		DashboardVNCRelayPort,
+	)
+
+	if want, have := bootstrap.HostConfigHash(fleet), bootstrap.HostConfigHash(got); want != have {
+		t.Fatalf("driftUpdateConfig hash = %s, canonical fleet hash = %s\n"+
+			"a fleet-wide field is missing from driftUpdateConfig (or newly per-host in HostConfigHash); "+
+			"hosts would be stamped converged to a config they never received", have, want)
 	}
 }


### PR DESCRIPTION
## What changed

Two commits:

1. The drift-update path now passes the fleet's Tailscale tags to the host.
2. `driftUpdateConfig` is extracted out of `reconcileNormal` and pinned by a test asserting it hashes identically to the canonical fleet config.

## Why

As of 04:22 UTC on 2026-08-18, 11 of 13 production Mac minis were terminal `Failed` with `TartKubeletUpdateExceededRetries`. That failure reason normally means the SSH accept path is wedged, but the message said otherwise:

```
tart-kubelet update: install tailscale: tailscale credential is an OAuth client
secret but TailscaleTags is empty; OAuth-minted keys must be tagged at join time
```

## Root cause

`updateCfg` in the drift branch of `reconcileNormal` never set `TailscaleTags`. Both of the other two places that build this config do: the first-boot `bootstrap.Run` call, and the canonical `HostConfigHash` in `cmd/manager`.

`renderTailscaleScript` feeds `HostConfigHash`, so this was already wrong before it started failing. The drift loop pushed a `tailscale up` with no `--advertise-tags` at all, while stamping each host as converged to a hash computed with them. `bootstrap_test.go` already asserts those two configs hash differently, so the skew was provable the whole time; nothing was comparing them.

A legacy `tskey-auth-` pre-auth key hid it, because such a key carries its own tag binding and joins fine untagged. An OAuth client secret does not: the key it mints is always tagged and has no default to fall back on, so the tag must be named at join time. When the production credential was swapped to an OAuth client secret (ExternalSecret transition 04:19:51Z, first operator error 04:22:03Z), `validateTailscaleCredential` correctly refused every drift update and the fleet burned its retry budget into terminal state.

The guard was working as designed. It turned what would otherwise have been a 60s join timeout reading as a network fault into an exact error on `status.failureMessage`. The defect is the omitted field.

## Why the second commit

This is the fourth field lost from this literal — `node_exporter`, the log shipper, and the cache-volume flags each preceded it, and the literal already carries comments about all three. The failure mode is silent by construction: the host is marked converged either way, so a dropped field is invisible until something downstream needs it. Here that took months and a credential swap, by which point it froze the fleet.

`HostConfigHash` zeroes exactly the per-host fields, which makes the invariant mechanical: the drift config and the canonical fleet config must hash identically. Asserting it turns the next omission into a test failure instead of an incident. Extracting `driftUpdateConfig` is what lets the config be built without running a reconcile.

## Impact

Drift-freeze rather than an outage. All 13 nodes stayed `Ready` and kept serving CI. The cost was that no host config could land, including the drift-path reboot escalation from #12391 and the sshguard VM-egress fix. The fleet sat at `hostConfigHash=ed42c2c9` against a desired `a27ef5b4`.

Canary and staging showed no `failureReason` the same day, so they are still on pre-auth keys. They would fail identically the moment their credentials are swapped, so this wants to land before those envs migrate.

## Recovery

No `kubectl patch` needed, contrary to the alert's runbook annotation. `shouldClearTerminalFailure` re-arms a terminal machine once `--tartkubelet-terminal-retry-after` (default 30m) elapses since `Status.LastUpdateFailureTime`, which is visible live as `lastUpdateFailureTime` marching forward. Deploying this operator lets the fleet self-heal within one cooldown. Recovery rides the cooldown rather than the hash-drift exit, since the canonical hash is unchanged by this fix (it always included the tags).

`builders-fleet-rg4h9-kgp8s` is the exception: it carries the older `:22` i/o-timeout wedge and a weeks-stale `hostConfigHash=d7ad2050`, so it needs the separate recovery path.

## Validation

- `go build ./...`, `go vet ./...`, and `go test ./...` pass across the provider; `macos-host-bootstrap` passes too.
- The new assertion is load-bearing, not decorative: removing `TailscaleTags`, `NodeExporterBinary` or `CacheVolumeCASGiB` from `driftUpdateConfig` each turns it red. Both suites passed before this change, which is precisely the gap.
- ACL side checked: `tag:tuist-macmini-production` is present in `tagOwners` in `infra/tailscale/acls.json`, and the host script already appends `?ephemeral=true&preauthorized=true` for a `tskey-client-` credential, so the join has what it needs once the tag is advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
