### PR TITLE
fix(server): cancel abandoned xcresult parses and make processor Pods identifiable

### DIFF
--- a/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
+++ b/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
@@ -181,6 +181,17 @@ spec:
                   name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
                   key: object-storage-secret-key
             {{- end }}
+            # Per-Pod identity for error reports and Oban bookkeeping.
+            # Every VM booted from the Tart image carries the image's
+            # hostname, and the release runs with distribution disabled
+            # (no POD_IP reaches rel/env.sh.eex through the tart-kubelet
+            # env mount), so both Sentry's default server_name and Oban's
+            # `attempted_by` fall back to that one shared string and
+            # collapse the fleet into a single identity.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if .Values.xcresultProcessor.tailscale.enabled }}
             # Per-VM tailnet identity. tailscale-up.sh inside the VM
             # reads TAILSCALE_AUTH_KEY at boot and joins the tailnet

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -466,6 +466,19 @@ if Enum.member?([:prod, :stag, :can, :preview, :dev], env) do
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 end
 
+# Identity of the instance this node runs as, when the platform supplies one.
+#
+# Sentry and Oban both default to the OS hostname. That is unique per Pod on
+# the Linux deployments, but every VM booted from the xcresult-processor Tart
+# image reports the image's hostname, so on that fleet the default names all
+# Pods identically and an event cannot be traced back to the Pod that produced
+# it. The chart binds POD_NAME to metadata.name there.
+pod_name =
+  case System.get_env("POD_NAME") do
+    name when is_binary(name) and name != "" -> name
+    _ -> nil
+  end
+
 if Tuist.Environment.error_tracking_enabled?() do
   config :sentry,
     client: TuistCommon.SentryHTTPClient,
@@ -475,6 +488,10 @@ if Tuist.Environment.error_tracking_enabled?() do
     enable_source_code_context: true,
     root_source_code_paths: [File.cwd!()],
     before_send: {Tuist.SentryEventFilter, :before_send}
+
+  if pod_name do
+    config :sentry, server_name: pod_name
+  end
 end
 
 if Tuist.Environment.env() not in [:test] do
@@ -685,6 +702,13 @@ config :tuist, Oban,
 
 if !RuntimeConfig.peer_eligible?(mode) do
   config :tuist, Oban, peer: false
+end
+
+# Oban stamps this onto `oban_jobs.attempted_by`, which is what makes per-Pod
+# throughput answerable: given the Pod a failure came from, the jobs it
+# completed over the same window say whether it was wedged or working.
+if pod_name do
+  config :tuist, Oban, node: pod_name
 end
 
 # Registry config.

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -1,67 +1,25 @@
 import Foundation
+import os
 import Path
 import XCResultParser
 
-/// Errors raised at the NIF boundary, where a path that failed `AbsolutePath`
-/// validation leaves nothing to build an `XCResultParserError` from. The
-/// messages mirror their `XCResultParserError` counterparts so a given failure
-/// reads the same whichever type carries it.
-enum XCResultNIFError: LocalizedError {
-    case timedOut(path: String, seconds: Int)
-    case failedToParseOutput(path: String)
-
-    var errorDescription: String? {
-        switch self {
-        case let .timedOut(path, seconds):
-            return "xcresult parsing timed out after \(seconds)s at \(path)"
-        case let .failedToParseOutput(path):
-            return "Failed to parse xcresult output at \(path)"
-        }
-    }
-}
-
-/// Carries the parse outcome from the Task that produces it to the NIF thread
-/// that reads it.
+/// Outcome of a parse in the form the C boundary carries.
 ///
-/// A parse that outlives its timeout keeps writing here after the NIF has
-/// returned, so the storage outlives the call (the Task holds the only
-/// remaining reference) and every access is serialised. Writing the outcome
-/// through `finalize` in the same critical section it is read from keeps a
-/// late write from replacing the value the caller is about to receive.
-private final class ParseResultBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var result: Result<TestSummary, Error>?
-
-    func store(_ value: Result<TestSummary, Error>) {
-        lock.lock()
-        defer { lock.unlock() }
-        result = value
-    }
-
-    func value() -> Result<TestSummary, Error>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return result
-    }
-
-    func finalize(with value: Result<TestSummary, Error>) -> Result<TestSummary, Error> {
-        lock.lock()
-        defer { lock.unlock() }
-        result = value
-        return value
-    }
+/// Failures are reduced to their message because that is all `parse_xcresult`
+/// writes back, and it keeps the value `Sendable` so it can cross from the
+/// parse task to the thread blocked on it.
+private enum ParseOutcome: Sendable {
+    case parsed(TestSummary)
+    case failed(String)
 }
 
-/// Seconds a parse may run before it is cancelled.
+/// Seconds a parse may run before it cancels itself.
 private let timeoutSeconds = 600
 
-/// Seconds a cancelled parse is given to unwind before the NIF returns.
-///
-/// Cancellation reaches the `xcresulttool`/`sips` child through Command's
-/// `continuation.onTermination`, which terminates the process. Waiting for that
-/// to land keeps the child from surviving as an orphan holding a
-/// `CommandRunner` process-limiter permit for the lifetime of the BEAM, and
-/// keeps it from writing into the temp directory the worker deletes next.
+/// Seconds a cancelled parse is given to unwind before the caller gives up on
+/// it. Cancellation reaches the `xcresulttool`/`sips` child through Command's
+/// `continuation.onTermination`, which terminates the process; a child that
+/// ignores it would otherwise hold this thread for the life of the BEAM.
 private let cancellationGraceSeconds = 30
 
 @_cdecl("parse_xcresult")
@@ -74,45 +32,41 @@ public func parseXCResult(
     let path = String(cString: pathPtr)
     let rootDir = String(cString: rootDirPtr)
 
-    let box = ParseResultBox()
+    let outcome = OSAllocatedUnfairLock<ParseOutcome?>(initialState: nil)
     let semaphore = DispatchSemaphore(value: 0)
 
-    let task = Task { @Sendable in
-        defer { semaphore.signal() }
-
+    let task = Task {
+        let value: ParseOutcome
         do {
-            let xcresultPath = try AbsolutePath(validating: path)
-            let rootDirectory = try AbsolutePath(validating: rootDir)
-            // The server worker passes its per-run temp dir as rootDir and
-            // removes it wholesale once the run is processed, so it's also
-            // a directory we can export attachments into — point them there
-            // so the worker's cleanup reclaims them instead of leaking them
-            // in a process-wide temp dir.
-            guard let parsed = try await XCResultParser().parse(
-                path: xcresultPath,
-                rootDirectory: rootDirectory,
-                attachmentsDirectory: rootDirectory
-            ) else {
-                box.store(.failure(XCResultParserError.failedToParseOutput(xcresultPath)))
-                return
-            }
-            box.store(.success(parsed))
+            let parsed = try await parse(path: path, rootDir: rootDir, timeout: timeoutSeconds)
+            value = .parsed(parsed)
         } catch {
-            box.store(.failure(error))
+            value = .failed(error.localizedDescription)
         }
+        outcome.withLock { $0 = value }
+        semaphore.signal()
     }
 
-    let outcome: Result<TestSummary, Error>
-    if semaphore.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
+    // The parse cancels itself at `timeoutSeconds` and the task group it runs
+    // in cannot return until that cancellation has been awaited, so reaching
+    // this deadline means the child never honoured it. Nothing is read from
+    // `outcome` on that path, so a late write cannot race the value returned.
+    let deadline = DispatchTime.now() + .seconds(timeoutSeconds + cancellationGraceSeconds)
+    guard semaphore.wait(timeout: deadline) == .success else {
         task.cancel()
-        _ = semaphore.wait(timeout: .now() + .seconds(cancellationGraceSeconds))
-        outcome = box.finalize(with: .failure(timedOutError(path: path, seconds: timeoutSeconds)))
-    } else {
-        outcome = box.value() ?? .failure(XCResultNIFError.failedToParseOutput(path: path))
+        return write(
+            timedOutMessage(path: path, seconds: timeoutSeconds),
+            outputPtr: outputPtr,
+            outputLen: outputLen
+        )
     }
 
-    switch outcome {
-    case let .success(parsed):
+    guard let value = outcome.withLock({ $0 }) else {
+        return write(failedToParseMessage(path: path), outputPtr: outputPtr, outputLen: outputLen)
+    }
+
+    switch value {
+    case let .parsed(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)
             let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: jsonData.count)
@@ -126,27 +80,67 @@ public func parseXCResult(
             outputLen.pointee = Int32(jsonData.count)
             return 0
         } catch {
-            return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+            return write(error.localizedDescription, outputPtr: outputPtr, outputLen: outputLen)
         }
-    case let .failure(error):
-        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+    case let .failed(message):
+        return write(message, outputPtr: outputPtr, outputLen: outputLen)
     }
 }
 
-private func timedOutError(path: String, seconds: Int) -> Error {
-    guard let xcresultPath = try? AbsolutePath(validating: path) else {
-        return XCResultNIFError.timedOut(path: path, seconds: seconds)
+/// Runs the parse against a deadline, racing it with a sleeping sibling.
+///
+/// Losing the race cancels the winner's sibling, and the group cannot return
+/// until every child has been awaited, so a timed-out parse is torn down
+/// before the caller sees the error rather than left running with a
+/// `CommandRunner` process-limiter permit and a temp directory the worker is
+/// about to delete.
+private func parse(path: String, rootDir: String, timeout: Int) async throws -> TestSummary {
+    let xcresultPath = try AbsolutePath(validating: path)
+    let rootDirectory = try AbsolutePath(validating: rootDir)
+
+    return try await withThrowingTaskGroup(of: TestSummary?.self) { group in
+        group.addTask {
+            // The server worker passes its per-run temp dir as rootDir and
+            // removes it wholesale once the run is processed, so it's also
+            // a directory we can export attachments into — point them there
+            // so the worker's cleanup reclaims them instead of leaking them
+            // in a process-wide temp dir.
+            try await XCResultParser().parse(
+                path: xcresultPath,
+                rootDirectory: rootDirectory,
+                attachmentsDirectory: rootDirectory
+            )
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(timeout))
+            throw XCResultParserError.timedOut(xcresultPath, seconds: timeout)
+        }
+
+        defer { group.cancelAll() }
+
+        guard let finished = try await group.next(), let parsed = finished else {
+            throw XCResultParserError.failedToParseOutput(xcresultPath)
+        }
+        return parsed
     }
-    return XCResultParserError.timedOut(xcresultPath, seconds: seconds)
 }
 
-private func writeError(
-    _ error: Error,
+/// Mirror `XCResultParserError`'s descriptions, for the paths where no
+/// validated `AbsolutePath` is at hand to build the error itself from.
+private func timedOutMessage(path: String, seconds: Int) -> String {
+    "xcresult parsing timed out after \(seconds)s at \(path)"
+}
+
+private func failedToParseMessage(path: String) -> String {
+    "Failed to parse xcresult output at \(path)"
+}
+
+private func write(
+    _ message: String,
     outputPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     outputLen: UnsafeMutablePointer<Int32>
 ) -> Int32 {
-    let errorJSON =
-        "{\"error\": \"\(error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\""))\"}"
+    let errorJSON = "{\"error\": \"\(message.replacingOccurrences(of: "\"", with: "\\\""))\"}"
     let data = Array(errorJSON.utf8)
     let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: data.count)
     for (i, byte) in data.enumerated() {

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -2,6 +2,68 @@ import Foundation
 import Path
 import XCResultParser
 
+/// Errors raised at the NIF boundary, where a path that failed `AbsolutePath`
+/// validation leaves nothing to build an `XCResultParserError` from. The
+/// messages mirror their `XCResultParserError` counterparts so a given failure
+/// reads the same whichever type carries it.
+enum XCResultNIFError: LocalizedError {
+    case timedOut(path: String, seconds: Int)
+    case failedToParseOutput(path: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .timedOut(path, seconds):
+            return "xcresult parsing timed out after \(seconds)s at \(path)"
+        case let .failedToParseOutput(path):
+            return "Failed to parse xcresult output at \(path)"
+        }
+    }
+}
+
+/// Carries the parse outcome from the Task that produces it to the NIF thread
+/// that reads it.
+///
+/// A parse that outlives its timeout keeps writing here after the NIF has
+/// returned, so the storage outlives the call (the Task holds the only
+/// remaining reference) and every access is serialised. Writing the outcome
+/// through `finalize` in the same critical section it is read from keeps a
+/// late write from replacing the value the caller is about to receive.
+private final class ParseResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<TestSummary, Error>?
+
+    func store(_ value: Result<TestSummary, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        result = value
+    }
+
+    func value() -> Result<TestSummary, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return result
+    }
+
+    func finalize(with value: Result<TestSummary, Error>) -> Result<TestSummary, Error> {
+        lock.lock()
+        defer { lock.unlock() }
+        result = value
+        return value
+    }
+}
+
+/// Seconds a parse may run before it is cancelled.
+private let timeoutSeconds = 600
+
+/// Seconds a cancelled parse is given to unwind before the NIF returns.
+///
+/// Cancellation reaches the `xcresulttool`/`sips` child through Command's
+/// `continuation.onTermination`, which terminates the process. Waiting for that
+/// to land keeps the child from surviving as an orphan holding a
+/// `CommandRunner` process-limiter permit for the lifetime of the BEAM, and
+/// keeps it from writing into the temp directory the worker deletes next.
+private let cancellationGraceSeconds = 30
+
 @_cdecl("parse_xcresult")
 public func parseXCResult(
     _ pathPtr: UnsafePointer<CChar>,
@@ -12,12 +74,12 @@ public func parseXCResult(
     let path = String(cString: pathPtr)
     let rootDir = String(cString: rootDirPtr)
 
-    nonisolated(unsafe) var result: Result<TestSummary, Error> = .failure(
-        XCResultParserError.failedToParseOutput(try! AbsolutePath(validating: path))
-    )
+    let box = ParseResultBox()
     let semaphore = DispatchSemaphore(value: 0)
 
-    Task { @Sendable in
+    let task = Task { @Sendable in
+        defer { semaphore.signal() }
+
         do {
             let xcresultPath = try AbsolutePath(validating: path)
             let rootDirectory = try AbsolutePath(validating: rootDir)
@@ -31,24 +93,25 @@ public func parseXCResult(
                 rootDirectory: rootDirectory,
                 attachmentsDirectory: rootDirectory
             ) else {
-                result = .failure(XCResultParserError.failedToParseOutput(xcresultPath))
-                semaphore.signal()
+                box.store(.failure(XCResultParserError.failedToParseOutput(xcresultPath)))
                 return
             }
-            result = .success(parsed)
+            box.store(.success(parsed))
         } catch {
-            result = .failure(error)
+            box.store(.failure(error))
         }
-        semaphore.signal()
     }
 
-    let timeoutSeconds = 600
-    let timeout = semaphore.wait(timeout: .now() + .seconds(timeoutSeconds))
-    if timeout == .timedOut {
-        result = .failure(XCResultParserError.timedOut(try! AbsolutePath(validating: path), seconds: timeoutSeconds))
+    let outcome: Result<TestSummary, Error>
+    if semaphore.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
+        task.cancel()
+        _ = semaphore.wait(timeout: .now() + .seconds(cancellationGraceSeconds))
+        outcome = box.finalize(with: .failure(timedOutError(path: path, seconds: timeoutSeconds)))
+    } else {
+        outcome = box.value() ?? .failure(XCResultNIFError.failedToParseOutput(path: path))
     }
 
-    switch result {
+    switch outcome {
     case let .success(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)
@@ -68,6 +131,13 @@ public func parseXCResult(
     case let .failure(error):
         return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
     }
+}
+
+private func timedOutError(path: String, seconds: Int) -> Error {
+    guard let xcresultPath = try? AbsolutePath(validating: path) else {
+        return XCResultNIFError.timedOut(path: path, seconds: seconds)
+    }
+    return XCResultParserError.timedOut(xcresultPath, seconds: seconds)
 }
 
 private func writeError(

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -117,7 +117,9 @@ public struct XCResultParser: Sendable {
                 _ = try await commandRunner.run(
                     arguments: [
                         "/bin/sh", "-c",
-                        "/usr/bin/xcrun xcresulttool get test-results tests --path '\(path.pathString)' > '\(tempFile.pathString)'",
+                        // `exec` replaces the shell with the tool so cancellation, which signals
+                        // only the direct child, reaches xcresulttool instead of orphaning it.
+                        "exec /usr/bin/xcrun xcresulttool get test-results tests --path '\(path.pathString)' > '\(tempFile.pathString)'",
                     ]
                 ).concatenatedString()
 
@@ -727,7 +729,9 @@ public struct XCResultParser: Sendable {
             _ = try await commandRunner.run(
                 arguments: [
                     "/bin/sh", "-c",
-                    "/usr/bin/xcrun xcresulttool get log --type action --compact --path '\(xcresultPath.pathString)' > '\(tempFile.pathString)'",
+                    // `exec` replaces the shell with the tool so cancellation, which signals
+                    // only the direct child, reaches xcresulttool instead of orphaning it.
+                    "exec /usr/bin/xcrun xcresulttool get log --type action --compact --path '\(xcresultPath.pathString)' > '\(tempFile.pathString)'",
                 ]
             ).concatenatedString()
 
@@ -816,7 +820,9 @@ public struct XCResultParser: Sendable {
             _ = try await commandRunner.run(
                 arguments: [
                     "/bin/sh", "-c",
-                    "/usr/bin/xcrun xcresulttool export attachments --path '\(xcresultPath.pathString)' --output-path '\(temporaryDirectory.pathString)' 2>/dev/null",
+                    // `exec` replaces the shell with the tool so cancellation, which signals
+                    // only the direct child, reaches xcresulttool instead of orphaning it.
+                    "exec /usr/bin/xcrun xcresulttool export attachments --path '\(xcresultPath.pathString)' --output-path '\(temporaryDirectory.pathString)' 2>/dev/null",
                 ]
             ).concatenatedString()
 

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -1,6 +1,7 @@
 import Command
 import FileSystem
 import Foundation
+import os
 import Path
 import Testing
 @testable import XCResultParser
@@ -57,6 +58,30 @@ private struct RoutingXCResultToolStub: CommandRunning {
                 let tail = command[redirect.upperBound...]
                 if let close = tail.firstIndex(of: "'") {
                     try? payload.write(toFile: String(tail[..<close]), atomically: true, encoding: .utf8)
+                }
+            }
+            continuation.finish()
+        }
+    }
+}
+
+/// Records the shell payload of every command the parser issues.
+private struct RecordingXCResultToolStub: CommandRunning {
+    let testResultsJSON: String
+    let commands = OSAllocatedUnfairLock<[String]>(initialState: [])
+
+    func run(
+        arguments: [String],
+        environment _: [String: String],
+        workingDirectory _: AbsolutePath?
+    ) -> AsyncThrowingStream<CommandEvent, any Error> {
+        let command = arguments.last ?? ""
+        commands.withLock { $0.append(command) }
+        return AsyncThrowingStream { continuation in
+            if let redirect = command.range(of: "> '") {
+                let tail = command[redirect.upperBound...]
+                if let close = tail.firstIndex(of: "'") {
+                    try? testResultsJSON.write(toFile: String(tail[..<close]), atomically: true, encoding: .utf8)
                 }
             }
             continuation.finish()
@@ -526,4 +551,69 @@ struct XCResultParserTests {
         #expect(summary.testCases.map(\.name) == ["Issues recorded without an associated test or suite"])
         #expect(summary.status == .failed)
     }
+
+    /// The parser shells out through `/bin/sh -c`. Without `exec` the shell
+    /// forks the tool and waits, so `Process.terminate()` on cancellation
+    /// signals the shell only and the tool keeps running, reparented, holding
+    /// its process-limiter permit and writing into a temp directory the caller
+    /// is about to delete.
+    @Test
+    func shellCommandsExecTheToolSoTheyStayCancellable() async throws {
+        let runner = RecordingXCResultToolStub(testResultsJSON: "{}")
+        let parser = XCResultParser(commandRunner: runner)
+
+        _ = try? await parser.parse(path: try AbsolutePath(validating: "/tmp/app.xcresult"), rootDirectory: nil)
+
+        let commands = runner.commands.withLock { $0 }
+        #expect(!commands.isEmpty)
+        for command in commands where command.contains("xcresulttool") {
+            #expect(command.hasPrefix("exec "), "not cancellable, shell would fork and wait: \(command)")
+        }
+    }
+
+    /// Guards the mechanism itself rather than the spelling: cancelling the
+    /// task must leave no descendant behind.
+    @Test
+    func cancellingACommandTerminatesItsRealChildProcess() async throws {
+        // Unique enough to identify this test's process in the table.
+        let marker = "774411"
+        defer { _ = runToCompletion("/usr/bin/pkill", ["-f", "sleep \(marker)"]) }
+
+        let task = Task {
+            for try await _ in CommandRunner().run(arguments: ["/bin/sh", "-c", "exec /bin/sleep \(marker)"]) {}
+        }
+
+        try await waitFor("the child to start") { processExists(marker) }
+        task.cancel()
+        try await waitFor("the child to be terminated") { !processExists(marker) }
+    }
+}
+
+private func runToCompletion(_ executable: String, _ arguments: [String]) -> Int32 {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+    } catch {
+        return -1
+    }
+    process.waitUntilExit()
+    return process.terminationStatus
+}
+
+private func processExists(_ marker: String) -> Bool {
+    runToCompletion("/usr/bin/pgrep", ["-f", "sleep \(marker)"]) == 0
+}
+
+/// Polls rather than sleeping a fixed interval, so the test is neither slow
+/// when the transition is fast nor flaky when the machine is loaded.
+private func waitFor(_ description: String, _ condition: @Sendable () -> Bool) async throws {
+    for _ in 0 ..< 100 {
+        if condition() { return }
+        try await Task.sleep(for: .milliseconds(100))
+    }
+    Issue.record("Timed out waiting for \(description)")
 }


### PR DESCRIPTION
## What changed

Two independent fixes to the xcresult processor, both aimed at the recurring `xcresult parsing timed out after 600s` failures.

1. The 600s timeout is now **structured**: the parse races a sleeping sibling in a task group, so a timeout cancels and tears down the parse instead of abandoning it.
2. The xcresult-processor Deployment now gives each Pod a **distinct identity** in Sentry and Oban.

## Why

### The timeout is a hang, not a slow bundle

`Oban.PerformError: ProcessXcresultWorker failed with "xcresult parsing timed out after 600s"` has been firing steadily: 70 prod events in the last 14 days across many unrelated accounts.

It is not a large or slow result bundle. On the most recent occurrence, attempt 1 burned the full 600s and attempt 2 processed the identical archive in **1.72 seconds**, a 350x gap. An earlier occurrence showed the same shape at 10.5s.

The wall is also not set too low. Over the same day the fleet completed 793 jobs at p50 3.91s, p95 86.7s, p99 175.8s, and a maximum of 349.9s. Genuinely slow parses finish well inside 600s, so the wall is above the observed maximum and its victims are jobs that would otherwise land near the median. Raising the timeout would not help.

### Root cause of the amplification

The wall wrapped an unstructured `Task` whose handle was discarded, so on timeout it abandoned the work rather than cancelling it. The consequences compound:

- the `Task` and its `xcresulttool` / `sips` children keep running for the life of the BEAM,
- each orphan holds a `CommandRunner` process-limiter permit permanently,
- the worker's cleanup deletes the temp directory out from under the orphan,
- the 600s wait blocks a dirty CPU scheduler thread, and the queue runs at concurrency 4.

That turns one random hang into a fleet event. The Sentry distribution shows exactly that signature: of the 70 events, roughly 45 fall inside a single 2 hour 40 minute window, arriving in groups of 3 to 4 at ten-minute boundaries. Groups of about 4 spaced exactly 600s apart is every Oban slot on a Pod entering and hitting the wall in lockstep, across unrelated accounts. Per-bundle slowness cannot produce that shape.

### Why the identity change ships alongside it

The leading explanation for an isolated hang is that the job landed on a Pod that had already accumulated orphans and so had no permit free, meaning it blocked before doing any work. That fits every observation: 1.7s of real work, 600s of waiting, and 83 other jobs completing normally at p50 2.89s during the very same window.

It cannot currently be confirmed. Every VM booted from the Tart image reports the image's hostname, so Sentry's `server_name` and Oban's `attempted_by` both read the same constant string for every Pod. There is no way to tell whether those 83 healthy jobs ran on the same Pod as the hung one, which would refute the explanation, or on the other Pods, which would support it.

## Why this approach

**Cancel rather than raise the timeout.** The victim needed 1.7s of work. A job that hangs at 600s hangs at 900s too.

**Cancellation had to be made to reach the tool, which it did not.** `CommandRunner` cancels through `continuation.onTermination`, which calls `Process.terminate()` on its direct child. For the three `xcresulttool` reads that child is `/bin/sh`, and `sh` forks the tool and waits on it, so the signal killed the shell and left `xcresulttool` running, reparented, still holding its process-limiter permit and still writing into the temp directory the worker deletes on cleanup. Cancelling correctly at the Swift level would have changed nothing on its own. The shell payloads are now `exec`-prefixed, so the shell replaces itself with the tool rather than forking it, and the redirection is still set up before the exec.

**Put the timeout inside the async world rather than around it.** The original shape, a semaphore wait in the synchronous NIF entry point with the result handed back through a `nonisolated(unsafe) var`, is what made this hard to fix safely. Cancelling from there needs a hand-rolled `@unchecked Sendable` box, a second timed wait for the cancellation to land, and a write-and-read-in-one-critical-section dance so a late write cannot replace the returned value.

Racing the parse against a sleeping sibling in a `withThrowingTaskGroup` removes all of that. Whichever child finishes first, the deferred `cancelAll()` cancels the other, and a task group cannot return until every child has been awaited. A timed-out parse is therefore torn down before the caller sees the error, which is a stronger guarantee than waiting out a grace period. It also lets both `try! AbsolutePath(validating:)` calls, the same class of node-killer as the unsynchronised write, become ordinary `try` in an async throwing function.

The one remaining timed wait is a backstop for a child that ignores cancellation, for instance one wedged in an uninterruptible syscall, which would otherwise hold a dirty scheduler thread for the life of the BEAM. Nothing is read from the shared slot on that path, so a late write cannot race the returned value. The slot itself is an `OSAllocatedUnfairLock` over a `Sendable` enum, matching the primitive already used in `TuistURLSessionTransport`; failures cross the boundary as their message, which is all the C layer ever wrote back. `Synchronization.Mutex` would be the more current choice but needs a macOS 15 floor, and this package targets macOS 14.

**Both halves of the identity change are required.** Oban overwrites `attempted_by` on every attempt, so a job that times out and then succeeds records only the Pod of the successful attempt, and the `errors` entries carry no node at all. The Sentry event is the only artifact emitted from the Pod that hung at the moment it hung, so it must carry the name. Oban's `node` then answers the second half, what that Pod completed over the same window, which is what separates a wedged Pod from a healthy one. `POD_NAME` reaches the guest through the existing tart-kubelet env mount that `inject-env.sh` already sources, so no image rebuild is needed.

## Impact

- A timed-out parse no longer leaks a process-limiter permit or a running subprocess, which should remove the mechanism that turns isolated hangs into bursts.
- In the normal timeout path the job reports as soon as the group unwinds. Only a parse that ignores cancellation waits out the extra backstop window. Timeouts are 0.12 percent of jobs, so neither is a throughput concern.
- Error messages are unchanged, so existing Sentry grouping and any alerting on those strings keep working.
- Sentry events from the xcresult processor will report the Pod name rather than the shared VM hostname. Nothing else changes for the Linux deployments, where `POD_NAME` is absent and both defaults are already per-Pod.

## Validation

- The process shape was verified directly rather than reasoned about. `/bin/sh -c '/bin/sleep 45 > file'` runs as a shell with a separate `sleep` child, and after `SIGTERM` to the shell the `sleep` survives with a new parent. With `exec` the process *is* the tool, has no children, and dies on `SIGTERM`; the full `sh` -> `xcrun` -> tool chain collapses into one PID, so `terminate()` lands on `xcresulttool` itself.
- `mix format --check-formatted config/runtime.exs` passes.
- `helm template` renders the xcresult-processor Deployment with `POD_NAME` bound to `metadata.name`, emitted unconditionally rather than inside the Tailscale block.
- Verified both config keys exist so neither crashes at boot: `server_name` is in the Sentry 11.0.4 config schema, and Oban 2.20.1 validates `node` against `~r/^\S+$/`, which a Pod name satisfies.
- Postgres confirms the premise: the job behind the most recent report completed on attempt 2 in 1.72s, and the same-day percentiles above come from the retained `oban_jobs` window.

Two tests cover this: one asserts the parser's `xcresulttool` commands are `exec`-prefixed, the other cancels a real command and asserts no descendant process survives. The first drives `parse` through a recording stub, so it covers the first shell-out for certain and the later ones only if the stubbed payload lets the parse proceed that far; the second is the one that guards the mechanism.

**The Swift is not compile-verified locally, and the new tests have not been run.** This package cannot be resolved on a dev machine: `--replace-scm-with-registry` fails with `duplicate key found: 'Package@swift-5.9.0.swift'`, and plain SCM resolution fails with a registry/source-control duplicate-target error for Mockable. `swiftc -frontend -parse` passes, and the API shapes it depends on were checked by hand against the SDK interfaces and in-tree usage (`OSAllocatedUnfairLock.withLock` requires `R: Sendable`, satisfied by `Void` and the enum; `AbsolutePath` is `Sendable`, since the shipping CLI calls `concurrentMap` on `[AbsolutePath]` through an extension constrained to `Element: Sendable`). CI builds the NIF and is the real check here.

Note that `oban_jobs` retains only about 2 hours for this queue, so Sentry is the only historical record of these timeouts. That is part of why the per-Pod label matters.

## Deliberately not included

- `ProcessType=Background` in the processor image launchd plist, which gives the BEAM and every child low CPU QoS and throttled disk I/O. `Adaptive` is the right class, but it is an image change with its own rollout.
- Per-phase timeouts. The single 600s bucket spans four subprocess phases, so the error still cannot say which one hung. That is the follow-up that turns the next occurrence into a diagnosis on its own, and it is also the answer for a child that never honours cancellation.

