### PR TITLE
fix(server): space out the runner job insights run rows

### DIFF
--- a/server/assets/app/css/pages/runner_job.css
+++ b/server/assets/app/css/pages/runner_job.css
@@ -277,7 +277,7 @@
   & [data-part="insights-run-list"] {
     display: flex;
     flex-direction: column;
-    gap: var(--noora-spacing-1);
+    gap: var(--noora-spacing-4);
     margin-top: auto;
     border-top: 1px solid var(--noora-surface-border-secondary);
     padding-top: var(--noora-spacing-4);


### PR DESCRIPTION
## What changed

`insights-run-list` on the runner job page now stacks its rows with `--noora-spacing-4` (8px) instead of `--noora-spacing-1` (2px).

## Why

The Insights card on a runner job page lists the linked build runs (and test runs) as bordered card rows. Each row carries its own `box-shadow` border and `border-radius`, but the list flex gap was set to the smallest token on the spacing scale, 0.125rem. With a single run the list looked fine, because the only visible separation was the section's top border. As soon as a job linked two or more runs, the row borders sat 2px apart and read as one merged block rather than as separate rows.

## Root cause

The gap token was simply too small for a list of bordered elements. `--noora-spacing-1` works for tight intra-element stacks such as `insights-run-main` (title above subtitle, no borders involved), but not for sibling cards that each draw a boundary.

## Why this value

8px matches `steps-section`, the other list of bordered cards rendered further down the same page, so the two lists on the runner job page now share one rhythm. Bumping to `--noora-spacing-2`/`-3` (4px/6px) would have relieved the crowding without lining up with anything already on the page.

The rule is shared by the Builds and the Tests panel, so both get the fix from the single change.

## Impact

Purely visual, scoped to the runner job page Insights card. No template, LiveView, or data changes.

## Validation

- `mise run format` from `server/` reports the file unchanged, so the edit is already formatter-clean.
- Reviewed the surrounding rules in `assets/app/css/pages/runner_job.css` to confirm no other selector depends on the old gap: `insights-run-list` is matched only by this block.