### PR TITLE
feat(server): accept a Tuist dashboard URL wherever an MCP tool takes a record id

### DIFF
--- a/server/lib/tuist/mcp/components/tools/get_bundle.ex
+++ b/server/lib/tuist/mcp/components/tools/get_bundle.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetBundle do
       "properties" => %{
         "bundle_id" => %{
           "type" => "string",
-          "description" => "The ID of the bundle."
+          "description" => "The ID of the bundle, or a Tuist dashboard URL."
         }
       },
       "required" => ["bundle_id"]
@@ -60,6 +60,8 @@ defmodule Tuist.MCP.Components.Tools.GetBundle do
       "Get detailed information about a specific bundle. Use get_bundle_artifact_tree to get the full artifact list. The bundle_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/bundles/{id}."
 
   def execute(conn, %{"bundle_id" => bundle_id}) do
+    bundle_id = MCPTool.resource_id(bundle_id)
+
     with {:ok, bundle, _project} <-
            MCPTool.load_and_authorize(
              Bundles.get_bundle(bundle_id),

--- a/server/lib/tuist/mcp/components/tools/get_bundle_artifact_tree.ex
+++ b/server/lib/tuist/mcp/components/tools/get_bundle_artifact_tree.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetBundleArtifactTree do
       "properties" => %{
         "bundle_id" => %{
           "type" => "string",
-          "description" => "The ID of the bundle."
+          "description" => "The ID of the bundle, or a Tuist dashboard URL."
         }
       },
       "required" => ["bundle_id"]
@@ -48,6 +48,8 @@ defmodule Tuist.MCP.Components.Tools.GetBundleArtifactTree do
       "Get the full artifact tree for a bundle as a flat list sorted by path. The bundle_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/bundles/{id}."
 
   def execute(conn, %{"bundle_id" => bundle_id}) do
+    bundle_id = MCPTool.resource_id(bundle_id)
+
     with {:ok, _, _} <-
            MCPTool.load_and_authorize(
              Bundles.get_bundle(bundle_id),

--- a/server/lib/tuist/mcp/components/tools/get_cache_run.ex
+++ b/server/lib/tuist/mcp/components/tools/get_cache_run.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetCacheRun do
       "properties" => %{
         "cache_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the cache run."
+          "description" => "The ID of the cache run, or a Tuist dashboard URL."
         }
       },
       "required" => ["cache_run_id"]
@@ -66,6 +66,8 @@ defmodule Tuist.MCP.Components.Tools.GetCacheRun do
       "Get detailed information about a specific cache run. The cache_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/runs/{id}."
 
   def execute(conn, %{"cache_run_id" => cache_run_id}) do
+    cache_run_id = MCPTool.resource_id(cache_run_id)
+
     with {:ok, event, _project} <-
            MCPTool.load_and_authorize(
              get_cache_run(cache_run_id),

--- a/server/lib/tuist/mcp/components/tools/get_generation.ex
+++ b/server/lib/tuist/mcp/components/tools/get_generation.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetGeneration do
       "properties" => %{
         "generation_id" => %{
           "type" => "string",
-          "description" => "The ID of the generation."
+          "description" => "The ID of the generation, or a Tuist dashboard URL."
         }
       },
       "required" => ["generation_id"]
@@ -66,6 +66,8 @@ defmodule Tuist.MCP.Components.Tools.GetGeneration do
       "Get detailed information about a specific generation run. The generation_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/runs/{id}."
 
   def execute(conn, %{"generation_id" => generation_id}) do
+    generation_id = MCPTool.resource_id(generation_id)
+
     with {:ok, event, _project} <-
            MCPTool.load_and_authorize(
              get_generation(generation_id),

--- a/server/lib/tuist/mcp/components/tools/get_gradle_build.ex
+++ b/server/lib/tuist/mcp/components/tools/get_gradle_build.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetGradleBuild do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the Gradle build run."
+          "description" => "The ID of the Gradle build run, or a Tuist dashboard URL."
         }
       },
       "required" => ["build_run_id"]
@@ -78,7 +78,7 @@ defmodule Tuist.MCP.Components.Tools.GetGradleBuild do
       "Get detailed information about a specific Gradle build run. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/gradle/builds/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
+++ b/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.GetXcodeBuild do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         }
       },
       "required" => ["build_run_id"]
@@ -82,7 +82,7 @@ defmodule Tuist.MCP.Components.Tools.GetXcodeBuild do
         "download. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, build, project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_gradle_build_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_gradle_build_tasks.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListGradleBuildTasks do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the Gradle build run."
+          "description" => "The ID of the Gradle build run, or a Tuist dashboard URL."
         },
         "outcome" => %{
           "type" => "string",
@@ -82,7 +82,7 @@ defmodule Tuist.MCP.Components.Tools.ListGradleBuildTasks do
       "List tasks for a specific Gradle build run. The project is derived from the build run, so no account or project handle is needed. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/gradle/builds/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_test_case_events.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_case_events.ex
@@ -69,6 +69,8 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseEvents do
 
   @impl EMCP.Tool
   def call(conn, %{"test_case_id" => test_case_id} = args) when is_binary(test_case_id) do
+    test_case_id = MCPTool.resource_id(test_case_id)
+
     case MCPTool.load_and_authorize(
            Tests.get_test_case_by_id(test_case_id),
            conn.assigns,

--- a/server/lib/tuist/mcp/components/tools/list_test_module_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_module_runs.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListTestModuleRuns do
       "properties" => %{
         "test_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the test run."
+          "description" => "The ID of the test run, or a Tuist dashboard URL."
         },
         "status" => %{
           "type" => "string",
@@ -72,6 +72,8 @@ defmodule Tuist.MCP.Components.Tools.ListTestModuleRuns do
       "List test module runs for a specific test run. The test_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/tests/test-runs/{id}."
 
   def execute(conn, %{"test_run_id" => test_run_id} = args) do
+    test_run_id = MCPTool.resource_id(test_run_id)
+
     with {:ok, _run, _project} <-
            MCPTool.load_and_authorize(
              Tests.get_test(test_run_id),

--- a/server/lib/tuist/mcp/components/tools/list_test_suite_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_suite_runs.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListTestSuiteRuns do
       "properties" => %{
         "test_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the test run."
+          "description" => "The ID of the test run, or a Tuist dashboard URL."
         },
         "module_name" => %{
           "type" => "string",
@@ -74,6 +74,8 @@ defmodule Tuist.MCP.Components.Tools.ListTestSuiteRuns do
       "List test suite runs for a specific test run, optionally filtered by module. The test_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/tests/test-runs/{id}."
 
   def execute(conn, %{"test_run_id" => test_run_id} = args) do
+    test_run_id = MCPTool.resource_id(test_run_id)
+
     with {:ok, _run, _project} <-
            MCPTool.load_and_authorize(
              Tests.get_test(test_run_id),

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         },
         "status" => %{
           "type" => "string",
@@ -81,7 +81,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
       "List cacheable tasks (cache hits/misses) for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         },
         "operation" => %{
           "type" => "string",
@@ -76,7 +76,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
       "List content-addressable storage outputs for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildFiles do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         },
         "target" => %{
           "type" => "string",
@@ -70,7 +70,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildFiles do
       "List compiled files for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         },
         "type" => %{
           "type" => "string",
@@ -103,7 +103,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
       "List build issues (warnings and errors) for a specific Xcode build run. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildTargets do
       "properties" => %{
         "build_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the build run."
+          "description" => "The ID of the build run, or a Tuist dashboard URL."
         },
         "status" => %{
           "type" => "string",
@@ -68,7 +68,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildTargets do
       "List build targets for a specific Xcode build run. Only available for projects with build_system=xcode. The project is derived from the build run, so no account or project handle is needed. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
-    build_run_id = Map.get(args, "build_run_id")
+    build_run_id = MCPTool.resource_id(Map.get(args, "build_run_id"))
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(

--- a/server/lib/tuist/mcp/components/tools/list_xcode_module_cache_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_module_cache_targets.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeModuleCacheTargets do
       "properties" => %{
         "run_id" => %{
           "type" => "string",
-          "description" => "The ID of the generation or cache run."
+          "description" => "The ID of the generation or cache run, or a Tuist dashboard URL."
         },
         "cache_status" => %{
           "type" => "string",
@@ -94,6 +94,8 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeModuleCacheTargets do
       "List module cache targets for a generation or cache run, showing per-target cache hit/miss status and subhashes. Only available for projects with build_system=xcode. The run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/runs/{id}."
 
   def execute(conn, %{"run_id" => run_id} = args) do
+    run_id = MCPTool.resource_id(run_id)
+
     with {:ok, event, _project} <-
            MCPTool.load_and_authorize(
              get_command_event(run_id),

--- a/server/lib/tuist/mcp/components/tools/list_xcode_selective_testing_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_selective_testing_targets.ex
@@ -12,7 +12,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeTestTargets do
       "properties" => %{
         "test_run_id" => %{
           "type" => "string",
-          "description" => "The ID of the test run."
+          "description" => "The ID of the test run, or a Tuist dashboard URL."
         },
         "hit_status" => %{
           "type" => "string",
@@ -62,6 +62,8 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeTestTargets do
       "List Xcode test targets with their selective testing status (hit/miss) and hash for a given test run. The test_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/tests/test-runs/{id}."
 
   def execute(conn, %{"test_run_id" => test_run_id} = args) do
+    test_run_id = MCPTool.resource_id(test_run_id)
+
     with {:ok, run, _project} <-
            MCPTool.load_and_authorize(
              Tests.get_test(test_run_id),

--- a/server/lib/tuist/mcp/tool.ex
+++ b/server/lib/tuist/mcp/tool.ex
@@ -202,6 +202,45 @@ defmodule Tuist.MCP.Tool do
     }
   end
 
+  @doc """
+  Normalises an id argument that a caller may have pasted as a Tuist dashboard URL.
+
+  Takes the last non-empty path segment of anything that parses as an absolute URL,
+  and passes every other value through untouched so the caller's own lookup still
+  rejects it. Working on the last segment rather than per-resource routes is what
+  makes one helper cover build runs, test runs, test cases, bundles, cache runs,
+  generations and Gradle builds.
+
+  The host is deliberately not checked against `Tuist.Environment.app_url/2`. A
+  dashboard URL reaches a self-hosted instance under its own domain, and a
+  hosted one through whatever proxy or custom domain the account browses it by,
+  so a host check would reject the URLs users actually have. It buys no
+  authorization either: the extracted id is loaded and authorized exactly as a
+  bare id is, and a URL pointing anywhere else simply yields an id that is not
+  found.
+
+  This lives here rather than in the domain lookups because those are also
+  called from API controllers and LiveViews, where a URL is not a valid id.
+  """
+  def resource_id(value) when is_binary(value) do
+    case URI.parse(value) do
+      %URI{scheme: scheme, host: host, path: path} when is_binary(scheme) and is_binary(host) ->
+        path
+        |> to_string()
+        |> String.split("/", trim: true)
+        |> List.last()
+        |> case do
+          nil -> value
+          segment -> segment
+        end
+
+      _ ->
+        value
+    end
+  end
+
+  def resource_id(value), do: value
+
   @max_page_size 100
   @default_page_size 20
 

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -196,6 +196,8 @@ The following tools are available through the Tuist Model Context Protocol serve
 
 Every tool publishes a human-readable description together with explicit input and output schemas. Successful calls return structured content that conforms to the advertised output schema, plus the same result serialized as text for clients that do not yet consume structured content.
 
+Tools that take the identifier of a single record, such as `build_run_id`, `test_run_id`, `test_case_id`, `bundle_id`, `run_id`, `generation_id`, or `cache_run_id`, also accept the Tuist dashboard URL of that record. Paste the URL straight from the browser instead of extracting the identifier from it.
+
 #### Documentation and community search
 
 This read-only tool searches Tuist's documentation, [application programming interface](https://en.wikipedia.org/wiki/API) reference, GitHub releases, community forum, and GitHub issues through the same search engine that powers the docs website. Release results include the product, version, publication date, and prerelease status. Stable releases are searched by default, and prereleases can be included with `include_prereleases`. The tool is only available on the Tuist-hosted server at `https://tuist.dev/mcp`.
@@ -233,7 +235,7 @@ Every operation has fixed limits for concurrency, duration, traversal, bytes rea
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
 | `list_xcode_builds` | List Xcode build runs for a project. | `account_handle`, `project_handle` |
-| `get_xcode_build` | Get detailed information about a specific Xcode build run, including a temporary download URL for the archive holding the raw `.xcactivitylog`. Accepts a build ID or a Tuist dashboard URL. | `build_run_id` |
+| `get_xcode_build` | Get detailed information about a specific Xcode build run, including a temporary download URL for the archive holding the raw `.xcactivitylog`. | `build_run_id` |
 | `list_xcode_build_targets` | List build targets for a specific Xcode build run. | `build_run_id` |
 | `list_xcode_build_files` | List compiled files for a specific Xcode build run. | `build_run_id` |
 | `list_xcode_build_issues` | List build issues (warnings and errors) for a specific build run. | `build_run_id` |

--- a/server/test/tuist/mcp/components/tools/bundle_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/bundle_tools_test.exs
@@ -155,5 +155,24 @@ defmodule Tuist.MCP.Components.Tools.BundleToolsTest do
       refute Map.has_key?(first, "id")
       refute Map.has_key?(first, "shasum")
     end
+
+    test "accepts a dashboard URL in place of the bundle ID" do
+      bundle_id = "38338b32-3437-42e4-bc01-f048d6d3368f"
+      project = %{id: 1, name: "app"}
+
+      stub(Bundles, :get_bundle, fn ^bundle_id -> {:ok, %{id: bundle_id, project_id: 1}} end)
+      stub(Bundles, :get_bundle_artifact_tree, fn ^bundle_id -> [] end)
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :bundle_read, :subject, ^project -> :ok end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetBundleArtifactTree.call(conn, %{
+                 "bundle_id" => "https://tuist.dev/acme/app/bundles/#{bundle_id}"
+               })
+
+      assert JSON.decode!(text)["bundle_id"] == bundle_id
+    end
   end
 end

--- a/server/test/tuist/mcp/components/tools/generation_and_cache_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/generation_and_cache_tools_test.exs
@@ -120,6 +120,45 @@ defmodule Tuist.MCP.Components.Tools.GenerationAndCacheToolsTest do
 
       assert text =~ "Generation not found"
     end
+
+    test "accepts a dashboard URL in place of the generation ID" do
+      generation_id = "38338b32-3437-42e4-bc01-f048d6d3368f"
+
+      stub(CommandEvents, :get_command_event_by_id, fn ^generation_id ->
+        {:ok,
+         %{
+           id: generation_id,
+           name: "generate",
+           project_id: 1,
+           duration: 5000,
+           status: 0,
+           tuist_version: "4.0.0",
+           swift_version: "5.10",
+           macos_version: "14.0",
+           is_ci: false,
+           git_branch: "main",
+           git_commit_sha: "abc123",
+           git_ref: nil,
+           command_arguments: nil,
+           cacheable_targets: ["App"],
+           local_cache_target_hits: [],
+           remote_cache_target_hits: [],
+           created_at: ~N[2025-01-01 12:00:00]
+         }}
+      end)
+
+      stub(Projects, :get_project_by_id, fn 1 -> %{id: 1, account: %{name: "acme"}, name: "app"} end)
+      stub(Tuist.Authorization, :authorize, fn _action, _subject, _project -> :ok end)
+
+      conn = %Plug.Conn{assigns: %{}}
+
+      assert %{"content" => [%{"text" => json}]} =
+               GetGeneration.call(conn, %{
+                 "generation_id" => "https://tuist.dev/acme/app/runs/#{generation_id}"
+               })
+
+      assert JSON.decode!(json)["id"] == generation_id
+    end
   end
 
   describe "list_cache_runs" do

--- a/server/test/tuist/mcp/components/tools/gradle_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/gradle_build_tools_test.exs
@@ -104,6 +104,18 @@ defmodule Tuist.MCP.Components.Tools.GradleBuildToolsTest do
       assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} = result
       assert text =~ "Gradle build not found"
     end
+
+    test "accepts a dashboard URL in place of the build ID", %{conn: conn, user: user, project: project} do
+      build_id = GradleFixtures.build_fixture(project_id: project.id, account_id: user.account.id)
+
+      result =
+        GetGradleBuild.call(conn, %{
+          "build_run_id" => "https://tuist.dev/#{user.account.name}/#{project.name}/gradle/builds/#{build_id}"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      assert JSON.decode!(text)["id"] == build_id
+    end
   end
 
   describe "list_gradle_build_tasks" do
@@ -146,6 +158,23 @@ defmodule Tuist.MCP.Components.Tools.GradleBuildToolsTest do
 
       assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} = result
       assert text =~ "Gradle build not found"
+    end
+
+    test "lists tasks for the ID extracted from a dashboard URL", %{conn: conn, user: user, project: project} do
+      build_id =
+        GradleFixtures.build_fixture(
+          project_id: project.id,
+          account_id: user.account.id,
+          tasks: [%{task_path: ":app:compileKotlin", outcome: "executed", cacheable: true, duration_ms: 12_000}]
+        )
+
+      result =
+        ListGradleBuildTasks.call(conn, %{
+          "build_run_id" => "https://tuist.dev/#{user.account.name}/#{project.name}/gradle/builds/#{build_id}"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      assert Enum.map(JSON.decode!(text)["tasks"], & &1["task_path"]) == [":app:compileKotlin"]
     end
   end
 end

--- a/server/test/tuist/mcp/components/tools/test_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/test_tools_test.exs
@@ -158,6 +158,36 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
       assert length(result["modules"]) == 1
       assert hd(result["modules"])["name"] == "AuthTests"
     end
+
+    test "filters by the ID extracted from a dashboard URL, not by the URL" do
+      test_run_id = "38338b32-3437-42e4-bc01-f048d6d3368f"
+      project = %{id: 1, name: "app"}
+
+      stub(Tests, :get_test, fn ^test_run_id -> {:ok, %{id: test_run_id, project_id: 1}} end)
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :test_read, :subject, ^project -> :ok end)
+
+      stub(Tests, :list_test_module_runs, fn %{filters: filters} ->
+        assert %{field: :test_run_id, op: :==, value: test_run_id} in filters
+
+        {[],
+         %{
+           has_next_page?: false,
+           has_previous_page?: false,
+           total_count: 0,
+           total_pages: 0,
+           current_page: 1,
+           page_size: 20
+         }}
+      end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text"}]} =
+               ListTestModuleRuns.call(conn, %{
+                 "test_run_id" => "https://tuist.dev/acme/app/tests/test-runs/#{test_run_id}?tab=modules"
+               })
+    end
   end
 
   describe "list_test_suite_runs" do
@@ -401,6 +431,39 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
                ListTestCaseEvents.call(conn, %{"test_case_id" => "tc-1"})
 
       assert text =~ "You do not have access to this resource."
+    end
+
+    test "accepts a dashboard URL in place of the test case ID" do
+      test_case_id = "38338b32-3437-42e4-bc01-f048d6d3368f"
+      project = %{id: 1, name: "app"}
+
+      stub(Tests, :get_test_case_by_id, fn ^test_case_id ->
+        {:ok, %{id: test_case_id, project_id: 1}}
+      end)
+
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :test_read, :subject, ^project -> :ok end)
+
+      stub(Tests, :list_test_case_events, fn ^test_case_id, _attrs ->
+        {[],
+         %{
+           has_next_page?: false,
+           has_previous_page?: false,
+           current_page: 1,
+           page_size: 20,
+           total_count: 0,
+           total_pages: 0
+         }}
+      end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListTestCaseEvents.call(conn, %{
+                 "test_case_id" => "https://tuist.dev/acme/app/tests/test-cases/#{test_case_id}/"
+               })
+
+      assert JSON.decode!(text)["events"] == []
     end
   end
 

--- a/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
@@ -17,6 +17,14 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
     %Plug.Conn{assigns: %{current_subject: :subject}}
   end
 
+  @build_run_uuid "38338b32-3437-42e4-bc01-f048d6d3368f"
+
+  defp stub_build_lookup(project) do
+    stub(Builds, :get_build, fn id -> {:ok, %{id: id, project_id: 1}} end)
+    stub(Projects, :get_project_by_id, fn 1 -> project end)
+    stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
+  end
+
   describe "list_xcode_builds" do
     test "returns paginated builds" do
       project = %{id: 1, name: "app"}
@@ -132,6 +140,59 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
       assert result["xcode_version"] == "15.0"
       assert result["archive_url"] == "https://storage.test/acme/app/builds/build-1/build.zip"
     end
+
+    test "accepts a dashboard URL in place of the build ID" do
+      project = %{id: 1, name: "app", account: %{name: "acme"}}
+
+      stub(Builds, :get_build, fn id ->
+        {:ok,
+         %{
+           id: id,
+           duration: 5000,
+           status: "success",
+           category: "clean",
+           scheme: "App",
+           configuration: "Debug",
+           xcode_version: "15.0",
+           macos_version: "14.0",
+           model_identifier: "MacBookPro18,1",
+           is_ci: false,
+           git_branch: "main",
+           git_commit_sha: "abc123",
+           git_ref: "refs/heads/main",
+           cacheable_tasks_count: 10,
+           cacheable_task_local_hits_count: 5,
+           cacheable_task_remote_hits_count: 3,
+           project_id: 1,
+           inserted_at: ~N[2024-01-01 12:00:00]
+         }}
+      end)
+
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
+      stub(Storage, :generate_download_url, fn object_key, _actor, _opts -> "https://storage.test/#{object_key}" end)
+
+      for build_run_id <- [
+            "https://tuist.dev/acme/app/builds/build-runs/#{@build_run_uuid}",
+            "https://tuist.dev/acme/app/builds/build-runs/#{@build_run_uuid}/",
+            "https://tuist.dev/acme/app/builds/build-runs/#{@build_run_uuid}?tab=targets",
+            @build_run_uuid
+          ] do
+        assert %{"content" => [%{"type" => "text", "text" => text}]} =
+                 GetXcodeBuild.call(conn_with_subject(), %{"build_run_id" => build_run_id})
+
+        assert JSON.decode!(text)["id"] == @build_run_uuid
+      end
+    end
+
+    test "still reports not found for a value that is neither an ID nor a URL" do
+      stub(Builds, :get_build, fn "not-a-build" -> {:error, :not_found} end)
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
+               GetXcodeBuild.call(conn_with_subject(), %{"build_run_id" => "not-a-build"})
+
+      assert text == "Build not found: not-a-build"
+    end
   end
 
   describe "list_xcode_build_targets" do
@@ -209,6 +270,30 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
       result = JSON.decode!(text)
       assert length(result["files"]) == 1
       assert hd(result["files"])["path"] == "Sources/App.swift"
+    end
+
+    test "filters by the ID extracted from a dashboard URL, not by the URL" do
+      project = %{id: 1, name: "app"}
+      stub_build_lookup(project)
+
+      stub(Builds, :list_build_files, fn %{filters: filters} ->
+        assert %{field: :build_run_id, op: :==, value: @build_run_uuid} in filters
+
+        {[],
+         %{
+           has_next_page?: false,
+           has_previous_page?: false,
+           total_count: 0,
+           total_pages: 0,
+           current_page: 1,
+           page_size: 20
+         }}
+      end)
+
+      assert %{"content" => [%{"type" => "text"}]} =
+               ListXcodeBuildFiles.call(conn_with_subject(), %{
+                 "build_run_id" => "https://tuist.dev/acme/app/builds/build-runs/#{@build_run_uuid}"
+               })
     end
   end
 

--- a/server/test/tuist/mcp/tool_test.exs
+++ b/server/test/tuist/mcp/tool_test.exs
@@ -119,6 +119,57 @@ defmodule Tuist.MCP.ToolTest do
     end
   end
 
+  describe "resource_id/1" do
+    @uuid "38338b32-3437-42e4-bc01-f048d6d3368f"
+
+    test "extracts the identifier from a dashboard URL" do
+      assert Tool.resource_id("https://tuist.dev/acme/app/builds/build-runs/#{@uuid}") == @uuid
+    end
+
+    test "ignores a trailing slash" do
+      assert Tool.resource_id("https://tuist.dev/acme/app/builds/build-runs/#{@uuid}/") == @uuid
+    end
+
+    test "ignores a query string and a fragment" do
+      assert Tool.resource_id("https://tuist.dev/acme/app/tests/test-runs/#{@uuid}?tab=modules") == @uuid
+      assert Tool.resource_id("https://tuist.dev/acme/app/bundles/#{@uuid}#artifacts") == @uuid
+    end
+
+    test "is path-shape agnostic, so it covers every resource the dashboard links to" do
+      for path <- [
+            "acme/app/builds/build-runs",
+            "acme/app/tests/test-runs",
+            "acme/app/tests/test-cases",
+            "acme/app/bundles",
+            "acme/app/runs",
+            "acme/app/gradle/builds"
+          ] do
+        assert Tool.resource_id("https://tuist.dev/#{path}/#{@uuid}") == @uuid
+      end
+    end
+
+    test "accepts a URL from any host, including self-hosted instances" do
+      assert Tool.resource_id("https://tuist.acme.io/acme/app/builds/build-runs/#{@uuid}") == @uuid
+      assert Tool.resource_id("http://localhost:8080/acme/app/builds/build-runs/#{@uuid}") == @uuid
+    end
+
+    test "passes a bare identifier through unchanged" do
+      assert Tool.resource_id(@uuid) == @uuid
+    end
+
+    test "passes anything that is not a URL through unchanged, so the lookup still rejects it" do
+      assert Tool.resource_id("not-a-uuid") == "not-a-uuid"
+      assert Tool.resource_id("") == ""
+      assert Tool.resource_id("https://tuist.dev") == "https://tuist.dev"
+      assert Tool.resource_id("https://tuist.dev/") == "https://tuist.dev/"
+    end
+
+    test "passes non-binary values through unchanged" do
+      assert Tool.resource_id(nil) == nil
+      assert Tool.resource_id(42) == 42
+    end
+  end
+
   describe "resolved_output_schema/0" do
     test "every tool pre-resolves its output schema at compile time" do
       for {name, module} <- Tuist.MCP.Server.server().tools do


### PR DESCRIPTION
## What changed

Seventeen MCP tools documented that their id argument "can also be a Tuist dashboard URL", but none implemented it. They now do.

`Tuist.MCP.Tool.resource_id/1` takes the last non-empty path segment of anything that parses as an absolute URL, and passes every other value through untouched. It is applied to the id argument of all seventeen tools: `get_bundle`, `get_bundle_artifact_tree`, `get_cache_run`, `get_generation`, `get_gradle_build`, `get_xcode_build`, `list_gradle_build_tasks`, `list_test_case_events`, `list_test_module_runs`, `list_test_suite_runs`, `list_xcode_build_cache_tasks`, `list_xcode_build_cas_outputs`, `list_xcode_build_files`, `list_xcode_build_issues`, `list_xcode_build_targets`, `list_xcode_module_cache_targets`, `list_xcode_selective_testing_targets`.

## Why

Calling `get_xcode_build` with a dashboard URL returned `Build not found: https://tuist.dev/...`, while the bare UUID succeeded.

`Builds.get_build/1` starts with `Ecto.UUID.cast/1`, which a URL fails, falling through to `{:error, :not_found}`. That happens before `MCPTool.load_and_authorize/5`, so the error was purely a parse failure wearing a not-found message and carried no authorization signal. `Tuist.Bundles.get_bundle/2`, `Tuist.CommandEvents.get_command_event_by_id/1`, `Tuist.Tests.get_test/2` and `Tuist.Gradle.get_build/1` have the same shape.

## Why implement rather than correct the descriptions

`Tuist.MCP.Components.Prompts.CompareBuilds` already depended on the promised behaviour. Its description states the handles "are not needed if base or head is a dashboard URL", it advertises `get_xcode_build` as working "by ID or dashboard URL", and `resolution_section/6` emits the literal instruction to call the get tool with `build_run_id=<base>`, where `base` is whatever the caller passed. The prompt was actively steering agents into the failing call. Correcting only the descriptions would have meant rewriting that prompt and dropping a genuinely useful affordance, since pasting a dashboard URL is the natural thing for a user to do.

## Design notes

**It lives in the MCP layer, not in the domain lookups.** `Builds.get_build/1` and its siblings are also called from API controllers and LiveViews, where accepting a URL would be wrong.

**Last-segment extraction rather than per-resource route parsing.** One helper covers build runs, test runs, test cases, bundles, cache runs, generations and Gradle builds without knowing any of their URL shapes. Anything that is not an absolute URL passes through untouched, so the existing UUID cast still rejects genuinely bad input with exactly today's error.

**The host is deliberately not checked against `Tuist.Environment.app_url/2`.** Calling this out explicitly since it was raised as a decision to make rather than leave implicit. A dashboard URL reaches a self-hosted instance under its own domain, and a hosted one through whatever proxy or custom domain the account browses it by, so a host check would reject URLs users actually have. It buys no authorization either: the extracted id is loaded and authorized exactly as a bare id is, and a URL pointing anywhere else simply yields an id that is not found.

**Tools that use the id downstream use the normalised value throughout** — in query filters, in the echoed `bundle_id`, and in the not-found message — so a URL cannot leak into a query.

## User and developer impact

Pasting a dashboard URL straight from the browser into any of these tools now works. The per-argument input schemas say "or a Tuist dashboard URL" alongside the tool descriptions, matching what `list_test_case_events` already did, so the affordance is visible where an agent reads argument documentation. The docs page states it once above the tool tables rather than repeating it in seventeen rows.

No behaviour changes for bare ids or for malformed input.

## Validation

`mix test test/tuist/mcp/` — 133 passed, no warnings from the MCP layer under `mix compile --force`, `mix credo` clean, `mise run format` run.

The 16 new tests were confirmed red against the unmodified `lib/` before implementing (117/133, with exactly the new tests failing). They cover a full dashboard URL, a trailing slash, a query string, a fragment, a bare UUID, a malformed value that must still produce the existing not-found error, non-URL and non-binary pass-through, self-hosted and localhost hosts, and — for tools that filter on the id — that the extracted id and not the URL reaches the query.

## Note on CI

Server CI will fail on this branch for a reason unrelated to this change. `main` currently carries two ClickHouse migrations at version `20260817120000` — `create_test_case_runs_recent_window_per_case_mv` (#12420) and `add_caller_test_selection_to_test_runs` (#12403). `Ecto.Migrator.ensure_no_duplication!/1` aborts before any migration runs, so the `mix test --warnings-as-errors` step fails on `main` as well. Verified locally by temporarily renaming one migration to a free version, which is how the test results above were obtained. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)