### PR TITLE
fix(server): stop bundle size checks from silently never posting

### DIFF
--- a/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
+++ b/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
@@ -6,6 +6,7 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
   import Ecto.Query
 
   alias Tuist.Bundles
+  alias Tuist.Bundles.Bundle
   alias Tuist.Environment
   alias Tuist.GitHub.Client
   alias Tuist.Projects
@@ -15,9 +16,7 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
 
   @check_name "tuist/bundle-size"
 
-  # The bundle is written through `Tuist.IngestRepo` and read back here through
-  # `Tuist.ClickHouseRepo`. Those are separate connections, so a bundle enqueued
-  # on upload is not always visible by the time this job runs.
+  # Bounds the fallback in `resolve_bundle/1` that still reads the bundle back.
   @not_found_snooze_seconds 5
   @not_found_max_attempts 5
 
@@ -25,11 +24,11 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
   def perform(%Oban.Job{
         id: job_id,
         attempt: attempt,
-        args: %{"bundle_id" => bundle_id, "project_id" => project_id, "git_commit_sha" => git_commit_sha} = args
+        args: %{"project_id" => project_id, "git_commit_sha" => git_commit_sha} = args
       }) do
     cancel_competing_jobs(job_id, args)
 
-    with {:ok, bundle} <- Bundles.get_bundle(bundle_id),
+    with {:ok, bundle} <- resolve_bundle(args),
          true <- should_run?(bundle),
          project = Projects.get_project_by_id(project_id),
          true <- project != nil,
@@ -53,6 +52,33 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
         :ok
     end
   end
+
+  # The bundle is written through `Tuist.IngestRepo` and read back through
+  # `Tuist.ClickHouseRepo`, a separate connection that does not always see the
+  # row by the time this job runs. The upload already holds every field the
+  # check reads, so it carries them on the job rather than reading them back.
+  # Only those fields are populated here.
+  defp resolve_bundle(%{
+         "bundle_id" => id,
+         "bundle_name" => name,
+         "git_commit_sha" => git_commit_sha,
+         "git_ref" => git_ref,
+         "install_size" => install_size,
+         "download_size" => download_size
+       }) do
+    {:ok,
+     %Bundle{
+       id: id,
+       name: name,
+       git_commit_sha: git_commit_sha,
+       git_ref: git_ref,
+       install_size: install_size,
+       download_size: download_size
+     }}
+  end
+
+  # Jobs enqueued before the bundle fields were carried on the job.
+  defp resolve_bundle(%{"bundle_id" => id}), do: Bundles.get_bundle(id)
 
   defp should_run?(bundle) do
     bundle.git_commit_sha != nil &&

--- a/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
+++ b/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
@@ -15,9 +15,16 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
 
   @check_name "tuist/bundle-size"
 
+  # The bundle is written through `Tuist.IngestRepo` and read back here through
+  # `Tuist.ClickHouseRepo`. Those are separate connections, so a bundle enqueued
+  # on upload is not always visible by the time this job runs.
+  @not_found_snooze_seconds 5
+  @not_found_max_attempts 5
+
   @impl Oban.Worker
   def perform(%Oban.Job{
         id: job_id,
+        attempt: attempt,
         args: %{"bundle_id" => bundle_id, "project_id" => project_id, "git_commit_sha" => git_commit_sha} = args
       }) do
     cancel_competing_jobs(job_id, args)
@@ -39,7 +46,11 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
         post_check_run(project, bundle, head_sha, result)
       end
     else
-      _ -> :ok
+      {:error, :not_found} when attempt < @not_found_max_attempts ->
+        {:snooze, @not_found_snooze_seconds}
+
+      _ ->
+        :ok
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/bundles_controller.ex
+++ b/server/lib/tuist_web/controllers/api/bundles_controller.ex
@@ -389,7 +389,15 @@ defmodule TuistWeb.API.BundlesController do
 
   defp maybe_enqueue_threshold_check(bundle, project) do
     if bundle.git_commit_sha && bundle.git_ref do
-      %{bundle_id: bundle.id, project_id: project.id, git_commit_sha: bundle.git_commit_sha}
+      %{
+        bundle_id: bundle.id,
+        project_id: project.id,
+        git_commit_sha: bundle.git_commit_sha,
+        bundle_name: bundle.name,
+        git_ref: bundle.git_ref,
+        install_size: bundle.install_size,
+        download_size: bundle.download_size
+      }
       |> Tuist.Bundles.Workers.BundleThresholdWorker.new()
       |> Oban.insert()
     end

--- a/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
+++ b/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
@@ -296,6 +296,88 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorkerTest do
       assert :ok == BundleThresholdWorker.perform(job)
     end
 
+    test "evaluates the bundle carried in the job args without reading it back" do
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "org/repo",
+            provider: :github
+          ]
+        )
+
+      BundlesFixtures.bundle_threshold_fixture(
+        project: project,
+        name: "Strict",
+        deviation_percentage: 5.0
+      )
+
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        name: "App",
+        install_size: 1000,
+        git_branch: "main",
+        inserted_at: ~U[2024-01-01 00:00:00Z]
+      )
+
+      stub(Environment, :github_app_configured?, fn -> true end)
+      stub(Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Client, :get_pull_request, fn _params ->
+        {:ok, %{"head" => %{"sha" => "real-head-sha"}}}
+      end)
+
+      expect(Client, :create_check_run, fn params ->
+        assert params.conclusion == "action_required"
+        assert params.output.summary =~ "Strict"
+        {:ok, %{"id" => 1}}
+      end)
+
+      job = %Oban.Job{
+        id: 1,
+        attempt: 1,
+        args: %{
+          "bundle_id" => UUIDv7.generate(),
+          "project_id" => project.id,
+          "git_commit_sha" => "abc123",
+          "bundle_name" => "App",
+          "git_ref" => "refs/pull/1/merge",
+          "install_size" => 1200,
+          "download_size" => nil
+        }
+      }
+
+      assert :ok == BundleThresholdWorker.perform(job)
+    end
+
+    test "skips when the bundle carried in the job args is not on a PR ref" do
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "org/repo",
+            provider: :github
+          ]
+        )
+
+      stub(Environment, :github_app_configured?, fn -> true end)
+      reject(&Client.create_check_run/1)
+
+      job = %Oban.Job{
+        id: 1,
+        attempt: 1,
+        args: %{
+          "bundle_id" => UUIDv7.generate(),
+          "project_id" => project.id,
+          "git_commit_sha" => "abc123",
+          "bundle_name" => "App",
+          "git_ref" => "refs/heads/main",
+          "install_size" => 1200,
+          "download_size" => nil
+        }
+      }
+
+      assert :ok == BundleThresholdWorker.perform(job)
+    end
+
     test "snoozes when the bundle is not visible yet" do
       project = ProjectsFixtures.project_fixture()
 

--- a/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
+++ b/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
@@ -69,6 +69,7 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorkerTest do
         )
 
       stub(Environment, :github_app_configured?, fn -> true end)
+      reject(&Client.create_check_run/1)
 
       job = %Oban.Job{
         id: 1,
@@ -99,6 +100,7 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorkerTest do
         )
 
       stub(Environment, :github_app_configured?, fn -> true end)
+      reject(&Client.create_check_run/1)
 
       job = %Oban.Job{
         id: 1,
@@ -286,6 +288,44 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorkerTest do
         id: 1,
         args: %{
           "bundle_id" => bundle.id,
+          "project_id" => project.id,
+          "git_commit_sha" => "abc123"
+        }
+      }
+
+      assert :ok == BundleThresholdWorker.perform(job)
+    end
+
+    test "snoozes when the bundle is not visible yet" do
+      project = ProjectsFixtures.project_fixture()
+
+      stub(Environment, :github_app_configured?, fn -> true end)
+      reject(&Client.create_check_run/1)
+
+      job = %Oban.Job{
+        id: 1,
+        attempt: 1,
+        args: %{
+          "bundle_id" => UUIDv7.generate(),
+          "project_id" => project.id,
+          "git_commit_sha" => "abc123"
+        }
+      }
+
+      assert {:snooze, _} = BundleThresholdWorker.perform(job)
+    end
+
+    test "stops snoozing when the bundle is still not visible on the last attempt" do
+      project = ProjectsFixtures.project_fixture()
+
+      stub(Environment, :github_app_configured?, fn -> true end)
+      reject(&Client.create_check_run/1)
+
+      job = %Oban.Job{
+        id: 1,
+        attempt: 5,
+        args: %{
+          "bundle_id" => UUIDv7.generate(),
           "project_id" => project.id,
           "git_commit_sha" => "abc123"
         }

--- a/server/test/tuist_web/controllers/api/bundles_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/bundles_controller_test.exs
@@ -308,7 +308,13 @@ defmodule TuistWeb.API.BundlesControllerTest do
 
       assert_enqueued(
         worker: BundleThresholdWorker,
-        args: %{project_id: project.id, git_commit_sha: "abc123"}
+        args: %{
+          project_id: project.id,
+          git_commit_sha: "abc123",
+          bundle_name: "Test Bundle",
+          git_ref: "refs/pull/1/merge",
+          install_size: 1024
+        }
       )
     end
 


### PR DESCRIPTION
### What changed

`tuist/bundle-size` checks were silently never posting for roughly one in three bundles. Two commits, the second superseding the first as the primary fix.

**1. Carry the bundle on the job (`59f970c721`).** The worker no longer reads back the bundle it was enqueued for. `maybe_enqueue_threshold_check/2` now puts `bundle_name`, `git_ref`, `install_size` and `download_size` in the job args, and `resolve_bundle/1` rebuilds the struct from them. The worker touches no ClickHouse connection for the bundle under check, so the race cannot happen.

**2. Snooze on a missing bundle (`9f7c5f9cc6`).** Retained as the fallback in `resolve_bundle/1`. It covers jobs enqueued with the old args shape that are still in flight across a deploy, which would otherwise fail permanently on a `FunctionClauseError` once the new args are required.

### Root cause

A read-after-write race across two ClickHouse connections.

The bundle row is written through `Tuist.IngestRepo` (`IngestRepo.insert_all(Bundle, ...)`). The controller then enqueued the worker with no delay. The worker started about 12ms later and its first statement was `Bundles.get_bundle(bundle_id)`, which reads through `Tuist.ClickHouseRepo`: a different repo with a different connection pool.

The row was frequently not visible yet, so `get_bundle/1` returned `{:error, :not_found}`, the `with` chain fell through to `else -> :ok`, and the job reported success having posted nothing. No error, no retry, no check run.

This is not the app-side ingestion buffer. `Bundle` does not `use Tuist.Ingestion.Bufferable` and has no `Bundle.Buffer` child spec. The lag sits below the application, between the two connections.

### Evidence

Production `oban_jobs` durations for this worker are cleanly bimodal, with nothing at all between 30ms and 199ms:

| Bucket | Jobs (of last 42) | Duration |
|--------|-------------------|----------|
| Early bail | 14 | 26-30ms |
| Real path | 28 | 199-1522ms |

The fast bucket cannot be the real path, which makes two GitHub API calls and, at the time, also nested the bundle's entire artifact tree. A representative affected bundle had 8,052 artifact rows.

It is a race rather than per-project misconfiguration: projects 4212, 2792 and 2909 each appear in *both* buckets. A static guard such as `Projects.has_vcs_connection?/1` or `Tuist.VCS.github_app_credentials/1` would fail deterministically for a given project. These do not.

### Why this approach

**The read was never necessary.** `Bundles.create_bundle/2` returns a bundle built in memory from `Ecto.Changeset.apply_changes/1`, not one read back from ClickHouse. The upload already holds every field the check needs, so re-reading it introduced the race for no gain.

**The check needs very little.** `evaluate_project_thresholds/2` reads only `name`, `install_size` and `download_size`. The rest of the worker uses `id`, `git_ref` and `git_commit_sha`. The artifact tree is never touched, so the old `get_bundle/1` call was loading and nesting thousands of artifact rows for nothing. Removing it is also a straight performance win.

**Why not confirm the insert before enqueueing.** The insert is already confirmed: `IngestRepo.insert_all/2` returns before the enqueue. What is unknown is when the *other* connection can see the row. Establishing that means polling `ClickHouseRepo` inside the bundle upload request, which moves the wait into the user-facing response, is still a spin-wait, and still needs a bound and a fallback.

**Why not run the check synchronously.** It makes two GitHub API calls and measures at 199-1522ms. That belongs off the upload request.

**Why the snooze is bounded by `attempt`.** Oban increments `max_attempts` on every snooze specifically so snoozing does not consume a retry, while `attempt` still increments per execution. `max_attempts: 20` would therefore never terminate the loop, and a bundle that genuinely never materialises would snooze forever.

**Why not a Bufferable buffer.** `Bundle` is not buffered, so that would address a mechanism which is not the cause.

Every other early exit is untouched. A project with no VCS connection, no GitHub App credentials, or no thresholds configured still returns `:ok` without retrying. The new not-found clause cannot swallow another branch either: `get_bundle/1` is the only step that produces `{:error, :not_found}`, `VCS.github_app_credentials/1` returns a map or `nil`, and the rest return booleans.

### Impact

Bundle size checks on PRs stop silently vanishing, and the worker no longer loads the artifact tree it never used. No user-facing strings were added, so no gettext changes are needed.

### How to test locally

```bash
cd server && mix test test/tuist/bundles/workers/bundle_threshold_worker_test.exs test/tuist_web/controllers/api/bundles_controller_test.exs
```

Validation run on this change:

- Red before green on both commits. The snooze test first failed with `left: {:snooze, _}` / `right: :ok`, the exact silent-success signature. The args tests then failed with `right: {:snooze, 5}`, proving they exercised the read path before the fix.
- `mix test` across the worker, `bundles_test.exs` and `bundles_controller_test.exs` with `--warnings-as-errors`: 99 passed.
- `mix format` and `mix credo` clean on all four touched files.

New tests cover a bundle absent from ClickHouse being evaluated and posting a check run purely from the job args, the PR-ref guard on that path, the controller carrying the fields, and the fallback returning `{:snooze, _}` then `:ok` once the attempt bound is reached. The two existing silent-`:ok` exits, no VCS connection and no thresholds configured, were extended with guards asserting they still do not snooze and post no check run.
