### PR TITLE
fix(infra): harden the guest-writable status share readers against symlinks and FIFOs

### DIFF
--- a/infra/tart-kubelet/internal/podagent/guest_file_test.go
+++ b/infra/tart-kubelet/internal/podagent/guest_file_test.go
@@ -1,0 +1,151 @@
+package podagent
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The status share is a writable virtio-fs mount the guest owns, and the guest
+// runs untrusted customer CI. Every reader below therefore takes an
+// attacker-chosen path holding attacker-chosen content. A symlink makes the
+// host resolve and read some other file on the guest's behalf; a FIFO parks the
+// host inside the open itself until something writes to the other end, wedging
+// the reconcile for as long as the guest cares to hold it.
+var guestStatusReaders = []struct {
+	name string
+	file string
+	// content is content this reader accepts. Used twice: as the symlink
+	// target's body, so a rejected read proves the link was not followed
+	// rather than proving the target merely failed to parse; and as the
+	// well-formed file that must keep being accepted.
+	content string
+	// accepted reports whether the reader came back with something the
+	// caller would act on.
+	accepted func(statusDir string) bool
+}{
+	{
+		name:    "runner-rc",
+		file:    runnerExitFile,
+		content: "7\n",
+		accepted: func(d string) bool {
+			_, ok := readRunnerExit(d)
+			return ok
+		},
+	},
+	{
+		name:    "runner-rc mtime",
+		file:    runnerExitFile,
+		content: "7\n",
+		accepted: func(d string) bool {
+			_, ok := readRunnerExitTime(d)
+			return ok
+		},
+	},
+	{
+		name:     "volume-upload-ms",
+		file:     uploadMillisFile,
+		content:  "4200\n",
+		accepted: func(d string) bool { return readUploadMillis(d) != -1 },
+	},
+	{
+		name:     "cache-fill-percent",
+		file:     fillPercentFile,
+		content:  "42\n",
+		accepted: func(d string) bool { return readFillPercent(d) != -1 },
+	},
+	{
+		name:     "cache-promote-result",
+		file:     promoteResultFile,
+		content:  "accepted 9\n",
+		accepted: func(d string) bool { return readPromoteResult(d).Result != "" },
+	},
+	{
+		name:     "volume-head.json",
+		file:     volumeHeadFile,
+		content:  `{"generation":9,"digest":"deadbeef","download_url":"https://example.invalid/head"}`,
+		accepted: func(d string) bool { return readVolumeHead(d) != nil },
+	},
+	{
+		name:    "cache-dirty",
+		file:    dirtyMarkerFile,
+		content: "1\n",
+		accepted: func(d string) bool {
+			present, _ := readDirtyMarker(d)
+			return present
+		},
+	},
+}
+
+// The happy path is the whole point of the hardening being narrow: a guest that
+// writes a plain file must keep being read exactly as before.
+func TestGuestStatusReadersAcceptRegularFile(t *testing.T) {
+	for _, tc := range guestStatusReaders {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if !tc.accepted(dir) {
+				t.Error("reader rejected a well-formed guest file")
+			}
+		})
+	}
+}
+
+func TestGuestStatusReadersRejectSymlink(t *testing.T) {
+	for _, tc := range guestStatusReaders {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			secret := filepath.Join(t.TempDir(), "host-secret")
+			if err := os.WriteFile(secret, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write secret: %v", err)
+			}
+			if err := os.Symlink(secret, filepath.Join(dir, tc.file)); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+			if tc.accepted(dir) {
+				t.Error("guest symlink to a host file was followed")
+			}
+		})
+	}
+}
+
+func TestGuestStatusReadersDoNotBlockOnFIFO(t *testing.T) {
+	for _, tc := range guestStatusReaders {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := syscall.Mkfifo(filepath.Join(dir, tc.file), 0o600); err != nil {
+				t.Skipf("mkfifo unsupported: %v", err)
+			}
+
+			done := make(chan bool, 1)
+			go func() { done <- tc.accepted(dir) }()
+
+			select {
+			case ok := <-done:
+				if ok {
+					t.Error("reader accepted a FIFO")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("reader blocked on a guest-planted FIFO")
+			}
+		})
+	}
+}
+
+func TestGuestStatusReadersRejectDirectory(t *testing.T) {
+	for _, tc := range guestStatusReaders {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, tc.file), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if tc.accepted(dir) {
+				t.Error("reader accepted a directory")
+			}
+		})
+	}
+}

--- a/infra/tart-kubelet/internal/podagent/volume_reconcile.go
+++ b/infra/tart-kubelet/internal/podagent/volume_reconcile.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -82,6 +84,67 @@ const dirtyMarkerFile = "cache-dirty"
 // see runnerTermination.
 const runnerExitFile = "runner-rc"
 
+// openGuestFile opens a file the guest wrote into the status share and requires
+// it to be a plain file. Both the path and its contents are attacker-chosen: the
+// share is writable by the guest, and the guest runs untrusted customer CI.
+// O_NOFOLLOW stops a guest-planted symlink from making the host resolve and read
+// some other file on its behalf. O_NONBLOCK stops a FIFO from parking the caller
+// inside the open until something writes to the other end, which nothing ever
+// does: one job could otherwise wedge a reconcile for as long as it liked. The
+// regular-file check cannot stand in for O_NONBLOCK there, because it never runs
+// if the open never returns.
+//
+// Returns the handle and its stat together, so a reader that wants metadata
+// rather than bytes fstats what it already opened instead of racing a second
+// path lookup against the guest.
+func openGuestFile(statusDir, name string) (*os.File, os.FileInfo, bool) {
+	if statusDir == "" {
+		return nil, nil, false
+	}
+	f, err := os.OpenFile(
+		filepath.Join(statusDir, name),
+		os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK,
+		0,
+	)
+	if err != nil {
+		return nil, nil, false
+	}
+	fi, err := f.Stat()
+	if err != nil || !fi.Mode().IsRegular() {
+		f.Close()
+		return nil, nil, false
+	}
+	return f, fi, true
+}
+
+// guestMarkerMaxBytes bounds the scalar markers: an exit code, a percentage, a
+// millisecond count, a promote outcome. Set orders of magnitude above anything
+// the guest legitimately writes, so it binds only on a file the host has no
+// reason to be holding in memory in the first place.
+const guestMarkerMaxBytes = 4 << 10
+
+// guestHeadMaxBytes bounds volume-head.json, whose presigned download URL is the
+// one field that is not a handful of bytes.
+const guestHeadMaxBytes = 64 << 10
+
+// readGuestFile returns the bytes of a guest-written status file, or false when
+// the guest left something other than a plain file. Oversize reads as absent
+// rather than truncated: every caller parses a whole value, and half of one is
+// not a value.
+func readGuestFile(statusDir, name string, maxBytes int64) ([]byte, bool) {
+	f, _, ok := openGuestFile(statusDir, name)
+	if !ok {
+		return nil, false
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil || int64(len(b)) > maxBytes {
+		return nil, false
+	}
+	return b, true
+}
+
 // readRunnerExit reads the guest-reported exit code from the status share.
 // The bool is false when the guest reported nothing usable.
 //
@@ -94,11 +157,8 @@ const runnerExitFile = "runner-rc"
 // this file exists to close. Out of range therefore reads as unreported,
 // the same as no file at all.
 func readRunnerExit(statusDir string) (int32, bool) {
-	if statusDir == "" {
-		return 0, false
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, runnerExitFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, runnerExitFile, guestMarkerMaxBytes)
+	if !ok {
 		return 0, false
 	}
 	// ParseInt over Atoi so an oversized value fails here rather than
@@ -114,13 +174,11 @@ func readRunnerExit(statusDir string) (int32, bool) {
 // is the moment it halted. Used to date a stop on the recovered path,
 // where no `tart run` handle survived to have observed the exit itself.
 func readRunnerExitTime(statusDir string) (time.Time, bool) {
-	if statusDir == "" {
+	f, fi, ok := openGuestFile(statusDir, runnerExitFile)
+	if !ok {
 		return time.Time{}, false
 	}
-	fi, err := os.Stat(filepath.Join(statusDir, runnerExitFile))
-	if err != nil {
-		return time.Time{}, false
-	}
+	defer f.Close()
 	return fi.ModTime(), true
 }
 
@@ -321,11 +379,8 @@ const uploadMillisFile = "volume-upload-ms"
 // readUploadMillis returns the guest-reported upload duration in ms, or -1 when
 // absent (no promote, or the job did not upload).
 func readUploadMillis(statusDir string) int64 {
-	if statusDir == "" {
-		return -1
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, uploadMillisFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, uploadMillisFile, guestMarkerMaxBytes)
+	if !ok {
 		return -1
 	}
 	ms, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
@@ -343,11 +398,8 @@ const fillPercentFile = "cache-fill-percent"
 
 // readFillPercent returns the guest-reported image fill %, or -1 when absent.
 func readFillPercent(statusDir string) int {
-	if statusDir == "" {
-		return -1
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, fillPercentFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, fillPercentFile, guestMarkerMaxBytes)
+	if !ok {
 		return -1
 	}
 	pct, err := strconv.Atoi(strings.TrimSpace(string(b)))
@@ -415,11 +467,8 @@ type promoteResult struct {
 
 // readPromoteResult parses the guest-relayed promote outcome.
 func readPromoteResult(statusDir string) promoteResult {
-	if statusDir == "" {
-		return promoteResult{}
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, promoteResultFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, promoteResultFile, guestMarkerMaxBytes)
+	if !ok {
 		return promoteResult{}
 	}
 	fields := strings.Fields(string(b))
@@ -455,11 +504,8 @@ type volumeHead struct {
 }
 
 func readVolumeHead(statusDir string) *volumeHead {
-	if statusDir == "" {
-		return nil
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, volumeHeadFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, volumeHeadFile, guestHeadMaxBytes)
+	if !ok {
 		return nil
 	}
 	var h volumeHead
@@ -729,11 +775,8 @@ func (r *Reconciler) finalizeVolume(entry *Entry, actualAccount string, cleanExi
 // Returns (present, dirty): present is false when the guest never wrote it
 // (crashed / incomplete job), which the caller treats as "discard".
 func readDirtyMarker(statusDir string) (present, dirty bool) {
-	if statusDir == "" {
-		return false, false
-	}
-	b, err := os.ReadFile(filepath.Join(statusDir, dirtyMarkerFile))
-	if err != nil {
+	b, ok := readGuestFile(statusDir, dirtyMarkerFile, guestMarkerMaxBytes)
+	if !ok {
 		return false, false
 	}
 	return true, strings.TrimSpace(string(b)) == "1"


### PR DESCRIPTION
## What changed

Seven readers of the guest-writable status share in `tart-kubelet` now open with `O_NOFOLLOW|O_NONBLOCK` and require a regular file, routed through a single pair of helpers in `infra/tart-kubelet/internal/podagent/volume_reconcile.go`:

| Function | File |
| --- | --- |
| `readRunnerExit` | `runner-rc` |
| `readRunnerExitTime` | `runner-rc` |
| `readUploadMillis` | `volume-upload-ms` |
| `readFillPercent` | `cache-fill-percent` |
| `readPromoteResult` | `cache-promote-result` |
| `readVolumeHead` | `volume-head.json` |
| `readDirtyMarker` | `cache-dirty` |

`openGuestFile` does the open and the `Mode().IsRegular()` check, returning the handle and its stat together. `readGuestFile` layers on top for the six that want bytes. `readRunnerExitTime` takes `ModTime()` off the handle it already opened.

## Why

The status share is a writable virtio-fs mount at `/Volumes/My Shared Files/status`, and the guest runs untrusted customer CI. Every file the host reads back therefore sits at an attacker-chosen path holding attacker-chosen content. Six of these readers used `os.ReadFile` and `readRunnerExitTime` used `os.Stat`; both resolve symbolic links, and `os.ReadFile` parks inside the `open` when the path is a FIFO nothing ever writes to.

**Availability is the sharper edge.** A job that leaves a FIFO at `cache-dirty` or `runner-rc` wedges a tart-kubelet reconcile indefinitely, from inside the job, at no cost to itself. The share is fresh per VM, so the blast radius is that VM's own job, which is exactly the case that matters: the job is the attacker.

**Disclosure is mostly blunted but not zero.** Most of these parse into tightly constrained values (an int 0-255, a percentage, a millisecond count), so a symlink to a host file usually just fails to parse. `readVolumeHead` is the exception worth flagging to a reviewer: it parses JSON and its contents, including `tree_digest`, flow onward to the server.

## Root cause and precedent

Same bug, same share, same shape as the one found in review on https://github.com/tuist/tuist/pull/12492 and fixed for `readRunnerLog` in `19329b21b7`. That fix hardened one reader; these were the remaining seven. This PR uses that commit as the template.

Note that `19329b21b7` is not an ancestor of this branch, so `readRunnerLog` does not exist here and there was nothing to rewrite onto the shared helper. When #12492 lands, pointing it at `readGuestFile(statusDir, runnerLogFile, ...)` is a two-line follow-up. It is not a correctness gap either way, since that reader is already hardened on its own branch.

## Why a helper rather than seven copies

Eight call sites with identical needs. Copy-pasting the flag set seven more times makes the next reader added to this file a coin flip on whether the author remembers both flags. The `openGuestFile` / `readGuestFile` split exists because `readRunnerExitTime` wants metadata rather than bytes, and fstat-ing the handle it already holds is strictly better than the `os.Lstat` alternative: there is no second path lookup for the guest to win.

## One thing to push back on if you disagree

`readGuestFile` takes a `maxBytes` bound: 4 KiB for the scalar markers, 64 KiB for `volume-head.json`, whose presigned download URL is the one field that is not tiny. Oversize reads as absent rather than truncated, since every caller parses a whole value and half of one is not a value.

This goes slightly past a strict symlink-and-FIFO fix. The reasoning: an unbounded `io.ReadAll` of a guest-controlled regular file is the same availability problem wearing a different hat, and the limits sit orders of magnitude above anything a real guest writes, so they cannot bind on the happy path. Happy to drop it if you would rather keep the diff strictly scoped.

## Impact

No behaviour change for a well-behaved guest. A guest writing a plain file is read exactly as before, and a test asserts that for all seven readers. No protocol change: nothing about what the guest writes or how it is parsed moves.

## Validation

Tests were written first and failed loudly before the fix, which matters most for the FIFO case:

| | before | after |
| --- | --- | --- |
| symlink followed | 7 / 7 | 0 / 7 |
| FIFO blocked full 5s timeout | 6 / 7 | 0 / 7 |
| `readRunnerExitTime` accepts FIFO and directory | yes | no |
| podagent suite wall-clock | 30.7s | 8.3s |

The 30 seconds was almost entirely readers sitting in `open`. Directory cases already passed for the `os.ReadFile` readers via `EISDIR`; kept anyway, mirroring the precedent's coverage.

Full validation, with `go clean -testcache` first, all green:

```
cd infra/tart-kubelet && gofmt -l internal/ && go vet ./... && go build ./... && go test ./...
```

Also swept the package for any other read against `statusDir` that might have been missed. There are none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
