### PR TITLE
fix(infra): give the fleet/per-host config split a single definition

### DIFF
--- a/infra/cluster-api-provider-tuist/cmd/manager/main.go
+++ b/infra/cluster-api-provider-tuist/cmd/manager/main.go
@@ -431,13 +431,30 @@ func main() {
 	if egressProxyGroup != "" && egressNamespace != "" {
 		vncRelayPort = macos.DashboardVNCRelayPort
 	}
-	hostConfigHash := bootstrap.HostConfigHash(bootstrap.Config{
-		TartKubeletBinary:       tartKubeletBinary,
-		TailscaleBinaries:       tailscaleBinaries,
-		NodeExporterBinary:      nodeExporterBinary,
-		LogShipperBinary:        logShipperBinary,
-		LogShipURL:              logShipURL,
-		LogShipEnv:              logShipEnv,
+	// One fleet config, used for both things that must agree: the hash the
+	// reconciler stamps on a Machine, and the config it pushes to the host.
+	// They were separate literals -- this one, and a field-by-field assembly
+	// in each of the controller's two push paths -- with nothing tying them
+	// together, so a field added here but missed there made the operator
+	// record a host as converged to a config it had never received.
+	fleetConfig := bootstrap.Config{
+		TartKubeletBinary:  tartKubeletBinary,
+		TartTarball:        tartTarball,
+		TailscaleBinaries:  tailscaleBinaries,
+		NodeExporterBinary: nodeExporterBinary,
+		LogShipperBinary:   logShipperBinary,
+		LogShipURL:         logShipURL,
+		LogShipEnv:         logShipEnv,
+		// Per-env Tailscale tag, e.g. `tag:tuist-macmini-staging`.
+		// Flows in from the Helm chart's macosFleet.tailscale.tags
+		// via --tailscale-tags. ACL grants the matching env's
+		// `tag:tuist-k8s-<env>` dial access to this tag on the
+		// scrape ports; cross-env scraping is blocked once the
+		// wide-open catch-all is removed.
+		//
+		// Load-bearing, not cosmetic: an OAuth-minted credential carries
+		// no default tag, so a host config pushed without these cannot
+		// join the tailnet at all.
 		TailscaleTags:           parseCommaList(tailscaleTagsRaw),
 		TailscaleAcceptRoutes:   tailscaleAcceptRoutes,
 		VMKuraEgressCIDR:        vmKuraEgressCIDR,
@@ -451,7 +468,8 @@ func main() {
 		CacheVolumeMasterCapGiB: cacheVolumeMasterCapGiB,
 		CacheVolumeCASGiB:       cacheVolumeCASGiB,
 		VNCRelayPort:            vncRelayPort,
-	})
+	}
+	hostConfigHash := bootstrap.HostConfigHash(fleetConfig)
 	setupLog.Info("computed host config hash", "hash", hostConfigHash)
 
 	restConfig := ctrl.GetConfigOrDie()
@@ -538,41 +556,16 @@ func main() {
 	}
 
 	if err := (&macos.ScalewayAppleSiliconMachineReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		ScalewayClient:       scwClient,
-		CredentialsManager:   credsManager,
-		Recorder:             mgr.GetEventRecorderFor("scalewayapplesiliconmachine-controller"),
-		Kubeconfig:           kubeconfigBuilder,
-		TartKubeletBinary:    tartKubeletBinary,
-		TartKubeletBinarySHA: binarySHA,
-		HostConfigHash:       hostConfigHash,
-		TartTarball:          tartTarball,
-		TailscaleBinaries:    tailscaleBinaries,
-		NodeExporterBinary:   nodeExporterBinary,
-		LogShipperBinary:     logShipperBinary,
-		LogShipURL:           logShipURL,
-		LogShipEnv:           logShipEnv,
-		// Per-env Tailscale tag, e.g. `tag:tuist-macmini-staging`.
-		// Flows in from the Helm chart's macosFleet.tailscale.tags
-		// via --tailscale-tags. ACL grants the matching env's
-		// `tag:tuist-k8s-<env>` dial access to this tag on the
-		// scrape ports; cross-env scraping is blocked once the
-		// wide-open catch-all is removed.
-		TailscaleTags:                 parseCommaList(tailscaleTagsRaw),
-		TailscaleAcceptRoutes:         tailscaleAcceptRoutes,
-		VMKuraEgressCIDR:              vmKuraEgressCIDR,
-		VMClusterDNSIP:                vmClusterDNSIP,
+		Client:                        mgr.GetClient(),
+		Scheme:                        mgr.GetScheme(),
+		ScalewayClient:                scwClient,
+		CredentialsManager:            credsManager,
+		Recorder:                      mgr.GetEventRecorderFor("scalewayapplesiliconmachine-controller"),
+		Kubeconfig:                    kubeconfigBuilder,
+		TartKubeletBinarySHA:          binarySHA,
+		FleetConfig:                   fleetConfig,
 		VMCachePNName:                 vmCachePNName,
-		VMCachePNCIDR:                 vmCachePNCIDR,
-		SSHIngressAllowCIDRs:          parseCommaList(sshIngressAllowRaw),
 		VPC:                           vpcClient,
-		TartKubeletHostCPU:            tartKubeletHostCPU,
-		TartKubeletHostMemoryMB:       tartKubeletHostMemory,
-		TartKubeletMaxPods:            tartKubeletMaxPods,
-		RunnerCacheVolumeGiB:          runnerCacheVolumeGiB,
-		CacheVolumeMasterCapGiB:       cacheVolumeMasterCapGiB,
-		CacheVolumeCASGiB:             cacheVolumeCASGiB,
 		TartKubeletMaxUpdateAttempts:  int32(tartKubeletMaxUpdateAttempts),
 		TartKubeletTerminalRetryAfter: terminalRetryAfter,
 		BootstrapRebootAfter:          int32(bootstrapRebootAfter),

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -71,101 +71,26 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// Required for tart-kubelet to authenticate to the cluster.
 	Kubeconfig *kubeconfig.Builder
 
-	// TartKubeletBinary is the darwin/arm64 binary baked into the
-	// operator's own image. Read once at operator startup, uploaded to
-	// each Mac mini over SSH at provision time and on every drift-
-	// detected rolling update.
-	TartKubeletBinary []byte
+	// FleetConfig is every field of the host config that is identical
+	// across the fleet: the operator-image binaries and the chart-driven
+	// fleet settings. The manager builds it once, hands the same value
+	// here, and derives HostConfigHash from it, so what the operator
+	// hashes and what it pushes cannot be two different things.
+	//
+	// Both push paths start from this value and overlay only per-host
+	// fields (see bootstrap.PerHost). Previously each path assembled its
+	// own bootstrap.Config field by field from separate reconciler
+	// fields, and a field wired into one path but not the other made the
+	// operator stamp a host as converged to a config it never received.
+	// The Tailscale tags were lost that way and froze the production
+	// fleet on 2026-08-18.
+	FleetConfig bootstrap.Config
 
 	// TartKubeletBinarySHA is the SHA-256 of TartKubeletBinary. Used
 	// as the version stamp on each ScalewayAppleSiliconMachine: when
 	// status.tartKubeletBinarySHA != this value, the reconciler
 	// re-uploads + reloads launchd.
 	TartKubeletBinarySHA string
-
-	// HostConfigHash is the fleet-wide canonical hash of every host
-	// config the operator pushes (bootstrap.HostConfigHash over the
-	// rendered install scripts + embedded binaries). It's the version
-	// stamp that drives the host-config drift loop: when
-	// status.hostConfigHash != this value the reconciler re-pushes the
-	// host config. Broader than TartKubeletBinarySHA, which only catches
-	// a tart-kubelet binary change — this also catches a script tweak or
-	// a fleet-config (CIDR/tags/accept-routes) change.
-	HostConfigHash string
-
-	// TartTarball is the gzipped tar of the upstream `tart.app` bundle
-	// pinned in the operator's Dockerfile and read at startup. Uploaded
-	// to each Mac mini over SSH at first bootstrap. We do not run a
-	// drift loop on the Tart version: a Mac mini already running VMs
-	// can't safely have its hypervisor swapped out from under them, so
-	// upgrading Tart fleet-wide goes through Machine replacement (the
-	// new Mac mini gets the operator-image-pinned Tart on bootstrap).
-	TartTarball []byte
-
-	// TailscaleBinaries is the gzipped tarball of darwin/arm64
-	// `tailscale` + `tailscaled` cross-built from upstream source at
-	// the operator-image-pinned tag (TAILSCALE_VERSION in the
-	// Dockerfile). Same drift policy as TartTarball: version bumps
-	// roll via operator-image replacement, not in-place updates of
-	// running hosts (the running tailnet connection doesn't tolerate
-	// a daemon swap mid-flight). Empty disables the Tailscale step.
-	TailscaleBinaries []byte
-
-	// NodeExporterBinary is the darwin/arm64 node_exporter binary,
-	// cross-compiled in the operator image. Installed on each Mac
-	// mini at bootstrap and supervised by launchd; scraped over the
-	// tailnet at <node-ip>:9100. Empty disables the host-metrics
-	// step (paired with TailscaleBinaries — node_exporter without
-	// Tailscale would bind to a public interface, which is the kind
-	// of mistake we don't want a chart-level toggle to make easy).
-	NodeExporterBinary []byte
-
-	// LogShipperBinary is the darwin/arm64 tuist-log-shipper binary,
-	// cross-built in the operator image from infra/macos-log-shipper.
-	// Installed on each Mac mini at bootstrap and supervised by
-	// launchd; it tails /var/log/tart-kubelet.log and pushes to
-	// LogShipURL. Empty disables the host-log step.
-	//
-	// Logs travel the opposite direction from metrics — pushed by the
-	// host rather than scraped by the cluster — because there is no
-	// scrapeable surface for a file. That is also why this cannot be a
-	// DaemonSet: a Pod on a macOS Node is a Tart VM with no view of the
-	// host filesystem.
-	LogShipperBinary []byte
-
-	// LogShipURL is the Loki push endpoint the host agent POSTs to,
-	// including the /loki/api/v1/push path. Empty disables the
-	// host-log step. See bootstrap.Config.LogShipURL for why it points
-	// at the in-cluster Alloy receiver over the tailnet rather than at
-	// Grafana Cloud directly.
-	LogShipURL string
-
-	// LogShipEnv is the `env` stream label on shipped host logs.
-	LogShipEnv string
-
-	// TailscaleTags are the Tailscale ACL tags every Mac mini in
-	// the fleet advertises at `tailscale up` time (e.g.
-	// `["tag:tuist-macmini"]`). Must be in the scope of the
-	// operator-namespace OAuth credential and declared in acls.json's
-	// tagOwners block. Required with that credential, which always
-	// mints tagged keys and carries no default tag; empty only works
-	// with a legacy pre-auth key.
-	TailscaleTags []string
-
-	// TailscaleAcceptRoutes makes every Mac mini run `tailscale up
-	// --accept-routes`, installing the subnet routes the cluster's
-	// Connector advertises (the Service CIDR) so Tart runner VMs can
-	// reach the in-cluster Kura runner-cache Service. See
-	// bootstrap.Config.TailscaleAcceptRoutes for the single-
-	// advertiser caveat.
-	TailscaleAcceptRoutes bool
-
-	// VMKuraEgressCIDR / VMClusterDNSIP parameterize the VM egress
-	// firewall's runner-cache carve-out (Kura ports on the Service
-	// CIDR + cluster DNS). Empty leaves the firewall as a pure
-	// blocklist. See the bootstrap.Config fields of the same names.
-	VMKuraEgressCIDR string
-	VMClusterDNSIP   string
 
 	// VMCachePNName / VMCachePNCIDR configure the Scaleway Private
 	// Network carrying the kura runner-cache NodePort endpoints.
@@ -177,37 +102,12 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// disables the PN data plane. See
 	// bootstrap.Config.VMCachePNCIDR / VMCachePNVLAN.
 	VMCachePNName string
-	VMCachePNCIDR string
-
-	// SSHIngressAllowCIDRs are the source ranges, beyond the tailnet
-	// and loopback, allowed to reach :22 on each Mac mini. Flows into
-	// bootstrap.Config.SSHIngressAllowCIDRs, where a pf anchor drops
-	// everything else so internet scan traffic can't exhaust the ssh
-	// listen backlog. Rides the drift loop, so a policy change lands on
-	// existing minis with the next operator-image roll.
-	SSHIngressAllowCIDRs []string
 
 	// VPC find-or-creates the runner-cache Private Network the Mac
 	// fleet shares with the Elastic Metal cache node, resolving
 	// VMCachePNName to an ID. Same shared client as the EM reconciler,
 	// so the two fleets land on one PN per env.
 	VPC *scaleway.VPCClient
-
-	// TartKubelet host advertising — passed into bootstrap which bakes
-	// them into the launchd plist on each Mac mini.
-	TartKubeletHostCPU      int
-	TartKubeletHostMemoryMB int
-	TartKubeletMaxPods      int
-
-	// RunnerCacheVolumeGiB / CacheVolumeMasterCapGiB turn on per-account
-	// cache volumes on the Mac fleet: bootstrap provisions a
-	// quota-bounded APFS volume of RunnerCacheVolumeGiB and passes
-	// --runner-cache-root (+ optional per-master cap) to tart-kubelet. 0
-	// leaves the feature off. See the bootstrap.Config fields of the same
-	// names.
-	RunnerCacheVolumeGiB    int
-	CacheVolumeMasterCapGiB int
-	CacheVolumeCASGiB       int
 
 	// TartKubeletMaxUpdateAttempts caps how many times the drift loop
 	// retries a failing UpdateTartKubelet before transitioning the CR
@@ -661,43 +561,22 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		vncRelayHost := r.dashboardVNCRelayHost(machine.Name)
-		vncRelayPort := r.dashboardVNCRelayPort()
 
-		fingerprint, err := bootstrap.Run(ctx, bootstrap.Config{
-			IP:                      ip,
-			SSHUser:                 bootstrapCreds.SSHUsername,
-			UserPassword:            bootstrapCreds.SudoPassword,
-			SSHPrivateKey:           sshKey,
-			NodeName:                machine.Name,
-			ProviderID:              providerIDOf(machine),
-			Kubeconfig:              kubeconfigYAML,
-			TartKubeletBinary:       r.TartKubeletBinary,
-			TartTarball:             r.TartTarball,
-			TailscaleBinaries:       r.TailscaleBinaries,
-			TailscaleAuthKey:        tailscaleAuthKey,
-			TailscaleTags:           r.TailscaleTags,
-			TailscaleAcceptRoutes:   r.TailscaleAcceptRoutes,
-			VMKuraEgressCIDR:        r.VMKuraEgressCIDR,
-			VMClusterDNSIP:          r.VMClusterDNSIP,
-			VMCachePNCIDR:           r.VMCachePNCIDR,
-			SSHIngressAllowCIDRs:    r.SSHIngressAllowCIDRs,
-			VMCachePNVLAN:           vmCachePNVLAN,
-			NodeExporterBinary:      r.NodeExporterBinary,
-			LogShipperBinary:        r.LogShipperBinary,
-			LogShipURL:              r.LogShipURL,
-			LogShipEnv:              r.LogShipEnv,
-			HostCPU:                 hostCPUFor(machine, r.TartKubeletHostCPU),
-			HostMemoryMB:            hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
-			MaxPods:                 r.TartKubeletMaxPods,
-			RunnerCacheVolumeGiB:    r.RunnerCacheVolumeGiB,
-			CacheVolumeMasterCapGiB: r.CacheVolumeMasterCapGiB,
-			CacheVolumeCASGiB:       r.CacheVolumeCASGiB,
-			VNCRelayHost:            vncRelayHost,
-			VNCRelayPort:            vncRelayPort,
-			NodeLabels:              machineNodeLabels(machine),
-			KnownHostFingerprint:    bootstrapCreds.HostFingerprint,
-			GHActionsRunner:         ghRunner,
-		})
+		fingerprint, err := bootstrap.Run(ctx, r.hostConfig(machine, bootstrap.PerHost{
+			IP:                   ip,
+			SSHUser:              bootstrapCreds.SSHUsername,
+			UserPassword:         bootstrapCreds.SudoPassword,
+			SSHPrivateKey:        sshKey,
+			NodeName:             machine.Name,
+			ProviderID:           providerIDOf(machine),
+			Kubeconfig:           kubeconfigYAML,
+			TailscaleAuthKey:     tailscaleAuthKey,
+			VMCachePNVLAN:        vmCachePNVLAN,
+			VNCRelayHost:         vncRelayHost,
+			NodeLabels:           machineNodeLabels(machine),
+			KnownHostFingerprint: bootstrapCreds.HostFingerprint,
+			GHActionsRunner:      ghRunner,
+		}))
 		// Persist whatever fingerprint Run captured even on the error
 		// path, so a transient bootstrap failure doesn't lose the
 		// TOFU pin we already verified successfully.
@@ -740,7 +619,11 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// moves the hash and re-pushes the host config. Existing machines
 	// carry an empty Status.HostConfigHash, so the first reconcile after
 	// this upgrade drifts once and re-pushes — the intended migration.
-	configDrift := hostConfigDrift(r.HostConfigHash, machine.Status.HostConfigHash)
+	// Resolved per machine, not read from a fleet-wide field: HostCPU and
+	// HostMemoryMB are overridable per Machine, so the desired hash for an
+	// overridden host is not the fleet's. See desiredHostConfigHash.
+	desiredHostConfigHash := r.desiredHostConfigHash(machine)
+	configDrift := hostConfigDrift(desiredHostConfigHash, machine.Status.HostConfigHash)
 	// Once a CR enters the terminal-failed state (FailureReason set
 	// and FailureMessage describes the underlying error) we stop
 	// firing the drift loop. CAPI core takes over: surfaces the
@@ -772,7 +655,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// fleet and silently miss them. The cooldown gives such a host one fresh
 	// attempt budget per interval once it is reachable again.
 	if shouldClearTerminalFailure(
-		r.HostConfigHash,
+		desiredHostConfigHash,
 		machine.Status.FailedHostConfigHash,
 		terminalFailure,
 		machine.Status.LastUpdateFailureTime,
@@ -780,7 +663,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		time.Now(),
 	) {
 		reason := "host config drifted since the failure was recorded"
-		if r.HostConfigHash != "" && r.HostConfigHash == machine.Status.FailedHostConfigHash {
+		if desiredHostConfigHash != "" && desiredHostConfigHash == machine.Status.FailedHostConfigHash {
 			reason = "retry cooldown elapsed"
 		}
 		clearUpdateFailure(machine, reason, logger, r.Recorder)
@@ -793,7 +676,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		}
 		identity, err := r.CredentialsManager.EnsureNodeIdentity(ctx, machine.Name, "")
 		if err != nil {
-			recordUpdateFailure(machine, fmt.Errorf("ensure node identity: %w", err), r.TartKubeletMaxUpdateAttempts, r.HostConfigHash, logger, r.Recorder)
+			recordUpdateFailure(machine, fmt.Errorf("ensure node identity: %w", err), r.TartKubeletMaxUpdateAttempts, desiredHostConfigHash, logger, r.Recorder)
 			if machine.Status.FailureReason != nil {
 				return ctrl.Result{}, nil
 			}
@@ -801,7 +684,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		}
 		kubeconfigYAML, err := r.Kubeconfig.Render(ctx, machine.Name, identity.Token, identity.CA)
 		if err != nil {
-			recordUpdateFailure(machine, fmt.Errorf("render kubeconfig: %w", err), r.TartKubeletMaxUpdateAttempts, r.HostConfigHash, logger, r.Recorder)
+			recordUpdateFailure(machine, fmt.Errorf("render kubeconfig: %w", err), r.TartKubeletMaxUpdateAttempts, desiredHostConfigHash, logger, r.Recorder)
 			if machine.Status.FailureReason != nil {
 				return ctrl.Result{}, nil
 			}
@@ -815,7 +698,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		// way to keep the plist render correct.
 		tailscaleAuthKey, err := r.CredentialsManager.GetTailscaleAuthKey(ctx)
 		if err != nil {
-			recordUpdateFailure(machine, fmt.Errorf("get tailscale auth key: %w", err), r.TartKubeletMaxUpdateAttempts, r.HostConfigHash, logger, r.Recorder)
+			recordUpdateFailure(machine, fmt.Errorf("get tailscale auth key: %w", err), r.TartKubeletMaxUpdateAttempts, desiredHostConfigHash, logger, r.Recorder)
 			if machine.Status.FailureReason != nil {
 				return ctrl.Result{}, nil
 			}
@@ -831,17 +714,32 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			vmCachePNVLAN = 0
 		}
 		vncRelayHost := r.dashboardVNCRelayHost(machine.Name)
-		vncRelayPort := r.dashboardVNCRelayPort()
 
 		// The drift update dials the mini's public IP first (see the
 		// tailnet fallback right after this call). cfg.IP is a pure dial
 		// target on the update path — HostConfigHash strips it and nothing
 		// else reads it — so the fallback re-points it without changing
 		// what we push.
-		updateCfg := r.driftUpdateConfig(
-			machine, ip, bootstrapCreds, sshKey, kubeconfigYAML,
-			tailscaleAuthKey, vmCachePNVLAN, vncRelayHost, vncRelayPort,
-		)
+		updateCfg := r.hostConfig(machine, bootstrap.PerHost{
+			IP:               ip,
+			SSHUser:          bootstrapCreds.SSHUsername,
+			SSHPrivateKey:    sshKey,
+			NodeName:         machine.Name,
+			ProviderID:       providerIDOf(machine),
+			Kubeconfig:       kubeconfigYAML,
+			TailscaleAuthKey: tailscaleAuthKey,
+			VMCachePNVLAN:    vmCachePNVLAN,
+			VNCRelayHost:     vncRelayHost,
+			NodeLabels:       machineNodeLabels(machine),
+			// Builder hosts must keep `--disable-vm-gc` across binary
+			// rolls. This path re-renders the plist but doesn't re-resolve
+			// GHActionsRunner (which renderLaunchdPlist otherwise keys the
+			// flag off), so carry the builder signal explicitly — without
+			// it the roll strips the flag and the orphan-VM GC reaps the
+			// in-flight image-bake VM mid-`tart push`.
+			DisableVMGC:          machine.Spec.GHActionsRunner != nil,
+			KnownHostFingerprint: bootstrapCreds.HostFingerprint,
+		})
 		fingerprint, err := bootstrap.UpdateTartKubelet(ctx, updateCfg)
 		// Tailnet fallback. A running runner mini filters inbound :22 on
 		// its public interface once Internet Sharing / vmnet reconfigures
@@ -874,19 +772,19 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			}
 		}
 		if err != nil {
-			recordUpdateFailure(machine, fmt.Errorf("tart-kubelet update: %w", err), r.TartKubeletMaxUpdateAttempts, r.HostConfigHash, logger, r.Recorder)
+			recordUpdateFailure(machine, fmt.Errorf("tart-kubelet update: %w", err), r.TartKubeletMaxUpdateAttempts, desiredHostConfigHash, logger, r.Recorder)
 			if machine.Status.FailureReason != nil {
 				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 		}
 		machine.Status.TartKubeletBinarySHA = r.TartKubeletBinarySHA
-		machine.Status.HostConfigHash = r.HostConfigHash
+		machine.Status.HostConfigHash = desiredHostConfigHash
 		machine.Status.TartKubeletUpdateAttempts = 0
 		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "AgentRolled",
 			"Rolled tart-kubelet to %s", r.TartKubeletBinarySHA)
 		logger.Info("rolled new tart-kubelet", "host", ip, "sha", r.TartKubeletBinarySHA,
-			"hostConfigHash", r.HostConfigHash)
+			"hostConfigHash", desiredHostConfigHash)
 	}
 
 	// Stage 4: materialise the per-machine Tailscale egress Service
@@ -1224,98 +1122,39 @@ func shouldClearTerminalFailure(
 	return !now.Before(lastFailure.Time.Add(retryAfter))
 }
 
-// driftUpdateConfig assembles the Config the drift loop pushes to a host that
-// is already bootstrapped. Split out of reconcileNormal so a test can pin the
-// invariant that makes the drift loop honest: every fleet-wide field the
-// canonical HostConfigHash is computed over must be set here too. When one is
-// missing the operator still stamps the host as converged, so the host reports
-// a config it never received and the skew is invisible until something
-// downstream happens to need the dropped field. That has now happened four
-// times — node_exporter, the log shipper, the cache-volume flags, and the
-// Tailscale tags — which is why the invariant is asserted rather than reviewed.
+// hostConfig is the config for one Mac mini: the fleet-wide config the manager
+// built, with this machine's per-host fields overlaid. Both push paths go
+// through it, so neither can push a config the operator did not hash.
 //
-// Only per-host fields may differ from the canonical config; HostConfigHash
-// zeroes exactly those, so the test compares the two hashes directly.
-func (r *ScalewayAppleSiliconMachineReconciler) driftUpdateConfig(
+// HostCPU / HostMemoryMB are the one seam. They are fleet-wide in the hash --
+// a chart-level change to either must roll the fleet -- but a Machine may
+// override them per host, so they are resolved here rather than in PerHost.
+// desiredHostConfigHash resolves them identically, which is what keeps the
+// stamp on an overridden host equal to the hash of what that host received.
+func (r *ScalewayAppleSiliconMachineReconciler) hostConfig(
 	machine *infrav1.ScalewayAppleSiliconMachine,
-	ip string,
-	bootstrapCreds *credentials.MachineBootstrap,
-	sshKey []byte,
-	kubeconfigYAML string,
-	tailscaleAuthKey string,
-	vmCachePNVLAN uint32,
-	vncRelayHost string,
-	vncRelayPort int,
+	perHost bootstrap.PerHost,
 ) bootstrap.Config {
-	return bootstrap.Config{
-		IP:                ip,
-		SSHUser:           bootstrapCreds.SSHUsername,
-		SSHPrivateKey:     sshKey,
-		NodeName:          machine.Name,
-		ProviderID:        providerIDOf(machine),
-		Kubeconfig:        kubeconfigYAML,
-		TartKubeletBinary: r.TartKubeletBinary,
-		TailscaleBinaries: r.TailscaleBinaries,
-		TailscaleAuthKey:  tailscaleAuthKey,
-		// Tailscale + firewall config rides the drift loop too —
-		// UpdateTartKubelet re-runs installTailscale and
-		// installVMEgressFirewall, so an accept-routes or
-		// carve-out values change lands on existing minis with
-		// the next operator-image roll instead of waiting for
-		// re-provisioning.
-		// The tags are load-bearing, not cosmetic: an OAuth-minted
-		// credential carries no default tag, so a push without them
-		// cannot join the tailnet at all. They also feed
-		// HostConfigHash, so omitting them here stamped hosts as
-		// converged to a hash whose tailscale script they never got.
-		TailscaleTags:         r.TailscaleTags,
-		TailscaleAcceptRoutes: r.TailscaleAcceptRoutes,
-		VMKuraEgressCIDR:      r.VMKuraEgressCIDR,
-		VMClusterDNSIP:        r.VMClusterDNSIP,
-		VMCachePNCIDR:         r.VMCachePNCIDR,
-		SSHIngressAllowCIDRs:  r.SSHIngressAllowCIDRs,
-		VMCachePNVLAN:         vmCachePNVLAN,
-		// node_exporter is re-installed on every drift-loop run,
-		// not just on first bootstrap, so a chart-driven binary
-		// bump (NODE_EXPORTER_VERSION ARG in the operator
-		// Dockerfile) lands on running minis the next time the
-		// tart-kubelet binary drifts. Forgetting this here made
-		// node_exporter silently skip on every drift update —
-		// installNodeExporter short-circuits when its binary is
-		// empty.
-		NodeExporterBinary: r.NodeExporterBinary,
-		// Same reason node_exporter rides this path: the agent and its push
-		// URL both come from the operator, so an image bump or a values
-		// change has to reach already-bootstrapped minis here or it never
-		// lands on the fleet at all.
-		LogShipperBinary: r.LogShipperBinary,
-		LogShipURL:       r.LogShipURL,
-		LogShipEnv:       r.LogShipEnv,
-		HostCPU:          hostCPUFor(machine, r.TartKubeletHostCPU),
-		HostMemoryMB:     hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
-		MaxPods:          r.TartKubeletMaxPods,
-		// Per-account cache volumes must ride the drift loop
-		// too: the volume flag + provisioning land on already-bootstrapped
-		// minis via UpdateTartKubelet, not first-boot Run. Omitting these
-		// left the plist without --runner-cache-root (tart-kubelet booted
-		// every VM cold) and skipped installRunnerCacheVolume, while the
-		// operator's canonical HostConfigHash still reflected the enabled
-		// config — so the roll looked applied but the feature was off.
-		RunnerCacheVolumeGiB:    r.RunnerCacheVolumeGiB,
-		CacheVolumeMasterCapGiB: r.CacheVolumeMasterCapGiB,
-		CacheVolumeCASGiB:       r.CacheVolumeCASGiB,
-		VNCRelayHost:            vncRelayHost,
-		VNCRelayPort:            vncRelayPort,
-		NodeLabels:              machineNodeLabels(machine),
-		// Builder hosts must keep `--disable-vm-gc` across binary
-		// rolls. This path re-renders the plist but doesn't re-resolve
-		// GHActionsRunner (which renderLaunchdPlist otherwise keys the
-		// flag off), so carry the builder signal explicitly — without
-		// it the roll strips the flag and the orphan-VM GC reaps the
-		// in-flight image-bake VM mid-`tart push`.
-		DisableVMGC:          machine.Spec.GHActionsRunner != nil,
-		KnownHostFingerprint: bootstrapCreds.HostFingerprint,
-	}
+	cfg := r.FleetConfig
+	cfg.HostCPU = hostCPUFor(machine, r.FleetConfig.HostCPU)
+	cfg.HostMemoryMB = hostMemoryMBFor(machine, r.FleetConfig.HostMemoryMB)
+	return cfg.WithPerHost(perHost)
+}
+
+// desiredHostConfigHash is the fingerprint of the config this machine should be
+// running. It is the hash of exactly what hostConfig would push, so a host is
+// only ever stamped with a hash of the config it actually received.
+//
+// It is computed per machine rather than once per fleet because HostCPU and
+// HostMemoryMB are overridable per Machine. A single fleet constant was correct
+// for every host that took the fleet defaults and quietly wrong for one that
+// did not: the operator pushed the overridden config and then stamped the
+// fleet hash on it, so the host read as converged to a config it had never
+// been sent, and a later change to the overridden field could not drift it.
+func (r *ScalewayAppleSiliconMachineReconciler) desiredHostConfigHash(
+	machine *infrav1.ScalewayAppleSiliconMachine,
+) string {
+	return bootstrap.HostConfigHash(r.hostConfig(machine, bootstrap.PerHost{}))
 }
 
 // recordUpdateFailure increments the drift-loop retry counter and,
@@ -1716,10 +1555,10 @@ func machineIP(m *infrav1.ScalewayAppleSiliconMachine) string {
 // Returns 0 (and no error) when the PN data plane is not configured
 // or the machine has no Scaleway server yet.
 func (r *ScalewayAppleSiliconMachineReconciler) ensureVMCachePN(ctx context.Context, machine *infrav1.ScalewayAppleSiliconMachine) (uint32, error) {
-	if r.VMCachePNName == "" || r.VMCachePNCIDR == "" || machine.Status.ServerID == "" {
+	if r.VMCachePNName == "" || r.FleetConfig.VMCachePNCIDR == "" || machine.Status.ServerID == "" {
 		return 0, nil
 	}
-	pnID, err := r.VPC.EnsurePrivateNetworkByName(ctx, scaleway.RegionFromZoneString(machine.Spec.Zone), r.VMCachePNName, r.VMCachePNCIDR)
+	pnID, err := r.VPC.EnsurePrivateNetworkByName(ctx, scaleway.RegionFromZoneString(machine.Spec.Zone), r.VMCachePNName, r.FleetConfig.VMCachePNCIDR)
 	if err != nil {
 		return 0, err
 	}

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
@@ -1399,89 +1398,110 @@ func TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers(t *testing.T) {
 	}
 }
 
-// The drift loop is only honest if what it pushes is what the operator hashed.
-// HostConfigHash is a fleet-wide fingerprint the reconciler stamps on a Machine
-// to mean "this host has the current config"; it is computed in cmd/manager
-// from operator-image + fleet-config inputs, with every per-host field left
-// zero. HostConfigHash zeroes exactly that same set, so a drift config that
-// carries all the fleet-wide fields must hash identically to the canonical one.
+// The drift loop is only honest if what it pushes is what the operator stamps.
+// hostConfig builds what a given Mac mini receives; desiredHostConfigHash is
+// the fingerprint the reconciler writes to Status.HostConfigHash to mean "this
+// host is converged". If those two ever describe different configs the host is
+// recorded as running something it never received, and the skew is invisible
+// until something downstream needs the part that was dropped.
 //
-// A field dropped from driftUpdateConfig therefore shows up here as a hash
-// mismatch, which is the failure the fleet cannot otherwise see: the host is
-// marked converged while the dropped field never reached it. node_exporter, the
-// log shipper, the cache-volume flags and the Tailscale tags were each lost this
-// way, the last one freezing the whole production fleet once the credential
-// swap to a Tailscale OAuth client made an untagged join impossible.
+// That is not a hypothetical: node_exporter, the log shipper, the cache-volume
+// flags and the Tailscale tags were each lost this way, the last one freezing
+// the production fleet once the credential swap to a Tailscale OAuth client
+// made an untagged join impossible.
 //
-// Every fleet-wide field is set to a distinctive non-zero value, so a field
-// that goes missing can't coincidentally match the canonical config's zero.
-func TestDriftUpdateConfig_HashesEqualToCanonicalFleetConfig(t *testing.T) {
-	fleet := bootstrap.Config{
-		TartKubeletBinary:       []byte("tart-kubelet-binary"),
-		TailscaleBinaries:       []byte("tailscale-binaries"),
-		NodeExporterBinary:      []byte("node-exporter-binary"),
-		LogShipperBinary:        []byte("log-shipper-binary"),
-		LogShipURL:              "http://alloy.example.ts.net:3100/loki/api/v1/push",
-		LogShipEnv:              "production",
-		TailscaleTags:           []string{"tag:tuist-macmini-production"},
-		TailscaleAcceptRoutes:   true,
-		VMKuraEgressCIDR:        "10.128.0.0/12",
-		VMClusterDNSIP:          "10.96.0.10",
-		VMCachePNCIDR:           "172.16.0.0/22",
-		SSHIngressAllowCIDRs:    []string{"116.202.0.10/32"},
-		HostCPU:                 8,
-		HostMemoryMB:            14336,
-		MaxPods:                 3,
-		RunnerCacheVolumeGiB:    80,
-		CacheVolumeMasterCapGiB: 20,
-		CacheVolumeCASGiB:       11,
-		VNCRelayPort:            DashboardVNCRelayPort,
-	}
-
+// The per-host/fleet-wide split itself is pinned in the bootstrap package
+// (TestWithPerHostReplacesExactlyThePerHostFields). What is checked here is the
+// operator's side of the contract: that both ends resolve the per-machine
+// fields the same way.
+func TestHostConfig_HashMatchesWhatIsStampedOnTheMachine(t *testing.T) {
 	r := &ScalewayAppleSiliconMachineReconciler{
-		TartKubeletBinary:       fleet.TartKubeletBinary,
-		TailscaleBinaries:       fleet.TailscaleBinaries,
-		NodeExporterBinary:      fleet.NodeExporterBinary,
-		LogShipperBinary:        fleet.LogShipperBinary,
-		LogShipURL:              fleet.LogShipURL,
-		LogShipEnv:              fleet.LogShipEnv,
-		TailscaleTags:           fleet.TailscaleTags,
-		TailscaleAcceptRoutes:   fleet.TailscaleAcceptRoutes,
-		VMKuraEgressCIDR:        fleet.VMKuraEgressCIDR,
-		VMClusterDNSIP:          fleet.VMClusterDNSIP,
-		VMCachePNCIDR:           fleet.VMCachePNCIDR,
-		SSHIngressAllowCIDRs:    fleet.SSHIngressAllowCIDRs,
-		TartKubeletHostCPU:      fleet.HostCPU,
-		TartKubeletHostMemoryMB: fleet.HostMemoryMB,
-		TartKubeletMaxPods:      fleet.MaxPods,
-		RunnerCacheVolumeGiB:    fleet.RunnerCacheVolumeGiB,
-		CacheVolumeMasterCapGiB: fleet.CacheVolumeMasterCapGiB,
-		CacheVolumeCASGiB:       fleet.CacheVolumeCASGiB,
+		FleetConfig: bootstrap.Config{
+			TartKubeletBinary:       []byte("tart-kubelet-binary"),
+			TailscaleBinaries:       []byte("tailscale-binaries"),
+			NodeExporterBinary:      []byte("node-exporter-binary"),
+			LogShipperBinary:        []byte("log-shipper-binary"),
+			LogShipURL:              "http://alloy.example.ts.net:3100/loki/api/v1/push",
+			LogShipEnv:              "production",
+			TailscaleTags:           []string{"tag:tuist-macmini-production"},
+			TailscaleAcceptRoutes:   true,
+			VMKuraEgressCIDR:        "10.128.0.0/12",
+			VMClusterDNSIP:          "10.96.0.10",
+			VMCachePNCIDR:           "172.16.0.0/22",
+			SSHIngressAllowCIDRs:    []string{"116.202.0.10/32"},
+			HostCPU:                 8,
+			HostMemoryMB:            14336,
+			MaxPods:                 3,
+			RunnerCacheVolumeGiB:    80,
+			CacheVolumeMasterCapGiB: 20,
+			CacheVolumeCASGiB:       11,
+			VNCRelayPort:            DashboardVNCRelayPort,
+		},
 	}
 
-	// Per-host values, all distinct from the canonical config's zeroes. If
-	// HostConfigHash ever stops neutralizing one of these the hashes diverge
-	// here too, which is equally worth catching: it would make a fleet-wide
-	// fingerprint differ per host and every drift check fire forever.
-	machine := &infrav1.ScalewayAppleSiliconMachine{}
-	machine.Name = "tuist-tuist-runners-fleet-mndbc-2t7nk"
-	machine.Spec.ProviderID = ptr.To("scw-applesilicon://fr-par-1/c0b4b946")
+	// Per-host values, all distinct from the fleet config's zeroes, so a field
+	// that leaks into the fingerprint cannot coincidentally match.
+	perHost := bootstrap.PerHost{
+		IP:                   "51.15.1.1",
+		SSHUser:              "m1",
+		UserPassword:         "sudo-password",
+		SSHPrivateKey:        []byte("ssh-private-key"),
+		NodeName:             "tuist-tuist-runners-fleet-mndbc-2t7nk",
+		ProviderID:           "scw-applesilicon://fr-par-1/c0b4b946",
+		Kubeconfig:           "apiVersion: v1\nkind: Config\n",
+		TailscaleAuthKey:     "tskey-client-secret",
+		VNCRelayHost:         "vnc-relay.example",
+		VMCachePNVLAN:        42,
+		KnownHostFingerprint: "SHA256:abc",
+		NodeLabels:           map[string]string{"tuist.dev/fleet": "runners"},
+		DisableVMGC:          true,
+	}
 
-	got := r.driftUpdateConfig(
-		machine,
-		"51.15.1.1",
-		&credentials.MachineBootstrap{SSHUsername: "m1", HostFingerprint: "SHA256:abc"},
-		[]byte("ssh-private-key"),
-		"apiVersion: v1\nkind: Config\n",
-		"tskey-client-secret",
-		42,
-		"vnc-relay.example",
-		DashboardVNCRelayPort,
-	)
+	for _, tc := range []struct {
+		name    string
+		machine *infrav1.ScalewayAppleSiliconMachine
+	}{
+		{
+			name:    "fleet defaults",
+			machine: &infrav1.ScalewayAppleSiliconMachine{},
+		},
+		{
+			// The case a single fleet-wide hash got wrong: the operator pushed
+			// the overridden config and then stamped the fleet's hash on it, so
+			// the host read as converged to a config it had never been sent and
+			// a later change to the overridden field could not drift it.
+			name: "per-machine host size override",
+			machine: func() *infrav1.ScalewayAppleSiliconMachine {
+				m := &infrav1.ScalewayAppleSiliconMachine{}
+				m.Spec.HostCPU = 10
+				m.Spec.HostMemoryMB = 20480
+				return m
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pushed := r.hostConfig(tc.machine, perHost)
+			if want, have := r.desiredHostConfigHash(tc.machine), bootstrap.HostConfigHash(pushed); want != have {
+				t.Fatalf("hash of pushed config = %s, stamped hash = %s\n"+
+					"the host would be recorded as converged to a config it never received", have, want)
+			}
+		})
+	}
+}
 
-	if want, have := bootstrap.HostConfigHash(fleet), bootstrap.HostConfigHash(got); want != have {
-		t.Fatalf("driftUpdateConfig hash = %s, canonical fleet hash = %s\n"+
-			"a fleet-wide field is missing from driftUpdateConfig (or newly per-host in HostConfigHash); "+
-			"hosts would be stamped converged to a config they never received", have, want)
+// A per-machine override must actually move the fingerprint. Without this, a
+// hash that ignored the override would satisfy the test above trivially -- both
+// sides would agree on a value that does not describe the pushed config.
+func TestDesiredHostConfigHash_MovesWithPerMachineOverride(t *testing.T) {
+	r := &ScalewayAppleSiliconMachineReconciler{
+		FleetConfig: bootstrap.Config{HostCPU: 8, HostMemoryMB: 14336, MaxPods: 3},
+	}
+	base := &infrav1.ScalewayAppleSiliconMachine{}
+	overridden := &infrav1.ScalewayAppleSiliconMachine{}
+	overridden.Spec.HostCPU = 10
+
+	if r.desiredHostConfigHash(base) == r.desiredHostConfigHash(overridden) {
+		t.Fatal("a machine overriding HostCPU hashes the same as one on the fleet default; " +
+			"the override is not reaching the fingerprint")
 	}
 }

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -563,6 +563,69 @@ func UpdateTartKubelet(ctx context.Context, cfg Config) (string, error) {
 	return hk.Observed(), nil
 }
 
+// PerHost carries every Config field whose value belongs to one specific Mac
+// mini rather than to the fleet. It exists so that split has exactly one
+// definition in the codebase.
+//
+// It used to have two, written far apart: an assignment list in the operator's
+// drift-update path naming the fleet-wide fields, and the zeroing list in
+// HostConfigHash naming the per-host ones. Nothing tied them together, so a
+// field added to Config and wired into only one of them left the operator
+// pushing a config that did not match the hash it then stamped on the host --
+// the host was recorded as converged to a config it had never received, and
+// the skew stayed invisible until something downstream needed the dropped
+// field. node_exporter, the log shipper and the cache-volume flags were each
+// lost that way. The fourth, the Tailscale tags, froze the production Mac mini
+// fleet on 2026-08-18: once the shared credential became a Tailscale OAuth
+// client secret, an untagged join was no longer possible at all.
+//
+// With one definition the failure cannot recur. WithPerHost applies these
+// fields on top of a fleet config, and HostConfigHash strips them by applying
+// an empty PerHost, so the two lists are the same list.
+type PerHost struct {
+	IP                   string
+	SSHUser              string
+	UserPassword         string
+	SSHPrivateKey        []byte
+	NodeName             string
+	ProviderID           string
+	Kubeconfig           string
+	TailscaleAuthKey     string
+	VNCRelayHost         string
+	VMCachePNVLAN        uint32
+	KnownHostFingerprint string
+	NodeLabels           map[string]string
+	GHActionsRunner      *GHActionsRunnerConfig
+	// DisableVMGC is a per-host role signal (builder hosts set it); the
+	// launchd plist renderer keys --disable-vm-gc off it.
+	DisableVMGC bool
+	// SkipTailscaleInstall is transport-only: it gates whether
+	// installTailscale runs and changes no rendered output.
+	SkipTailscaleInstall bool
+}
+
+// WithPerHost returns a copy of c with the per-host fields replaced by p.
+// The receiver is a fleet config, identical across the fleet; the result is
+// what one host actually receives.
+func (c Config) WithPerHost(p PerHost) Config {
+	c.IP = p.IP
+	c.SSHUser = p.SSHUser
+	c.UserPassword = p.UserPassword
+	c.SSHPrivateKey = p.SSHPrivateKey
+	c.NodeName = p.NodeName
+	c.ProviderID = p.ProviderID
+	c.Kubeconfig = p.Kubeconfig
+	c.TailscaleAuthKey = p.TailscaleAuthKey
+	c.VNCRelayHost = p.VNCRelayHost
+	c.VMCachePNVLAN = p.VMCachePNVLAN
+	c.KnownHostFingerprint = p.KnownHostFingerprint
+	c.NodeLabels = p.NodeLabels
+	c.GHActionsRunner = p.GHActionsRunner
+	c.DisableVMGC = p.DisableVMGC
+	c.SkipTailscaleInstall = p.SkipTailscaleInstall
+	return c
+}
+
 // HostConfigHash is a fleet-wide canonical fingerprint of everything the
 // operator pushes to a host: the rendered install scripts (firewall +
 // vmnat, PN interface, launchd job + plist, Tailscale, node_exporter,
@@ -585,26 +648,10 @@ func UpdateTartKubelet(ctx context.Context, cfg Config) (string, error) {
 func HostConfigHash(cfg Config) string {
 	// Strip per-host / volatile fields so the fingerprint is fleet-wide.
 	// Fleet-config fields (CIDRs, tags, accept-routes, host CPU/mem/pods)
-	// and the embedded binaries are kept.
-	cfg.IP = ""
-	cfg.SSHUser = ""
-	cfg.UserPassword = ""
-	cfg.SSHPrivateKey = nil
-	cfg.NodeName = ""
-	cfg.ProviderID = ""
-	cfg.Kubeconfig = ""
-	cfg.TailscaleAuthKey = ""
-	cfg.VNCRelayHost = ""
-	cfg.VMCachePNVLAN = 0
-	cfg.KnownHostFingerprint = ""
-	cfg.GHActionsRunner = nil
-	cfg.NodeLabels = nil
-	// Per-host role signal (builder hosts set it); the launchd plist
-	// renderer keys --disable-vm-gc off it, so neutralize it too.
-	cfg.DisableVMGC = false
-	// Transport-only: gates whether installTailscale runs, changes no
-	// rendered output. Neutralized so it can never perturb the hash.
-	cfg.SkipTailscaleInstall = false
+	// and the embedded binaries are kept. Stripping is an empty overlay
+	// rather than its own zeroing list, so the set of per-host fields is
+	// defined once, in PerHost, and cannot drift from what callers apply.
+	cfg = cfg.WithPerHost(PerHost{})
 
 	var b strings.Builder
 

--- a/infra/macos-host-bootstrap/perhost_test.go
+++ b/infra/macos-host-bootstrap/perhost_test.go
@@ -1,0 +1,132 @@
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+)
+
+// fleetWideConfigFields are the Config fields that are identical across every
+// host in a fleet, and so must survive a WithPerHost overlay and feed
+// HostConfigHash. Adding a field to Config means naming it here or in PerHost;
+// TestConfigFieldsAreEitherFleetWideOrPerHost fails until one of them does.
+//
+// This list is not the mechanism that keeps the drift path honest -- the single
+// PerHost definition is. It is the tripwire that makes a new Config field a
+// deliberate decision about which side of the split it belongs on, because
+// every past outage in this area began with that decision being made
+// implicitly, by whichever construction sites the author happened to edit.
+var fleetWideConfigFields = map[string]bool{
+	"TartKubeletBinary":       true,
+	"TartTarball":             true,
+	"TailscaleBinaries":       true,
+	"TailscaleTags":           true,
+	"TailscaleAcceptRoutes":   true,
+	"VMKuraEgressCIDR":        true,
+	"VMClusterDNSIP":          true,
+	"VMCachePNCIDR":           true,
+	"SSHIngressAllowCIDRs":    true,
+	"NodeExporterBinary":      true,
+	"LogShipperBinary":        true,
+	"LogShipURL":              true,
+	"LogShipEnv":              true,
+	"HostCPU":                 true,
+	"HostMemoryMB":            true,
+	"MaxPods":                 true,
+	"RunnerCacheVolumeGiB":    true,
+	"CacheVolumeMasterCapGiB": true,
+	"CacheVolumeCASGiB":       true,
+	"VNCRelayPort":            true,
+}
+
+// Every Config field is either fleet-wide or per-host, and PerHost is the
+// authority on the second set. A field that is neither has no defined
+// behaviour: HostConfigHash would fold it into a fleet-wide fingerprint while
+// a caller set it per host, which is exactly the shape that stamps a host as
+// converged to a config it never received.
+func TestConfigFieldsAreEitherFleetWideOrPerHost(t *testing.T) {
+	perHost := map[string]bool{}
+	pt := reflect.TypeOf(PerHost{})
+	for i := range pt.NumField() {
+		perHost[pt.Field(i).Name] = true
+	}
+
+	ct := reflect.TypeOf(Config{})
+	for i := range ct.NumField() {
+		name := ct.Field(i).Name
+		switch {
+		case perHost[name] && fleetWideConfigFields[name]:
+			t.Errorf("Config.%s is listed as both per-host and fleet-wide; it must be exactly one", name)
+		case !perHost[name] && !fleetWideConfigFields[name]:
+			t.Errorf("Config.%s is neither in PerHost nor in fleetWideConfigFields.\n"+
+				"Decide which it is: per-host fields go in PerHost (HostConfigHash strips them, "+
+				"and every push path sets them through the overlay); fleet-wide fields go in the "+
+				"list above and must be set on the operator's single fleet config.", name)
+		}
+	}
+}
+
+// WithPerHost must replace precisely the per-host fields and leave every
+// fleet-wide one untouched. This is what lets HostConfigHash strip per-host
+// state by applying an empty PerHost: if the overlay touched a fleet-wide
+// field the fingerprint would lose it, and if it missed a per-host field the
+// fingerprint would vary per host and every machine would drift forever.
+func TestWithPerHostReplacesExactlyThePerHostFields(t *testing.T) {
+	fleet := nonZeroConfig(t)
+	got := fleet.WithPerHost(PerHost{})
+
+	gv, fv := reflect.ValueOf(got), reflect.ValueOf(fleet)
+	ct := reflect.TypeOf(Config{})
+	for i := range ct.NumField() {
+		name := ct.Field(i).Name
+		zeroed := gv.Field(i).IsZero()
+		if fleetWideConfigFields[name] && zeroed {
+			t.Errorf("WithPerHost cleared fleet-wide Config.%s; HostConfigHash would stop tracking it", name)
+		}
+		if !fleetWideConfigFields[name] && !zeroed {
+			t.Errorf("WithPerHost left per-host Config.%s set to %v; the fleet fingerprint would vary per host",
+				name, gv.Field(i).Interface())
+		}
+	}
+	_ = fv
+}
+
+// nonZeroConfig builds a Config with every field set to a distinctive non-zero
+// value, so a field the overlay silently drops cannot coincidentally match the
+// zero it was supposed to keep.
+func nonZeroConfig(t *testing.T) Config {
+	t.Helper()
+	var cfg Config
+	v := reflect.ValueOf(&cfg).Elem()
+	for i := range v.NumField() {
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("x")
+		case reflect.Int, reflect.Int32, reflect.Int64:
+			f.SetInt(7)
+		case reflect.Uint, reflect.Uint32, reflect.Uint64:
+			f.SetUint(7)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Slice:
+			f.Set(reflect.MakeSlice(f.Type(), 1, 1))
+			if f.Type().Elem().Kind() == reflect.String {
+				f.Index(0).SetString("x")
+			} else {
+				f.Index(0).Set(reflect.New(f.Type().Elem()).Elem())
+				if f.Type().Elem().Kind() == reflect.Uint8 {
+					f.Index(0).SetUint(1)
+				}
+			}
+		case reflect.Map:
+			m := reflect.MakeMap(f.Type())
+			m.SetMapIndex(reflect.ValueOf("k"), reflect.ValueOf("v"))
+			f.Set(m)
+		case reflect.Ptr:
+			f.Set(reflect.New(f.Type().Elem()))
+		default:
+			t.Fatalf("nonZeroConfig does not know how to fill Config.%s (kind %s); teach it", v.Type().Field(i).Name, f.Kind())
+		}
+	}
+	return cfg
+}


### PR DESCRIPTION
## What changed

The fleet/per-host split of the Mac mini host config now has exactly one definition.

`bootstrap.PerHost` names the per-host fields once. `Config.WithPerHost` applies them, and `HostConfigHash` strips them by applying an empty `PerHost`, so the list the operator overlays and the list the hash zeroes are literally the same list. The manager builds a single fleet config, derives the hash from it and hands the same value to the reconciler, and both push paths (first boot and drift update) start from it and overlay only per-host fields.

Net effect: 19 duplicated reconciler fields and two hand-maintained `bootstrap.Config` literals collapse into one.

## Why

The drift-update path and the canonical hash each assembled their own `bootstrap.Config` field by field, and nothing connected them. A field wired into one but not the other made the operator push a config that did not match the hash it then stamped on the host. The host was then recorded as converged to a config it had never received, and the skew stayed invisible until something downstream happened to need the dropped field.

That has happened four times: node_exporter, the log shipper, the cache-volume flags, and the Tailscale tags. The last one froze 11 of 13 production Mac minis on 2026-08-18 with `TartKubeletUpdateExceededRetries`, once the shared credential became a Tailscale OAuth client secret and `validateTailscaleCredential` began rejecting an untagged join outright.

## Why this over the obvious alternative

https://github.com/tuist/tuist/pull/12433 fixed the instance and added a test intended to pin the invariant. That test compares two hand-written literals: a `fleet` config in the test and the reconciler it builds beside it. It catches a regression on any field someone remembered to enumerate there, and it is currently complete. But a field added to `Config` in future and missed on the drift path is also missed in the test's literal, so both sides read zero, the hashes match, and the test passes. The guard still depended on the same human step that failed four times.

Making the split structural removes that dependency instead of testing around it. The invariant is now upheld by there being one list rather than by anyone maintaining a mirror of it.

## Latent bug fixed along the way

`HostCPU` and `HostMemoryMB` are overridable per Machine via `spec.hostCPU` / `spec.hostMemoryMB`, but they are hashed as fleet-wide and the reconciler stamped a single fleet constant. A host with an override was therefore pushed one config and stamped with a different config's hash, and a later change to the overridden field could not drift it.

The desired hash is now resolved per machine from exactly what `hostConfig` would push. No live host is affected: all three machines currently setting overrides (one in production, two in staging) set them to their fleet defaults of 8 / 14336, so their hashes are unchanged.

## Impact

`HostConfigHash` is byte-identical before and after. Verified by running the same probe config through this branch and through `origin/main`:

```
new (this branch): 69df6e23f05c24d37406df034f9fb39d0ff09c5b814a3baf8c5093ab94a4bb24
old (origin/main): 69df6e23f05c24d37406df034f9fb39d0ff09c5b814a3baf8c5093ab94a4bb24
```

So this change does not by itself move the hash or roll the fleet. A release cut from it still rebuilds the operator image, and any change in the embedded binaries moves the hash as usual.

Note that this touches `infra/cluster-api-provider-tuist/` and `infra/macos-host-bootstrap/`, both in the capi-scaleway component's `include_paths`, so merging contributes to the next `capi-scaleway@*` release.

## Validation

- `go build`, `go vet`, `gofmt` and the full `go test ./...` suites pass in both `infra/macos-host-bootstrap` and `infra/cluster-api-provider-tuist`.
- The new guards were confirmed to fail on the two regression shapes they exist for, then restored:
  - dropping a per-host assignment from `WithPerHost` fails `TestWithPerHostReplacesExactlyThePerHostFields` with `WithPerHost left per-host Config.TailscaleAuthKey set to x`
  - adding an unclassified field to `Config` fails `TestConfigFieldsAreEitherFleetWideOrPerHost` with `Config.NewFleetKnob is neither in PerHost nor in fleetWideConfigFields`
- `TestHostConfig_HashMatchesWhatIsStampedOnTheMachine` covers both a default machine and one with per-machine size overrides.
- `TestDesiredHostConfigHash_MovesWithPerMachineOverride` pins that an override actually reaches the fingerprint, so the test above cannot pass trivially.

## Still open, deliberately not in this PR

Canary and staging are both still running an operator without the https://github.com/tuist/tuist/pull/12433 fix (0.22.5 and 0.22.4). Canary is cycling through its retry budget and staging is fully terminal. Getting them onto a fixed operator is a deploy decision, separate from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
