### PR TITLE
fix(cli): Add interrupt and terminate signal handlers

### DIFF
--- a/cli/Sources/tuist/TuistCLI.swift
+++ b/cli/Sources/tuist/TuistCLI.swift
@@ -1,16 +1,63 @@
+import Dispatch
 import Foundation
 import Path
+
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
 
 @main
 @_documentation(visibility: private)
 private enum TuistCLI {
+    private static var signalSource: DispatchSourceSignal?
+
     static func main() async throws {
-        try await initDependencies { sessionPaths in
-            try await TuistCommand.main(
-                logFilePath: sessionPaths.logFilePath,
-                sessionDirectory: sessionPaths.sessionDirectory,
-                networkFilePath: sessionPaths.networkFilePath
-            )
+        let commandTask = Task {
+            try await initDependencies { sessionPaths in
+                try await TuistCommand.main(
+                    logFilePath: sessionPaths.logFilePath,
+                    sessionDirectory: sessionPaths.sessionDirectory,
+                    networkFilePath: sessionPaths.networkFilePath
+                )
+            }
         }
+
+        let signalSources = installSignalHandlers {
+            commandTask.cancel()
+        }
+        defer { uninstallSignalHandlers(signalSources) }
+
+        try await commandTask.value
+    }
+
+    private static func installSignalHandlers(
+        onSignal: @escaping @Sendable () -> Void
+    ) -> (DispatchSourceSignal, DispatchSourceSignal) {
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, SIG_IGN)
+
+        let queue = DispatchQueue(label: "dev.tuist.signals", qos: .userInitiated)
+        let interruptSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: queue)
+        let terminationSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: queue)
+
+        interruptSource.setEventHandler(handler: onSignal)
+        terminationSource.setEventHandler(handler: onSignal)
+        interruptSource.resume()
+        terminationSource.resume()
+        signalSource = interruptSource
+
+        return (interruptSource, terminationSource)
+    }
+
+    private static func uninstallSignalHandlers(
+        _ sources: (DispatchSourceSignal, DispatchSourceSignal)
+    ) {
+        sources.0.cancel()
+        sources.1.cancel()
+        signalSource = nil
+        signal(SIGINT, SIG_DFL)
+        signal(SIGTERM, SIG_DFL)
     }
 }


### PR DESCRIPTION
> Describe here the purpose of your PR.

Ensure Tuist cancels and cleans up xcodebuild and its test-runner descendants when interrupted. Tuist now handles SIGINT and SIGTERM, while [CommandRunner PR](https://github.com/tuist/Command/pull/303) terminates the spawned process group on cancellation. 

**Concrete example of issue I saw**
Run UI tests from tuist test command and then when UI tests are executing kill the command by Ctrl + c . The tuist process will get killed but you will see that UI tests will keep running in the simulator. Open the Activity Monitor and you will find an xcodebuild process still alive. Kill that process and that would terminate the UI tests run.


### How to test locally

> Document how to test your changes locally

Before this change, the UItests keep running after the tuist process is killed, after this change the UItests stop running after the tuist process gets killed.



