### PR TITLE
fix(server): drain the transition outbox in the step attribution test

### DIFF
--- a/server/test/tuist_web/live/runner_job_live_test.exs
+++ b/server/test/tuist_web/live/runner_job_live_test.exs
@@ -514,6 +514,8 @@ defmodule TuistWeb.RunnerJobLiveTest do
         end)
       )
 
+    flush_outbox!()
+
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/runners/runs/314010/jobs/31401")
     document = Floki.parse_fragment!(html)
 


### PR DESCRIPTION
## What changed

One line of test setup: `flush_outbox!()` in the `TuistWeb.RunnerJobLiveTest` test
"attributes a build only to the step it ran in when steps share a second", between
`JobSteps.record/1` and the `live/2` mount.

## Why

The Server workflow's `Test` job has failed on every push to `main` since 12:12 UTC on
19 August 2026. That test is the only failure: it raises `NotFoundError` from
`RunnerJobLive.mount/3` before any of its assertions run, so the job exits 2 with
6785/6786 passing.

## Root cause

A semantic merge conflict between two PRs that were each green on their own branch:

- [#12466](https://github.com/tuist/tuist/pull/12466) (12:06, the last green run) added
  this test. It enqueues a runner job and then mounts the job view. At that point
  `Jobs.enqueue` still wrote the job straight to ClickHouse, so the view found it.
- [#12050](https://github.com/tuist/tuist/pull/12050) (12:12, the first red run) made the
  transition outbox the sole path by which runner jobs reach ClickHouse.

Neither branch contained the other's change, so CI had no run where both were present
until the second one merged. Every other test in the file already drains the outbox with
`flush_outbox!()` between enqueueing and mounting. This one was written without it
because it did not need one yet.

## Why this fix rather than something broader

The drain is the actual missing step, and the change matches the position the sibling
steps test already uses. The structural weakness underneath is that `flush_outbox!/0` is
a copy-pasted private helper in six separate test files, so a new test can silently omit
it and get a confusing `NotFoundError` instead of a clear signal. Consolidating that is
worth doing, but it touches every runner test file and does not belong in a change whose
job is to turn `main` green.

## The chrome_not_found errors are not the cause

Worth stating plainly, because they dominate the job log and read like the failure. They
are pre-existing noise: the last green run (32250898277) emitted 5256 of them and still
passed. They come from the Open Graph renderer's headless-browser pool restarting in a
hot loop in an environment without Chrome. That failure mode is already understood and
documented in `Tuist.Application.RuntimeChildren.open_graph_image_renderer/1`, which gates
the pool to `:web` pod mode for exactly this reason. The test environment is not gated, so
the pool starts and hot-loops against a CI image that has no Chrome, while
`Tuist.OpenGraphImageRenderer` is Mimic-stubbed and never actually used by the suite.
Filed as a follow-up rather than folded in here.

## Also worth knowing

The exit-code-1 runs between 12:14 and 13:52 were a different fault, the duplicated ingest
migration version, already fixed on `main` by
[#12480](https://github.com/tuist/tuist/pull/12480). Every run after it fails only on this
test, so this change should be the last thing standing between `main` and green.

## Validation

- The test fails on `main` at `test/tuist_web/live/runner_job_live_test.exs:417` with the
  same `NotFoundError` seen in CI, and passes with this change.
- `mix test --warnings-as-errors test/tuist_web/live/runner_job_live_test.exs`: 32 passed.
- `mix test --warnings-as-errors` over `test/tuist/runners` plus the runner LiveView and
  controller tests: 646 passed.
- `mix format --check-formatted` clean.

Unblocks the merge queue on `main`, where a permanently failing required check would
freeze every merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
