### PR TITLE
fix(kura): keep the release build alive when the remote cache goes away

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -463,16 +463,7 @@ jobs:
           # --binary-only builds just //:kura (opt via kura/.bazelrc); //... would pull in the test
           # target, which can't cross-compile. compile-args adds the cross --config on the macOS
           # x86_64 leg and is empty for the native legs.
-          BUILD_LOG="$RUNNER_TEMP/kura-bazel-${TARGET}.log"
-          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }} 2>&1 | tee "$BUILD_LOG"
-
-          # .bazelrc makes the remote cache non-fatal, and Bazel degrades to local execution without
-          # printing anything, so a cache that is unreachable at startup is otherwise invisible here.
-          # Surface it: either Bazel logged a cache error, or the cache was configured and served
-          # nothing. Warning only: a cold build still ships a correct binary.
-          if [ -f .bazelrc.tuist ] && { grep -q "Remote Cache:" "$BUILD_LOG" || ! grep -q "remote cache hit" "$BUILD_LOG"; }; then
-            echo "::warning::Tuist remote cache degraded for ${TARGET}: Bazel fell back to local execution. The binary is unaffected; the build was cold."
-          fi
+          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }}
 
           STAGE_DIR="$(mktemp -d)"
           cp bazel-bin/kura "$STAGE_DIR/kura"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -463,7 +463,16 @@ jobs:
           # --binary-only builds just //:kura (opt via kura/.bazelrc); //... would pull in the test
           # target, which can't cross-compile. compile-args adds the cross --config on the macOS
           # x86_64 leg and is empty for the native legs.
-          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }}
+          BUILD_LOG="$RUNNER_TEMP/kura-bazel-${TARGET}.log"
+          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }} 2>&1 | tee "$BUILD_LOG"
+
+          # .bazelrc makes the remote cache non-fatal, and Bazel degrades to local execution without
+          # printing anything, so a cache that is unreachable at startup is otherwise invisible here.
+          # Surface it: either Bazel logged a cache error, or the cache was configured and served
+          # nothing. Warning only: a cold build still ships a correct binary.
+          if [ -f .bazelrc.tuist ] && { grep -q "Remote Cache:" "$BUILD_LOG" || ! grep -q "remote cache hit" "$BUILD_LOG"; }; then
+            echo "::warning::Tuist remote cache degraded for ${TARGET}: Bazel fell back to local execution. The binary is unaffected; the build was cold."
+          fi
 
           STAGE_DIR="$(mktemp -d)"
           cp bazel-bin/kura "$STAGE_DIR/kura"

--- a/kura/.bazelrc
+++ b/kura/.bazelrc
@@ -1,6 +1,13 @@
 # When available, load the tuist-specific configuration
 try-import %workspace%/.bazelrc.tuist
 
+# Treat the remote cache from .bazelrc.tuist as best-effort: fall back to local execution when it
+# is unreachable or drains mid-build, instead of failing the build with "Failed to query remote
+# execution capabilities". --remote_local_fallback covers only --remote_executor on its own; the
+# incompatible_ flag extends it to --remote_cache. Both are inert without a remote cache.
+build --remote_local_fallback
+build --incompatible_remote_local_fallback_for_remote_cache
+
 # Build opt globally: the runtime and e2e images are assembled from this binary, so it must match
 # the optimized binary that ships, and one compilation mode keeps every job on a single warm cache
 # keyspace. Side effect: `bazel test` then runs with debug_assertions off (like `cargo test --release`).


### PR DESCRIPTION
Both macOS legs of "Release Kura Binary" failed in [this production deployment run](https://github.com/tuist/tuist/actions/runs/32463262994) with exit 34 and no binary produced.

## What happened

Not a compile error. The Tuist remote cache went away mid-build:

1. Nearly the whole build was remote cache hits (726 hits, 1 local action). With build-without-the-bytes, intermediate outputs such as `liblz4.a` and `librocksdb.a` were never downloaded locally. The cache then reported `UNAVAILABLE: server is draining`, and the final link could not refetch them: `Lost inputs no longer available remotely`.
2. Bazel's built-in eviction retry re-ran and aborted immediately with `Failed to query remote execution capabilities: Connection refused`. The endpoint written into `.bazelrc.tuist` at setup time is a single node address, so a node that goes away has no failover.

On the infrastructure side the pod behind that endpoint failed its kubelet liveness probe and was restarted in place, leaving it unready for about 60 seconds. That instability is being tracked separately. This PR is about the build not surviving it.

## Why this took the release down

The job already treats the cache as best effort: `tuist bazel setup` runs with `continue-on-error`, and `.bazelrc` try-imports `.bazelrc.tuist`, so a job whose setup fails builds cold instead of blocking the release. That only covered the cache being unavailable *before* the build. A cache that died during one still failed the release.

## The change

Two flags in `kura/.bazelrc`:

```
build --remote_local_fallback
build --incompatible_remote_local_fallback_for_remote_cache
```

The pairing is the non-obvious part. `--remote_local_fallback` on its own applies only to `--remote_executor`, so an unreachable `--remote_cache` stays fatal; `--incompatible_remote_local_fallback_for_remote_cache` is what extends it to the cache. Verified both ways, see below.

Chosen over wrapping the build in a shell retry that moves `.bazelrc.tuist` aside and rebuilds. That would also work, but it reimplements in bash what Bazel already models, and it only kicks in after a whole build has failed. The flags degrade at the point of failure instead.

Both flags are inert when no remote cache is configured, so the no-access path documented in `kura/AGENTS.md` is unchanged, and behaviour against a healthy cache is unchanged because the fallback only engages on failure.

## For reviewers

Two things I deliberately did not do, both worth a second opinion:

**The fallback is silent.** Bazel prints nothing when it degrades to local execution, so a persistently unreachable cache would surface only as release jobs that are quietly much slower. A build-log grep promoting this to a GitHub annotation is in this branch's history and was reverted on purpose: it couples the release job to Bazel console output and warns on a job nobody watches. Cache health belongs in Kura's own alerting, which currently has no restart or readiness alert.

**A cold fallback build may be tight against the job's 60 minute timeout.** Adding `--remote_download_all` on the release legs would keep intermediates on disk so a mid-build cache death cannot strand them, at the cost of downloading every intermediate on the happy path too. Left out as a separate call, since a cold build inside that timeout is already the accepted design for the setup-failure path.

The branch has three commits: the fix, the annotation experiment, and its revert. Net diff is `kura/.bazelrc` only.

### How to test locally

```bash
cd kura && bazel build --remote_cache=grpc://127.0.0.1:1 //bazel/third_party/lz4:lz4_include
```

On `main` this exits 34 with the same `Failed to query remote execution capabilities` error seen in CI. On this branch it exits 0, building locally instead. Verified on Bazel 9.1.0, the version pinned in `kura/.bazelversion`. A scratch workspace confirmed that `--remote_local_fallback` alone still exits 34, so both flags are required.
