### PR TITLE
feat(infra): publish the macOS runner guest log off the VM

### DIFF
--- a/infra/macos-log-shipper/AGENTS.md
+++ b/infra/macos-log-shipper/AGENTS.md
@@ -161,31 +161,33 @@ the agent is off, so a re-enable that resumed from the stale offset would
 replay the whole disabled window in one burst. A re-enable starts at the end of
 the file, the same as a first install.
 
-## Guest stdout is a separate problem — `tart run` cannot capture it
+## Guest stdout reaches Loki through tart-kubelet, not through this agent
 
-The runner VMs' `dispatch-poll.sh` output (the `cache dirty=` /
-`cache image detached` lines that a CAS-poisoning investigation wants) does
-**not** ride this agent, and cannot be made to without new plumbing. Two
-independent reasons, both checked against what is actually deployed:
+The runner VMs' `dispatch-poll.sh` output does **not** ride this agent directly,
+and cannot: the guest redirects to a file inside itself
+(`exec >>/var/log/tuist-runner/poll.log 2>&1`), the host's
+`/var/log/tart-vms/<vm>.log` holds `tart run`'s own output rather than the
+guest's, and Tart 2.32.1 has no macOS-guest console capture (`--serial` attaches
+a virtio console a macOS guest never writes to).
 
-1. **The guest redirects before anything reaches a console.** `dispatch-poll.sh`
-   opens with `exec >>/var/log/tuist-runner/poll.log 2>&1`, so its output goes
-   to a file *inside* the guest. The host's `/var/log/tart-vms/<vm>.log` (which
-   tart-kubelet already captures) holds `tart run`'s own output, not the
-   guest's.
-2. **Tart has no macOS-guest console capture.** At the pinned 2.32.1, the only
-   options are `--serial` / `--serial-path`, which attach a
-   `VZVirtioConsoleDeviceSerialPortConfiguration` and are documented upstream as
-   "useful for debugging Linux Kernel". A macOS guest boots to the framebuffer
-   and puts nothing on that device.
+It arrives anyway, by a shorter route. The guest mirrors its log into the
+writable status share it already owns (`/Volumes/My Shared Files/status` → the
+host's `VolumeStatusDir`) as `runner.log`, and **tart-kubelet re-emits a bounded
+tail to its own stdout at teardown**, just before `deleteByKey` removes the
+share. That stdout is `/var/log/tart-kubelet.log` — the file this agent already
+tails. So the trail lands in Loki with no change here.
 
-The cheapest path if this is picked up: the guest already has a **writable**
-host share (`/Volumes/My Shared Files/status` → the host's `VolumeStatusDir`,
-where it writes `cache-dirty` and `volume-head.json`), so `dispatch-poll.sh`
-could `tee` into it and this agent could tail that directory. That is a real
-design step, not a free one — the share is per-VM and ephemeral, so the agent
-would need glob discovery, per-file position churn, and a story for the pools
-where cache volumes are off and the share does not exist at all.
+That indirection is deliberate. Tailing the shares directly was the obvious
+design and is the worse one: the share is per-VM and ephemeral, so the agent
+would need glob discovery, per-file position churn, and its own answer for the
+pools where cache volumes are off and no share exists. Routing through
+tart-kubelet costs one bounded read on a path that already had to touch the
+share to recover the exit code, and this agent stays a single-file tailer.
+
+The tradeoffs to know: the tail is emitted at teardown, so it is forensics after
+the fact, not a live stream; a VM that never terminates, or one killed before its
+EXIT trap runs, publishes nothing this way. The second case still reaches the
+cluster distinguishably, as `TartRunExited` rather than a reported exit code.
 
 ## Do not add log rotation for the tailed file
 

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -467,6 +467,22 @@ customer-facing profile selection.
    `TartRunExited` rather than laundering tart's zero into a clean
    runner exit.
 
+   The exit code alone is not enough, because it does not separate
+   the two cases that matter: a runner that finished its job and a
+   runner that halted without ever taking one both report 0. So the
+   trap also publishes `runner.log` — `dispatch-poll.sh`'s own
+   output — into the same share, and tart-kubelet re-emits a bounded
+   tail of it to its own stdout before teardown deletes the share.
+   That stdout is already tailed by the host log shipper, so the
+   trail reaches Loki without the shipper having to discover
+   per-VM shares. Copied from the trap rather than `tee`d as the
+   script runs, so a still-running tee cannot flush a duplicate tail
+   after the copy. Same `status`-share dependency as `runner-rc`:
+   pools with cache volumes off keep the old behaviour of logging
+   only inside the guest, and a guest killed before its trap runs
+   publishes nothing — that case already arrives distinguishably as
+   `TartRunExited`.
+
 For the customer-facing dispatch label and capacity model see
 `server/lib/tuist/runners.ex` and `infra/helm/tuist/values.yaml`
 (`runnersFleet.pools[]`) — they're the right place for routing

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -39,6 +39,34 @@ exec >>"${LOG}" 2>&1
 # reason.
 STATUS_SHARE="/Volumes/My Shared Files/status"
 
+# publish_runner_log copies this script's log into the status share on
+# the way out, so it survives the VM. `${LOG}` lives inside the ephemeral
+# guest and dies with it, which is why a runner that halts without ever
+# taking its job leaves an exit code and nothing that explains it: the
+# EXIT trap reports 0 both for a finished job and for a runner that gave
+# up, so the code alone cannot separate them. tart-kubelet re-emits a
+# bounded tail of this file to its own stdout before teardown deletes the
+# share, and that reaches Loki via the host log shipper.
+#
+# A copy from the trap rather than a `tee` alongside `${LOG}`. A tee is
+# the obvious shape and the wrong one here: it would still be running
+# when the trap fires, so its buffered tail can land after this copy and
+# duplicate it, and bash 3.2 (what /bin/bash is on macOS) does not report
+# a process substitution's PID in `$!`, so there is no portable way to
+# reap it first. Copying after the last line is written is exact.
+#
+# The cost is that a guest killed without running its trap publishes
+# nothing — but that case already reaches the host distinguishably, as
+# `TartRunExited` rather than a reported exit code.
+#
+# Guarded on the share being mounted, exactly like report_runner_exit:
+# pools with the cache-volume feature off have no share, and there the
+# guest keeps logging only to `${LOG}`.
+publish_runner_log() {
+  [ -d "${STATUS_SHARE:-}" ] || return 0
+  cp "${LOG}" "${STATUS_SHARE}/runner.log" 2>/dev/null || true
+}
+
 # report_runner_exit hands this script's exit code to the host through
 # the writable status share, for tart-kubelet to publish as the Pod's
 # terminated container state.
@@ -71,7 +99,7 @@ report_runner_exit() {
 # refilling. The trap fires once on EXIT so the happy path
 # (clean ./run.sh exit) and every error path halt the VM the
 # same way.
-trap '_rc=$?; report_runner_exit "${_rc}"; echo "$(date -u +%FT%TZ) dispatch-poll: exiting (rc=${_rc}); halting VM"; sudo /sbin/shutdown -h now || true; exit "${_rc}"' EXIT
+trap '_rc=$?; report_runner_exit "${_rc}"; echo "$(date -u +%FT%TZ) dispatch-poll: exiting (rc=${_rc}); halting VM"; publish_runner_log; sudo /sbin/shutdown -h now || true; exit "${_rc}"' EXIT
 
 if [ ! -f /etc/tuist.env ]; then
   echo "$(date -u +%FT%TZ) dispatch-poll: /etc/tuist.env missing; aborting"

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -290,6 +290,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			// status share (and the guest's report in it) with it.
 			exitCode, exitReason := r.runnerTermination(entry, exitErr)
 			finishedAt := runnerFinishedAt(entry)
+			// Re-emit the guest's own log before deleteByKey takes the
+			// status share with it. This is tart-kubelet's durable stdout,
+			// which the host log shipper already tails, so the trail reaches
+			// Loki without the shipper needing to discover per-VM shares.
+			// Unconditional: exitCode does not discriminate here (a runner
+			// that halted without taking a job reports 0 exactly like a
+			// finished one), so gating on it would drop the cases worth
+			// keeping.
+			if tail := readRunnerLog(entry.VolumeStatusDir); tail != "" {
+				logger.Info("runner log", "vm", entry.VMName, "runnerLog", tail)
+			}
 			r.finalizeVolume(entry, pod.Labels[runnerAccountLabel], exitErr == nil)
 			_ = r.deleteByKey(ctx, pod.Namespace, pod.Name)
 
@@ -1239,6 +1250,12 @@ func (r *Reconciler) podStatus(ctx context.Context, pod *corev1.Pod) (*corev1.Po
 		// and the only exit time there will ever be.
 		exitCode, exitReason := r.runnerTermination(entry, nil)
 		finishedAt := runnerFinishedAt(entry)
+		// Same reason as the terminal path: publish the guest's log while
+		// the share still exists. This path has even less to go on — there
+		// is no `tart run` error at all — so the log is the whole story.
+		if tail := readRunnerLog(entry.VolumeStatusDir); tail != "" {
+			log.FromContext(ctx).Info("runner log", "vm", entry.VMName, "runnerLog", tail)
+		}
 		r.finalizeVolume(entry, pod.Labels[runnerAccountLabel], true)
 		// Tear down the Tart clone + Store entry so the host state mirrors what
 		// the API server will see post-update, then mark the Pod Succeeded so

--- a/infra/tart-kubelet/internal/podagent/runner_log_test.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func writeRunnerLog(t *testing.T, body string) string {
@@ -80,5 +82,56 @@ func TestReadRunnerLogBoundsBytes(t *testing.T) {
 
 	if got := len(readRunnerLog(dir)); got > runnerLogTailBytes {
 		t.Errorf("got %d bytes, want at most %d", got, runnerLogTailBytes)
+	}
+}
+
+// The status share is written by the guest, which runs untrusted customer
+// CI. Anything it leaves at runner.log that is not a plain file is an
+// attempt to make the host read something else on its behalf, and the
+// host publishes what it reads straight to Loki.
+func TestReadRunnerLogRejectsGuestSymlink(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(t.TempDir(), "host-secret")
+	if err := os.WriteFile(secret, []byte("host-only-content\n"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	if err := os.Symlink(secret, filepath.Join(dir, runnerLogFile)); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if got := readRunnerLog(dir); got != "" {
+		t.Errorf("got %q, want \"\" — a guest symlink must not be followed", got)
+	}
+}
+
+func TestReadRunnerLogRejectsNonRegularFile(t *testing.T) {
+	// A FIFO is the other half of the same trick: without O_NONBLOCK the
+	// open alone parks the reconcile until someone writes.
+	dir := t.TempDir()
+	if err := syscall.Mkfifo(filepath.Join(dir, runnerLogFile), 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- readRunnerLog(dir) }()
+
+	select {
+	case got := <-done:
+		if got != "" {
+			t.Errorf("got %q, want \"\"", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("readRunnerLog blocked on a FIFO")
+	}
+}
+
+func TestReadRunnerLogRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, runnerLogFile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if got := readRunnerLog(dir); got != "" {
+		t.Errorf("got %q, want \"\"", got)
 	}
 }

--- a/infra/tart-kubelet/internal/podagent/runner_log_test.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log_test.go
@@ -1,0 +1,84 @@
+package podagent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRunnerLog(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, runnerLogFile), []byte(body), 0o644); err != nil {
+		t.Fatalf("write runner log: %v", err)
+	}
+	return dir
+}
+
+func TestReadRunnerLogAbsent(t *testing.T) {
+	// No status share at all is the pools-without-cache-volumes case,
+	// and it must degrade to "nothing to say" rather than an error.
+	if got := readRunnerLog(""); got != "" {
+		t.Errorf("empty statusDir = %q, want \"\"", got)
+	}
+	if got := readRunnerLog(t.TempDir()); got != "" {
+		t.Errorf("missing file = %q, want \"\"", got)
+	}
+}
+
+func TestReadRunnerLogShortFileReturnedWhole(t *testing.T) {
+	dir := writeRunnerLog(t, "first\nsecond\nthird\n")
+
+	got := readRunnerLog(dir)
+
+	if got != "first\nsecond\nthird" {
+		t.Errorf("got %q, want the whole file without its trailing newline", got)
+	}
+}
+
+func TestReadRunnerLogKeepsTailNotHead(t *testing.T) {
+	// The whole point is the last thing a runner said before it gave up,
+	// so an over-long log must lose its beginning, never its end.
+	var b strings.Builder
+	for i := range runnerLogTailLines * 2 {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	dir := writeRunnerLog(t, b.String())
+
+	lines := strings.Split(readRunnerLog(dir), "\n")
+
+	if len(lines) > runnerLogTailLines {
+		t.Fatalf("got %d lines, want at most %d", len(lines), runnerLogTailLines)
+	}
+	want := fmt.Sprintf("line-%d", runnerLogTailLines*2-1)
+	if lines[len(lines)-1] != want {
+		t.Errorf("last line = %q, want %q", lines[len(lines)-1], want)
+	}
+}
+
+func TestReadRunnerLogDropsPartialFirstLine(t *testing.T) {
+	// A byte-bounded read lands mid-line; emitting that fragment would
+	// put a corrupt-looking record at the top of every large capture.
+	head := strings.Repeat("x", runnerLogTailBytes)
+	dir := writeRunnerLog(t, head+"\ncomplete-line\n")
+
+	got := readRunnerLog(dir)
+
+	if strings.Contains(got, "x") {
+		t.Errorf("got %q, want the truncated first line dropped", got)
+	}
+	if got != "complete-line" {
+		t.Errorf("got %q, want %q", got, "complete-line")
+	}
+}
+
+func TestReadRunnerLogBoundsBytes(t *testing.T) {
+	// One pathological line must not blow up the log record it lands in.
+	dir := writeRunnerLog(t, strings.Repeat("y", runnerLogTailBytes*3)+"\n")
+
+	if got := len(readRunnerLog(dir)); got > runnerLogTailBytes {
+		t.Errorf("got %d bytes, want at most %d", got, runnerLogTailBytes)
+	}
+}

--- a/infra/tart-kubelet/internal/podagent/volume_reconcile.go
+++ b/infra/tart-kubelet/internal/podagent/volume_reconcile.go
@@ -82,6 +82,30 @@ const dirtyMarkerFile = "cache-dirty"
 // see runnerTermination.
 const runnerExitFile = "runner-rc"
 
+// runnerLogFile is dispatch-poll.sh's own output, mirrored into the
+// writable status share by the guest so it outlives the VM. The copy
+// inside the guest (/var/log/tuist-runner/poll.log) dies with the VM at
+// teardown, and Tart cannot capture a macOS guest's console, so without
+// this the host has an exit code and nothing that explains it.
+//
+// That gap is not academic: the trap reports 0 both for a finished job
+// and for a runner that halted without ever taking one, so the exit code
+// alone cannot tell those apart. This file is what does.
+//
+// Absent for the same two reasons as runnerExitFile — a guest killed
+// before its trap ran, and hosts with no status share attached at all.
+const runnerLogFile = "runner.log"
+
+// runnerLogTailLines / runnerLogTailBytes bound what publishRunnerLog
+// re-emits. dispatch-poll.sh is quiet by design — the job's own output
+// goes to GitHub server-side, so this log is warm-standby ticks plus the
+// cache teardown trail — but the file is guest-writable, so it is bounded
+// rather than trusted.
+const (
+	runnerLogTailLines = 200
+	runnerLogTailBytes = 64 << 10
+)
+
 // readRunnerExit reads the guest-reported exit code from the status share.
 // The bool is false when the guest reported nothing usable.
 //
@@ -108,6 +132,49 @@ func readRunnerExit(statusDir string) (int32, bool) {
 		return 0, false
 	}
 	return int32(code), true
+}
+
+// readRunnerLog returns a bounded tail of the guest's mirrored log, or
+// "" when there is nothing usable. Callers re-emit it to tart-kubelet's
+// own stdout before teardown deletes the share.
+//
+// Tail rather than head: the interesting part of a runner that gave up
+// is what it said last. Bounded twice because the file is guest-written
+// — by bytes first so a single pathological line cannot blow up the log
+// record, then by lines.
+func readRunnerLog(statusDir string) string {
+	if statusDir == "" {
+		return ""
+	}
+	f, err := os.Open(filepath.Join(statusDir, runnerLogFile))
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	offset := int64(0)
+	if fi.Size() > runnerLogTailBytes {
+		offset = fi.Size() - runnerLogTailBytes
+	}
+	b := make([]byte, fi.Size()-offset)
+	if _, err := f.ReadAt(b, offset); err != nil {
+		return ""
+	}
+
+	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
+	// A byte-bounded read almost certainly starts mid-line; drop that
+	// fragment so the tail begins on a real record.
+	if offset > 0 && len(lines) > 1 {
+		lines = lines[1:]
+	}
+	if len(lines) > runnerLogTailLines {
+		lines = lines[len(lines)-runnerLogTailLines:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // readRunnerExitTime returns when the guest wrote its exit report, which

--- a/infra/tart-kubelet/internal/podagent/volume_reconcile.go
+++ b/infra/tart-kubelet/internal/podagent/volume_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -142,18 +143,31 @@ func readRunnerExit(statusDir string) (int32, bool) {
 // is what it said last. Bounded twice because the file is guest-written
 // — by bytes first so a single pathological line cannot blow up the log
 // record, then by lines.
+//
+// Opened O_NOFOLLOW and required to be a regular file, because the guest
+// writes this path and the guest runs untrusted customer CI. A job that
+// replaces runner.log with a symlink would otherwise have the host
+// resolve it and publish up to runnerLogTailBytes of a host-readable
+// file to Loki — the guest picks the target, the host does the reading.
+// O_NONBLOCK covers the same trick with a FIFO, where the open itself
+// would park this reconcile until something wrote to the other end.
+// Whatever the guest left is inspected but never trusted to be a file.
 func readRunnerLog(statusDir string) string {
 	if statusDir == "" {
 		return ""
 	}
-	f, err := os.Open(filepath.Join(statusDir, runnerLogFile))
+	f, err := os.OpenFile(
+		filepath.Join(statusDir, runnerLogFile),
+		os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK,
+		0,
+	)
 	if err != nil {
 		return ""
 	}
 	defer f.Close()
 
 	fi, err := f.Stat()
-	if err != nil {
+	if err != nil || !fi.Mode().IsRegular() {
 		return ""
 	}
 	offset := int64(0)


### PR DESCRIPTION
> Describe here the purpose of your PR.

A macOS runner that halts without ever taking its job currently leaves an exit code and nothing that explains it. This carries the guest's own log off the VM so those deaths can be diagnosed.

### The gap

`dispatch-poll.sh`'s EXIT trap reports `0` both for a finished job and for a runner that gave up, so the exit code cannot separate the two. The script's log lives at `/var/log/tuist-runner/poll.log` **inside** the ephemeral guest and dies with it. Tart 2.32.1 has no macOS-guest console capture, and the host's `/var/log/tart-vms/<vm>.log` holds `tart run`'s output rather than the guest's. So nothing carried that trail off the VM.

This is not hypothetical. Investigating a customer's 6m04s runner pickup delay, every one of the 43 pods that produced an `orphaned running row — GH still queued` line in a 24h window terminated `exitCode=0 reason=Completed`. On Linux the equivalent question was answered in a single Loki query, because Linux runners are ordinary containers whose stdout is collected; the macOS half was unanswerable.

### What changed

- **Guest** (`dispatch-poll.sh`): `publish_runner_log` copies `${LOG}` into `${STATUS_SHARE}/runner.log`, called from the EXIT trap after the final message and before the halt. Guarded on the share being mounted, exactly like `report_runner_exit`.
- **Host** (`tart-kubelet` `internal/podagent`): `readRunnerLog` returns a bounded tail (200 lines / 64 KiB, byte-bounded first, partial leading line dropped). Both terminal paths in `reconciler.go` — the `Run != nil` branch and the recovered `Run == nil` branch — log it as `"runner log"` **before** `deleteByKey` removes the share.

`tart-kubelet`'s stdout is `/var/log/tart-kubelet.log`, which the host log shipper already tails, so the trail reaches Loki with **no change to the shipper**.

### Decisions a reviewer should know

**Routed through tart-kubelet, not by having the shipper tail the shares.** The shares are the obvious target and the worse one: they are per-VM and ephemeral, so tailing them needs glob discovery, per-file position churn, and a separate answer for pools where cache volumes are off and no share exists. Going through tart-kubelet costs one bounded read on a path that already had to open the share to recover the exit code, and the shipper stays a single-file tailer. `infra/macos-log-shipper/AGENTS.md` previously described this as impossible without new plumbing; that section is rewritten.

**A copy from the trap, not a `tee`.** The tee was written first and backed out. It is still running when the trap fires, so its buffered tail can land *after* the copy and duplicate it — and macOS `/bin/bash` is 3.2, which does not set `$!` for a process substitution, so there is no portable way to reap it first. Copying after the last line is written is exact. The cost is that a guest killed before its trap runs publishes nothing, which already reaches the cluster distinguishably as `TartRunExited`.

**Emitted unconditionally, not gated on the exit code.** Gating is exactly what makes the runners-controller's existing `abnormalEnd` death-log capture blind here: every runner in question reports `0`, so any exit-code gate drops the whole population worth capturing.

### This does nothing until both halves roll

`dispatch-poll.sh` is baked into the runner image, so it needs a `release-runner-image` run plus a `runnersFleet.runnerImage` pin. `tart-kubelet` rides the CAPI operator image and reaches hosts on an SSH drift roll (its bytes are in `bootstrap.HostConfigHash`). Until both land, macOS strandings still explain nothing.

This is instrumentation only. It does not address the two actual defects found alongside it — the 300s cron recovery latency, and job/runner bookkeeping that assumes GitHub binds a job to the runner we minted it for when it binds by label set.

### How to test locally

> Document how to test your changes locally

```bash
cd infra/tart-kubelet && go build ./... && go vet ./... && go test ./internal/podagent/
bash -n infra/runner-image/dispatch-poll.sh
```

The five tests in `runner_log_test.go` cover absent share, whole-file, tail-not-head, partial-first-line drop, and byte bounding. They were checked against a mutant: removing the partial-line drop fails `TestReadRunnerLogDropsPartialFirstLine`.

Once both halves are rolled, confirm in Loki with `{job="tuist-macos-tart-kubelet"} |= "runner log"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
