### PR TITLE
fix(infra): alert on unschedulable pods and document the registry-pg decommission

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -233,3 +233,65 @@ base backup.
 `barman_cloud_cloudnative_pg_io_*`. The operator's `cnpg_collector_*` backup
 timestamps do NOT track plugin backups, so point backup panels and alerts at the
 `barman_cloud_*` series.
+
+## Decommissioning a cluster
+
+Deleting the `Cluster` CR deletes the Pods, Services, and PVCs the operator
+owns. It does **not** delete the underlying Hetzner Cloud Volume:
+`hcloud-volumes` sets `reclaimPolicy: Retain` deliberately
+([`infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml`](../k8s/mgmt/bootstrap/hcloud-csi-values.yaml)),
+so the PV outlives its PVC in `Released` and the volume stays allocated and
+billed. The `released-pv-reaper` CronJob
+([`infra/helm/tuist/templates/released-pv-reaper.yaml`](../helm/tuist/templates/released-pv-reaper.yaml))
+exists for exactly this, but it ships `dryRun: true` and no environment
+overrides it today, so it only logs. Until an environment arms it, the volume
+has to be deleted by hand.
+
+Order matters: once the PVC is gone, the PV is the only object still holding
+the volume handle.
+
+1. Record the handle first — `kubectl get pv <name> -o jsonpath='{.spec.csi.volumeHandle}'`.
+   Cluster-scoped reads on `persistentvolumes` are not available to the normal
+   SSO identity, so this needs JIT elevation.
+2. Confirm the data is disposable, or take a final base backup.
+3. Delete the `Cluster` CR.
+4. Delete the `Released` PV, then delete the volume in the `tuist-workloads`
+   Hetzner project.
+
+### The orphaned `registry` namespace
+
+`registry/registry-pg` is a live example still waiting on this. It was created
+on 2026-06-15 by a standalone `registry` chart that moved the registry's Oban
+journal from SQLite onto CloudNativePG. Two days later the sync workers moved
+to the server under `TUIST_MODE=registry_sync`, the registry app became a
+stateless read frontend with no Repo, and the commit that did it also deleted
+the chart's `cnpg-cluster.yaml`. Neither that chart nor its removal ever landed
+on `main` — the registry moved into the `tuist` chart's `registry-*` templates
+in the `tuist` namespace instead — so nothing has run `helm upgrade` or
+`helm uninstall` against the old release since. Its `Cluster`, three Services,
+and PVC were left running in a namespace no chart owns.
+
+Its Pod has been `Pending` since 2026-07-06, when the node its volume was
+pinned to was destroyed, so the database has served nothing for six weeks with
+no consequence. Nothing depends on the data: the registry's source of truth is
+its Tigris bucket, and the Oban journal the cluster held is regenerable from a
+sync. It should be removed with the steps above, deleting the `registry`
+namespace once the `Cluster` is gone.
+
+### How the volume ended up unschedulable
+
+The PVC's `volume.kubernetes.io/selected-node` names an OVH bare-metal kura
+node, which should never have been a candidate for an `hcloud-volumes` PVC.
+It was, because `hcloud-csi-node` still ran there: the DaemonSet's node
+affinity excluded non-Hetzner pools by enumerating pool names, and the list
+only covered the pools that existed when each entry was written. With the
+driver registered on that node, the scheduler treated it as a valid
+`selected-node` for a `WaitForFirstConsumer` claim and the provisioner bound a
+location-pinned Hetzner volume behind a Pod that could only ever run off
+Hetzner.
+
+That enumeration bug is already fixed — `hcloud-csi-values.yaml` now excludes
+by provider label (`node.cluster.x-k8s.io/instance-type NotIn [ovh, dedibox,
+scaleway]`) so a new region on an existing provider needs no edit — but the fix
+landed on 2026-07-03, after this volume was bound on 2026-06-16. The stranded
+PVC is residue from the window before it, not a live misconfiguration.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1041,6 +1041,57 @@ muted, and this is the only signal covering a class of failure that
 previously went unnoticed for two months. Twenty-four hours clears the
 worst case with margin and still catches a wedge the next day.
 
+### Pod cannot be scheduled
+
+Catches a Pod the scheduler has given up placing. Nothing else in this
+document covers it, because an unscheduled Pod produces none of the
+signals the other workload rules read: it has no container, so there is
+no waiting reason, no termination reason, and no restart count, and it
+never had a ready endpoint to lose. Its Services keep existing with zero
+endpoints, which reads as "no traffic" rather than "no backend".
+
+That is how `registry/registry-pg-1` — the sole instance of a
+CloudNativePG cluster — sat `Pending` in production from 2026-07-06 to
+2026-08-18 without anyone noticing. Its volume had been provisioned
+against a node that was later destroyed, and Hetzner Cloud Volumes are
+location-bound, so the replacement Pod could not satisfy the volume's
+node affinity anywhere in the cluster. All three of that cluster's
+Services served zero endpoints for six weeks.
+
+```promql
+max by (cluster, namespace, pod) (
+  kube_pod_status_unschedulable{namespace!="tuist-runners"}
+) == 1
+```
+
+- Pending period: 30 minutes
+- Severity: warning
+- Summary: `Pod {{ $labels.namespace }}/{{ $labels.pod }} has been unschedulable for 30 minutes in {{ $labels.cluster }}`
+
+No metric change is needed. The kube-state-metrics tuning in
+[`values.yaml`](./values.yaml) already keeps `kube_pod_status_unschedulable`
+cluster-wide while dropping the rest of `kube_pod_*` for the runner
+namespace, on the grounds that it is a cheap placement signal — so the
+series for this incident existed in Grafana Cloud the whole time and
+nothing read it.
+
+`tuist-runners` is excluded rather than alerted on. Unschedulable Pods
+are an expected steady state there: the autoscaler deliberately asks for
+more replicas than the fleet can bin-pack, and the surplus stays
+unschedulable until hosts free up. The real runner-side failure is
+already covered by *Runner queue not draining*, which measures queue age
+and does not confuse a capacity ceiling with a fault. Idle Linux runners
+would not have matched this rule in any case — they are `Pending` because
+their dispatch poller runs as an init container, not because the
+scheduler could not place them.
+
+Thirty minutes clears the ordinary path where a Pod waits on the cluster
+autoscaler to add a node, and is short enough that a volume-affinity or
+taint mistake surfaces the same morning instead of six weeks later. This
+is a warning rather than a page because it fires on any workload in any
+namespace: the Pod that motivated it was critical, but most Pods that
+briefly cannot schedule are not.
+
 ### Kubernetes request latency
 
 ```promql


### PR DESCRIPTION
## What's wrong

`registry/registry-pg-1` in `tuist-k8s-production` has been `Pending` for 43 days. All three of its CloudNativePG Services — `registry-pg-r`, `registry-pg-ro`, `registry-pg-rw` — have served **zero endpoints** that whole time. The database has been completely unreachable, not degraded, and nothing complained.

It is dead weight, and it should be deleted.

## Is it used by anything?

No. The evidence is consistent from four directions:

- The registry app on `main` has no `Repo`, no `postgrex`/`ecto_sql` in `mix.exs`, no `repo/` directory, and no `DATABASE_URL` anywhere in `registry/`.
- No file in this repository — chart, config, workflow or source — contains the string `registry-pg`.
- The live registry is healthy in the `tuist` namespace (`tuist-tuist-registry`, 2/2 Running), rendered by the `tuist` chart's `registry-*` templates. The Swift sync worker (`tuist-tuist-swift-registry-sync`) gets its `DATABASE_URL` from the main `tuist-tuist-pg` cluster.
- Six weeks of total unavailability produced no incident.

## How it got orphaned

- **2026-06-15** — a standalone `registry` chart moved the registry's Oban journal from SQLite onto CloudNativePG, adding `infra/helm/registry/templates/cnpg-cluster.yaml`. Deployed to production; the `Cluster`, Services and PVC appear on 2026-06-16.
- **2026-06-17** — two days later, the sync workers moved to the server under `TUIST_MODE=registry_sync`. The registry became a stateless read frontend and the commit deleted `cnpg-cluster.yaml`, noting that a `helm upgrade` would drop the cluster: *safe, nothing depends on its data anymore, the bucket is the source of truth*.
- That upgrade never happened. **Neither the chart nor its removal ever landed on `main`** — the registry moved into the `tuist` chart in the `tuist` namespace instead, and `infra/helm/registry/` has never existed on `main`. So no `helm upgrade` and no `helm uninstall` has run against the old release since. Its objects were left running in a namespace no chart owns.
- **2026-07-06** — the node its volume was pinned to was destroyed. The replacement Pod could not be placed and has been `Pending` ever since.

This is why the PR contains no deletion. Following the [once#222](https://github.com/tuist/once/pull/222) pattern is not possible here: **there is nothing in the repo that renders this cluster.** The removal is an operational action, and what the repo can carry is the runbook and the missing signal.

## Why a Hetzner volume was bound to an OVH node

The PVC's `volume.kubernetes.io/selected-node` names `tuist-kura-us-east-rsgh4-vshwz-qcjhf`, an OVH bare-metal kura node that no longer exists, against storageClass `hcloud-volumes`.

`hcloud-csi-node` ran there. At the time, the DaemonSet's node affinity excluded non-Hetzner pools by **enumerating pool names**, and the list only covered the pools that existed when each entry was written — `runners-linux` and `darwin` on 2026-06-16, with `kura-dedibox` and `kura-ovh-staging` added on 06-23 and 06-26. `hcloud-csi-values.yaml` documents this exact failure mode in its own comments, from a prior occurrence. With the driver registered on that node, the scheduler treated it as a valid `selected-node` for a `WaitForFirstConsumer` claim, and the provisioner bound a location-pinned Hetzner Cloud volume behind a Pod that could only ever run off Hetzner.

**That bug is already fixed.** `57dbaf4738` (2026-07-03) switched the exclusion to the provider label `node.cluster.x-k8s.io/instance-type NotIn [ovh, dedibox, scaleway]`, so a new region on an existing provider needs no edit. The fix landed **after** this volume bound on 06-16, so the stranded PVC is residue from the window before it, not a live misconfiguration. No action is needed to prevent recurrence on other pools.

## Why nobody noticed for 43 days

An unscheduled Pod produces none of the signals the existing rules read. It has no container, so there is no waiting reason, no termination reason and no restart count. It never had a ready endpoint to lose. Its Services keep existing with zero endpoints, which reads as *no traffic* rather than *no backend*.

`infra/helm/k8s-monitoring/alerts.md` has no rule on `kube_pod_status_unschedulable` and none on endpoint availability. The metric itself was never the problem — the kube-state-metrics tuning in `values.yaml` explicitly keeps `kube_pod_status_unschedulable` cluster-wide as "a cheap placement signal", dropping only the rest of `kube_pod_*` for the runner namespace. **The series existed in Grafana Cloud for all 43 days and nothing read it.** So the repo change is the documented query, not a metric change.

`tuist-runners` is excluded from the rule. Unschedulable Pods are an expected steady state there — the autoscaler deliberately over-asks and the surplus waits for hosts — and the real runner failure is already covered by *Runner queue not draining*, which measures queue age. Idle Linux runners would not have matched anyway: they are `Pending` because their dispatch poller runs as an init container, not because the scheduler could not place them.

Warning rather than critical, at a 30-minute pending period: the rule fires on any workload in any namespace, and while the Pod that motivated it was a database, most Pods that briefly cannot schedule are not. Thirty minutes clears a normal wait on the cluster autoscaler and still surfaces a volume-affinity or taint mistake the same morning.

## The Retain trap in the cleanup

`hcloud-volumes` sets `reclaimPolicy: Retain` on purpose, so deleting the `Cluster` deletes the PVC but leaves the PV `Released` and the **Hetzner volume allocated and billed**. `released-pv-reaper` exists for this, but it still ships `dryRun: true` with no environment overriding it, so today it only logs.

The consequence is an ordering constraint, and it is the reason the runbook leads with it: once the PVC is gone the PV is the only object still holding the volume handle, and reading a PV needs JIT elevation. Record the handle *first*. This is the same `Retain` orphan pattern that stranded 250 volumes (~36 TB) in `tuist-workloads` in July.

## Changes

- `infra/helm/k8s-monitoring/alerts.md` — new warning alert **Pod cannot be scheduled**, with the query, the `tuist-runners` exclusion and its rationale, and the pending-period reasoning.
- `infra/cnpg/README.md` — new **Decommissioning a cluster** section: the `Retain` caveat and the ordered steps, the orphaned `registry` namespace as a worked example still awaiting cleanup, and how the volume was stranded.

Alert rules are Grafana UI-managed, so merging this documents the rule; **someone still has to create it in Grafana**.

## Validation

- Read-only `kubectl` against `tuist-k8s-production` for Pod, PVC, Service, endpoint, node and event state, and for the healthy registry Pods in `tuist`.
- Node topology confirms the scheduler message: the 5 nodes failing PV node affinity are the untainted Hetzner `fsn1` nodes; every other node is tainted, unschedulable, or non-Hetzner.
- Git history for the chart lifecycle (add 06-15, remove 06-17, never on `main`) and the CSI affinity timeline (pool enumeration → provider label on 07-03).
- Confirmed the registry app on `main` has no Repo/postgrex/`DATABASE_URL`, and that nothing in the repo references `registry-pg`.
- Link targets in both files verified to exist.

Not verified: reading the PV's `nodeAffinity` and `csi.volumeHandle`, and the CNPG `Cluster` spec, need JIT elevation. The CSI mechanism above is inferred from the affinity history and the `WaitForFirstConsumer` provisioning path rather than read from a `CSINode` object, which is also RBAC-forbidden. Neither changes the recommendation.

## Suggested follow-up

Delete the cluster per the new runbook, then the `registry` namespace. Take a final base backup first if you want a paper trail, though the Oban journal it held is regenerable from a sync and the registry's source of truth is its Tigris bucket. **Not done here — this PR proposes and documents; it deploys nothing.**
