### PR TITLE
feat(infra): let a write elevation observe, tune, and retire CNPG clusters

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -69,9 +69,9 @@ subjects:
 # omits cluster-scoped and custom resources, so a view-tier identity (every
 # member + their agents) can't observe the infra it routinely needs to:
 # nodes, CAPI machines, our Scaleway provider CRs, the Kura CRs, the
-# RunnerPool CRs, the CNPG Postgres clusters, CRDs, and RBAC objects. This aggregates into `view` via
-# the label below (no extra binding; both tuist-admins and tuist-eng
-# inherit it), and is strictly
+# RunnerPool CRs, the CNPG Postgres clusters, CRDs, and RBAC objects. This
+# aggregates into `view` via the label below (no extra binding; both
+# tuist-admins and tuist-eng inherit it), and is strictly
 # `get`/`list`/`watch` with no `secrets` rule, so the view tier's deliberate
 # Secret exclusion is untouched. None of these resource kinds embed secret
 # data (CAPI/Kura/CNPG reference Secrets by name, never inline).
@@ -174,15 +174,15 @@ rules:
 #     an incident-time action that cannot destroy anything. No delete: pruning
 #     the archive is barman's retention job, not an operator's.
 #
-# `delete` on `clusters` is withheld, and that is the one place this diverges
+# `delete` on `clusters` is withheld from THIS role, which is where it diverges
 # from `tuist-edit-kura-write`. A Kura CR is regenerable (the control plane
-# re-renders it and the mesh refills), so granting delete there costs a cache
-# warm-up. A CNPG `Cluster` is not: deleting it deletes the PVCs it owns, and
-# `tuist-tuist-pg` is the production datastore. Nothing a TTL-bounded elevation
-# is for requires destroying a database, and a genuine decommission is rare,
-# deliberate, and reviewed. It stays an admin action. `create` is withheld for
-# the same reason inverted: standing up a datastore is a chart change, not an
-# operator action.
+# re-renders it and the mesh refills), so delete rides along with the other
+# verbs there. A CNPG `Cluster` is not: deleting it deletes the PVCs it owns.
+# Retiring a cluster is still a real operation, so the capability does exist,
+# but it lives in `tuist-cnpg-decommission` below on a direct binding to the
+# elevation group rather than in this aggregated role, so it cannot be
+# inherited by anything else that later binds `edit`. `create` is withheld
+# outright: standing up a datastore is a chart change, not an operator action.
 #
 # Scoped to named kinds rather than `*` so future kinds in the group (Database,
 # Publication, Subscription) do not silently inherit write access, following
@@ -201,6 +201,66 @@ rules:
   - apiGroups: ["postgresql.cnpg.io"]
     resources: ["backups"]
     verbs: ["get", "list", "watch", "create"]
+---
+# Decommission capability for RETIRING a CNPG cluster. Separated from
+# `tuist-edit-cnpg-write` above because `delete` on a datastore deserves a
+# tighter binding than the rest of the CNPG verbs, and modelled on
+# `tuist-fleet-unwedge` below rather than on the aggregated roles.
+#
+# Why it exists at all: there is no tier between the JIT write elevation and
+# the break-glass kubeconfig. Withholding cluster deletion from the elevation
+# does not make the operation safer, it makes the only route to it the
+# emergency path, so a planned decommission of a dead cluster would be done
+# with credentials reserved for incidents. That inverts the access policy.
+# Gating it behind an elevation that is requested with a stated intent,
+# TTL-bounded, and audited is the stronger control.
+#
+# Why the blast radius is acceptable: every managed cluster archives WAL
+# continuously and takes base backups to Tigris through the Barman Cloud
+# Plugin, and the `ObjectStore` CR holding that archive is a separate object
+# that a Cluster delete does not touch. The PVCs are `hcloud-volumes`, which
+# is `reclaimPolicy: Retain`, so they outlive the Cluster too. Deleting a
+# Cluster CR is therefore a severe outage and a restore, not data loss.
+#
+# Like `tuist-fleet-unwedge`, this is NOT aggregated into `edit`. It binds
+# straight to `tuist-<env>-write` below, so the capability is welded to an
+# active elevation and cannot be inherited by a service account or a team
+# namespace through some later RoleBinding onto the generic `edit` role.
+#
+# Deliberately narrow: `clusters` only, `delete` only. Poolers, backups and
+# scheduled backups keep the non-destructive verbs granted above. Namespaces
+# stay untouched, so retiring a cluster leaves an empty namespace behind for
+# an admin to sweep; that is inert, and granting namespace deletion here
+# would reach every namespace in the cluster, not just a retired one.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-cnpg-decommission
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["delete"]
+---
+# Bind the decommission role straight to this env's write-elevation group, so
+# cluster deletion lives ONLY on an active `tuist-<env>-write` elevation and
+# never on the generic `edit` tier. Per-env like the bindings above, so a prod
+# elevation cannot retire a staging cluster or vice versa.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tuist-{{ .Values.tuistEnv }}-write-cnpg-decommission
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tuist-cnpg-decommission
+subjects:
+  - kind: Group
+    name: tuist-{{ .Values.tuistEnv }}-write
+    apiGroup: rbac.authorization.k8s.io
 ---
 # Host-recovery capability for UN-WEDGING a single fleet host without the
 # break-glass kubeconfig. A tart-kubelet host whose drift roll can't reach it

--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -69,12 +69,12 @@ subjects:
 # omits cluster-scoped and custom resources, so a view-tier identity (every
 # member + their agents) can't observe the infra it routinely needs to:
 # nodes, CAPI machines, our Scaleway provider CRs, the Kura CRs, the
-# RunnerPool CRs, CRDs, and RBAC objects. This aggregates into `view` via
+# RunnerPool CRs, the CNPG Postgres clusters, CRDs, and RBAC objects. This aggregates into `view` via
 # the label below (no extra binding; both tuist-admins and tuist-eng
 # inherit it), and is strictly
 # `get`/`list`/`watch` with no `secrets` rule, so the view tier's deliberate
 # Secret exclusion is untouched. None of these resource kinds embed secret
-# data (CAPI/Kura reference Secrets by name, never inline).
+# data (CAPI/Kura/CNPG reference Secrets by name, never inline).
 #
 # RBAC read (clusterroles/rolebindings) is the one deliberate widening of the
 # upstream `view` shape: it exposes the authorization graph, which `view`
@@ -102,6 +102,8 @@ rules:
       - infrastructure.cluster.x-k8s.io
       - kura.tuist.dev
       - tuist.dev
+      - postgresql.cnpg.io
+      - barmancloud.cnpg.io
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
@@ -154,6 +156,51 @@ rules:
   - apiGroups: ["tuist.dev"]
     resources: ["runnerpools"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+---
+# CNPG analog of `tuist-edit-kura-write`, and deliberately narrower. The
+# CloudNativePG clusters (`tuist-tuist-pg`, `tuist-ops-pg`, and their per-env
+# equivalents) were invisible to every tier until now: `postgresql.cnpg.io` was
+# absent from `tuist-view-infra-read` above, and `edit` covers no custom
+# resources at all. So an operator holding an active write elevation could not
+# read a Cluster's status, let alone patch one, during exactly the incident the
+# elevation exists for.
+#
+# Mutation is limited to verbs that change how a cluster runs, never whether it
+# exists:
+#   * clusters, poolers, scheduledbackups: update/patch. The real incident
+#     actions: bump `instances`, adjust resources, change a `primaryUpdate`
+#     strategy, annotate to force a reconcile, flip a pooler.
+#   * backups: create. Taking an ad-hoc base backup before a risky change is
+#     an incident-time action that cannot destroy anything. No delete: pruning
+#     the archive is barman's retention job, not an operator's.
+#
+# `delete` on `clusters` is withheld, and that is the one place this diverges
+# from `tuist-edit-kura-write`. A Kura CR is regenerable (the control plane
+# re-renders it and the mesh refills), so granting delete there costs a cache
+# warm-up. A CNPG `Cluster` is not: deleting it deletes the PVCs it owns, and
+# `tuist-tuist-pg` is the production datastore. Nothing a TTL-bounded elevation
+# is for requires destroying a database, and a genuine decommission is rare,
+# deliberate, and reviewed. It stays an admin action. `create` is withheld for
+# the same reason inverted: standing up a datastore is a chart change, not an
+# operator action.
+#
+# Scoped to named kinds rather than `*` so future kinds in the group (Database,
+# Publication, Subscription) do not silently inherit write access, following
+# `tuist-edit-runners-write`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-edit-cnpg-write
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "poolers", "scheduledbackups"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["backups"]
+    verbs: ["get", "list", "watch", "create"]
 ---
 # Host-recovery capability for UN-WEDGING a single fleet host without the
 # break-glass kubeconfig. A tart-kubelet host whose drift roll can't reach it


### PR DESCRIPTION
## What's wrong

CloudNativePG is invisible to every access tier we have.

The JIT elevation path has exactly one axis, environment. `/elevate <env>` maps through a fixed three-entry table to `tuist-{staging,canary,production}-write`, and all three bind to the built-in **`edit`** ClusterRole. `edit` covers no custom resources. And `postgresql.cnpg.io` is also missing from the `tuist-view-infra-read` aggregation that backfills CRD reads for `cluster.x-k8s.io`, `kura.tuist.dev` and `tuist.dev`.

The result: an operator holding an active production write elevation cannot read a CNPG `Cluster`'s status, let alone patch or retire one. That is the state during exactly the incident the elevation exists for, on `tuist-tuist-pg`, the production datastore.

## How it surfaced

Found while trying to decommission the orphaned `registry-pg` cluster (see [#12442](https://github.com/tuist/tuist/pull/12442)). An elevation was granted and turned out not to reach the resource:

```
can-i delete clusters.postgresql.cnpg.io -n registry   ->  no
namespaces                                             ->  [get list watch]
```

The sharper problem is what the tier *did* allow. `edit` covers Pods and PVCs, so the one action available was deleting the Pod and PVC directly, leaving the `Cluster` CR in place. The operator would have reconciled both straight back and provisioned a **second** volume, stranding the first. So the tier was not merely insufficient; it was shaped to permit the harmful action and refuse the correct one.

## Changes

All in `infra/helm/pomerium/templates/access-tiers.yaml`.

**Reads** are added to the existing view aggregation for `postgresql.cnpg.io` and `barmancloud.cnpg.io`, so cluster health and backup state are observable without any elevation. That block's existing safety argument carries over unchanged: these CRs reference Secrets by name and never inline them, so the view tier's deliberate Secret exclusion is untouched.

**Tuning** gets a new `tuist-edit-cnpg-write` ClusterRole aggregated into `edit`:

| Resources | Verbs |
|---|---|
| `clusters`, `poolers`, `scheduledbackups` | `get, list, watch, update, patch` |
| `backups` | `get, list, watch, create` |

`update/patch` covers the real incident actions: bump `instances`, adjust resources, change a `primaryUpdate` strategy, annotate to force a reconcile, flip a pooler. `create` on `backups` covers taking an ad-hoc base backup before a risky change. No `delete` on backups: pruning the archive is barman's retention job.

**Decommissioning** gets `tuist-cnpg-decommission`: `delete` on `clusters`, nothing else, bound **directly** to `tuist-<env>-write` rather than aggregated into `edit`.

## Why decommissioning is included, and why it is bound separately

The first pass of this PR withheld cluster deletion, on the grounds that no elevation should be able to destroy a datastore. That reasoning does not survive contact with the access model, and reviewers should know it was reversed deliberately.

There is no tier between the JIT write elevation and the break-glass kubeconfig. Withholding the verb therefore does not remove the capability, it **relocates it to the emergency path**: retiring a dead cluster would be done with credentials reserved for incidents, which inverts the access policy rather than reinforcing it. An elevation that is requested with a stated intent, TTL-bounded and audited is the stronger control.

The blast radius was also overstated. Every managed cluster archives WAL continuously and takes base backups to Tigris through the Barman Cloud Plugin, and the `ObjectStore` CR holding that archive is a **separate object** that a Cluster delete does not touch. The PVCs are `hcloud-volumes`, which is `reclaimPolicy: Retain`, so they outlive the Cluster too. Deleting a Cluster CR is a severe outage and a restore, not data loss.

The direct binding is the same device `tuist-fleet-unwedge` already uses for `delete machines`: it welds the verb to an active elevation so it cannot be inherited by a service account or a team namespace through some later RoleBinding onto the generic `edit` role.

Namespaces stay untouched. Granting namespace deletion would reach every namespace in the cluster rather than a retired one, so a retired cluster leaves an inert empty namespace for an admin to sweep.

Kinds are enumerated rather than globbed throughout, so future kinds in the group (`Database`, `Publication`, `Subscription`) do not silently inherit write access, following the precedent `tuist-edit-runners-write` set by scoping to `runnerpools` instead of all of `tuist.dev`.

## Effect

After this deploys, an active `tuist-<env>-write` elevation can:

```bash
kubectl --context tuist-k8s-production delete cluster.postgresql.cnpg.io registry-pg -n registry
```

which is what unblocks [#12442](https://github.com/tuist/tuist/pull/12442)'s cleanup without break-glass.

## Validation

- `helm lint` clean.
- `helm template --set tuistEnv=production` renders `tuist-cnpg-decommission` with `delete` on `clusters` and **no** aggregation label, its ClusterRoleBinding pointing at `tuist-production-write`, and `tuist-edit-cnpg-write` still carrying no `delete` verb in any rule.
- `tuist-view-infra-read` renders with both `postgresql.cnpg.io` and `barmancloud.cnpg.io`.
- The live gap this fixes was confirmed against `tuist-k8s-production` under an active `group:tuist-production-write` elevation.

## Rollout note

This is RBAC, so it takes effect on the next `pomerium` chart deploy per environment. Worth a real review rather than a rubber stamp: it widens what an active write elevation can do, and the argument for where the line sits is the substance of the change.
