### PR TITLE
fix(server): authenticate ClickHouse dictionary sources used by backfill migrations

### DIFF
--- a/server/lib/tuist/clickhouse_dictionary_source.ex
+++ b/server/lib/tuist/clickhouse_dictionary_source.ex
@@ -14,7 +14,20 @@ defmodule Tuist.ClickHouseDictionarySource do
   Host and port stay out of the clause on purpose. Omitted, they default to the
   server's own address and native port, which is what a same-instance lookup
   wants; the repo's port is the HTTP one the source would not dial anyway.
+
+  Issue the resulting statement with `query_opts/0`, which keeps the credential
+  out of both logs that would otherwise receive it.
   """
+
+  @doc """
+  Query options for a statement rendered with `local_table/2`.
+
+  `log: false` keeps the credential out of the application log. `log_queries: 0`
+  keeps the whole statement out of `system.query_log`: ClickHouse masks
+  dictionary source passwords there on its own, but it does so from the parsed
+  statement, so anything that fails to parse is logged verbatim instead.
+  """
+  def query_opts, do: [log: false, settings: [log_queries: 0]]
 
   def local_table(repo, table) do
     config = repo.config()

--- a/server/lib/tuist/clickhouse_dictionary_source.ex
+++ b/server/lib/tuist/clickhouse_dictionary_source.ex
@@ -1,0 +1,39 @@
+defmodule Tuist.ClickHouseDictionarySource do
+  @moduledoc """
+  Builds the `SOURCE` clause for dictionaries that read a table living in the
+  same ClickHouse instance the repo is connected to.
+
+  A `CLICKHOUSE` dictionary source is resolved by the ClickHouse server, not by
+  the client that issued the `CREATE DICTIONARY`, so the server authenticates it
+  separately. With no user named in the source it falls back to `default` with
+  an empty password, which only succeeds on a server that has no password set.
+  Installs following the published self-hosted Compose file do set one, so every
+  backfill dictionary died there with `AUTHENTICATION_FAILED`. Name the
+  credentials the repo already connects with instead.
+
+  Host and port stay out of the clause on purpose. Omitted, they default to the
+  server's own address and native port, which is what a same-instance lookup
+  wants; the repo's port is the HTTP one the source would not dial anyway.
+  """
+
+  def local_table(repo, table) do
+    config = repo.config()
+
+    "CLICKHOUSE(TABLE #{literal(table)}#{credentials(config[:username], config[:password])})"
+  end
+
+  defp credentials(nil, _password), do: ""
+
+  defp credentials(username, password) do
+    " USER #{literal(username)} PASSWORD #{literal(password || "")}"
+  end
+
+  defp literal(value) do
+    escaped =
+      value
+      |> String.replace("\\", "\\\\")
+      |> String.replace("'", "\\'")
+
+    "'" <> escaped <> "'"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
@@ -1,4 +1,5 @@
 defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
+  alias Tuist.ClickHouseDictionarySource
   alias Tuist.IngestRepo
   alias Tuist.Repo
   use Ecto.Migration
@@ -123,16 +124,20 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
     # Create a dictionary for efficient lookup
     dict_name = "event_to_test_run_dict_#{:os.system_time(:second)}_#{:rand.uniform(1000)}"
 
-    IngestRepo.query!("""
-      CREATE DICTIONARY #{dict_name} (
-        event_id UUID,
-        test_run_id UUID
-      )
-      PRIMARY KEY event_id
-      SOURCE(CLICKHOUSE(TABLE '#{temp_table_name}'))
-      LAYOUT(HASHED())
-      LIFETIME(0)
-    """)
+    IngestRepo.query!(
+      """
+        CREATE DICTIONARY #{dict_name} (
+          event_id UUID,
+          test_run_id UUID
+        )
+        PRIMARY KEY event_id
+        SOURCE(#{ClickHouseDictionarySource.local_table(IngestRepo, temp_table_name)})
+        LAYOUT(HASHED())
+        LIFETIME(0)
+      """,
+      [],
+      log: false
+    )
 
     IngestRepo.query!("""
       ALTER TABLE command_events

--- a/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
@@ -136,7 +136,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
         LIFETIME(0)
       """,
       [],
-      log: false
+      ClickHouseDictionarySource.query_opts()
     )
 
     IngestRepo.query!("""

--- a/server/priv/ingest_repo/migrations/20260422120001_backfill_denormalized_fields_in_test_module_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120001_backfill_denormalized_fields_in_test_module_runs.exs
@@ -21,6 +21,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestModuleRuns
   3. Drop the dictionary once the mutation completes.
   """
   use Ecto.Migration
+  alias Tuist.ClickHouseDictionarySource
   alias Tuist.IngestRepo
   require Logger
 
@@ -31,19 +32,23 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestModuleRuns
   def up do
     IngestRepo.query!("DROP DICTIONARY IF EXISTS #{@dict_name}")
 
-    IngestRepo.query!("""
-    CREATE DICTIONARY #{@dict_name} (
-      id UUID,
-      project_id Int64,
-      is_ci Bool,
-      git_branch String,
-      ran_at DateTime64(6)
+    IngestRepo.query!(
+      """
+      CREATE DICTIONARY #{@dict_name} (
+        id UUID,
+        project_id Int64,
+        is_ci Bool,
+        git_branch String,
+        ran_at DateTime64(6)
+      )
+      PRIMARY KEY id
+      SOURCE(#{ClickHouseDictionarySource.local_table(IngestRepo, "test_runs")})
+      LAYOUT(HASHED())
+      LIFETIME(0)
+      """,
+      [],
+      log: false
     )
-    PRIMARY KEY id
-    SOURCE(CLICKHOUSE(TABLE 'test_runs'))
-    LAYOUT(HASHED())
-    LIFETIME(0)
-    """)
 
     Logger.info("Starting test_module_runs denormalized backfill mutation")
 

--- a/server/priv/ingest_repo/migrations/20260422120001_backfill_denormalized_fields_in_test_module_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120001_backfill_denormalized_fields_in_test_module_runs.exs
@@ -47,7 +47,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestModuleRuns
       LIFETIME(0)
       """,
       [],
-      log: false
+      ClickHouseDictionarySource.query_opts()
     )
 
     Logger.info("Starting test_module_runs denormalized backfill mutation")

--- a/server/priv/ingest_repo/migrations/20260422120002_backfill_denormalized_fields_in_test_suite_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120002_backfill_denormalized_fields_in_test_suite_runs.exs
@@ -32,7 +32,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestSuiteRuns 
       LIFETIME(0)
       """,
       [],
-      log: false
+      ClickHouseDictionarySource.query_opts()
     )
 
     Logger.info("Starting test_suite_runs denormalized backfill mutation")

--- a/server/priv/ingest_repo/migrations/20260422120002_backfill_denormalized_fields_in_test_suite_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120002_backfill_denormalized_fields_in_test_suite_runs.exs
@@ -6,6 +6,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestSuiteRuns 
   strategy.
   """
   use Ecto.Migration
+  alias Tuist.ClickHouseDictionarySource
   alias Tuist.IngestRepo
   require Logger
 
@@ -16,19 +17,23 @@ defmodule Tuist.IngestRepo.Migrations.BackfillDenormalizedFieldsInTestSuiteRuns 
   def up do
     IngestRepo.query!("DROP DICTIONARY IF EXISTS #{@dict_name}")
 
-    IngestRepo.query!("""
-    CREATE DICTIONARY #{@dict_name} (
-      id UUID,
-      project_id Int64,
-      is_ci Bool,
-      git_branch String,
-      ran_at DateTime64(6)
+    IngestRepo.query!(
+      """
+      CREATE DICTIONARY #{@dict_name} (
+        id UUID,
+        project_id Int64,
+        is_ci Bool,
+        git_branch String,
+        ran_at DateTime64(6)
+      )
+      PRIMARY KEY id
+      SOURCE(#{ClickHouseDictionarySource.local_table(IngestRepo, "test_runs")})
+      LAYOUT(HASHED())
+      LIFETIME(0)
+      """,
+      [],
+      log: false
     )
-    PRIMARY KEY id
-    SOURCE(CLICKHOUSE(TABLE 'test_runs'))
-    LAYOUT(HASHED())
-    LIFETIME(0)
-    """)
 
     Logger.info("Starting test_suite_runs denormalized backfill mutation")
 

--- a/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
+++ b/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
@@ -10,6 +10,7 @@ defmodule Tuist.IngestRepo.Migrations.DenormalizeProjectIdOnCasOutputs do
   materialized projection.
   """
   use Ecto.Migration
+  alias Tuist.ClickHouseDictionarySource
   alias Tuist.IngestRepo
   require Logger
 
@@ -39,16 +40,20 @@ defmodule Tuist.IngestRepo.Migrations.DenormalizeProjectIdOnCasOutputs do
   end
 
   defp create_project_ids_dictionary do
-    IngestRepo.query!("""
-    CREATE DICTIONARY #{@dict_name} (
-      id UUID,
-      project_id Int64
+    IngestRepo.query!(
+      """
+      CREATE DICTIONARY #{@dict_name} (
+        id UUID,
+        project_id Int64
+      )
+      PRIMARY KEY id
+      SOURCE(#{ClickHouseDictionarySource.local_table(IngestRepo, "build_runs")})
+      LAYOUT(HASHED())
+      LIFETIME(0)
+      """,
+      [],
+      log: false
     )
-    PRIMARY KEY id
-    SOURCE(CLICKHOUSE(TABLE 'build_runs'))
-    LAYOUT(HASHED())
-    LIFETIME(0)
-    """)
   end
 
   defp add_project_id_column do

--- a/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
+++ b/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
@@ -52,7 +52,7 @@ defmodule Tuist.IngestRepo.Migrations.DenormalizeProjectIdOnCasOutputs do
       LIFETIME(0)
       """,
       [],
-      log: false
+      ClickHouseDictionarySource.query_opts()
     )
   end
 

--- a/server/priv/ingest_repo/migrations/20260721115000_add_project_id_to_test_case_events.exs
+++ b/server/priv/ingest_repo/migrations/20260721115000_add_project_id_to_test_case_events.exs
@@ -85,7 +85,7 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToTestCaseEvents do
       LIFETIME(0)
       """,
       [],
-      log: false
+      ClickHouseDictionarySource.query_opts()
     )
   end
 

--- a/server/priv/ingest_repo/migrations/20260721115000_add_project_id_to_test_case_events.exs
+++ b/server/priv/ingest_repo/migrations/20260721115000_add_project_id_to_test_case_events.exs
@@ -16,6 +16,7 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToTestCaseEvents do
   """
   use Ecto.Migration
 
+  alias Tuist.ClickHouseDictionarySource
   alias Tuist.IngestRepo
   alias Tuist.Repo
 
@@ -72,16 +73,20 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToTestCaseEvents do
     # `test_cases` is a ReplacingMergeTree, so the source can hold several rows
     # per id. `project_id` never changes for a test case, so whichever row the
     # dictionary keeps carries the same answer.
-    IngestRepo.query!("""
-    CREATE DICTIONARY #{@dict_name} (
-      id UUID,
-      project_id Int64
+    IngestRepo.query!(
+      """
+      CREATE DICTIONARY #{@dict_name} (
+        id UUID,
+        project_id Int64
+      )
+      PRIMARY KEY id
+      SOURCE(#{ClickHouseDictionarySource.local_table(IngestRepo, "test_cases")})
+      LAYOUT(HASHED())
+      LIFETIME(0)
+      """,
+      [],
+      log: false
     )
-    PRIMARY KEY id
-    SOURCE(CLICKHOUSE(TABLE 'test_cases'))
-    LAYOUT(HASHED())
-    LIFETIME(0)
-    """)
   end
 
   defp backfill_project_id do

--- a/server/test/tuist/clickhouse_dictionary_source_test.exs
+++ b/server/test/tuist/clickhouse_dictionary_source_test.exs
@@ -1,0 +1,47 @@
+defmodule Tuist.ClickHouseDictionarySourceTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.ClickHouseDictionarySource
+
+  defmodule PasswordlessRepo do
+    @moduledoc false
+    def config, do: [hostname: "127.0.0.1", port: 8123, database: "tuist_test"]
+  end
+
+  defmodule AuthenticatedRepo do
+    @moduledoc false
+    def config, do: [username: "tuist", password: "s3cret", database: "tuist"]
+  end
+
+  defmodule QuotedCredentialsRepo do
+    @moduledoc false
+    def config, do: [username: "o'brien", password: "back\\slash'quote"]
+  end
+
+  defmodule BlankPasswordRepo do
+    @moduledoc false
+    def config, do: [username: "tuist"]
+  end
+
+  describe "local_table/2" do
+    test "omits credentials when the repo authenticates with none" do
+      assert ClickHouseDictionarySource.local_table(PasswordlessRepo, "test_cases") ==
+               "CLICKHOUSE(TABLE 'test_cases')"
+    end
+
+    test "carries the credentials the repo itself connects with" do
+      assert ClickHouseDictionarySource.local_table(AuthenticatedRepo, "test_cases") ==
+               "CLICKHOUSE(TABLE 'test_cases' USER 'tuist' PASSWORD 's3cret')"
+    end
+
+    test "escapes quotes and backslashes so a password cannot break out of its literal" do
+      assert ClickHouseDictionarySource.local_table(QuotedCredentialsRepo, "test_cases") ==
+               "CLICKHOUSE(TABLE 'test_cases' USER 'o\\'brien' PASSWORD 'back\\\\slash\\'quote')"
+    end
+
+    test "sends an empty password for a user configured without one" do
+      assert ClickHouseDictionarySource.local_table(BlankPasswordRepo, "test_cases") ==
+               "CLICKHOUSE(TABLE 'test_cases' USER 'tuist' PASSWORD '')"
+    end
+  end
+end

--- a/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
+++ b/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
@@ -33,4 +33,28 @@ defmodule Tuist.IngestRepo.DictionarySourceCredentialsTest do
            Render the source with `Tuist.ClickHouseDictionarySource.local_table/2` instead.
            """
   end
+
+  test "every credential-bearing statement is issued with the redacting query options" do
+    unredacted =
+      @migrations_path
+      |> Path.join("*.exs")
+      |> Path.wildcard()
+      |> Enum.filter(fn path ->
+        source = File.read!(path)
+
+        String.contains?(source, "ClickHouseDictionarySource.local_table(") and
+          not String.contains?(source, "ClickHouseDictionarySource.query_opts()")
+      end)
+      |> Enum.map(&Path.basename/1)
+      |> Enum.sort()
+
+    assert unredacted == [],
+           """
+           These migrations render a dictionary source carrying a password but do not issue \
+           the statement with `Tuist.ClickHouseDictionarySource.query_opts/0`, so a statement \
+           that fails to parse reaches `system.query_log` verbatim:
+
+           #{Enum.map_join(unredacted, "\n", &("  " <> &1))}
+           """
+  end
 end

--- a/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
+++ b/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
@@ -1,0 +1,36 @@
+defmodule Tuist.IngestRepo.DictionarySourceCredentialsTest do
+  @moduledoc """
+  A `CLICKHOUSE` dictionary source is resolved inside the ClickHouse server, so
+  it authenticates separately from the connection that created it. Naming no
+  user makes it fall back to `default` with an empty password, which passes on
+  a server with no password set and fails everywhere else with Code 516. Dev,
+  test and the managed instance are all passwordless, so no environment we run
+  migrations against catches this; only the source text does.
+  """
+  use ExUnit.Case, async: true
+
+  @migrations_path Path.join([__DIR__, "..", "..", "..", "priv", "ingest_repo", "migrations"])
+
+  test "every dictionary reading a local table names the credentials the repo connects with" do
+    anonymous =
+      @migrations_path
+      |> Path.join("*.exs")
+      |> Path.wildcard()
+      |> Enum.filter(fn path ->
+        path |> File.read!() |> String.contains?("SOURCE(CLICKHOUSE(")
+      end)
+      |> Enum.map(&Path.basename/1)
+      |> Enum.sort()
+
+    assert anonymous == [],
+           """
+           These migrations build a dictionary whose source names no user, so ClickHouse \
+           authenticates it as `default` with an empty password and fails with Code 516 on \
+           any instance that sets one:
+
+           #{Enum.map_join(anonymous, "\n", &("  " <> &1))}
+
+           Render the source with `Tuist.ClickHouseDictionarySource.local_table/2` instead.
+           """
+  end
+end


### PR DESCRIPTION
## What changed

Every ClickHouse backfill migration that builds a dictionary over a local table now names the credentials the repo already connects with, instead of leaving the source anonymous.

- New `Tuist.ClickHouseDictionarySource.local_table/2` renders the `SOURCE(CLICKHOUSE(...))` clause from `repo.config()`, escaping the user and password so neither can break out of its SQL literal. When the repo authenticates with no user (dev, test) it emits the bare clause it emits today, so nothing changes there.
- The five migrations that create such a dictionary use it: `20251118211224`, `20260422120001`, `20260422120002`, `20260609120000`, and `20260721115000`.
- Those `CREATE DICTIONARY` calls pass `log: false` so the password does not reach the query log.

Host and port stay out of the clause on purpose. Omitted, they default to the server's own address and native port, which is what a same-instance lookup wants; the repo's port is the HTTP one the source would not dial anyway.

## Why

A clean disaster-recovery restore on a self-hosted instance got past the projection migrations fixed in #12468 and then died on `20260721115000_add_project_id_to_test_case_events` with:

```
Code: 516. DB::Exception: Authentication failed: password is incorrect, or there is no user with such name
```

### Root cause

A `CLICKHOUSE` dictionary source is resolved inside the ClickHouse server, not by the client that issued the `CREATE DICTIONARY`. The server therefore authenticates it separately from the connection that created it, using the user named in the source. With no user named, it falls back to `default` with an empty password. That succeeds on a server with no password set, which is why this never surfaced on the managed instance or in dev and test, and fails on any install that sets one, including the published self-hosted Compose setup.

`CREATE DICTIONARY` itself does not fail, because dictionaries load lazily. The failure lands on the first `dictGet` inside the backfill mutation, which is why it reads as a migration failure rather than a configuration one.

### Why this shape

The obvious alternative was to drop dictionaries entirely and back these columns with a `Join` engine table plus `joinGet`, which needs no credentials at all. That rewrites the memory and failure profile of five migrations that have already run against the production dataset, to fix an authentication problem. Naming the credentials keeps the reviewed backfill behaviour intact and matches the precedent already in this directory, where the `postgresql()` backfills pass their credentials explicitly.

All five were fixed rather than just the reported one. A fresh self-hosted install runs the whole chain, and the earlier four only escaped the report because the tables they read were empty at that point in the restore, so no `dictGet` ever forced a load.

## Impact

Self-hosted instances with a password-protected ClickHouse can complete a restore-and-upgrade through the full migration chain. Instances that have already run these migrations are unaffected; the migrations are not re-run. No schema or data-shape change, so `server/data-export.md` is unchanged.

## Validation

- A regression guard asserts no migration builds a dictionary whose source names no user. It fails against the pre-fix migrations, naming all five, and passes after. Dev, test and the managed instance all run a passwordless ClickHouse, so no environment we migrate against exercises this authentication; the source text is the only place it is catchable.
- New unit tests for `local_table/2` cover the no-credentials, credentials, empty-password, and quote/backslash-escaping cases.
- Reproduced the reported failure against a local ClickHouse 26.1: a dictionary whose source names a wrong password fails its first `dictGet` with exactly `Code: 516 ... (AUTHENTICATION_FAILED)`, confirming the source authenticates independently of the creating connection.
- Ran the `20260721115000` backfill path end to end against a password-protected ClickHouse user with `Tuist.IngestRepo` configured by URL: the helper emitted `CLICKHOUSE(TABLE 'test_cases' USER '...' PASSWORD '...')`, the dictionary loaded, and the mutation backfilled `project_id` correctly.
- Verified a password containing a single quote and a backslash survives the emitted literal and authenticates.
- `mix credo` reports no issues, `mix format --check-formatted` passes, and the changed files compile without warnings.

## Follow-up

The remaining projection migrations in the restore range were checked for the Error 344 class that #12468 fixed. `cas_outputs` and `command_events` are plain MergeTree, and `test_runs` already inherits `deduplicate_merge_projection_mode = 'rebuild'` from `20260529100000`, so none of them need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
