### PR TITLE
fix(server): keep the flaky-state backfill working on ClickHouse 25

### DIFF
--- a/server/lib/tuist/clickhouse_capabilities.ex
+++ b/server/lib/tuist/clickhouse_capabilities.ex
@@ -13,6 +13,8 @@ defmodule Tuist.ClickHouseCapabilities do
 
   alias Tuist.Environment
 
+  @deduplicate_insert_select_since [26, 1]
+
   @doc """
   Whether `generateSerialID/1` is usable against `repo`, which requires a
   configured ClickHouse Keeper (or ZooKeeper); without one it raises
@@ -31,6 +33,46 @@ defmodule Tuist.ClickHouseCapabilities do
         # assume no Keeper and the managed instance quietly gets random legacy
         # IDs instead of serial ones.
         raise "Could not determine whether ClickHouse supports serial IDs: #{Exception.message(error)}"
+    end
+  end
+
+  @doc """
+  The version of the ClickHouse server behind `repo`, as a list of integers.
+
+  `version/0` is a plain function rather than a system table, so unlike the
+  `system.*` reads elsewhere in this module it also answers inside a ClickHouse
+  transaction, which is what the Ecto sandbox wraps every test in.
+  """
+  def server_version(repo) do
+    case repo.query("SELECT version()") do
+      {:ok, %{rows: [[version]]}} ->
+        version
+        |> String.split(".")
+        |> Enum.take_while(&numeric?/1)
+        |> Enum.map(&String.to_integer/1)
+
+      {:error, error} ->
+        raise "Could not determine the ClickHouse server version: #{Exception.message(error)}"
+    end
+  end
+
+  defp numeric?(version_component), do: match?({_integer, ""}, Integer.parse(version_component))
+
+  @doc """
+  Settings that make an `INSERT SELECT` deduplicate against its
+  `insert_deduplication_token`, so a retried insert cannot duplicate rows.
+
+  `deduplicate_insert_select` arrived in ClickHouse 26.1, where `force_enable`
+  raises instead of silently skipping deduplication when the server judges the
+  select unstable. Earlier releases in the supported range reject the name with
+  `UNKNOWN_SETTING`, and deduplicate `INSERT SELECT` whenever `insert_deduplicate`
+  is on, which is the behaviour `force_enable` asks for.
+  """
+  def insert_select_deduplication_settings(repo) do
+    if Enum.take(server_version(repo), 2) >= @deduplicate_insert_select_since do
+      [deduplicate_insert_select: "force_enable"]
+    else
+      []
     end
   end
 

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -23,6 +23,7 @@ defmodule Tuist.Tests do
 
   alias Tuist.Accounts.Account
   alias Tuist.Automations
+  alias Tuist.ClickHouseCapabilities
   alias Tuist.ClickHouseRepo
   alias Tuist.Environment
   alias Tuist.IngestRepo
@@ -3756,11 +3757,11 @@ defmodule Tuist.Tests do
         git_commit_sha: git_commit_sha,
         test_case_run_ids: test_case_run_ids
       },
-      settings: [
-        insert_deduplication_token: "test-case-run-flaky-correction:#{flaky_correction_batch_id(test_case_run_ids)}",
-        deduplicate_insert_select: "force_enable",
-        deduplicate_blocks_in_dependent_materialized_views: 1
-      ]
+      settings:
+        [
+          insert_deduplication_token: "test-case-run-flaky-correction:#{flaky_correction_batch_id(test_case_run_ids)}",
+          deduplicate_blocks_in_dependent_materialized_views: 1
+        ] ++ ClickHouseCapabilities.insert_select_deduplication_settings(IngestRepo)
     )
   end
 

--- a/server/priv/ingest_repo/migrations/20260728120000_add_is_flaky_to_test_case_runs_by_commit.exs
+++ b/server/priv/ingest_repo/migrations/20260728120000_add_is_flaky_to_test_case_runs_by_commit.exs
@@ -9,6 +9,7 @@ defmodule Tuist.IngestRepo.Migrations.AddIsFlakyToTestCaseRunsByCommit do
   """
   use Ecto.Migration
 
+  alias Tuist.ClickHouseCapabilities
   alias Tuist.IngestRepo
 
   require Logger
@@ -90,6 +91,9 @@ defmodule Tuist.IngestRepo.Migrations.AddIsFlakyToTestCaseRunsByCommit do
         %{table: @source_table}
       )
 
+    deduplication_settings =
+      ClickHouseCapabilities.insert_select_deduplication_settings(IngestRepo)
+
     for [partition] <- partitions do
       Logger.info("Backfilling flaky rows from partition #{partition} into #{@canonical_table}")
 
@@ -105,13 +109,14 @@ defmodule Tuist.IngestRepo.Migrations.AddIsFlakyToTestCaseRunsByCommit do
           """,
           %{partition: String.to_integer(partition)},
           timeout: 1_200_000,
-          settings: [
-            insert_deduplication_token: "test-case-runs-by-commit-is-flaky-backfill:#{partition}",
-            deduplicate_insert_select: "force_enable",
-            max_threads: 1,
-            max_memory_usage: @backfill_max_memory_usage,
-            max_bytes_before_external_sort: @backfill_external_sort_threshold
-          ]
+          settings:
+            [
+              insert_deduplication_token:
+                "test-case-runs-by-commit-is-flaky-backfill:#{partition}",
+              max_threads: 1,
+              max_memory_usage: @backfill_max_memory_usage,
+              max_bytes_before_external_sort: @backfill_external_sort_threshold
+            ] ++ deduplication_settings
         )
       end)
     end

--- a/server/test/tuist/clickhouse_capabilities_test.exs
+++ b/server/test/tuist/clickhouse_capabilities_test.exs
@@ -20,6 +20,21 @@ defmodule Tuist.ClickHouseCapabilitiesTest do
     def query(_statement), do: {:error, %Ch.Error{code: 210, message: "connection refused"}}
   end
 
+  defmodule ModernRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [["26.1.2.11"]]}}
+  end
+
+  defmodule LegacyRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [["25.7.7.68"]]}}
+  end
+
+  defmodule RebuiltRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [["25.3.6.10034.altinitystable"]]}}
+  end
+
   describe "serial_ids_supported?/1" do
     test "is true when the server has coordination configured" do
       assert ClickHouseCapabilities.serial_ids_supported?(KeeperRepo)
@@ -56,6 +71,34 @@ defmodule Tuist.ClickHouseCapabilitiesTest do
 
       assert ClickHouseCapabilities.use_serial_ids?(KeeperRepo)
       refute ClickHouseCapabilities.use_serial_ids?(KeeperlessRepo)
+    end
+  end
+
+  describe "server_version/1" do
+    test "reads the running server's version" do
+      assert ClickHouseCapabilities.server_version(ModernRepo) == [26, 1, 2, 11]
+    end
+
+    test "stops at the first component a rebuilt distribution appends" do
+      assert ClickHouseCapabilities.server_version(RebuiltRepo) == [25, 3, 6, 10_034]
+    end
+
+    test "raises rather than guessing when the server cannot answer" do
+      assert_raise RuntimeError, ~r/Could not determine/, fn ->
+        ClickHouseCapabilities.server_version(UnreachableRepo)
+      end
+    end
+  end
+
+  describe "insert_select_deduplication_settings/1" do
+    test "asks for deduplication when the server can enforce it" do
+      assert ClickHouseCapabilities.insert_select_deduplication_settings(ModernRepo) ==
+               [deduplicate_insert_select: "force_enable"]
+    end
+
+    test "is empty on a server that predates the setting, which deduplicates anyway" do
+      assert ClickHouseCapabilities.insert_select_deduplication_settings(LegacyRepo) == []
+      assert ClickHouseCapabilities.insert_select_deduplication_settings(RebuiltRepo) == []
     end
   end
 end


### PR DESCRIPTION
### What changed

`deduplicate_insert_select` is now sent only to ClickHouse servers that declare it, instead of unconditionally.

`Tuist.ClickHouseCapabilities` gains `server_version/1` and `insert_select_deduplication_settings/1`. The two places that asked for `force_enable` deduplication, the flaky-state backfill in `20260728120000_add_is_flaky_to_test_case_runs_by_commit` and the flaky-correction insert in `Tuist.Tests`, now build their settings through the latter.

### Why

`deduplicate_insert_select` only exists from ClickHouse 26.1 onwards, and additionally in a late 25.12 patch. Our compatibility matrix documents ClickHouse 25 as the minimum supported version. A self-hosted deployment updating on 25.7.7.68 could not get past the migration:

```
Code: 115. DB::Exception: Unknown setting 'deduplicate_insert_select'. (UNKNOWN_SETTING) (version 25.7.7.68)
```

I verified the version boundary directly against `src/Core/Settings.cpp` at each release tag: the setting is absent in 25.7.x, in 25.8 LTS through patch .31, and in 25.12.1, and present from a late 25.12 patch and from 26.1.

Nothing in our own infrastructure exercises the documented range. Dev and CI pin 26.1, the Helm chart ships 26.1, and the bundled Docker Compose ships 26.5, so a setting introduced after 25.7 is a latent hard failure that only self-hosters reach.

The migration was not the only exposure. `Tuist.Tests.insert_test_case_run_flaky_corrections/3` sends the same setting on a runtime insert, so on ClickHouse 25 every flaky correction would have failed continuously, not just the one-time migration. I swept every ClickHouse setting the server sends against a live 25.7 instance, and `deduplicate_insert_select` is the only one it does not declare, so the blast radius is exactly these two call sites.

### Root cause and why this approach

Behaviour is preserved on both sides of the version boundary rather than simply dropping the setting.

Releases before 26.1 deduplicate `INSERT SELECT` whenever `insert_deduplicate` is on. ClickHouse's own settings history records the pre-26.1 behaviour as `enable_even_for_bad_queries`, which is what `force_enable` asks for, so omitting the setting on those releases keeps the backfill's token-based restart safety intact. From 26.1 the default changed to `enable_when_possible`, which can silently skip deduplication when the server judges the select unstable, so `force_enable` still goes out there and still raises rather than skipping.

Dropping the setting everywhere was the obvious alternative and was rejected. Both queries carry `ORDER BY ALL` and would very likely be judged stable under `enable_when_possible`, but that turns a loud failure into silent duplicate rows on the exact path that exists to stop double-applied corrections.

The probe reads `version()` rather than `system.settings`. Querying the setting by name is the more direct question, and that was the first implementation, but no ClickHouse system table can be read inside a transaction, which is what the Ecto sandbox wraps every test in. `Tuist.Tests` corrections run on such a path and died with `Code: 48 NOT_IMPLEMENTED`. Our own suite caught it. `version()` is a plain function and answers anywhere, including inside a transaction.

Version parsing stops at the first non-numeric component, so rebuilt distributions that append a suffix to the version string parse rather than crash.

### Impact

Self-hosted deployments on ClickHouse 25 can complete this migration and keep flaky corrections working. The compatibility matrix stays accurate at ClickHouse 25 and needs no change. Deployments on 26.1 and newer are unaffected and keep the `force_enable` assertion.

Only deployments with existing data in `test_case_runs` ever hit this. On a fresh install the table has no partitions, the backfill loop never runs, and the setting is never sent, which is why this reads as an update-path failure rather than an install failure.

### How to test locally

Reproducing needs a real pre-26.1 server, since the version pinned for dev is 26.1.

1. Download `clickhouse-macos-aarch64` from the `v25.7.7.68-stable` GitHub release and start it on spare ports with its own data directory.
2. Point `Tuist.Repo` and `Tuist.IngestRepo` at scratch databases, migrate Postgres fully, then migrate ClickHouse with `to_exclusive: 20260728120000`.
3. Insert one row into `test_case_runs` with `is_flaky = true`, so the source table has an active partition for the backfill to walk.
4. Run the remaining ClickHouse migrations. Before this change they abort with `UNKNOWN_SETTING`; after it they complete.

Checks run:

- Full ClickHouse migration set green on a real 25.7.7.68 server where it previously aborted.
- Replaying the backfill insert with the same `insert_deduplication_token` on 25.7 leaves the row count unchanged, confirming the restart safety the migration depends on survives without the setting.
- A 26.1 server still receives `deduplicate_insert_select: "force_enable"`.
- `mix test test/tuist/tests_test.exs` 285 passed, including the cross-run flaky detection test that caught the transaction problem, and `mix test test/tuist/clickhouse_capabilities_test.exs` 11 passed.
- `mix format --check-formatted` and `mix credo` clean on the changed files.
