### PR TITLE
fix(server): read the recent-window backfill in narrower blocks

### DIFF
--- a/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
+++ b/server/priv/ingest_repo/migrations/20260818120000_backfill_test_case_runs_recent_window_per_case.exs
@@ -274,8 +274,10 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
           -- 100. That is not the shape the earlier attempt measured at 625 MiB
           -- chunks: that one built `entries x keys` intermediates for the whole
           -- block through a per-entry lookup inside `arrayMap`. `has` returns a
-          -- scalar and allocates nothing, and `max_block_size` bounds what is
-          -- in flight regardless.
+          -- scalar, so this adds two filtered copies rather than a cross
+          -- product. It is not free, though, and the budget is shared with the
+          -- reader and the `FINAL` merge, which is why `max_block_size` below
+          -- is what bounds all three.
           arrayMap(entry -> tupleElement(entry, 1), flaky_keyed) AS flaky_keys,
           arrayMap(entry -> tupleElement(entry, 1), successful_keyed) AS successful_keys
         FROM (
@@ -307,7 +309,15 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestCaseRunsRecentWindowPerCase do
       )
       SETTINGS
         max_threads = 2,
-        max_block_size = 4096,
+        -- 4096 overran the budget below on the first project whose parts are
+        -- large enough to matter: 1.87 GiB wanted against 1.86 GiB allowed,
+        -- reported once from the part reader (`max_rows_to_read = 4096`, which
+        -- is this setting) and once from the `FINAL` merge, so it is the whole
+        -- query rather than one operator. Rows in flight scale this directly,
+        -- and the ceiling is shared with live traffic, so it is cheaper to read
+        -- narrower than to claim more of the 8 GiB the environment budgets for
+        -- every Tuist query together.
+        max_block_size = 1024,
         max_memory_usage = 2000000000
       """,
       params,


### PR DESCRIPTION
With the pairing fixed by [#12457](https://github.com/tuist/tuist/pull/12457), the backfill gets past project 1000 and dies at project 1059 on memory instead:

```
Code: 241. DB::Exception: Query memory limit exceeded: would use 1.87 GiB
(attempt to allocate chunk of 4.00 MiB), maximum: 1.86 GiB
```

## Why this is the whole query, not one operator

The Job retried four times and reported the allocation from two different places:

```
attempt 1  (while reading column recent_runs) ... from mark 2 with
           max_rows_to_read = 4096 ... While executing MergeTreeSelect
attempt 2  ... While executing Aggregating...
```

`max_rows_to_read = 4096` is this query's own `max_block_size`. The reader, the `FINAL` merge and the array expressions all draw on one per-query budget, and rows in flight scale all three. So the lever is how much is read at once, not which operator happened to ask for the last 4 MiB.

## Why not raise the ceiling

`max_memory_usage` could go up: the environment pins `maxMemoryUsageForUserBytes` at 8 GiB against an 18 GiB replica, and this query currently asks for 1.86 GiB. But that 8 GiB is the aggregate budget for *every* Tuist read and write, the backfill runs against live traffic, and the values file is explicit that the point of the cap is to leave room for background merges rather than to discover pressure at the process ceiling. Taking a larger share for one migration is the expensive way to fix a query that is simply reading too wide.

Dropping `max_block_size` from 4096 to 1024 cuts in-flight rows fourfold at the cost of more blocks. The overrun was ~10 MiB against 1.86 GiB, so this is a wide margin rather than a squeeze past the line, which matters because projects 2382 (144k test cases) and 2772 (132k) are still ahead of 1059 (80k).

## Why this surfaced only now

Both earlier attempts died at project 1000, about twenty seconds in, on `SIZES_OF_ARRAYS_DONT_MATCH`. No attempt had ever reached a project whose parts are large enough to strain the reader, so nothing about this was observable until the pairing was correct. It is the next failure in the queue rather than a regression from #12457.

## What is not claimed

That 1024 is the right number by measurement. `system.query_log` is not reachable through the read-only endpoint, so peak usage per range could not be read directly; the value is chosen to leave a wide margin over a ~10 MiB overrun rather than tuned to a profile. If it trips again on 2382 or 2772, the evidence will say whether to go narrower or to raise the ceiling after all.

Duration is also now worth watching. Narrower blocks mean more of them, and the helm pre-upgrade hook has a 60-minute `--atomic` budget that no attempt has yet exercised past the first minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
