### PR TITLE
feat(skills): document and synchronize agent plugins

### DIFF
--- a/.github/workflows/skills-release.yml
+++ b/.github/workflows/skills-release.yml
@@ -109,6 +109,38 @@ jobs:
             echo "No changes to push"
           fi
 
+      - name: Push to tuist/agent-plugin
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/tuist/agent-plugin.git /tmp/agent-plugin
+          rm -rf /tmp/agent-plugin/skills
+          cp -r skills/skills /tmp/agent-plugin/skills
+          cd /tmp/agent-plugin
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Sync Tuist skills"
+            git push origin main
+          else
+            echo "No changes to push"
+          fi
+
+      - name: Push to tuist/cursor-plugin
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/tuist/cursor-plugin.git /tmp/cursor-plugin
+          rm -rf /tmp/cursor-plugin/plugins/tuist/skills
+          cp -r skills/skills /tmp/cursor-plugin/plugins/tuist/skills
+          cd /tmp/cursor-plugin
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Sync Tuist skills"
+            git push origin main
+          else
+            echo "No changes to push"
+          fi
+
       - name: Create Skills GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/skills-release.yml
+++ b/.github/workflows/skills-release.yml
@@ -141,6 +141,22 @@ jobs:
             echo "No changes to push"
           fi
 
+      - name: Push to tuist/claude-plugin
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/tuist/claude-plugin.git /tmp/claude-plugin
+          rm -rf /tmp/claude-plugin/plugins/tuist/skills
+          cp -r skills/skills /tmp/claude-plugin/plugins/tuist/skills
+          cd /tmp/claude-plugin
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Sync Tuist skills"
+            git push origin main
+          else
+            echo "No changes to push"
+          fi
+
       - name: Create Skills GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -396,6 +396,7 @@ defmodule Tuist.Docs.Sidebar do
           %Item{
             label: "Agentic coding",
             items: [
+              %Item{label: "Plugins", slug: "/en/guides/features/agentic-coding/plugins"},
               %Item{label: "MCP", slug: "/en/guides/features/agentic-coding/mcp"},
               %Item{label: "Skills", slug: "/en/guides/features/agentic-coding/skills"}
             ]

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -18,6 +18,8 @@ The account setup tools require user authentication. They are not available to p
 
 Model Context Protocol tools and <.localized_link href="/guides/features/agentic-coding/skills">skills</.localized_link> can overlap in what they do. Given the current overlap between the two, choose one approach per workflow and use it consistently instead of mixing both in the same flow.
 
+For clients that support plugin installation, use the <.localized_link href="/guides/features/agentic-coding/plugins">Tuist plugins</.localized_link> to install both together.
+
 ## Configuration
 
 Add `https://tuist.dev/mcp` as a remote Model Context Protocol server in your client. Tuist advertises both [Open Authorization](https://oauth.net/2/) discovery metadata and the current [auth.md protocol](https://workos.com/auth-md) at `https://tuist.dev/auth.md`.

--- a/server/priv/docs/en/guides/features/agentic-coding/plugins.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/plugins.md
@@ -8,7 +8,7 @@
 
 # Plugins
 
-Tuist packages its agent skills and hosted [Model Context Protocol](https://modelcontextprotocol.io/) server as plugins so you can install both together. Choose the package that matches your coding agent.
+Tuist packages its agent skills and hosted MCP server as plugins so you can install both together. Choose the package that matches your coding agent.
 
 ## Cursor
 
@@ -18,7 +18,7 @@ Install the [Tuist plugin for Cursor](https://github.com/tuist/cursor-plugin) fr
 2. Search for **Tuist**.
 3. Select **Install**, then choose whether to install it for the current project or your user account.
 
-You can also type `/add-plugin` in Cursor to open the same installation flow. The plugin provides Tuist skills and connects Cursor to the hosted Model Context Protocol server.
+You can also type `/add-plugin` in Cursor to open the same installation flow. The plugin provides Tuist skills and connects Cursor to the hosted MCP server.
 
 If your organization manages Cursor marketplaces, import `https://github.com/tuist/cursor-plugin` from **Settings → Plugins → Team Marketplaces → Import Marketplace** first.
 
@@ -30,7 +30,7 @@ The [Tuist Agent Plugin](https://github.com/tuist/agent-plugin) follows the open
 git clone https://github.com/tuist/agent-plugin.git
 ```
 
-It installs Tuist skills and registers `https://tuist.dev/mcp` as a remote Model Context Protocol server. For clients that do not yet support Agent Plugins, install the [skills](/guides/features/agentic-coding/skills) or configure the [Model Context Protocol server](/guides/features/agentic-coding/mcp) separately.
+It installs Tuist skills and registers `https://tuist.dev/mcp` as a remote MCP server. For clients that do not yet support Agent Plugins, install the [skills](/guides/features/agentic-coding/skills) or configure the [MCP server](/guides/features/agentic-coding/mcp) separately.
 
 ## Authentication
 
@@ -40,4 +40,4 @@ Most skills use the Tuist command-line interface, so authenticate it once before
 tuist auth login
 ```
 
-The hosted Model Context Protocol server requests its own sign-in when needed. See the [Model Context Protocol guide](/guides/features/agentic-coding/mcp) for client-specific setup and authentication details.
+The hosted MCP server requests its own sign-in when needed. See the [MCP guide](/guides/features/agentic-coding/mcp) for client-specific setup and authentication details.

--- a/server/priv/docs/en/guides/features/agentic-coding/plugins.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/plugins.md
@@ -1,0 +1,43 @@
+---
+{
+  "title": "Plugins",
+  "titleTemplate": ":title · Agentic coding · Features · Guides · Tuist",
+  "description": "Install Tuist's plugin for Cursor or the vendor-neutral Agent Plugins package."
+}
+---
+
+# Plugins
+
+Tuist packages its agent skills and hosted [Model Context Protocol](https://modelcontextprotocol.io/) server as plugins so you can install both together. Choose the package that matches your coding agent.
+
+## Cursor
+
+Install the [Tuist plugin for Cursor](https://github.com/tuist/cursor-plugin) from the [Cursor Marketplace](https://cursor.com/marketplace):
+
+1. Open **Customize** in the Cursor sidebar.
+2. Search for **Tuist**.
+3. Select **Install**, then choose whether to install it for the current project or your user account.
+
+You can also type `/add-plugin` in Cursor to open the same installation flow. The plugin provides Tuist skills and connects Cursor to the hosted Model Context Protocol server.
+
+If your organization manages Cursor marketplaces, import `https://github.com/tuist/cursor-plugin` from **Settings → Plugins → Team Marketplaces → Import Marketplace** first.
+
+## Other coding agents
+
+The [Tuist Agent Plugin](https://github.com/tuist/agent-plugin) follows the open, vendor-neutral [Agent Plugins](https://agent-plugins.org/) standard. Point a compatible client at the repository, following that client's instructions for installing or referencing plugin directories:
+
+```bash
+git clone https://github.com/tuist/agent-plugin.git
+```
+
+It installs Tuist skills and registers `https://tuist.dev/mcp` as a remote Model Context Protocol server. For clients that do not yet support Agent Plugins, install the [skills](/guides/features/agentic-coding/skills) or configure the [Model Context Protocol server](/guides/features/agentic-coding/mcp) separately.
+
+## Authentication
+
+Most skills use the Tuist command-line interface, so authenticate it once before asking an agent to access your project data:
+
+```bash
+tuist auth login
+```
+
+The hosted Model Context Protocol server requests its own sign-in when needed. See the [Model Context Protocol guide](/guides/features/agentic-coding/mcp) for client-specific setup and authentication details.

--- a/server/priv/docs/en/guides/features/agentic-coding/plugins.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/plugins.md
@@ -12,7 +12,7 @@ Tuist packages its agent skills and hosted MCP server as plugins so you can inst
 
 ## Claude Code
 
-The [Tuist Claude Code marketplace](https://github.com/tuist/claude-plugin) packages the Tuist plugin from the private repository required by [Claude Code managed marketplace restrictions](https://code.claude.com/docs/en/plugin-marketplaces#managed-marketplace-restrictions). Members with repository access can install it with:
+The [Tuist Claude Code marketplace](https://github.com/tuist/claude-plugin) packages the Tuist plugin for installation with:
 
 ```bash
 claude plugin marketplace add tuist/claude-plugin

--- a/server/priv/docs/en/guides/features/agentic-coding/plugins.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/plugins.md
@@ -10,6 +10,17 @@
 
 Tuist packages its agent skills and hosted MCP server as plugins so you can install both together. Choose the package that matches your coding agent.
 
+## Claude Code
+
+The [Tuist Claude Code marketplace](https://github.com/tuist/claude-plugin) packages the Tuist plugin from the private repository required by [Claude Code managed marketplace restrictions](https://code.claude.com/docs/en/plugin-marketplaces#managed-marketplace-restrictions). Members with repository access can install it with:
+
+```bash
+claude plugin marketplace add tuist/claude-plugin
+claude plugin install tuist@tuist-plugins
+```
+
+The plugin provides Tuist skills and connects Claude Code to the hosted MCP server.
+
 ## Cursor
 
 Install the [Tuist plugin for Cursor](https://github.com/tuist/cursor-plugin) from the [Cursor Marketplace](https://cursor.com/marketplace):

--- a/server/priv/docs/en/guides/features/agentic-coding/skills.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/skills.md
@@ -10,6 +10,8 @@
 
 Skills are pre-built instruction sets for performing complex, multi-step Tuist tasks. Instead of manually guiding an agent through a migration or setup process, you install a skill and let the agent handle it.
 
+If your coding agent supports plugins, the [Tuist plugins](/guides/features/agentic-coding/plugins) install these skills and the hosted Model Context Protocol server together.
+
 ## Available skills
 
 | Skill | Description |


### PR DESCRIPTION
## What changed

- Added an Agentic coding plugins guide for the Tuist Claude Code marketplace, Tuist Cursor plugin, and Tuist Agent Plugin.
- Linked the guide from the sidebar and existing skills and MCP guides.
- Extended the skills release workflow to copy the canonical `skills/skills` directory to the `main` branches of `tuist/agent-plugin`, `tuist/cursor-plugin`, and `tuist/claude-plugin`.

## Why

The plugins package the same Tuist skills with the hosted MCP server, but they were not discoverable from the product documentation. The plugin repositories also required manual updates when the source skills changed.

## Approach

The existing skills release workflow already publishes the canonical skills to `tuist/agent-skills`. The new steps use the same authenticated release token and only commit to each plugin repository when the copied skills differ.

## Impact

Users can discover and install the appropriate plugin from the documentation. Future skill releases keep all plugin repositories aligned with the source of truth automatically.

### How to test locally

- `git diff --check`
- `claude plugin validate .` in `tuist/claude-plugin`: passed with the expected advisory warning that versioning is commit-based.
- `claude plugin validate plugins/tuist` in `tuist/claude-plugin`: passed with the same advisory warning.
- Attempted `mix docs.validate_page priv/docs/en/guides/features/agentic-coding/plugins.md` from `server/`; it could not run because this worktree does not have the required Elixir dependencies installed.
