### PR TITLE
fix(server): permit agent input on public content

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -18,7 +18,7 @@ defmodule TuistWeb.Router do
   alias TuistWeb.Plugs.SentryContextPlug
   alias TuistWeb.Plugs.UeberauthHostPlug
 
-  @public_robots_txt [train_ai: true, search: true]
+  @public_robots_txt [train_ai: true, search: true, ai_input: true]
   @marketing_route_metadata %{type: :marketing, robots_txt: @public_robots_txt}
   @docs_route_metadata %{type: :docs, robots_txt: @public_robots_txt}
 

--- a/server/test/tuist_web/controllers/robots_txt_controller_test.exs
+++ b/server/test/tuist_web/controllers/robots_txt_controller_test.exs
@@ -7,11 +7,11 @@ defmodule TuistWeb.RobotsTxtControllerTest do
       body = response(conn, 200)
 
       assert body =~ "Content-Signal: ai-train=no, search=no, ai-input=no"
-      assert body =~ "Content-Usage: /$ train-ai=y, search=y"
-      assert body =~ "Content-Usage: /blog train-ai=y, search=y"
-      assert body =~ "Content-Usage: /customers train-ai=y, search=y"
-      assert body =~ "Content-Usage: /en/docs train-ai=y, search=y"
-      assert body =~ "Content-Usage: /en/docs-markdown train-ai=y, search=y"
+      assert body =~ "Content-Usage: /$ train-ai=y, search=y, ai-input=y"
+      assert body =~ "Content-Usage: /blog train-ai=y, search=y, ai-input=y"
+      assert body =~ "Content-Usage: /customers train-ai=y, search=y, ai-input=y"
+      assert body =~ "Content-Usage: /en/docs train-ai=y, search=y, ai-input=y"
+      assert body =~ "Content-Usage: /en/docs-markdown train-ai=y, search=y, ai-input=y"
       assert body =~ "Disallow: /api/"
       assert body =~ "Disallow: /docs"
       assert body =~ "Disallow: /*/module-cache"


### PR DESCRIPTION
## What changed

- Mark public marketing pages, documentation, and markdown documentation as allowing agent input in the generated `robots.txt` policy.
- Update the policy test to assert the explicit opt-in on representative public paths.

## Why

The site-wide policy is restrictive by default. Public content already opted into search and training use, but did not opt into agent input, which could cause compatible agents to treat public documentation as unavailable.

## Approach

The shared route metadata now includes `ai_input: true`. This keeps authenticated dashboard routes excluded while applying the opt-in consistently to every public marketing and documentation route.

## Impact

Public documentation is explicitly available for agent input. No authenticated product data becomes crawlable.

## Validation

- `git diff --check`
- `mix test test/tuist_web/controllers/robots_txt_controller_test.exs` could not run because the worktree lacks server dependencies.

### How to test locally

After installing the server dependencies, run:

```sh
cd server
mix test test/tuist_web/controllers/robots_txt_controller_test.exs
```
