### PR TITLE
fix(docs): use installed 1Password command

### DIFF
--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -53,7 +53,9 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Build ProjectDescription documentation
-        run: mise run --skip-tools docs:project-description
+        run: >-
+          MISE_PROJECT_ROOT="$GITHUB_WORKSPACE" mise exec swift@6.2.4 --
+          bash mise/tasks/docs/project-description.sh
       - name: Save Swift Package Manager cache
         uses: actions/cache/save@v4
         with:
@@ -68,5 +70,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
           CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
         run: >-
-          op run -- wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
+          mise exec node@20.12.0 npm:wrangler@4.30.0 -- /usr/local/bin/op run --
+          wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
           --project-name tuist-projectdescription .build/documentation

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build-deploy:
     name: Build and deploy
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     container:
       image: swift:6.2
     timeout-minutes: 30

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -35,8 +35,6 @@ jobs:
   build-deploy:
     name: Build and deploy
     runs-on: tuist-linux
-    container:
-      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -48,12 +46,10 @@ jobs:
           path: .build
           key: linux-project-description-docc-${{ hashFiles('Package.resolved') }}
           restore-keys: linux-project-description-docc-
-      - name: Install system dependencies
-        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "node@20.12.0 npm:wrangler@4.30.0"
+          install_args: "swift@6.2.4 node@20.12.0 npm:wrangler@4.30.0"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Build ProjectDescription documentation

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -1,0 +1,76 @@
+name: ProjectDescription documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - cli/Sources/ProjectDescription/**
+      - Package.swift
+      - Package.resolved
+      - mise/tasks/docs/project-description.sh
+      - .github/workflows/project-description-docs.yml
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - cli/Sources/ProjectDescription/**
+      - Package.swift
+      - Package.resolved
+      - mise/tasks/docs/project-description.sh
+      - .github/workflows/project-description-docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: project-description-docs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  build-deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Swift Package Manager cache
+        id: package-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: linux-project-description-docc-${{ hashFiles('Package.resolved') }}
+          restore-keys: linux-project-description-docc-
+      - name: Install system dependencies
+        run: apt-get update -qq && apt-get install -y --no-install-recommends curl
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "node@20.12.0 npm:wrangler@4.30.0"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Build ProjectDescription documentation
+        run: mise run --skip-tools docs:project-description
+      - name: Save Swift Package Manager cache
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: ${{ steps.package-cache.outputs.cache-primary-key }}
+      - uses: 1password/install-cli-action@v2
+        if: github.ref == 'refs/heads/main'
+      - name: Deploy to Cloudflare Pages
+        if: github.ref == 'refs/heads/main'
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
+          CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
+        run: >-
+          op run -- wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
+          --project-name tuist-projectdescription .build/documentation

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -70,6 +70,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
           CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
         run: >-
-          mise exec node@20.12.0 npm:wrangler@4.30.0 -- /usr/local/bin/op run --
+          mise exec node@20.12.0 npm:wrangler@4.30.0 -- op run --
           wrangler pages deploy --commit-hash ${{ github.sha }} --branch main
           --project-name tuist-projectdescription .build/documentation


### PR DESCRIPTION
## What changed

- Invoke the `op` command installed by the 1Password action instead of a hard-coded filesystem path.

## Why

The restored ProjectDescription documentation workflow built successfully after merge, but could not publish the generated site.

## Root cause

The 1Password action adds its command to the runner path. It does not install it at `/usr/local/bin/op`, so the deployment step failed before it could resolve the Cloudflare credentials.

## Approach

Use the command on the runner path, matching the repository's other 1Password-enabled workflows.

## Impact

Pushes to `main` can publish the generated ProjectDescription documentation to Cloudflare Pages.

## Validation

- Parsed `.github/workflows/project-description-docs.yml` with `yq`.
- Ran `git diff --check`.
- Inspected the failed production deployment: https://github.com/tuist/tuist/actions/runs/32369554418/job/96426695778