### PR TITLE
docs(infra): correct the claim that only xcode-xips needs GHCR auth

### DIFF
--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -93,9 +93,14 @@ session state to lose.
 
 **Why this one stays on GHCR.** Every image this workflow *publishes*
 goes to the Tuist OCI registry on the tailnet, but the .xip mirror it
-*reads* deliberately does not follow, and it is the only artifact in
-the set that is not anonymously pullable (hence the explicit `oras
-login ghcr.io` in the workflow). The reason is the writer, not the
+*reads* deliberately does not follow. It needs its own credential to
+pull, which is what the explicit `oras login ghcr.io` in the workflow
+is for. That is not special to the mirror: `ghcr.io/tuist/macos-tahoe-xcode`
+answers an anonymous token request with `403 DENIED` too, so anything
+reading either one from CI has to authenticate. Checking from a laptop
+is misleading here, because a developer's `~/.docker/config.json`
+usually carries GHCR credentials already and the pull silently
+succeeds. The reason the mirror stays put is the writer, not the
 reader: the mirror's only writer is `mise run xcode-mirror:upload`
 running on a maintainer's Mac over a home link. Measured from one with
 the same 512 MB blob, that push is 136s to GHCR against 481s to the


### PR DESCRIPTION
The `xcode-xips` note in `infra/macos-xcode-image/AGENTS.md` claimed the mirror is the only artifact in the set that is not anonymously pullable. That is wrong, and I wrote it, so this corrects it.

`ghcr.io/tuist/macos-tahoe-xcode` refuses anonymous token requests too. Observed when a build cloned it without logging in first:

```
Error: AuthFailed(why: "received unexpected HTTP status code 403 while retrieving an authentication token",
  details: "{\"errors\":[{\"code\":\"DENIED\",\"message\":\"denied\"}]}")
```

**Why the original claim looked true.** I checked with `crane ls` from a laptop, where `~/.docker/config.json` already holds GHCR credentials, so the pull succeeds and looks anonymous. CI has no such credentials unless the workflow logs in, which is the case that actually matters. The note now says so, since the next person is likely to check the same wrong way.

**Scope.** Reasoning only. The decision to keep the mirror on GHCR is unchanged and never rested on this point: it stays because its only writer is a maintainer's laptop, where the same 512 MB blob measures 136s to GHCR against 481s to the tailnet registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)