### PR TITLE
fix(server): label the bundle field in size threshold forms

### DIFF
--- a/server/lib/tuist_web/live/project_bundle_settings_live.html.heex
+++ b/server/lib/tuist_web/live/project_bundle_settings_live.html.heex
@@ -168,7 +168,7 @@
               </div>
               <div data-part="schedule-row">
                 <label data-part="schedule-label">
-                  {dgettext("dashboard_projects", "Name")}
+                  {dgettext("dashboard_projects", "Bundle name")}
                 </label>
                 <.text_input
                   type="basic"
@@ -327,13 +327,14 @@
                     </div>
                     <div data-part="schedule-row">
                       <label data-part="schedule-label">
-                        {dgettext("dashboard_projects", "Name")}
+                        {dgettext("dashboard_projects", "Bundle name")}
                       </label>
                       <.text_input
                         type="basic"
                         id={"edit-threshold-bundle-name-#{threshold.id}"}
                         name="bundle_name"
                         value={form[:bundle_name] || threshold.bundle_name || ""}
+                        placeholder={dgettext("dashboard_projects", "e.g. MyApp (optional)")}
                         phx-keyup="update_edit_form_bundle_name"
                         phx-value-id={threshold.id}
                         phx-debounce="300"

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -142,7 +142,7 @@ msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:898
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:350
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
 #: lib/tuist_web/live/project_notifications_live.html.heex:495
 #: lib/tuist_web/live/project_notifications_live.html.heex:840
@@ -275,10 +275,8 @@ msgstr ""
 #: lib/tuist_web/live/project_automations_live.html.heex:82
 #: lib/tuist_web/live/project_automations_live.html.heex:939
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:265
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:330
 #: lib/tuist_web/live/project_notifications_live.html.heex:278
 #: lib/tuist_web/live/project_notifications_live.html.heex:426
 #: lib/tuist_web/live/project_notifications_live.html.heex:520
@@ -556,7 +554,7 @@ msgid "Never"
 msgstr ""
 
 #: lib/tuist_web/live/project_automations_live.html.heex:908
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:359
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #: lib/tuist_web/live/project_settings_live.html.heex:149
 #, elixir-autogen, elixir-format
@@ -885,6 +883,7 @@ msgid "Scheme"
 msgstr ""
 
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:178
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:337
 #: lib/tuist_web/live/project_notifications_live.html.heex:419
 #: lib/tuist_web/live/project_notifications_live.html.heex:433
 #: lib/tuist_web/live/project_notifications_live.html.heex:749
@@ -946,12 +945,14 @@ msgstr ""
 msgid "Block PRs when the <strong>%{size_label}</strong> of <strong>%{bundle_name}</strong> increases by more than <strong>%{deviation}%</strong> compared to the latest bundle on <strong>%{baseline_branch}</strong>."
 msgstr ""
 
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:228
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "Bundle name"
 msgstr ""
 
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:386
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Create a threshold to block PRs when bundle size exceeds a limit"
 msgstr ""
@@ -967,7 +968,7 @@ msgstr ""
 msgid "Deviation %"
 msgstr ""
 
-#: lib/tuist_web/live/project_bundle_settings_live.html.heex:384
+#: lib/tuist_web/live/project_bundle_settings_live.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "No size thresholds"
 msgstr ""


### PR DESCRIPTION
## What changed

The Create and Edit size threshold modals on the project bundle settings page both rendered two fields labeled **Name**. The second one is renamed to **Bundle name**, and the edit modal gets the same `e.g. MyApp (optional)` placeholder the create modal already had.

## Why

Feedback from the team: with two identically labeled fields in one short form, there is nothing on screen to tell you what the second one does. You have to submit and inspect the result to find out.

## Root cause

The two fields map to different attributes, `name` (the threshold's own name, used in the thresholds table and in notifications) and `bundle_name` (optional filter that scopes the threshold to a single app/bundle), but the `bundle_name` field's label was written as the generic "Name" in both modals. The thresholds table below the form already labels the same attribute "Bundle name", so the form was the only place using the ambiguous wording.

## Why this over the alternatives

Renaming the *first* field instead (for example to "Threshold name") would also disambiguate, but it would break alignment with the existing "Bundle name" table column and would churn a translation string that is shared with several other project settings screens. Relabeling only the bundle field reuses the `Bundle name` msgid that already exists in the catalog, so no new string needs translating.

Adding helper text under the field was considered and rejected: the label alone carries the meaning, and the modal is already dense with five rows.

## Impact

Users creating or editing a bundle size threshold can tell the two fields apart from the labels. No behavior, schema, or API change; the field names, event handlers, and element ids are untouched.

## Validation

- `mix test test/tuist_web/live/project_bundle_settings_live_test.exs` — 5 tests, all passing.
- `mix format` on the changed template.
- `mix gettext.extract` re-run; only `priv/gettext/dashboard_projects.pot` is updated, and only to move the two references onto the existing `Bundle name` msgid. No `.po` files are touched. Incidental line-number churn that extraction produced in `dashboard_runners.pot` (pre-existing staleness, unrelated to this change) was reverted to keep the diff scoped.