### PR TITLE
fix(infra): apply the tailnet resolver on the drift path

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -539,6 +539,16 @@ func UpdateTartKubelet(ctx context.Context, cfg Config) (string, error) {
 	if err := installTailscale(ctx, client, cfg); err != nil {
 		return hk.Observed(), fmt.Errorf("install tailscale: %w", err)
 	}
+	// Re-run on the drift path because the resolver is part of
+	// HostConfigHash: without this step a roll converges the stamped hash
+	// while the host still has no /etc/resolver/ts.net, so the fleet reads
+	// as correct while crane, oras and tart keep getting NXDOMAIN on every
+	// tailnet name. Unconditional, unlike installTailscale above: writing
+	// the file restarts nothing, so it is safe on the tailnet fallback that
+	// sets SkipTailscaleInstall.
+	if err := installTailnetResolver(ctx, client); err != nil {
+		return hk.Observed(), fmt.Errorf("install tailnet resolver: %w", err)
+	}
 	if err := installSSHIngressGuard(ctx, client, cfg); err != nil {
 		return hk.Observed(), fmt.Errorf("refresh ssh ingress guard: %w", err)
 	}

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -5,10 +5,14 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1092,18 +1096,147 @@ func TestRenderTailnetResolverScript_FlushesTheNegativeCache(t *testing.T) {
 	}
 }
 
-// The resolver has to reach existing hosts, not just newly bootstrapped
-// ones. It does that only by being part of the fleet-wide fingerprint the
-// drift loop compares against.
-func TestHostConfigHash_CoversTheTailnetResolver(t *testing.T) {
-	base := Config{NodeName: "n1", SSHUser: "m1", TartKubeletBinary: []byte("bin")}
-	h := HostConfigHash(base)
-	// Recomputing must be stable, or every reconcile would see drift and
-	// re-push to every host forever.
-	if h != HostConfigHash(base) {
-		t.Fatal("HostConfigHash must be deterministic")
+// hashPartInstaller names the step that re-applies each part of
+// HostConfigHash on an already-bootstrapped host, across both of the
+// sections it hashes: the rendered scripts and the embedded binary SHAs.
+//
+// Being in the hash is not the same as reaching a host, and the gap between
+// the two is silent in the worst possible way: a part that moves the
+// fingerprint makes the drift loop roll every mini, and if nothing on the
+// update path re-applies it, the roll succeeds and stamps the host
+// converged without the host ever changing. The fleet then reports itself
+// correct while carrying none of the config. A part is therefore a promise
+// that UpdateTartKubelet keeps, and this table is where the promise is
+// written down.
+//
+// Several parts share an installer, which is why this maps to a step rather
+// than pairing names one to one: installVMEgressFirewall renders both the
+// firewall anchor and the NAT helper, and each binary rides the same step
+// that installs the script driving it.
+//
+// Bootstrap-only work must not appear in the hash at all rather than
+// appear here unmapped: TartTarball is the standing example, omitted
+// because the hypervisor cannot be swapped under running VMs.
+var hashPartInstaller = map[string]string{
+	"firewall":             "installVMEgressFirewall",
+	"vmnat":                "installVMEgressFirewall",
+	"pn-interface":         "installVMCachePNInterface",
+	"runner-cache-volume":  "installRunnerCacheVolume",
+	"launchd":              "loadTartKubeletLaunchd",
+	"launchd-plist":        "loadTartKubeletLaunchd",
+	"tailscale":            "installTailscale",
+	"node-exporter":        "installNodeExporter",
+	"tailnet-resolver":     "installTailnetResolver",
+	"log-shipper":          "installLogShipper",
+	"tart-kubelet-install": "installTartKubelet",
+	"ssh-reachability":     "installSSHReachability",
+	"ssh-ingress-guard":    "installSSHIngressGuard",
+
+	"tart-kubelet":         "installTartKubelet",
+	"tailscale-binaries":   "installTailscale",
+	"node-exporter-binary": "installNodeExporter",
+	"log-shipper-binary":   "installLogShipper",
+}
+
+// Reads the source rather than the behaviour because the invariant is
+// structural: both sides are lists a person edits, and nothing in the type
+// system ties one to the other. Driving a real UpdateTartKubelet would need
+// a live SSH host and would still only prove the steps it happened to
+// reach.
+func TestUpdateTartKubelet_AppliesEveryHashedStep(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "bootstrap.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse bootstrap.go: %v", err)
 	}
-	if !strings.Contains(renderTailnetResolverScript(), "100.100.100.100") {
-		t.Fatal("resolver script missing from the hashed set")
+
+	parts := hashedPartNames(t, file)
+	if len(parts) == 0 {
+		t.Fatal("found no hashed part names in HostConfigHash; the part table moved or changed shape")
 	}
+	called := calledFunctions(t, file, "UpdateTartKubelet")
+
+	for _, part := range parts {
+		installer, mapped := hashPartInstaller[part]
+		if !mapped {
+			t.Errorf("HostConfigHash part %q has no entry in hashPartInstaller: name the step that re-applies it on the drift path, or drop the part from the hash if the work is bootstrap-only", part)
+			continue
+		}
+		if !called[installer] {
+			t.Errorf("HostConfigHash part %q is applied by %s, which UpdateTartKubelet never calls: a roll would stamp the host converged without applying it", part, installer)
+		}
+	}
+
+	hashed := make(map[string]bool, len(parts))
+	for _, part := range parts {
+		hashed[part] = true
+	}
+	for part := range hashPartInstaller {
+		if !hashed[part] {
+			t.Errorf("hashPartInstaller names %q, which HostConfigHash no longer hashes; drop the stale entry", part)
+		}
+	}
+}
+
+// hashedPartNames returns the `name` field of every element of the
+// `[]struct{ name, script string }` table HostConfigHash iterates.
+func hashedPartNames(t *testing.T, file *ast.File) []string {
+	t.Helper()
+
+	var names []string
+	ast.Inspect(findFunc(t, file, "HostConfigHash"), func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		// The part table is the only composite literal here whose elements
+		// are themselves two-string literals.
+		for _, elt := range lit.Elts {
+			inner, ok := elt.(*ast.CompositeLit)
+			if !ok || len(inner.Elts) != 2 {
+				return true
+			}
+			name, ok := inner.Elts[0].(*ast.BasicLit)
+			if !ok || name.Kind != token.STRING {
+				return true
+			}
+			unquoted, err := strconv.Unquote(name.Value)
+			if err != nil {
+				t.Fatalf("unquote part name %s: %v", name.Value, err)
+			}
+			names = append(names, unquoted)
+		}
+		return false
+	})
+	return names
+}
+
+// calledFunctions returns the names of the functions called directly in the
+// named function's body.
+func calledFunctions(t *testing.T, file *ast.File, name string) map[string]bool {
+	t.Helper()
+
+	called := map[string]bool{}
+	ast.Inspect(findFunc(t, file, name), func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			if ident, ok := call.Fun.(*ast.Ident); ok {
+				called[ident.Name] = true
+			}
+		}
+		return true
+	})
+	return called
+}
+
+func findFunc(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Recv == nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("no function %s in bootstrap.go", name)
+	return nil
 }


### PR DESCRIPTION
`/etc/resolver/ts.net` reached newly provisioned Mac minis and no existing one, while the fleet reported itself converged.

## What changed

`UpdateTartKubelet` now calls `installTailnetResolver`, and a new test asserts that every part `HostConfigHash` hashes is re-applied by a step the drift path actually calls.

## Root cause

[#12413](https://github.com/tuist/tuist/pull/12413) added `installTailnetResolver` with a single call site, in `bootstrap.Run`. That function runs only when the operator provisions a host ([`scalewayapplesiliconmachine_controller.go:565`](https://github.com/tuist/tuist/blob/main/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go#L565)). Drift goes through `UpdateTartKubelet`, which re-runs tailscale, the SSH ingress guard, node_exporter, the kubelet and the log shipper, and never touched the resolver.

The combination with the hash is worse than a plain omission. The step is folded into `HostConfigHash`, so every mini's desired fingerprint moved and the drift loop rolled the entire fleet. Each roll then ran an update that did not write the file and reported success, so the operator stamped the host as converged. The result is a fleet that reads as correct while `crane`, `oras` and `tart` still get NXDOMAIN on every tailnet name, which is exactly the failure that got [#12334](https://github.com/tuist/tuist/pull/12334) reverted.

That would have landed the moment the image-build workflows moved `OCI_REGISTRY_HOST` onto the registry's tailnet name, and it would have presented as a credential problem rather than a DNS one.

## Why a source-reading test

Both sides of this invariant are hand-edited lists with nothing in the type system tying them together: the part table in `HostConfigHash` and the step sequence in `UpdateTartKubelet`. Driving a real `UpdateTartKubelet` needs a live SSH host and would still only prove the steps that run happened to be reached, so it cannot fail on the step that is missing.

The test parses `bootstrap.go`, collects the part names from both hashed sections (the rendered scripts and the embedded binary SHAs), and checks each one against `hashPartInstaller`, a table naming the step that re-applies it. A part with no entry fails, which forces a decision rather than allowing a silent default: name the step, or keep the work out of the hash the way `TartTarball` already is. A stale entry fails too.

Writing that table surfaced a second section I had not accounted for. The four embedded binary SHAs are hash parts on the same terms, and all four are already on the drift path, so they are now covered rather than merely correct by luck.

This closes the step dimension of the gap. The field dimension, where the drift `bootstrap.Config` omitted a value the canonical config set, is what took the fleet down in [#12433](https://github.com/tuist/tuist/pull/12433); [#12439](https://github.com/tuist/tuist/pull/12439) closed that one by giving both paths a single `hostConfig` definition. Same shape, rotated: one was a missing field, this is a missing step, and neither test catches the other.

## Impact

Existing minis get `/etc/resolver/ts.net` on their next reconcile, which is the prerequisite for pointing `OCI_REGISTRY_HOST` at the registry's tailnet name. Nothing else changes on the host: the step writes one file and flushes the DNS cache, restarts no service, and is idempotent.

It is unconditional, unlike `installTailscale` immediately above it. The tailnet fallback sets `SkipTailscaleInstall` because swapping the tailscaled binary would drop the session the update rides, and writing a resolver file has no such hazard.

As a `fix(infra):` commit this is releasable for the CAPI provider, so it cuts a `capi-scaleway` release carrying both this fix and #12433, which the fleet currently needs: production is back on `0.22.5` because a `capi_image_tag` pin only survives until the next deploy of that environment.

## Validation

```
go test ./...                         ok
gofmt -l .                            clean
go vet ./...                          clean
cluster-api-provider-tuist go build   ok
```

The new test was confirmed load-bearing by removing the `installTailnetResolver` call from `UpdateTartKubelet` and re-running it:

```
--- FAIL: TestUpdateTartKubelet_AppliesEveryHashedStep
    HostConfigHash part "tailnet-resolver" is applied by installTailnetResolver,
    which UpdateTartKubelet never calls: a roll would stamp the host converged
    without applying it
```

Its first run also failed on the four unmapped binary parts, which is how that second hashed section was found.

Not verified on a host: the production macOS fleet cannot take a config roll right now (13/13 machines terminal on `0.22.5` with `TailscaleTags is empty`), so the first real proof will be the reconcile that follows this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
