### PR TITLE
fix(server): pair the recent-window backfill arrays by shared run keys

### DIFF
--- a/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
+++ b/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
@@ -22,20 +22,33 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
   allocated in 625 MiB chunks and exceeded the memory limit on its own.
 
   Alignment is not free, though, and assuming it is what failed this migration
-  in production. `groupArraySorted` orders on the whole tuple, so the flag
-  breaks ties on the run key rather than being ignored after it. A run key
-  carrying two physical entries can straddle the source's 100-entry ceiling and
-  be cut on different sides of it in the two aggregates, which retain key sets
-  differing by their largest key. Measured on production, that is every test
-  case that is both at the ceiling and holds a duplicate key: 9 of 4108 in a
-  20,000-case sample, and none at all in the three groups missing either
-  condition. ClickHouse compares the lengths before it evaluates anything, so
-  one such test case aborts the insert for its whole range.
+  in production twice. The key sets diverge for at least three reasons, and each
+  one was found only after the repair aimed at the previous one shipped:
 
-  Equal largest keys mean identical key sets, because truncation keeps the
-  smallest tuples and a key below both maxima cannot be missing from either.
-  Unequal maxima are resolved by dropping the larger from both, which costs the
-  single oldest run of the test cases that diverge and nothing anywhere else.
+    * `groupArraySorted` orders on the whole tuple, so the flag breaks ties on
+      the run key rather than being ignored after it. A run key carrying two
+      physical entries can straddle the source's 100-entry ceiling and be cut on
+      different sides of it in the two aggregates.
+    * `recent_successful_runs` was added later, by `20260702120000`, with its own
+      backfill. Wherever that did not reproduce the older aggregate exactly, keys
+      are missing from the interior rather than the tail. One test case in
+      project 1000 carries 17 such keys starting at position 84 of 100, which is
+      exactly the 17-entry delta the second production failure reported.
+    * A test case can hold one aggregate and not the other at all, which is a
+      zero-length array against a full one.
+
+  So the arrays are restricted to the keys they share rather than repaired
+  cause by cause. `arrayFilter` preserves order, so both sides come out carrying
+  the same keys in the same positions and entry `i` is the same run on both,
+  whatever the inputs looked like. That is correct without enumerating the
+  causes, including the one nobody has found yet, and it is strictly more
+  faithful than trimming: where a boundary repair drops every key above the
+  smaller maximum, this drops only the keys that are genuinely unpaired.
+
+  Cost is a membership test per entry against an array capped at 100. That is
+  not the shape measured at 625 MiB chunks: that one built `entries x keys`
+  intermediates for the whole block through a per-entry lookup inside
+  `arrayMap`. `has` returns a scalar and allocates nothing.
 
   Depth is inherited, not extended. The source holds 100 physical entries, so a
   logical run re-inserted to set `is_flaky` consumes two of them and a test case
@@ -228,8 +241,8 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
                 tupleElement(flaky_entry, 1) * 4
                 + toInt64(tupleElement(flaky_entry, 2)) * 2
                 + toInt64(tupleElement(successful_entry, 2)),
-              arrayFilter(entry -> tupleElement(entry, 1) <= keep_through, flaky_keyed),
-              arrayFilter(entry -> tupleElement(entry, 1) <= keep_through, successful_keyed)
+              arrayFilter(entry -> has(successful_keys, tupleElement(entry, 1)), flaky_keyed),
+              arrayFilter(entry -> has(flaky_keys, tupleElement(entry, 1)), successful_keyed)
             )
           )
         ) AS recent_runs
@@ -239,30 +252,32 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
           test_case_id,
           flaky_keyed,
           successful_keyed,
-          -- Both aggregates see the same runs, but `groupArraySorted` orders on
-          -- the whole tuple, so the flag breaks ties on the run key. A run key
-          -- carrying two physical entries can therefore straddle the source's
-          -- 100-entry ceiling and be cut on different sides of it in the two
-          -- aggregates, leaving key sets that differ by their largest key.
-          -- Zipping those positionally pairs a run against a different run, and
-          -- ClickHouse rejects the unequal lengths outright.
+          -- Restricting both sides to the keys they share is what makes the
+          -- positional zip below sound. Filtering preserves order, and both
+          -- results carry the same keys, so entry `i` is the same run on both
+          -- sides whatever the inputs looked like.
           --
-          -- Equal largest keys mean identical key sets: truncation keeps the
-          -- smallest tuples, so a key below both maxima cannot be missing from
-          -- either. Unequal maxima are resolved by dropping the larger, which
-          -- costs the single oldest run of the test cases that actually
-          -- diverge. Key lookup would pair them exactly, and is what the
-          -- earlier attempt measured at 625 MiB chunks; this stays a single
-          -- pass over arrays already in hand.
-          if(
-            arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)) =
-              arrayMax(arrayMap(entry -> tupleElement(entry, 1), successful_keyed)),
-            arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)),
-            least(
-              arrayMax(arrayMap(entry -> tupleElement(entry, 1), flaky_keyed)),
-              arrayMax(arrayMap(entry -> tupleElement(entry, 1), successful_keyed))
-            ) - 1
-          ) AS keep_through
+          -- The alternative was to reason about *why* the key sets differ and
+          -- repair only that. Two causes are known: `groupArraySorted` orders
+          -- on the whole tuple, so the flag breaks ties on the run key and a
+          -- duplicated key straddling the source's 100-entry ceiling is cut on
+          -- different sides in the two aggregates; and
+          -- `recent_successful_runs` was added later, by `20260702120000`,
+          -- with its own backfill, so wherever that did not reproduce the
+          -- older aggregate exactly, keys are missing from the interior rather
+          -- than the tail. A boundary repair addresses the first and not the
+          -- second, which is how this migration failed twice. Intersecting is
+          -- correct without knowing the cause, including one nobody has found
+          -- yet.
+          --
+          -- The cost is a membership test per entry against an array capped at
+          -- 100. That is not the shape the earlier attempt measured at 625 MiB
+          -- chunks: that one built `entries x keys` intermediates for the whole
+          -- block through a per-entry lookup inside `arrayMap`. `has` returns a
+          -- scalar and allocates nothing, and `max_block_size` bounds what is
+          -- in flight regardless.
+          arrayMap(entry -> tupleElement(entry, 1), flaky_keyed) AS flaky_keys,
+          arrayMap(entry -> tupleElement(entry, 1), successful_keyed) AS successful_keys
         FROM (
           SELECT
             project_id,


### PR DESCRIPTION
The production deploy still fails in the pre-upgrade migration Job, with the same error class [#12453](https://github.com/tuist/tuist/pull/12453) was meant to end:

```
Code: 190. DB::Exception: Arrays passed to arrayMap must have equal size.
Argument 3 has size 246275 which differs with the size of another argument, 246258
```

#12453 is a partial fix. It repairs one cause of key-set divergence and leaves two others, so this replaces its mechanism rather than adding to it.

## What #12453 got wrong

It trimmed both arrays to the smaller maximum run key, on the premise that the key sets could only diverge at the source's 100-entry ceiling: `groupArraySorted` orders on the whole tuple, so the flag breaks ties on the key and a duplicated key straddling the ceiling is cut on different sides in the two aggregates. That cause is real. It is not the only one.

`recent_successful_runs` was added later, by `20260702120000`, with its own backfill. Wherever that did not reproduce the older aggregate exactly, the missing keys sit in the **interior**, not the tail, and no boundary trim can reach them. The migration also survives a test case holding one aggregate and not the other at all, which is a zero-length array against a full one.

The offending row, found by walking the projects in the order the migration processes them and landing on the first one after the last logged split:

| | |
|---|---|
| project | 1000 |
| both arrays | 100 keys |
| keys in flaky only / successful only | 17 / 17 |
| first divergence at position | 84 of 100 |
| after the #12453 trim | 82 vs 99 |
| after intersecting | 83 and 83 |

That 17 is exactly the `246275 - 246258` from the production error. A single test case aborts the insert for its whole range, because ClickHouse compares lengths before evaluating anything.

## The fix

Restrict both arrays to the keys they share:

```sql
arrayFilter(entry -> has(successful_keys, tupleElement(entry, 1)), flaky_keyed),
arrayFilter(entry -> has(flaky_keys,      tupleElement(entry, 1)), successful_keyed)
```

`arrayFilter` preserves order, so both sides come out carrying the same keys in the same positions and entry `i` is the same run on both. That holds regardless of *why* the sets differed, which matters here: this migration has now failed twice on causes discovered one at a time, and the third repair should not depend on having finally enumerated them all.

It is also strictly more faithful than trimming. A boundary trim drops every key above the smaller maximum; this drops only the entries that are genuinely unpaired.

## Why not key lookup

The moduledoc rejected key-based pairing after measuring 625 MiB chunks, and that constraint is unchanged. But that shape was a per-entry lookup inside `arrayMap` materialising `entries x keys` for the whole block. `has` returns a scalar and allocates nothing, over arrays capped at 100 entries, with `max_block_size` bounding what is in flight regardless.

## Validation

Against a local ClickHouse, on a fixture carrying each divergence shape actually observed. Both expressions were run per shape:

| shape | #12453 (merged) | this PR |
|---|---|---|
| aligned key sets | `[-39,-34,-31]` | `[-39,-34,-31]` |
| boundary divergence | `[-39]` | `[-39,-34]` |
| interior / tail divergence | **Code 190** | `[-119,-114]` |
| one aggregate empty | **Code 190** | `[]` |

The merged fix reproduces the production failure locally on the last two shapes, which is the regression test this change needed. On aligned inputs the two agree exactly, so well-behaved rows are untouched. On boundary divergence this keeps two entries where the trim kept one. The packing is checkable by hand: key `-10` with flaky `0` and successful `1` is `-40 + 0 + 1 = -39`.

Against production ClickHouse, read-only, complete scans (not sampled):

```
projects 1,2,3,4,5,165        14846 test cases   0 break with intersection
project  165                   7373 test cases  14 key-set divergences, 0 break
projects 926,939,940,944,948,
         1000,1005            18379 test cases   1 breaks #12453 (project 1000), 0 break with intersection
```

Coverage is targeted rather than exhaustive: 1,568,485 logical test cases exist and the read-only console cannot scan the largest projects, since `FINAL` forces a cross-part merge before `LIMIT` applies. The fleet-wide claim rests on the structural argument, not the sample; the sample exists to reproduce the known failure and confirm the repair.

`20260818120000` is still not recorded in `schema_migrations`, so it has never completed and is corrected in place.

## Correction to #12453's evidence

Its validation reported `0 differing rows` over 50,000 production test cases. That query used `LIMIT 50000` with no `ORDER BY`, which reads a prefix of the `(project_id, test_case_id)` sort key — the lowest project IDs only. It was a complete scan of an unrepresentative slice presented as a fleet-wide property, and it is why the interior case was missed. The local fixture above exists so the next change to this query is checked against the shapes rather than against whichever rows a scan happens to reach first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
