### PR TITLE
feat(infra): report Kubernetes objects no chart renders and no controller owns

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -20,6 +20,7 @@ on:
       - Mgmt Cluster Apply
       - Noora
       - Noora Storybook Deployment
+      - Orphan Drift
       - Processor
       - Processor Deploy
       - Secret Scanning

--- a/.github/workflows/orphan-drift.yml
+++ b/.github/workflows/orphan-drift.yml
@@ -1,0 +1,239 @@
+name: Orphan Drift
+
+# Weekly report of live Kubernetes objects that no chart on main renders and
+# no controller owns.
+#
+# Three orphans were found by hand on 2026-08-18/19 (tuist/tuist#12442,
+# tuist/tuist#12467, and the kuragateways CRD left behind by
+# tuist/tuist#11644). Each was invisible to every signal we had -- no alert,
+# no dashboard, and `helm list` reported healthy releases throughout -- and
+# each was noticed only because a person went looking. They share one
+# signature, and nothing looked for it. This does.
+#
+# Why a workflow and not a CronJob in the chart, the way released-pv-reaper
+# and tailscale-device-reaper are built: the left-hand side of the comparison
+# is "what does main render", which needs the repository, helm, and network
+# access to pull subchart dependencies. A CronJob shipped inside the tuist
+# chart would only ever know its own chart's render, at whatever commit last
+# deployed -- not platform's, pomerium's, or the four production-only charts,
+# and not main. Cluster access is the easier half to move: the same per-env
+# kubeconfig the deploy uses already exists in 1Password.
+#
+# Report only. It never deletes: two of the three known cases needed a human
+# decision about whether the data behind them mattered.
+#
+# Required secrets:
+#   OP_SERVICE_ACCOUNT_TOKEN (per GitHub Environment server-k8s-<env>) --
+#     read-only on the tuist-k8s-<env> vault, where the cluster kubeconfig
+#     is stored as the Document `kubeconfig: tuist-<env>`. Same secret the
+#     deploy and the CNPG restore drill use.
+#   CACHE_OP_SERVICE_ACCOUNT_TOKEN (repository) -- reads the Slack webhook,
+#     same as notify-failure.yml.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC, after the CNPG restore drill
+  workflow_dispatch:
+    inputs:
+      min_age_hours:
+        description: Ignore objects younger than this many hours
+        required: false
+        default: "24"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - infra/orphan-drift/**
+      - infra/mise/tasks/k8s/orphan-drift-check.sh
+      - .github/workflows/orphan-drift.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: orphan-drift-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
+  MISE_GITHUB_SLSA: false
+
+jobs:
+  # On a pull request there are no cluster credentials, so the check cannot
+  # run. What can be validated is everything that breaks silently the rest of
+  # the time: that every chart named in releases.txt still renders, and that
+  # every allowlist rule still parses and carries a reason.
+  validate:
+    name: Validate config
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked helm jq yq"
+          cache: "false"
+      - name: Every allowlist rule has three columns and a reason
+        run: |
+          set -euo pipefail
+          exit_status=0
+          line_number=0
+          while IFS= read -r line; do
+            line_number=$((line_number + 1))
+            rule="${line%%#*}"
+            [ -n "${rule// }" ] || continue
+            columns=$(printf '%s\n' "$rule" | awk '{print NF}')
+            if [ "$columns" -ne 3 ]; then
+              echo "::error file=infra/orphan-drift/allowlist.txt,line=$line_number::expected 3 columns, found $columns"
+              exit_status=1
+            fi
+            case "$line" in
+              *"#"*) ;;
+              *)
+                echo "::error file=infra/orphan-drift/allowlist.txt,line=$line_number::allowlist rule has no reason comment"
+                exit_status=1
+                ;;
+            esac
+          done < infra/orphan-drift/allowlist.txt
+          exit $exit_status
+      - name: Every release in releases.txt renders
+        # The check subtracts the rendered set from the live set, so a chart
+        # that stops rendering does not fail loudly -- it quietly reports
+        # every object it owns as an orphan. Catch that here, on the pull
+        # request that causes it, rather than in a Monday Slack message.
+        run: RENDER_ONLY=1 mise -C infra run k8s:orphan-drift-check all
+
+  check:
+    name: Check ${{ matrix.environment }}
+    if: github.event_name != 'pull_request'
+    runs-on: tuist-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [staging, canary, production]
+    environment:
+      name: server-k8s-${{ matrix.environment }}
+    timeout-minutes: 20
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      MIN_AGE_HOURS: ${{ inputs.min_age_hours || '24' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked helm kubectl jq yq"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-${{ matrix.environment }}" \
+            --vault "tuist-k8s-${{ matrix.environment }}" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: Report candidate orphans
+        env:
+          JSON_OUT: ${{ runner.temp }}/orphans-${{ matrix.environment }}.json
+        run: mise -C infra run k8s:orphan-drift-check ${{ matrix.environment }}
+      - name: Write job summary
+        if: always()
+        env:
+          JSON_PATH: ${{ runner.temp }}/orphans-${{ matrix.environment }}.json
+        run: |
+          set -euo pipefail
+          {
+            echo "## ${{ matrix.environment }}"
+            echo
+            if [ ! -s "$JSON_PATH" ]; then
+              echo "The check did not complete. See the job log."
+            elif [ "$(jq 'length' < "$JSON_PATH")" -eq 0 ]; then
+              echo "No candidate orphans."
+            else
+              echo "| Kind | Namespace | Name | Age |"
+              echo "| --- | --- | --- | --- |"
+              jq -r '.[] | "| \(.groupKind) | \(if .namespace == "" then "_cluster_" else .namespace end) | \(.name) | \(.ageDays)d |"' \
+                < "$JSON_PATH"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: orphans-${{ matrix.environment }}
+          path: ${{ runner.temp }}/orphans-${{ matrix.environment }}.json
+          if-no-files-found: ignore
+          retention-days: 90
+
+  report:
+    name: Report to Slack
+    needs: [check]
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: orphans-*
+          path: findings
+          merge-multiple: false
+      - uses: 1password/install-cli-action@v2
+      - name: Load Slack webhook from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')
+          echo "::add-mask::$SLACK_WEBHOOK_URL"
+          echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> "$GITHUB_ENV"
+      - name: Build Slack payload
+        # Posted every week, findings or not. A report that only speaks up
+        # when something is wrong cannot be told apart from one that has
+        # stopped running -- which is how released-pv-reaper has sat in
+        # dryRun in every environment since it shipped, with nobody noticing
+        # that nobody was reading it. The weekly line is the heartbeat.
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CHECK_RESULT: ${{ needs.check.result }}
+        run: |
+          set -euo pipefail
+          summary=""
+          total=0
+          for environment in staging canary production; do
+            file="findings/orphans-$environment/orphans-$environment.json"
+            if [ ! -s "$file" ]; then
+              summary="${summary}\n• *${environment}*: check did not complete"
+              continue
+            fi
+            count=$(jq 'length' < "$file")
+            total=$((total + count))
+            if [ "$count" -eq 0 ]; then
+              summary="${summary}\n• *${environment}*: clean"
+            else
+              lines=$(jq -r '.[] | "    ‣ \(.groupKind) \(if .namespace == "" then "" else .namespace + "/" end)\(.name) (\(.ageDays)d)"' < "$file")
+              summary="${summary}\n• *${environment}*: ${count} candidate orphan(s)\n${lines}"
+            fi
+          done
+          if [ "$total" -eq 0 ] && [ "$CHECK_RESULT" = "success" ]; then
+            heading=":white_check_mark: <${RUN_URL}|Orphan drift check>: no candidate orphans in any environment."
+          else
+            heading=":mag: <${RUN_URL}|Orphan drift check>: ${total} candidate orphan(s). Live objects no chart on main renders and no controller owns -- triage before deleting."
+          fi
+          jq -n --arg text "$(printf '%b' "${heading}${summary}")" '{text: $text}' \
+            > "$RUNNER_TEMP/slack-payload.json"
+      - uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: ${{ runner.temp }}/slack-payload.json
+      - name: Fail if a check job did not complete
+        # Findings themselves are not a failure -- they are the product. A
+        # job that could not run is, and it routes through notify-failure.yml.
+        if: needs.check.result != 'success'
+        run: |
+          echo "::error::one or more environment checks did not complete"
+          exit 1

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -13,6 +13,8 @@ When editing this chart, anything gated behind `managedSecrets` must stay gated 
 
 Two grace-period garbage collectors live here, both off or in dry-run by default and both documented at length in their own templates: `released-pv-reaper` (orphaned Hetzner block volumes) and `tailscale-device-reaper` (abandoned tagged tailnet devices). The Tailscale one runs per env and each instance requires `tailscaleDeviceReaper.tags` set to that env's ACL tags — all envs share a single tailnet, and that list is what confines a reaper to its own devices. It must match the tag scope of the env's OAuth client; see §5d of [`k8s/onboarding.md`](k8s/onboarding.md).
 
+A third sweep, [`orphan-drift/`](orphan-drift/README.md), deliberately does *not* live here. It compares live cluster objects against what every chart on `main` renders, so it needs the repository and all the charts at once — not just this one, at whatever commit last deployed. It runs as a scheduled workflow instead, and reports rather than reaps.
+
 ### `helm/noora-storybook/` — standalone Noora Storybook chart
 Dedicated chart for the public `storybook.noora.tuist.dev` release. It deploys independently from the Tuist server so Noora Storybook changes do not have to share the server release boundary.
 
@@ -79,6 +81,9 @@ forwards with the token it already holds. Installed and drift-rolled by
 
 ### `registry-router/` — Cloudflare Worker for the Tuist registry path
 Routes `tuist.dev/api/registry/*` to the standalone registry frontend at `registry.tuist.dev`. The ingress hostname is an origin, not a separately advertised registry endpoint.
+
+### `orphan-drift/` — abandoned-object report
+Weekly report of live Kubernetes objects that no chart on `main` renders and no controller owns — the signature shared by the `registry-pg` CNPG cluster, the stranded `hetzner-staging-runners` KuraInstances, and the `kuragateways` CRD, none of which any dashboard, alert, or Helm state could see. Config is `releases.txt` (chart → environment wiring, which must be extended whenever a workflow starts deploying a new chart) and `allowlist.txt`. Report-only; it deletes nothing. Driven by `.github/workflows/orphan-drift.yml` and `mise -C infra run k8s:orphan-drift-check`. See [`orphan-drift/README.md`](orphan-drift/README.md).
 
 ### `cnpg/` — CloudNativePG bootstrap SQL
 SQL files for per-table GRANTs that don't fit CNPG's `managed.roles[]` declarative surface (`tuist_processor` writes on Oban tables; `tuist_ops_ro` extras on top of `pg_read_all_data`). The actual `Cluster` / `ScheduledBackup` / ESO Secret manifests are rendered by the main Helm chart whenever `postgresql.cnpg.enabled` is true or `postgresql.mode == "cnpg"`; this directory holds only the operator-run SQL that can't fit in the chart.

--- a/infra/mise/tasks/k8s/orphan-drift-check.sh
+++ b/infra/mise/tasks/k8s/orphan-drift-check.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+#MISE description="Report live Kubernetes objects that no chart on main renders and no controller owns."
+#USAGE arg "<environment>" help="Environment to check (staging | canary | production)"
+
+# Finds the class of orphan that every other signal misses: an object that is
+# live in a cluster, is rendered by no chart on main, and has no
+# ownerReferences. All three have to hold at once, and that conjunction is
+# what makes the report small enough to read.
+#
+# Why each half exists:
+#
+#   * Not rendered by main. Helm only prunes what a release still tracks, so
+#     an object created by a chart that never landed on main (a feature-branch
+#     `helm upgrade`, a hand-applied manifest) is invisible to every later
+#     `helm upgrade` -- nothing will ever prune it, and `helm list` shows a
+#     healthy release. CRDs are worse: Helm does not prune them at all, so a
+#     CRD outlives the chart that introduced it indefinitely.
+#   * No ownerReferences. This is the filter that makes the report usable. The
+#     clusters are full of objects no chart renders on purpose -- CNPG's Pods
+#     and Services, the kura-controller's StatefulSets, every ReplicaSet --
+#     and all of them carry an ownerReference to the thing that reconciles
+#     them. An object with no owner is one nothing is watching: if it should
+#     not exist, nothing will notice.
+#
+# Measured against the three orphans found by hand on 2026-08-18/19
+# (tuist/tuist#12442, tuist/tuist#12467, the kuragateways CRD left by
+# tuist/tuist#11644): all three had no ownerReferences, none was rendered by
+# main, and none surfaced in a dashboard, an alert, or helm state. They were
+# found because a person went looking.
+#
+# Report only. It deletes nothing and is not built to: two of those three
+# needed a human decision about whether the data behind them mattered.
+#
+# Environment knobs:
+#   KUBECTL_CONTEXT   kubectl context to read (default: current context)
+#   MIN_AGE_HOURS     ignore objects younger than this (default 24)
+#   JSON_OUT          also write the findings as JSON to this path
+#   RELEASES_FILE     override infra/orphan-drift/releases.txt
+#   ALLOWLIST_FILE    override infra/orphan-drift/allowlist.txt
+#   RENDER_ONLY       render every release and exit; no cluster access needed
+
+set -euo pipefail
+
+ENVIRONMENT="${1:-}"
+if [ -z "$ENVIRONMENT" ]; then
+  echo "usage: orphan-drift-check.sh <staging|canary|production>" >&2
+  echo "       RENDER_ONLY=1 orphan-drift-check.sh all   # validate charts, no cluster" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RELEASES_FILE="${RELEASES_FILE:-$REPO_ROOT/infra/orphan-drift/releases.txt}"
+ALLOWLIST_FILE="${ALLOWLIST_FILE:-$REPO_ROOT/infra/orphan-drift/allowlist.txt}"
+MIN_AGE_HOURS="${MIN_AGE_HOURS:-24}"
+JSON_OUT="${JSON_OUT:-}"
+
+KUBECTL=(kubectl)
+if [ -n "${KUBECTL_CONTEXT:-}" ]; then
+  KUBECTL+=(--context "$KUBECTL_CONTEXT")
+fi
+KUBECTL+=(--request-timeout=60s)
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*" >&2; }
+
+# Custom API groups we own end to end. Every resource the cluster reports in
+# these groups is policed, so a CRD we add later is covered without editing
+# this list -- which is the point, since an abandoned CRD is one of the three
+# cases this check exists for.
+OWNED_API_GROUPS=(kura.tuist.dev tuist.dev postgresql.cnpg.io)
+
+# Built-in kinds worth policing, as `<group>:<resource>` (empty group = core).
+# Deliberately narrow: these are the kinds that cost money or serve traffic
+# when abandoned, and they are the kinds all three known orphans took.
+# Widening this (to ConfigMaps, Secrets, ServiceAccounts, RBAC) buys a much
+# larger report for objects that are inert when stranded.
+BUILTIN_RESOURCES=(
+  :namespaces
+  :services
+  apps:deployments
+  apps:statefulsets
+  apiextensions.k8s.io:customresourcedefinitions
+)
+
+# Image tags are resolved at deploy time from git tags and pushed images, and
+# a few templates hard-fail without them. None of them affects which objects
+# render -- only what those objects run -- so the check pins placeholders
+# rather than reimplementing the deploy workflow's tag resolution.
+PLACEHOLDER_SETS=(
+  # Top-level image.tag is the single-component charts (slack,
+  # noora-storybook, typesense, tuist-ops); the rest are the tuist chart's.
+  --set image.tag=orphan-drift
+  --set server.image.tag=orphan-drift
+  --set codebaseSearch.image.tag=orphan-drift
+  --set registry.image.tag=orphan-drift
+  --set kuraController.image.tag=orphan-drift
+  --set kuraRuntime.image.tag=orphan-drift
+  --set xcresultProcessor.image.tag=orphan-drift
+  --set macosFleet.image.tag=orphan-drift
+  --set runnersController.image.tag=orphan-drift
+  --set runnersFleet.runnerImageSemver=0.0.0
+  --set runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/tuist-linux-runner:orphan-drift
+)
+
+# Renders one release exactly as the check compares it. Shared with
+# RENDER_ONLY so the config validated on a pull request is the same config the
+# scheduled run uses -- a chart that stops rendering does not fail the check
+# loudly, it silently reports every object it owns as an orphan.
+template_release() {
+  local chart="$1" release="$2" namespace="$3" values="$4" out="$5"
+  local chart_dir="$REPO_ROOT/$chart"
+  local values_args=() values_file
+
+  for values_file in $values; do
+    values_args+=(-f "$chart_dir/$values_file")
+  done
+
+  # Subchart tarballs have to be present for `helm template` to resolve
+  # dependency references; no-op for charts without `dependencies:`.
+  if grep -q '^dependencies:' "$chart_dir/Chart.yaml"; then
+    helm dependency update "$chart_dir" >/dev/null
+  fi
+
+  # --include-crds matters: the tuist and platform charts ship CRDs under
+  # crds/, which the deploy applies separately (`kubectl apply -f crds/`).
+  # Without it every chart CRD would be reported as an orphan.
+  helm template "$release" "$chart_dir" \
+    --namespace "$namespace" --include-crds \
+    "${values_args[@]}" "${PLACEHOLDER_SETS[@]}" > "$out"
+}
+
+release_rows() {
+  grep -v '^[[:space:]]*#' "$RELEASES_FILE" | awk 'NF'
+}
+
+# RENDER_ONLY validates the repository half without touching a cluster, which
+# is all a pull request can check: every release still renders, so the
+# comparison still has a left-hand side.
+if [ -n "${RENDER_ONLY:-}" ]; then
+  render_status=0
+  while read -r environment chart release namespace values; do
+    [ "$ENVIRONMENT" = "all" ] || [ "$environment" = "$ENVIRONMENT" ] || continue
+    if template_release "$chart" "$release" "$namespace" "$values" /dev/null; then
+      echo "ok    $environment $release ($chart)"
+    else
+      echo "FAIL  $environment $release ($chart)" >&2
+      render_status=1
+    fi
+  done < <(release_rows)
+  exit $render_status
+fi
+
+##
+## 1. Resource scope: what kinds to police, and which of them are cluster-scoped.
+##
+## Read from the cluster's discovery API rather than `kubectl api-resources`,
+## whose columns are positional and shift with the optional SHORTNAMES and
+## CATEGORIES fields. Scope matters twice: it decides what to list, and it
+## decides how a rendered object's namespace is normalised below.
+##
+log "Discovering policed resources"
+
+resource_rows="$WORK_DIR/resources.tsv" # <resource.group> <group> <Kind> <namespaced>
+: > "$resource_rows"
+
+# Prints one row per listable, non-subresource in a group's preferred version.
+discover_group() {
+  local group="$1" group_version raw
+  if [ -z "$group" ]; then
+    group_version="v1"
+    raw="$("${KUBECTL[@]}" get --raw /api/v1)" || return 1
+  else
+    group_version="$("${KUBECTL[@]}" get --raw "/apis/$group" 2>/dev/null |
+      jq -r '.preferredVersion.version // empty')"
+    [ -n "$group_version" ] || return 1
+    raw="$("${KUBECTL[@]}" get --raw "/apis/$group/$group_version" 2>/dev/null)" || return 1
+  fi
+  printf '%s' "$raw" | jq -r --arg group "$group" '
+    .resources[]
+    # Subresources ("deployments/status") are not objects.
+    | select(.name | test("/") | not)
+    | select((.verbs // []) | index("list"))
+    | [(.name + (if $group == "" then "" else "." + $group end)), $group, .kind, (.namespaced | tostring)]
+    | @tsv'
+}
+
+for entry in "${BUILTIN_RESOURCES[@]}"; do
+  group="${entry%%:*}"
+  resource="${entry#*:}"
+  [ -z "$group" ] || resource="$resource.$group"
+  discover_group "$group" | awk -F'\t' -v want="$resource" '$1 == want' >> "$resource_rows"
+done
+
+for group in "${OWNED_API_GROUPS[@]}"; do
+  if ! rows="$(discover_group "$group")" || [ -z "$rows" ]; then
+    echo "note: API group $group is not served by this cluster" >&2
+    continue
+  fi
+  printf '%s\n' "$rows" >> "$resource_rows"
+done
+
+if [ ! -s "$resource_rows" ]; then
+  echo "ERROR: discovered no resources to police -- is the cluster reachable?" >&2
+  exit 1
+fi
+
+sort -u "$resource_rows" -o "$resource_rows"
+
+# group|Kind -> namespaced, consumed by the rendered-side namespace defaulting.
+scope_json="$WORK_DIR/scope.json"
+jq -R -s 'split("\n") | map(select(length > 0) | split("\t"))
+  | map({ key: (.[1] + "|" + .[2]), value: (.[3] == "true") }) | from_entries' \
+  < "$resource_rows" > "$scope_json"
+
+echo "Policing: $(cut -f1 "$resource_rows" | tr '\n' ' ')" >&2
+
+##
+## 2. Rendered side: every object identity main's charts produce for this env.
+##
+log "Rendering charts for $ENVIRONMENT"
+
+rendered_ids="$WORK_DIR/rendered.txt"
+: > "$rendered_ids"
+rendered_releases=0
+
+while read -r environment chart release namespace values; do
+  [ "$environment" = "$ENVIRONMENT" ] || continue
+  rendered_releases=$((rendered_releases + 1))
+
+  render="$WORK_DIR/render-$release.yaml"
+  template_release "$chart" "$release" "$namespace" "$values" "$render"
+
+  # An object that omits metadata.namespace lands in the release namespace,
+  # so that is what a namespaced kind defaults to here. Cluster-scoped kinds
+  # are forced to empty on both sides so the two halves compare.
+  yq -o=json -I=0 'select(.kind != null and .metadata.name != null)
+      | [.apiVersion, .kind, (.metadata.namespace // ""), .metadata.name]' "$render" |
+    jq -r --arg release_ns "$namespace" --slurpfile scope "$scope_json" '
+      . as [$api_version, $kind, $object_ns, $name]
+      | select($api_version != null and $kind != null and $name != null)
+      | (if ($api_version | test("/")) then ($api_version | split("/")[0]) else "" end) as $group
+      | ($group + "|" + $kind) as $gk
+      | select($scope[0] | has($gk))
+      | (if $scope[0][$gk] then (if $object_ns == "" then $release_ns else $object_ns end) else "" end) as $ns
+      | [$group, $kind, $ns, $name] | @tsv' >> "$rendered_ids"
+done < <(release_rows)
+
+if [ "$rendered_releases" -eq 0 ]; then
+  echo "ERROR: no releases in $RELEASES_FILE for environment '$ENVIRONMENT'" >&2
+  exit 1
+fi
+
+sort -u "$rendered_ids" -o "$rendered_ids"
+echo "Rendered $rendered_releases release(s), $(wc -l < "$rendered_ids" | tr -d ' ') policed object identities" >&2
+
+##
+## 3. Live side: unowned objects of the policed kinds.
+##
+log "Listing live objects"
+
+live_json="$WORK_DIR/live.json"
+: > "$live_json"
+
+# pipefail (set at the top) is load-bearing here: a failed `kubectl get` in
+# this pipeline aborts the run rather than feeding jq nothing and reporting a
+# healthy-looking short list. Under-reporting is the failure this check cannot
+# afford -- it is indistinguishable from a clean cluster.
+while IFS=$'\t' read -r resource _group _kind _namespaced; do
+  "${KUBECTL[@]}" get "$resource" --all-namespaces -o json |
+    jq -c --argjson min_age_hours "$MIN_AGE_HOURS" --arg environment "$ENVIRONMENT" '
+      .items[]
+      # An owned object is somebody else'"'"'s problem by construction: whatever
+      # holds the ownerReference is reconciling it, and garbage collection
+      # removes it when the owner goes. This is the filter that keeps CNPG
+      # pods, kura StatefulSets and every ReplicaSet out of the report.
+      | select((.metadata.ownerReferences // []) | length == 0)
+      # Already terminating -- finalizers can hold this for a while.
+      | select(.metadata.deletionTimestamp == null)
+      | select(.metadata.creationTimestamp != null)
+      | ((now - (.metadata.creationTimestamp | fromdateiso8601)) / 3600) as $age_hours
+      # A deploy in flight while the check runs would otherwise report the
+      # objects it is still creating.
+      | select($age_hours >= $min_age_hours)
+      | {
+          group: (if (.apiVersion | test("/")) then (.apiVersion | split("/")[0]) else "" end),
+          kind: .kind,
+          namespace: (.metadata.namespace // ""),
+          name: .metadata.name,
+          ageDays: (($age_hours / 24) | floor),
+          createdAt: .metadata.creationTimestamp,
+          environment: $environment,
+        }' >> "$live_json"
+done < "$resource_rows"
+
+echo "Found $(wc -l < "$live_json" | tr -d ' ') live unowned object(s) older than ${MIN_AGE_HOURS}h" >&2
+
+##
+## 4. Subtract the rendered set, then the allowlist.
+##
+log "Comparing"
+
+findings_json="$WORK_DIR/findings.json"
+jq -s \
+  --rawfile rendered "$rendered_ids" \
+  --rawfile allowlist "$ALLOWLIST_FILE" '
+  def key: [.group, .kind, .namespace, .name] | join("\t");
+
+  # Allowlist columns are literal text with `*` as the only wildcard, so a
+  # rule reads like the object it excuses rather than like a regex.
+  def glob_to_regex:
+    "^" + (gsub("(?<c>[.^$|()\\[\\]{}+?\\\\])"; "\\\(.c)") | gsub("\\*"; ".*")) + "$";
+
+  ($rendered | split("\n") | map(select(length > 0)) | INDEX(.)) as $rendered_set
+  | ($allowlist | split("\n")
+      | map(sub("[[:space:]]*#.*$"; "") | split("[[:space:]]+"; "") | map(select(length > 0)))
+      | map(select(length == 3))
+      | map({
+          group_kind: (.[0] | glob_to_regex),
+          namespace: (.[1] | (if . == "-" then "" else . end) | glob_to_regex),
+          name: (.[2] | glob_to_regex),
+        })) as $allowlist_rules
+  | map(. + { groupKind: ((if .group == "" then "core" else .group end) + "/" + .kind) })
+  | map(select(key as $object_key | ($rendered_set | has($object_key)) | not))
+  | map(select(. as $object
+      | $allowlist_rules
+      | any(. as $rule
+            | ($object.groupKind | test($rule.group_kind))
+              and ($object.namespace | test($rule.namespace))
+              and ($object.name | test($rule.name)))
+      | not))
+  | sort_by(-.ageDays)' < "$live_json" > "$findings_json"
+
+if [ -n "$JSON_OUT" ]; then
+  cp "$findings_json" "$JSON_OUT"
+fi
+
+count="$(jq 'length' < "$findings_json")"
+
+if [ "$count" -eq 0 ]; then
+  echo "orphan-drift-check: $ENVIRONMENT: no candidate orphans"
+  exit 0
+fi
+
+echo "orphan-drift-check: $ENVIRONMENT: $count candidate orphan(s)"
+echo
+jq -r '(["KIND","NAMESPACE","NAME","AGE"] | @tsv),
+       (.[] | [.groupKind, (if .namespace == "" then "-" else .namespace end), .name, "\(.ageDays)d"] | @tsv)' \
+  < "$findings_json" | column -t -s $'\t'

--- a/infra/orphan-drift/README.md
+++ b/infra/orphan-drift/README.md
@@ -1,0 +1,128 @@
+# Orphan drift check
+
+Finds live Kubernetes objects that **no chart on `main` renders** and that
+**no controller owns**.
+
+- Check: [`infra/mise/tasks/k8s/orphan-drift-check.sh`](../mise/tasks/k8s/orphan-drift-check.sh)
+- Schedule: [`.github/workflows/orphan-drift.yml`](../../.github/workflows/orphan-drift.yml), Mondays 07:00 UTC, one Slack message per run
+- Config: [`releases.txt`](releases.txt) (chart → environment wiring), [`allowlist.txt`](allowlist.txt)
+
+## Why
+
+Three orphans were found by hand on 2026-08-18/19:
+
+| Orphan | Cluster | Age | Why nothing caught it |
+| --- | --- | --- | --- |
+| `registry/registry-pg` CNPG cluster ([#12442](https://github.com/tuist/tuist/issues/12442)) | production | 43d `Pending` | Created by a `registry` chart that only ever existed on a feature branch. No `helm upgrade` from `main` could prune it, and `helm list` showed a healthy release the whole time. |
+| 11 `kura-<account>-staging` KuraInstances ([#12467](https://github.com/tuist/tuist/issues/12467)) | staging | 33d unschedulable | Stranded in the retired `hetzner-staging-runners` region. Their Postgres rows were gone, and the reconciler that removes them is row-driven, so it could not see them. |
+| `kuragateways.kura.tuist.dev` CRD + CR + Deployment | all three | 6 weeks | Helm does not prune CRDs, so the CRD outlived the controller removed in [#11644](https://github.com/tuist/tuist/pull/11644). |
+
+None appeared in a dashboard, an alert, or Helm state. Each was found because
+a person went looking.
+
+## How it decides
+
+An object is reported when all three hold:
+
+1. Its identity `(group, Kind, namespace, name)` is absent from the union of
+   every chart in `releases.txt` rendered for that environment.
+2. It has no `ownerReferences`.
+3. It is older than `MIN_AGE_HOURS` (default 24) and not already terminating.
+
+The owner-reference filter is what makes the report readable. The clusters are
+full of objects no chart renders on purpose — CNPG's Pods and Services, the
+kura-controller's StatefulSets, every ReplicaSet — and every one of them
+carries an `ownerReference` to whatever reconciles it. An object with no owner
+is one nothing is watching. Measured on the first run: 747 unowned objects
+across the three clusters, 8 findings after the allowlist.
+
+Policed kinds are `Namespace`, `Service`, `Deployment`, `StatefulSet`,
+`CustomResourceDefinition`, and every resource in the API groups we own
+(`kura.tuist.dev`, `tuist.dev`, `postgresql.cnpg.io`). Those are the kinds
+that cost money or serve traffic when abandoned; a stranded ConfigMap is
+inert.
+
+**Helm state is deliberately not consulted.** "Belongs to a live Helm release"
+is the tempting exemption and it is the wrong one: `registry-pg` had a
+perfectly healthy release, created by a chart that never reached `main`. Helm
+state is precisely the signal that failed.
+
+## Acting on a finding
+
+The check never deletes, and it should not start to. Two of the three known
+cases needed a human decision about whether the data behind them mattered.
+
+1. **Establish what created it.** `kubectl get <kind> <name> -o yaml`. A
+   `kubectl.kubernetes.io/last-applied-configuration` annotation means it was
+   hand-applied. `app.kubernetes.io/managed-by: Helm` without a release that
+   renders it means a branch-only chart or a wrong-namespace apply.
+2. **Establish whether it does anything.** Zero endpoints, zero ready
+   replicas, `Pending` for weeks — or, worse, warm capacity nobody asked for.
+3. **Decide.** Either delete it, or add an allowlist rule with a reason. Both
+   are fine outcomes; leaving it in the report is not, because a report with
+   permanent noise stops being read.
+
+## Tuning the allowlist
+
+Rules are `<group>/<Kind>  <namespace>  <name>`, `core` for the core group,
+`-` for cluster-scoped, `*` the only wildcard, and a reason after `#`.
+
+Keep rules narrow. All three known orphans were a single object inside a
+namespace full of legitimate ones, so a rule that covers a whole namespace or
+a whole API group is usually a rule that will hide the next one. Two shapes
+are worth copying:
+
+- **Kura instances are allowed by region, not by namespace.** The 11 orphans
+  in #12467 sat in the `kura` namespace alongside dozens of live instances; a
+  `kura/*` rule would have hidden them forever. Retiring a region is now a
+  one-line deletion here, and its leftovers become findings on the next run.
+- **`*.infrastructure.cluster.x-k8s.io` is not allowlisted**, even though the
+  neighbouring CAPI groups are. That group is ours — its CRDs ship in
+  `infra/helm/tuist/crds/` — so a CRD in it that `main` does not render is a
+  real finding. The first run proved it: four abandoned CRDs.
+
+## Adding a chart
+
+When a workflow starts installing a chart into a managed cluster, add its row
+to `releases.txt` in the same PR, with the release name and namespace matching
+the `helm upgrade --install` exactly. A chart that is deployed but unlisted
+makes every object it owns look orphaned.
+
+That noise is the deliberate failure direction: it names the missing chart, in
+a report a human reads, on the next run. The alternative — a check that
+assumes coverage it does not have — fails the way the three orphans above did.
+
+## Running it locally
+
+Read-only, so the normal SSO kubeconfig is enough for most kinds. Note that
+`customresourcedefinitions` is cluster-scoped: the `tuist-view-infra-read`
+role grants it (see `infra/helm/pomerium/templates/access-tiers.yaml`), but a
+plain upstream `view` binding does not, which is why CI uses the in-cluster
+ServiceAccount kubeconfig instead.
+
+```bash
+KUBECTL_CONTEXT=tuist-k8s-production mise -C infra run k8s:orphan-drift-check production
+```
+
+Validate the config without a cluster (this is what runs on a pull request):
+
+```bash
+RENDER_ONLY=1 mise -C infra run k8s:orphan-drift-check all
+```
+
+Knobs: `KUBECTL_CONTEXT`, `MIN_AGE_HOURS`, `JSON_OUT`, `RELEASES_FILE`,
+`ALLOWLIST_FILE`, `RENDER_ONLY`.
+
+## Known gaps
+
+- **Peer Services are matched by shape, not region.** The kura-controller
+  creates `kura-<account>-peers` alongside each KuraInstance without an
+  `ownerReference`, so they are allowlisted on name shape. A stranded
+  region's Services are therefore not reported, only its KuraInstance — which
+  is the object worth acting on, since deleting it reaps the rest. Setting an
+  `ownerReference` on them in the controller would remove the rule entirely.
+- **Namespaces created by `--create-namespace`** are outside their release by
+  design and are allowlisted one by one. A new environment needs a new line.
+- **Sibling repositories** (`tuist/once`, `tuist/condukt`) deploy into the
+  production cluster from their own charts. The check renders nothing from
+  them, so their namespaces are allowlisted whole.

--- a/infra/orphan-drift/allowlist.txt
+++ b/infra/orphan-drift/allowlist.txt
@@ -1,0 +1,148 @@
+# Allowlist for the orphan drift check.
+#
+# Columns, whitespace-separated, `#` starts a comment:
+#   <group>/<Kind>   <namespace>   <name>
+#
+# `core` is the core API group. `-` in the namespace column means
+# cluster-scoped. `*` is the only wildcard and matches any run of characters;
+# everything else is literal.
+#
+# Every rule carries a reason. A rule without one is indistinguishable from
+# the orphan it is hiding, and this file is the only place a reader can tell
+# "nothing installs this any more" apart from "something we do not render
+# installs this on purpose".
+#
+# Rules are deliberately narrow. Widening one to cover a whole API group or a
+# whole namespace is how the check goes quiet: the three orphans it exists to
+# find were all a single object inside a namespace full of legitimate ones.
+
+# --- Kubernetes itself ---------------------------------------------------
+# Created by the apiserver / kubeadm, not by anything we install.
+core/Namespace                                 -             default                    # kubeadm
+core/Namespace                                 -             kube-system                # kubeadm
+core/Namespace                                 -             kube-public                # kubeadm
+core/Namespace                                 -             kube-node-lease            # kubeadm
+core/Service                                   default       kubernetes                 # apiserver's own endpoint
+
+# --- Namespaces Helm creates but does not track --------------------------
+# `helm upgrade --install --create-namespace` creates the namespace outside
+# the release, so it is in no rendered manifest and never will be. Deleting
+# the release leaves it behind by design.
+core/Namespace                                 -             tuist                      # --create-namespace (server-deployment.yml)
+core/Namespace                                 -             tuist-staging              # --create-namespace (server-deployment.yml)
+core/Namespace                                 -             tuist-canary               # --create-namespace (server-deployment.yml)
+core/Namespace                                 -             observability              # --create-namespace (k8s-monitoring)
+core/Namespace                                 -             platform                   # created by k8s:install-platform before the chart
+core/Namespace                                 -             tailscale-operator         # --create-namespace (tailscale-operator)
+core/Namespace                                 -             pomerium                   # --create-namespace (pomerium-deployment.yml)
+core/Namespace                                 -             slack                      # --create-namespace (slack-deployment.yml)
+core/Namespace                                 -             noora                      # --create-namespace (noora-storybook-deployment.yml)
+core/Namespace                                 -             typesense                  # --create-namespace (typesense-deployment.yml)
+core/Namespace                                 -             tuist-ops                  # --create-namespace (tuist-ops-deployment.yml)
+
+# --- Workload cluster bootstrap ------------------------------------------
+# infra/k8s/mgmt/bootstrap/ installs these once at cluster onboarding via
+# Helm releases this check does not render (Cilium, HCCM, hcloud-csi, ESO's
+# ClusterSecretStore). They are re-applied by their own workflows
+# (hccm-deployment.yml, csi-deployment.yml), not by a chart on main.
+apiextensions.k8s.io/CustomResourceDefinition  -             *.cilium.io                # Cilium CNI (bootstrap)
+core/Namespace                                 -             cilium-secrets             # Cilium CNI (bootstrap)
+apps/Deployment                                kube-system   cilium-operator            # Cilium CNI (bootstrap)
+core/Service                                   kube-system   cilium-envoy               # Cilium CNI (bootstrap)
+core/Service                                   kube-system   hubble-*                   # Cilium Hubble (bootstrap)
+apps/Deployment                                kube-system   hubble-relay               # Cilium Hubble (bootstrap)
+apps/Deployment                                kube-system   coredns                    # kubeadm cluster DNS
+core/Service                                   kube-system   kube-dns                   # kubeadm cluster DNS
+apps/Deployment                                kube-system   hcloud-cloud-controller-manager  # HCCM (hccm-deployment.yml)
+apps/Deployment                                kube-system   hcloud-csi-controller      # hcloud-csi (csi-deployment.yml)
+apiextensions.k8s.io/CustomResourceDefinition  -             volumesnapshot*.snapshot.storage.k8s.io  # hcloud-csi external-snapshotter
+core/Namespace                                 -             onepassword                # ESO ClusterSecretStore (bootstrap)
+core/Namespace                                 -             local-path-storage          # k3s/local-path provisioner (bootstrap)
+
+# --- Cluster API ---------------------------------------------------------
+# clusterctl installs the CAPI core, bootstrap and control-plane providers
+# into the workload cluster (see infra/k8s/onboarding.md); no chart renders
+# them.
+#
+# Note what is NOT here: `*.infrastructure.cluster.x-k8s.io`. That group is
+# ours -- its CRDs ship in infra/helm/tuist/crds/ and the deploy applies them
+# -- so a CRD in it that main does not render is a real finding, and blanket-
+# allowlisting the group would hide exactly the case this check is for. The
+# CAPI core group is enumerated by name for the same reason.
+apiextensions.k8s.io/CustomResourceDefinition  -             *.addons.cluster.x-k8s.io        # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             *.bootstrap.cluster.x-k8s.io     # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             *.controlplane.cluster.x-k8s.io  # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             *.ipam.cluster.x-k8s.io          # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             *.runtime.cluster.x-k8s.io       # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             *.clusterctl.cluster.x-k8s.io    # CAPI (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             clusters.cluster.x-k8s.io           # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             clusterclasses.cluster.x-k8s.io     # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machines.cluster.x-k8s.io           # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machinesets.cluster.x-k8s.io        # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machinepools.cluster.x-k8s.io       # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machinedeployments.cluster.x-k8s.io # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machinehealthchecks.cluster.x-k8s.io # CAPI core (clusterctl)
+apiextensions.k8s.io/CustomResourceDefinition  -             machinedrainrules.cluster.x-k8s.io   # CAPI core (clusterctl)
+core/Namespace                                 -             capi-system                          # CAPI (clusterctl)
+core/Namespace                                 -             capi-kubeadm-bootstrap-system        # CAPI (clusterctl)
+core/Namespace                                 -             capi-kubeadm-control-plane-system    # CAPI (clusterctl)
+apps/Deployment  capi-system                        capi-controller-manager                       # CAPI (clusterctl)
+apps/Deployment  capi-kubeadm-bootstrap-system      capi-kubeadm-bootstrap-controller-manager     # CAPI (clusterctl)
+apps/Deployment  capi-kubeadm-control-plane-system  capi-kubeadm-control-plane-controller-manager # CAPI (clusterctl)
+core/Service     capi-system                        capi-webhook-service                          # CAPI (clusterctl)
+core/Service     capi-kubeadm-bootstrap-system      capi-kubeadm-bootstrap-webhook-service        # CAPI (clusterctl)
+core/Service     capi-kubeadm-control-plane-system  capi-kubeadm-control-plane-webhook-service    # CAPI (clusterctl)
+
+# --- Tailscale operator proxies ------------------------------------------
+# The operator materialises a StatefulSet + Service per exposed Service /
+# Connector in its own namespace. They cannot carry an ownerReference: the
+# object they belong to lives in another namespace, and Kubernetes has no
+# cross-namespace ownership. The CAPI provider adds the ExternalName aliases
+# that point at them.
+#
+# Stale registrations in this space are already policed -- by
+# tailscale-device-reaper, which reaps the tailnet device rather than the
+# Kubernetes object. See infra/helm/tuist/templates/tailscale-device-reaper.yaml.
+core/Service      tailscale-operator  ts-*                       # tailscale-operator proxy
+apps/StatefulSet  tailscale-operator  ts-*                       # tailscale-operator proxy
+core/Service      tailscale-operator  tuist-tuist-*              # CAPI provider egress alias (ExternalName)
+
+# --- Kura per-account regional instances ---------------------------------
+# The server creates one KuraInstance per (account, region) from Postgres
+# rows, so no chart renders them and they have no owner. The kura-controller
+# then creates their peer Services in the same namespace.
+#
+# Allowed by REGION, not by namespace. The 11 orphans in tuist/tuist#12467
+# were stranded in the retired `hetzner-staging-runners` region and sat
+# alongside dozens of live instances; a `kura/*` rule would have hidden them
+# permanently. Region suffixes here are the name form of the slugs in
+# TUIST_KURA_AVAILABLE_REGIONS (values-managed-<env>.yaml) -- retiring a
+# region means deleting its line, which turns every leftover instance in it
+# into a finding on the next run.
+kura.tuist.dev/KuraInstance  kura  kura-*-scw-fr-par     # region scw-fr-par-runners
+kura.tuist.dev/KuraInstance  kura  kura-*-eu-central-1   # region eu-central
+kura.tuist.dev/KuraInstance  kura  kura-*-ca-east-1      # region ca-east (production + staging validation)
+kura.tuist.dev/KuraInstance  kura  kura-*-us-east-1      # region us-east (production)
+kura.tuist.dev/KuraInstance  kura  kura-*-us-west-1      # region us-west (production)
+# Peer Services carry no region in their name, so they are matched on shape.
+# They are reaped with their KuraInstance, which is the object worth reporting.
+core/Service  kura  kura-*-peers         # kura-controller, per KuraInstance
+core/Service  kura  kura-*-peers-public  # kura-controller, per KuraInstance
+
+# --- Workloads deployed from sibling repositories ------------------------
+# Helm releases installed into the production cluster by charts that live in
+# their own repository. This check renders nothing from those repos, so it
+# has no opinion to offer about anything inside their namespaces -- which is
+# why these rules are whole-namespace where every rule above is not.
+#
+# They are excused by name rather than by a "belongs to a live Helm release"
+# test. That test is the tempting generalisation and it is the wrong one:
+# `registry/registry-pg` (tuist/tuist#12442) had a perfectly healthy Helm
+# release too, created by a chart that only ever existed on a branch. Helm
+# state is precisely the signal that failed.
+core/Namespace   -                   once-production     # github.com/tuist/once
+apps/Deployment  once-production     *                   # github.com/tuist/once
+core/Service     once-production     *                   # github.com/tuist/once
+core/Namespace   -                   condukt-production  # github.com/tuist/condukt
+apps/Deployment  condukt-production  *                   # github.com/tuist/condukt
+core/Service     condukt-production  *                   # github.com/tuist/condukt

--- a/infra/orphan-drift/releases.txt
+++ b/infra/orphan-drift/releases.txt
@@ -1,0 +1,51 @@
+# Chart -> environment wiring for the orphan drift check.
+#
+# One row per Helm release that a deploy workflow installs into a managed
+# cluster. The check renders each row and unions the rendered object
+# identities; anything live that is missing from that union is a candidate
+# orphan. So a chart that is deployed but NOT listed here makes every object
+# it owns look orphaned.
+#
+# That is the deliberate failure direction. A missing row produces noise in a
+# report a human reads, and the noise names the chart that is missing; a
+# tolerant check that silently assumed coverage would produce the failure this
+# whole thing exists to catch. When you add a deploy workflow that installs a
+# chart, add its row here in the same PR.
+#
+# Columns, whitespace-separated:
+#   <environment>  <chart path>  <release name>  <namespace>  <values files...>
+#
+# Release name and namespace must match the `helm upgrade --install` in the
+# workflow that deploys the chart -- they are part of the rendered object
+# identity, so a mismatch here reports real objects as orphans.
+
+# --- staging -------------------------------------------------------------
+# .github/workflows/server-deployment.yml
+staging     infra/helm/tuist              tuist              tuist-staging       values-managed-common.yaml values-managed-staging.yaml
+staging     infra/helm/k8s-monitoring     k8s-monitoring     observability       values-staging.yaml
+staging     infra/helm/tailscale-operator tailscale-operator tailscale-operator  values-staging.yaml
+staging     infra/helm/platform           platform           platform            values-hetzner.yaml values-tuist-staging.yaml
+# .github/workflows/pomerium-deployment.yml
+staging     infra/helm/pomerium           pomerium-kube      pomerium            values-staging.yaml
+
+# --- canary --------------------------------------------------------------
+canary      infra/helm/tuist              tuist              tuist-canary        values-managed-common.yaml values-managed-canary.yaml
+canary      infra/helm/k8s-monitoring     k8s-monitoring     observability       values-canary.yaml
+canary      infra/helm/tailscale-operator tailscale-operator tailscale-operator  values-canary.yaml
+canary      infra/helm/platform           platform           platform            values-hetzner.yaml values-tuist-canary.yaml
+canary      infra/helm/pomerium           pomerium-kube      pomerium            values-canary.yaml
+
+# --- production ----------------------------------------------------------
+production  infra/helm/tuist              tuist              tuist               values-managed-common.yaml values-managed-production.yaml
+production  infra/helm/k8s-monitoring     k8s-monitoring     observability       values-production.yaml
+production  infra/helm/tailscale-operator tailscale-operator tailscale-operator  values-production.yaml
+production  infra/helm/platform           platform           platform            values-hetzner.yaml values-tuist.yaml
+production  infra/helm/pomerium           pomerium-kube      pomerium            values-production.yaml
+# .github/workflows/slack-deployment.yml
+production  infra/helm/slack              slack              slack               values-production.yaml
+# .github/workflows/noora-storybook-deployment.yml
+production  infra/helm/noora-storybook    noora-storybook    noora               values-production.yaml
+# .github/workflows/tuist-ops-deployment.yml
+production  infra/helm/tuist-ops          tuist-ops          tuist-ops           values-managed-production.yaml
+# .github/workflows/typesense-deployment.yml
+production  infra/helm/typesense          typesense          typesense           values-production.yaml


### PR DESCRIPTION
## What changed

A weekly report of live Kubernetes objects that **no chart on `main` renders** and that **no controller owns**.

- `infra/mise/tasks/k8s/orphan-drift-check.sh` — the check, runnable locally as `mise -C infra run k8s:orphan-drift-check <env>`.
- `infra/orphan-drift/releases.txt` — chart → environment wiring (19 releases across the three managed clusters).
- `infra/orphan-drift/allowlist.txt` — 68 rules, each with a reason.
- `.github/workflows/orphan-drift.yml` — Mondays 07:00 UTC, one job per environment, one Slack message per run. Registered in `notify-failure.yml`.
- `infra/orphan-drift/README.md` — how to triage a finding and how to tune the allowlist.

Report-only. It deletes nothing, and the README argues it should stay that way.

## Why

Three orphans were found by hand on 2026-08-18/19. Each was invisible to every signal we had, and each was noticed only because a person went looking:

| Orphan | Age | Why nothing caught it |
| --- | --- | --- |
| `registry/registry-pg` CNPG cluster (#12442) | 43d `Pending`, all Services on zero endpoints | Created by a `registry` chart that only ever existed on a feature branch. No `helm upgrade` from `main` could prune it, and `helm list` showed a healthy release throughout. |
| 11 `kura-<account>-staging` KuraInstances (#12467) | 33d unschedulable | Stranded in the retired `hetzner-staging-runners` region. Their Postgres rows were gone, and the reconciler that removes them is row-driven, so it could never see them. |
| `kuragateways.kura.tuist.dev` CRD + CR + Deployment | 6 weeks | Helm does not prune CRDs, so the CRD outlived the controller removed in #11644. |

They share one signature: live, rendered by no chart on `main`, no `ownerReferences`.

## How it decides

An object is reported when its identity `(group, Kind, namespace, name)` is absent from the union of every rendered chart for that environment, it has no `ownerReferences`, and it is older than `MIN_AGE_HOURS` (default 24) and not already terminating.

The owner-reference filter is what makes the report readable rather than a second inventory. The clusters are full of objects no chart renders on purpose — CNPG's Pods and Services, the kura-controller's StatefulSets, every ReplicaSet — and every one carries an `ownerReference` to whatever reconciles it. An object with no owner is one nothing is watching.

Policed kinds: `Namespace`, `Service`, `Deployment`, `StatefulSet`, `CustomResourceDefinition`, plus every resource in the API groups we own (`kura.tuist.dev`, `tuist.dev`, `postgresql.cnpg.io`) — discovered dynamically, so a CRD added later is covered without editing the list, which matters given one of the three cases was an abandoned CRD.

## Validation

Run against all three clusters. **747 live unowned objects → 8 findings, every one a real orphan**:

| Environment | Live unowned | After rendered-set subtraction | After allowlist |
| --- | --- | --- | --- |
| staging | 246 | 112 | 6 |
| canary | 212 | — | 1 |
| production | 289 | — | 7 → 1 |

The findings:

- **4 abandoned CRDs** — `scalewayapplesiliconclusters`, `scalewayapplesiliconfleets`, `scalewayinstancemachines`, `scalewayinstancemachinetemplates`, all in `infrastructure.cluster.x-k8s.io`. None of those kinds exists anywhere in the repo (not in `infra/cluster-api-provider-tuist/api/`, not in any chart), and all four have zero instances. Same signature as the `kuragateways` CRD, 64–105 days old. `scalewayapplesiliconclusters` is present in all three clusters.
- **`default/tuist-tuist-capi-scaleway-applesilicon`** (staging, 54d) — a Deployment labelled `app.kubernetes.io/managed-by: Helm`, `helm.sh/chart: tuist-0.2.0`, carrying a `last-applied-configuration` annotation: a hand-applied render of the chart's template that landed in `default` instead of `tuist-staging`. 2 desired replicas, 0 ready. The chart's real copy runs correctly in `tuist-staging`.
- **`tuist-runners/tuist-tuist-runner-pool-linux-ubuntu-22-04-large`** (staging, 84d) — a hand-applied RunnerPool labelled `tuist.dev/stack: manual-validate`, with `autoscaling.enabled: true` and `minWarmPoolFloor: 1`. It is holding warm capacity for a dispatch label no chart declares.
- The two production namespaces initially flagged (`once-production`, `condukt-production`) are live releases from `tuist/once` and `tuist/condukt` and are now allowlisted.

Triage of the eight is deliberately not in this PR — the check is report-only and two of the three original cases needed a human decision about the data behind them.

Also verified: `RENDER_ONLY=1 mise -C infra run k8s:orphan-drift-check all` renders all 19 releases; the allowlist validator accepts the real file and rejects both a four-column rule and a rule with no reason; the Slack payload renders correctly against the real findings.

## Design decisions worth reviewing

**A workflow, not a CronJob in the chart.** `released-pv-reaper` was the closest precedent, but the left-hand side of this comparison is *what `main` renders*, which needs the repository, helm, and network access for subchart dependencies. A CronJob shipped inside the tuist chart would only ever know its own chart's render, at whatever commit last deployed — not platform's, pomerium's, or the four production-only charts, and not `main`. Cluster access was the easier half to move: the same per-env kubeconfig the deploy already reads from 1Password is an in-cluster ServiceAccount, which the cluster-scoped `customresourcedefinitions` reads require.

**It posts to Slack every week, findings or not.** The brief flagged that `released-pv-reaper` is still `dryRun: true` everywhere with no override — a report nobody arms. There is nothing to arm here, but the sharper version of that failure is a report that has silently stopped running. A message that only appears when something is wrong is indistinguishable from one that is not being produced, so the clean weeks get a one-line heartbeat.

**Helm state is deliberately not consulted.** "Belongs to a live Helm release" is the tempting exemption and it is the wrong one: `registry-pg` had a perfectly healthy release, created by a chart that never reached `main`. Helm state is precisely the signal that failed. The two sibling-repo namespaces are excused by name instead.

**Kura instances are allowlisted by region, not by namespace.** The server creates one KuraInstance per (account, region) from Postgres rows, so none of them is rendered or owned — 16 in staging alone. A `kura/*` rule would have permanently hidden case #2, whose 11 orphans sat in that same namespace. The allowlist instead names the live region suffixes, so retiring a region is a one-line deletion here and its leftovers become findings on the next run.

**`*.infrastructure.cluster.x-k8s.io` is not allowlisted**, though the neighbouring CAPI groups (installed by clusterctl) are. That group is ours — its CRDs ship in `infra/helm/tuist/crds/` — so a CRD in it that `main` does not render is a real finding. That decision is what surfaced four of the eight.

**A chart missing from `releases.txt` produces noise, not silence.** Every object it owns is reported as an orphan, and the report names the chart. That is the deliberate failure direction; a check that assumed coverage it did not have would fail the way the three orphans did. A pull-request job renders every listed release so a chart that stops rendering fails on the PR that causes it, rather than in a Monday morning Slack message.

## Follow-ups, not in this PR

- Triage the eight findings.
- The kura-controller could set an `ownerReference` on the `kura-<account>-peers` Services it creates alongside each KuraInstance, which would remove two allowlist rules and let those Services be policed by region too.
