### PR TITLE
fix(infra): serialise registry pushes again until uploads are reliable

### DIFF
--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -208,7 +208,13 @@ jobs:
           local-name: macos-tahoe-xcode
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/macos-tahoe-xcode:${{ steps.build.outputs.tag }}
           chunk-size: "64"
-          concurrency: "4"
+          # Deliberately serialised. Four uploads in flight measured
+          # 13.1 MB/s against 3.2 MB/s here, but the registry loses blob
+          # upload sessions under that parallelism and fails the push
+          # with a 500, logging `error resolving upload: s3aws: Path not
+          # found .../_uploads/<uuid>/data`. Reliability wins until that
+          # is fixed; see the chunk size above, which is the change that
+          # actually cut request volume.
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -153,7 +153,13 @@ jobs:
           local-name: tuist-runner
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ steps.image-tag.outputs.value }}
           chunk-size: "64"
-          concurrency: "4"
+          # Deliberately serialised. Four uploads in flight measured
+          # 13.1 MB/s against 3.2 MB/s here, but the registry loses blob
+          # upload sessions under that parallelism and fails the push
+          # with a 500, logging `error resolving upload: s3aws: Path not
+          # found .../_uploads/<uuid>/data`. Reliability wins until that
+          # is fixed; see the chunk size above, which is the change that
+          # actually cut request volume.
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1003,7 +1003,13 @@ jobs:
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:latest
           chunk-size: "64"
-          concurrency: "4"
+          # Deliberately serialised. Four uploads in flight measured
+          # 13.1 MB/s against 3.2 MB/s here, but the registry loses blob
+          # upload sessions under that parallelism and fails the push
+          # with a 500, logging `error resolving upload: s3aws: Path not
+          # found .../_uploads/<uuid>/data`. Reliability wins until that
+          # is fixed; see the chunk size above, which is the change that
+          # actually cut request volume.
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4
@@ -1147,7 +1153,13 @@ jobs:
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}-${{ needs.check-releases.outputs.runner-image-next-version-number }}
             ${{ vars.OCI_REGISTRY_HOST }}/tuist-runner:${{ steps.build.outputs.profile }}
           chunk-size: "64"
-          concurrency: "4"
+          # Deliberately serialised. Four uploads in flight measured
+          # 13.1 MB/s against 3.2 MB/s here, but the registry loses blob
+          # upload sessions under that parallelism and fails the push
+          # with a 500, logging `error resolving upload: s3aws: Path not
+          # found .../_uploads/<uuid>/data`. Reliability wins until that
+          # is fixed; see the chunk size above, which is the change that
+          # actually cut request volume.
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -148,7 +148,13 @@ jobs:
           local-name: tuist-xcresult-processor
           remote-names: ${{ vars.OCI_REGISTRY_HOST }}/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
           chunk-size: "64"
-          concurrency: "4"
+          # Deliberately serialised. Four uploads in flight measured
+          # 13.1 MB/s against 3.2 MB/s here, but the registry loses blob
+          # upload sessions under that parallelism and fails the push
+          # with a 500, logging `error resolving upload: s3aws: Path not
+          # found .../_uploads/<uuid>/data`. Reliability wins until that
+          # is fixed; see the chunk size above, which is the change that
+          # actually cut request volume.
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## What changed

Removes `concurrency: "4"` from every registry-bound `tart-push`, returning them to serialised uploads. `chunk-size: "64"` stays everywhere, including the two release-path calls that had been silently falling back to `3`.

## Why

[#12479](https://github.com/tuist/tuist/pull/12479) set `concurrency: "4"` and did exactly what it claimed, taking throughput from 3.2 MB/s to 13.1 MB/s. It also broke pushes of new large images, **including on the release path**.

The registry loses in-progress blob upload sessions under that parallelism. Clients see an opaque 500; the registry logs the real cause:

```
error resolving upload: s3aws: Path not found:
  /docker/registry/v2/repositories/<repo>/_uploads/<uuid>/data
```

Observed against both `tuist-runner` and `tuist-xcresult-processor`, so it is not repo-specific and it does affect `server-production-deployment.yml`. `tart` retried through all 8 attempts and the step timed out. The same underlying failure is what makes `crane copy` unusable against this registry, where it surfaces as `RANGE_INVALID` instead.

## Measurements

Same host, same image, both after the sidecar CPU bump was live:

| concurrency | throughput | uploads |
|---|---|---|
| 4 | 13.1 MB/s | sessions lost within ~9 min |
| 1 | 3.2 MB/s | clean |

## What is not implicated

**The sidecar CPU bump stays.** Serialised throughput measures 3.2 MB/s both before and after it, with the sidecar sitting at 396m of its 2000m limit. Its headroom only ever paid off through parallelism, so it costs nothing to leave in place and it is the right shape once uploads are reliable.

**The chunk size stays.** That is the change that actually cut request volume, roughly 1,000 requests for a 50 GB image instead of 17,000, and it is not what breaks uploads: the base image seed pushed all five tags at chunk size 64 with uploads serialised.

## Honest framing

This is a mitigation, not a fix, and it is undoing a regression I introduced. #12479 changed three things at once on the release path (chunk size, concurrency, and the server's CPU ceiling), which is why it took a controlled run at concurrency 1 to work out which one was responsible.

The registry should tolerate concurrent blob uploads. Until it does, this ceiling stays where it is. An intermediate concurrency of 2 was not tested and might buy some of the throughput back safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
