### PR TITLE
fix(handbook): run the deploy on a Node version Wrangler supports

### DIFF
--- a/handbook/mise.toml
+++ b/handbook/mise.toml
@@ -1,6 +1,6 @@
 [tools]
     aube = "1.6.2"
-    node = "20.12.0"
+    node = "22.12.0"
     "npm:wrangler" = "4.30.0"
 
 [hooks]


### PR DESCRIPTION
The handbook has not deployed since May. Every run of the workflow since then has failed, and handbook.tuist.io currently serves whatever was published before that.

## Root cause

The build is fine. It passes on Node 20 and always has. The deploy step is what fails, because Wrangler now requires Node 22 or newer and refuses to start:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.12.0.
```

`handbook/mise.toml` pins `node = "20.12.0"`.

## Why it went unnoticed

The deploy step is guarded on `github.ref == 'refs/heads/main'`. Pull request runs therefore build and stop, and stay green. Only the run on `main` reaches the deploy, so the workflow looked healthy on every pull request while the published site quietly fell behind.

## What changed

Bumps the pin to 22.12.0, matching `status/`, which is the closest sibling: also a Cloudflare deploy, also driven by Wrangler, and already on that version.

## Validation

- `mise current node` in `handbook/` resolves 22.12.0
- `mise run build` in `handbook/` completes, which also verifies there are no dead links

The deploy step itself can only be proven on `main`, since that is where it is gated. Worth watching the first run after merge.

## Impact

Several merged handbook changes are written but not served, including the two new security policies and the rewritten shared responsibility model. They go live with the first successful deploy.
