### PR TITLE
fix(server): stop the cache download spec claiming a 200 means a cache hit

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -525,6 +525,11 @@ public struct Client: APIProtocol {
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
     ///
+    /// The URL is signed from the request parameters alone, without a storage round trip, so
+    /// this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+    /// miss, or treat a failing download as the miss signal.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache`.
     /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)`.
     public func downloadCacheArtifact(_ input: Operations.downloadCacheArtifact.Input) async throws -> Operations.downloadCacheArtifact.Output {
@@ -2704,6 +2709,13 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
+                    name: "git_branch",
+                    value: input.query.git_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -2713,13 +2725,6 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "page_size",
                     value: input.query.page_size
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,
@@ -4891,9 +4896,13 @@ public struct Client: APIProtocol {
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
     ///
+    /// It is the only cache endpoint that reaches storage to answer, so it is what clients
+    /// should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+    /// checking storage and answers 200 either way.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache/exists`.
     /// - Remark: Generated from `#/paths//api/cache/exists/get(cacheArtifactExists)`.
-    @available(*, deprecated)
     public func cacheArtifactExists(_ input: Operations.cacheArtifactExists.Input) async throws -> Operations.cacheArtifactExists.Output {
         try await client.send(
             input: input,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -38,6 +38,11 @@ public protocol APIProtocol: Sendable {
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
     ///
+    /// The URL is signed from the request parameters alone, without a storage round trip, so
+    /// this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+    /// miss, or treat a failing download as the miss signal.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache`.
     /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)`.
     func downloadCacheArtifact(_ input: Operations.downloadCacheArtifact.Input) async throws -> Operations.downloadCacheArtifact.Output
@@ -239,9 +244,13 @@ public protocol APIProtocol: Sendable {
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
     ///
+    /// It is the only cache endpoint that reaches storage to answer, so it is what clients
+    /// should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+    /// checking storage and answers 200 either way.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache/exists`.
     /// - Remark: Generated from `#/paths//api/cache/exists/get(cacheArtifactExists)`.
-    @available(*, deprecated)
     func cacheArtifactExists(_ input: Operations.cacheArtifactExists.Input) async throws -> Operations.cacheArtifactExists.Output
     /// List CAS outputs for a given build.
     ///
@@ -801,6 +810,11 @@ extension APIProtocol {
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
     ///
+    /// The URL is signed from the request parameters alone, without a storage round trip, so
+    /// this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+    /// miss, or treat a failing download as the miss signal.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache`.
     /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)`.
     public func downloadCacheArtifact(
@@ -1294,9 +1308,13 @@ extension APIProtocol {
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
     ///
+    /// It is the only cache endpoint that reaches storage to answer, so it is what clients
+    /// should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+    /// checking storage and answers 200 either way.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache/exists`.
     /// - Remark: Generated from `#/paths//api/cache/exists/get(cacheArtifactExists)`.
-    @available(*, deprecated)
     public func cacheArtifactExists(
         query: Operations.cacheArtifactExists.Input.Query,
         headers: Operations.cacheArtifactExists.Input.Headers = .init()
@@ -2701,6 +2719,10 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/TestParams/model_identifier`.
             public var model_identifier: Swift.String?
+            /// The tests the caller asked this run to be limited to, as `Module/Suite` or `Module/Suite/testCase`. Filters Tuist itself applies, for a shard or for quarantine, are not included, since those are already known from the shard plan and the project's quarantine state.
+            ///
+            /// - Remark: Generated from `#/components/schemas/TestParams/only_test_identifiers`.
+            public var only_test_identifiers: [Swift.String]?
             /// The scheme used for the test run.
             ///
             /// - Remark: Generated from `#/components/schemas/TestParams/scheme`.
@@ -2713,6 +2735,10 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/TestParams/shard_plan_id`.
             public var shard_plan_id: Swift.String?
+            /// The tests the caller asked this run to exclude.
+            ///
+            /// - Remark: Generated from `#/components/schemas/TestParams/skip_test_identifiers`.
+            public var skip_test_identifiers: [Swift.String]?
             /// The status of the test run.
             ///
             /// - Remark: Generated from `#/components/schemas/TestParams/status`.
@@ -3234,9 +3260,11 @@ public enum Components {
             ///   - is_ci: Indicates if the run was executed on a Continuous Integration (CI) system.
             ///   - macos_version: The version of macOS used during the run.
             ///   - model_identifier: Identifier for the model where the run was executed, such as MacBookAir10,1.
+            ///   - only_test_identifiers: The tests the caller asked this run to be limited to, as `Module/Suite` or `Module/Suite/testCase`. Filters Tuist itself applies, for a shard or for quarantine, are not included, since those are already known from the shard plan and the project's quarantine state.
             ///   - scheme: The scheme used for the test run.
             ///   - shard_index: The zero-based shard index for this test result.
             ///   - shard_plan_id: The shard plan ID if this test run is part of a sharded execution.
+            ///   - skip_test_identifiers: The tests the caller asked this run to exclude.
             ///   - status: The status of the test run.
             ///   - test_modules: The test modules associated with the test run.
             ///   - xcode_version: The version of Xcode used during the run.
@@ -3257,9 +3285,11 @@ public enum Components {
                 is_ci: Swift.Bool,
                 macos_version: Swift.String? = nil,
                 model_identifier: Swift.String? = nil,
+                only_test_identifiers: [Swift.String]? = nil,
                 scheme: Swift.String? = nil,
                 shard_index: Swift.Int? = nil,
                 shard_plan_id: Swift.String? = nil,
+                skip_test_identifiers: [Swift.String]? = nil,
                 status: Components.Schemas.TestParams.statusPayload? = nil,
                 test_modules: Components.Schemas.TestParams.test_modulesPayload,
                 xcode_version: Swift.String? = nil
@@ -3280,9 +3310,11 @@ public enum Components {
                 self.is_ci = is_ci
                 self.macos_version = macos_version
                 self.model_identifier = model_identifier
+                self.only_test_identifiers = only_test_identifiers
                 self.scheme = scheme
                 self.shard_index = shard_index
                 self.shard_plan_id = shard_plan_id
+                self.skip_test_identifiers = skip_test_identifiers
                 self.status = status
                 self.test_modules = test_modules
                 self.xcode_version = xcode_version
@@ -3304,9 +3336,11 @@ public enum Components {
                 case is_ci
                 case macos_version
                 case model_identifier
+                case only_test_identifiers
                 case scheme
                 case shard_index
                 case shard_plan_id
+                case skip_test_identifiers
                 case status
                 case test_modules
                 case xcode_version
@@ -9691,13 +9725,13 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact`.
         public struct AbsentCacheArtifact: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorPayload`.
-            public struct errorPayloadPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorPayload/code`.
+            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorsPayload`.
+            public struct errorsPayloadPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorsPayload/code`.
                 public var code: Swift.String?
-                /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorPayload/message`.
+                /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errorsPayload/message`.
                 public var message: Swift.String?
-                /// Creates a new `errorPayloadPayload`.
+                /// Creates a new `errorsPayloadPayload`.
                 ///
                 /// - Parameters:
                 ///   - code:
@@ -9714,19 +9748,19 @@ public enum Components {
                     case message
                 }
             }
-            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/error`.
-            public typealias errorPayload = [Components.Schemas.AbsentCacheArtifact.errorPayloadPayload]
-            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/error`.
-            public var error: Components.Schemas.AbsentCacheArtifact.errorPayload?
+            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errors`.
+            public typealias errorsPayload = [Components.Schemas.AbsentCacheArtifact.errorsPayloadPayload]
+            /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact/errors`.
+            public var errors: Components.Schemas.AbsentCacheArtifact.errorsPayload?
             /// Creates a new `AbsentCacheArtifact`.
             ///
             /// - Parameters:
-            ///   - error:
-            public init(error: Components.Schemas.AbsentCacheArtifact.errorPayload? = nil) {
-                self.error = error
+            ///   - errors:
+            public init(errors: Components.Schemas.AbsentCacheArtifact.errorsPayload? = nil) {
+                self.errors = errors
             }
             public enum CodingKeys: String, CodingKey {
-                case error
+                case errors
             }
         }
         /// The maximum number of issues to return in a single page.
@@ -12742,6 +12776,11 @@ public enum Operations {
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
     ///
+    /// The URL is signed from the request parameters alone, without a storage round trip, so
+    /// this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+    /// miss, or treat a failing download as the miss signal.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache`.
     /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)`.
     public enum downloadCacheArtifact {
@@ -12839,7 +12878,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The artifact exists and is downloadable
+            /// A signed download URL was generated. The URL is returned without verifying that the artifact is stored, so this status does not imply a cache hit: a hash that was never uploaded is signed just the same, and the download then fails with a 404 at the storage provider.
             ///
             /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)/responses/200`.
             ///
@@ -13043,7 +13082,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The project or the cache artifact doesn't exist
+            /// The project doesn't exist
             ///
             /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)/responses/404`.
             ///
@@ -19206,6 +19245,10 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -19214,24 +19257,20 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
+                ///   - git_branch: Filter bundles by git branch.
                 ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
-                ///   - git_branch: Filter bundles by git branch.
                 public init(
+                    git_branch: Swift.String? = nil,
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    page_size: Swift.Int? = nil
                 ) {
+                    self.git_branch = git_branch
                     self.page = page
                     self.page_size = page_size
-                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -26523,6 +26562,11 @@ public enum Operations {
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
     ///
+    /// It is the only cache endpoint that reaches storage to answer, so it is what clients
+    /// should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+    /// checking storage and answers 200 either way.
+    ///
+    ///
     /// - Remark: HTTP `GET /api/cache/exists`.
     /// - Remark: Generated from `#/paths//api/cache/exists/get(cacheArtifactExists)`.
     public enum cacheArtifactExists {
@@ -26830,13 +26874,13 @@ public enum Operations {
                 @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json`.
                     public struct jsonPayload: Codable, Hashable, Sendable {
-                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorPayload`.
-                        public struct errorPayloadPayload: Codable, Hashable, Sendable {
-                            /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorPayload/code`.
+                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorsPayload`.
+                        public struct errorsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorsPayload/code`.
                             public var code: Swift.String?
-                            /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorPayload/message`.
+                            /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errorsPayload/message`.
                             public var message: Swift.String?
-                            /// Creates a new `errorPayloadPayload`.
+                            /// Creates a new `errorsPayloadPayload`.
                             ///
                             /// - Parameters:
                             ///   - code:
@@ -26853,19 +26897,19 @@ public enum Operations {
                                 case message
                             }
                         }
-                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/error`.
-                        public typealias errorPayload = [Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorPayloadPayload]
-                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/error`.
-                        public var error: Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorPayload?
+                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errors`.
+                        public typealias errorsPayload = [Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/json/errors`.
+                        public var errors: Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorsPayload?
                         /// Creates a new `jsonPayload`.
                         ///
                         /// - Parameters:
-                        ///   - error:
-                        public init(error: Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorPayload? = nil) {
-                            self.error = error
+                        ///   - errors:
+                        public init(errors: Operations.cacheArtifactExists.Output.NotFound.Body.jsonPayload.errorsPayload? = nil) {
+                            self.errors = errors
                         }
                         public enum CodingKeys: String, CodingKey {
-                            case error
+                            case errors
                         }
                     }
                     /// - Remark: Generated from `#/paths/api/cache/exists/GET/responses/404/content/application\/json`.

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -152,6 +152,15 @@ components:
           type: string
           x-struct:
           x-validate:
+        only_test_identifiers:
+          description: The tests the caller asked this run to be limited to, as `Module/Suite` or `Module/Suite/testCase`. Filters Tuist itself applies, for a shard or for quarantine, are not included, since those are already known from the shard plan and the project's quarantine state.
+          items:
+            type: string
+            x-struct:
+            x-validate:
+          type: array
+          x-struct:
+          x-validate:
         scheme:
           description: The scheme used for the test run.
           type: string
@@ -166,6 +175,15 @@ components:
         shard_plan_id:
           description: The shard plan ID if this test run is part of a sharded execution.
           type: string
+          x-struct:
+          x-validate:
+        skip_test_identifiers:
+          description: The tests the caller asked this run to exclude.
+          items:
+            type: string
+            x-struct:
+            x-validate:
+          type: array
           x-struct:
           x-validate:
         status:
@@ -1789,7 +1807,7 @@ components:
           x-struct:
           x-validate:
         git_branch:
-          description: The git branch the tests are built from. The suite inventory is read from this branch's history, falling back to the project's default branch.
+          description: "The git branch the tests are built from. The suite inventory is read from this branch's history, falling back to the project's default branch."
           type: string
           x-struct:
           x-validate:
@@ -5131,7 +5149,7 @@ components:
       x-validate:
     AbsentCacheArtifact:
       properties:
-        error:
+        errors:
           items:
             properties:
               code:
@@ -6767,7 +6785,12 @@ paths:
   /api/cache:
     get:
       callbacks: {}
-      description: This endpoint returns a signed URL that can be used to download an artifact from the cache.
+      description: |
+        This endpoint returns a signed URL that can be used to download an artifact from the cache.
+
+        The URL is signed from the request parameters alone, without a storage round trip, so
+        this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+        miss, or treat a failing download as the miss signal.
       operationId: downloadCacheArtifact
       parameters:
         - description: The category of the cache. It's used to differentiate between different types of caches.
@@ -6806,7 +6829,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CacheArtifactDownloadURL'
-          description: The artifact exists and is downloadable
+          description: 'A signed download URL was generated. The URL is returned without verifying that the artifact is stored, so this status does not imply a cache hit: a hash that was never uploaded is signed just the same, and the download then fails with a 404 at the storage provider.'
         '401':
           content:
             application/json:
@@ -6830,7 +6853,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: The project or the cache artifact doesn't exist
+          description: The project doesn't exist
       summary: Downloads an artifact from the cache.
       tags:
         - Cache
@@ -8807,10 +8830,10 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: The handle of the account.
-          in: path
-          name: account_handle
-          required: true
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
           schema:
             type: string
             x-struct:
@@ -8823,20 +8846,20 @@ paths:
             type: integer
             x-struct:
             x-validate:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
         - description: Number of items per page.
           in: query
           name: page_size
           required: false
           schema:
             type: integer
-            x-struct:
-            x-validate:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
             x-struct:
             x-validate:
         - description: The handle of the project.
@@ -11278,8 +11301,12 @@ paths:
   /api/cache/exists:
     get:
       callbacks: {}
-      deprecated: true
-      description: This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
+      description: |
+        This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
+
+        It is the only cache endpoint that reaches storage to answer, so it is what clients
+        should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+        checking storage and answers 200 either way.
       operationId: cacheArtifactExists
       parameters:
         - description: The category of the cache. It's used to differentiate between different types of caches.
@@ -11359,7 +11386,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  error:
+                  errors:
                     items:
                       properties:
                         code:
@@ -16451,7 +16478,7 @@ paths:
                   x-struct:
                   x-validate:
                 git_branch:
-                  description: The git branch the tests are built from. The suite inventory is read from this branch's history, falling back to the project's default branch.
+                  description: "The git branch the tests are built from. The suite inventory is read from this branch's history, falling back to the project's default branch."
                   type: string
                   x-struct:
                   x-validate:

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,9 +63,9 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
+                    git_branch: gitBranch,
                     page: page,
-                    page_size: pageSize,
-                    git_branch: gitBranch
+                    page_size: pageSize
                 )
             )
         )

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -278,7 +278,13 @@ defmodule TuistWeb.API.CacheController do
 
   operation(:download,
     summary: "Downloads an artifact from the cache.",
-    description: "This endpoint returns a signed URL that can be used to download an artifact from the cache.",
+    description: """
+    This endpoint returns a signed URL that can be used to download an artifact from the cache.
+
+    The URL is signed from the request parameters alone, without a storage round trip, so
+    this endpoint cannot report a cache miss. Use `cacheArtifactExists` to tell a hit from a
+    miss, or treat a failing download as the miss signal.
+    """,
     operation_id: "downloadCacheArtifact",
     parameters: [
       cache_category: [
@@ -302,10 +308,12 @@ defmodule TuistWeb.API.CacheController do
       name: [in: :query, type: :string, required: true, description: "The name of the artifact."]
     ],
     responses: %{
-      ok: {"The artifact exists and is downloadable", "application/json", CacheArtifactDownloadURL},
+      ok:
+        {"A signed download URL was generated. The URL is returned without verifying that the artifact is stored, so this status does not imply a cache hit: a hash that was never uploaded is signed just the same, and the download then fails with a 404 at the storage provider.",
+         "application/json", CacheArtifactDownloadURL},
       unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
       forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
-      not_found: {"The project or the cache artifact doesn't exist", "application/json", Error},
+      not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
   )
@@ -348,10 +356,14 @@ defmodule TuistWeb.API.CacheController do
 
   operation(:exists,
     summary: "It checks if an artifact exists in the cache.",
-    description:
-      "This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.",
+    description: """
+    This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
+
+    It is the only cache endpoint that reaches storage to answer, so it is what clients
+    should use to tell a cache hit from a miss. `downloadCacheArtifact` signs a URL without
+    checking storage and answers 200 either way.
+    """,
     operation_id: "cacheArtifactExists",
-    deprecated: true,
     parameters: [
       cache_category: [
         in: :query,
@@ -396,7 +408,7 @@ defmodule TuistWeb.API.CacheController do
            title: "AbsentCacheArtifact",
            type: :object,
            properties: %{
-             error: %Schema{
+             errors: %Schema{
                type: :array,
                items: %Schema{
                  type: :object,

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -673,6 +673,106 @@ defmodule TuistWeb.API.CacheControllerTest do
       response = json_response(conn, 200)
       assert response["data"]["url"] == download_url
     end
+
+    test "returns a signed url without consulting storage, so an unstored hash is still a 200", %{
+      conn: conn,
+      cache: cache
+    } do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      {:ok, account} = Accounts.get_account_by_id(project.account_id)
+      hash = "hash-that-was-never-uploaded"
+      name = "name"
+      project_slug = "#{account.name}/#{project.name}"
+      cache_category = "builds"
+      download_url = "https://tuist.dev/download/1234"
+      object_key = "#{project_slug}/#{cache_category}/#{hash}/#{name}"
+
+      reject(&Storage.object_exists?/2)
+
+      expect(Storage, :generate_download_url, fn ^object_key, _, _ ->
+        download_url
+      end)
+
+      conn = Authentication.put_current_project(conn, project)
+
+      # When
+      conn =
+        conn
+        |> assign(:cache, cache)
+        |> get(~p"/api/cache",
+          hash: hash,
+          name: name,
+          project_id: project_slug,
+          cache_category: cache_category
+        )
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["data"]["url"] == download_url
+    end
+  end
+
+  describe "GET /api/cache/exists" do
+    test "returns ok when the artifact is stored", %{conn: conn, cache: cache} do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      {:ok, account} = Accounts.get_account_by_id(project.account_id)
+      hash = "hash"
+      name = "name"
+      project_slug = "#{account.name}/#{project.name}"
+      cache_category = "builds"
+      object_key = "#{project_slug}/#{cache_category}/#{hash}/#{name}"
+
+      expect(Storage, :object_exists?, fn ^object_key, _ -> true end)
+
+      conn = Authentication.put_current_project(conn, project)
+
+      # When
+      conn =
+        conn
+        |> assign(:cache, cache)
+        |> get(~p"/api/cache/exists",
+          hash: hash,
+          name: name,
+          project_id: project_slug,
+          cache_category: cache_category
+        )
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["status"] == "success"
+    end
+
+    test "returns not found when the artifact is absent", %{conn: conn, cache: cache} do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      {:ok, account} = Accounts.get_account_by_id(project.account_id)
+      hash = "hash"
+      name = "name"
+      project_slug = "#{account.name}/#{project.name}"
+      cache_category = "builds"
+      object_key = "#{project_slug}/#{cache_category}/#{hash}/#{name}"
+
+      expect(Storage, :object_exists?, fn ^object_key, _ -> false end)
+
+      conn = Authentication.put_current_project(conn, project)
+
+      # When
+      conn =
+        conn
+        |> assign(:cache, cache)
+        |> get(~p"/api/cache/exists",
+          hash: hash,
+          name: name,
+          project_id: project_slug,
+          cache_category: cache_category
+        )
+
+      # Then
+      response = json_response(conn, 404)
+      assert [%{"code" => "not_found", "message" => "The artifact was not found"}] = response["errors"]
+    end
   end
 
   describe "GET /api/projects/:account_handle/:project_handle/cache/ac/:hash" do


### PR DESCRIPTION
## What changed

`GET /api/cache` (`downloadCacheArtifact`) signs a URL from the request parameters and returns 200 unconditionally. It never consults storage. The spec described the 200 as "The artifact exists and is downloadable" and the 404 as "The project or the cache artifact doesn't exist", neither of which is true of the handler.

The spec is what is wrong here, not the server, so only the documentation changes:

- **200** now states that a signed URL is returned without verifying the object is stored, that the status does not imply a cache hit, and that a hash which was never uploaded is signed just the same and then fails with a 404 at the storage provider.
- **404** is narrowed to the project case, which is the only one the `selected_project` plug can produce.
- The operation description points at `cacheArtifactExists` for hit/miss detection.

This also un-deprecates `cacheArtifactExists` (`GET /api/cache/exists`) and fixes a second spec/handler mismatch on it: the 404 schema documented an `error` property while the handler sends `errors`.

## Why

Minting the URL without a storage round trip is intentional and keeps the download path cheap, so the endpoint's behaviour is deliberately left alone. But because the spec promised existence, HAR captures of a total cache miss read as a fully warm cache, which sends anyone debugging a miss down the wrong path and inflates any hit rate derived from status codes.

This is not a regression. Before [#8960](https://github.com/tuist/tuist/pull/8960) the handler called `Storage.object_exists?` only to emit analytics, with the `json(conn, ...)` call outside that block, so it returned 200 either way. The spec has been wrong about this endpoint for its whole life.

## On the deprecation

`deprecated: true` has been on `cacheArtifactExists` since the server was first imported (`e06bda5d310`) and since the CLI spec first landed (`fbcd17d05d`). Both are squashed imports from then private repositories, so no rationale is recorded anywhere in this repository.

I could not find a successor. `downloadCacheArtifact` is the endpoint that does not check, `getCacheActionItem` covers action-cache items in a different namespace, and the cache service's `HEAD /api/cache/module/:id` belongs to the Xcode module-cache lane with its own key space. Since `exists` is the only cache endpoint that reaches storage to answer, it is precisely what a client needs in order to detect a miss, so a deprecation flag was steering clients away from the one thing that works. The CLI also still ships `CacheExistsService` against it.

If the deprecation was in fact intentional for a reason that lives outside this repository, say so and I will restore the flag and document the intended migration instead.

## Reviewer notes

**The CLI diff is larger than the cache changes.** Regenerating with `mise run generate-api-cli-code` flushed drift unrelated to this PR, since the generator's ordering is not stable enough to gate on in CI and nothing enforces spec freshness between regenerations:

- `TestParams` was missing `only_test_identifiers` and `skip_test_identifiers`. Additive and optional, so no call sites change.
- The `listBundles` query parameters reordered to `git_branch, page, page_size`. Swift enforces argument order even when labels are given, so the regenerated memberwise init stopped matching `ListBundlesService`, which called it in the old order. That call site is reordered in the same commit.

I audited every other changed declaration in `Types.swift`: `listBundles` is the only ordering change, and the renamed payload property has no references outside the generated files. `CacheExistsService` does not decode the 404 body, so the rename does not reach it.

The two commits are split so the server change can be reviewed without the regeneration noise.

## How to test locally

```bash
cd server && mix test test/tuist_web/controllers/api/cache_controller_test.exs
```

46 pass, up from 43. The three new tests are:

- `GET /api/cache/exists` returning 200 when stored and 404 when absent, pinning the real 404 body shape. This endpoint had no coverage at all before, which felt too thin for something being promoted to the supported miss signal.
- A download test using `reject(&Storage.object_exists?/2)`, so "never consults storage, still a 200" is enforced rather than only described.

**Swift compilation:** the CLI does not build in the worktree this was written in, where `tuist install` fails with `duplicate key found: 'Package@swift-5.9.0.swift'`, a pre-existing SwiftPM issue unrelated to these changes. CI covers it instead: `SwiftPM Build`, `Linux Build`, `Linux Unit Tests` and `Build Acceptance Tests` all pass on this PR, so the `ListBundlesService` reorder and the regenerated OpenAPI files do compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
