### PR TITLE
fix(cli): stop failing setup on launchd's ambiguous bootstrap refusal

### DIFF
--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -154,13 +154,12 @@ public struct LaunchAgentService: LaunchAgentServicing {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: bootoutTimeout)
 
-        while await isLoadedIgnoringFailures(label: label) {
-            if clock.now >= deadline || Task.isCancelled {
-                Logger.current.debug("\(label) is still loaded after booting it out. Continuing.")
-                return
-            }
+        while clock.now < deadline, !Task.isCancelled {
+            if await !isLoadedIgnoringFailures(label: label) { return }
             try? await Task.sleep(for: .milliseconds(100))
         }
+
+        Logger.current.debug("\(label) is still loaded after booting it out. Continuing.")
     }
 
     private func isLoadedIgnoringFailures(label: String) async -> Bool {

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -40,13 +40,16 @@ public protocol LaunchAgentServicing {
 public struct LaunchAgentService: LaunchAgentServicing {
     private let fileSystem: FileSysteming
     private let launchctlController: LaunchctlControlling
+    private let bootoutTimeout: Duration
 
     public init(
         fileSystem: FileSysteming = FileSystem(),
-        launchctlController: LaunchctlControlling = LaunchctlController()
+        launchctlController: LaunchctlControlling = LaunchctlController(),
+        bootoutTimeout: Duration = .seconds(3)
     ) {
         self.fileSystem = fileSystem
         self.launchctlController = launchctlController
+        self.bootoutTimeout = bootoutTimeout
     }
 
     public func setupLaunchAgent(
@@ -69,6 +72,7 @@ public struct LaunchAgentService: LaunchAgentServicing {
         if try await launchctlController.isLoaded(label: label) {
             Logger.current.debug("Existing LaunchAgent found. Booting out...")
             try await launchctlController.bootout(label: label)
+            await waitUntilBootedOut(label: label)
         }
 
         if try await fileSystem.exists(plistPath) {
@@ -101,6 +105,22 @@ public struct LaunchAgentService: LaunchAgentServicing {
             try await launchctlController.bootstrap(plistPath: plistPath)
             Logger.current.debug("Bootstrapped LaunchAgent")
         } catch let commandError as CommandError {
+            // `5` is launchd's catch-all, covering both a label that is already
+            // bootstrapped and a plist it cannot load at all, so the code alone
+            // cannot decide. Ask the domain instead: the label being there means
+            // the bootstrap was redundant and setup has what it wanted.
+            //
+            // Deliberately narrower than the blanket tolerance this replaces
+            // (removed in #12014), which reported success for an agent that had
+            // genuinely failed to load. Do not widen it back to every `5`.
+            if case .terminated(5, _, _) = commandError,
+               await isLoadedIgnoringFailures(label: label)
+            {
+                Logger.current.debug(
+                    "launchctl refused to bootstrap \(label), which is already loaded: \(commandError)"
+                )
+                return
+            }
             var message = String(describing: commandError)
             if let stderrContent = try? await fileSystem.readTextFile(at: stderrLogPath),
                !stderrContent.isEmpty
@@ -119,6 +139,32 @@ public struct LaunchAgentService: LaunchAgentServicing {
         }
 
         Logger.current.debug("LaunchAgent configured and loaded successfully")
+    }
+
+    /// `bootout` returns once launchd has accepted the removal, not once the job
+    /// has left the domain, so a bootstrap issued straight after can still land
+    /// on the outgoing label. Waiting also stops a caller's readiness check from
+    /// passing against the previous daemon, which would report success for a
+    /// configuration that never took effect.
+    ///
+    /// Gives up rather than throwing: a label that outlives the wait leaves the
+    /// bootstrap facing the same ambiguity it already resolves against the
+    /// domain.
+    private func waitUntilBootedOut(label: String) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: bootoutTimeout)
+
+        while await isLoadedIgnoringFailures(label: label) {
+            if clock.now >= deadline || Task.isCancelled {
+                Logger.current.debug("\(label) is still loaded after booting it out. Continuing.")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+    }
+
+    private func isLoadedIgnoringFailures(label: String) async -> Bool {
+        (try? await launchctlController.isLoaded(label: label)) ?? false
     }
 
     public func restartLaunchAgent(label: String) async throws {

--- a/cli/Sources/TuistLaunchctl/LaunchctlController.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchctlController.swift
@@ -78,10 +78,24 @@ public struct LaunchctlController: LaunchctlControlling {
             .awaitCompletion()
             return true
         } catch let error as CommandError {
-            if case .terminated = error {
-                return false
-            }
-            throw error
+            guard case let .terminated(code, stderr, _) = error else { throw error }
+            guard Self.describesAMissingService(code: code, stderr: stderr) else { throw error }
+            return false
         }
+    }
+
+    /// `launchctl print` exits non-zero both for a service that is not there and
+    /// for every other failure, so only the missing-service termination may be
+    /// read as "not loaded". Reading the rest that way reports a loaded agent as
+    /// absent, which skips the bootout and leaves the bootstrap after it landing
+    /// on a live label.
+    ///
+    /// Matched on the code and the wording together because neither is a
+    /// contract: launchctl's status for a missing service is not stable across
+    /// macOS versions, and a reworded message under a known code still has to
+    /// resolve.
+    private static func describesAMissingService(code: Int32, stderr: String) -> Bool {
+        code == 113 || code == ESRCH
+            || stderr.lowercased().contains("could not find service")
     }
 }

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -545,12 +545,13 @@ struct LaunchAgentServiceTests {
         let subject = LaunchAgentService(
             fileSystem: fileSystem,
             launchctlController: launchctlController,
-            bootoutTimeout: .zero
+            bootoutTimeout: .milliseconds(250)
         )
         launchctlController.reset()
+        let answers = AnswerSequence(answers: [true])
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .willProduce { _ in answers.next() }
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
             .willReturn()
@@ -564,6 +565,7 @@ struct LaunchAgentServiceTests {
             programArguments: ["test-start"]
         )
 
+        #expect(answers.consumed > 1, "the wait must poll rather than give up on the pre-bootout answer")
         verify(launchctlController)
             .bootstrap(plistPath: .any)
             .called(1)

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -12,6 +12,30 @@ import TuistTesting
 
 @testable import TuistLaunchctl
 
+/// Hands out one answer per call so a test can drive a poll to completion. The
+/// last answer repeats, so an over-eager poll fails on `consumed` rather than
+/// running off the end.
+private final class AnswerSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private let answers: [Bool]
+    private var index = 0
+
+    init(answers: [Bool]) {
+        self.answers = answers
+    }
+
+    var consumed: Int {
+        lock.withLock { index }
+    }
+
+    func next() -> Bool {
+        lock.withLock {
+            defer { index += 1 }
+            return answers[min(index, answers.count - 1)]
+        }
+    }
+}
+
 struct LaunchAgentServiceTests {
     private let subject: LaunchAgentService
     private let fileSystem = FileSystem()
@@ -20,7 +44,8 @@ struct LaunchAgentServiceTests {
     init() {
         subject = LaunchAgentService(
             fileSystem: fileSystem,
-            launchctlController: launchctlController
+            launchctlController: launchctlController,
+            bootoutTimeout: .milliseconds(500)
         )
         given(launchctlController)
             .isLoaded(label: .any)
@@ -428,6 +453,120 @@ struct LaunchAgentServiceTests {
         )
         let plistContent = try await fileSystem.readTextFile(at: expectedPlistPath)
         #expect(plistContent.contains(currentMisePath.pathString.replacingOccurrences(of: "/private", with: "")))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_succeedsWhenBootstrapIsRefusedAndTheLabelIsInTheDomain() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        launchctlController.reset()
+        let answers = AnswerSequence(answers: [false, true])
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willProduce { _ in answers.next() }
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willThrow(
+                CommandError.terminated(
+                    5,
+                    stderr: "Bootstrap failed: 5: Input/output error",
+                    command: ["/bin/launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/tuist.test.plist"]
+                )
+            )
+
+        try await subject.setupLaunchAgent(
+            label: "tuist.test",
+            plistFileName: "tuist.test.plist",
+            programArguments: ["test-start"]
+        )
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_throwsWhenBootstrapIsRefusedAndTheLabelIsAbsent() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        let bootstrapError = CommandError.terminated(
+            5,
+            stderr: "Bootstrap failed: 5: Input/output error",
+            command: ["/bin/launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/tuist.test.plist"]
+        )
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willThrow(bootstrapError)
+
+        await #expect(
+            throws: LaunchAgentServiceError
+                .failedToLoadLaunchAgent(String(describing: bootstrapError))
+        ) {
+            try await subject.setupLaunchAgent(
+                label: "tuist.test",
+                plistFileName: "tuist.test.plist",
+                programArguments: ["test-start"]
+            )
+        }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_bootstrapsOnlyOnceTheBootedOutAgentHasLeftTheDomain() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        launchctlController.reset()
+        let answers = AnswerSequence(answers: [true, true, false])
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willProduce { _ in answers.next() }
+        given(launchctlController)
+            .bootout(label: .value("tuist.test"))
+            .willReturn()
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willReturn()
+
+        try await subject.setupLaunchAgent(
+            label: "tuist.test",
+            plistFileName: "tuist.test.plist",
+            programArguments: ["test-start"]
+        )
+
+        #expect(answers.consumed == 3)
+        verify(launchctlController)
+            .bootstrap(plistPath: .any)
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_bootstrapsAnywayWhenTheBootedOutAgentNeverLeavesTheDomain() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        let subject = LaunchAgentService(
+            fileSystem: fileSystem,
+            launchctlController: launchctlController,
+            bootoutTimeout: .zero
+        )
+        launchctlController.reset()
+        given(launchctlController)
+            .isLoaded(label: .value("tuist.test"))
+            .willReturn(true)
+        given(launchctlController)
+            .bootout(label: .value("tuist.test"))
+            .willReturn()
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willReturn()
+
+        try await subject.setupLaunchAgent(
+            label: "tuist.test",
+            plistFileName: "tuist.test.plist",
+            programArguments: ["test-start"]
+        )
+
+        verify(launchctlController)
+            .bootstrap(plistPath: .any)
+            .called(1)
     }
 
     @Test func restartLaunchAgent_kickstartsLoadedAgent() async throws {

--- a/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
@@ -172,6 +172,53 @@ struct LaunchctlControllerTests {
         #expect(isLoaded == false)
     }
 
+    @Test func isLoaded_returnsFalseWhenLaunchctlPrintCannotFindTheServiceUnderAnotherCode() async throws {
+        // Given
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.finish(throwing: CommandError.terminated(
+                    3,
+                    stderr: "Could not find service \"tuist.cache.org_project\" in domain for port",
+                    command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
+                ))
+            })
+
+        // When
+        let isLoaded = try await subject.isLoaded(label: label)
+
+        // Then
+        #expect(isLoaded == false)
+    }
+
+    @Test func isLoaded_propagatesTerminationsThatAreNotAMissingService() async throws {
+        // Given
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.finish(throwing: CommandError.terminated(
+                    1,
+                    stderr: "Bootstrap failed: 5: Input/output error",
+                    command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
+                ))
+            })
+
+        // When / Then
+        await #expect(throws: CommandError.self) {
+            _ = try await subject.isLoaded(label: label)
+        }
+    }
+
     @Test func isLoaded_propagatesNonTerminatedErrors() async throws {
         // Given
         let label = "tuist.cache.org_project"


### PR DESCRIPTION
`tuist setup cache` aborts on CI with:

```
The command '/bin/launchctl bootstrap gui/501 ~/Library/LaunchAgents/tuist.cache.<account>_<project>.plist' terminated with the code 5:
Bootstrap failed: 5: Input/output error
```

Found while investigating an unrelated customer report. One account hit it **217 times between 2026-08-11 and 2026-08-18**, on every CI job, starting the day they upgraded 4.202.6 → 4.203.4.

### Root cause

A regression from #12014, which deleted the branch that recognised exit `5`:

```swift
case .terminated(5, _, _):
    Logger.current.debug("LaunchAgent already bootstrapped by launchd, skipping explicit bootstrap")
```

Every `CommandError` from `bootstrap` became fatal. The bootstrap was very likely returning `5` before that commit too; it was simply tolerated. `git log 4.203.4..HEAD -- cli/Sources/TuistLaunchctl/` is empty, so `main` still has the bug.

### Why not just restore the old branch

`5` is launchd's catch-all. It covers a label that is **already bootstrapped** (benign) and a plist that **cannot be loaded at all** (fatal), so the exit code alone cannot tell them apart. Restoring the blanket tolerance would reintroduce exactly what #12014 set out to fix: reporting success for an agent that never loaded.

So on `5`, ask the domain instead. The label being present means the bootstrap was redundant and setup has what it wanted; the label being absent means the `5` was real and the original error is thrown as today.

I first considered deferring the verdict to `ensureCacheDaemonIsListening`, the socket check #12014 added. That does not hold for every caller: `SetupInsightsCommandService` also calls `setupLaunchAgent` and has no readiness check, so it would have started reporting success for a metrics agent that failed to load. Resolving the ambiguity inside `LaunchAgentService` works for all callers and still composes with the socket check on the cache path.

### Also in this PR, since both can produce the spurious `5`

- **`isLoaded` read every non-zero `launchctl print` exit as "not loaded"** (`LaunchctlController`). A transient failure therefore skipped the bootout and left the following bootstrap landing on a live label. Only a missing-service termination may be read that way now, matched on code (`113` or `ESRCH`) **and** wording, since neither is stable across macOS versions. Everything else propagates.
- **`bootout` returns once launchd accepts the removal, not once the job leaves the domain.** A bootstrap issued straight after can still hit the outgoing label, which is the shape of back-to-back jobs on a reused runner. Setup now waits for the label to go, bounded by an injectable `bootoutTimeout` (3s default), and gives up rather than throwing. The wait also stops a caller's readiness check from passing against the *previous* daemon, which would report success for a configuration that never took effect.

### Impact

CI jobs that run `tuist setup cache` on a reused macOS runner stop failing on a redundant bootstrap. A genuinely unloadable plist still fails, with the same error as today.

### How to test locally

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistLaunchctlTests \
  -only-testing TuistKitTests/SetupCacheCommandServiceTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

48 tests pass. Six are new and were confirmed red before the implementation landed:

- `setupLaunchAgent_succeedsWhenBootstrapIsRefusedAndTheLabelIsInTheDomain`
- `setupLaunchAgent_throwsWhenBootstrapIsRefusedAndTheLabelIsAbsent`
- `setupLaunchAgent_bootstrapsOnlyOnceTheBootedOutAgentHasLeftTheDomain`
- `setupLaunchAgent_bootstrapsAnywayWhenTheBootedOutAgentNeverLeavesTheDomain`
- `isLoaded_returnsFalseWhenLaunchctlPrintCannotFindTheServiceUnderAnotherCode`
- `isLoaded_propagatesTerminationsThatAreNotAMissingService`

Note for anyone adding tests here: the suite's `init` registers an `.any` stub for `isLoaded`, which wins over a per-test override unless you call `launchctlController.reset()` first.

### Reviewer notes

- Not backported. The affected account is pinned to 4.203.4, so reaching them needs a separate 4.203.x backport decision.
- The tolerance is deliberately narrower than the pre-#12014 behaviour. The comment at the call site says so explicitly, to stop it being widened back to every `5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
