### PR TITLE
fix(infra): keep Oban latency buckets only for the alerted workers

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -109,6 +109,29 @@ k8s-monitoring:
           regex = "integrations/(process|self)"
           action = "drop"
         }
+        # The non-destructive PromEx scrape keeps one bucket set per worker for
+        # the pod's lifetime. Only ProcessBuildWorker and ProcessXcresultWorker
+        # have latency alerts, so their buckets are kept and the rest dropped.
+        # `_count` and `_sum` are untouched, so per-worker rates and averages
+        # still cover every worker.
+        write_relabel_config {
+          source_labels = ["__name__", "worker"]
+          separator = ";"
+          regex = "tuist_oban_job_(processing_duration|queue_time)_milliseconds_bucket;(Tuist\\.Builds\\.Workers\\.ProcessBuildWorker|Tuist\\.Tests\\.Workers\\.ProcessXcresultWorker)"
+          target_label = "__tmp_keep_oban_bucket"
+          replacement = "true"
+          action = "replace"
+        }
+        write_relabel_config {
+          source_labels = ["__name__", "__tmp_keep_oban_bucket"]
+          separator = ";"
+          regex = "tuist_oban_job_(processing_duration|queue_time)_milliseconds_bucket;"
+          action = "drop"
+        }
+        write_relabel_config {
+          regex = "__tmp_keep_oban_bucket"
+          action = "labeldrop"
+        }
 
     grafana-cloud-logs:
       type: loki


### PR DESCRIPTION
Trims the second largest contributor to the Grafana Cloud metrics cardinality
increase that has been firing the "Anomaly: Metrics Usage" alert since
2026-08-13.

## Why

[#12302](https://github.com/tuist/tuist/pull/12302) made `StripedPeep.scrape/1`
non-destructive. That change is correct for Prometheus semantics and should not be
reverted, but it means every label combination a pod has ever observed stays in its
export for the pod's whole lifetime instead of only the combinations seen since the
last scrape. Cardinality now ramps all day and resets on each deploy.

Net effect: active series went from a flat 72k to 77k baseline to a 85k to 108k
sawtooth, and billable series from 78.3k to 106.9k. That is roughly +28.5k series.

[#12432](https://github.com/tuist/tuist/pull/12432) dropped the `status` tag from the
Phoenix duration histogram and took its peak from 16,608 to about 9,024, which
arrested the growth. The Oban duration histograms were left untouched and are the
next largest contributor, sawtoothing from about 1.3k to 3.7k series each per deploy
cycle.

## Why this approach over trimming the tag set

The obvious move was to trim the Oban tags the same way #12432 trimmed Phoenix.
Measured at peak, that does not pay:

| Combination space | Combos |
| --- | --- |
| `env` x `name` x `queue` x `state` x `worker` | 148 |
| `env` x `name` x `queue` x `worker` | 124 |

Dropping `state` saves 16%, not the 4x its four values suggest, because nearly every
worker only ever emits `success` and the other states are rare. That is about 1,170
series, roughly 4% of the excess. It would also break three panels in
`infra/grafana-dashboards/xcresult-processor.json` that read `_count` filtered by
`state`, since a `distribution` drops a tag from `_bucket`, `_sum` and `_count`
together.

Dropping `worker` instead would save more, but `worker` is the dimension five alert
rules depend on. Trimming buckets was also rejected: the boundaries straddling 60s
are exactly what gives the p99 alerts their resolution at the threshold they fire on.

Only `Tuist.Builds.Workers.ProcessBuildWorker` and
`Tuist.Tests.Workers.ProcessXcresultWorker` have latency alerts, and together they
are 88 of 3,652 bucket series. Keeping buckets only for those two clears about 7,100
series across both metrics, roughly 25% of the excess, for about 6x the saving of the
`state` trim.

## What changed

Three `write_relabel_config` rules at the metrics destination in
`infra/helm/k8s-monitoring/values.yaml`, using the same temp-label keep/drop pattern
already used for `__tmp_keep_runner_pod_metric` and `__tmp_keep_net_iface` in that
file.

They live at the destination rather than on a scrape job because the two retained
workers report under different jobs: `tuist` for the server and
`tuist-macos-pod-metrics` for the xcresult processor, so no single scrape job covers
both.

## Impact

`_count` and `_sum` are untouched, so per-worker rates and averages still cover every
worker. Only the distribution shape of unalerted workers is lost.

Known loss: the latency heatmaps in `infra/grafana-dashboards/oban.json` (lines 359
and 431) aggregate buckets across all workers and will narrow to the retained two.

## Reviewer note, separate from this change

While confirming the alerts that justify keeping `worker`, I found that five Oban
alert rules have returned NoData for at least 30 days: Build processing duration,
Build queue duration, XCResult processing duration, XCResult queue duration, and
XCResult queue depth.

All five select `job="prometheus.scrape.tuist"` and `instance="production"`. Neither
value exists. The real `job` is `tuist` or `tuist-macos-pod-metrics`, and `instance`
is `<aggregated>` because Adaptive Metrics collapses it, so `env="production"` is the
label to use. `prometheus.scrape.tuist` looks like an Alloy component name rather
than a scraped `job` label, so these were probably never correct rather than having
drifted.

This does not change the reasoning above, since those two workers are still the ones
whose latency should page, but the alerts need repairing in the Grafana UI. That is
not something this PR can do, as the rules are not in the repo.

### How to test locally

The rules only take effect at remote write, so verification is rendering plus
simulation rather than a running cluster.

Render the chart and confirm the rules reach the Alloy config:

```
cd infra/helm/k8s-monitoring
helm dependency build
helm template t . -f values.yaml -f values-production.yaml | grep -A4 '"__name__", "worker"'
```

Repeat with `values-canary.yaml`, `values-staging.yaml` and `values-management.yaml`.
Remember to `rm -rf charts` afterwards, since that directory is not gitignored.

Relabel behaviour was verified by simulating Prometheus semantics against 13 real
label sets: both retained workers on both metrics, other workers, `_count` and
`_sum`, the attempts histogram, the Phoenix histogram, a dot-wildcard near miss, and
a series carrying no `worker` label. All passed, and no temp label leaks into the
output. It was also confirmed against production that no bucket series currently
lacks a `worker` label, which matters because such a series would be dropped.
