### PR TITLE
fix(server): scope the ClickHouse query capture in tests to the calling process

### DIFF
--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -10503,10 +10503,17 @@ defmodule Tuist.TestsTest do
     test_pid = self()
     handler_id = "clickhouse-queries-#{System.unique_integer([:positive])}"
 
+    # `:telemetry` handlers are global, so an async test running alongside this
+    # one would otherwise land its queries in the captured list and shift the
+    # positions the ordering assertions read.
     :telemetry.attach_many(
       handler_id,
       [[:tuist, :click_house_repo, :query], [:tuist, :ingest_repo, :query]],
-      fn _event, _measurements, %{query: query}, _config -> send(test_pid, {:clickhouse_query, query}) end,
+      fn _event, _measurements, %{query: query}, _config ->
+        if test_pid == self() or test_pid in Process.get(:"$callers", []) do
+          send(test_pid, {:clickhouse_query, query})
+        end
+      end,
       nil
     )
 


### PR DESCRIPTION
`capture_clickhouse_queries/1` in `server/test/tuist/tests_test.exs` attached a `:telemetry` handler for `[:tuist, :click_house_repo, :query]` and `[:tuist, :ingest_repo, :query]`. `:telemetry` handlers are global to the VM, so with ExUnit running async tests concurrently the handler recorded queries emitted by every other test running at the same moment, not just the ones inside the captured function.

That made `test "claims the shard mapping before writing the run row"` flaky. It asserts `mapping_insert < run_insert` on `Enum.find_index/2` positions within the captured list, and unrelated concurrent `INSERT INTO "shard_runs"` / `INSERT INTO "test_runs"` from other tests shifted those indices. The observed failure was `left: 4, right: 2`. It passed in isolation and in narrow runs, and failed when the file ran alongside e.g. `test/tuist/tests/analytics_test.exs`, `test/tuist_web/live/*`, `test/tuist/automations`. The other two call sites of the helper carried the same latent flakiness.

### What changed

The handler now checks the emitting process before recording. Ecto emits the query event from the process that issued the query (DBConnection runs its log callback in the client process), so `self()` inside the handler is the originating process. The handler records only when that process is the test itself or has the test in its `$callers`.

The `$callers` half is load-bearing rather than defensive: `Tests.create_test/1` writes part of its work through `Tuist.Tasks.run_async/1`, which uses `Task.start/1`, and `Task` propagates `$callers` to the spawned process. A plain `self() == test_pid` check would silently drop those.

### Why this shape

The alternative was filtering on telemetry metadata, but Ecto's query metadata carries no field identifying the originating process, so there is nothing there to key on. Making the capture non-global (per-test handler ids are already unique) does not help either, since `:telemetry` dispatch is by event name across the whole VM. The process identity available inside the handler is the only discriminator.

### How to test locally

From `server/`:

    mix test test/tuist/tests_test.exs:2255

    mix test test/tuist/tests_test.exs test/tuist/tests/analytics_test.exs test/tuist_web/live test/tuist/automations test/tuist/automations_test.exs

### Validation

- `mix test test/tuist/tests_test.exs:2255` passes, and both `shard_runs` and `test_runs` inserts are still found, so the filter is not swallowing the real queries. A filter that dropped everything would make the `refute`-based sibling test pass vacuously but would fail this one.
- The broad file set above ran 3x with the fix with no `tests_test.exs` failures.
- The broad run is a weak signal on its own: the same set ran twice on the unmodified tree without reproducing the flake, so the interleaving is probabilistic. The mechanism was proven directly with a throwaway test (since deleted) that emitted a fake `INSERT INTO "test_runs"` from an unrelated process during a capture. The old handler records it, the new one does not, and a query emitted from a `Task.async` inside the captured function is still recorded. All three assertions passed.
- `mix format --check-formatted` clean.

### Unrelated failures in that file set

Two failures show up in the broad run and are pre-existing. They reproduce on the unmodified tree and in isolation, and this change is confined to `tests_test.exs`:

- `TuistWeb.LayoutLiveTest` "uses the session locale for translated dashboard labels"
- `TuistWeb.Marketing.MarketingCustomersLiveTest` "renders the localized Hyperconnect title for Korean visitors"

Both need a non-`en` locale, which the `:test` env does not compile unless `TUIST_DEV_ALL_LOCALES=1`. They look like they are missing the `:locale` tag that `test_helper.exs` excludes for exactly this reason. Left alone here as out of scope.
