### PR TITLE
perf(infra): upload Tart image layers four at a time

### DIFF
--- a/.github/actions/tart-push/action.yml
+++ b/.github/actions/tart-push/action.yml
@@ -16,9 +16,12 @@ inputs:
     required: false
     default: "8"
   concurrency:
-    description: Number of concurrent registry uploads within Tart
+    description: >-
+      Number of disk layers Tart uploads at once. Chunks within a layer are
+      strictly sequential, so this is the only lever on upload throughput.
+      See the note on the push call below.
     required: false
-    default: "1"
+    default: "4"
   chunk-size:
     description: >-
       Upload chunk size in megabytes, or 0 for monolithic uploads. GHCR
@@ -120,25 +123,26 @@ runs:
           attempt_log="${RUNNER_TEMP:-/tmp}/tart-push-${GITHUB_RUN_ID:-local}-${attempt}.log"
           echo "Tart push attempt ${attempt}/${TART_PUSH_ATTEMPTS} at $(date -u +%H:%M:%SZ)" >&2
 
-          # Both upload modes were measured against this image on
-          # 2026-08-12, and 3 megabytes is the least bad of the two:
+          # Chunk size stays at 3 megabytes. GHCR rejects chunks of 4MB
+          # and up, so this is already the largest chunk it accepts, and
+          # monolithic does not work at this image size: every attempt
+          # died with "The request timed out" partway through the disk
+          # (best attempt reached 42%). That error is a URLError raised
+          # by Tart's own client, not a registry response, and because
+          # Tart retries a failed blob whole, a monolithic stall costs
+          # the entire 512 MiB layer instead of one chunk.
           #
-          #   chunked, 3MB   ~17,000 requests for a ~50 gigabyte disk,
-          #                  roughly 120 per minute, which trips GHCR's
-          #                  secondary rate limit under load. GHCR
-          #                  rejects chunks of 4MB and up, so this is
-          #                  already the largest chunk it accepts.
-          #   monolithic     one request per blob, no rate limiting seen,
-          #                  but every attempt died with "The request
-          #                  timed out" partway through the disk (best
-          #                  attempt reached 42%). That error is a
-          #                  URLError raised by Tart's own client, not a
-          #                  registry response.
-          #
-          # Do not "fix" a rate-limited push by reaching for a larger
-          # chunk or for monolithic. The levers that remain are the retry
-          # budget below, not pushing several large images concurrently,
-          # and the image size itself.
+          # Throughput therefore comes from concurrency, not chunk size.
+          # A single stream measured 6.1 MB/s on the 2026-08-21 release
+          # (18.6 gigabytes of new layers in 50.6 minutes), where the
+          # link itself connects to ghcr.io in 11ms: roughly 370ms of
+          # every 489ms request is GHCR-side per-chunk cost, paid one
+          # chunk at a time. Running layers in parallel does not change
+          # how many requests the push makes in total, only how long it
+          # takes to make them, and the retry loop below already makes a
+          # throttle cheap. If GHCR's secondary rate limit does start
+          # biting, lower `concurrency` rather than reaching for a larger
+          # chunk or for monolithic.
           #
           # Retrying is worth more than it looks: Tart splits the disk
           # into layers of at most 512 MiB, and skips any layer whose

--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -51,7 +51,7 @@ jobs:
     # A fresh Xcode major's `-downloadAllPlatforms` pulls brand-new
     # simulator runtimes from Apple that aren't cached yet, which can
     # push the build step alone past 50 min (26.6 took ~54 min) and
-    # leave little room for a deliberately low-concurrency image upload.
+    # leave little room for the image upload that follows.
     # Three hours covers both phases and the upload's retry budget.
     timeout-minutes: 180
     steps:
@@ -195,10 +195,6 @@ jobs:
           set -euo pipefail
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login --username tuist-bot --password-stdin ghcr.io
 
-      # 64 MB chunks, where GHCR was pinned at 3 because it rejects
-      # anything from 4 up and rate-limited the resulting request
-      # volume. For a ~50 GB image that is roughly 1,000 requests
-      # instead of ~17,000, which is the reason for the move.
       - name: Push image to GHCR
         timeout-minutes: 90
         env:


### PR DESCRIPTION
Speeds up `tart push` by uploading four disk layers at a time instead of one.

### What changed

`concurrency` on the shared `tart-push` action goes from `1` to `4`, which is Tart's own default. No call site overrides it, so this applies to all five: the macOS + Xcode image, the runner image, the xcresult-processor image, and both pushes in the production deployment workflow.

Two comments that no longer describe the code are dropped: one in `macos-xcode-image.yml` calling the upload "deliberately low-concurrency", and one describing 64 MB chunks left over from a registry that is no longer in the picture. The rationale note on the push call is rewritten around the measurement below.

### Why

The push dominates every Tart image build. On the [2026-08-21 release](https://github.com/tuist/tuist/actions/runs/32463262994/job/96753106889) the runner image for Xcode 26.0.1 spent 2m53s building and **54m49s pushing**, and it succeeded on the first attempt: no retries, no rate limiting. It was simply slow.

### Root cause

Cross-referencing the OCI manifest against the push log:

| | |
|---|---|
| disk layers | 261 (512 MiB each) |
| image size | 57.9 GB compressed / 140 GB raw |
| identical to `macos-tahoe-xcode:26-0-1` | 210 layers, 39.3 GB |
| genuinely new per release | 53 layers, 18.6 GB |

The 210 shared layers dedupe through Tart's `blobExists` check and cost about 4 minutes in total. The 53 new layers took **50.6 minutes**, which is 6.1 MB/s, or 489 ms per 3 MB chunk. The builder's own probe in that log connects to ghcr.io in 11 ms, so roughly 370 ms of every request is GHCR-side per-chunk cost.

That cost is charged per request and is largely independent of chunk size. Tart's `pushBlob` sends a layer's chunks strictly sequentially, taking the next upload location from each response, so a single stream is latency-bound rather than bandwidth-bound. Running layers in parallel is the only lever on throughput, and `DiskV2.push` already exposes it through `--concurrency`.

### Why not the obvious alternatives

**Bigger chunks.** GHCR rejects chunks of 4 MB and up, so 3 MB is already the ceiling.

**Monolithic uploads.** Measured previously and they fail at this image size. Tart retries a failed blob whole, so a stall costs an entire 512 MiB layer instead of one chunk, and the push never converges.

**Compression.** Worth checking, and it is not the lever. Two real layers were pulled from GHCR, LZ4-decompressed with the exact call `DiskV2.swift` makes, and recompressed:

| layer | Tart / LZ4 | zstd -3 | zstd -9 |
|---|---|---|---|
| dense (simulator runtimes) | 506 MB | 502 MB (0.8%) | 501 MB (0.9%) |
| mixed (toolchain, frameworks) | 279 MB | 228 MB (18.4%) | 217 MB (22.2%) |

Across the whole image, 49 layers totalling 26.1 GB are genuinely incompressible, 83 layers totalling 31.4 GB compress about 18% better, and the rest are sparse and already near zero. Weighted, that is roughly 10% off a 58 GB image, in exchange for patching Tart (LZ4 is hardcoded, with no flag) and breaking pull compatibility with every deployed Tart.

### Why raising concurrency is safe

The original pin to `1` was to stay under GHCR's secondary rate limit. Lowering concurrency does not reduce how many requests the push makes, only how long it takes to make them; the measured rate at concurrency 1 was 123 requests per minute. The retry loop already makes a throttle cheap, and the reason is in the existing comment: Tart skips any layer whose digest the registry already has, so attempts accumulate rather than restart, and a 403 costs one backoff instead of the upload so far. If GHCR does start throttling, the fix is to lower `concurrency` again, not to reach for a larger chunk or monolithic.

### Impact

If throughput scales close to linearly, the 18.6 GB of new layers should move in roughly 13 minutes instead of 50, taking a runner image build from about 58 minutes to under 20. Every server release currently rebuilds five runner images plus the xcresult-processor image (whose push was 47m45s in the same run), so this is a large share of release wall-clock. Concurrency also parallelises the LZ4 compression and the two SHA-256 passes Tart runs per layer, which is what makes even fully deduped layers cost 3 to 6 seconds each today.

### How to test locally

There is no local reproduction; this is a CI-only path. It is exercised by triggering an image build and comparing the push step's duration against the 54m49s baseline linked above:

```bash
gh workflow run macos-xcode-image.yml -f xcode_version=26.0.1
```

Static checks that were run:

```bash
yq -e '.' .github/actions/tart-push/action.yml
```

Watch the push step's log for `Registry concurrency: 4` and for any `hit a registry rate limit; retrying` warnings. The retry loop bounds the downside if GHCR throttles.

### Follow-ups worth considering (not in this PR)

- Tart never uses OCI cross-repository blob mounting (`Registry.swift` has no `mount` handling) and `blobExists` only checks the target namespace. A brand new Xcode profile therefore uploads all 58 GB even though 210 of its layers already exist in `tuist/macos-tahoe-xcode`. Pre-seeding the target repository with `crane copy` before the push would mount those server-side.
- The Layer 2 delta is a runner tarball, a handful of scripts, a Go binary and some plists, yet 53 layers change, because Tart's layer boundaries are fixed 512 MiB disk offsets and booting macOS scatters APFS writes across them. Fetching the agent at boot instead of baking it would mean runner images only rebuild when Xcode changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
