### PR TITLE
fix(server): attribute a build to the step it ran in

### DIFF
--- a/server/lib/tuist_web/live/runner_job_live.ex
+++ b/server/lib/tuist_web/live/runner_job_live.ex
@@ -311,11 +311,14 @@ defmodule TuistWeb.RunnerJobLive do
 
   @doc """
   The step window associated with build or test insights.
+
+  `run_windows` maps a build run's id to the wall-clock window taken from its
+  command event; see `step_insights/4`.
   """
-  def insight_step_window(steps, runs, kind) do
+  def insight_step_window(steps, runs, kind, run_windows \\ %{}) do
     steps
     |> Enum.filter(fn step ->
-      Enum.any?(runs, &step_overlaps_run?(step, &1, kind))
+      Enum.any?(runs, &step_overlaps_run?(step, &1, kind, run_windows))
     end)
     |> step_window()
   end
@@ -419,9 +422,19 @@ defmodule TuistWeb.RunnerJobLive do
 
   def test_status_badge_props(_), do: %{label: dgettext("dashboard_runners", "Unknown"), color: "neutral"}
 
-  def step_insights(step, build_runs, test_runs) do
+  @doc """
+  The build and test runs attributed to a step.
+
+  `run_windows` maps a build run's id to `%{min:, max:}` in epoch milliseconds,
+  built from the run's command event. A build row carries no timestamp of its
+  own — `inserted_at` is stamped when the CLI's POST lands, which is a couple of
+  seconds after the build ended, since the xcactivitylog is bundled and uploaded
+  first. Attributing off that anchor drags the window past the step the build
+  ran in and into the ones that follow it.
+  """
+  def step_insights(step, build_runs, test_runs, run_windows \\ %{}) do
     %{
-      build_runs: matching_step_build_runs(step, build_runs),
+      build_runs: matching_step_build_runs(step, build_runs, run_windows),
       test_runs: matching_step_test_runs(step, test_runs)
     }
   end
@@ -472,6 +485,7 @@ defmodule TuistWeb.RunnerJobLive do
         |> assign(:insights_projects_by_id, %{})
         |> assign(:linked_build_runs, [])
         |> assign(:linked_test_runs, [])
+        |> assign(:linked_build_run_windows, %{})
         |> assign(:linked_build_module_cache_summary, module_cache_summary([]))
         |> assign(:linked_test_selective_testing_summary, selective_testing_summary([]))
 
@@ -479,7 +493,7 @@ defmodule TuistWeb.RunnerJobLive do
         build_runs = Jobs.list_runner_build_runs(projects, job.workflow_run_id)
         test_runs = Jobs.list_runner_test_runs(projects, job.workflow_run_id)
 
-        build_command_events = build_runs |> Jobs.command_events_for_runs(:build) |> Enum.reject(&is_nil/1)
+        build_command_events = Jobs.command_events_for_runs(build_runs, :build)
         test_command_events = test_runs |> Jobs.command_events_for_runs(:test) |> Enum.reject(&is_nil/1)
 
         socket
@@ -487,27 +501,70 @@ defmodule TuistWeb.RunnerJobLive do
         |> assign(:insights_projects_by_id, Map.new(projects, &{&1.id, &1}))
         |> assign(:linked_build_runs, build_runs)
         |> assign(:linked_test_runs, test_runs)
-        |> assign(:linked_build_module_cache_summary, module_cache_summary(build_command_events))
+        |> assign(:linked_build_run_windows, build_run_windows(build_runs, build_command_events))
+        |> assign(:linked_build_module_cache_summary, module_cache_summary(Enum.reject(build_command_events, &is_nil/1)))
         |> assign(:linked_test_selective_testing_summary, selective_testing_summary(test_command_events))
     end
   end
 
-  defp matching_step_build_runs(step, build_runs) do
-    Enum.filter(build_runs, &step_overlaps_run?(step, &1, :build))
+  # `Jobs.command_events_for_runs/2` returns one entry per run, in order, so the
+  # zip pairs each build with its own event.
+  defp build_run_windows(build_runs, command_events) do
+    build_runs
+    |> Enum.zip(command_events)
+    |> Enum.reduce(%{}, fn {run, command_event}, acc ->
+      case command_event_window(command_event) do
+        nil -> acc
+        window -> Map.put(acc, run.id, window)
+      end
+    end)
+  end
+
+  defp command_event_window(%{ran_at: ran_at, duration: duration}) do
+    case timestamp_epoch_ms(ran_at) do
+      nil -> nil
+      started_at -> %{min: started_at, max: started_at + max(duration || 0, 0)}
+    end
+  end
+
+  defp command_event_window(_), do: nil
+
+  defp matching_step_build_runs(step, build_runs, run_windows) do
+    Enum.filter(build_runs, &step_overlaps_run?(step, &1, :build, run_windows))
   end
 
   defp matching_step_test_runs(step, test_runs) do
-    Enum.filter(test_runs, &step_overlaps_run?(step, &1, :test))
+    Enum.filter(test_runs, &step_overlaps_run?(step, &1, :test, %{}))
   end
 
-  defp step_overlaps_run?(step, run, kind) do
-    case {step_timestamp_window(step), insight_run_window(run, kind)} do
-      {%{min: step_start, max: step_end}, %{min: run_start, max: run_end}} ->
-        step_start <= run_end and run_start <= step_end
-
-      _ ->
-        false
+  defp step_overlaps_run?(step, run, kind, run_windows) do
+    case {step_timestamp_window(step), insight_run_window(run, kind, run_windows)} do
+      {%{} = step_window, %{} = run_window} -> meaningful_overlap?(step_window, run_window)
+      _ -> false
     end
+  end
+
+  # A step is attributed a run when the two windows overlap by at least half of
+  # the shorter one. GitHub reports step boundaries at whole-second granularity
+  # and runner jobs fan out concurrent steps that share a second, so a bare
+  # intersection test hands a run a chip on every step it brushes — including
+  # ones it only touches for milliseconds.
+  defp meaningful_overlap?(%{min: step_start, max: step_end} = step_window, %{min: run_start, max: run_end} = run_window) do
+    overlap = min(step_end, run_end) - max(step_start, run_start)
+    shortest = min(step_end - step_start, run_end - run_start)
+
+    cond do
+      # An instant — a 0ms step, or a run with no measured duration — has no
+      # overlap to weigh, so it counts only where it falls strictly inside the
+      # other window. Sharing a boundary is not evidence it ran there.
+      shortest == 0 -> strictly_within?(step_window, run_window)
+      overlap <= 0 -> false
+      true -> overlap * 2 >= shortest
+    end
+  end
+
+  defp strictly_within?(%{min: a_start, max: a_end}, %{min: b_start, max: b_end}) do
+    (a_start > b_start and a_end < b_end) or (b_start > a_start and b_end < a_end)
   end
 
   defp step_timestamp_window(%{started_at: %DateTime{} = started_at, completed_at: %DateTime{} = completed_at}) do
@@ -515,6 +572,12 @@ defmodule TuistWeb.RunnerJobLive do
   end
 
   defp step_timestamp_window(_), do: nil
+
+  defp insight_run_window(%{id: id} = run, :build, run_windows) do
+    Map.get(run_windows, id) || insight_run_window(run, :build)
+  end
+
+  defp insight_run_window(run, kind, _run_windows), do: insight_run_window(run, kind)
 
   defp insight_run_window(%{inserted_at: inserted_at, duration: duration}, :build) do
     case timestamp_epoch_ms(inserted_at) do

--- a/server/lib/tuist_web/live/runner_job_live.html.heex
+++ b/server/lib/tuist_web/live/runner_job_live.html.heex
@@ -237,7 +237,12 @@
                   <% build_project = Map.get(@insights_projects_by_id, build.project_id) %>
                   <% row_status_props = TuistWeb.RunnerJobLive.build_status_badge_props(build) %>
                   <% build_step_window =
-                    TuistWeb.RunnerJobLive.insight_step_window(@steps, [build], :build) %>
+                    TuistWeb.RunnerJobLive.insight_step_window(
+                      @steps,
+                      [build],
+                      :build,
+                      @linked_build_run_windows
+                    ) %>
                   <.link
                     :if={build_project}
                     navigate={
@@ -408,7 +413,12 @@
           <% step_duration = TuistWeb.RunnerJobLive.step_duration_ms(step) %>
           <% expanded = TuistWeb.RunnerJobLive.step_expanded?(@expanded_steps, step) %>
           <% step_insights =
-            TuistWeb.RunnerJobLive.step_insights(step, @linked_build_runs, @linked_test_runs) %>
+            TuistWeb.RunnerJobLive.step_insights(
+              step,
+              @linked_build_runs,
+              @linked_test_runs,
+              @linked_build_run_windows
+            ) %>
           <% latest_step_build = List.first(step_insights.build_runs) %>
           <% latest_step_test = List.first(step_insights.test_runs) %>
           <div

--- a/server/test/tuist_web/live/runner_job_live_test.exs
+++ b/server/test/tuist_web/live/runner_job_live_test.exs
@@ -177,6 +177,9 @@ defmodule TuistWeb.RunnerJobLiveTest do
       name: "xcodebuild",
       is_ci: true,
       build_run_id: build_run.id,
+      ran_at: ~N[2026-05-28 10:01:00.000000],
+      created_at: ~N[2026-05-28 10:03:00.000000],
+      duration: 120_000,
       cacheable_targets: ["App", "Core", "UI", "Networking"],
       local_cache_target_hits: ["App"],
       remote_cache_target_hits: ["Core", "UI"]
@@ -187,6 +190,9 @@ defmodule TuistWeb.RunnerJobLiveTest do
       name: "xcodebuild",
       is_ci: true,
       build_run_id: second_build_run.id,
+      ran_at: ~N[2026-05-28 10:01:00.000000],
+      created_at: ~N[2026-05-28 10:02:00.000000],
+      duration: 60_000,
       cacheable_targets: ["AppClip", "AppClipCore"],
       local_cache_target_hits: ["AppClip"],
       remote_cache_target_hits: []
@@ -256,7 +262,7 @@ defmodule TuistWeb.RunnerJobLiveTest do
     )
 
     step_started_at = ~U[2026-05-28 10:00:00.000000Z]
-    step_completed_at = ~U[2026-05-28 10:03:30.000000Z]
+    step_completed_at = ~U[2026-05-28 10:05:00.000000Z]
 
     :ok =
       JobSteps.record([
@@ -397,6 +403,131 @@ defmodule TuistWeb.RunnerJobLiveTest do
 
     refute expanded =~ ~s(data-part="step-insight-detail")
     assert expanded =~ "No logs were captured for this step."
+  end
+
+  test "attributes a build only to the step it ran in when steps share a second", %{
+    conn: conn,
+    account: account
+  } do
+    project =
+      ProjectsFixtures.project_fixture(
+        name: "mobile-app-#{System.unique_integer([:positive])}",
+        account: account,
+        vcs_connection: [repository_full_handle: "tuist/tuist"]
+      )
+
+    :ok =
+      Jobs.enqueue(%{
+        workflow_job_id: 31_401,
+        account_id: account.id,
+        fleet_name: "macos-xcode-26.4",
+        repository: "tuist/tuist",
+        workflow_run_id: 314_010,
+        workflow_name: "Release",
+        run_attempt: 1,
+        job_name: "Archive",
+        head_branch: "main",
+        head_sha: "abcdef1234567890"
+      })
+
+    # Geometry taken from a real archive job: two sequential archive steps
+    # followed by a fan of packaging steps that all start within the same
+    # second, and one skipped step with no timestamps.
+    {:ok, app_build} =
+      RunsFixtures.build_fixture(
+        project_id: project.id,
+        user_id: account.id,
+        scheme: "App",
+        duration: 389_939,
+        inserted_at: ~N[2026-08-19 05:59:30.248190],
+        ci_provider: "github",
+        ci_project_handle: "tuist/tuist",
+        ci_run_id: "314010"
+      )
+
+    {:ok, beta_build} =
+      RunsFixtures.build_fixture(
+        project_id: project.id,
+        user_id: account.id,
+        scheme: "AppBeta",
+        duration: 39_405,
+        inserted_at: ~N[2026-08-19 06:00:18.133027],
+        ci_provider: "github",
+        ci_project_handle: "tuist/tuist",
+        ci_run_id: "314010"
+      )
+
+    CommandEventsFixtures.command_event_fixture(
+      project_id: project.id,
+      name: "xcodebuild",
+      is_ci: true,
+      build_run_id: app_build.id,
+      ran_at: ~N[2026-08-19 05:52:52.000000],
+      created_at: ~N[2026-08-19 05:59:30.248631],
+      duration: 397_553
+    )
+
+    CommandEventsFixtures.command_event_fixture(
+      project_id: project.id,
+      name: "xcodebuild",
+      is_ci: true,
+      build_run_id: beta_build.id,
+      ran_at: ~N[2026-08-19 05:59:32.000000],
+      created_at: ~N[2026-08-19 06:00:16.558430],
+      duration: 43_750
+    )
+
+    steps = [
+      {16, "Archive App", ~U[2026-08-19 05:52:52.000000Z], ~U[2026-08-19 05:59:32.000000Z]},
+      {17, "Archive AppBeta", ~U[2026-08-19 05:59:32.000000Z], ~U[2026-08-19 06:00:17.000000Z]},
+      {18, "Validate archive outputs", ~U[2026-08-19 06:00:17.000000Z], ~U[2026-08-19 06:00:18.000000Z]},
+      {19, "Collect asset catalog outputs", ~U[2026-08-19 06:00:18.000000Z], ~U[2026-08-19 06:00:18.000000Z]},
+      {20, "Save asset catalog output cache", nil, ~U[2026-08-19 06:00:18.000000Z]},
+      {21, "Package distribution artifacts", ~U[2026-08-19 06:00:18.000000Z], ~U[2026-08-19 06:00:28.000000Z]},
+      {22, "Create build manifest", ~U[2026-08-19 06:00:18.000000Z], ~U[2026-08-19 06:00:18.000000Z]},
+      {23, "Wait for distribution artifacts", ~U[2026-08-19 06:00:18.000000Z], ~U[2026-08-19 06:00:28.000000Z]},
+      {24, "Upload build manifest", ~U[2026-08-19 06:00:28.000000Z], ~U[2026-08-19 06:00:30.000000Z]}
+    ]
+
+    :ok =
+      JobSteps.record(
+        Enum.map(steps, fn {number, name, started_at, completed_at} ->
+          %{
+            workflow_job_id: 31_401,
+            account_id: account.id,
+            number: number,
+            name: name,
+            status: "completed",
+            conclusion: if(started_at, do: "success", else: "skipped"),
+            started_at: started_at,
+            completed_at: completed_at
+          }
+        end)
+      )
+
+    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/runners/runs/314010/jobs/31401")
+    document = Floki.parse_fragment!(html)
+
+    chip_schemes = fn number ->
+      document
+      |> Floki.find("#runner-step-#{number} a[data-part='step-insight-chip'][data-kind='build']")
+      |> Enum.map(fn chip ->
+        chip |> Floki.find("[data-part='step-insight-chip-label']") |> Floki.text() |> String.trim()
+      end)
+    end
+
+    assert chip_schemes.(16) == ["App"]
+    assert chip_schemes.(17) == ["AppBeta"]
+
+    # The build ended before any of these ran; they only shared a second with
+    # the moment its result reached the server.
+    for number <- [18, 19, 20, 21, 22, 23, 24] do
+      assert chip_schemes.(number) == [], "step #{number} should not be attributed a build"
+    end
+
+    assert document
+           |> Floki.find("a[data-part='step-insight-chip'][data-kind='build']")
+           |> length() == 2
   end
 
   test "renders the captured steps for a completed job", %{conn: conn, account: account} do


### PR DESCRIPTION
> Describe here the purpose of your PR.

The runner job detail page attributed one build to six consecutive steps. On an archive job, a single 39s build showed a `Build <scheme>` chip on the archive step and on every packaging step that followed it.

### Root cause

The step chips are not reported by anything. They are inferred at render time by intersecting each step's `[started_at, completed_at]` with a build window reconstructed as `[inserted_at - duration, inserted_at]`.

A build row carries no timestamp of its own. `inserted_at` is stamped when the CLI's POST lands, and the CLI bundles and uploads the xcactivitylog *before* POSTing, so that anchor sits a couple of seconds past the moment the build actually ended. `ProcessBuildWorker` deliberately carries the anchor over when it replaces the row, so the drift is permanent.

On the job that surfaced this, the build truly ran `05:59:32.000 -> 06:00:15.750` and was anchored at `06:00:18.133` - a 2.4s overhang. That was enough, because GitHub reports step boundaries at whole-second granularity and runner jobs fan out concurrent steps that share a second: four packaging steps all start within the second at `06:00:18`. Four of the five spurious chips came from 133ms of overlap or from a zero-width step touching a boundary. The only step in the run that escaped was the one with null timestamps.

| step | window | overlap with the old build window | chip |
| --- | --- | --- | --- |
| Archive (first scheme) | 05:52:52 - 05:59:32 | none | no |
| Archive (second scheme) | 05:59:32 - 06:00:17 | 38.27s | yes, correct |
| Validate archive outputs | 06:00:17 - 06:00:18 | 1.00s | yes, spurious |
| Collect asset catalog outputs | 06:00:18 - 06:00:18 | 0s, point touch | yes, spurious |
| Save asset catalog output cache | null start | no window | no |
| Package distribution artifacts | 06:00:18 - 06:00:28 | 133ms | yes, spurious |
| Create build manifest | 06:00:18 - 06:00:18 | 0s, point touch | yes, spurious |
| Wait for distribution artifacts | 06:00:18 - 06:00:28 | 133ms | yes, spurious |
| Upload build manifest | 06:00:28 - 06:00:30 | none | no |

### What changed

**The build window is anchored on real time.** `insight_run_window/3` now prefers the linked command event's `ran_at` plus duration, which is the actual start of the invocation. Those command events were already being loaded in `assign_runner_insights` for the cache summaries and then discarded; they are now also folded into a `build_id => window` map. A build with no command event falls back to the previous reconstruction.

**Attribution requires meaningful overlap.** Anchoring alone is not enough - with second-granular boundaries a neighbouring step can still brush the window. The two windows must now overlap by at least half of the shorter one, so a step fully inside a run and a run fully inside a step both still attribute, while a millisecond graze does not. An instant (a 0ms step, or a run with no measured duration) attributes only where it falls strictly inside the other window; sharing a boundary is not evidence it ran there. This applies to test chips too, since the same granularity problem exists there.

### Why this over the alternatives

Persisting a real timestamp on `build_runs` would be the deeper fix, and the data exists - `XCActivityLogParser` returns `time_started_recording` and `time_stopped_recording`, which `build_processor.ex` uses to window machine metrics and then explicitly drops. That is a schema change plus a backfill, and it would not help builds that arrive complete in a single POST without going through the processor. `command_events.ran_at` is correct for both paths, is already loaded on this page, and is already what the `:test` branch of the same function uses - builds were the odd one out.

The overlap rule is scale-free on purpose. An absolute tolerance (say "ignore overlaps under a second") would drop legitimately short builds, and would still mis-attribute whenever the fallback anchor is in play.

### Reviewer notes

Two fixtures in the existing insights test had to be made coherent, and they are worth a look because the old any-overlap rule is what let them pass:

- its build command events set no `ran_at` at all, so they defaulted to `Time.utc_now()`, nowhere near the fixture's 2026-05-28 job. They now carry windows matching their builds.
- its test run started at `10:03:15` and ran 90s, ending 75 seconds after the step it was credited to had closed. A run cannot outlive its step in production, so that step was extended.

Each step still renders only the newest matching run, so a step can match several builds and show one. That behaviour is unchanged.

### How to test locally

The regression test replays the real job's geometry - two archive steps, the packaging fan sharing `06:00:18`, the skipped step with no timestamps, and both builds with their real `inserted_at`, `ran_at` and duration values:

```
mix test test/tuist_web/live/runner_job_live_test.exs
```

To see it fail on the previous behaviour, stash the two `lib/` files and run it again; it fails at `Validate archive outputs`, the first spurious chip.

Validation run: the full `runner_job_live` file is 32/32, and the wider runner suites (`runner_jobs_live`, `runner_workflow_live`, `runners/jobs`) are 121/121. `mix format --check-formatted` and `mix credo` are clean.
