### PR TITLE
fix(ops): allow atlas.tuist.dev to receive a project-access grant

### DIFF
--- a/infra/helm/tuist-ops/templates/deployment.yaml
+++ b/infra/helm/tuist-ops/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: |-
                 {{- .Values.pomerium.publicKey | nindent 16 }}
             {{- end }}
+            {{- with .Values.projectAccess.returnToAllowlist }}
+            - name: PROJECT_ACCESS_RETURN_TO_ALLOWLIST
+              value: {{ join "," . | quote }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "tuist-ops.runtimeSecretName" . }}

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -28,6 +28,20 @@ pomerium:
   audience: ops.tuist.dev
   publicKey: ""
 
+# Origins a signed project-access grant may be handed back to. The reason
+# form refuses any `return_to` outside this list, so a minted token cannot
+# be redirected to a host we do not run. Unset, tuist-ops falls back to
+# https://tuist.dev alone.
+#
+# atlas.tuist.dev is here because Atlas' MCP proxy sends an operator to the
+# reason form whenever a customer account is refused, and receives the grant
+# on the way back at /mcps/:server/operator-grant. Without it that round trip
+# answers 400 and the whole flow is unreachable.
+projectAccess:
+  returnToAllowlist:
+    - https://tuist.dev
+    - https://atlas.tuist.dev
+
 # Internal name used by the tailscale operator to expose this
 # Service as a tailnet device. Pomerium pods in workload clusters
 # dial this hostname through their cluster's tailscale-egress

--- a/infra/k8s/operator-project-access-audit.md
+++ b/infra/k8s/operator-project-access-audit.md
@@ -181,4 +181,8 @@ a separate follow-up.)
 
 6. **`return_to` allowlist.** Set `PROJECT_ACCESS_RETURN_TO_ALLOWLIST` on ops to the
    app origin(s) (defaults to `https://tuist.dev`) so a signed token can't be
-   redirected to an attacker host.
+   redirected to an attacker host. Now set from the chart
+   (`projectAccess.returnToAllowlist` in `infra/helm/tuist-ops/values.yaml`),
+   listing `https://tuist.dev` and `https://atlas.tuist.dev`. Add an origin here
+   only when we run it and it has a route that consumes the grant — every entry
+   is somewhere a minted token may legitimately be sent.


### PR DESCRIPTION
## What

`GrantController` refuses any `return_to` whose origin is outside `PROJECT_ACCESS_RETURN_TO_ALLOWLIST`. The `tuist-ops` chart never set that variable, so ops falls back to the code default — `["https://tuist.dev"]`.

Atlas sends operators to the reason form and receives the minted grant at `https://atlas.tuist.dev/mcps/:server/operator-grant?state=…`. That origin isn't allowed, so every grant request originating from Atlas is refused with `400 Bad request: return_to is not an allowed destination`.

This sets the allowlist from the chart, naming both origins.

## Why it went unnoticed

`infra/k8s/operator-project-access-audit.md` lists setting this as an outstanding item (step 6). It was never done, and nothing failed loudly because the only consumer that needed a second origin — Atlas' MCP proxy — shipped later and its half was never walked end to end.

## Found by

Walking the flow for real: an Atlas MCP tool call for a customer account was refused, the offered link 404'd (a separate bug — the path was wrong, fixed in tuist/atlas#419), and tracing that back through this controller surfaced the allowlist as the *next* failure waiting behind it.

Both fixes are needed. With only the Atlas path fix merged, following the link returns 400 instead of 404.

## Notes for review

- **This widens a deliberate anti-redirect control**, so it deserves a real look rather than a rubber stamp. The check exists so a signed grant cannot be handed to a host we don't run; every entry is somewhere a token may legitimately be sent. `atlas.tuist.dev` qualifies — it's ours, and it has a route that consumes the grant, verifies it came from a request that user started, and refuses anything but the read tier.
- Kept as a curated list rather than a suffix match on `*.tuist.dev`. A wildcard would admit any future subdomain automatically, including ones that never consume a grant.
- The audit runbook is updated to say where the value now lives and what the bar is for adding to it.
- Rendered check:

  ```
  helm template infra/helm/tuist-ops --set image.tag=test
  #   - name: PROJECT_ACCESS_RETURN_TO_ALLOWLIST
  #     value: "https://tuist.dev,https://atlas.tuist.dev"
  ```

- Takes effect on the next tuist-ops deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)