### PR TITLE
fix(server): pair the recent-window backfill arrays by run key boundary

### DIFF
--- a/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
+++ b/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
@@ -15,14 +15,27 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
 
   ## Reconstruction
 
-  Both materialized views read the same `test_case_runs` rows, and
-  `groupArraySorted` truncates on the sort key before the flag, so both
-  aggregates always retain the same run keys per test case. De-duplicating each
-  to one entry per key therefore yields two arrays aligned element for element,
-  which zip in a single pass. Zipping by key lookup instead is quadratic, and in
-  a vectorised engine that materialises `entries x keys` intermediates for the
-  whole block: it allocated in 625 MiB chunks and exceeded the memory limit on
-  its own.
+  Both materialized views read the same `test_case_runs` rows, so de-duplicating
+  each aggregate to one entry per run key yields two arrays that zip in a single
+  pass. Zipping by key lookup instead is quadratic, and in a vectorised engine
+  that materialises `entries x keys` intermediates for the whole block: it
+  allocated in 625 MiB chunks and exceeded the memory limit on its own.
+
+  Alignment is not free, though, and assuming it is what failed this migration
+  in production. `groupArraySorted` orders on the whole tuple, so the flag
+  breaks ties on the run key rather than being ignored after it. A run key
+  carrying two physical entries can straddle the source's 100-entry ceiling and
+  be cut on different sides of it in the two aggregates, which retain key sets
+  differing by their largest key. Measured on production, that is every test
+  case that is both at the ceiling and holds a duplicate key: 9 of 4108 in a
+  20,000-case sample, and none at all in the three groups missing either
+  condition. ClickHouse compares the lengths before it evaluates anything, so
+  one such test case aborts the insert for its whole range.
+
+  Equal largest keys mean identical key sets, because truncation keeps the
+  smallest tuples and a key below both maxima cannot be missing from either.
+  Unequal maxima are resolved by dropping the larger from both, which costs the
+  single oldest run of the test cases that diverge and nothing anywhere else.
 
   Depth is inherited, not extended. The source holds 100 physical entries, so a
   logical run re-inserted to set `is_flaky` consumes two of them and a test case
@@ -215,16 +228,8 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
                 tupleElement(flaky_entry, 1) * 4
                 + toInt64(tupleElement(flaky_entry, 2)) * 2
                 + toInt64(tupleElement(successful_entry, 2)),
-              arrayFilter(
-                (entry, next_entry) -> tupleElement(entry, 1) != tupleElement(next_entry, 1),
-                flaky_runs,
-                arrayShiftLeft(flaky_runs, 1, #{@flag_sentinel})
-              ),
-              arrayFilter(
-                (entry, next_entry) -> tupleElement(entry, 1) != tupleElement(next_entry, 1),
-                successful_runs,
-                arrayShiftLeft(successful_runs, 1, #{@flag_sentinel})
-              )
+              arrayFilter(entry -> tupleElement(entry, 1) <= keep_through, flaky_keyed),
+              arrayFilter(entry -> tupleElement(entry, 1) <= keep_through, successful_keyed)
             )
           )
         ) AS recent_runs
@@ -232,12 +237,58 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
         SELECT
           project_id,
           test_case_id,
-          finalizeAggregation(recent_runs) AS flaky_runs,
-          finalizeAggregation(recent_successful_runs) AS successful_runs
-        FROM #{@source_table} FINAL
-        WHERE project_id = {project_id:Int64}
-          AND test_case_id >= {lower:UUID}
-          #{upper_clause}
+          flaky_keyed,
+          successful_keyed,
+          -- Both aggregates see the same runs, but `groupArraySorted` orders on
+          -- the whole tuple, so the flag breaks ties on the run key. A run key
+          -- carrying two physical entries can therefore straddle the source's
+          -- 100-entry ceiling and be cut on different sides of it in the two
+          -- aggregates, leaving key sets that differ by their largest key.
+          -- Zipping those positionally pairs a run against a different run, and
+          -- ClickHouse rejects the unequal lengths outright.
+          --
+          -- Equal largest keys mean identical key sets: truncation keeps the
+          -- smallest tuples, so a key below both maxima cannot be missing from
+          -- either. Unequal maxima are resolved by dropping the larger, which
+          -- costs the single oldest run of the test cases that actually
+          -- diverge. Key lookup would pair them exactly, and is what the
+          -- earlier attempt measured at 625 MiB chunks; this stays a single
+          -- pass over arrays already in hand.
+          if(
+            arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)) =
+              arrayMax(arrayMap(entry -> tupleElement(entry, 1), successful_keyed)),
+            arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)),
+            least(
+              arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)),
+              arrayMax(arrayMap(entry -> tupleElement(entry, 1), successful_keyed))
+            ) - 1
+          ) AS keep_through
+        FROM (
+          SELECT
+            project_id,
+            test_case_id,
+            arrayFilter(
+              (entry, next_entry) -> tupleElement(entry, 1) != tupleElement(next_entry, 1),
+              flaky_runs,
+              arrayShiftLeft(flaky_runs, 1, #{@flag_sentinel})
+            ) AS flaky_keyed,
+            arrayFilter(
+              (entry, next_entry) -> tupleElement(entry, 1) != tupleElement(next_entry, 1),
+              successful_runs,
+              arrayShiftLeft(successful_runs, 1, #{@flag_sentinel})
+            ) AS successful_keyed
+          FROM (
+            SELECT
+              project_id,
+              test_case_id,
+              finalizeAggregation(recent_runs) AS flaky_runs,
+              finalizeAggregation(recent_successful_runs) AS successful_runs
+            FROM #{@source_table} FINAL
+            WHERE project_id = {project_id:Int64}
+              AND test_case_id >= {lower:UUID}
+              #{upper_clause}
+          )
+        )
       )
       SETTINGS
         max_threads = 2,


### PR DESCRIPTION
The production deploy cascade is blocked: the pre-upgrade migration Job fails, helm rolls the release back, and every subsequent attempt re-runs the same migration and fails the same way.

```
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to
rollback-on-failure being set: pre-upgrade hooks failed: resource
Job/tuist/tuist-tuist-server-migrate not ready. status: Failed, message: Job Failed. failed: 4/1
```

```
== Running 20260818120000 BackfillTestCaseRunsRecentWindowPerCase.up/0 forward
** (Ch.Error) Code: 190. DB::Exception: Arrays passed to arrayMap must have equal size.
   Argument 3 has size 60235 which differs with the size of another argument, 60229
   (SIZES_OF_ARRAYS_DONT_MATCH)
```

## Root cause

The backfill de-duplicates `recent_runs` and `recent_successful_runs` to one entry per run key and zips them positionally. The moduledoc justifies that with an invariant that does not hold:

> `groupArraySorted` truncates on the sort key before the flag, so both aggregates always retain the same run keys per test case.

The comparator is the whole `Tuple(Int64, UInt8)`, so the flag participates in the ordering rather than being ignored after the key. The two aggregates carry different flags for the same run (`is_flaky` against `status = 'success'`), so a run key holding two physical entries can straddle the source's 100-entry ceiling and be cut on different sides of it. The retained key sets then differ by their largest key.

Measured on production, the divergence lands exactly where that reasoning predicts and nowhere else:

| at 100-entry ceiling | has duplicate keys | test cases | key-set mismatches |
|---|---|---|---|
| no | no | 5509 | 0 |
| no | yes | 491 | 0 |
| yes | no | 9892 | 0 |
| yes | yes | 4108 | **9** |

Both conditions are required. Roughly 0.05% of test cases, but ClickHouse compares lengths before evaluating anything, so one of them aborts the insert for its entire range, and the ranges are large.

The key sets differ, not just their lengths, so trimming to a common prefix would pair runs against the wrong runs instead of failing. That silent-corruption variant is worse than the crash.

## The fix

Trim both arrays to the smaller maximum key, but only when the maxima disagree.

Equal maxima imply identical key sets: truncation keeps the smallest tuples, so a key below both maxima cannot be missing from either. Unequal maxima are resolved by dropping the larger from both, costing the single oldest run of the test cases that actually diverge.

## Why not pair by key

Key lookup pairs exactly and needs no trimming, and the moduledoc records why it was rejected: in a vectorised engine it materialises `entries x keys` intermediates for the whole block, allocating in 625 MiB chunks until it exceeded the memory limit on its own. That constraint has not changed, and it is what broke earlier backfills in this table family.

This stays a single pass over arrays already in hand: two `arrayMax` calls and two `arrayFilter` calls per row, no cross product, no new intermediates.

## Cost

Measured over 50,000 production test cases:

| | trimming unconditionally | trimming only on disagreement |
|---|---|---|
| key mismatches after | 0 | 0 |
| test cases trimmed | 50,000 | 16 |
| entries dropped | 3.104% | 0.0007% |

Dropping one entry from every test case would also be correct, and 3% of an aggregate sized for headroom is not worth spending when the conditional form costs 0.0007%.

The loss is a prefix shortening of an already-inherited window, which the migration's own depth section already accounts for: the source holds 100 physical entries and a re-inserted run consumes two, so a test case already recovers between 50 and 100 distinct runs.

## Validation

Run against production ClickHouse, read-only, over 50,000 test cases.

The rewritten SELECT completes where the original aborts: 50,000 rows, 1,540,735 entries, no empty rows, no size error.

Equivalence on the rows the original could process at all:

```
comparable_rows  49990
differing_rows       0
bad_flag_bits        0
unsorted_rows        0
```

Byte-identical output wherever the original worked, flag bits intact, output still sorted for `groupArraySortedState`. The change is a strict superset: unchanged where the original succeeded, defined where it aborted.

`20260818120000` is **not** recorded in `schema_migrations` (only `20260817120000`, at 17:47:57Z), so the migration never completed and is corrected in place rather than superseded. Re-running is safe on the migration's own terms: a run reinserted with an identical packed value collapses on read.

Not covered here: the moduledoc's claim was load-bearing and unverifiable at write time, and nothing asserts the two aggregates stay aligned. This trims defensively instead of assuming, but a guard on the source MVs would be the durable answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
