### PR TITLE
fix(docs): restore ProjectDescription publishing

### DIFF
--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -53,7 +53,9 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Build ProjectDescription documentation
-        run: mise run --skip-tools docs:project-description
+        run: >-
+          MISE_PROJECT_ROOT="$GITHUB_WORKSPACE" mise exec swift@6.2.4 --
+          bash mise/tasks/docs/project-description.sh
       - name: Save Swift Package Manager cache
         uses: actions/cache/save@v4
         with:
@@ -68,5 +70,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
           CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
         run: >-
-          op run -- wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
+          mise exec node@20.12.0 npm:wrangler@4.30.0 -- /usr/local/bin/op run --
+          wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
           --project-name tuist-projectdescription .build/documentation

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build-deploy:
     name: Build and deploy
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     container:
       image: swift:6.2
     timeout-minutes: 30

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -35,8 +35,6 @@ jobs:
   build-deploy:
     name: Build and deploy
     runs-on: tuist-linux
-    container:
-      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -48,12 +46,10 @@ jobs:
           path: .build
           key: linux-project-description-docc-${{ hashFiles('Package.resolved') }}
           restore-keys: linux-project-description-docc-
-      - name: Install system dependencies
-        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "node@20.12.0 npm:wrangler@4.30.0"
+          install_args: "swift@6.2.4 node@20.12.0 npm:wrangler@4.30.0"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Build ProjectDescription documentation

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -1,0 +1,76 @@
+name: ProjectDescription documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - cli/Sources/ProjectDescription/**
+      - Package.swift
+      - Package.resolved
+      - mise/tasks/docs/project-description.sh
+      - .github/workflows/project-description-docs.yml
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - cli/Sources/ProjectDescription/**
+      - Package.swift
+      - Package.resolved
+      - mise/tasks/docs/project-description.sh
+      - .github/workflows/project-description-docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: project-description-docs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  build-deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Swift Package Manager cache
+        id: package-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: linux-project-description-docc-${{ hashFiles('Package.resolved') }}
+          restore-keys: linux-project-description-docc-
+      - name: Install system dependencies
+        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "node@20.12.0 npm:wrangler@4.30.0"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Build ProjectDescription documentation
+        run: mise run --skip-tools docs:project-description
+      - name: Save Swift Package Manager cache
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: ${{ steps.package-cache.outputs.cache-primary-key }}
+      - uses: 1password/install-cli-action@v2
+        if: github.ref == 'refs/heads/main'
+      - name: Deploy to Cloudflare Pages
+        if: github.ref == 'refs/heads/main'
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
+          CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
+        run: >-
+          op run -- wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
+          --project-name tuist-projectdescription .build/documentation


### PR DESCRIPTION
## What changed

- Restores a dedicated GitHub Actions workflow that builds the ProjectDescription reference documentation.
- Builds the documentation for relevant pull requests, deploys the generated site only from `main`, and provides a manual trigger for the initial backfill.
- Restores the Cloudflare Pages deployment for `tuist-projectdescription`.

## Why

The public ProjectDescription reference stopped updating after the documentation migration. New manifest types, including `TestPlan.generated`, have therefore not appeared on the published site.

## Root cause

The migration in #10083 removed `.github/workflows/docs.yml`, which contained the only ProjectDescription build-and-deploy job. The local `docs:project-description` task remained, but no workflow invoked it or deployed its output.

## Approach

The workflow uses the existing generation task, retains the previous Swift Package Manager cache and Cloudflare Pages target, and keeps deployment restricted to `main`. Its path filters cover the ProjectDescription source, package resolution, generator task, and workflow itself.

## Impact

After this pull request merges, dispatching the workflow will publish the current ProjectDescription reference. Later relevant changes on `main` will keep it current automatically.

## Validation

- `mise run docs:project-description`
  - Succeeded and generated the `TestPlan` reference page with the `.generated` option documentation.
- Parsed `.github/workflows/project-description-docs.yml` with Ruby and `yq`.
- Ran `git diff --check`.