### PR TITLE
fix(server): make ClickHouse projection migrations carry their own dedup mode

### DIFF
--- a/server/priv/ingest_repo/migrations/20260529100000_add_artifact_retention_projections.exs
+++ b/server/priv/ingest_repo/migrations/20260529100000_add_artifact_retention_projections.exs
@@ -1,10 +1,37 @@
 defmodule Tuist.IngestRepo.Migrations.AddArtifactRetentionProjections do
+  @moduledoc """
+  Adds the projections the artifact retention sweeps scan by.
+
+  `build_runs` and `test_runs` are ReplacingMergeTree, and ClickHouse rejects
+  `ADD PROJECTION` on a non-plain MergeTree while the table still carries the
+  default `deduplicate_merge_projection_mode = 'throw'`. Both tables were
+  switched to `'rebuild'` by the migrations that added their `proj_by_id`
+  projections, but that setting lives in the table's `SETTINGS` clause, so any
+  instance whose table metadata was recreated without it (a restore from a
+  schema dump, say) arrives here with `'throw'` and fails on error 344. Set the
+  mode here rather than inherit it, so this migration stands on its own.
+
+  `shard_plans` and `test_case_run_attachments` are plain MergeTree, which
+  ignores the setting entirely.
+  """
   use Ecto.Migration
 
   @disable_ddl_transaction true
   @disable_migration_lock true
 
   def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
+    """
+
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE build_runs

--- a/server/priv/ingest_repo/migrations/20260812120000_add_updated_at_version_to_build_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260812120000_add_updated_at_version_to_build_runs.exs
@@ -29,6 +29,10 @@ defmodule Tuist.IngestRepo.Migrations.AddUpdatedAtVersionToBuildRuns do
   because a replacement carries the placeholder's `inserted_at`, which says
   nothing about when the row was written.
 
+  Columns, skipping indexes and projections are all reconstructed from
+  `system.*` so the copy is a faithful reproduction of whatever the instance
+  actually has; hardcoding any of them here drops the rest on the floor.
+
   The old table is left behind as `build_runs_new` — the replay reads from it,
   and it makes the swap reversible. A follow-up migration drops it once the new
   table has been verified, the same sequence used by the previous `build_runs`
@@ -68,15 +72,12 @@ defmodule Tuist.IngestRepo.Migrations.AddUpdatedAtVersionToBuildRuns do
     columns = column_names("build_runs")
     column_definitions = column_definitions("build_runs")
     indexes = index_definitions("build_runs")
+    projections = projection_definitions("build_runs")
 
     IngestRepo.query!("""
     CREATE TABLE build_runs_new (
       #{column_definitions},
-      updated_at DateTime64(6) DEFAULT inserted_at#{if indexes != "", do: ",\n  #{indexes}", else: ""},
-      PROJECTION proj_by_id (
-        SELECT *
-        ORDER BY id
-      )
+      updated_at DateTime64(6) DEFAULT inserted_at#{if indexes != "", do: ",\n  #{indexes}", else: ""}#{if projections != "", do: ",\n  #{projections}", else: ""}
     ) ENGINE = ReplacingMergeTree(updated_at)
     PARTITION BY toYYYYMM(inserted_at)
     ORDER BY (project_id, id)
@@ -142,6 +143,20 @@ defmodule Tuist.IngestRepo.Migrations.AddUpdatedAtVersionToBuildRuns do
       )
 
     rows
+  end
+
+  defp projection_definitions(table_name) do
+    {:ok, %{rows: rows}} =
+      IngestRepo.query(
+        """
+        SELECT name, query
+        FROM system.projections
+        WHERE database = currentDatabase() AND table = {table:String}
+        """,
+        %{table: table_name}
+      )
+
+    Enum.map_join(rows, ",\n  ", fn [name, query] -> "PROJECTION #{name} (#{query})" end)
   end
 
   defp index_definitions(table_name) do

--- a/server/priv/ingest_repo/migrations/20260819120000_readd_artifact_retention_projection_to_build_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260819120000_readd_artifact_retention_projection_to_build_runs.exs
@@ -1,0 +1,45 @@
+defmodule Tuist.IngestRepo.Migrations.ReaddArtifactRetentionProjectionToBuildRuns do
+  @moduledoc """
+  Puts `proj_artifact_retention_by_project_inserted_at` back on `build_runs`.
+
+  `20260529100000` added it, then the `updated_at` table swap in
+  `20260812120000` rebuilt `build_runs` with a hardcoded `proj_by_id` as its
+  only projection, so the retention projection was dropped on every instance
+  that ran the swap. `Tuist.Storage.ExpiredArtifacts.delete_build_archives/3`
+  scans `project_id IN (...) AND inserted_at < cutoff`, and the table sorts by
+  `(project_id, id)`, so without it the `inserted_at` bound falls back to
+  reading every part for the account's projects.
+
+  The swap migration now reconstructs projections from `system.projections`,
+  which keeps fresh installs whole; this one repairs the instances that already
+  passed it. `IF NOT EXISTS` makes the two orderings agree.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # ClickHouse rejects ADD PROJECTION on a ReplacingMergeTree still carrying
+    # the default `deduplicate_merge_projection_mode = 'throw'`.
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    ADD PROJECTION IF NOT EXISTS proj_artifact_retention_by_project_inserted_at (
+      SELECT id, project_id, inserted_at
+      ORDER BY project_id, inserted_at
+    )
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE build_runs DROP PROJECTION IF EXISTS proj_artifact_retention_by_project_inserted_at"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260819120001_materialize_artifact_retention_projection_on_build_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260819120001_materialize_artifact_retention_projection_on_build_runs.exs
@@ -1,0 +1,23 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeArtifactRetentionProjectionOnBuildRuns do
+  @moduledoc """
+  Materializes `proj_artifact_retention_by_project_inserted_at` across the
+  existing parts of `build_runs`. The preceding migration only recorded the
+  projection definition; this one does the part rewrite.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MATERIALIZE PROJECTION proj_artifact_retention_by_project_inserted_at
+    """
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## What changed

Two independent fixes to the ClickHouse `build_runs` projection migrations.

**1. `20260529100000_add_artifact_retention_projections` now sets `deduplicate_merge_projection_mode = 'rebuild'` itself** on `build_runs` and `test_runs` before adding projections to them.

**2. The `20260812120000` table swap now reconstructs projections from `system.projections`** instead of hardcoding a single `PROJECTION proj_by_id`, and a new forward migration re-adds and materializes `proj_artifact_retention_by_project_inserted_at` on `build_runs` for instances that already ran the swap.

## Why

### The migration failure

A self-hosted instance reported a reproducible failure while validating disaster recovery: restoring a snapshot (PostgreSQL at `20260514120000`, ClickHouse at `20260513120000`) and upgrading to 1.255.3 or 1.260.1 aborts on `20260529100000` with

```
Code: 344. DB::Exception: ADD PROJECTION is not supported in ReplacingMergeTree
with deduplicate_merge_projection_mode = throw.
```

ClickHouse refuses `ADD PROJECTION` on any non-plain MergeTree while the table carries the default `deduplicate_merge_projection_mode = 'throw'`. That default is still `throw` as of 26.1 (`system.merge_tree_settings` reports `changed = 0`).

The repo flips that setting **once per table**, in whichever migration first adds a projection there:

| Table | Migration that sets `rebuild` |
|---|---|
| `test_case_runs` | `20260116134753` |
| `test_module_runs` / `test_suite_runs` | `20260422120003` / `20260422120005` |
| `build_runs` | `20260430120002` |
| `test_runs` | `20260430120004` |

Every later projection migration on those tables carries no guard of its own; only 5 of the 26 `ADD PROJECTION` migrations set the mode. `20260529100000` is where that bites, because it is the one that touches ReplacingMergeTree tables (`build_runs`, `test_runs`) without having flipped them itself. `shard_plans` and `test_case_run_attachments`, its other two targets, are plain MergeTree and ignore the setting entirely.

### Root cause

The setting lives in the table's `SETTINGS` clause, not in `schema_migrations`. Anything that recreates table metadata without copying it — a restore from a schema dump, a hand-rolled bootstrap, a swap migration that forgets it — silently resets the table to `throw` while `schema_migrations` still records `20260430120002` as applied, so Ecto never replays the ALTER. The migration chain then breaks at the next projection added to that table.

The fix is to stop treating an unrelated earlier migration's side effect as a precondition. Editing `20260529100000` in place rather than adding a follow-up is deliberate: instances that already passed it skip it and are unaffected, and instances that cannot get past it are exactly the ones that need the corrected body.

### The dropped projection

While confirming which tables actually carry the setting, `build_runs` turned out to have lost a projection. `20260812120000` swaps `build_runs` for a rebuilt table so the ReplacingMergeTree version column can change. It reconstructs columns from `system.columns` and skipping indexes from `system.data_skipping_indices`, but hardcodes a single `PROJECTION proj_by_id` — so `proj_artifact_retention_by_project_inserted_at`, added by `20260529100000` three months earlier, is not carried over, and nothing re-adds it.

Confirmed on a fully migrated database (CH migrations through `20260818120000`): `build_runs` has only `proj_by_id`, while `test_runs`, `shard_plans` and `test_case_run_attachments` all still have their retention projections. Fresh installs are affected too, since the swap runs after the projection is added.

`Tuist.Storage.ExpiredArtifacts.delete_build_archives/3` scans `build_runs` by `project_id IN (...) AND inserted_at < cutoff`, but the table is `ORDER BY (project_id, id)`, so the `inserted_at` bound is not served by the sort key. The retention sweep has been running without the structure built for it since the swap landed.

Reconstructing projections from `system.*` the same way indexes already are keeps fresh installs whole; the forward migration repairs instances past the swap. `ADD PROJECTION IF NOT EXISTS` makes the two orderings agree.

## Impact

- Self-hosted instances blocked at `20260529100000` can upgrade. Anyone hitting this before the fix ships can unblock in place with `ALTER TABLE build_runs MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'` (and the same for `test_runs`), then re-run migrations.
- Build-archive retention scans get their projection back. The materialize step rewrites existing parts, so expect the usual background part-rewrite load on large instances.
- No schema change for anything already correct; every statement is idempotent.

## Validation

Run against ClickHouse 26.1.2.11:

- Reproduced the reported failure exactly: `ADD PROJECTION` on a ReplacingMergeTree without the setting returns error 344, and the same statement succeeds after the `MODIFY SETTING` the migration now issues.
- Rendered the swap migration's `CREATE TABLE` from `system.projections` on a table holding both projections and confirmed both survive into the swapped-in table.
- Applied `20260819120000` and `20260819120001` to a fully migrated database: `build_runs` ends with `proj_by_id` and `proj_artifact_retention_by_project_inserted_at`. Rolled both back (projection gone, `proj_by_id` retained) and re-applied (both present).
- `mix format --check-formatted` clean; `mix excellent_migrations.check_safety` reports nothing for any of the four changed files.

## Follow-up worth considering

The per-table one-time flip is load-bearing across 21 unguarded `ADD PROJECTION` migrations. Setting `deduplicate_merge_projection_mode` in each migration that adds a projection, rather than relying on inheritance, would remove the whole class of failure. Not done here to keep this change scoped to the reported break.
