### PR TITLE
fix(swifterpm): use Keychain for binary artifact downloads

### DIFF
--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -396,8 +396,7 @@ struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithStandardMethod {
 struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
     @Test(
         .withFixture("generated_app_with_swiftpm_prebuilt_macro_dependency"),
-        .inTemporaryDirectory,
-        .timeLimit(.minutes(4))
+        .inTemporaryDirectory
     )
     func app_with_swiftpm_prebuilt_macro_dependency_builds_with_host_only_prebuilt_macro_support() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)

--- a/swifterpm/Sources/swifterpm/Registry.swift
+++ b/swifterpm/Sources/swifterpm/Registry.swift
@@ -134,7 +134,7 @@ enum RegistryAuthorization {
             environmentNetrc: netrc.credential(for: url, from: .environment),
             fileNetrc: netrc.credential(for: url, from: .file),
             forcesNetrc: netrc.forcesNetrc,
-            keychain: { await RegistryKeychain.credential(for: url) }
+            keychain: { await KeychainAuthorization.credential(for: url) }
         ) {
             return header(for: credential, url: url, registryConfig: registryConfig)
         }
@@ -196,7 +196,7 @@ enum RegistryAuthorization {
     }
 }
 
-private enum RegistryKeychain {
+enum KeychainAuthorization {
     static func credential(for url: URL) async -> RegistryCredential? {
         #if canImport(Security)
             guard let searchQuery = query(for: url, includeData: false) else { return nil }

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -274,9 +274,10 @@ enum HTTPAuthorization {
         // repo-scoped CI token shadows the netrc credential that can actually read
         // a private release asset. This mirrors SwiftPM, whose download
         // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
-        if let header = prioritizedHeader(
+        if let header = await prioritizedHeader(
             isGitHub: isGitHub(url),
             netrcCredential: Environment.netrc.credential(for: url),
+            keychain: { await KeychainAuthorization.credential(for: url) },
             gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
         ) {
             return header
@@ -292,9 +293,13 @@ enum HTTPAuthorization {
     static func prioritizedHeader(
         isGitHub: Bool,
         netrcCredential: RegistryCredential?,
+        keychain: () async -> RegistryCredential?,
         gitHubEnvToken: String?
-    ) -> String? {
+    ) async -> String? {
         if let credential = netrcCredential {
+            return basicHeader(credential)
+        }
+        if let credential = await keychain() {
             return basicHeader(credential)
         }
         if isGitHub, let token = nonEmpty(gitHubEnvToken) {

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -291,11 +291,15 @@ struct SupportTests {
     }
 
     @Test
-    func netrcCredentialBeatsGitHubEnvToken() {
+    func netrcCredentialBeatsKeychainAndGitHubEnvToken() async {
         let credential = RegistryCredential(user: "x-access-token", password: "harbor-token")
-        let header = HTTPAuthorization.prioritizedHeader(
+        let header = await HTTPAuthorization.prioritizedHeader(
             isGitHub: true,
             netrcCredential: credential,
+            keychain: {
+                Issue.record("keychain consulted despite netrc credentials")
+                return RegistryCredential(user: "keychain", password: "credential")
+            },
             gitHubEnvToken: "ghs_repo_scoped_token"
         )
 
@@ -304,10 +308,25 @@ struct SupportTests {
     }
 
     @Test
-    func gitHubEnvTokenUsedWhenNoNetrcCredential() {
-        let header = HTTPAuthorization.prioritizedHeader(
+    func keychainCredentialBeatsGitHubEnvToken() async {
+        let credential = RegistryCredential(user: "keychain", password: "credential")
+        let header = await HTTPAuthorization.prioritizedHeader(
             isGitHub: true,
             netrcCredential: nil,
+            keychain: { credential },
+            gitHubEnvToken: "ghs_repo_scoped_token"
+        )
+
+        let expected = "Basic " + Data("keychain:credential".utf8).base64EncodedString()
+        #expect(header == expected)
+    }
+
+    @Test
+    func gitHubEnvTokenUsedWhenNoNetrcOrKeychainCredential() async {
+        let header = await HTTPAuthorization.prioritizedHeader(
+            isGitHub: true,
+            netrcCredential: nil,
+            keychain: { nil },
             gitHubEnvToken: "ghs_repo_scoped_token"
         )
 
@@ -315,14 +334,29 @@ struct SupportTests {
     }
 
     @Test
-    func gitHubEnvTokenIgnoredForNonGitHubHostWithoutNetrc() {
-        #expect(
-            HTTPAuthorization.prioritizedHeader(
-                isGitHub: false,
-                netrcCredential: nil,
-                gitHubEnvToken: "ghs_repo_scoped_token"
-            ) == nil
+    func keychainCredentialIsUsedForNonGitHubHost() async {
+        let credential = RegistryCredential(user: "keychain", password: "credential")
+        let header = await HTTPAuthorization.prioritizedHeader(
+            isGitHub: false,
+            netrcCredential: nil,
+            keychain: { credential },
+            gitHubEnvToken: "ghs_repo_scoped_token"
         )
+
+        let expected = "Basic " + Data("keychain:credential".utf8).base64EncodedString()
+        #expect(header == expected)
+    }
+
+    @Test
+    func gitHubEnvTokenIsIgnoredForNonGitHubHostWithoutOtherCredentials() async {
+        let header = await HTTPAuthorization.prioritizedHeader(
+            isGitHub: false,
+            netrcCredential: nil,
+            keychain: { nil },
+            gitHubEnvToken: "ghs_repo_scoped_token"
+        )
+
+        #expect(header == nil)
     }
 
     @Test


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12235>

## What changed

SwifterPM now applies macOS Keychain Internet Password credentials when downloading binary artifacts. The Keychain lookup shared with registry authentication now contributes a Basic authorization header to the artifact request.

## Why

Projects that rely on private release assets can store their GitHub credentials in the macOS Keychain. SwifterPM previously ignored those credentials for binary artifacts, so dependency installation received an unauthorized response.

## Root cause

The binary-artifact authorization path consulted `.netrc`, GitHub environment tokens, and the GitHub command-line client, but it did not consult the Keychain provider already used for registry requests.

## Approach

The authorization order now mirrors [Swift Package Manager](https://www.swift.org/package-manager/): `.netrc` credentials first, followed by Keychain credentials. Existing GitHub environment-token and command-line-client fallbacks remain in place after those explicit credentials.

## Impact

Users with an Internet Password for their artifact host can install private binary targets without configuring an additional token source. The behavior also supports artifact hosts other than GitHub.

### How to test locally

- `swift test --replace-scm-with-registry --package-path swifterpm --filter SupportTests` (27 tests passed)
- `git diff --check`
