### PR TITLE
fix(infra): right-size the canary control plane and egress pool to cpx22

### DIFF
--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -32,7 +32,7 @@ clusters/
 | Cluster | CP | Workers |
 |---|---|---|
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: bare-metal Robot (`pool=runners-linux`) |
-| `tuist-canary` | 3× cpx32 | md-0: 2× cpx32; md-egress: 2× cpx32 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
+| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
 | `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -25,7 +25,7 @@ spec:
       - name: region
         value: fsn1
       - name: hcloudControlPlaneMachineType
-        value: cpx32
+        value: cpx22
       # Roll out the kubeadm compatibility fallback in canary first. With the
       # local-mode feature enabled, new control-plane kubelets point at their
       # own not-yet-running control-plane endpoint and never start the etcd
@@ -101,8 +101,11 @@ spec:
               maxInFlight: 1
           variables:
             overrides:
+              # Forwards/SNATs server egress only — runs no application
+              # workload, so it doesn't need the general pool's dedicated
+              # vCPU shape.
               - name: hcloudWorkerMachineType
-                value: cpx32
+                value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
               # Isolate the gateway pool: only cilium, hcloud-csi, the egress


### PR DESCRIPTION
## What changed

`tuist-canary` moves from `cpx32` to `cpx22` for two roles:

- the control plane (`hcloudControlPlaneMachineType`, 3 replicas)
- the stable-egress gateway pool (`md-egress` override, 2 replicas)

`md-0` stays on `cpx32`. The inventory table in `infra/k8s/clusters/README.md` is updated to match.

## Why

Canary was the only cluster running `cpx32` in these two roles:

| | control plane | md-0 | md-egress |
|---|---|---|---|
| production | `cpx22` | `ccx23` | `cpx22` |
| staging | `cpx22` | `cpx32` | `cpx22` |
| canary (before) | `cpx32` | `cpx32` | `cpx32` |

Canary's file header says it "mirrors staging shape", and staging uses `cpx22` for both. So canary was provisioned a size above the environment it gates, while carrying a fraction of production's traffic.

For the egress pool specifically, production's override already states the reasoning, which applies identically to canary: the pool forwards and SNATs server egress and runs no application workload, so it does not need the general pool's dedicated-vCPU shape. That comment is carried over here.

The strongest signal that this is drift rather than intent: canary's own pool comment still describes "these 4 GB nodes" (the `cpx22` shape) while the machine type had moved to `cpx32`. The comment was written for the size this PR restores.

## How it was found

While attributing the Hetzner Cloud usage report to workloads. The two pools cost roughly EUR 80/mo more than the production-equivalent shapes, about EUR 960/yr, for capacity canary does not need.

Worth noting separately: canary's nodes were all created after the 15 June 2026 Hetzner price increase, so they already bill at current rates. The replacements this rollout creates carry no additional price change.

## Impact

Rolls canary's control plane (3 nodes) and egress pool (2 nodes). Both use `RollingUpdate` with `maxSurge: 1` / `maxUnavailable: 0`, so replacements come up before old nodes drain.

The egress pool keeps its `unhealthyInRange: "[0-1]"` + `maxInFlight: 1` remediation floor, so one gateway stays serving throughout. The stable-egress controller moves the Floating IP to a Ready candidate as nodes cycle, which is the failover path this pool exists to exercise.

No production change. If canary shows control-plane pressure at `cpx22`, that is itself a useful signal ahead of production, which runs the same shape.

## Validation

Measured live usage on both clusters (`kubectl top nodes`) to check the target shape against real load. Production already runs `cpx22` in both roles under heavier load than canary carries, which is the direct evidence that the shape fits.

Egress pool, comfortably within range:

| node | pool shape | memory |
|---|---|---|
| `tuist-md-egress-5ql7b-6p9hl-6wzlv` (production) | cpx22 | 1383Mi / 37% |
| `tuist-md-egress-5ql7b-6p9hl-r4rrm` (production) | cpx22 | 1510Mi / 40% |
| `tuist-canary-md-egress-p75zm-csp6c-698vd` | cpx32 today | 1163Mi |
| `tuist-canary-md-egress-p75zm-csp6c-p99t9` | cpx32 today | 1572Mi |

Canary's egress nodes use 1163-1572Mi, which lands at roughly 31-42% of a `cpx22` — the same band production sits in.

Control plane, tighter but within the production band:

| node | pool shape | memory |
|---|---|---|
| `tuist-twnzm-lh4cz` (production) | cpx22 | 2576Mi / 69% |
| `tuist-twnzm-n96lt` (production) | cpx22 | 2398Mi / 64% |
| `tuist-twnzm-sbc29` (production) | cpx22 | 2472Mi / 66% |
| `tuist-canary-q295m-26l67` | cpx32 today | 2670Mi |
| `tuist-canary-q295m-9pwz4` | cpx32 today | 2931Mi |
| `tuist-canary-q295m-vtg5f` | cpx32 today | 2422Mi |

Canary's busiest control-plane node (2931Mi) projects to about 79% of a `cpx22`, against production's 64-69% on the same shape. Workable, but with less headroom than production has, so this pool is worth watching after the rollout. That signal arriving on canary first is the intended behaviour.

Also checked:

- Machine types compared across all three cluster CRs; canary confirmed the sole outlier in both roles.
- Egress-pool rollout strategy and health-check floor confirmed unchanged.
- No corresponding change needed in `clusterclass-tuist.yaml`: both values are per-cluster variables, not class defaults.
- `md-0` deliberately excluded: `tuist-canary-md-0-rwjfn-j7n97-qv752` is already at 6568Mi / 85% memory, so that pool has no room to shrink.

Not yet validated: the actual rollout. This has not been applied to canary.
