### PR TITLE
fix(server): stop rounding away sub-decimal bundle size thresholds in the PR check

### DIFF
--- a/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
+++ b/server/lib/tuist/bundles/workers/bundle_threshold_worker.ex
@@ -132,9 +132,9 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorker do
 
     | Metric | Baseline | Current | Change |
     |--------|----------|---------|--------|
-    | #{metric_label} | #{ByteFormatter.format_bytes(baseline_size)} | #{ByteFormatter.format_bytes(current_size)} | +#{Float.round(deviation, 1)}% |
+    | #{metric_label} | #{ByteFormatter.format_bytes(baseline_size)} | #{ByteFormatter.format_bytes(current_size)} | +#{Float.round(deviation, 2)}% |
 
-    **Threshold:** #{Float.round(threshold.deviation_percentage, 1)}% on `#{threshold.baseline_branch}`#{if threshold.bundle_name, do: " (bundle: #{threshold.bundle_name})", else: ""}
+    **Threshold:** #{threshold.deviation_percentage}% on `#{threshold.baseline_branch}`#{if threshold.bundle_name, do: " (bundle: #{threshold.bundle_name})", else: ""}
 
     [View bundle details](#{bundle_url})
     """

--- a/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
+++ b/server/test/tuist/bundles/workers/bundle_threshold_worker_test.exs
@@ -231,6 +231,65 @@ defmodule Tuist.Bundles.Workers.BundleThresholdWorkerTest do
       assert :ok == BundleThresholdWorker.perform(job)
     end
 
+    test "reports the configured threshold and the deviation without losing sub-decimal precision" do
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "org/repo",
+            provider: :github
+          ]
+        )
+
+      BundlesFixtures.bundle_threshold_fixture(
+        project: project,
+        name: "Download size PR check",
+        metric: :download_size,
+        deviation_percentage: 0.15
+      )
+
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        download_size: 100_000,
+        git_branch: "main",
+        inserted_at: ~U[2024-01-01 00:00:00Z]
+      )
+
+      bundle =
+        BundlesFixtures.bundle_fixture(
+          project: project,
+          download_size: 100_170,
+          git_branch: "feature",
+          git_commit_sha: "abc123",
+          git_ref: "refs/pull/1/merge",
+          inserted_at: ~U[2024-01-02 00:00:00Z]
+        )
+
+      stub(Environment, :github_app_configured?, fn -> true end)
+      stub(Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      expect(Client, :get_pull_request, fn _params ->
+        {:ok, %{"head" => %{"sha" => "real-head-sha"}}}
+      end)
+
+      expect(Client, :create_check_run, fn params ->
+        assert params.conclusion == "action_required"
+        assert params.output.summary =~ "**Threshold:** 0.15%"
+        assert params.output.summary =~ "+0.17%"
+        {:ok, %{"id" => 1}}
+      end)
+
+      job = %Oban.Job{
+        id: 1,
+        args: %{
+          "bundle_id" => bundle.id,
+          "project_id" => project.id,
+          "git_commit_sha" => "abc123"
+        }
+      }
+
+      assert :ok == BundleThresholdWorker.perform(job)
+    end
+
     test "reports violation when first threshold passes but second violates" do
       project =
         ProjectsFixtures.project_fixture(


### PR DESCRIPTION
## What changed

The bundle size PR check run rendered both the configured threshold and the measured deviation through `Float.round(x, 1)`. The threshold is now rendered verbatim, and the deviation is rounded to two decimals instead of one.

## Why

A user configured a download size threshold below 0.15% and the check run reported:

> **Threshold:** 0.1% on `main`

which does not match anything they set, and reads as if the platform silently coarsened their configuration.

## Root cause

Display-only rounding in `build_check_run_output/2`. `Float.round(0.15, 1)` is `0.1`, not `0.2`, because 0.15 as an IEEE 754 double is `0.1499999999999999944...` and rounds down. Any threshold under 0.15% collapsed to `0.1%` or `0.0%` in the summary.

The gate itself was never affected. `Tuist.Bundles.check_threshold_deviation/3` compares the raw float:

```elixir
deviation = (current_size - baseline_size) / baseline_size * 100
if deviation > threshold.deviation_percentage do
```

Nothing truncates on save either. The column is a float, and the settings LiveView parses input with `Float.parse/1`. So the check was always correct; only the explanation of the check was wrong. That is still worth fixing: a threshold report that disagrees with the configured value is what makes people distrust the gate.

## Why this approach

Two obvious alternatives were rejected:

- **Round both to more decimals** (e.g. `Float.round(x, 3)`). Still lossy at some arbitrary cutoff, and it pads the common case with trailing zeros (`5.0%` becomes `5.0%`, but `5.005%` thresholds still round). The threshold is user-entered and always short, so there is no reason to round it at all. Interpolating the float directly is what the settings table already does.
- **Round the deviation to match the threshold's precision.** More faithful, but it means deriving decimal places from a float's string form, which misbehaves for values Elixir renders in scientific notation. Two decimals covers the thresholds people actually configure without that complexity.

One decimal was kept on `ByteFormatter.format_bytes/1`; sizes are not compared against the threshold, so their precision is not load-bearing.

## Impact

Check run summaries now show the threshold as configured. A 0.15% threshold reports `Threshold: 0.15%` instead of `Threshold: 0.1%`, and a 0.17% deviation reports `+0.17%` instead of `+0.2%`. No behavior change to whether a check passes or fails, and no data migration.

## Residual gap

A threshold with three or more decimals (0.001%) can still display a deviation as `+0.0%`. Left alone deliberately rather than adding precision-matching logic for a case nobody has hit.

## Validation

Added a regression test that configures a 0.15% threshold against a 0.17% deviation and asserts the rendered summary. It fails on `main` with `Threshold: 0.1%` / `+0.2%` and passes with the fix.

```
mix test test/tuist/bundles/workers/bundle_threshold_worker_test.exs test/tuist/bundles_test.exs
Result: 68 passed
```

`mix format` and `mix credo` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
