### PR TITLE
fix(infra): raise the OCI registry's push throughput ceiling

### DIFF
--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -208,6 +208,7 @@ jobs:
           local-name: macos-tahoe-xcode
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/macos-tahoe-xcode:${{ steps.build.outputs.tag }}
           chunk-size: "64"
+          concurrency: "4"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -153,6 +153,7 @@ jobs:
           local-name: tuist-runner
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}
           chunk-size: "64"
+          concurrency: "4"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1002,6 +1002,8 @@ jobs:
           remote-names: |
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:latest
+          chunk-size: "64"
+          concurrency: "4"
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4
@@ -1144,6 +1146,8 @@ jobs:
           remote-names: |
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ needs.check-releases.outputs.runner-image-next-version-number }}
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}
+          chunk-size: "64"
+          concurrency: "4"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -148,6 +148,7 @@ jobs:
           local-name: tuist-xcresult-processor
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
           chunk-size: "64"
+          concurrency: "4"
 
       - name: Cleanup
         if: always()

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2301,7 +2301,19 @@ ociRegistry:
         cpu: 50m
         memory: 64Mi
       limits:
-        cpu: 500m
+        # Every byte in or out of the registry crosses this daemon, so
+        # its ceiling is the registry's ceiling. Measured 2026-08-19
+        # pushing a base image from a builder: the sidecar sat pinned at
+        # 498m against the previous 500m limit while the registry
+        # container idled at 115m of its 2000m and the host node ran at
+        # 12% of 16 cores. Throughput tracked the cap exactly, 3.2 MB/s
+        # with one upload in flight and 6.3 MB/s with four, which is
+        # this daemon saturating rather than the registry, the disk or
+        # the link. Raising the cap is the only thing that moves it:
+        # TS_USERSPACE is already false, so the faster kernel-TUN path
+        # is in use and the remaining cost is WireGuard crypto in
+        # tailscaled, which parallelises across concurrent streams.
+        cpu: "2"
         memory: 256Mi
     # The cert sidecar is idle almost always: one `tailscale cert` call,
     # then a day's sleep.


### PR DESCRIPTION
## What changed

Three changes that together lift the Tuist OCI registry's push throughput:

1. `ociRegistry.tailscale.resources.limits.cpu`: `500m` to `2`
2. `concurrency: "4"` on every tart-push call that targets the registry
3. `chunk-size: "64"` on the two release-path pushes in `server-production-deployment.yml`, which were passing nothing and silently getting `3`

## Why

Pushing a base image runs at 3.2 MB/s. That matters twice over: a 50 to 60 GB image is published on every Xcode release, and the same path will carry the whole Mac fleet's pulls once the consume half of the registry migration lands.

All numbers below were measured on the live production registry on 2026-08-19 while pushing `macos-tahoe-xcode` from builder `tuist-tuist-builders-fleet-rg4h9-nzdn4`.

### Root cause 1: the tailscale sidecar is the hard ceiling

Every byte in or out of the registry crosses this daemon, so its ceiling is the registry's ceiling. It was pinned at its limit while nothing else was working:

| | concurrency 1 | concurrency 4 |
|---|---|---|
| Throughput | 3.2 MB/s | 6.3 MB/s |
| tailscale sidecar CPU | 302m | **498m against a 500m limit** |
| oci-registry CPU | 43m / 2000m | 115m / 2000m |
| oci-registry memory | 165Mi / 2Gi | 629Mi / 2Gi |

Throughput tracked the cap and nothing else came close. Ruled out along the way: the tailnet path is direct rather than DERP-relayed, the host node runs at 12% of 16 cores, nginx already has `client_max_body_size 0` and request buffering off, and the GHCR pull of the same image completes in 9 minutes so the link is not the constraint.

`TS_USERSPACE` is already `false`, so the faster kernel-TUN path is in use and the remaining cost is WireGuard crypto inside tailscaled. That parallelises across concurrent streams, so giving it more CPU is the lever that remains.

### Root cause 2: clients pushed single-file into a registry provisioned for parallelism

`tart-push` defaults to one upload in flight, and no caller overrode it. Meanwhile the registry's memory limit is sized on the explicit premise that "a push runs several concurrently". Four in-flight 64 MB parts is 256 MiB, comfortably inside 2Gi, and the observed 629Mi confirms it.

Measured, this alone took the push from 3.2 to 6.3 MB/s before the sidecar became the binding constraint.

### Root cause 3: the release path still used the GHCR-era chunk size

The two `tart-push` calls in `server-production-deployment.yml` pass no `chunk-size` and so fall back to the action default of `3`, which exists only because GHCR rejects chunks of 4 MB and up. Against this registry that is roughly 17,000 requests for a 50 GB image where 64 MB chunks need about 1,000.

The dispatch workflows (`macos-xcode-image.yml`, `runner-image.yml`, `xcresult-processor-image.yml`) already pass `64`. The release path, which is the one that actually publishes images, was missed. Of the two client-side fixes this is the more consequential, and it is a pre-existing bug rather than a tuning choice.

## Why this shape

The action's `concurrency` default stays at `1` rather than changing globally, matching how `chunk-size` is already handled per caller. A future GHCR-bound caller then keeps the settings that backend needs, since GHCR rate-limits request volume and is the reason both conservative defaults exist.

Considered and rejected for now: stop crossing the tailnet for cluster-local traffic entirely, since the registry has a ClusterIP Service. That is a much larger change, it does not help the builders (which are off-cluster and must cross the tailnet regardless), and it is not needed to fix the ceiling.

Also worth stating, because it looks tempting: pushing several images in parallel across both builders does not help while the sidecar is capped. They share it, so it splits the same budget rather than adding to it.

## Impact

Every image publish to the registry gets faster, and the release path gets the larger share of it because it was on 3 MB chunks. The ceiling this removes also sits in front of the consume half of the migration, where the whole fleet pulls base images through the same sidecar.

No behaviour changes, no interface changes. The CPU limit is a ceiling and not a reservation, so the sidecar keeps its 50m request and consumes more only while a transfer is in flight.

## Validation

- The concurrency change is validated end to end: measured 3.2 MB/s to 6.3 MB/s on a real push, with the registry's memory moving 165Mi to 629Mi exactly as four in-flight 64 MB parts predicts.
- The sidecar limit is justified by the pinned 498m/500m reading plus 14 idle cores on the node, but its effect is **not** yet measured, because it needs a production deploy to take effect.

Draft until that measurement exists. Once it deploys I will push another base image and record the resulting throughput here, so the number that justifies the limit is an observation rather than an extrapolation. I got this wrong once already in this investigation: I predicted 3 to 4x from concurrency alone and got 2x, because the sidecar cap absorbed the difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
