### PR TITLE
fix(server): route translations through Hive

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -44,8 +44,8 @@ jobs:
         run: mix deps.get
       - name: Run translations
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: elixir translate.exs --model "openai:gpt-4.1-mini"
+          HIVE_INFERENCE_API_KEY: ${{ secrets.HIVE_INFERENCE_API_KEY }}
+        run: elixir translate.exs --model "hive:Translator"
       - name: Check for changes
         id: changes
         run: |

--- a/translate.exs
+++ b/translate.exs
@@ -422,9 +422,10 @@ defmodule L10n.Translator do
   Resolves a model string into a req_llm-compatible model reference.
 
   Handles `"ollama:model_name"` by configuring a local OpenAI-compatible
-  endpoint at `localhost:11434`. All other model strings (e.g.,
-  `"anthropic:claude-sonnet-4-6"`, `"openai:gpt-4.1"`) are passed through
-  directly to req_llm.
+  endpoint at `localhost:11434`, and `"hive:profile_name"` by configuring
+  Hive's OpenAI-compatible chat-completions endpoint. All other model strings
+  (e.g., `"anthropic:claude-sonnet-4-6"`, `"openai:gpt-4.1"`) are passed
+  through directly to req_llm.
   """
   def resolve_model(model_string) do
     case String.split(model_string, ":", parts: 2) do
@@ -435,6 +436,17 @@ defmodule L10n.Translator do
           provider: :openai,
           id: model_id,
           base_url: "http://localhost:11434/v1"
+        })
+
+      ["hive", profile_name] ->
+        ReqLLM.put_key(:openai_api_key, System.fetch_env!("HIVE_INFERENCE_API_KEY"))
+
+        ReqLLM.model!(%{
+          provider: :openai,
+          id: profile_name,
+          base_url:
+            System.get_env("HIVE_INFERENCE_BASE_URL", "https://hive.tuist.dev/inference/v1"),
+          extra: %{wire: %{protocol: "openai_chat"}}
         })
 
       _ ->
@@ -495,7 +507,13 @@ defmodule L10n.Translator do
 
     resolved_model = resolve_model(model)
 
-    case generate_text_with_retries(resolved_model, messages, timeout, locale) do
+    case generate_text_with_retries(
+           resolved_model,
+           messages,
+           timeout,
+           locale,
+           String.starts_with?(model, "hive:")
+         ) do
       {:ok, response} ->
         text =
           response
@@ -512,22 +530,38 @@ defmodule L10n.Translator do
     end
   end
 
-  def generate_text_with_retries(resolved_model, messages, timeout, locale, attempt \\ 1) do
+  def generate_text_with_retries(
+        resolved_model,
+        messages,
+        timeout,
+        locale,
+        stream?,
+        attempt \\ 1
+      ) do
     opts =
       resolved_model
       |> token_limit_option()
       |> Keyword.put(:receive_timeout, timeout)
 
-    case ReqLLM.generate_text(resolved_model, messages, opts) do
+    result =
+      if stream? do
+        with {:ok, response} <- ReqLLM.stream_text(resolved_model, messages, opts) do
+          ReqLLM.StreamResponse.to_response(response)
+        end
+      else
+        ReqLLM.generate_text(resolved_model, messages, opts)
+      end
+
+    case result do
       {:ok, response} ->
         {:ok, response}
 
       {:error, error} ->
-        handle_retry(error, resolved_model, messages, timeout, locale, attempt)
+        handle_retry(error, resolved_model, messages, timeout, locale, stream?, attempt)
     end
   end
 
-  defp handle_retry(error, resolved_model, messages, timeout, locale, attempt) do
+  defp handle_retry(error, resolved_model, messages, timeout, locale, stream?, attempt) do
     case retry_delay_ms(error, attempt) do
       nil ->
         {:error, Exception.message(error)}
@@ -538,7 +572,14 @@ defmodule L10n.Translator do
         )
 
         Process.sleep(delay)
-        generate_text_with_retries(resolved_model, messages, timeout, locale, attempt + 1)
+        generate_text_with_retries(
+          resolved_model,
+          messages,
+          timeout,
+          locale,
+          stream?,
+          attempt + 1
+        )
     end
   end
 


### PR DESCRIPTION
## What changed

- Route the localization workflow through Hive's `Translator` inference profile.
- Add `hive:profile_name` model resolution with Hive's chat-completions endpoint.
- Collect streamed Hive responses before validating and writing the translated result.

## Why

Translation requests should use the organization-managed inference gateway so provider credentials stay outside the repository and the profile can be retargeted without further workflow changes.

## Root cause

The workflow used an invalid direct OpenAI credential. The selected Hive profile routes to Qwen3.7-Plus, which requires streamed responses, while the translator previously used non-streaming requests.

## Approach

Use Hive's OpenAI-compatible chat-completions interface and explicitly select its chat protocol. Keep the existing request path for all non-Hive models, while materializing streamed Hive responses into the response type used by the existing validation flow.

## Impact

The workflow now reads `HIVE_INFERENCE_API_KEY` from repository secrets and uses the stable `Translator` profile name. Future provider or model changes can be made in Hive without repository edits.

## Validation

- Confirmed the Hive token can access the `Translator` profile.
- Confirmed streaming requests reach `Qwen/Qwen3.7-Plus`.
- Ran an isolated forced Japanese `.po` translation: 1 translated, 0 errors.
- Ran `git diff --check`.
