### PR TITLE
fix(infra): resolve the OCI registry through getaddrinfo in the login guard

### DIFF
--- a/.github/actions/oci-registry-login/action.yml
+++ b/.github/actions/oci-registry-login/action.yml
@@ -96,7 +96,7 @@ runs:
         # only resolver every client here shares. `dig` and `host` read
         # /etc/resolv.conf and ignore the scoped resolvers under
         # /etc/resolver, so on macOS they answer NXDOMAIN for exactly the
-        # tailnet names crane resolves fine — a guard built on either
+        # tailnet names crane resolves fine. A guard built on either
         # fails the job once the resolver is in place. `host` is also
         # wrong in the other direction: it exits 0 for a name that
         # returns no records, which is how the withdrawn `oci.tuist.dev`

--- a/.github/actions/oci-registry-login/action.yml
+++ b/.github/actions/oci-registry-login/action.yml
@@ -37,7 +37,7 @@ description: >-
 
 inputs:
   host:
-    description: Registry host, e.g. `oci.tuist.dev`
+    description: Registry host, e.g. `tuist-oci-production.taild6d7bb.ts.net`
     required: true
   op-service-account-token:
     description: 1Password service-account token, scoped to the vault below
@@ -88,17 +88,47 @@ runs:
           echo "TART_REGISTRY_PASSWORD=${password}"
         } >> "$GITHUB_ENV"
 
+        # Resolve first: a failure here is the scoped resolver missing
+        # from this host, not a credential problem, and the two look
+        # nothing alike once you know which you are reading.
+        #
+        # The check has to go through getaddrinfo, because that is the
+        # only resolver every client here shares. `dig` and `host` read
+        # /etc/resolv.conf and ignore the scoped resolvers under
+        # /etc/resolver, so on macOS they answer NXDOMAIN for exactly the
+        # tailnet names crane resolves fine — a guard built on either
+        # fails the job once the resolver is in place. `host` is also
+        # wrong in the other direction: it exits 0 for a name that
+        # returns no records, which is how the withdrawn `oci.tuist.dev`
+        # walked straight past this guard and surfaced as an opaque
+        # crane error instead. And `getent` does not exist on macOS, so
+        # the check it fronted never ran on these builders at all.
+        resolves_via_getaddrinfo() {
+          if command -v python3 >/dev/null 2>&1; then
+            python3 -c 'import socket, sys; socket.getaddrinfo(sys.argv[1], 443)' "$1" >/dev/null 2>&1
+          elif command -v dscacheutil >/dev/null 2>&1; then
+            dscacheutil -q host -a name "$1" 2>/dev/null | grep -qE '^ipv?6?_?address:'
+          else
+            getent hosts "$1" >/dev/null 2>&1
+          fi
+        }
+
+        if ! resolves_via_getaddrinfo "$REGISTRY_HOST"; then
+          case "$REGISTRY_HOST" in
+            *.ts.net)
+              echo "::error::${REGISTRY_HOST} does not resolve on this runner. It is a tailnet name, and tailscaled on macOS does not rewrite the system resolver, so it only resolves through the scoped /etc/resolver/ts.net pointing at 100.100.100.100. That file is installed by the CAPI host bootstrap (installTailnetResolver), on both the first-bootstrap and the drift path; check the host carries it and that the operator is new enough to apply it on drift."
+              ;;
+            *)
+              echo "::error::${REGISTRY_HOST} does not resolve on this runner."
+              ;;
+          esac
+          exit 1
+        fi
+
         # crane and oras both persist to ~/.docker/config.json, which
         # Tart reads through the Docker credential-helper protocol. That
         # sidesteps the macOS keychain, whose "User interaction" prompt
         # is not reachable from the LaunchAgent these builders run under.
-        # Resolve first: a failure here is the scoped resolver missing
-        # from this host, not a credential problem, and the two look
-        # nothing alike once you know which you are reading.
-        if ! getent hosts "$REGISTRY_HOST" >/dev/null 2>&1 && ! host "$REGISTRY_HOST" >/dev/null 2>&1; then
-          echo "::error::${REGISTRY_HOST} does not resolve on this runner. It is a tailnet name; check that /etc/resolver/ts.net exists and points at 100.100.100.100 (installed by the CAPI host bootstrap)."
-          exit 1
-        fi
 
         printf '%s' "$password" | crane auth login --username "$username" --password-stdin "$REGISTRY_HOST"
         printf '%s' "$password" | oras login "$REGISTRY_HOST" --username "$username" --password-stdin

--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -99,13 +99,13 @@ login ghcr.io` in the workflow). The reason is the writer, not the
 reader: the mirror's only writer is `mise run xcode-mirror:upload`
 running on a maintainer's Mac over a home link. Measured from one with
 the same 512 MB blob, that push is 136s to GHCR against 481s to the
-tailnet-only registry — a ten-minute upload one way, closer to forty
+tailnet-only registry: a ten-minute upload one way, closer to forty
 the other. Worse, a fresh Tailscale session starts on a DERP relay and
 only upgrades to a direct path once NAT traversal succeeds; over the
 relay these uploads fail outright rather than merely crawl, which is
 exactly what an occasional, once-per-Xcode-release task gets. GHCR's
 rate limits were never the problem for a single-blob artifact pushed a
-handful of times a year — they were the problem for the ~50 GB images,
+handful of times a year. They were the problem for the ~50 GB images,
 and those are pushed from a builder over a datacenter link and do go
 to our registry. Revisit only if the upload path stops being a
 maintainer laptop.

--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -91,6 +91,25 @@ mirror that holds every Xcode .xip we've published. CAPI-managed
 builder Macs can rotate without breaking CI; the workflow has no
 session state to lose.
 
+**Why this one stays on GHCR.** Every image this workflow *publishes*
+goes to the Tuist OCI registry on the tailnet, but the .xip mirror it
+*reads* deliberately does not follow, and it is the only artifact in
+the set that is not anonymously pullable (hence the explicit `oras
+login ghcr.io` in the workflow). The reason is the writer, not the
+reader: the mirror's only writer is `mise run xcode-mirror:upload`
+running on a maintainer's Mac over a home link. Measured from one with
+the same 512 MB blob, that push is 136s to GHCR against 481s to the
+tailnet-only registry — a ten-minute upload one way, closer to forty
+the other. Worse, a fresh Tailscale session starts on a DERP relay and
+only upgrades to a direct path once NAT traversal succeeds; over the
+relay these uploads fail outright rather than merely crawl, which is
+exactly what an occasional, once-per-Xcode-release task gets. GHCR's
+rate limits were never the problem for a single-blob artifact pushed a
+handful of times a year — they were the problem for the ~50 GB images,
+and those are pushed from a builder over a datacenter link and do go
+to our registry. Revisit only if the upload path stops being a
+maintainer laptop.
+
 The mirror is operator-populated. Apple's `developer.apple.com`
 auth requires a real Apple ID + post-2FA cookies that we can't
 keep alive non-interactively in the cluster (xcodes can't be


### PR DESCRIPTION
## What changed

The DNS guard in `.github/actions/oci-registry-login` now resolves through `getaddrinfo`, the same path `crane`, `oras` and `tart` use, instead of through `getent` and `host`. It prefers `python3`, falling back to `dscacheutil` on macOS and `getent` elsewhere. The error message for a `.ts.net` host now points at the scoped resolver and at the operator version that applies it.

Also records, in `infra/macos-xcode-image/AGENTS.md`, why the `xcode-xips` mirror stays on GHCR while the images built from it move to the Tuist OCI registry.

## Why

The guard exists so that an unresolvable registry host names DNS instead of surfacing as an opaque credential error. It did not fire when the vanity name `oci.tuist.dev` was withdrawn, and it would have started firing spuriously the moment the tailnet name began working. Both halves are the same underlying mistake: the guard resolved through tools that are not the resolver the real clients use.

**Root cause, first half.** `getent` does not exist on macOS, and every consumer of this action runs on `[self-hosted, macos, bare-metal, vm-image-builder]`. So the first half of the condition never ran on these builders at all, and everything fell through to `host`. `host` exits 0 for a name that resolves to no records, which is exactly what the withdrawn vanity name does. Verified on builder `tuist-tuist-builders-fleet-rg4h9-kgp8s`: `host oci.tuist.dev` prints nothing and exits 0. So the guard passed and `crane` failed one step later with `dial tcp: lookup oci.tuist.dev: no such host`, which is the failure that got the first attempt at this migration reverted.

**Root cause, second half.** `dig` and `host` read `/etc/resolv.conf` and ignore the macOS scoped resolvers under `/etc/resolver/`. Once `/etc/resolver/ts.net` is installed, they will keep answering NXDOMAIN for precisely the `.ts.net` names that `crane` resolves correctly. Swapping one of these tools for the other would have traded a silent miss for a guaranteed false failure on every image build.

## Why this approach

The only check that cannot drift from the clients is the one that calls the same resolver they do. `python3 socket.getaddrinfo` is literally that call. `dscacheutil` is kept as a fallback because it goes through the same Directory Service path, and `getent` is retained last so the action stays correct if it is ever used from a Linux runner.

Deliberately not used: `dig`/`host` for the reason above; `tailscale status` or a ping of the tailnet IP, because being on the tailnet and being able to resolve tailnet names are different properties on macOS, and conflating them is what took image publishing down in the first place.

## Impact

Image builds that cannot resolve the registry now fail in about five seconds with a message naming DNS, instead of running to the login step and reporting an authentication problem that does not exist. No change to the credential flow.

## Validation

Guard logic, run on builder `tuist-tuist-builders-fleet-rg4h9-kgp8s`, comparing the old condition against the new one:

```
HOST                                           OLD        NEW
oci.tuist.dev                                  PASS       FAIL
tuist-oci-production.taild6d7bb.ts.net         FAIL       FAIL
ghcr.io                                        PASS       PASS
definitely-not-a-real-host.invalid             FAIL       FAIL
```

The first row is the bug: the old guard passed the withdrawn name. The third row confirms no false positive on a name that genuinely resolves. The `dscacheutil` fallback was exercised separately and agrees on both `ghcr.io` and the tailnet name.

End to end in CI, run 32175717686 on this branch, dispatched against the still-unflipped `OCI_REGISTRY_HOST`:

```
##[error]oci.tuist.dev does not resolve on this runner.
##[error]Process completed with exit code 1.
```

That confirms the composite action's quoting and the shell function survive the `run:` block, and that the step now fails fast at the guard.

## Not in this PR

The `OCI_REGISTRY_HOST` repository variable is still `oci.tuist.dev`. Flipping it to `tuist-oci-production.taild6d7bb.ts.net` is blocked until the builders actually carry `/etc/resolver/ts.net`. As of this PR they do not: the file is absent on both `tuist-tuist-builders-fleet-rg4h9-kgp8s` and `-xqzbl`, the deployed CAPI operator is `0.23.0` rather than the `0.23.1` that applies the resolver on the drift path, and the `0.23.1` production deploy rolled back on an unrelated ClickHouse backfill migration. The only file under `/etc/resolver/` on those hosts is `search.tailscale`, which tailscaled writes with a `search` line and no `nameserver`, which is why these names are NXDOMAIN today.

This PR is useful independently of that flip: with it, whichever host is missing the resolver says so directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
