### PR TITLE
fix(server): keep the nightly Stripe meter sync under the API rate limit

### DIFF
--- a/server/lib/tuist/billing/workers/sync_customer_stripe_meters_worker.ex
+++ b/server/lib/tuist/billing/workers/sync_customer_stripe_meters_worker.ex
@@ -2,6 +2,10 @@ defmodule Tuist.Billing.Workers.SyncCustomerStripeMetersWorker do
   @moduledoc """
   Snapshots a customer's meter values for the parent billing period
   and fans out one Stripe reporting job per meter.
+
+  A customer that earned nothing over the period finishes without
+  reaching Stripe at all, which is the common case: the billable
+  customer list is far larger than the set with usage on any given day.
   """
   # A boundary lookup that can't reach Stripe fails the job instead of
   # snapshotting an unsplit window, so retries have to finish while the
@@ -51,33 +55,50 @@ defmodule Tuist.Billing.Workers.SyncCustomerStripeMetersWorker do
     {:ok, account} = Accounts.get_account_from_customer_id(customer_id)
 
     include_qa = FunWithFlags.enabled?(:qa_billing_enabled, for: account)
+    day = {period_start, period_end}
 
-    # Snapshot each service period the day covers separately. A day that
-    # straddles a subscription renewal or its cancellation produces one set
-    # of jobs per side, each reporting only the usage its own period earned,
-    # so no event ever crosses an invoice boundary.
-    #
-    # A failed boundary lookup fails the whole job rather than snapshotting
-    # the day as one window. The snapshot is permanent — a child never
-    # re-queries usage — so guessing the boundary wrong here cannot be
-    # corrected later.
-    case Billing.usage_windows(account, period_start, period_end) do
-      {:ok, windows} ->
-        windows
-        |> Enum.flat_map(&meter_jobs(account, customer_id, &1, include_qa))
-        |> Oban.insert_all()
-
+    # Measure the whole day before looking up any boundary. Meter values are
+    # sums of non-negative usage, so a day that earned nothing has no
+    # sub-window that earned anything either, and there is nothing to
+    # attribute to either side of a boundary. Most billable customers are
+    # idle on any given day, and boundary discovery costs a Stripe request
+    # each, so this is what keeps the nightly run off Stripe's rate limit.
+    case Billing.customer_meter_values(account, period_start, period_end, include_qa: include_qa) do
+      [] ->
         :ok
 
-      {:error, reason} ->
-        {:error, reason}
+      day_values ->
+        # Snapshot each service period the day covers separately. A day that
+        # straddles a subscription renewal or its cancellation produces one set
+        # of jobs per side, each reporting only the usage its own period earned,
+        # so no event ever crosses an invoice boundary.
+        #
+        # A failed boundary lookup fails the whole job rather than snapshotting
+        # the day as one window. The snapshot is permanent — a child never
+        # re-queries usage — so guessing the boundary wrong here cannot be
+        # corrected later.
+        with {:ok, windows} <- Billing.usage_windows(account, period_start, period_end) do
+          windows
+          |> Enum.flat_map(fn
+            # No boundary fell inside the day, so the only window is the one
+            # already measured above and re-aggregating it would just repeat
+            # the same ClickHouse work.
+            ^day -> meter_jobs(customer_id, day, day_values)
+            window -> meter_jobs(customer_id, window, window_values(account, window, include_qa))
+          end)
+          |> Oban.insert_all()
+
+          :ok
+        end
     end
   end
 
-  defp meter_jobs(account, customer_id, {window_start, window_end}, include_qa) do
-    account
-    |> Billing.customer_meter_values(window_start, window_end, include_qa: include_qa)
-    |> Enum.map(fn meter ->
+  defp window_values(account, {window_start, window_end}, include_qa) do
+    Billing.customer_meter_values(account, window_start, window_end, include_qa: include_qa)
+  end
+
+  defp meter_jobs(customer_id, {window_start, window_end}, values) do
+    Enum.map(values, fn meter ->
       SyncCustomerStripeMeterWorker.new(%{
         customer_id: customer_id,
         event_name: meter.event_name,

--- a/server/lib/tuist/billing/workers/sync_stripe_meters_worker.ex
+++ b/server/lib/tuist/billing/workers/sync_stripe_meters_worker.ex
@@ -25,11 +25,30 @@ defmodule Tuist.Billing.Workers.SyncStripeMetersWorker do
   deduplicates against it rather than racing it. Narrower windows still
   occur internally when `Billing.usage_windows/3` splits at a subscription
   boundary; both paths split identically, so the identifiers match.
+
+  Either way the customer jobs are released in per-second batches rather
+  than all at once, so the Stripe requests they go on to make arrive at a
+  bounded rate.
   """
   use Oban.Worker, max_attempts: 1
 
   alias Tuist.Accounts
   alias Tuist.Billing.Workers.SyncCustomerStripeMetersWorker
+
+  # Customer jobs are released in per-second batches rather than all at
+  # once. Each one spends a Stripe request discovering service-period
+  # boundaries before its meter jobs post their events, so an unthrottled
+  # fan-out put the whole billable customer list on the wire within a
+  # couple of seconds. Stripe's live-mode limit is around 100 requests per
+  # second, and it answered most of that burst with HTTP 429 while the
+  # shared HTTP connection pool returned transport errors for the rest.
+  #
+  # This rate keeps the resulting request rate an order of magnitude below
+  # the limit even if every customer turned out to have usage, and stretches
+  # the fan-out over minutes — nothing against the multi-hour budget the
+  # reporting delay already fits into (see the moduledoc on the retry cap in
+  # `SyncCustomerStripeMeterWorker`).
+  @customers_per_second 10
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"period_start" => period_start, "period_end" => period_end}}) do
@@ -71,15 +90,28 @@ defmodule Tuist.Billing.Workers.SyncStripeMetersWorker do
 
   defp sync(%DateTime{} = period_start, %DateTime{} = period_end) do
     Accounts.list_billable_customers()
-    |> Enum.map(
-      &SyncCustomerStripeMetersWorker.new(%{
-        customer_id: &1,
-        period_start: DateTime.to_unix(period_start, :microsecond),
-        period_end: DateTime.to_unix(period_end, :microsecond)
-      })
-    )
+    |> Enum.with_index()
+    |> Enum.map(fn {customer_id, index} ->
+      SyncCustomerStripeMetersWorker.new(
+        %{
+          customer_id: customer_id,
+          period_start: DateTime.to_unix(period_start, :microsecond),
+          period_end: DateTime.to_unix(period_end, :microsecond)
+        },
+        release_opts(index)
+      )
+    end)
     |> Oban.insert_all()
 
     :ok
+  end
+
+  # The first batch carries no schedule at all, so it is available the
+  # moment it is inserted rather than waiting on job staging.
+  defp release_opts(index) do
+    case div(index, @customers_per_second) do
+      0 -> []
+      seconds -> [schedule_in: seconds]
+    end
   end
 end

--- a/server/test/tuist/billing/sync_customer_stripe_meters_worker_test.exs
+++ b/server/test/tuist/billing/sync_customer_stripe_meters_worker_test.exs
@@ -101,11 +101,13 @@ defmodule Tuist.Billing.Workers.SyncCustomerStripeMetersWorkerTest do
 
     stub(FunWithFlags, :enabled?, fn :qa_billing_enabled, [for: ^account] -> false end)
 
+    stub(Billing, :customer_meter_values, fn ^account, _window_start, _window_end, [include_qa: false] ->
+      [%{event_name: "remote_cache_hit", value: 7}]
+    end)
+
     stub(Billing, :usage_windows, fn ^account, ^period_start_datetime, ^period_end_datetime ->
       {:error, error}
     end)
-
-    reject(&Billing.customer_meter_values/4)
 
     assert {:error, ^error} =
              SyncCustomerStripeMetersWorker.perform(%Oban.Job{
@@ -141,5 +143,76 @@ defmodule Tuist.Billing.Workers.SyncCustomerStripeMetersWorkerTest do
     assert is_integer(job.args["period_start"])
     assert is_integer(job.args["period_end"])
     assert job.args["period_end"] > job.args["period_start"]
+  end
+
+  test "skips boundary discovery when the day earned nothing" do
+    customer_id = UUIDv7.generate()
+    %{account: account} = AccountsFixtures.user_fixture(customer_id: customer_id)
+    period_start_datetime = ~U[2026-07-16 00:00:00.000000Z]
+    period_end_datetime = ~U[2026-07-17 00:00:00.000000Z]
+
+    stub(FunWithFlags, :enabled?, fn :qa_billing_enabled, [for: ^account] -> false end)
+
+    expect(Billing, :customer_meter_values, fn ^account,
+                                               ^period_start_datetime,
+                                               ^period_end_datetime,
+                                               [include_qa: false] ->
+      []
+    end)
+
+    # Boundary discovery costs a Stripe request, and the overwhelming
+    # majority of billable customers earn nothing on a given day. Splitting
+    # a window that has no usage to attribute to either side changes
+    # nothing, so the request is not worth spending.
+    reject(&Billing.usage_windows/3)
+
+    assert :ok =
+             SyncCustomerStripeMetersWorker.perform(%Oban.Job{
+               id: 791,
+               args: %{
+                 "customer_id" => customer_id,
+                 "period_start" => DateTime.to_unix(period_start_datetime, :microsecond),
+                 "period_end" => DateTime.to_unix(period_end_datetime, :microsecond)
+               }
+             })
+
+    assert all_enqueued(worker: SyncCustomerStripeMeterWorker) == []
+  end
+
+  test "snapshots usage once when no boundary splits the day" do
+    customer_id = UUIDv7.generate()
+    %{account: account} = AccountsFixtures.user_fixture(customer_id: customer_id)
+    period_start_datetime = ~U[2026-07-16 00:00:00.000000Z]
+    period_end_datetime = ~U[2026-07-17 00:00:00.000000Z]
+
+    stub(FunWithFlags, :enabled?, fn :qa_billing_enabled, [for: ^account] -> false end)
+
+    stub(Billing, :usage_windows, fn ^account, ^period_start_datetime, ^period_end_datetime ->
+      {:ok, [{period_start_datetime, period_end_datetime}]}
+    end)
+
+    # Exactly one invocation: the unsplit window is the day the gate
+    # already measured, and each snapshot aggregates over ClickHouse.
+    expect(Billing, :customer_meter_values, 1, fn ^account,
+                                                  ^period_start_datetime,
+                                                  ^period_end_datetime,
+                                                  [include_qa: false] ->
+      [%{event_name: "remote_cache_hit", value: 12}]
+    end)
+
+    assert :ok =
+             SyncCustomerStripeMetersWorker.perform(%Oban.Job{
+               id: 792,
+               args: %{
+                 "customer_id" => customer_id,
+                 "period_start" => DateTime.to_unix(period_start_datetime, :microsecond),
+                 "period_end" => DateTime.to_unix(period_end_datetime, :microsecond)
+               }
+             })
+
+    [job] = all_enqueued(worker: SyncCustomerStripeMeterWorker)
+    assert job.args["value"] == 12
+    assert job.args["period_start"] == DateTime.to_unix(period_start_datetime, :microsecond)
+    assert job.args["period_end"] == DateTime.to_unix(period_end_datetime, :microsecond)
   end
 end

--- a/server/test/tuist/billing/sync_stripe_meters_worker_test.exs
+++ b/server/test/tuist/billing/sync_stripe_meters_worker_test.exs
@@ -254,4 +254,39 @@ defmodule Tuist.Billing.Workers.SyncStripeMetersWorkerWorkerTest do
 
     assert all_enqueued(worker: SyncCustomerStripeMetersWorker) == []
   end
+
+  test "spreads the customer fan-out over time instead of releasing it in one burst" do
+    # More customers than one second's worth of fan-out, so the assertion
+    # sees an actual spread rather than a single batch that happens to fit.
+    customer_ids =
+      Enum.map(1..12, fn index ->
+        customer_id = "account-spread-#{index}-#{UUIDv7.generate()}"
+        AccountsFixtures.user_fixture(customer_id: customer_id)
+        customer_id
+      end)
+
+    period_start = ~U[2026-07-04 00:00:00.000000Z]
+    period_end = ~U[2026-07-05 00:00:00.000000Z]
+
+    assert :ok =
+             SyncStripeMetersWorker.perform(%Oban.Job{
+               args: %{
+                 "period_start" => DateTime.to_unix(period_start, :microsecond),
+                 "period_end" => DateTime.to_unix(period_end, :microsecond)
+               }
+             })
+
+    jobs = all_enqueued(worker: SyncCustomerStripeMetersWorker)
+
+    assert jobs |> Enum.map(& &1.args["customer_id"]) |> Enum.sort() == Enum.sort(customer_ids)
+
+    # Every customer job spends a Stripe request on a subscription lookup
+    # before its meter jobs post their events. Released together they
+    # arrive as one burst and Stripe answers most of it with HTTP 429, so
+    # the fan-out has to land in per-second batches instead.
+    batches = jobs |> Enum.group_by(& &1.scheduled_at) |> Map.values()
+
+    assert length(batches) > 1
+    assert batches |> Enum.map(&length/1) |> Enum.max() < length(jobs)
+  end
 end


### PR DESCRIPTION
Fixes two production errors from the nightly Stripe meter reporting, both first seen at 00:00 UTC on 2026-08-20:

- [TUIST-4H7](https://tuist.sentry.io/issues/141714486/): `Stripe.Error` with `code: :rate_limit_error` (HTTP 429), 424 events.
- [TUIST-4H8](https://tuist.sentry.io/issues/141714593/): `Stripe.Error` with `source: :network, hackney_reason: :invalid_state`, 4 events.

### Root cause

Both fire from `Tuist.Billing.Workers.SyncCustomerStripeMetersWorker`, and both are the same bug: an unthrottled fan-out.

`SyncStripeMetersWorker` runs on an `@daily` cron and inserts one `SyncCustomerStripeMetersWorker` job per billable customer in a single `Oban.insert_all`, every job immediately available. Each of those jobs calls `Stripe.Subscription.retrieve/1` through `Billing.usage_windows/3` to discover service-period boundaries before its meter jobs post their events. So at 00:00 UTC the entire billable customer list goes on the wire inside a couple of seconds.

Stripe's live-mode limit is around 100 requests per second, and it answered most of that burst with HTTP 429. The same burst saturated the shared hackney connection pool, which is where the `:invalid_state` transport errors came from. Two symptoms, one cause, which is why both issues appeared inside the same 22 second window.

Production numbers for the shape of the problem:

| | count |
| --- | --- |
| accounts with a `customer_id` (jobs enqueued nightly) | 1,748 |
| of those, accounts with a subscription row (a Stripe retrieve every night) | 554 |
| of those, accounts with any usage on 2026-08-19 | ~52 |

### What changed

Two changes, both aimed at the request arrival rate rather than at retrying harder.

**1. Boundary discovery is gated on the period having earned something** (`SyncCustomerStripeMetersWorker`).

Meter values are sums of non-negative usage, so a period that earned nothing has no sub-window that earned anything either, and there is nothing to attribute to either side of a boundary. The split cannot change the outcome, so the Stripe request that discovers it is not worth spending. That takes nightly subscription retrieves from 554 down to roughly the number of accounts with actual usage.

The worker now measures the whole day first and only reaches Stripe when that comes back non-empty. When no boundary splits the day, the single window is the one already measured, so those values are reused instead of re-running the same ClickHouse aggregate.

**2. The fan-out is released in per-second batches** (`SyncStripeMetersWorker`).

Customer jobs are scheduled 10 per second instead of all at once, so the requests that remain arrive at a bounded rate that stays an order of magnitude below Stripe's limit even if every customer turned out to have usage. This is the part that survives growth: the gate alone would leave a burst that scales with the active customer base.

Spreading costs minutes. The reporting delay already has to fit inside the invoice-finalization grace period (up to 72h), and the child worker's retry cap already budgets ~11h, so minutes are free.

### Why not the obvious alternatives

- **Retry harder, or widen the backoff.** These jobs already retry up to 12 times. Retrying does not reduce the burst, it only moves it, and every failed attempt reports to Sentry, which is how one cron run produced 424 events.
- **A dedicated low-concurrency Oban queue.** Oban OSS enforces concurrency per node, so the effective global limit would be the queue limit times the web pod count, and it would shift silently whenever the deployment scales. Scheduling in the parent is deterministic and independent of pod count.
- **Caching subscription periods locally.** This is the real route to zero Stripe calls in this path, but it needs a migration, webhook sync, and a backfill, and it introduces staleness exactly on renewal and cancellation days, which are the only days the boundary matters. `Billing.usage_windows/3` reads from Stripe deliberately for that reason, and this PR leaves that alone.

### Impact

Reporting semantics are unchanged:

- A failed boundary lookup still fails the whole job rather than snapshotting an unsplit window.
- A day that straddles a renewal or a cancellation is still snapshotted once per side.
- Event identifiers and idempotency keys are untouched, so nothing double-reports or dedupes differently.

Per-account work strictly decreases. Accounts without a subscription do the same single ClickHouse aggregate as before. Accounts with a subscription go from one Stripe call plus one aggregate to one aggregate, and the Stripe call only when they actually have usage.

### How to test locally

```bash
cd server && mix test test/tuist/billing/ test/tuist/billing_test.exs test/tuist/oban/runtime_config_test.exs
```

116 tests pass. Both new tests were confirmed red before the change:

- `skips boundary discovery when the day earned nothing` failed on `Billing.usage_windows/3` being called anyway.
- `spreads the customer fan-out over time instead of releasing it in one burst` failed because every job shared a single `scheduled_at`.

`mix credo` is clean and the changed files are formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
