### PR TITLE
fix(kura): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
### Purpose

`cargo audit` currently fails on **every** kura build, main included, not just on open PRs. The advisory database now carries [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258): `h2` 0.4.13 is vulnerable to unbounded empty DATA frames, where a peer can send an endless stream of empty DATA frames and drive CPU and memory consumption without ever advancing the connection. Fixed in 0.4.16.

This is a lockfile-only bump. Nothing in kura changes behaviourally.

### Why the diff is two lines

`h2` is a transitive dependency (via the hyper/tonic stack), and its own dependency list is identical between 0.4.13 and 0.4.16, so only the version and checksum need to move.

Letting cargo resolve the bump instead (`cargo update -p h2`, with or without `--precise`) also rewrote seven unrelated `windows-sys` entries down to older versions. That is resolver churn this fix does not need, it is irrelevant to a service that ships on Linux and macOS, and it would likely ping-pong with the dependency bot. So the two lines that matter are edited directly.

`cargo metadata --locked` accepts the result, which is cargo confirming the lockfile is self-consistent and that it wants no re-resolve.

### Impact

Unblocks the `Audit` job for kura across the repository. Picked up automatically by Bazel, since rules_rs resolves the crate graph from `Cargo.toml` and `Cargo.lock` on each build.

Note that `cargo audit` also reports five pre-existing **allowed warnings** (`paste` and `rustls-pemfile` unmaintained, `anyhow` and `memmap2` unsoundness, `spin` yanked). Those are warnings rather than vulnerabilities and do not fail the job. They are untouched here, and `memmap2` in particular is worth a separate look given kura maps segment files directly.

### How to test locally

From `kura/`:

```bash
cargo audit
```

It should report the five allowed warnings and no vulnerabilities.

### Validation run

- `cargo metadata --locked`: accepted, so no re-resolve is pending.
- `cargo build --all-targets`: clean.
- `cargo test --lib`: 725 passed, 0 failed, 1 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
