### PR TITLE
fix(server): unblock the image scan on the August Chromium CVE batch

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,6 +10,7 @@ on:
       - noora/**
       - .github/workflows/server.yml
       - server/pnpm-lock.yaml
+      - .trivyignore
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -19,6 +20,7 @@ on:
       - .github/workflows/server.yml
       - server/pnpm-lock.yaml
       - noora/aube-lock.yaml
+      - .trivyignore
   merge_group: {}
 
 permissions:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,26 +1,26 @@
 # Vulnerabilities ignored by Trivy. Each entry must carry a reason.
-# Revisit when the upstream tool ships a fix and bump the pinned version
-# in server/Dockerfile to drop the entry.
+# Revisit whenever the scan turns red: drop entries whose fixed package has
+# landed in the Debian suite the runner image tracks (bookworm-security).
 
-# CVE-2026-33186 (CRITICAL): google.golang.org/grpc/authz authorization
-# bypass via improper HTTP/2 path validation. Bundled by helm v3.20.2
-# (grpc v1.72.2). Helm v4.1.4 still bundles grpc v1.78.0; the fix is
-# in grpc v1.79.3 which no helm release ships yet. The vulnerability
-# is in the gRPC server-side authz package; helm uses gRPC as a client
-# to talk to its plugin system and never serves authz-gated gRPC
-# traffic, so the practical exposure is zero. Drop this entry once a
-# helm release bundling grpc >= 1.79.3 lands and Dockerfile is bumped.
-CVE-2026-33186
-
-# The following Common Vulnerabilities and Exposures (CVEs) are high-severity
-# Chromium vulnerabilities fixed in 151.0.7922.47-1. The server runtime uses
-# Debian Bookworm's multi-architecture base image, whose current security
-# repository provides 150.0.7871.181-1~deb12u1. Debian Unstable has the fixed
-# package, but installing it on Bookworm would replace hundreds of core
-# packages, including the core C library and systemd. Keep the supported stable
-# image and remove these entries as soon as Debian backports the fixed Chromium
-# version to Bookworm security. https://www.cve.org/
-CVE-2026-16804
-CVE-2026-16805
-CVE-2026-16806
-CVE-2026-16807
+# High-severity Chromium vulnerabilities fixed upstream in 151.0.7922.169.
+# Debian fixed them for bookworm in 151.0.7922.169-1~deb12u1 (DLA-4749-1), but
+# bookworm-security still publishes 151.0.7922.137-1~deb12u1, so `apt-get
+# upgrade` in server/Dockerfile has no patched package to install. Only trixie
+# and unstable carry the fixed build today, and pulling Chromium from either
+# onto bookworm would replace hundreds of core packages including glibc.
+# Chromium is present solely to render Open Graph images. It renders markup the
+# server builds from fixed templates, with only length-validated text
+# interpolated in, and never navigates to a remote page, so the crafted-page
+# vector every one of these CVEs requires is not reachable. Drop these entries
+# once bookworm-security publishes 151.0.7922.169-1~deb12u1.
+CVE-2026-76033
+CVE-2026-76036
+CVE-2026-76037
+CVE-2026-76038
+CVE-2026-76039
+CVE-2026-76040
+CVE-2026-76041
+CVE-2026-76043
+CVE-2026-76044
+CVE-2026-76045
+CVE-2026-76047


### PR DESCRIPTION
The [Server workflow's Docker build job](https://github.com/tuist/tuist/actions/runs/32458989970/job/96701901629) fails its Trivy scan with 33 HIGH findings: 11 Chromium CVEs (`CVE-2026-76033` through `CVE-2026-76047`) reported once each against `chromium`, `chromium-common`, and `chromium-sandbox`.

### There is nothing to upgrade

The first thing I checked was whether this was just a stale package, since reaching for a suppression is only defensible once an upgrade is ruled out:

- `server/Dockerfile` already runs `apt-get update && apt-get upgrade` behind an `APT_CACHE_BUST` arg that CI feeds the commit SHA, so the build picks up everything the suite offers.
- Debian records the bookworm fix as `151.0.7922.169-1~deb12u1` (DLA-4749-1), but the bookworm-security archive still publishes `151.0.7922.137-1~deb12u1`, which is exactly what the image installs. Last archive publication was 2026-08-20 21:28 UTC. The backport has not landed.
- Only trixie-security (`151.0.7922.169-1~deb13u1`, confirmed published) and unstable carry the fixed build. Pulling Chromium from either onto bookworm replaces hundreds of core packages including glibc, which is the same reason the previous Chromium block rejected that route.

So the batch is suppressed in `.trivyignore` until the backport arrives, which is the pattern that file already documents. Switching the runtime base image to trixie would genuinely fix it, but that is a deliberate infra migration and not something to do under a CVE deadline. See the note at the bottom.

Actual exposure is nil. Chromium is in the image solely to render Open Graph images, and `Tuist.OpenGraphImageTemplates` builds that markup from fixed templates with only length-validated text interpolated in. It never navigates to a remote page, which is the crafted-page vector all eleven CVEs require.

### Two dead entries dropped in the same pass

Rewriting the block surfaced two suppressions that can no longer fire:

- `CVE-2026-16804` through `CVE-2026-16807`. Debian fixed these for bookworm in `151.0.7922.71-1~deb12u1` and the image now ships `.137`. The old comment claimed they were fixed in `151.0.7922.47-1`, which was the unstable version, not bookworm's.
- `CVE-2026-33186`. That covered grpc bundled by helm, and helm left `server/Dockerfile` in #12297. The failing run confirms it, scanning zero language-specific files.

Leaving dead entries in place is how an ignore file rots into permanently suppressing something real, so they go now rather than later.

### Second commit: the workflow never ran on this file

`.trivyignore` was outside the Server workflow's `push` and `pull_request` path filters, so a change touching only that file did not trigger the workflow at all. The ignore list was never checked against the scan that consumes it, and this fix could not be validated before merge. The second commit adds the path to both filters. The file gets edited on every Chromium CVE batch, so this is a recurring blind spot rather than a one-off.

### How to test locally

Build the image and run the same scan CI runs:

```bash
docker buildx build --load --file server/Dockerfile --tag tuist/tuist --build-arg APT_CACHE_BUST="$(git rev-parse HEAD)" .
```

```bash
trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 --no-progress --ignorefile "$PWD/.trivyignore" tuist/tuist
```

It should exit 0. To confirm the suppression is exact rather than over-broad, drop `--ignorefile` and check that the CVE IDs reported are precisely the eleven listed in `.trivyignore`, with nothing extra suppressed and nothing reported left uncovered.

### Reviewer notes

- **The validating job does not run on a draft PR.** `docker_build` is gated on `github.event.pull_request.draft == false`, so the Trivy scan stays skipped until this is marked ready for review. That is the one job that proves the change works.
- **Verification done so far** was against upstream data rather than a local image build: the eleven reported CVE IDs were diffed against the new ignore list for an exact 11-for-11 match in both directions, each dropped entry's bookworm fixed version was read off Debian's security tracker, and the archive contents were read off the bookworm-security package index. Note that the tracker's suite-version column shows the pending upload and will claim the fix is already present; the lower fixed-version table is the one Trivy consumes.
- **These entries are meant to be temporary.** Once bookworm-security publishes `151.0.7922.169-1~deb12u1`, all eleven can be deleted and the scan should stay green on its own.
- **Bookworm is now oldstable** (`Suite: oldstable-security`), which is why these batches keep landing late and why this file keeps needing edits. A trixie base-image migration would put Chromium back on Debian's normal patch cadence. Worth scheduling separately.
