### PR TITLE
fix(server): scope runner recovery telemetry handlers to the emitting test

### DIFF
--- a/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
@@ -91,11 +91,30 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
       expect(Jobs, :record_queued, fn _wfid -> :ok end)
       expect(Claims, :release, fn _wfid, _handle -> :ok end)
 
-      ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_recovery()])
+      # Every recovery worker emits this event and telemetry handlers are
+      # VM-global, so `:telemetry_test.attach_event_handlers/2` would forward
+      # a sibling `async: true` module's emission into this mailbox and it
+      # would win the `assert_receive`. The handler runs in the emitting
+      # process, so pinning it to ours keeps only the event this test caused.
+      handler_id = make_ref()
+      test_pid = self()
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          Telemetry.event_name_recovery(),
+          fn _name, measurements, metadata, _config ->
+            if self() == test_pid do
+              send(test_pid, {:recovery, handler_id, measurements, metadata})
+            end
+          end,
+          nil
+        )
 
       assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
 
-      assert_receive {[:tuist, :runners, :recovery], ^ref, measurements, metadata}
+      assert_receive {:recovery, ^handler_id, measurements, metadata}
       assert metadata.kind == "orphan_requeued"
       assert metadata.fleet == "tuist-tuist-runner-pool-macos-26-6"
       assert_in_delta measurements.stranded_ms, 90_000, 5_000

--- a/server/test/tuist/runners/workers/webhook_redelivery_worker_test.exs
+++ b/server/test/tuist/runners/workers/webhook_redelivery_worker_test.exs
@@ -267,14 +267,22 @@ defmodule Tuist.Runners.Workers.WebhookRedeliveryWorkerTest do
     end
 
     test "emits recovery telemetry with kind=redelivered" do
+      # Same VM-global handler caveat as OrphanedRunnersWorkerTest: without
+      # the emitting-process check this forwards every other recovery
+      # worker's event into whichever `async: true` test emitted it.
+      handler_id = make_ref()
+      test_pid = self()
+
       :telemetry.attach(
-        "webhook-redelivery-test",
+        handler_id,
         Tuist.Runners.Telemetry.event_name_recovery(),
-        fn _e, m, meta, _ -> send(self(), {:recovery, m, meta}) end,
+        fn _e, m, meta, _ ->
+          if self() == test_pid, do: send(test_pid, {:recovery, handler_id, m, meta})
+        end,
         nil
       )
 
-      on_exit(fn -> :telemetry.detach("webhook-redelivery-test") end)
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       failed = delivery(id: 8_001)
 
@@ -284,7 +292,7 @@ defmodule Tuist.Runners.Workers.WebhookRedeliveryWorkerTest do
 
       assert :ok = WebhookRedeliveryWorker.perform(%Oban.Job{})
 
-      assert_received {:recovery, %{count: 1}, %{kind: "redelivered"}}
+      assert_received {:recovery, ^handler_id, %{count: 1}, %{kind: "redelivered"}}
     end
   end
 


### PR DESCRIPTION
Fixes an order-dependent failure in `OrphanedRunnersWorkerTest` "recovery telemetry carries the fleet and how long the job sat stranded".

## What changed

`orphaned_runners_worker_test.exs` and `webhook_redelivery_worker_test.exs` now attach their `[:tuist, :runners, :recovery]` telemetry handler manually and forward the event only when the handler runs in the test's own process.

## Why

The test attached its handler with `:telemetry_test.attach_event_handlers/2`, which installs a VM-global handler: it forwards every emission of the event into the attaching test's mailbox regardless of which process emitted it. Pinning the returned ref does not help, because the ref identifies the handler rather than the emitter.

Eight call sites emit `[:tuist, :runners, :recovery]` (every recovery worker, plus `runner_pods_controller` and `runner_job_metrics_controller`), and several of their test modules are `async: true`. Whichever emitted first won the `assert_receive`, so the test asserted on another module's metadata.

## Root cause evidence

The originally reported failure showed `kind == "redelivered"`. Reproducing at the same seed here produced `kind == "orphaned_stamped_pod"` instead. The intruding value changes between runs, and `OrphanedRunnersWorker` has no code path that emits either kind, which rules out the intuitive first guess of Mimic stub or fixture leakage. The `delivery_id=5001` 422 warning that accompanied the original report was a concurrent test's log landing in the same captured output, not a causal signal.

## Why this fix over the alternatives

Telemetry handlers execute synchronously in the emitting process, so `self() == test_pid` is an exact filter.

Widening the `assert_receive` timeout would not help, because the foreign event arrives first rather than late. Narrowing the `assert_receive` pattern to match on `kind` would pass today but would silently race again as soon as a second emitter of the same kind appears.

`WebhookRedeliveryWorkerTest` is the mirror of the same hazard rather than unrelated cleanup: its handler sent to the emitting process, injecting `{:recovery, ...}` messages into unrelated async tests' mailboxes, and it used a fixed string handler id that would collide if another module reused it. It gets the same process check and a `make_ref/0` id. Both tests also carry the handler id in the message and pin it, so a stray global handler elsewhere cannot match.

## Impact

Test-only. No production code changed, and the assertions themselves are unchanged.

## Deliberately not changed

`jobs_test.exs:1211` and `storage_test.exs` use the same global-handler pattern. They pass today, `jobs_test` because it filters on a distinctive fleet name in its `assert_receive` pattern and `storage_test` because each test uses its own event name, but they are protected by coincidence rather than by construction. Worth revisiting if either event gains a second emitter.

### How to test locally

From `server/`, the order that reproduces the failure on `main`:

```
mix test test/tuist/runners/ test/tuist/billing_test.exs test/tuist/billing/ test/tuist/command_events_test.exs --seed 424242
```

Validation run on this branch: seed 424242 goes from 1 failure out of 640 to 640 passed. Also green at seeds 129644, 7777, 1, 313131 and 999999, in isolation (23 passed), and under `mix format --check-formatted` and `mix credo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
