### PR TITLE
feat(server): guard the ClickHouse version floor in code and in CI

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -286,6 +286,73 @@ jobs:
         run: mise run --no-deps db:reset
       - name: Run tests
         run: mix test --warnings-as-errors
+  test-clickhouse-floor:
+    name: Test (oldest supported ClickHouse)
+    # The self-hosting requirements promise ClickHouse 25, but every ClickHouse
+    # we operate is newer: dev and the Test job pin 26.1, the Helm chart ships
+    # 26.1, and the bundled Compose file ships 26.5. Nothing exercised the
+    # documented floor, so a query setting or function introduced after it
+    # reached self-hosted deployments as a failed migration rather than as a
+    # failed build (#12515). Running the suite here replays every ClickHouse
+    # migration and every runtime query against the floor.
+    #
+    # 25.8 is the oldest ClickHouse 25 still receiving upstream patches; 25.3
+    # LTS stopped in February 2026. Keep this in step with
+    # @minimum_supported_version in lib/tuist/clickhouse_capabilities.ex and the
+    # matrix in priv/docs/en/guides/server/self-host/server.md.
+    runs-on: tuist-linux-large
+    timeout-minutes: 75
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    env:
+      CLICKHOUSE_FLOOR_VERSION: "25.8.31.9-lts"
+      # Matches the Test job. Several locale assertions live in tests that carry
+      # no `:locale` tag, so they run either way and fail against the "en"-only
+      # locale set that `mix test` compiles by default.
+      TUIST_DEV_ALL_LOCALES: "1"
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-server-mix
+        with:
+          mise-version: ${{ env.MISE_VERSION }}
+          mix-cache-key: mix-test-v2
+          mix-cache-restore-key: mix-test-v2-
+          restore-mix-cache: "false"
+      # Not passed through mise-install-args: that path installs `--locked`, and
+      # mise.lock pins the version the rest of CI runs on.
+      - name: Pin ClickHouse to the oldest supported release
+        run: |
+          mise use "github:ClickHouse/ClickHouse@${CLICKHOUSE_FLOOR_VERSION}"
+          clickhouse --version
+      - name: Restore CLDR locale cache
+        uses: actions/cache@v4
+        with:
+          path: server/_build/cldr/locales
+          key: cldr-locales-v1-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            cldr-locales-v1-
+      - name: Prefetch CLDR locale data
+        run: mise/tasks/cldr/prefetch-locale-data.sh
+      - name: Compile
+        run: mix compile --warnings-as-errors
+      - name: Start ClickHouse
+        run: mise run --no-deps clickhouse:start
+      - name: Setup database
+        run: mise run --no-deps db:reset
+      - name: Run tests
+        run: mix test --warnings-as-errors
   credo:
     name: Credo
     runs-on: tuist-linux

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -296,15 +296,13 @@ jobs:
     # failed build (#12515). Running the suite here replays every ClickHouse
     # migration and every runtime query against the floor.
     #
-    # 25.8 is the oldest ClickHouse 25 still receiving upstream patches; 25.3
-    # LTS stopped in February 2026. Keep this in step with
-    # @minimum_supported_version in lib/tuist/clickhouse_capabilities.ex and the
-    # matrix in priv/docs/en/guides/server/self-host/server.md.
+    # The release under test comes from Tuist.ClickHouseVersions, which is also
+    # what the migration guard asserts and what the self-hosting requirements
+    # publish, so the three cannot drift apart.
     runs-on: tuist-linux-large
     timeout-minutes: 75
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     env:
-      CLICKHOUSE_FLOOR_VERSION: "25.8.31.9-lts"
       # Matches the Test job. Several locale assertions live in tests that carry
       # no `:locale` tag, so they run either way and fail against the "en"-only
       # locale set that `mix test` compiles by default.
@@ -324,6 +322,16 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve the oldest supported ClickHouse release
+        run: |
+          file=lib/tuist/clickhouse_versions.ex
+          version="$(grep -E '^\s*@oldest_tested_release' "$file" | sed -E 's/.*"([^"]+)".*/\1/' | head -1)"
+          if [ -z "$version" ]; then
+            echo "Could not resolve @oldest_tested_release from $file" >&2
+            exit 1
+          fi
+          echo "CLICKHOUSE_FLOOR_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Testing against ClickHouse ${version}"
       - uses: ./.github/actions/setup-server-mix
         with:
           mise-version: ${{ env.MISE_VERSION }}

--- a/server/lib/tuist/clickhouse_capabilities.ex
+++ b/server/lib/tuist/clickhouse_capabilities.ex
@@ -11,10 +11,13 @@ defmodule Tuist.ClickHouseCapabilities do
   the server what it supports instead.
   """
 
+  alias Tuist.ClickHouseVersions
   alias Tuist.Environment
 
   @deduplicate_insert_select_since [26, 1]
-  @minimum_supported_version [25]
+  @minimum_supported_version ClickHouseVersions.minimum_supported_version()
+                             |> String.split(".")
+                             |> Enum.map(&String.to_integer/1)
 
   @doc """
   Whether `generateSerialID/1` is usable against `repo`, which requires a

--- a/server/lib/tuist/clickhouse_capabilities.ex
+++ b/server/lib/tuist/clickhouse_capabilities.ex
@@ -14,6 +14,7 @@ defmodule Tuist.ClickHouseCapabilities do
   alias Tuist.Environment
 
   @deduplicate_insert_select_since [26, 1]
+  @minimum_supported_version [25]
 
   @doc """
   Whether `generateSerialID/1` is usable against `repo`, which requires a
@@ -57,6 +58,32 @@ defmodule Tuist.ClickHouseCapabilities do
   end
 
   defp numeric?(version_component), do: match?({_integer, ""}, Integer.parse(version_component))
+
+  @doc """
+  Raises unless `repo` runs a ClickHouse release within the supported range
+  published in the self-hosting requirements.
+
+  The version gates in this module reason about that range rather than about
+  every release ClickHouse has ever shipped: `insert_select_deduplication_settings/1`
+  omits `deduplicate_insert_select` below 26.1 because releases in the supported
+  range deduplicate `INSERT SELECT` under `insert_deduplicate` on their own. Below
+  the floor that premise is untested, so an upgrade stops here, before any
+  migration has run, instead of failing part-way through against a server whose
+  behaviour we do not model.
+  """
+  def assert_supported_version!(repo) do
+    version = server_version(repo)
+
+    if Enum.take(version, length(@minimum_supported_version)) < @minimum_supported_version do
+      raise """
+      ClickHouse #{Enum.join(version, ".")} is older than the minimum version Tuist supports (#{Enum.join(@minimum_supported_version, ".")}).
+
+      Upgrade ClickHouse before upgrading Tuist. No migration has run, so the database is unchanged.
+      """
+    end
+
+    :ok
+  end
 
   @doc """
   Settings that make an `INSERT SELECT` deduplicate against its

--- a/server/lib/tuist/clickhouse_versions.ex
+++ b/server/lib/tuist/clickhouse_versions.ex
@@ -1,0 +1,29 @@
+defmodule Tuist.ClickHouseVersions do
+  @moduledoc """
+  Canonical facts about ClickHouse version support, shared by the migration
+  guard (`Tuist.ClickHouseCapabilities`), the docs self-hosting requirements,
+  and the CI job that runs the suite against the oldest supported release.
+
+  This is a dependency-free leaf module on purpose, like `Tuist.CLIVersions`:
+  the docs loader expands it at compile time, and the CI job reads the release
+  straight out of this file.
+  """
+
+  @minimum_supported_version "25"
+  @oldest_tested_release "25.8.31.9-lts"
+
+  @doc """
+  The oldest ClickHouse major version the server supports. Migrations refuse to
+  run below it, and the self-hosting requirements publish it.
+  """
+  def minimum_supported_version, do: @minimum_supported_version
+
+  @doc """
+  The release CI installs to exercise `minimum_supported_version/0`.
+
+  The oldest ClickHouse 25 still receiving upstream patches: 25.3 LTS stopped in
+  February 2026. It also predates `deduplicate_insert_select`, so the job covers
+  the version gate in `Tuist.ClickHouseCapabilities` rather than bypassing it.
+  """
+  def oldest_tested_release, do: @oldest_tested_release
+end

--- a/server/lib/tuist/clickhouse_versions.ex
+++ b/server/lib/tuist/clickhouse_versions.ex
@@ -10,7 +10,7 @@ defmodule Tuist.ClickHouseVersions do
   """
 
   @minimum_supported_version "25"
-  @oldest_tested_release "25.8.31.9-lts"
+  @oldest_tested_release "25.7.7.68-stable"
 
   @doc """
   The oldest ClickHouse major version the server supports. Migrations refuse to
@@ -21,9 +21,14 @@ defmodule Tuist.ClickHouseVersions do
   @doc """
   The release CI installs to exercise `minimum_supported_version/0`.
 
-  The oldest ClickHouse 25 still receiving upstream patches: 25.3 LTS stopped in
-  February 2026. It also predates `deduplicate_insert_select`, so the job covers
-  the version gate in `Tuist.ClickHouseCapabilities` rather than bypassing it.
+  Tracks the oldest release known to be running in a self-hosted deployment,
+  rather than the oldest release upstream still patches. Those diverge: this one
+  is not an LTS and upstream has moved on, but it is what the fleet runs, and it
+  is the release that surfaced the `deduplicate_insert_select` failure. Lower it
+  when a deployment is found below it.
+
+  It predates `deduplicate_insert_select`, so the job covers the version gate in
+  `Tuist.ClickHouseCapabilities` rather than bypassing it.
   """
   def oldest_tested_release, do: @oldest_tested_release
 end

--- a/server/lib/tuist/docs_loader.ex
+++ b/server/lib/tuist/docs_loader.ex
@@ -235,6 +235,10 @@ defmodule Tuist.Docs.Loader do
       "{{minimum_supported_cli_version}}",
       Tuist.CLIVersions.minimum_supported_version()
     )
+    |> String.replace(
+      "{{minimum_supported_clickhouse_version}}",
+      Tuist.ClickHouseVersions.minimum_supported_version()
+    )
     |> String.replace("{{runner_default_profiles_table}}", runner_default_profiles_table())
     |> String.replace("{{runner_linux_shapes_table}}", runner_shapes_table(:linux))
     |> String.replace("{{runner_macos_shapes_table}}", runner_shapes_table(:macos))

--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -4,6 +4,7 @@ defmodule Tuist.Release do
   installed.
   """
   alias Ecto.Adapters.SQL
+  alias Tuist.ClickHouseCapabilities
   alias Tuist.Environment
   alias Tuist.IngestRepo
 
@@ -44,6 +45,8 @@ defmodule Tuist.Release do
     Logger.info(
       "Migrating with a pool of size of #{:tuist |> Application.get_env(Tuist.Repo) |> Keyword.get(:pool_size)}"
     )
+
+    assert_supported_clickhouse_version()
 
     for repo <- repos() do
       {:ok, _, _} =
@@ -152,6 +155,15 @@ defmodule Tuist.Release do
       Tuist.Repo,
       Keyword.merge(config, Environment.database_config_from_url(url))
     )
+  end
+
+  # Ahead of the migration loop rather than inside it: `repos/0` migrates Postgres
+  # first, so checking per-repo would only reject a below-floor ClickHouse after
+  # Postgres had already migrated.
+  defp assert_supported_clickhouse_version do
+    if IngestRepo in repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(IngestRepo, &ClickHouseCapabilities.assert_supported_version!/1)
+    end
   end
 
   defp ensure_database_schema(repo) when repo == Tuist.Repo do

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -62,7 +62,7 @@ Tuist server has been tested and is compatible with the following minimum versio
 | Component | Minimum Version | Notes |
 | --- | --- | --- |
 | PostgreSQL | 15 | |
-| ClickHouse | 25 | Required for analytics |
+| ClickHouse | {{minimum_supported_clickhouse_version}} | Required for analytics |
 
 ### Running Docker-virtualized images {#running-dockervirtualized-images}
 

--- a/server/test/tuist/clickhouse_capabilities_test.exs
+++ b/server/test/tuist/clickhouse_capabilities_test.exs
@@ -35,6 +35,11 @@ defmodule Tuist.ClickHouseCapabilitiesTest do
     def query(_statement), do: {:ok, %{rows: [["25.3.6.10034.altinitystable"]]}}
   end
 
+  defmodule UnsupportedRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [["24.8.14.39"]]}}
+  end
+
   describe "serial_ids_supported?/1" do
     test "is true when the server has coordination configured" do
       assert ClickHouseCapabilities.serial_ids_supported?(KeeperRepo)
@@ -99,6 +104,20 @@ defmodule Tuist.ClickHouseCapabilitiesTest do
     test "is empty on a server that predates the setting, which deduplicates anyway" do
       assert ClickHouseCapabilities.insert_select_deduplication_settings(LegacyRepo) == []
       assert ClickHouseCapabilities.insert_select_deduplication_settings(RebuiltRepo) == []
+    end
+  end
+
+  describe "assert_supported_version!/1" do
+    test "passes on servers within the supported range" do
+      assert ClickHouseCapabilities.assert_supported_version!(ModernRepo) == :ok
+      assert ClickHouseCapabilities.assert_supported_version!(LegacyRepo) == :ok
+      assert ClickHouseCapabilities.assert_supported_version!(RebuiltRepo) == :ok
+    end
+
+    test "raises on a server below the floor, naming the version it found" do
+      assert_raise RuntimeError, ~r/ClickHouse 24\.8\.14\.39 is older than the minimum/, fn ->
+        ClickHouseCapabilities.assert_supported_version!(UnsupportedRepo)
+      end
     end
   end
 end

--- a/server/test/tuist/docs_test.exs
+++ b/server/test/tuist/docs_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.DocsTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  alias Tuist.ClickHouseVersions
   alias Tuist.Docs
   alias Tuist.Docs.CLI
   alias Tuist.Docs.NimblePublisher.Cache
@@ -95,6 +96,13 @@ defmodule Tuist.DocsTest do
 
       assert page.body =~
                ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
+    end
+
+    test "renders the compatibility matrix from the canonical ClickHouse version" do
+      page = Docs.get_page("/en/guides/server/self-host/server")
+
+      assert page.body =~
+               ~s(<td>ClickHouse</td><td>#{ClickHouseVersions.minimum_supported_version()}</td>)
     end
 
     test "does not cache missing pages" do


### PR DESCRIPTION
Follow-up to https://github.com/tuist/tuist/pull/12515.

### What changed

`Tuist.ClickHouseVersions` becomes the single source of truth for ClickHouse version support, following the `Tuist.CLIVersions` precedent: a dependency-free leaf module the docs loader can expand at compile time. Three consumers read from it.

- `Tuist.ClickHouseCapabilities` derives its floor from `minimum_supported_version/0` and gains `assert_supported_version!/1`. `Tuist.Release.migrate` calls it before migrating anything, so a self-hosted upgrade against a below-floor ClickHouse stops with a message naming the version it found rather than failing part-way through with `UNKNOWN_SETTING`.
- The self-hosting requirements table renders the same value through a `{{minimum_supported_clickhouse_version}}` macro.
- A new `Test (oldest supported ClickHouse)` job runs the full server suite against the release named by `oldest_tested_release/0`, resolved out of the module rather than pinned in the workflow.

### Why

https://github.com/tuist/tuist/pull/12515 fixed a migration that sent `deduplicate_insert_select`, a setting that only exists from ClickHouse 26.1, to servers documented as supported. The fix was correct but reactive: nothing prevents the next one.

The gap is that no ClickHouse we run is below 26.1. Dev and CI pin 26.1.2.11, the Helm chart ships 26.1, and the bundled Compose file ships 26.5, while the self-hosting requirements promise ClickHouse 25. The floor lived only in prose, duplicated across the translated install docs, with nothing in code or CI asserting it. The first thing to exercise it was a self-hoster's failed migration.

### Why the suite, and not a migration run

The obvious guard, migrating a fresh database on an old server, would not have caught the original bug. The backfill loops over active partitions from `system.parts`, and a fresh install has none, so the loop body never executes and the setting is never sent. All 218 ingest migrations replay identically on a fresh install; it is precisely the data-dependent branches that a fresh migrate skips.

Running the suite covers both halves. It replays every ClickHouse migration and also exercises `Tuist.Tests.insert_test_case_run_flaky_corrections/3`, the runtime call site that would have failed on every flaky correction rather than once at migration time.

### Why 25.7.7.68

Support is a claim about deployments, not about which branches upstream still backports to, and here the two diverge. A self-hosted deployment runs 25.7.7.68: not an LTS, and upstream has moved past it. It is also the version in the `UNKNOWN_SETTING` report behind https://github.com/tuist/tuist/pull/12515, so a pin above it would have been blind to precisely the deployment that surfaced the failure this work exists to prevent.

Choosing it from upstream release policy instead, the newest patch of the oldest LTS line still receiving fixes, lands on 25.8 and misses that deployment entirely. It is also the wrong direction on a second axis: the newest patch of a line is blind to anything a patch release added after it, and a future backport of `deduplicate_insert_select` into 25.8 would have silently stopped the job exercising the version gate at all. `@oldest_tested_release` should be lowered whenever a deployment is found below it.

Viability was checked against a real server rather than assumed: 25.7.7.68 carries every setting the server sends except `deduplicate_insert_select`, which is the property that keeps the job covering the gate rather than bypassing it.

### Reviewer notes

The assertion runs ahead of the migration loop, not inside it. `repos/0` migrates Postgres first, so a per-repo check would reject a below-floor ClickHouse only after Postgres had already migrated, which would contradict the error message.

The floor ClickHouse is pinned with `mise use` rather than through `mise-install-args`. That path installs `--locked`, and `mise.lock` pins the version the rest of CI runs on, so passing the tool there would silently keep 26.1. `mise use` was verified to leave the rest of `mise.toml` untouched.

The job is otherwise an exact mirror of `Test`, including `TUIST_DEV_ALL_LOCALES` and the CLDR cache steps. Several locale assertions live in tests that carry no `:locale` tag, so they run either way and fail against the "en"-only locale set.

The docs link is the one that can break silently, since a stale macro renders as literal braces to readers, so a test asserts the rendered table carries the module's value.

One gap this does not close: the docs promise ClickHouse 25 and the job tests 25.8, so 25.0 through 25.7 stay untested. `minimum_supported_version/0` is left at `25` to match what we publish today rather than silently narrowing the promise. Raising the documented minimum to 25.8 would close it and is a product call worth making separately.

### How to test locally

`config/runtime.exs` re-pins the test ClickHouse port from `TUIST_SERVER_CLICKHOUSE_HTTP_PORT` after `config/test.exs` is read, and the mise shim re-applies its own value for that variable, so neither editing `config/test.exs` nor overriding the variable inline has any effect. Pointing the suite at another server means bypassing the shim while keeping the environment it injects:

1. `mise install "github:ClickHouse/ClickHouse@25.7.7.68-stable"`, then start it on spare ports with its own data directory, overriding the `TUIST_SERVER_CLICKHOUSE_*` port and runtime-directory variables. Never point it at the dev data directory: opening a 26.1 store with a 25.7 binary is a downgrade in place.
2. Run mix with `eval "$(mise env -s bash)"` applied, then override `TUIST_SERVER_CLICKHOUSE_HTTP_PORT` plus `TUIST_SERVER_TEST_CLICKHOUSE_DB` and `TUIST_SERVER_TEST_POSTGRES_DB`, and invoke the binary from `$(mise where elixir)/bin/mix` rather than the shim. Reconstructing that environment by hand instead drops `TUIST_HOSTED` and `TUIST_EE`, which redirects marketing routes to the login page and produces around 1500 unrelated failures.

Checks run:

- Full suite against a real 25.7.7.68 server: **7034/7038 passed**. The four failures are locale tests needing the full locale set, and the same four fail against the 26.1 dev server locally, so they are independent of the ClickHouse version. This is why the job sets `TUIST_DEV_ALL_LOCALES`.
- All 560 migrations apply cleanly on 25.7.7.68.
- No `UNKNOWN_SETTING`, `UNKNOWN_FUNCTION`, or `NOT_IMPLEMENTED` anywhere in the run.
- Probed real 25.3, 25.7, and 25.8 servers over HTTP for every ClickHouse setting the server sends. 25.7 and 25.8 reject only `deduplicate_insert_select`; 25.3 additionally rejects `query_plan_optimize_lazy_materialization`, which `config/test.exs` sets on the connection, so the suite cannot run there.
- Confirmed the suite reaches the runtime call site: a probe in the non-empty clause of `Tuist.Tests.insert_test_case_run_flaky_corrections/3` is hit by `test/tuist/tests_test.exs:5197`. A migrate-only job cannot reach it, since the function is private to `Tuist.Tests` and the seeds never call it, and a fresh migrate cannot reach the migration half either, because the backfill iterates active partitions and a fresh database has none.
- `mix test test/tuist/clickhouse_capabilities_test.exs test/tuist/docs_test.exs` 25 passed. Both guards verified non-vacuous: lowering the floor to 20 turns the version test red, and hardcoding the docs table while bumping the module turns the docs test red.
- Rendered the requirements page through the docs loader and confirmed the macro expands to the module's value.
- Ran the workflow's extraction command against the module: resolves the release, and exits non-zero if the attribute is renamed.
- Confirmed `mise use` rewrites only the ClickHouse entry and leaves the rest of `mise.toml` intact.
- `mix format --check-formatted` and `mix credo` clean on the changed files.

The job itself has not run yet: server jobs are gated on `draft == false`, so it is skipped while this PR is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
