### PR TITLE
fix(swifterpm,cli): load local packages at their declared path

### DIFF
--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -224,6 +224,17 @@ enum ManifestFileSystemDependencyGraph {
                 parentPackageDir: item.parentPackageDir,
                 dependency: item.dependency
             )
+            // Resolving symlinks identifies the package, so two declared paths reaching the
+            // same directory are visited once and a cycle through a link terminates. It must
+            // not choose where the dump runs: SwiftPM loads a local dependency at the path the
+            // manifest declared, and reports it that way in `dump-package` output and in
+            // `workspace-state.json`, so dumping the resolved directory instead makes
+            // swifterpm disagree with SwiftPM about where a package lives. A declared path
+            // that is a symlink then dumps whatever its target resolves to, which is a package
+            // nobody declared when the link leaves the package's own directory: the dump either
+            // fails against a directory the manifest never named, or succeeds against the wrong
+            // manifest. `chdir` follows the link on its own, so the declared path reaches the
+            // same package without the substitution.
             let canonicalPath = PathCanonicalizer.realpath(packagePath)
             guard seenPackagePaths.insert(canonicalPath.path).inserted else {
                 continue
@@ -232,7 +243,7 @@ enum ManifestFileSystemDependencyGraph {
             let manifest: Any
             do {
                 manifest = try await ManifestLoader.dumpPackage(
-                    packageDir: canonicalPath,
+                    packageDir: packagePath,
                     disableSandbox: disableSandbox
                 )
             } catch {
@@ -248,10 +259,14 @@ enum ManifestFileSystemDependencyGraph {
             result.append(
                 ManifestFileSystemPackage(
                     dependency: item.dependency,
-                    packagePath: canonicalPath,
+                    packagePath: packagePath,
                     manifest: manifest
                 )
             )
+            // A child's own path is resolved against the parent's real directory, not its
+            // declared one: `packagePathForFileSystemDependency` folds `..` textually, which
+            // only matches the directory `chdir` would reach when no link was crossed on the
+            // way in. SwiftPM emits these paths absolute, so this is the defensive branch.
             for child in try ManifestParser.fileSystemDependencies(manifest) {
                 queue.append((parentPackageDir: canonicalPath, dependency: child))
             }
@@ -260,10 +275,11 @@ enum ManifestFileSystemDependencyGraph {
         return result
     }
 
-    /// The failure above names the directory the dump was attempted in, which is the declared
-    /// path only when nothing along the way is a symlink. When the two differ, that sentence
-    /// names a directory nobody declared and reads like a typo, while the redirect is the whole
-    /// diagnosis: a local dependency whose path lands somewhere other than the package.
+    /// The failure above names the declared path, because that is where the dump ran. When a
+    /// link on the way in sends that path somewhere else, the directory it lands in is the
+    /// whole diagnosis and nothing else in the message carries it: a manifest missing from the
+    /// declared path reads as a package that was never generated until you can see that the
+    /// path resolves out of the package's own directory.
     private static func redirect(declared: String, canonical: URL) -> String {
         canonical.path == declared ? "" : ", which resolves to \(canonical.path),"
     }

--- a/swifterpm/Tests/swifterpmTests/ManifestTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestTests.swift
@@ -415,6 +415,119 @@ struct ManifestTests {
     }
 
     @Test
+    func localPackageDeclaredThroughASymlinkLoadsItAtTheDeclaredPath() async throws {
+        try await withTemporaryDirectory { directory in
+            // A local package reached through a symlink is ordinary in a monorepo: the
+            // directory is generated or shared and linked into place. SwiftPM loads it at the
+            // declared path and records that path in `workspace-state.json`, so swifterpm has
+            // to as well, or the two describe the same dependency by different directories.
+            let realPackageDir = directory.appendingPathComponent("store/Keys")
+            try await writeMinimalPackageManifest(at: realPackageDir, name: "Keys")
+            let rootPackageDir = directory.appendingPathComponent("app/Tuist")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            let declaredPackageDir = directory.appendingPathComponent("app/Packages/Keys")
+            try await fileSystem.makeDirectory(
+                at: declaredPackageDir.deletingLastPathComponent().absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            _ = try await SystemProcess.run(
+                "/bin/ln", ["-s", "../../store/Keys", declaredPackageDir.path])
+
+            let packages = try await ManifestFileSystemDependencyGraph.collect(
+                rootPackageDir: rootPackageDir,
+                rootManifest: [
+                    "dependencies": [
+                        ["fileSystem": [["identity": "keys", "path": declaredPackageDir.path]]]
+                    ]
+                ],
+                disableSandbox: true
+            )
+
+            #expect(packages.count == 1)
+            #expect(packages.first.map { ManifestParser.packageName($0.manifest) } == "Keys")
+            #expect(packages.first?.packagePath.path == declaredPackageDir.path)
+        }
+    }
+
+    @Test
+    func localPackageWhoseSymlinkLeavesTheDeclaredPathFailsAgainstThatPath() async throws {
+        try await withTemporaryDirectory { directory in
+            // The link resolves out of the package's own directory, so the declared path names
+            // a package and the directory it lands in holds none. Dumping the resolved
+            // directory reported a failure against a path the manifest never named, which read
+            // as a typo; the declared path is what the reader can act on, and the redirect is
+            // what tells them the link is the reason.
+            let rootPackageDir = directory.appendingPathComponent("app/Tuist")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            let declaredPackageDir = directory.appendingPathComponent("app/Packages/Keys")
+            try await fileSystem.makeDirectory(
+                at: declaredPackageDir.deletingLastPathComponent().absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            _ = try await SystemProcess.run("/bin/ln", ["-s", "..", declaredPackageDir.path])
+            let landsIn = PathCanonicalizer.realpath(declaredPackageDir)
+
+            do {
+                _ = try await ManifestFileSystemDependencyGraph.collect(
+                    rootPackageDir: rootPackageDir,
+                    rootManifest: [
+                        "dependencies": [
+                            ["fileSystem": [["identity": "keys", "path": declaredPackageDir.path]]]
+                        ]
+                    ],
+                    disableSandbox: true
+                )
+                Issue.record("expected the local package manifest to fail to load")
+            } catch {
+                let description = "\(error)"
+                #expect(description.contains("declared as \"\(declaredPackageDir.path)\""))
+                #expect(description.contains("which resolves to \(landsIn.path)"))
+                #expect(description.contains("no Package.swift in \(declaredPackageDir.path)"))
+            }
+        }
+    }
+
+    @Test
+    func localPackagesReachingTheSameDirectoryAreCollectedOnce() async throws {
+        try await withTemporaryDirectory { directory in
+            // Resolving symlinks still decides identity, which is what stops a diamond from
+            // dumping the same package twice and a link that points back up the tree from
+            // queueing for ever.
+            let realPackageDir = directory.appendingPathComponent("store/Feature")
+            try await writeMinimalPackageManifest(at: realPackageDir, name: "Feature")
+            let rootPackageDir = directory.appendingPathComponent("app/Tuist")
+            try await writeMinimalPackageManifest(at: rootPackageDir, name: "Root")
+            let packagesDir = directory.appendingPathComponent("app/Packages")
+            try await fileSystem.makeDirectory(
+                at: packagesDir.absolutePath, options: [.createTargetParentDirectories])
+            let first = packagesDir.appendingPathComponent("Feature")
+            let second = packagesDir.appendingPathComponent("FeatureAlias")
+            for link in [first, second] {
+                _ = try await SystemProcess.run(
+                    "/bin/ln", ["-s", "../../store/Feature", link.path])
+            }
+
+            let packages = try await ManifestFileSystemDependencyGraph.collect(
+                rootPackageDir: rootPackageDir,
+                rootManifest: [
+                    "dependencies": [
+                        [
+                            "fileSystem": [
+                                ["identity": "feature", "path": first.path],
+                                ["identity": "feature-alias", "path": second.path],
+                            ]
+                        ]
+                    ]
+                ],
+                disableSandbox: true
+            )
+
+            #expect(packages.count == 1)
+            #expect(packages.first?.packagePath.path == first.path)
+        }
+    }
+
+    @Test
     func dumpingASubdirectoryOfAPackageDoesNotStandInForTheEnclosingPackage() async throws {
         try await withTemporaryDirectory { directory in
             // Root resolution runs through the same dump and defaults to the working

--- a/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/PackageInfoCacheTests.swift
@@ -199,9 +199,9 @@ struct PackageInfoCacheTests {
                 packages.compactMap { $0["identity"] as? String } == [
                     "local-one", "local-two",
                 ])
-            #expect(
-                packages.first?["package_path"] as? String
-                    == PathCanonicalizer.realpath(localOne).path)
+            // The declared path, which is the one SwiftPM loads the dependency at and records
+            // for it, rather than wherever the links along it happen to land today.
+            #expect(packages.first?["package_path"] as? String == localOne.path)
             for package in packages {
                 let packageInfoPath = try #require(package["package_info_path"] as? String)
                 #expect(try await fileSystem.exists(URL(fileURLWithPath: packageInfoPath).absolutePath))

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -361,8 +361,12 @@ struct RestoreTests {
             )
 
             #expect(Set(refsByIdentity.keys) == ["local-one", "local-two"])
-            let expectedLocalOne = PathCanonicalizer.realpath(localOne).path
-            let expectedLocalTwo = PathCanonicalizer.realpath(localTwo).path
+            // SwiftPM writes a fileSystem dependency's `location` and `state.path` as the path
+            // the manifest declared, even when a link on the way in points somewhere else, so
+            // a workspace state that recorded the resolved directory described the same
+            // dependency by a directory SwiftPM never names.
+            let expectedLocalOne = localOne.path
+            let expectedLocalTwo = localTwo.path
             #expect(refsByIdentity["local-one"]?["location"] as? String == expectedLocalOne)
             #expect(refsByIdentity["local-two"]?["location"] as? String == expectedLocalTwo)
             #expect(


### PR DESCRIPTION
Local Swift package dependencies declared with `.package(path:)` were loaded from, and recorded as, a directory the manifest never named. That is a divergence from SwiftPM on its own, and it is also the mechanism behind an intermittent `tuist install` failure reported by a user on 4.203.4.

## What changed

`ManifestFileSystemDependencyGraph.collect` no longer lets the symlink-resolved path decide where the manifest dump runs or what the graph records. It now:

- runs `swift package dump-package` at the path the manifest declared
- stores that declared path on `ManifestFileSystemPackage`, so it flows into `workspace-state.json` and the package info cache rather than the resolved one
- keeps `PathCanonicalizer.realpath` for the visited-set key only, so a diamond is still collected once and a link pointing back up the tree still terminates

Three tests cover the symlink cases. Two existing tests in `RestoreTests` and `PackageInfoCacheTests` asserted the resolved path in workspace state and package info, and now assert the declared path.

## Why

SwiftPM loads a local dependency at the path the manifest declared. It does not resolve symlinks to decide that, and it records the declared path in both `dump-package` output and `workspace-state.json`. Verified against the shipping toolchain with a local package reached through a symlink:

```
swifterpm before   location : <root>/store/Keys
swifterpm after    location : <root>/app/Packages/Keys
stock SwiftPM      location : <root>/app/Packages/Keys
```

Any project with a symlinked local package therefore had Tuist describing the dependency by a directory SwiftPM never names, and that path reaches the generated project through the package info cache.

## Root cause

A user on 4.203.4 saw `tuist install` fail on roughly one continuous integration run in six with:

```
failed to load the manifest for the local package keys,
declared as ".../iAuditor/Packages/Keys" by .../iAuditor/Tuist:
no Package.swift in .../iAuditor:
error: Could not find Package.swift in this directory or any of its parent directories.
```

The two paths in that message differ by two components, because `collect` printed the declared path and then attributed the failure to the resolved one. Shell instrumentation from the same failing run showed that the declared path was a real directory holding a `Package.swift`, created before the run started and unchanged after it, and that libc `realpath` on that identical path resolved it to itself seconds after the failure.

So `PathCanonicalizer.realpath` returned a directory two levels above the declared package path for a path that libc resolves to itself. The dump then ran in that directory, which holds no manifest and has no ancestor package, and SwiftPM reported the generic message above. Why the resolved value was wrong is not established. This change makes the dump independent of it either way.

## Approach

Two alternatives were considered.

Improving the message only is what `redirect(declared:canonical:)` already does on `main`. It makes a recurrence legible, but the dump still runs in the wrong directory and the recorded path still diverges from SwiftPM's.

Removing `PathCanonicalizer.realpath` from `collect` entirely was rejected. Resolving symlinks is what keeps the traversal terminating when a declared path points back up the tree, and what stops a package reached by two declared spellings being collected twice.

Keeping it for identity and not for location gets both. `chdir` follows symlinks on its own, so the declared path reaches exactly the same package without the substitution, which is confirmed by the new test that loads a package through a symlink and asserts both the package name and the recorded path.

## Impact

- Projects with a symlinked local package now record the same `location` and `state.path` that SwiftPM writes for that dependency.
- Package info cache filenames hash `packagePath`, so the first run after this change re-dumps those entries once. No user action needed.
- No behaviour change for projects whose local packages are plain directories.
- A declared path that genuinely points at a directory with no package still fails, correctly, and now names the declared path instead of wherever the link landed.

## Validation

- `bazel test //:swifterpm_tests` from `swifterpm/`: 169 tests across 21 suites pass.
- Built the `swifterpm` binary before and after and ran both against a fixture shaped like the reported failure, confirming the recorded path changes to the declared one and matches stock SwiftPM's `workspace-state.json`.
- Confirmed with the shipping toolchain that `swift package dump-package` emits `fileSystem[].path` unresolved, and that `chdir` through a symlinked package directory resolves `packageKind.root` to the real package.

### How to test locally

```bash
cd swifterpm
mise exec -- bazel test --test_output=summary //:swifterpm_tests
```

To exercise the reported shape end to end:

```bash
cd swifterpm && mise exec -- bazel build //:swifterpm

# a local package reached through a symlink
mkdir -p /tmp/demo/app/Packages /tmp/demo/app/Tuist /tmp/demo/store/Keys/Sources/Keys
cat > /tmp/demo/store/Keys/Package.swift <<'EOF'
// swift-tools-version: 6.0
import PackageDescription
let package = Package(name: "Keys", products: [.library(name: "Keys", targets: ["Keys"])], targets: [.target(name: "Keys")])
EOF
echo "public enum Keys {}" > /tmp/demo/store/Keys/Sources/Keys/F.swift
cat > /tmp/demo/app/Tuist/Package.swift <<'EOF'
// swift-tools-version: 6.0
import PackageDescription
let package = Package(name: "Root", dependencies: [.package(path: "../Packages/Keys")])
EOF
ln -s ../../store/Keys /tmp/demo/app/Packages/Keys

./bazel-bin/swifterpm --package-path /tmp/demo/app/Tuist resolve
python3 -c "import json;print(json.load(open('/tmp/demo/app/Tuist/.build/workspace-state.json'))['object']['dependencies'][0]['packageRef']['location'])"
```

The printed location should be `/tmp/demo/app/Packages/Keys`, the declared path, which is what `swift package resolve` writes for the same fixture. Before this change it was `/tmp/demo/store/Keys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
