### PR TITLE
fix(infra): tag fleet releases only when the image is published, and never pin a version that isn't

### DIFF
--- a/.github/scripts/ghcr-image-published.sh
+++ b/.github/scripts/ghcr-image-published.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Answers whether a GHCR manifest exists, for the one question the release
+# and deploy paths both have to ask: is the image the Helm chart pulls
+# actually there?
+#
+# Exit 0 - published, or absence could not be proven.
+# Exit 1 - GHCR definitively answered 404.
+#
+# The asymmetry is deliberate and is the whole contract. Only a 404 proves
+# absence; auth failures, throttling and transport errors prove nothing.
+# Treating those as "missing" would let a blip withhold the tag for a
+# release that did publish, or silently downgrade a component mid-deploy,
+# and both are worse than the failure this check exists to catch.
+#
+# Usage: ghcr-image-published.sh <repository> <tag>
+#   e.g. ghcr-image-published.sh tuist/tuist-xcresult-processor 0.78.1
+#
+# GITHUB_TOKEN is used when set and falls back to an anonymous pull token,
+# which is what actually authorizes these packages today. A probe that can
+# obtain no token at all warns rather than failing: it cannot answer the
+# question, and a check that quietly always says "published" is worse than
+# one that says so out loud.
+set -uo pipefail
+
+repository="${1:?usage: ghcr-image-published.sh <repository> <tag>}"
+image_tag="${2:?usage: ghcr-image-published.sh <repository> <tag>}"
+
+token_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull"
+extract_token() { sed -n 's/.*"token":"\([^"]*\)".*/\1/p'; }
+
+token=""
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  token="$(curl -sSL --max-time 30 -u "x-access-token:${GITHUB_TOKEN}" "$token_url" 2>/dev/null | extract_token)"
+fi
+if [ -z "$token" ]; then
+  token="$(curl -sSL --max-time 30 "$token_url" 2>/dev/null | extract_token)"
+fi
+if [ -z "$token" ]; then
+  echo "::warning::Could not obtain a GHCR pull token for ${repository}; treating ${repository}:${image_tag} as published. This check is not protecting anything until that is fixed."
+  exit 0
+fi
+
+status="$(
+  curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+    -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+    -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/${repository}/manifests/${image_tag}" 2>/dev/null
+)"
+
+[ "$status" != "404" ]

--- a/.github/scripts/ghcr-image-published.sh
+++ b/.github/scripts/ghcr-image-published.sh
@@ -16,39 +16,68 @@
 # Usage: ghcr-image-published.sh <repository> <tag>
 #   e.g. ghcr-image-published.sh tuist/tuist-xcresult-processor 0.78.1
 #
-# GITHUB_TOKEN is used when set and falls back to an anonymous pull token,
-# which is what actually authorizes these packages today. A probe that can
-# obtain no token at all warns rather than failing: it cannot answer the
-# question, and a check that quietly always says "published" is worse than
-# one that says so out loud.
+# This talks to ghcr.io, which is not the api.github.com bucket that CI
+# exhausts; it returns no x-ratelimit accounting at all. GITHUB_TOKEN is
+# used when set so the requests bill to the token rather than to a runner
+# egress IP shared by the whole fleet, and falls back to an anonymous pull
+# token. A probe that can obtain no token warns rather than failing: it
+# cannot answer the question, and a check that quietly always says
+# "published" is worse than one that says so out loud.
 set -uo pipefail
 
 repository="${1:?usage: ghcr-image-published.sh <repository> <tag>}"
 image_tag="${2:?usage: ghcr-image-published.sh <repository> <tag>}"
 
-token_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull"
-extract_token() { sed -n 's/.*"token":"\([^"]*\)".*/\1/p'; }
+token_cache="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ghcr-pull-token"
 
-token=""
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  token="$(curl -sSL --max-time 30 -u "x-access-token:${GITHUB_TOKEN}" "$token_url" 2>/dev/null | extract_token)"
-fi
-if [ -z "$token" ]; then
-  token="$(curl -sSL --max-time 30 "$token_url" 2>/dev/null | extract_token)"
-fi
-if [ -z "$token" ]; then
-  echo "::warning::Could not obtain a GHCR pull token for ${repository}; treating ${repository}:${image_tag} as published. This check is not protecting anything until that is fixed."
-  exit 0
-fi
+fetch_token() {
+  local url="https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull"
+  local auth=()
+  [ -n "${GITHUB_TOKEN:-}" ] && auth=(-u "x-access-token:${GITHUB_TOKEN}")
+  local token
+  token="$(curl -sSL --max-time 30 "${auth[@]}" "$url" 2>/dev/null |
+    sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  [ -n "$token" ] || return 1
+  (umask 077; printf '%s' "$token" > "$token_cache")
+  printf '%s' "$token"
+}
 
-status="$(
+manifest_status() {
   curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
-    -H "Authorization: Bearer ${token}" \
+    -H "Authorization: Bearer $1" \
     -H 'Accept: application/vnd.oci.image.index.v1+json' \
     -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
     -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
     -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
     "https://ghcr.io/v2/${repository}/manifests/${image_tag}" 2>/dev/null
-)"
+}
+
+# One pull token covers every repository probed in a job, so it is cached
+# and reused across invocations instead of re-minted per image. That is an
+# optimization, not an assumption: a cached token rejected for this
+# repository is discarded and re-minted against it, so correctness holds
+# even if the shared-scope behaviour ever changes.
+token=""
+if [ -s "$token_cache" ]; then
+  token="$(cat "$token_cache")"
+fi
+[ -n "$token" ] || token="$(fetch_token)" || token=""
+
+if [ -n "$token" ]; then
+  status="$(manifest_status "$token")"
+  if [ "$status" = "401" ] || [ "$status" = "403" ]; then
+    rm -f "$token_cache"
+    if token="$(fetch_token)"; then
+      status="$(manifest_status "$token")"
+    fi
+  fi
+else
+  status=""
+fi
+
+if [ -z "$status" ]; then
+  echo "::warning::Could not reach GHCR to check ${repository}:${image_tag}; treating it as published. This check is not protecting anything until that is fixed."
+  exit 0
+fi
 
 [ "$status" != "404" ]

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -705,39 +705,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Only a definitive 404 means "never published". Anything else
-          # (auth, rate limit, a blip) is treated as published, so a flaky
-          # check can never silently downgrade a component.
+          # Shared with the release path's tag gate so the two can never
+          # disagree about the same image. The checkout is pinned to
+          # DEPLOY_SHA, so a re-promote of a commit predating the script
+          # simply skips the check — those pins already deployed once.
+          probe=.github/scripts/ghcr-image-published.sh
           image_published() {
-            repository="$1"
-            tag="$2"
-            auth=()
-            if [ -n "${GITHUB_TOKEN:-}" ]; then
-              auth=(-u "x-access-token:${GITHUB_TOKEN}")
-            fi
-            token="$(
-              curl -sSL --max-time 30 "${auth[@]}" \
-                "https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull" \
-                | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
-            )" || return 0
-            [ -n "$token" ] || return 0
-            status="$(
-              curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
-                -H "Authorization: Bearer ${token}" \
-                -H 'Accept: application/vnd.oci.image.index.v1+json' \
-                -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
-                -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
-                -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
-                "https://ghcr.io/v2/${repository}/manifests/${tag}"
-            )" || return 0
-            [ "$status" != "404" ]
+            [ -x "$probe" ] || return 0
+            "$probe" "$1" "$2"
           }
 
           # $1 tag prefix, $2 GHCR repository the version is pinned into.
           # An empty $2 skips the publication check: the macOS runner image
           # fans one semver out into a `macos-<xcode>-<semver>` tag per Xcode
-          # profile, so there is no single manifest to probe, and its tag is
-          # only cut when the whole build matrix succeeded.
+          # profile, so there is no single manifest to probe here. The
+          # release path checks every profile tag before cutting the semver.
           resolve() {
             prefix="$1"
             repository="${2:-}"

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -690,21 +690,79 @@ jobs:
         # the deployed commit, so a release that cuts a new tag rolls forward
         # on the next deploy. `--merged` makes a re-promote of an older SHA
         # resolve the versions as they were at that commit.
+        #
+        # A tag records that the release job reported success, not that its
+        # image reached GHCR, and nothing enforces that the two agree. A
+        # version pinned with no image behind it is the most expensive
+        # failure this workflow has: neither a Tart Pod (retries the pull
+        # forever in TartCreateFailed) nor a Linux Pod (ImagePullBackOff)
+        # fails on its own, so helm burns the full `--timeout` before rolling
+        # the release back, and every later deploy resolves the same dead
+        # tag. Walk the tags newest-first and pin the newest version that is
+        # actually pullable.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          resolve() {
-            git tag --list "${1}*" --merged "$DEPLOY_SHA" \
-              | sed "s|^${1}||" \
-              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sort -V | tail -n1
+
+          # Only a definitive 404 means "never published". Anything else
+          # (auth, rate limit, a blip) is treated as published, so a flaky
+          # check can never silently downgrade a component.
+          image_published() {
+            repository="$1"
+            tag="$2"
+            auth=()
+            if [ -n "${GITHUB_TOKEN:-}" ]; then
+              auth=(-u "x-access-token:${GITHUB_TOKEN}")
+            fi
+            token="$(
+              curl -sSL --max-time 30 "${auth[@]}" \
+                "https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull" \
+                | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
+            )" || return 0
+            [ -n "$token" ] || return 0
+            status="$(
+              curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
+                -H "Authorization: Bearer ${token}" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json' \
+                -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+                -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+                -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+                "https://ghcr.io/v2/${repository}/manifests/${tag}"
+            )" || return 0
+            [ "$status" != "404" ]
           }
+
+          # $1 tag prefix, $2 GHCR repository the version is pinned into.
+          # An empty $2 skips the publication check: the macOS runner image
+          # fans one semver out into a `macos-<xcode>-<semver>` tag per Xcode
+          # profile, so there is no single manifest to probe, and its tag is
+          # only cut when the whole build matrix succeeded.
+          resolve() {
+            prefix="$1"
+            repository="${2:-}"
+            versions="$(
+              git tag --list "${prefix}*" --merged "$DEPLOY_SHA" \
+                | sed "s|^${prefix}||" \
+                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                | sort -rV
+            )"
+            for version in $versions; do
+              if [ -z "$repository" ] || image_published "$repository" "$version"; then
+                echo "$version"
+                return 0
+              fi
+              echo "::warning::${prefix}${version} is tagged but ghcr.io/${repository}:${version} was never published; falling back to the previous version." >&2
+            done
+          }
+
           {
-            echo "XCRESULT_PROCESSOR_TAG=$(resolve 'xcresult-processor-image@')"
-            echo "KURA_RUNTIME_TAG=$(resolve 'kura@')"
+            echo "XCRESULT_PROCESSOR_TAG=$(resolve 'xcresult-processor-image@' 'tuist/tuist-xcresult-processor')"
+            echo "KURA_RUNTIME_TAG=$(resolve 'kura@' 'tuist/kura')"
             echo "RUNNER_IMAGE_SEMVER=$(resolve 'runner-image@')"
-            echo "LINUX_RUNNER_IMAGE_VERSION=$(resolve 'linux-runner-image@')"
-            echo "CAPI_TAG=$(resolve 'capi-scaleway@')"
-            echo "RUNNERS_CONTROLLER_TAG=$(resolve 'runners-controller@')"
+            echo "LINUX_RUNNER_IMAGE_VERSION=$(resolve 'linux-runner-image@' 'tuist/tuist-linux-runner')"
+            echo "CAPI_TAG=$(resolve 'capi-scaleway@' 'tuist/capi-provider-scaleway-applesilicon')"
+            echo "RUNNERS_CONTROLLER_TAG=$(resolve 'runners-controller@' 'tuist/tuist-runners-controller')"
           } >> "$GITHUB_ENV"
       - uses: jdx/mise-action@v3.2.0
         with:
@@ -892,6 +950,15 @@ jobs:
               sleep 30
               echo "::group::cluster snapshot $(date -u +%H:%M:%SZ)"
               kubectl -n "$NAMESPACE" get pods -o wide 2>&1 | tail -40 || true
+              # A Tart Pod carries its provisioning failure in
+              # `.status.message` and never emits a Warning event for it, so
+              # the STATUS column above reads `TartCreateFailed` with no
+              # reason attached and the events below stay silent. Print the
+              # messages too, or a stuck macOS Pod is undiagnosable from the
+              # action log alone.
+              echo "--- pod status messages ---"
+              kubectl -n "$NAMESPACE" get pods \
+                -o jsonpath='{range .items[?(@.status.message)]}{.metadata.name}{": "}{.status.reason}{" — "}{.status.message}{"\n"}{end}' 2>&1 | tail -10 || true
               echo "--- recent events ---"
               kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>&1 | tail -20 || true
               echo "::endgroup::"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1336,6 +1336,7 @@ jobs:
         release-xcresult-processor-image,
         release-runner-image,
         release-linux-runner-image,
+        tag-infra-releases,
       ]
     if: |
       always() &&
@@ -1536,7 +1537,7 @@ jobs:
             ${{ needs.release-helm.outputs.release-notes }}
 
       - name: Create CAPI Scaleway GitHub Release
-        if: needs.check-releases.outputs.capi-scaleway-should-release == 'true' && needs.release-capi-scaleway.result == 'success'
+        if: needs.tag-infra-releases.outputs.capi-scaleway-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1550,7 +1551,7 @@ jobs:
             ${{ needs.release-capi-scaleway.outputs.release-notes }}
 
       - name: Create runners-controller GitHub Release
-        if: needs.check-releases.outputs.runners-controller-should-release == 'true' && needs.release-runners-controller.result == 'success'
+        if: needs.tag-infra-releases.outputs.runners-controller-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1564,7 +1565,7 @@ jobs:
             ${{ needs.release-runners-controller.outputs.release-notes }}
 
       - name: Create stable-egress-controller GitHub Release
-        if: needs.check-releases.outputs.stable-egress-controller-should-release == 'true' && needs.release-stable-egress-controller.result == 'success'
+        if: needs.tag-infra-releases.outputs.stable-egress-controller-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1578,7 +1579,7 @@ jobs:
             ${{ needs.release-stable-egress-controller.outputs.release-notes }}
 
       - name: Create xcresult-processor-image GitHub Release
-        if: needs.check-releases.outputs.xcresult-processor-image-should-release == 'true' && needs.release-xcresult-processor-image.result == 'success'
+        if: needs.tag-infra-releases.outputs.xcresult-processor-image-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1592,7 +1593,7 @@ jobs:
             ${{ needs.release-xcresult-processor-image.outputs.release-notes }}
 
       - name: Create runner-image GitHub Release
-        if: needs.check-releases.outputs.runner-image-should-release == 'true' && needs.release-runner-image.result == 'success'
+        if: needs.tag-infra-releases.outputs.runner-image-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1607,7 +1608,7 @@ jobs:
             ${{ needs.release-runner-image.outputs.release-notes }}
 
       - name: Create linux-runner-image GitHub Release
-        if: needs.check-releases.outputs.linux-runner-image-should-release == 'true' && needs.release-linux-runner-image.result == 'success'
+        if: needs.tag-infra-releases.outputs.linux-runner-image-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1629,11 +1630,7 @@ jobs:
       # mgmt manifest image) land via Renovate PRs — see renovate.json.
 
       - name: Create Kura GitHub Release
-        if: |
-          needs.check-releases.outputs.kura-should-release == 'true' &&
-          needs.release-kura-prepare.result == 'success' &&
-          needs.release-kura-binaries.result == 'success' &&
-          needs.release-kura-docker.result == 'success'
+        if: needs.tag-infra-releases.outputs.kura-tagged == 'true'
         uses: softprops/action-gh-release@v2
         with:
           draft: false
@@ -1684,6 +1681,17 @@ jobs:
     if: always() && needs.check-releases.result == 'success'
     runs-on: tuist-linux
     timeout-minutes: 10
+    # `publish-releases` gates its GitHub Release steps on these so it can
+    # never create, through `action-gh-release`'s `tag_name`, a tag this job
+    # refused to push.
+    outputs:
+      capi-scaleway-tagged: ${{ steps.tag.outputs.capi-scaleway-tagged }}
+      runners-controller-tagged: ${{ steps.tag.outputs.runners-controller-tagged }}
+      stable-egress-controller-tagged: ${{ steps.tag.outputs.stable-egress-controller-tagged }}
+      xcresult-processor-image-tagged: ${{ steps.tag.outputs.xcresult-processor-image-tagged }}
+      runner-image-tagged: ${{ steps.tag.outputs.runner-image-tagged }}
+      linux-runner-image-tagged: ${{ steps.tag.outputs.linux-runner-image-tagged }}
+      kura-tagged: ${{ steps.tag.outputs.kura-tagged }}
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
     steps:
@@ -1692,41 +1700,128 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
       - name: Create and push fleet/runtime component tags
+        id: tag
         # server-deployment.yml resolves each image version from these
         # tags at deploy time, so they must exist on origin before the
         # deploy is dispatched. Idempotent: skip a tag that already exists.
+        #
+        # A job result of `success` proves the release job ran, not that the
+        # image reached the registry the chart pulls from, so every tag is
+        # gated on the image being there. The check MUST target the chart's
+        # address rather than wherever the release job pushed: a job that
+        # publishes to some other registry succeeds, and verifying its own
+        # push would confirm nothing. An untagged component simply stays on
+        # its previous version, which is the correct reading of a release
+        # that never published.
+        env:
+          RUNNER_IMAGE_XCODE_PROFILES: ${{ needs.check-releases.outputs.runner-image-matrix }}
         run: |
           set -euo pipefail
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+
+          image_missing() {
+            ! .github/scripts/ghcr-image-published.sh "$1" "$2"
+          }
+
           tag_release() {
-            # $1 should-release flag, $2 job result, $3 tag
-            [ "$1" = "true" ] || return 0
-            if [ "$2" != "success" ]; then
-              echo "Skipping $3 (release job result: $2)"
+            # $1 output key, $2 should-release flag, $3 job result, $4 tag,
+            # $5 GHCR repository the chart pulls the component from,
+            # $6... the image tags that release must have published
+            # (defaults to the version carried by the tag).
+            key="$1"; should="$2"; result="$3"; tag="$4"; repository="$5"
+            shift 5
+            image_tags=("$@")
+            [ "${#image_tags[@]}" -gt 0 ] || image_tags=("${tag##*@}")
+
+            tagged=false
+            if [ "$should" != "true" ]; then
+              echo "${key}-tagged=${tagged}" >> "$GITHUB_OUTPUT"
               return 0
             fi
-            if git ls-remote --tags --exit-code origin "refs/tags/$3" >/dev/null 2>&1; then
-              echo "Tag $3 already exists on origin"
-            else
-              git tag "$3"
-              git push origin "refs/tags/$3"
-              echo "Pushed $3"
+            if [ "$result" != "success" ]; then
+              echo "Skipping $tag (release job result: $result)"
+              echo "${key}-tagged=${tagged}" >> "$GITHUB_OUTPUT"
+              return 0
             fi
+            for image_tag in "${image_tags[@]}"; do
+              if image_missing "$repository" "$image_tag"; then
+                echo "::error::Refusing to tag ${tag}: ghcr.io/${repository}:${image_tag} is not published. The release job reported success, so it published somewhere the chart does not read. ${key} stays on its previous version."
+                echo "${key}-tagged=${tagged}" >> "$GITHUB_OUTPUT"
+                return 0
+              fi
+            done
+
+            if git ls-remote --tags --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "Tag $tag already exists on origin"
+            else
+              git tag "$tag"
+              git push origin "refs/tags/$tag"
+              echo "Pushed $tag"
+            fi
+            tagged=true
+            echo "${key}-tagged=${tagged}" >> "$GITHUB_OUTPUT"
           }
-          tag_release "${{ needs.check-releases.outputs.capi-scaleway-should-release }}" "${{ needs.release-capi-scaleway.result }}" "${{ needs.check-releases.outputs.capi-scaleway-next-version }}"
-          tag_release "${{ needs.check-releases.outputs.runners-controller-should-release }}" "${{ needs.release-runners-controller.result }}" "${{ needs.check-releases.outputs.runners-controller-next-version }}"
-          tag_release "${{ needs.check-releases.outputs.stable-egress-controller-should-release }}" "${{ needs.release-stable-egress-controller.result }}" "${{ needs.check-releases.outputs.stable-egress-controller-next-version }}"
-          tag_release "${{ needs.check-releases.outputs.xcresult-processor-image-should-release }}" "${{ needs.release-xcresult-processor-image.result }}" "${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}"
-          tag_release "${{ needs.check-releases.outputs.runner-image-should-release }}" "${{ needs.release-runner-image.result }}" "${{ needs.check-releases.outputs.runner-image-next-version }}"
-          tag_release "${{ needs.check-releases.outputs.linux-runner-image-should-release }}" "${{ needs.release-linux-runner-image.result }}" "${{ needs.check-releases.outputs.linux-runner-image-next-version }}"
+
+          # The macOS runner image fans one semver out into a
+          # `macos-<xcode-dashes>-<semver>` tag per Xcode profile, and the
+          # chart pulls each pool's own tag, so all of them have to exist
+          # before the semver is worth tagging.
+          runner_image_tags() {
+            version="$1"
+            echo "$RUNNER_IMAGE_XCODE_PROFILES" \
+              | jq -r --arg v "$version" '.xcode[] | "macos-" + (. | gsub("\\."; "-")) + "-" + $v'
+          }
+          tag_release capi-scaleway \
+            "${{ needs.check-releases.outputs.capi-scaleway-should-release }}" \
+            "${{ needs.release-capi-scaleway.result }}" \
+            "${{ needs.check-releases.outputs.capi-scaleway-next-version }}" \
+            tuist/capi-provider-scaleway-applesilicon
+          tag_release runners-controller \
+            "${{ needs.check-releases.outputs.runners-controller-should-release }}" \
+            "${{ needs.release-runners-controller.result }}" \
+            "${{ needs.check-releases.outputs.runners-controller-next-version }}" \
+            tuist/tuist-runners-controller
+          tag_release stable-egress-controller \
+            "${{ needs.check-releases.outputs.stable-egress-controller-should-release }}" \
+            "${{ needs.release-stable-egress-controller.result }}" \
+            "${{ needs.check-releases.outputs.stable-egress-controller-next-version }}" \
+            tuist/tuist-stable-egress-controller
+          tag_release xcresult-processor-image \
+            "${{ needs.check-releases.outputs.xcresult-processor-image-should-release }}" \
+            "${{ needs.release-xcresult-processor-image.result }}" \
+            "${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}" \
+            tuist/tuist-xcresult-processor
+          runner_image_profile_tags=()
+          if [ "${{ needs.check-releases.outputs.runner-image-should-release }}" = "true" ]; then
+            mapfile -t runner_image_profile_tags < <(runner_image_tags "${{ needs.check-releases.outputs.runner-image-next-version-number }}")
+            if [ "${#runner_image_profile_tags[@]}" -eq 0 ]; then
+              echo "::error::Could not derive the runner-image profile tags from the build matrix; refusing to guess which images to verify."
+              exit 1
+            fi
+          fi
+          tag_release runner-image \
+            "${{ needs.check-releases.outputs.runner-image-should-release }}" \
+            "${{ needs.release-runner-image.result }}" \
+            "${{ needs.check-releases.outputs.runner-image-next-version }}" \
+            tuist/tuist-runner \
+            "${runner_image_profile_tags[@]}"
+          tag_release linux-runner-image \
+            "${{ needs.check-releases.outputs.linux-runner-image-should-release }}" \
+            "${{ needs.release-linux-runner-image.result }}" \
+            "${{ needs.check-releases.outputs.linux-runner-image-next-version }}" \
+            tuist/tuist-linux-runner
           # Kura gates on the full prepare/binaries/docker chain, like the
           # old commit-and-release "Create Kura tag" step did.
           KURA_RESULT=skipped
           if [ "${{ needs.release-kura-prepare.result }}" = "success" ] && [ "${{ needs.release-kura-binaries.result }}" = "success" ] && [ "${{ needs.release-kura-docker.result }}" = "success" ]; then
             KURA_RESULT=success
           fi
-          tag_release "${{ needs.check-releases.outputs.kura-should-release }}" "$KURA_RESULT" "${{ needs.check-releases.outputs.kura-next-version }}"
+          tag_release kura \
+            "${{ needs.check-releases.outputs.kura-should-release }}" \
+            "$KURA_RESULT" \
+            "${{ needs.check-releases.outputs.kura-next-version }}" \
+            tuist/kura
 
   # --------------------------------------------------------------------------
   # Production deploy cascade - build → canary → acceptance tests → production,


### PR DESCRIPTION
Canary deploys have been failing since Aug 20, taking the production cascade with them. Run [32456544386](https://github.com/tuist/tuist/actions/runs/32456544386/job/96737582219) is the latest of four.

## What was wrong

The deploy pinned an image that does not exist.

`server-deployment.yml` resolves each fleet/runtime image to the highest `<component>@<semver>` tag merged into the deploy SHA, treating the tag as proof the image was published. It isn't — the tag is cut on the release **job result** alone. During the OCI-registry window (reverted in faba8c8647) the xcresult-processor build published somewhere the chart does not read, so `xcresult-processor-image@0.78.0` and `@0.78.1` were tagged with no GHCR manifest behind them:

```
ghcr.io/tuist/tuist-xcresult-processor:0.77.0 -> 200
ghcr.io/tuist/tuist-xcresult-processor:0.78.0 -> 404
ghcr.io/tuist/tuist-xcresult-processor:0.78.1 -> 404
```

Every deploy since then pinned `0.78.1`.

## Why it cost a full hour rather than failing fast

A Tart Pod retries the pull forever in `TartCreateFailed` and a Linux Pod sits in ImagePullBackOff. Neither fails on its own, so `helm --atomic --wait` burned the whole `--timeout 60m` before rolling the release back. And because the next run resolves the same dead tag, it could never self-heal — four canary deploys died identically between Aug 20 21:11 and Aug 21 10:07.

Only xcresult-processor was affected. The other five fleet components resolve to images that exist; the Tart-image components were the ones moved to the other registry, and `runner-image@0.13.5` predates the migration.

## The fix, in two halves

### 1. A tag is not created until the image is actually pullable

This is the real repair: make the tag mean what everything downstream already assumes it means.

**Two paths create these tags, and both had to be gated.** `tag-infra-releases` pushes them directly; `publish-releases` creates them as a side effect of `action-gh-release`'s `tag_name`. Gating only the first would have been silently bypassed by the second — which is how 0.78.0 and 0.78.1 came to exist in the first place. `tag-infra-releases` is now the single authority on whether a component released: it exposes `<component>-tagged`, and `publish-releases` gates its GitHub Release steps on those.

**The check targets the address the chart pulls from, not wherever the release job pushed.** That distinction is the entire point. A job publishing to another registry reports success, so verifying its own push would have confirmed nothing; only the chart's own address separates the two cases.

An untagged component stays on its previous version — the correct reading of a release that never published — and the server still deploys. A fleet image failing to publish should not block a server hotfix.

The macOS runner image fans one semver out into a `macos-<xcode>-<semver>` tag per Xcode profile and the chart pulls each pool's own tag, so all five are verified before the semver is cut. Partial matrix success can no longer produce a semver that ImagePullBackOffs some pools.

### 2. The deploy skips a version whose image is missing

The tag gate is prospective — it cannot retract `0.78.0` and `@0.78.1`, which still exist and still wedge canary today. So resolution also walks tags newest-first and pins the newest version whose manifest exists, warning on each skip.

This is not just cleanup for the two orphans. The fallback lands the deploy on exactly the version it would have used had the bad tag never been created, so the two halves agree on what "that release didn't happen" means. It also means no tag deletion is needed: the orphans become inert, and the next xcresult-processor release cuts 0.78.2 and rolls forward normally.

### Cost of the checks

`ghcr.io` is not the `api.github.com` bucket CI exhausts — it returns no `x-ratelimit` accounting at all, and the 60/hr unauthenticated core limit that mise has hit is a separate service. Both workflows already grant `packages: write`, so the probe authenticates with `GITHUB_TOKEN` and bills to the token rather than to a runner egress IP shared across the fleet.

One pull token covers every repository probed in a job, so it is cached and reused. Measured, end to end:

| | requests |
|---|---|
| Deploy, steady state | **6** |
| Deploy, today (walking past the two orphan tags) | **8** |
| Release run (one refused component + a five-profile runner fan-out) | **7** |

The reuse is an optimization, not an assumption: a cached token rejected for the repository at hand is discarded and re-minted against it, so a stale or corrupted cache self-heals rather than reporting the image missing.

### The shared probe

Both paths call `.github/scripts/ghcr-image-published.sh` so they can never disagree about the same image. Only a **404** proves absence — auth, throttling and transport errors count as present, so a blip can neither withhold a good tag nor downgrade a component mid-deploy. It falls back from `GITHUB_TOKEN` to an anonymous pull token, and warns if it can obtain neither: a probe that silently always answers "published" is worse than one that admits it cannot answer. The deploy side skips the check when the script is absent, since its checkout is pinned to `DEPLOY_SHA` and a re-promote of an older commit predates it.

### Deploy watcher

The watcher now prints pod `.status.message`. tart-kubelet emits **no Warning event** for a create failure — the reason lives only there — which is why an hour of cluster snapshots showed `TartCreateFailed` with nothing explaining it.

## How to test locally

The probe, against live GHCR:

```bash
.github/scripts/ghcr-image-published.sh tuist/tuist-xcresult-processor 0.77.0; echo "0.77.0 -> $?"
.github/scripts/ghcr-image-published.sh tuist/tuist-xcresult-processor 0.78.1; echo "0.78.1 -> $?"
```

Deploy-side resolution, against the failing SHA:

```bash
yq '.jobs.deploy.steps[] | select(.name == "Resolve fleet and runtime image versions from git tags") | .run' .github/workflows/server-deployment.yml > /tmp/resolve.sh
DEPLOY_SHA=a8dc76d4f08e97ed5ff97ff678e79153e444329b GITHUB_ENV=/tmp/env bash /tmp/resolve.sh; cat /tmp/env
```

It warns on 0.78.1 and 0.78.0 and pins `XCRESULT_PROCESSOR_TAG=0.77.0` — the image canary is already running.

## Validation run

- **Aug 20 release run replayed through the new tag job**, with the real GitHub expressions substituted: refuses `xcresult-processor-image@0.78.1` with an error annotation and reports `xcresult-processor-image-tagged=false`, so neither path creates the tag. The same replay with 0.77.0 tags and pushes normally.
- Unit cases over `tag_release`: job-failed, did-not-release, fully published fan-out (0.13.5, all five profiles), fan-out missing a profile.
- Probe exercised against live GHCR for present, absent, and scopeless-token inputs — the last one previously made the gate inert and now falls back to anonymous.
- Deploy-side resolution on the failing SHA pins 0.77.0; the other five components are byte-identical to the failed run's env. A re-promote of a pre-0.78.0 commit resolves unchanged and warns about nothing, so `--merged` semantics are preserved.
- Watcher jsonpath run against the live `tuist-canary` namespace surfaces reasons the old snapshot never showed.
- No dependency cycle introduced by `publish-releases` gaining `tag-infra-releases`; actionlint + shellcheck hold at the pre-change finding count.

Unrelated but worth flagging from those snapshots: node `tuist-canary-md-0-rwjfn-j7n97-qv752` is under DiskPressure and has evicted six registry pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

