### PR TITLE
fix(cache): cap nginx access log retention on cache hosts

### DIFF
--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -323,6 +323,18 @@
     };
   };
 
+  # The upstream nginx module rotates weekly, keeps 26 archives, and
+  # delaycompresses the newest one, which at cache request volumes leaves
+  # tens of gigabytes of access logs on the root filesystem. The SQLite
+  # databases live there too, so a full disk stops the app from booting.
+  # Alloy tails the live access.log into Loki, so the local archives only
+  # need to cover a short window.
+  services.logrotate.settings.nginx = {
+    frequency = "daily";
+    maxsize = "2G";
+    rotate = 14;
+  };
+
   security.acme = {
     acceptTerms = true;
     defaults = {


### PR DESCRIPTION
## What changed

`cache/platform/nginx.nix` now overrides the logrotate policy the upstream NixOS nginx module installs: rotate daily instead of weekly, rotate early once the live `access.log` passes 2 GB, and keep 14 archives instead of 26.

## Why

The `Cache Deploy` production job failed on `cache-us-east-2` with `container not ready after 120 seconds (unhealthy)` ([run 32481846906](https://github.com/tuist/tuist/actions/runs/32481846906/job/96772692354)). The health check only ever reported `Healthcheck socket is unavailable`, meaning the app never finished booting.

### Root cause

The host's root filesystem was 100% full, 0 bytes available. `Cache.Application.start/2` runs `Ecto.Migrator` for every repo before the supervision tree starts and pattern-matches on `{:ok, _, _}`, so a SQLite write that cannot allocate crashes the boot, the Phoenix socket is never created, and Kamal times out. Nine of the ten production hosts booted the same image fine, which is what pointed at the host rather than the release.

Two things had filled the 150 GB disk:

1. **40 GB of nginx access logs.** The upstream module's defaults (weekly, `rotate 26`, `delaycompress`) keep two uncompressed weekly logs of roughly 13 GB each plus five months of compressed archives. This is what the PR fixes.
2. **A 79 GB `key_value.sqlite`.** Xcode cache database interactions were turned off in production in #11153 (2026-06-08). That flag also gates `KeyValueEvictionWorker` and `SQLiteMaintenanceWorker`, so the database froze at whatever size it had reached and was never evicted or vacuumed again. It was deleted from every host; the repo recreates an empty one and re-runs migrations at boot.

The leak was fleet-wide, not specific to one host: `cache-us-east-3` was 226 MB from the same failure, and `cache-eu-central` was carrying 113 GB of logs plus a 134 GB frozen database.

### Why this fix

`maxsize` is what makes the cap hold regardless of traffic. Frequency alone does not: `cache-eu-central` writes roughly 8 GB of access logs a day, so daily rotation on its own would still leave an 8 GB uncompressed file. With the logrotate timer running hourly, `maxsize 2G` bounds the live log and every archive, so the worst case is a few GB per host instead of scaling with request volume.

Retention drops rather than grows because Alloy already tails the live `access.log` into Loki (`platform/alloy.nix`); the on-disk archives are a local buffer, not the system of record.

## Impact

Cache hosts stop accumulating unbounded access logs on the same filesystem as their SQLite databases. No behaviour change for request handling: only the rotation policy is touched, and the `log_format` and `access_log` directives are unchanged.

## Validation

- `nix-instantiate --parse cache/platform/nginx.nix` parses.
- `alejandra --check` reports no style issues.
- `nix eval .#nixosConfigurations.cache-us-east-2.config.services.logrotate.settings.nginx` renders `frequency = "daily"`, `maxsize = "2G"`, `rotate = 14`, with the module's `compress`, `su nginx nginx`, and `postrotate` hook preserved.
- Out of band, all ten production hosts were cleaned (rotated archives plus the abandoned key-value database) and the deploy was re-run. `cache-us-east-2` went from 0 bytes free to 99 GB and is serving again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
