### PR TITLE
fix(cli): generate macros as host build tools

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "16c29ce833f01572bc6afd554ec70177e2bd993c456ced7d61924a7705268d9f",
+  "originHash" : "35d76794b53a6a0577a17df5267c01f210145ab4a6b9a5b58b67a72d4f5ee17f",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -719,7 +719,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "9.14.0"
+        "version" : "9.16.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1843,7 +1843,7 @@ let package = Package(
         .package(id: "kishikawakatsumi.KeychainAccess", from: "4.2.2"),
         .package(id: "stencilproject.Stencil", exact: "0.15.1"),
         .package(id: "tuist.GraphViz", exact: "0.4.2"),
-        .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.14.0")),
+        .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.16.0")),
         .package(id: "cpisciotta.xcbeautify", from: "3.1.0"),
         .package(id: "krzysztofzablocki.Difference", from: "1.0.2"),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),

--- a/cli/Sources/TuistCore/Graph/ModelExtensions/Product+Core.swift
+++ b/cli/Sources/TuistCore/Graph/ModelExtensions/Product+Core.swift
@@ -45,7 +45,7 @@ extension Product {
         case .commandLineTool:
             return .commandLineTool
         case .macro:
-            return .commandLineTool
+            return .hostBuildTool
         case .appClip:
             return .onDemandInstallCapableApplication
         case .xpc:

--- a/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -206,11 +206,14 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
                 lhs: lhsFile.location.path,
                 rhs: rhsFile.location.path
             )
-        case let (.group(lhsGroup), .group(rhsGroup)):
+        case let (.group(lhsGroup), .group(rhsGroup)),
+             let (.group(lhsGroup), .fileSystemSynchronizedGroup(rhsGroup)),
+             let (.fileSystemSynchronizedGroup(lhsGroup), .group(rhsGroup)),
+             let (.fileSystemSynchronizedGroup(lhsGroup), .fileSystemSynchronizedGroup(rhsGroup)):
             return lhsGroup.location.path < rhsGroup.location.path
-        case (.file, .group):
+        case (.file, .group), (.file, .fileSystemSynchronizedGroup):
             return true
-        case (.group, .file):
+        case (.group, .file), (.fileSystemSynchronizedGroup, .file):
             return false
         }
     }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -319,7 +319,7 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
                 if refPath.extension == "xcodeproj" {
                     paths.append(refPath)
                 }
-            case let .group(group):
+            case let .group(group), let .fileSystemSynchronizedGroup(group):
                 // Set a new src root to account for projects in nested directories
                 let recursiveRoot = srcPath.appending(component: group.location.path)
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Targets/TargetDependency+GraphMapping.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Targets/TargetDependency+GraphMapping.swift
@@ -187,6 +187,8 @@ extension PBXProductType {
             return .extensionKitExtension
         case .commandLineTool:
             return .commandLineTool
+        case .hostBuildTool:
+            return .macro
         case .messagesExtension:
             return .messagesExtension
         case .stickerPack:

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Workspace/XCWorkspaceMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Workspace/XCWorkspaceMapper.swift
@@ -88,7 +88,7 @@ struct XCWorkspaceMapper: WorkspaceMapping {
                 if refPath.fileExtension == .xcodeproj {
                     paths.append(refPath)
                 }
-            case let .group(group):
+            case let .group(group), let .fileSystemSynchronizedGroup(group):
                 // For each group, create a nested source path and recurse.
                 let nestedSrcPath = srcPath.appending(component: group.location.path)
                 let groupPaths = try await extractProjectPaths(

--- a/cli/Tests/TuistGeneratorTests/Generator/StableStructureIntegrationTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/StableStructureIntegrationTests.swift
@@ -126,7 +126,7 @@ extension XCWorkspaceDataElement {
         case let .file(file):
             let path = file.location.path
             return path.hasSuffix(".xcodeproj") ? [path] : []
-        case let .group(elements):
+        case let .group(elements), let .fileSystemSynchronizedGroup(elements):
             return elements.children.flatMap(\.projectPaths)
         }
     }

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -101,6 +101,40 @@ struct TargetGeneratorTests {
         #expect(exception.platformFiltersByRelativePath == ["Resources/ios_only.mp4": ["ios"]])
     }
 
+    @Test func generateTarget_macro_usesHostBuildToolProductType() async throws {
+        // Given
+        let target = Target.test(name: "MacroImplementation", destinations: [.mac], product: .macro)
+        let project = Project.test(
+            path: path,
+            sourceRootPath: path,
+            xcodeProjPath: path.appending(component: "Test.xcodeproj"),
+            targets: [target]
+        )
+        let graphTraverser = GraphTraverser(graph: .test())
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // When
+        let (generatedTarget, _) = try await subject.generateTarget(
+            target: target,
+            project: project,
+            pbxproj: pbxproj,
+            pbxProject: pbxProject,
+            projectSettings: .test(),
+            fileElements: fileElements,
+            path: path,
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        #expect(generatedTarget.productType == .hostBuildTool)
+    }
+
     @Test func generateTarget_synchronizedGroups_mapsTargetHeadersIntoSynchronizedExceptions() async throws {
         // Given
         let buildableFolderPath = path.appending(component: "Sources")

--- a/cli/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
@@ -225,7 +225,7 @@ extension XCWorkspaceDataElement: CustomDebugStringConvertible {
         switch self {
         case let .file(file):
             return file.location.path
-        case let .group(group):
+        case let .group(group), let .fileSystemSynchronizedGroup(group):
             return group.debugDescription
         }
     }

--- a/cli/Tests/XcodeGraphMapperTests/MapperTests/Target/TargetDependencyExtensionsTests.swift
+++ b/cli/Tests/XcodeGraphMapperTests/MapperTests/Target/TargetDependencyExtensionsTests.swift
@@ -9,6 +9,11 @@ struct TargetDependencyExtensionsTests {
     let sourceDirectory = AssertionsTesting.fixturePath()
     let target = Target.test(platform: .iOS)
 
+    @Test("Maps host build tools to macros")
+    func mapProductType_HostBuildTool() {
+        #expect(PBXProductType.hostBuildTool.mapProductType() == .macro)
+    }
+
     @Test("Resolves a target dependency into a target graph dependency")
     func targetGraphDependency_Target() async throws {
         // Given

--- a/cli/Tests/XcodeGraphMapperTests/MapperTests/Workspace/XCWorkspaceMapperTests.swift
+++ b/cli/Tests/XcodeGraphMapperTests/MapperTests/Workspace/XCWorkspaceMapperTests.swift
@@ -54,6 +54,29 @@ struct XCWorkspaceMapperTests {
         #expect(workspace.schemes.isEmpty == true)
     }
 
+    @Test("Maps projects in synchronized workspace groups")
+    func map_FileSystemSynchronizedGroup() async throws {
+        // Given
+        let workspacePath = try AbsolutePath(validating: "/tmp/MyWorkspace.xcworkspace")
+        let workspaceDir = workspacePath.parentDirectory
+        let xcworkspace = XCWorkspace.test(
+            withElements: [
+                .fileSystemSynchronizedGroup(XCWorkspaceDataGroup(
+                    location: .group("NestedGroup"),
+                    name: "NestedGroup",
+                    children: [.test(relativePath: "Project.xcodeproj")]
+                )),
+            ], path: workspacePath.pathString
+        )
+        let mapper = XCWorkspaceMapper()
+
+        // When
+        let workspace = try await mapper.map(xcworkspace: xcworkspace)
+
+        // Then
+        #expect(workspace.projects == [workspaceDir.appending(components: ["NestedGroup", "Project.xcodeproj"])])
+    }
+
     @Test("Maps workspace with shared schemes")
     func map_WithSchemes() async throws {
         // Given


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/12207

## What changed

- Updated XcodeProj to version 9.16.0 and generate macro targets as host-build tools.
- Map host-build tools back to macro products when importing an existing Xcode project.
- Handle synchronized workspace groups introduced by the XcodeProj update.
- Added focused regression coverage for macro product types and synchronized workspace groups.

## Why

Xcode's indexing build preparation includes host-build tools but does not include ordinary command-line tools. Macro executables therefore need the dedicated host-build product type.

## Root cause

Tuist generated Swift macro targets as ordinary command-line tools. Their executables were not available to Xcode's index preparation under custom build configurations.

## Approach

Use the product type exposed by XcodeProj 9.16.0. This makes the macro executable part of the host build without restoring the former copy phase, which had caused duplicate output and incremental-build problems.

## Impact

Generated projects can compile and index community Swift macros under custom configurations, including Point-Free's CasePaths macro package.

### How to test locally

- `mise run cli:lint`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`
- Generate and build `examples/xcode/generated_framework_with_native_swift_macro` with Xcode.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace '-only-testing:TuistGeneratorTests/TargetGeneratorTests/generateTarget_macro_usesHostBuildToolProductType()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`
