### PR TITLE
fix(cli): keep Xcode compilation cache settings out of the module cache hash

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1852,6 +1852,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.rootDirectoryLocator.targetName),
                     .target(name: Module.constants.targetName),
                     .target(name: Module.environment.targetName),
+                    .target(name: Module.environmentTesting.targetName),
                     .target(name: Module.threadSafe.targetName),
                     .external(name: "PathKit"),
                     .external(name: "XcodeProj"),

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -418,13 +418,7 @@ public struct Environment: Environmenting {
     }
 
     public func cacheSocketPathString(for fullHandle: String) -> String {
-        let socketPathString = cacheSocketPath(for: fullHandle).pathString
-        let homeDirectoryPathString = homeDirectory.pathString
-        if socketPathString.hasPrefix(homeDirectoryPathString) {
-            return "$HOME" + socketPathString.dropFirst(homeDirectoryPathString.count)
-        } else {
-            return socketPathString
-        }
+        homeRelativePathString(cacheSocketPath(for: fullHandle))
     }
 
     public func cacheLaunchAgentLabel(for fullHandle: String) -> String {
@@ -447,13 +441,9 @@ public struct Environment: Environmenting {
     }
 
     public func homeRelativePathString(_ path: AbsolutePath) -> String {
-        let pathString = path.pathString
-        let homeDirectoryPathString = homeDirectory.pathString
-        if pathString.hasPrefix(homeDirectoryPathString) {
-            return "$HOME" + pathString.dropFirst(homeDirectoryPathString.count)
-        } else {
-            return pathString
-        }
+        guard path.isDescendantOfOrEqual(to: homeDirectory) else { return path.pathString }
+        let relativePath = path.relative(to: homeDirectory).pathString
+        return relativePath == "." ? "$HOME" : "$HOME/\(relativePath)"
     }
 
     public func casProxyLaunchAgentLabel() -> String {

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -88,6 +88,11 @@ public protocol Environmenting: Sendable {
     /// baked into a build setting.
     func casProxySocketPathString() -> String
 
+    /// A path with its `$HOME` prefix restored, so a value baked into a build setting
+    /// does not hard-code one machine's home directory. Paths outside `$HOME` are
+    /// returned unchanged.
+    func homeRelativePathString(_ path: AbsolutePath) -> String
+
     /// Returns the LaunchAgent label for the per-project Xcode cache daemon (the
     /// non-kura path) of the given full handle. Shared between `tuist setup cache`
     /// (which registers the LaunchAgent) and `tuist teardown cache` (which boots it out).
@@ -438,12 +443,10 @@ public struct Environment: Environmenting {
     }
 
     public func casProxySocketPathString() -> String {
-        homeRelative(casProxySocketPath())
+        homeRelativePathString(casProxySocketPath())
     }
 
-    /// A path with its `$HOME` prefix restored, so a value baked into a build
-    /// setting does not hard-code one machine's home directory.
-    private func homeRelative(_ path: AbsolutePath) -> String {
+    public func homeRelativePathString(_ path: AbsolutePath) -> String {
         let pathString = path.pathString
         let homeDirectoryPathString = homeDirectory.pathString
         if pathString.hasPrefix(homeDirectoryPathString) {

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -95,6 +95,16 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
         "$HOME/cas-proxy.sock"
     }
 
+    public func homeRelativePathString(_ path: AbsolutePath) -> String {
+        let pathString = path.pathString
+        let homeDirectoryPathString = homeDirectory.pathString
+        if pathString.hasPrefix(homeDirectoryPathString) {
+            return "$HOME" + pathString.dropFirst(homeDirectoryPathString.count)
+        } else {
+            return pathString
+        }
+    }
+
     public func casProxyLaunchAgentLabel() -> String {
         "tuist.cas-proxy"
     }

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -96,13 +96,9 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
     }
 
     public func homeRelativePathString(_ path: AbsolutePath) -> String {
-        let pathString = path.pathString
-        let homeDirectoryPathString = homeDirectory.pathString
-        if pathString.hasPrefix(homeDirectoryPathString) {
-            return "$HOME" + pathString.dropFirst(homeDirectoryPathString.count)
-        } else {
-            return pathString
-        }
+        guard path.isDescendantOfOrEqual(to: homeDirectory) else { return path.pathString }
+        let relativePath = path.relative(to: homeDirectory).pathString
+        return relativePath == "." ? "$HOME" : "$HOME/\(relativePath)"
     }
 
     public func casProxyLaunchAgentLabel() -> String {

--- a/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
@@ -69,7 +69,7 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
                 if let casPluginPath = try await resolvedCASPluginPath() {
                     baseSettings["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] = "YES"
                     baseSettings["COMPILATION_CACHE_ENABLE_PLUGIN"] = "YES"
-                    baseSettings["COMPILATION_CACHE_PLUGIN_PATH"] = .string(casPluginPath.pathString)
+                    baseSettings["COMPILATION_CACHE_PLUGIN_PATH"] = Self.pluginPathSetting(casPluginPath)
                     // Hand the plugin its per-project options as compiler flags, which
                     // reach every frontend — including an Xcode ⌘B build that carries
                     // no CLI environment — so the proxy can route (and honor the upload
@@ -153,6 +153,18 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
             return candidate
         }
         return nil
+    }
+
+    /// The CAS plugin dylib's path as it is written into the build setting.
+    ///
+    /// `$HOME`-relative for the same reason as the proxy socket: the value is baked
+    /// into the generated pbxproj and reaches the target content hash through the
+    /// project's base settings, so a raw install path (Homebrew locally, mise on CI)
+    /// would give identical code a different module-cache key on every machine.
+    /// A plugin installed outside `$HOME` has no prefix to factor out and is written
+    /// verbatim.
+    private static func pluginPathSetting(_ path: AbsolutePath) -> SettingValue {
+        .string(Environment.current.homeRelativePathString(path))
     }
 
     /// Appends the plugin's per-project `-cas-plugin-option` flags

--- a/cli/Sources/TuistHasher/SettingsContentHasher.swift
+++ b/cli/Sources/TuistHasher/SettingsContentHasher.swift
@@ -49,7 +49,8 @@ public struct SettingsContentHasher: SettingsContentHashing {
 
     private func hash(_ settingsDictionary: SettingsDictionary) throws -> String {
         let filteredSettings = settingsDictionary.compactMap { key, value -> (String, SettingValue)? in
-            let filteredValue = filterWarningFlags(from: value)
+            guard !Self.isCompilationCacheSetting(key) else { return nil }
+            let filteredValue = filterProductNeutralFlags(from: value)
             return filteredValue.map { (key, $0) }
         }
         let sortedAndNormalizedSettings = filteredSettings
@@ -58,13 +59,50 @@ public struct SettingsContentHasher: SettingsContentHashing {
         return try contentHasher.hash(sortedAndNormalizedSettings)
     }
 
-    private func filterWarningFlags(from value: SettingValue) -> SettingValue? {
+    /// Build settings that configure Xcode's compilation cache, written by
+    /// `XcodeCacheSettingsProjectMapper` into a project's base settings.
+    ///
+    /// They select where a compilation caches, not what it produces, so two builds
+    /// differing only here yield the same binary and must land on the same hash.
+    /// Hashing them splits the cache along axes that have nothing to do with the
+    /// code: `COMPILATION_CACHE_PLUGIN_PATH` carries the dylib's install path, which
+    /// differs between a Homebrew install and a mise one, and toggling
+    /// `enableCaching` or the `kura` client flag at all moves every target's hash.
+    private static func isCompilationCacheSetting(_ key: String) -> Bool {
+        key.hasPrefix("COMPILATION_CACHE_")
+    }
+
+    private func filterProductNeutralFlags(from value: SettingValue) -> SettingValue? {
         guard case let .array(elements) = value else {
             return value
         }
 
-        let filteredElements = filterWarningFlags(from: elements)
+        let filteredElements = filterCASPluginOptions(from: filterWarningFlags(from: elements))
         return filteredElements.isEmpty ? nil : .array(filteredElements)
+    }
+
+    /// Drops `-cas-plugin-option <value>` pairs, which `XcodeCacheSettingsProjectMapper`
+    /// appends to `OTHER_SWIFT_FLAGS` to reach compiler frontends that carry no CLI
+    /// environment. They configure the CAS plugin's routing and upload policy, not
+    /// codegen. `tuist-upload=false` is the one that matters in practice: the
+    /// documented `xcodeCache(upload: Environment.isCI)` policy sets it on developer
+    /// machines and not on CI, which would otherwise give the two disjoint cache keys
+    /// and deny developers every artifact CI warmed.
+    private func filterCASPluginOptions(from elements: [String]) -> [String] {
+        var result: [String] = []
+        var index = 0
+
+        while index < elements.count {
+            if elements[index] == "-cas-plugin-option", index + 1 < elements.count {
+                index += 2
+                continue
+            }
+
+            result.append(elements[index])
+            index += 1
+        }
+
+        return result
     }
 
     private func filterWarningFlags(from elements: [String]) -> [String] {

--- a/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
@@ -465,6 +465,46 @@ struct XcodeCacheSettingsProjectMapperTests {
         )
     }
 
+    /// A sibling directory whose name merely starts with the home directory's is not
+    /// under `$HOME`. Comparing the paths as strings would treat `/Users/me-tools` as
+    /// living inside `/Users/me` and emit `$HOME-tools/...`, which resolves nowhere.
+    @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment())
+    func map_whenPluginIsInHomeSiblingSharingItsPrefix_writesAbsolutePluginPath() async throws {
+        // Given
+        try stubXcodeVersion(Version(26, 0, 0))
+        let homeDirectory = Environment.current.homeDirectory
+        let siblingDirectory = homeDirectory.parentDirectory
+            .appending(component: homeDirectory.basename + "-tools")
+        let casPluginPath = siblingDirectory.appending(component: "libtuist_cas_plugin.dylib")
+        try await FileSystem().makeDirectory(at: siblingDirectory)
+        try await FileSystem().touch(casPluginPath)
+        let tuist = Tuist(
+            project: .generated(
+                .test(
+                    generationOptions: .test(enableCaching: true)
+                )
+            ),
+            fullHandle: "test-org/test-project",
+            inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            url: Constants.URLs.production
+        )
+        let subject = XcodeCacheSettingsProjectMapper(
+            tuist: tuist,
+            kuraEnabled: true,
+            casPluginCandidates: [casPluginPath]
+        )
+        let project = Project.test(name: "TestProject", settings: .test(base: [:]))
+
+        // When
+        let (mappedProject, _) = try await subject.map(project: project)
+
+        // Then
+        #expect(
+            mappedProject.settings.base["COMPILATION_CACHE_PLUGIN_PATH"]
+                == .string(casPluginPath.pathString)
+        )
+    }
+
     /// A plugin installed outside `$HOME` (a Homebrew prefix, say) has no `$HOME` to
     /// factor out and must be written verbatim.
     @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment())

--- a/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
@@ -9,6 +9,7 @@ import TuistConfig
 import TuistConstants
 import TuistCore
 import TuistEnvironment
+import TuistEnvironmentTesting
 import TuistSupport
 import TuistTesting
 import XcodeGraph
@@ -422,5 +423,81 @@ struct XcodeCacheSettingsProjectMapperTests {
         )
         #expect(baseSettings["COMPILATION_CACHE_PLUGIN_PATH"] == nil)
         #expect(baseSettings["OTHER_SWIFT_FLAGS"] == nil)
+    }
+
+    /// The plugin path is baked into the generated pbxproj and feeds the target
+    /// content hash through the project's base settings, so a raw install path
+    /// (Homebrew locally, mise on CI) would give the same code different module
+    /// cache keys on different machines. `COMPILATION_CACHE_REMOTE_SERVICE_PATH`
+    /// already gets this treatment via `casProxySocketPathString()`.
+    @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment())
+    func map_whenPluginIsUnderHome_writesHomeRelativePluginPath() async throws {
+        // Given
+        try stubXcodeVersion(Version(26, 0, 0))
+        let casPluginPath = Environment.current.homeDirectory
+            .appending(components: [".local", "share", "mise", "libtuist_cas_plugin.dylib"])
+        try await FileSystem().makeDirectory(at: casPluginPath.parentDirectory)
+        try await FileSystem().touch(casPluginPath)
+        let tuist = Tuist(
+            project: .generated(
+                .test(
+                    generationOptions: .test(enableCaching: true)
+                )
+            ),
+            fullHandle: "test-org/test-project",
+            inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            url: Constants.URLs.production
+        )
+        let subject = XcodeCacheSettingsProjectMapper(
+            tuist: tuist,
+            kuraEnabled: true,
+            casPluginCandidates: [casPluginPath]
+        )
+        let project = Project.test(name: "TestProject", settings: .test(base: [:]))
+
+        // When
+        let (mappedProject, _) = try await subject.map(project: project)
+
+        // Then
+        #expect(
+            mappedProject.settings.base["COMPILATION_CACHE_PLUGIN_PATH"]
+                == .string("$HOME/.local/share/mise/libtuist_cas_plugin.dylib")
+        )
+    }
+
+    /// A plugin installed outside `$HOME` (a Homebrew prefix, say) has no `$HOME` to
+    /// factor out and must be written verbatim.
+    @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment())
+    func map_whenPluginIsOutsideHome_writesAbsolutePluginPath() async throws {
+        // Given
+        try stubXcodeVersion(Version(26, 0, 0))
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let casPluginPath = temporaryDirectory.appending(component: "libtuist_cas_plugin.dylib")
+        try await FileSystem().touch(casPluginPath)
+        let tuist = Tuist(
+            project: .generated(
+                .test(
+                    generationOptions: .test(enableCaching: true)
+                )
+            ),
+            fullHandle: "test-org/test-project",
+            inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            url: Constants.URLs.production
+        )
+        let subject = XcodeCacheSettingsProjectMapper(
+            tuist: tuist,
+            kuraEnabled: true,
+            casPluginCandidates: [casPluginPath]
+        )
+        let project = Project.test(name: "TestProject", settings: .test(base: [:]))
+
+        // When
+        let (mappedProject, _) = try await subject.map(project: project)
+
+        // Then
+        #expect(
+            mappedProject.settings.base["COMPILATION_CACHE_PLUGIN_PATH"]
+                == .string(casPluginPath.pathString)
+        )
     }
 }

--- a/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
@@ -156,3 +156,98 @@ struct SettingsContentHasherBaseDebugTests {
         )
     }
 }
+
+struct SettingsContentHasherCompilationCacheTests {
+    private func makeSubject() -> SettingsContentHasher {
+        let contentHasher = MockContentHashing()
+        let xcconfigHasher = MockXCConfigContentHashing()
+        given(contentHasher)
+            .hash(Parameter<[String]>.any)
+            .willProduce { $0.joined(separator: ";") }
+        given(contentHasher)
+            .hash(Parameter<String>.any)
+            .willProduce { $0 + "-hash" }
+        return SettingsContentHasher(contentHasher: contentHasher, xcconfigHasher: xcconfigHasher)
+    }
+
+    private func settings(base: SettingsDictionary) -> Settings {
+        Settings(base: base, configurations: [BuildConfiguration.debug("Debug"): nil], defaultSettings: .none)
+    }
+
+    /// The compilation-cache settings select where a compilation caches, not what it
+    /// produces. `COMPILATION_CACHE_PLUGIN_PATH` in particular holds the dylib's
+    /// install path, which differs between a Homebrew install and a mise one, so
+    /// hashing it gives developer machines and CI disjoint keys for identical code.
+    @Test func hash_ignoresCompilationCacheSettings() async throws {
+        // Given
+        let subject = makeSubject()
+        let withoutCacheSettings = settings(base: ["SWIFT_VERSION": .string("5")])
+        let withCacheSettings = settings(base: [
+            "SWIFT_VERSION": .string("5"),
+            "COMPILATION_CACHE_ENABLE_CACHING": .string("YES"),
+            "COMPILATION_CACHE_ENABLE_PLUGIN": .string("YES"),
+            "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string("YES"),
+            "COMPILATION_CACHE_PLUGIN_PATH": .string("/opt/homebrew/lib/libtuist_cas_plugin.dylib"),
+            "COMPILATION_CACHE_REMOTE_SERVICE_PATH": .string("$HOME/.local/state/tuist/cas-proxy.sock"),
+        ])
+
+        // When / Then
+        #expect(try await subject.hash(settings: withCacheSettings) == subject.hash(settings: withoutCacheSettings))
+    }
+
+    /// Two machines that resolve the plugin to different install paths must agree.
+    @Test func hash_ignoresCompilationCachePluginPathDifferences() async throws {
+        // Given
+        let subject = makeSubject()
+        let homebrew = settings(base: [
+            "COMPILATION_CACHE_PLUGIN_PATH": .string("/opt/homebrew/lib/libtuist_cas_plugin.dylib"),
+        ])
+        let mise = settings(base: [
+            "COMPILATION_CACHE_PLUGIN_PATH": .string("/Users/ci/.local/share/mise/installs/tuist/lib/libtuist_cas_plugin.dylib"),
+        ])
+
+        // When / Then
+        #expect(try await subject.hash(settings: homebrew) == subject.hash(settings: mise))
+    }
+
+    /// `xcodeCache(upload:)` reaches the build as a `-cas-plugin-option` pair rather
+    /// than a `COMPILATION_CACHE_*` key, so filtering by key alone would still split
+    /// CI from local for the documented `upload: Environment.isCI` policy.
+    @Test func hash_ignoresCASPluginOptionsInOtherSwiftFlags() async throws {
+        // Given
+        let subject = makeSubject()
+        let uploading = settings(base: [
+            "OTHER_SWIFT_FLAGS": .array([
+                "$(inherited)",
+                "-cas-plugin-option", "tuist-instance=test-org/test-project",
+            ]),
+        ])
+        let readOnly = settings(base: [
+            "OTHER_SWIFT_FLAGS": .array([
+                "$(inherited)",
+                "-cas-plugin-option", "tuist-instance=test-org/test-project",
+                "-cas-plugin-option", "tuist-upload=false",
+            ]),
+        ])
+
+        // When / Then
+        #expect(try await subject.hash(settings: uploading) == subject.hash(settings: readOnly))
+    }
+
+    /// The filter must not swallow flags that do change the built product.
+    @Test func hash_keepsNonCASPluginOtherSwiftFlags() async throws {
+        // Given
+        let subject = makeSubject()
+        let plain = settings(base: [
+            "OTHER_SWIFT_FLAGS": .array(["$(inherited)", "-cas-plugin-option", "tuist-upload=false"]),
+        ])
+        let withRealFlag = settings(base: [
+            "OTHER_SWIFT_FLAGS": .array([
+                "$(inherited)", "-cas-plugin-option", "tuist-upload=false", "-DFEATURE_FLAG",
+            ]),
+        ])
+
+        // When / Then
+        #expect(try await subject.hash(settings: plain) != subject.hash(settings: withRealFlag))
+    }
+}


### PR DESCRIPTION
## What

Stops Xcode compilation cache settings from moving module cache keys, and writes `COMPILATION_CACHE_PLUGIN_PATH` `$HOME`-relative.

## Why

Reported by a user running both caches together (~240 targets, `fullHandle` set, kura enabled). Enabling the Xcode cache cost them the module cache, and they had to carry three workarounds to get both.

`XcodeCacheSettingsProjectMapper` writes its settings into `project.settings.base`, and `TargetContentHasher` folds `projectSettingsHash` (computed from `graphTarget.project.settings`) into every target hash. So each of these alone moves all of a project's target hashes, confirmed with `tuist hash cache`:

- `enableCaching` on/off
- `TUIST_FEATURE_FLAG_KURA` on/off
- `COMPILATION_CACHE_PLUGIN_PATH` (same dylib, different install path)
- `xcodeCache(upload:)` true/false

Two consequences. First, the plugin path is machine-varying: Homebrew locally, mise on CI. Second, the upload policy we document, `upload: Environment.isCI`, gives CI and developer machines different keys by construction, so developers reuse none of CI's warmed binaries.

### Root cause

These settings select where a compilation caches, not what it produces. Two builds differing only here yield the same binary, so they must land on the same hash. They were never meant to be hash inputs; nothing excluded them.

The plugin path is a separate, smaller oversight. Both sibling paths in the same mapper are already relocatable: the kura lane's `COMPILATION_CACHE_REMOTE_SERVICE_PATH` goes through `casProxySocketPathString()` → `homeRelative()`, whose comment says it exists "to be environment-independent when baked into a build setting", and the legacy lane's socket has its own inline `$HOME` substitution. `COMPILATION_CACHE_PLUGIN_PATH` was the one written raw.

## How

### 1. Keep the settings out of the hash

Filtering in `SettingsContentHasher`, following the `filterWarningFlags` precedent already there for `-Xfrontend -warn-*`:

- `COMPILATION_CACHE_*` keys, dropped wholesale.
- `-cas-plugin-option <value>` pairs, dropped from `OTHER_SWIFT_FLAGS`.

Both halves are needed. `xcodeCache(upload:)` does not reach the build as a `COMPILATION_CACHE_*` key at all; the mapper carries it as `-cas-plugin-option tuist-upload=false` so it reaches frontends that have no CLI environment. A key-only filter would have looked correct while still splitting CI from local for the documented upload policy.

Filtering rather than hashing pre-mapped settings: mappers run project-wide before hashing, so there is no clean seam to hash "settings as authored". Filtering matches the existing carve-out and keeps the rule where the reasoning lives.

### 2. Make the plugin path relocatable

`COMPILATION_CACHE_PLUGIN_PATH` now goes through the same helper as the socket, exposed as `Environmenting.homeRelativePathString(_:)`.

### 3. Fix that helper's `$HOME` comparison

The existing implementation tested `pathString.hasPrefix(homeDirectory.pathString)`, which treats any sibling whose name merely starts with the home directory's as living inside it. With `$HOME` at `/Users/me`, a plugin at `/Users/me-tools/...` became `$HOME-tools/...`, a path that resolves nowhere. Now it compares by path components via `isDescendantOfOrEqual(to:)` + `relative(to:)`, which drops the manual string surgery entirely.

`cacheSocketPathString` carried its own copy of the same string logic, and the same bug. It now calls the shared helper.

### Scope

`SettingsContentHasher`'s only consumer is `TargetContentHasher`, which feeds the binary cache and selective testing. No generation-staleness path reads it, so the generated pbxproj still tracks these settings and a changed plugin path still lands in the project.

Not touched: the prefix-mapping settings the same mapper writes. They are gated on Xcode 27, and the cache hash already includes `swiftlangVersion()` via `additionalStrings`, so they never split anything the compiler version has not already split.

`Module.swift` declares TuistGeneratorTests' dependency on TuistEnvironmentTesting explicitly. It resolved transitively through TuistTesting, but the graph linter rejects implicit dependencies.

## Impact

Developers and CI share module cache keys again with both caches on, and `upload: Environment.isCI` behaves as documented. This is a one-time hash change: every target rehashes once on upgrade, then stays stable across machines.

## Validation

Tests written first and confirmed red against unpatched sources:

- `hash_ignoresCompilationCacheSettings`, `hash_ignoresCompilationCachePluginPathDifferences`, `hash_ignoresCASPluginOptionsInOtherSwiftFlags` fail without the filter
- `map_whenPluginIsUnderHome_writesHomeRelativePluginPath` fails without the `homeRelative` fix
- `map_whenPluginIsInHomeSiblingSharingItsPrefix_writesAbsolutePluginPath` fails against the old `hasPrefix` comparison, passes with component comparison
- `hash_keepsNonCASPluginOtherSwiftFlags` and `map_whenPluginIsOutsideHome_writesAbsolutePluginPath` pass both ways, guarding against over-filtering

Green after: full `TuistHasherTests` and `TuistGeneratorTests` suites pass, including the pre-existing mapper tests. SwiftFormat and SwiftLint clean on the changed files.

## Follow-ups, not in this PR

- `tuist cache warm` has no `--` passthrough, so a build setting override applied to `tuist xcodebuild` cannot be applied to warming.
- Separately, the reporter measured 12 min/run on a unit suite by forcing `COMPILATION_CACHE_ENABLE_CACHING=NO` on CI, against a fully warm module cache. That points at fixed CAS overhead on a cold-CAS runner when the module cache already covers the work, and is unrelated to hashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
