### PR TITLE
fix(server): stop the Open Graph browser pool from starting under mix test

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -426,8 +426,15 @@ defmodule Tuist.Application do
   # user-data directory, so it is started only when hosted, and only in web
   # mode. See `RuntimeChildren.open_graph_image_renderer/1`. Everywhere else
   # render/2 falls back to libvips.
+  #
+  # Test is excluded on top of those gates: `mise.toml` exports TUIST_HOSTED=1
+  # for the whole repo, so the suite would otherwise start the pool on CI
+  # runners that have no Chrome and hit the retry loop documented in
+  # `RuntimeChildren.open_graph_image_renderer/1`. The suite never needs it —
+  # `Tuist.OpenGraphImageRenderer` is stubbed through Mimic wherever a test
+  # exercises Open Graph rendering.
   defp open_graph_image_children do
-    if Environment.tuist_hosted?() do
+    if Environment.tuist_hosted?() and not Environment.test?() do
       RuntimeChildren.open_graph_image_renderer(Environment.mode())
     else
       []

--- a/server/lib/tuist/application/runtime_children.ex
+++ b/server/lib/tuist/application/runtime_children.ex
@@ -31,10 +31,13 @@ defmodule Tuist.Application.RuntimeChildren do
   empty for every other mode. The renderer is reached only through the
   `TuistWeb` Open Graph endpoints, and the non-web images run on VMs
   without Chrome installed — `Browse.Pool.init_worker/1` raises
-  `:chrome_not_found` there, and because the pool is a permanent child
-  the supervisor restarts it in a hot loop (measured at ~120 restarts
-  per second on both xcresult-processor replicas), burning CPU on hosts
-  whose only job is CPU-bound xcresult parsing and flooding Sentry.
+  `:chrome_not_found` there. NimblePool catches that raise, drops the
+  worker and re-sends itself `:init_worker` with no backoff, so the pool
+  stays up and retries forever (measured at ~120 failures per second on
+  both xcresult-processor replicas), burning CPU on hosts whose only job
+  is CPU-bound xcresult parsing and flooding Sentry. `start_pool/1` cannot
+  intercept it: `NimblePool.start_link/2` has already returned `{:ok, pid}`
+  by then, so the `:ignore` branch never runs.
   """
   def open_graph_image_renderer(:web) do
     [

--- a/server/lib/tuist/open_graph_image_renderer.ex
+++ b/server/lib/tuist/open_graph_image_renderer.ex
@@ -14,11 +14,15 @@ defmodule Tuist.OpenGraphImageRenderer do
   @doc """
   Child specification for the browser pool backing the renderer.
 
-  `BrowseChrome.BrowserPool` is a NimblePool that warms its browsers eagerly, so
-  a machine without a usable Chrome would otherwise abort the whole supervision
-  tree at boot. Returning `:ignore` keeps the node booting without a pool and
-  lets `render/2` degrade to the fallback renderer, which is the right trade for
-  a feature that only backs social cards.
+  Returning `:ignore` on a `start_link/1` error keeps the node booting without a
+  pool and lets `render/2` degrade to the fallback renderer, which is the right
+  trade for a feature that only backs social cards.
+
+  This does not cover a missing Chrome. `BrowseChrome.BrowserPool` warms its
+  browsers eagerly, but NimblePool absorbs an `init_worker/1` raise and retries
+  it forever instead of failing `start_link/1`, so the pool must not be started
+  at all on a host without Chrome — see
+  `Tuist.Application.RuntimeChildren.open_graph_image_renderer/1`.
   """
   def child_spec(opts) do
     %{id: @pool, start: {__MODULE__, :start_pool, [opts]}, type: :worker}

--- a/server/test/tuist/application/runtime_children_test.exs
+++ b/server/test/tuist/application/runtime_children_test.exs
@@ -34,7 +34,7 @@ defmodule Tuist.Application.RuntimeChildrenTest do
         assert RuntimeChildren.open_graph_image_renderer(mode) == [],
                "expected no Tuist.OpenGraphImageRenderer child for #{inspect(mode)} — " <>
                  "non-web images have no Chrome installed, so Browse.Pool.init_worker/1 " <>
-                 "raises :chrome_not_found and the supervisor restarts the pool in a hot loop"
+                 "raises :chrome_not_found and NimblePool retries it forever without backoff"
       end
     end
   end

--- a/server/test/tuist/open_graph_image_renderer_test.exs
+++ b/server/test/tuist/open_graph_image_renderer_test.exs
@@ -33,4 +33,13 @@ defmodule Tuist.OpenGraphImageRendererTest do
       refute log =~ "terminating"
     end
   end
+
+  describe "the browser pool in the test environment" do
+    test "is not started" do
+      assert Process.whereis(Tuist.OpenGraphImagePool) == nil,
+             "the headless-browser pool must not start under `mix test` — CI runners have no " <>
+               "Chrome, and `Browse.Pool.init_worker/1` raising `:chrome_not_found` makes " <>
+               "NimblePool re-send itself `:init_worker` forever, flooding the suite output"
+    end
+  end
 end


### PR DESCRIPTION
The Open Graph headless-browser pool starts during `mix test` and spins on `:chrome_not_found`, emitting roughly 200 ten-line error blocks per Server workflow run. It never fails the job, but it interleaves with the progress dots and buries real failures. It hid the one-line `NotFoundError` investigated in https://github.com/tuist/tuist/pull/12486.

### Root cause

Two separate things had to line up.

**The test environment slips past both existing gates.** `mise.toml` exports `TUIST_HOSTED = "1"` for the whole repo, so `Environment.tuist_hosted?/0` is true under `mix test`, which defeats the gate added in https://github.com/tuist/tuist/pull/12323. `.github/workflows/server.yml` sets `MIX_ENV: test` workflow-wide, and `Environment.mode/0` defaults to `:web` when `TUIST_MODE` is unset, which defeats the pod-role gate added in https://github.com/tuist/tuist/pull/12307. The CI runner image has no Chrome, so every worker init raises. The same errors appear in the `db:reset` step for the same reason.

**Nothing catches the failure.** The existing docstrings describe this as the supervisor restarting a permanent child in a hot loop. That is not the mechanism. NimblePool catches the `init_worker/1` raise in `do_apply_worker_callback/4`, logs it, returns `{:remove, reason}`, and re-sends itself `:init_worker` with no backoff. The pool process stays alive, so `NimblePool.start_link/2` has already returned `{:ok, pid}` and the `{:error, reason} -> :ignore` branch in `start_pool/1` never runs. The supervisor never sees a crash either.

### What changed

`Tuist.Application.open_graph_image_children/0` now also requires `not Environment.test?()`. This mirrors how `marketing_stats` is already gated one function below, which is the established pattern in this module for environment gates as opposed to pod-role gates. `:web` behaviour in dev and production is unchanged.

The alternative would be probing for a Chrome binary before starting the pool. That is a larger change that alters production start-up behaviour to fix a test-only problem, so the targeted gate was preferred.

Both docstrings are corrected to describe the real mechanism, because the inaccurate version makes the `:ignore` branch look like it already covers a missing Chrome, which is exactly the assumption that let this regress three times.

Excluding `:test` is safe. The suite never needs the pool: `Tuist.OpenGraphImageRenderer` is Mimic-stubbed wherever a test exercises Open Graph rendering, and the renderer test starts its own task supervisor.

### The Fontconfig line is unrelated and stays

The same logs carry a `Fontconfig error: Cannot load default config file` line. It cannot come from Chrome, since Chrome never launches, which is what `:chrome_not_found` means. It comes from libvips: `Tuist.Marketing.OpenGraph` renders the fallback card through `Image.Text.text/2`, and on Linux that path reaches fontconfig via pango while the runner image ships no `/etc/fonts/fonts.conf`. It prints once per run, the render still succeeds, and it does not reproduce on macOS because the precompiled libvips there links CoreText instead. One line per run, so it is not part of the noise problem, and silencing it would mean changing the runner image.

Worth a separate look: with fontconfig unconfigured, the fallback card most likely renders in a default font rather than Inter Variable, and the tests only assert that a binary comes back, so that would go unnoticed. This affects CI-rendered fallbacks only, not production.

### Impact

CI Server test logs lose roughly 2,000 lines of interleaved stack traces per run, so a real failure is visible again. No runtime behaviour changes in dev or production.

### How to test locally

The pool starts locally too, because `TUIST_HOSTED=1` comes from `mise.toml`, so the regression test is red without the fix:

```bash
cd server && mix test test/tuist/open_graph_image_renderer_test.exs
```

To see the actual error flood, simulate a host without Chrome. Before the change this prints 95 error blocks in a 17-test run, and after it prints none:

```bash
cd server && TUIST_OG_IMAGE_CHROME_PATH=/nonexistent/chrome mix test test/tuist/open_graph_image_templates_test.exs test/tuist_web/controllers/open_graph_image_controller_test.exs
```

### Validation

- The added regression test was confirmed red before the fix, then green.
- OG-related suites pass: `open_graph_image_renderer_test`, `open_graph_image_templates_test`, `open_graph_images_test`, `open_graph_image_controller_test`, `open_graph_test`, `runtime_children_test`, 30 tests.
- Full `mix test --warnings-as-errors`, the CI invocation: 6752/6757 passed, with zero chrome lines and zero fontconfig lines. The 5 failures are pre-existing and reproduce identically on a clean tree with the change stashed, 0/5 either way. Four are the local single-locale compile gap that CI covers with `TUIST_DEV_ALL_LOCALES=1`, and the fifth is an unrelated `RunnerJobLive` test.
- `mix format --check-formatted` and `mix credo` are clean.
