### PR TITLE
perf(cli): time each GraphLinter check in the session log

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -3,6 +3,7 @@ import Foundation
 import struct TSCUtility.Version
 import TuistConfig
 import TuistCore
+import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -48,24 +49,47 @@ public struct GraphLinter: GraphLinting {
     ) async throws -> [LintingIssue] {
         var issues: [LintingIssue] = []
         try await issues.append(
-            contentsOf: graphTraverser.projects.concurrentMap { _, project async throws -> [LintingIssue] in
-                try await projectLinter.lint(project)
+            contentsOf: measure("projectLinter.lint") {
+                try await graphTraverser.projects.concurrentMap { _, project async throws -> [LintingIssue] in
+                    try await projectLinter.lint(project)
+                }
+                .flatMap { $0 }
             }
-            .flatMap { $0 }
         )
         try await issues.append(contentsOf: lintDependencies(
             graphTraverser: graphTraverser,
             configGeneratedProjectOptions: configGeneratedProjectOptions
         ))
-        issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintSchemesUnknownTargets(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintSchemesRunAction(graphTraverser: graphTraverser))
+        await issues.append(contentsOf: measure("lintMismatchingConfigurations") {
+            lintMismatchingConfigurations(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintWatchBundleIndentifiers") {
+            lintWatchBundleIndentifiers(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintCodeCoverageMode") {
+            lintCodeCoverageMode(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintSchemesUnknownTargets") {
+            lintSchemesUnknownTargets(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintSchemesRunAction") {
+            lintSchemesRunAction(graphTraverser: graphTraverser)
+        })
         return issues.promotingWarnings(with: configGeneratedProjectOptions.generationOptions.warningsAsErrors)
     }
 
     // MARK: - Fileprivate
+
+    /// Times an individual check so the linter's cost is attributable in the session log the same way the graph
+    /// mappers that run just before it are.
+    private func measure<T>(_ name: String, _ check: () async throws -> T) async rethrows -> T {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        defer {
+            let duration = Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000_000
+            Logger.current.debug("Lint check \(name) finished in \(String(format: "%.3f", duration))s")
+        }
+        return try await check()
+    }
 
     private func lintSchemesUnknownTargets(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let targets = graphTraverser.targets()
@@ -163,16 +187,30 @@ public struct GraphLinter: GraphLinting {
     ) async throws -> [LintingIssue] {
         var issues: [LintingIssue] = []
 
-        issues.append(contentsOf: lintDuplicatedProductNamesInDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintDependencyRelationships(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintLinkableDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: staticProductsLinter.lint(
-            graphTraverser: graphTraverser,
-            configGeneratedProjectOptions: configGeneratedProjectOptions
-        ))
-        try await issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
-        await issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
-        try await issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
+        await issues.append(contentsOf: measure("lintDuplicatedProductNamesInDependencies") {
+            lintDuplicatedProductNamesInDependencies(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintDependencyRelationships") {
+            lintDependencyRelationships(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintLinkableDependencies") {
+            lintLinkableDependencies(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("staticProductsLinter.lint") {
+            staticProductsLinter.lint(
+                graphTraverser: graphTraverser,
+                configGeneratedProjectOptions: configGeneratedProjectOptions
+            )
+        })
+        try await issues.append(contentsOf: measure("lintPrecompiledFrameworkDependencies") {
+            try await lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser)
+        })
+        await issues.append(contentsOf: measure("lintPackageDependencies") {
+            await lintPackageDependencies(graphTraverser: graphTraverser)
+        })
+        try await issues.append(contentsOf: measure("lintAppClip") {
+            try await lintAppClip(graphTraverser: graphTraverser)
+        })
 
         return issues
     }


### PR DESCRIPTION
Graph mappers log their own duration, so every mapper is attributable in a session log. `GraphLinter` logged
nothing, which left its cost invisible.

On a `tuist generate --binary-cache` session over roughly 330 projects and 1,430 targets, there was a ~14
second stretch with no log lines at all between the last `Mapper ... finished in` line and
`Generating workspace`. Identifying that gap as the linter meant reading the call path by hand: the generator
runs `lint(graphTraverser:)` between the mappers finishing and workspace generation starting. It also lints
the unfocused source graph rather than the graph being generated, which makes it more expensive than one
might assume.

### What changed

`GraphLinter.lint(graphTraverser:configGeneratedProjectOptions:)` runs seven checks in sequence, one of which
fans out into seven more. All thirteen now emit a debug line with their duration, through a single private
`measure` helper that uses the same `DispatchTime.now().uptimeNanoseconds` idiom as `GraphMapper`.

Wording and `%.3f` formatting match the existing mapper log, so `finished in` greps both:

```
Mapper StaticXCFrameworkModuleMapGraphMapper finished in 0.433s
Lint check staticProductsLinter.lint finished in 0.825s
```

The seven checks inside `lintDependencies` are timed individually rather than only as a group, because that
is where the cost concentrates. `lintDependencies` itself is deliberately not timed as a whole, so nothing is
double counted.

This is instrumentation only. No check body changed, and the helper wraps existing call sites rather than
restructuring the linter. Debug level keeps the lines out of the console and in the session log.

### What it found

Which check dominates was genuinely unknown before this, which is the point of the change. On this repo's
graph (`tuist generate TuistGenerator`, debug build, median of 3 warm runs with the cold run discarded):

| check | duration |
|---|---:|
| `lintDuplicatedProductNamesInDependencies` | 0.913s |
| `staticProductsLinter.lint` | 0.825s |
| `lintMismatchingConfigurations` | 0.079s |
| `lintLinkableDependencies` | 0.026s |
| `lintDependencyRelationships` | 0.018s |
| `projectLinter.lint` | 0.006s |
| the other seven checks | <0.001s |
| total | ~1.87s |

Two checks account for roughly 93% of linter time. `lintDuplicatedProductNamesInDependencies` was a
plausible candidate up front, since it walks every target's transitive closure via `allTargetDependencies`.
`staticProductsLinter.lint` sitting alongside it was not expected, and its samples were the noisiest of the
set, ranging 0.70s to 1.17s. `lintPrecompiledFrameworkDependencies` was the other plausible suspect because
it does filesystem existence checks, and it costs 0.001s.

This repo's graph is much smaller than the one the 14 second gap came from, and a debug build inflates
everything, so the shape is the result here rather than the absolute numbers.

### Overlap with an open PR

This same commit currently also sits on https://github.com/tuist/tuist/pull/12464, which parallelizes
`lintDuplicatedProductNamesInDependencies` and used this instrumentation to measure that change (0.913s down
to 0.244s on the same graph). The two should not both land. If this PR merges first, drop the commit from
that one. If that one merges first, this PR is redundant and can be closed.

### How to test locally

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

382 tests across 30 suites pass, including `GraphLinterTests`, so the instrumented path is exercised.
`mise run lint` is clean for this file.

The test suite does not prove the logging works, so this was also verified end to end by building the CLI and
running generate verbosely. That step mattered: at default verbosity the session log captures debug lines
from some subsystems but contained neither these lines nor the pre-existing mapper lines.

```bash
TUIST_CONFIG_VERBOSE=1 tuist generate TuistGenerator --no-open 2>&1 | grep "finished in"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
