### PR TITLE
fix(infra): scope the unschedulable-pod alert to production and correct the decommission runbook

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -294,40 +294,71 @@ exists for exactly this, but it ships `dryRun: true` and no environment
 overrides it today, so it only logs. Until an environment arms it, the volume
 has to be deleted by hand.
 
-Order matters: once the PVC is gone, the PV is the only object still holding
-the volume handle.
+Split it in two. Phase 1 removes the workload and is data-preserving, because
+`Retain` keeps the volume whatever happens to the PVC. Phase 2 destroys the
+data and can wait as long as you like; a stranded 10Gi volume costs well under
+a euro a month, so there is never a reason to rush it.
 
-1. Record the handle first — `kubectl get pv <name> -o jsonpath='{.spec.csi.volumeHandle}'`.
-   Cluster-scoped reads on `persistentvolumes` are not available to the normal
-   SSO identity, so this needs JIT elevation.
-2. Confirm the data is disposable, or take a final base backup.
-3. Delete the `Cluster` CR.
-4. Delete the `Released` PV, then delete the volume in the `tuist-workloads`
-   Hetzner project.
+Phase 1, under an active `/elevate <env>` write elevation:
 
-### The orphaned `registry` namespace
+1. Confirm the data is disposable, or take a final base backup. A Cluster whose
+   Pod has never started cannot be backed up at all, so decide before deleting.
+2. `kubectl delete cluster.postgresql.cnpg.io <name> -n <ns>`. The operator
+   removes the Pods, Services, and PVCs it owns.
 
-`registry/registry-pg` is a live example still waiting on this. It was created
-on 2026-06-15 by a standalone `registry` chart that moved the registry's Oban
-journal from SQLite onto CloudNativePG. Two days later the sync workers moved
-to the server under `TUIST_MODE=registry_sync`, the registry app became a
-stateless read frontend with no Repo, and the commit that did it also deleted
-the chart's `cnpg-cluster.yaml`. Neither that chart nor its removal ever landed
-on `main` — the registry moved into the `tuist` chart's `registry-*` templates
-in the `tuist` namespace instead — so nothing has run `helm upgrade` or
-`helm uninstall` against the old release since. Its `Cluster`, three Services,
-and PVC were left running in a namespace no chart owns.
+Phase 2, whenever you are satisfied nothing missed it:
 
-Its Pod has been `Pending` since 2026-07-06, when the node its volume was
-pinned to was destroyed, so the database has served nothing for six weeks with
-no consequence. Nothing depends on the data: the registry's source of truth is
-its Tigris bucket, and the Oban journal the cluster held is regenerable from a
-sync. It should be removed with the steps above, deleting the `registry`
-namespace once the `Cluster` is gone.
+3. `hcloud volume delete <id>` in the `tuist-workloads` project.
+
+Find the volume by the labels the CSI driver stamps on it rather than through
+the PV, which is what the earlier version of this runbook suggested:
+
+```bash
+hcloud volume list -l pvc-namespace=<ns>,pvc-name=<pvc>
+```
+
+That indirection is not cosmetic. `persistentvolumes` is cluster-scoped and
+readable by **no** tier here, elevated or not: it is absent from
+`tuist-view-infra-read` and from the CNPG roles added in
+[#12445](https://github.com/tuist/tuist/pull/12445). So `kubectl get pv` fails
+even mid-decommission, and the `hcloud` labels are the only route to the
+handle. The orphaned PV object is left behind for `released-pv-reaper` or an
+admin; it is inert once its volume is gone.
+
+Namespaces are likewise not deletable from the write tier, so a retired cluster
+leaves an empty namespace for an admin to sweep.
+
+### The orphaned `registry` namespace (worked example, completed)
+
+`registry/registry-pg` was decommissioned on 2026-08-19 by the steps above. It
+was created on 2026-06-15 by a standalone `registry` chart that moved the
+registry's Oban journal from SQLite onto CloudNativePG. Two days later the sync
+workers moved to the server under `TUIST_MODE=registry_sync`, the registry app
+became a stateless read frontend with no Repo, and the commit that did it also
+deleted the chart's `cnpg-cluster.yaml`. Neither that chart nor its removal
+ever landed on `main` (the registry moved into the `tuist` chart's
+`registry-*` templates in the `tuist` namespace instead), so nothing ran
+`helm upgrade` or `helm uninstall` against the old release again. Its
+`Cluster`, three Services, and PVC were left running in a namespace no chart
+owns.
+
+Its Pod sat `Pending` from 2026-07-06, when the node its volume was pinned to
+was destroyed, until the deletion: six weeks serving nothing, with no
+consequence and no alert. Nothing depended on the data. The registry's source
+of truth is its Tigris bucket, and the only migration ever run against that
+Postgres was `Oban.Migrations.up(version: 13)`, so the database held a job
+queue and no application tables at all.
+
+The generalisable part is how it stayed invisible. A Helm release deployed from
+a branch that never merged leaves objects no chart on `main` renders, so no
+deploy can ever prune them and no `helm uninstall` is ever run. Nothing owned
+them, nothing reconciled them, and their Services reported zero endpoints
+rather than an error. Worth grepping the live clusters for namespaces no chart
+owns; this was the third single-instance CNPG cluster found this way.
 
 ### How the volume ended up unschedulable
 
-The PVC's `volume.kubernetes.io/selected-node` names an OVH bare-metal kura
+The PVC's `volume.kubernetes.io/selected-node` named an OVH bare-metal kura
 node, which should never have been a candidate for an `hcloud-volumes` PVC.
 It was, because `hcloud-csi-node` still ran there: the DaemonSet's node
 affinity excluded non-Hetzner pools by enumerating pool names, and the list
@@ -335,7 +366,10 @@ only covered the pools that existed when each entry was written. With the
 driver registered on that node, the scheduler treated it as a valid
 `selected-node` for a `WaitForFirstConsumer` claim and the provisioner bound a
 location-pinned Hetzner volume behind a Pod that could only ever run off
-Hetzner.
+Hetzner. The volume was provisioned in Hetzner `ash`, a location the cluster
+has no nodes in at all, which is why the replacement Pod could never satisfy
+its node affinity: the scheduler reported the five untainted `fsn1` workers as
+failing it.
 
 That enumeration bug is already fixed — `hcloud-csi-values.yaml` now excludes
 by provider label (`node.cluster.x-k8s.io/instance-type NotIn [ovh, dedibox,

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1116,7 +1116,7 @@ endpoints, which reads as "no traffic" rather than "no backend".
 
 That is how `registry/registry-pg-1` — the sole instance of a
 CloudNativePG cluster — sat `Pending` in production from 2026-07-06 to
-2026-08-18 without anyone noticing. Its volume had been provisioned
+2026-08-19 without anyone noticing. Its volume had been provisioned
 against a node that was later destroyed, and Hetzner Cloud Volumes are
 location-bound, so the replacement Pod could not satisfy the volume's
 node affinity anywhere in the cluster. All three of that cluster's
@@ -1124,13 +1124,48 @@ Services served zero endpoints for six weeks.
 
 ```promql
 max by (cluster, namespace, pod) (
-  kube_pod_status_unschedulable{namespace!="tuist-runners"}
+  kube_pod_status_unschedulable{
+    cluster="tuist-production",
+    namespace!="tuist-runners"
+  }
 ) == 1
 ```
 
 - Pending period: 30 minutes
 - Severity: warning
+- No-data state: OK, and the same for the execution-error state
 - Summary: `Pod {{ $labels.namespace }}/{{ $labels.pod }} has been unschedulable for 30 minutes in {{ $labels.cluster }}`
+
+The no-data state is not incidental. Production's healthy baseline for
+this query is *no series at all*, so the rule sits in no-data rather than
+at zero whenever nothing is wrong. Left at the `Alerting` default it
+would fire permanently from the moment it is created.
+
+The `cluster` scope is also load-bearing, and this rule was documented
+without it first. Only production has a clean baseline. At the time of
+writing `tuist-staging` carries 15 permanently unschedulable Pods, so the
+unscoped query fires 15 times the instant it is saved:
+
+- 14 in `kura`. Eleven are `kura-<account>-staging` instances stranded in
+  the retired `hetzner-staging-runners` region, whose `kura` node pool was
+  deleted with it; their Postgres rows are gone, so the row-driven
+  reconciler cannot see the orphaned `KuraInstance` CRs and they sit
+  unschedulable indefinitely. The other three belong to
+  `kgw-…-eu-central-controller`, a Deployment left behind when the
+  per-account Kura gateway was removed in
+  [#11644](https://github.com/tuist/tuist/pull/11644).
+- 1 in `tailscale-operator`, from subnet-router Pod churn.
+
+Those are real cruft rather than a reason to widen the rule, but they
+have to be cleared before the scope can extend past production, or the
+alert is noise from its first evaluation. This is the failure mode the
+*Worker node pool stuck mid-rollout* rule warns about in its own pending-
+period note: a rule that cries wolf on the expected path gets muted, and
+a muted rule is worth less than no rule.
+
+Validate any change to this query against live data before saving it. The
+staging noise above was invisible in review and only showed up by running
+the expression over a 48-hour window.
 
 No metric change is needed. The kube-state-metrics tuning in
 [`values.yaml`](./values.yaml) already keeps `kube_pod_status_unschedulable`
@@ -1152,9 +1187,9 @@ scheduler could not place them.
 Thirty minutes clears the ordinary path where a Pod waits on the cluster
 autoscaler to add a node, and is short enough that a volume-affinity or
 taint mistake surfaces the same morning instead of six weeks later. This
-is a warning rather than a page because it fires on any workload in any
-namespace: the Pod that motivated it was critical, but most Pods that
-briefly cannot schedule are not.
+is a warning rather than a page because it fires on any production
+workload in any namespace: the Pod that motivated it was critical, but
+most Pods that briefly cannot schedule are not.
 
 ### Kubernetes request latency
 


### PR DESCRIPTION
Follow-up to [#12442](https://github.com/tuist/tuist/pull/12442), which is merged. Both corrections come from actually creating the alert rule and running the decommission, which surfaced things review could not.

## The alert query would have fired 15 times on creation

[#12442](https://github.com/tuist/tuist/pull/12442) documented the query without a `cluster` scope. It was never run against live data. Only production has a clean baseline:

```
count by (cluster, namespace) (kube_pod_status_unschedulable{namespace!="tuist-runners"} == 1)

tuist-staging / kura                 14
tuist-staging / tailscale-operator    1
tuist-production                      0
```

So saving the rule as documented produces 15 alerts on its first evaluation, all staging, most of them permanent. That is exactly the failure the *Worker node pool stuck mid-rollout* rule warns about in its own pending-period note: a rule that cries wolf on the expected path gets muted, and a muted rule is worth less than no rule.

The query is now scoped to `cluster="tuist-production"`.

## What that staging noise actually is

It is real cruft, not a reason to widen the rule, so the doc names it rather than just excluding it:

- **11 in `kura`** are `kura-<account>-staging` instances stranded in the retired `hetzner-staging-runners` region, whose `kura` node pool was deleted with it. Their `KuraInstance` CRs carry `tuist.dev/region: hetzner-staging-runners` and **no ownerReferences**. `reconcile_retired_region_servers` (added in [#12005](https://github.com/tuist/tuist/pull/12005)) drives teardown from the Postgres `Server` rows, and those rows are gone, so the orphaned CRs are invisible to it permanently. The reconciler runs every minute in staging and succeeds while these sit unschedulable.
- **3 in `kura`** belong to `kgw-…-eu-central-controller`, a Deployment left behind when the per-account Kura gateway was removed in [#11644](https://github.com/tuist/tuist/pull/11644). Helm does not prune CRDs, so `kuragateways.kura.tuist.dev` and its CR outlived the controller that reconciled them.
- **1 in `tailscale-operator`** is subnet-router Pod churn.

Clearing those is the prerequisite for extending the rule past production, and the doc says so.

## Three corrections to the decommission runbook

Each of these was wrong in a way only using it revealed.

**The volume handle cannot be read from the PV.** The runbook said to record it with `kubectl get pv -o jsonpath='{.spec.csi.volumeHandle}'` under JIT elevation. `persistentvolumes` is cluster-scoped and readable by **no** tier here, elevated or not: absent from `tuist-view-infra-read` and from the CNPG roles in [#12445](https://github.com/tuist/tuist/pull/12445). That command fails mid-decommission, after the PVC is already gone. The handle comes from the labels the CSI driver stamps on the volume instead:

```bash
hcloud volume list -l pvc-namespace=<ns>,pvc-name=<pvc>
```

**The steps are two phases, not one sequence.** `Retain` means deleting the Cluster preserves the volume, so phase 1 is fully data-preserving and phase 2 is the irreversible one. There is no reason to do them together, and a stranded 10Gi volume costs well under a euro a month.

**Deletion is no longer an admin action.** [#12445](https://github.com/tuist/tuist/pull/12445) gave the write elevation `delete` on `clusters.postgresql.cnpg.io`. Namespaces still are not deletable from that tier, so a retired cluster leaves an empty namespace behind, which the doc now states.

## Also

The no-data state is recorded, and it is not incidental: production's healthy baseline for this query is *no series at all*, so at Grafana's `Alerting` default the rule fires permanently from the moment it is created. Both no-data and execution-error are `OK`.

The `registry` example is rewritten as a completed decommission rather than a pending one, keeping the part that generalises: a Helm release deployed from a branch that never merged leaves objects no chart on `main` renders, so no deploy can prune them and no `helm uninstall` is ever run. That is the third single-instance CNPG cluster found this way.

The volume's location is added to the root-cause section. It was provisioned in Hetzner `ash`, a location the cluster has no nodes in at all, which is why the scheduler reported the five untainted `fsn1` workers as failing the PV's node affinity.

## Validation

- The counts above are from live instant and 48h range queries against `grafanacloud-prom`.
- The historical series confirms the rule would have worked: `registry/registry-pg-1` sat at `1` continuously across the whole 48h window until it was deleted.
- The rule is live as `Pod Cannot Be Scheduled` (`ffvn55h51mz28d`, folder `Alerts`, group `Infrastructure`), evaluating `normal` / `ok` with the scoped query this PR documents. The doc and the deployed rule agree.
- The runbook corrections are all from executing it: the `kubectl get pv` failure, the `hcloud` label lookup, and the two-phase split were each observed rather than reasoned about.
