### PR TITLE
fix(cli): relocate generated projects for registry packages out of the package root

### DIFF
--- a/cli/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
+++ b/cli/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
@@ -43,12 +43,12 @@ extension Project {
 
     public func derivedDirectoryPath(for target: Target) -> AbsolutePath {
         let resolvedSwiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
-            containingCheckout: path,
+            containingPackageSource: path,
             knownScratchDirectory: swiftPackageManagerScratchDirectory
         )
         if case .external = type,
            let resolvedSwiftPackageManagerScratchDirectory,
-           SwiftPackageManagerPaths.isPath(path, inCheckoutsOf: resolvedSwiftPackageManagerScratchDirectory)
+           SwiftPackageManagerPaths.isPath(path, inPackageSourcesOf: resolvedSwiftPackageManagerScratchDirectory)
         {
             return resolvedSwiftPackageManagerScratchDirectory
                 .appending(

--- a/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -21,12 +21,12 @@ public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
 
     private func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
         let swiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
-            containingCheckout: project.path,
+            containingPackageSource: project.path,
             knownScratchDirectory: project.swiftPackageManagerScratchDirectory
         )
         guard case .external = project.type,
               let swiftPackageManagerScratchDirectory,
-              SwiftPackageManagerPaths.isPath(project.path, inCheckoutsOf: swiftPackageManagerScratchDirectory)
+              SwiftPackageManagerPaths.isPath(project.path, inPackageSourcesOf: swiftPackageManagerScratchDirectory)
         else { return (project, []) }
         var project = project
         let xcodeProjBasename = project.xcodeProjPath.basename

--- a/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -132,7 +132,7 @@ public struct RecursiveManifestLoader: RecursiveManifestLoading {
                 && !manifests.contains(.workspace)
                 && !SwiftPackageManagerPaths.isPath(
                     $0,
-                    inSwiftPackageManagerCheckoutsOf: swiftPackageManagerScratchDirectory
+                    inSwiftPackageManagerPackageSourcesOf: swiftPackageManagerScratchDirectory
                 )
         }
 

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -330,7 +330,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                         nil
                     } else {
                         SwiftPackageManagerPaths
-                            .scratchDirectory(containingCheckout: packageInfo.folder)
+                            .scratchDirectory(containingPackageSource: packageInfo.folder)
                             .map { Path.path($0.pathString) }
                     }
                     result[.path(packageInfo.folder.pathString)] = DependenciesGraph.ExternalProject(

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
@@ -36,7 +36,7 @@ extension XcodeGraph.Workspace {
                 $0.basename != Constants.tuistDirectoryName
                     && !SwiftPackageManagerPaths.isPath(
                         $0,
-                        inSwiftPackageManagerCheckoutsOf: swiftPackageManagerScratchDirectory
+                        inSwiftPackageManagerPackageSourcesOf: swiftPackageManagerScratchDirectory
                     )
             }
             .uniqued()

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -838,7 +838,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             )
             moduleMapModuleName = resolvedModuleName
             let swiftPackageManagerScratchDirectory: AbsolutePath? = if packageType.isRemoteExternal {
-                SwiftPackageManagerPaths.scratchDirectory(containingCheckout: path)
+                SwiftPackageManagerPaths.scratchDirectory(containingPackageSource: path)
             } else {
                 nil
             }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -73,11 +73,11 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
         let generatedModuleMapPath: AbsolutePath
 
         let resolvedSwiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
-            containingCheckout: publicHeadersPath,
+            containingPackageSource: publicHeadersPath,
             knownScratchDirectory: swiftPackageManagerScratchDirectory
         )
         if let resolvedSwiftPackageManagerScratchDirectory,
-           SwiftPackageManagerPaths.isPath(publicHeadersPath, inCheckoutsOf: resolvedSwiftPackageManagerScratchDirectory)
+           SwiftPackageManagerPaths.isPath(publicHeadersPath, inPackageSourcesOf: resolvedSwiftPackageManagerScratchDirectory)
         {
             generatedModuleMapPath = resolvedSwiftPackageManagerScratchDirectory
                 .appending(

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerPaths.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerPaths.swift
@@ -2,51 +2,65 @@ import Path
 
 public enum SwiftPackageManagerPaths {
     public static let checkoutsDirectoryName = "checkouts"
+    public static let registryDirectoryName = "registry"
+    public static let registryDownloadsDirectoryName = "downloads"
     public static let defaultScratchDirectoryName = ".build"
 
     public static func checkoutsDirectory(in scratchDirectory: AbsolutePath) -> AbsolutePath {
         scratchDirectory.appending(component: checkoutsDirectoryName)
     }
 
-    public static func isPath(_ path: AbsolutePath, inCheckoutsOf scratchDirectory: AbsolutePath) -> Bool {
+    public static func registryDownloadsDirectory(in scratchDirectory: AbsolutePath) -> AbsolutePath {
+        scratchDirectory.appending(components: registryDirectoryName, registryDownloadsDirectoryName)
+    }
+
+    /// Whether `path` is one of the package sources SwiftPM materialises inside `scratchDirectory`:
+    /// a source-control checkout under `checkouts/`, or a registry download under `registry/downloads/`.
+    public static func isPath(_ path: AbsolutePath, inPackageSourcesOf scratchDirectory: AbsolutePath) -> Bool {
         path.isDescendantOfOrEqual(to: checkoutsDirectory(in: scratchDirectory))
+            || path.isDescendantOfOrEqual(to: registryDownloadsDirectory(in: scratchDirectory))
     }
 
     public static func isPath(
         _ path: AbsolutePath,
-        inSwiftPackageManagerCheckoutsOf scratchDirectory: AbsolutePath?
+        inSwiftPackageManagerPackageSourcesOf scratchDirectory: AbsolutePath?
     ) -> Bool {
         if let scratchDirectory {
-            return isPath(path, inCheckoutsOf: scratchDirectory)
+            return isPath(path, inPackageSourcesOf: scratchDirectory)
         }
-        return defaultScratchDirectory(containingCheckout: path) != nil
+        return defaultScratchDirectory(containingPackageSource: path) != nil
     }
 
-    public static func scratchDirectory(containingCheckout path: AbsolutePath) -> AbsolutePath? {
+    public static func scratchDirectory(containingPackageSource path: AbsolutePath) -> AbsolutePath? {
         var current = path
         while current != .root {
             if current.basename == checkoutsDirectoryName {
                 return current.parentDirectory
+            }
+            if current.basename == registryDownloadsDirectoryName,
+               current.parentDirectory.basename == registryDirectoryName
+            {
+                return current.parentDirectory.parentDirectory
             }
             current = current.parentDirectory
         }
         return nil
     }
 
-    public static func defaultScratchDirectory(containingCheckout path: AbsolutePath) -> AbsolutePath? {
-        guard let scratchDirectory = scratchDirectory(containingCheckout: path),
+    public static func defaultScratchDirectory(containingPackageSource path: AbsolutePath) -> AbsolutePath? {
+        guard let scratchDirectory = scratchDirectory(containingPackageSource: path),
               scratchDirectory.basename == defaultScratchDirectoryName
         else { return nil }
         return scratchDirectory
     }
 
     public static func scratchDirectory(
-        containingCheckout path: AbsolutePath,
+        containingPackageSource path: AbsolutePath,
         knownScratchDirectory: AbsolutePath?
     ) -> AbsolutePath? {
-        if let knownScratchDirectory, isPath(path, inCheckoutsOf: knownScratchDirectory) {
+        if let knownScratchDirectory, isPath(path, inPackageSourcesOf: knownScratchDirectory) {
             return knownScratchDirectory
         }
-        return defaultScratchDirectory(containingCheckout: path)
+        return defaultScratchDirectory(containingPackageSource: path)
     }
 }

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -207,4 +207,48 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
             projectPath.appending(component: "ExternalDependency.xcodeproj")
         )
     }
+
+    func test_map_whenExternalProjectIsARegistryDownload() throws {
+        // Given
+        let externalProjectBasePath = try temporaryPath()
+            .appending(component: Constants.SwiftPackageManager.packageBuildDirectoryName)
+        let externalProjectPath = externalProjectBasePath.appending(
+            components: [
+                "registry",
+                "downloads",
+                "google",
+                "promises",
+                "2.4.1",
+            ]
+        )
+        let externalProject = Project.test(
+            path: externalProjectPath,
+            sourceRootPath: externalProjectPath,
+            xcodeProjPath: externalProjectPath.appending(component: "Promises.xcodeproj"),
+            name: "Promises",
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: externalProjectBasePath
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try subject.map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            externalProjectBasePath.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesProjectDirectory,
+                    "Promises",
+                    "Promises.xcodeproj",
+                ]
+            )
+        )
+    }
 }

--- a/cli/Tests/TuistLoaderTests/Graph/ProjectCoreTests.swift
+++ b/cli/Tests/TuistLoaderTests/Graph/ProjectCoreTests.swift
@@ -59,4 +59,35 @@ final class ProjectCoreTests: TuistUnitTestCase {
             projectPath.appending(component: Constants.DerivedDirectory.name)
         )
     }
+
+    func test_derivedDirectoryPath_whenExternalProjectIsARegistryDownload() throws {
+        // Given
+        let scratchDirectory = try temporaryPath()
+            .appending(component: ".build")
+        let projectPath = scratchDirectory.appending(components: "registry", "downloads", "google", "promises", "2.4.1")
+        let target = Target.test(name: "Promises_FBLPromises")
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            xcodeProjPath: projectPath.appending(component: "Promises.xcodeproj"),
+            targets: [target],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // When
+        let got = project.derivedDirectoryPath(for: target)
+
+        // Then
+        XCTAssertEqual(
+            got,
+            scratchDirectory.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesTargetDirectory,
+                    target.name,
+                ]
+            )
+        )
+    }
 }


### PR DESCRIPTION
### Purpose

Tuist relocates the generated `.xcodeproj`, derived Info.plists, entitlements and module maps for external SwiftPM projects into `<scratch>/tuist-derived/`, so that nothing we generate is written inside a package's source tree. That relocation was gated on `SwiftPackageManagerPaths.isPath(_:inCheckoutsOf:)`, which only matched `<scratch>/checkouts/...`. Registry resolved packages are materialized at `<scratch>/registry/downloads/<scope>/<name>/<version>`, so they never took that path, and Tuist wrote its generated output straight into the package root instead.

That is harmless with stock SwiftPM, where the registry download root is a real directory private to the checkout. With swifterpm the root is a directory of symlinks into the globally shared `~/.cache/swifterpm/sources/...` entry, and it breaks builds two ways.

**Packages that ship their own Xcode project.** The symlink farm turns that root entry into a symlink into the shared cache. Our generated project is named after the package manifest, so for a package like Promises the names collide and `project.pbxproj` is written through the symlink into the shared cache, on top of the package's vendored project. Xcode then canonicalizes the project location, `$(SRCROOT)` becomes the cache directory, and every SRCROOT relative generated input goes missing:

```
error: Build input file cannot be found: '/Users/<user>/.cache/swifterpm/sources/google.promises/2.4.1-<hash>-registry/Derived/InfoPlists/Promises_FBLPromises-Info.plist'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Promises_FBLPromises' from project 'Promises')
```

**Packages without that collision.** Every `tuist install` rebuilds the symlink farm from the cache entries, which silently deletes the generated `Derived/` directory and the generated `<Package>.xcodeproj`. A build that does not regenerate first then fails the same way.

Both are the same root cause: generated output living inside a package root that swifterpm treats as shared, immutable and rebuildable. This was reported against 4.206.0-canary.5 by someone using the registry, and it reproduces deterministically from a clean cache.

### What changed

`SwiftPackageManagerPaths` now recognizes both locations SwiftPM materializes package sources into, `checkouts/` and `registry/downloads/`, so registry packages take the same `tuist-derived/` relocation that source control checkouts already had. The predicate and the scratch directory lookups are renamed to match the widened meaning (`inPackageSourcesOf:`, `inSwiftPackageManagerPackageSourcesOf:`, `containingPackageSource:`), and the seven call sites are updated.

Two of those call sites are worth a look on their own: the workspace and manifest globbing filters in `Workspace+ManifestMapper` and `RecursiveManifestLoader` were excluding source control checkouts from user project discovery but not registry downloads. They now exclude both.

I picked widening the path predicate over the obvious alternatives:

- Teaching swifterpm to preserve `Derived/` and the generated project across installs would keep generated output in a globally shared, content addressed cache that several checkouts on one machine write to and delete from. It also would not help the name collision case at all.
- Renaming the generated project to avoid colliding with vendored ones would fix only the first failure mode, leave the install wipe in place, and change project names that people's schemes and scripts already reference.

The chosen fix removes the whole class of problem: after it, nothing Tuist generates is written inside a package root, for any resolution kind.

### Impact

Registry resolved packages now behave exactly like source control ones. Generated projects move to `<scratch>/tuist-derived/Projects/<name>/`, derived files to `<scratch>/tuist-derived/Targets/<target>/`, and module maps to `<scratch>/tuist-derived/ModuleMaps/<module>/`. Package roots are left untouched, including packages that ship their own `.xcodeproj`.

Existing machines still have `Derived/` directories and overwritten `.xcodeproj` files sitting in `~/.cache/swifterpm/sources/*/*-registry/` from before this change. They become inert once this ships, but the vendored projects stay overwritten until those cache entries are re-fetched.

### How to test locally

Create a project with an iOS app target that depends on `.external(name: "FBLPromises")`, and a `Tuist/Package.swift` declaring `.package(url: "https://github.com/google/promises", exact: "2.4.1")`. Promises ships its own `Promises.xcodeproj`, which is what triggers the name collision.

```
rm -rf ~/.cache/swifterpm/sources/google.promises Tuist/.build Tuist/Package.resolved
tuist install --replace-scm-with-registry
tuist generate --no-open
xcodebuild -workspace <Project>.xcworkspace -scheme App -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
```

On `main` that fails with the error above. With this branch it succeeds, `Tuist/.build/registry/downloads/google/promises/2.4.1/` holds nothing we generated, and the vendored `Promises.xcodeproj` in the shared cache keeps its original `project.pbxproj`.

Then run `tuist install --replace-scm-with-registry` again and rebuild without regenerating. On `main` the generated output has been deleted and the build fails. With this branch it succeeds.

### Validation

Verified end to end with the project above, from a fully clean state each time (cache entry, `.build`, `Package.resolved` and DerivedData all removed):

| Flow | Before | After |
| --- | --- | --- |
| swifterpm, registry | `Build input file cannot be found` | build succeeds |
| swifterpm, registry, re-install without regenerating | generated output deleted, build fails | build succeeds |
| swifterpm, source control | build succeeds | build succeeds |
| stock SwiftPM, registry | build succeeds | build succeeds |

Unit tests: `test_derivedDirectoryPath_whenExternalProjectIsARegistryDownload` in `ProjectCoreTests` and `test_map_whenExternalProjectIsARegistryDownload` in `ExternalDependencyPathWorkspaceMapperTests`. Both fail with the predicate reverted to checkouts only and pass with the change, and I confirmed they actually execute rather than being silently filtered out, alongside the five existing cases in those suites.
