### PR TITLE
fix(kura): yield during CAS segment eviction, and alert on the cache restarts it caused

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -530,7 +530,8 @@ sum by (cluster, pod) (
   deployed rule keeps the raw `increase(...)` in query A and puts the
   comparison in threshold expression C as `gt 1.5`, matching the house pattern.
 - Summary: `Kura cache pod {{ $labels.pod }} restarted
-  {{ $value }} times in the last 6 hours in {{ $labels.cluster }}`
+  {{ $values.A.Value | printf "%.0f" }} times in the last 6 hours in
+  {{ $labels.cluster }}`
 
 **Nothing covered the `kura` namespace before this.** Two generic restart rules
 already existed and neither could have fired: `Pod restarts (possible
@@ -1199,8 +1200,9 @@ sum by (cluster, pod) (
 - Severity: warning
 - Already created: rule `cfvvcmpw0wqv4f`, folder `Alerts`, group `Cache`,
   receiver `Slack #notifications 2`
-- Summary: `Kura cache pod {{ $labels.pod }} failed {{ $value }} scrapes in the
-  last 6 hours in {{ $labels.cluster }}`
+- Summary: `Kura cache pod {{ $labels.pod }} failed
+  {{ $values.A.Value | printf "%.0f" }} scrapes in the last 6 hours in
+  {{ $labels.cluster }}`
 
 Kura serves `/metrics`, `/up` and `/ready` from the same axum server on the
 same port, so an Alloy scrape timeout and a kubelet probe timeout are two
@@ -1238,8 +1240,9 @@ max by (cluster, pod) (
 - Severity: warning
 - Already created: rule `dfvvcp2lfgb9cd`, folder `Alerts`, group `Cache`,
   receiver `Slack #notifications 2`
-- Summary: `Kura metadata store write buffer is {{ $value | humanizePercentage }}
-  full on {{ $labels.pod }} in {{ $labels.cluster }}`
+- Summary: `Kura metadata store write buffer is
+  {{ $values.A.Value | humanizePercentage }} full on {{ $labels.pod }} in
+  {{ $labels.cluster }}`
 
 The mechanism behind the two rules above, and the only one of the three visible
 *before* the pod stops answering.
@@ -2071,12 +2074,18 @@ min by (cluster, namespace, repo, database) (
    warnings. Note that **Keep Last State** is reachable from the UI but not
    from the provisioning API, which accepts only `OK`, `Alerting` and `Error`;
    use `OK` there for the same intent.
-10. Add the suggested summary, a `severity` label, and the notification contact
+10. Write value interpolations as `{{ $values.A.Value }}`, not `{{ $value }}`.
+    Every rule here is a data query plus a separate threshold expression, and on
+    a multi-ref-id rule `$value` expands to a string listing each ref id and its
+    value (`[ var='C0' labels={...} value=1 ]`) rather than the number from A.
+    That also breaks any pipe into `humanizePercentage` or `printf`, which want
+    a number. `{{ $labels.x }}` is unaffected.
+11. Add the suggested summary, a `severity` label, and the notification contact
    point used by the infrastructure team. Add `affected_service` to
    customer-visible rules as described in **Routing to Grafana IRM** above.
-11. Preview the raw metric selector and the final comparison separately against
+12. Preview the raw metric selector and the final comparison separately against
     recent data before saving it.
-12. For a rule whose healthy state is an empty result *and* whose unhealthy
+13. For a rule whose healthy state is an empty result *and* whose unhealthy
     state depends on the series existing (`Remote processing queue has no
     consumer`, `xcresult processor guest metrics unavailable fleet-wide`),
     confirm the paired telemetry-missing rule exists before relying on it.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -525,11 +525,19 @@ sum by (cluster, pod) (
 
 - Pending period: 10 minutes
 - Severity: critical
-- Label: `affected_service` set to the cache component (customer-visible: a
-  restarting node drops every cache request in flight, and the client sees a
-  hang or a failed build rather than a clean error)
+- Already created: rule `efvvcl6qu3tvkc`, folder `Alerts`, group `Cache`,
+  receiver `Slack #notifications 2`, alongside the other Kura rules. The
+  deployed rule keeps the raw `increase(...)` in query A and puts the
+  comparison in threshold expression C as `gt 1.5`, matching the house pattern.
 - Summary: `Kura cache pod {{ $labels.pod }} restarted
   {{ $value }} times in the last 6 hours in {{ $labels.cluster }}`
+
+**Nothing covered the `kura` namespace before this.** Two generic restart rules
+already existed and neither could have fired: `Pod restarts (possible
+overload)` is scoped `namespace="tuist"`, and both it and `Pod CrashLoop /
+Frequent Restarts` use thresholds (more than 2 in 15 minutes, more than 5 in an
+hour) far above this fault's rate. Check the namespace scope of a generic rule
+before assuming it covers a new workload.
 
 **This is the primary rule for the fault.** Backtested over the 7 days to
 2026-08-21 across all 30 production Kura pods, sampled every 10 minutes: it
@@ -565,12 +573,23 @@ absent_over_time(up{job="kura"}[15m])
 
 - Pending period: 0 minutes
 - Severity: critical
+- Already created: rule `ffvvcpp359qm8d`, folder `Alerts`, group `Cache`,
+  receiver `Slack #notifications 2`
 - Summary: `Kura cache scrape targets have disappeared in {{ $labels.cluster }}`
 
-The paired telemetry rule for the two Kura rules that read `up`. Those are
+The paired telemetry rule for the Kura rules that read `up`. Those are
 threshold rules with **No Data: Normal**, so they cannot distinguish a healthy
 fleet from a scrape configuration that stopped discovering the `kura` namespace
-altogether. Set **No Data** and **Error** to **Alerting** on this one.
+altogether.
+
+**Watch the polarity, which is the reverse of a threshold rule.**
+`absent_over_time` returns `1` when the series has been absent for the whole
+window and returns *nothing* when it is present, so the healthy state here is
+an empty result. **No Data** must therefore be **Normal**, not Alerting;
+setting it to Alerting makes the rule fire continuously while the fleet is
+healthy. Only **Error** goes to **Alerting**, because a failed evaluation does
+mean the safety net is not working. This corrects the general advice in step 8
+of **Create the rules in Grafana** for `absent_over_time` rules specifically.
 
 ### Runner host PN VLAN missing
 
@@ -1156,6 +1175,8 @@ sum by (cluster, pod) (
 
 - Pending period: 5 minutes
 - Severity: warning
+- Already created: rule `cfvvcmpw0wqv4f`, folder `Alerts`, group `Cache`,
+  receiver `Slack #notifications 2`
 - Summary: `Kura cache pod {{ $labels.pod }} failed {{ $value }} scrapes in the
   last 6 hours in {{ $labels.cluster }}`
 
@@ -1193,6 +1214,8 @@ max by (cluster, pod) (
 
 - Pending period: 10 minutes
 - Severity: warning
+- Already created: rule `dfvvcp2lfgb9cd`, folder `Alerts`, group `Cache`,
+  receiver `Slack #notifications 2`
 - Summary: `Kura metadata store write buffer is {{ $value | humanizePercentage }}
   full on {{ $labels.pod }} in {{ $labels.cluster }}`
 
@@ -1230,7 +1253,12 @@ gauge is unproven as a leading indicator, and 0.95 was chosen to sit between the
 measured normal peak and the one measured excursion rather than from any
 property of RocksDB.
 
-Use **Keep Last State** on **Error** here, as for the other capacity warnings.
+The deployed rule sets **Error** to **OK**: the provisioning API accepts only
+`OK`, `Alerting` and `Error` for that field, so the **Keep Last State** the
+capacity warnings use is reachable from the UI but not from a provisioned
+create. `OK` keeps a data-source error from fanning out a warning, which is the
+same intent.
+
 This gauge only exists while the pod is scrapeable, which is precisely the
 window this rule is for: once the stall is underway the series stops arriving
 and the restart rule takes over.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -512,6 +512,96 @@ separate them because every host, healthy or not, has quiet stretches. Scope thi
 to the runner fleet: `macos-fleet` and `builders-fleet` hosts sit at a couple of
 hundred B/s legitimately, since they run no cache-using VMs.
 
+### Kura cache pod unresponsive
+
+```promql
+avg by (cluster, pod) (
+  avg_over_time(up{job="kura"}[30m])
+) < 0.9
+```
+
+- Pending period: 5 minutes
+- Severity: critical
+- Label: `affected_service` set to the cache component (customer-visible: a
+  node that stops answering fails every cache request routed to it, and the
+  client sees a hang rather than an error)
+- Summary: `Kura cache pod {{ $labels.pod }} is failing scrapes in
+  {{ $labels.cluster }}`
+
+Kura serves `/metrics`, `/up` and `/ready` from the same axum server on the
+same port, so an Alloy scrape timeout and a kubelet probe timeout are the same
+event observed by two collectors. That makes `up` the only signal that sees the
+stall *itself*, independently of whether the kubelet decides to act on it.
+
+The distinction matters because most stalls do not become restarts. On
+2026-08-21 a single production pod accumulated 55 readiness timeouts and 30
+liveness timeouts over 23 hours, of which only 10 crossed the
+three-consecutive-failure liveness threshold. The other stalls dropped
+in-flight requests and left no trace outside these scrape gaps.
+
+**Why a scrape-success ratio and not `up == 0`.** A stall lasts roughly 60
+seconds, which is what three liveness failures at `periodSeconds: 20` costs. A
+rule shaped like the control-plane ones (`min_over_time(up[2m]) == 0`) needs the
+target down continuously for longer than any rollout, so it would never fire on
+this fault. Ten percent of failed scrapes over 30 minutes is about three misses
+at the default interval, the same evidence the kubelet acts on, and one rolling
+restart does not reach it.
+
+Do not scope this to one account. Every tenant runs the same binary on the same
+node pools, and a customer's cache stalling is the more serious version of the
+same fault.
+
+### Kura cache pod restart loop
+
+```promql
+sum by (cluster, pod) (
+  increase(kube_pod_container_status_restarts_total{
+    namespace="kura",
+    container="kura"
+  }[1h])
+) >= 2
+```
+
+- Pending period: 5 minutes
+- Severity: critical
+- Label: `affected_service` set to the cache component
+- Summary: `Kura cache pod {{ $labels.pod }} restarted
+  {{ $value }} times in the last hour in {{ $labels.cluster }}`
+
+Counts in-place container restarts, so a rollout cannot trigger it: a
+replacement pod starts its counter at zero. Every restart observed on this
+fault reports `Error` with exit code 137 and never `OOMKilled`, because the
+container is killed by the kubelet after `Container kura failed liveness
+probe`, not by the cgroup out-of-memory killer. A rule keyed on `OOMKilled`
+would not have seen any of it.
+
+A restart is not a cheap recovery here. The node loses its place in the mesh,
+its peers log `membership changed: lost peers`, and when it returns every peer
+runs a catch-up backfill pass against it: passes applying 27,716 artifacts and
+545 MB were logged in the minutes after one restart. That write burst is itself
+a trigger for the next stall, so restarts cluster.
+
+For the chronic form, add the same expression over `[24h]` with a `>= 3`
+threshold at severity warning. Healthy tenants sit at exactly zero restarts for
+weeks, so a day with three is already an outlier; in the week to 2026-08-21 the
+three pods of the account carrying the heaviest remote-execution traffic
+recorded 34, 7 and 7 while every other pod recorded none.
+
+### Kura cache telemetry missing
+
+```promql
+absent_over_time(up{job="kura"}[15m])
+```
+
+- Pending period: 0 minutes
+- Severity: critical
+- Summary: `Kura cache scrape targets have disappeared in {{ $labels.cluster }}`
+
+The paired telemetry rule for **Kura cache pod unresponsive**. That rule is a
+threshold rule with **No Data: Normal**, so it cannot distinguish a healthy
+fleet from a scrape configuration that stopped discovering the `kura` namespace
+altogether. Set **No Data** and **Error** to **Alerting** on this one.
+
 ### Runner host PN VLAN missing
 
 ```promql
@@ -1085,6 +1175,52 @@ after a non-throttling failure, so the cursor has already rotated beyond
 them and they wait a full catalog rotation for another look. A steady
 rate here is upstream repositories going away or a scope problem on the
 mirror's credential, not a quota problem.
+
+### Kura metadata store write buffer saturated
+
+```promql
+max by (cluster, pod) (
+  kura_rocksdb_write_buffer_usage_bytes
+  /
+  kura_rocksdb_write_buffer_capacity_bytes
+) > 0.9
+```
+
+- Pending period: 10 minutes
+- Severity: warning
+- Summary: `Kura metadata store write buffer is {{ $value | humanizePercentage }}
+  full on {{ $labels.pod }} in {{ $labels.cluster }}`
+
+The mechanism behind **Kura cache pod unresponsive** and **Kura cache pod
+restart loop**, and the only one of the three visible *before* the pod stops
+answering.
+
+Kura builds its metadata store with a RocksDB `WriteBufferManager` whose stall
+flag is enabled (`kura/src/store.rs`). Once memtable memory reaches the pool
+size, RocksDB blocks every thread inside its write call until a flush drains
+it. Those write calls run directly on tokio worker threads rather than on the
+blocking pool, so a saturated write buffer parks the runtime itself: the probe
+handlers stop being scheduled even though `/up` reads nothing but process-local
+config and takes no lock. Managed instances pin the pool with
+`KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES`, set in
+`kura/ops/helm/kura/values-managed.yaml` and in the kura-controller, to a value
+below what the process would otherwise derive from its memory limit, and the
+same allocation is shared with the block cache, so memtable growth evicts the
+read cache that the eviction scan depends on.
+
+The largest batch the store writes is CAS segment eviction, which deletes every
+artifact in a 512 MiB segment plus every action-cache entry cascading off those
+blobs in a single batch, and scans that whole segment index synchronously to
+build it. Four restarts across three pods and two node pools on 2026-08-21 each
+followed an eviction by 49 to 63 seconds, which is what three liveness failures
+at `periodSeconds: 20` costs. The cascade size does not predict it: evictions
+cascading 47 and 305 entries stalled the pod exactly as ones cascading 4,555 and
+7,360 did, so treat the eviction itself as the trigger rather than its fanout.
+
+Use **Keep Last State** on **Error** here, as for the other capacity warnings.
+This is a gauge that only exists while the pod is scrapeable, which is
+precisely the window this rule is for: once the stall is underway the series
+stops arriving and the two critical rules above take over.
 
 ### Worker node pool stuck mid-rollout
 

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -568,7 +568,11 @@ a trigger for the next stall, so restarts cluster.
 ### Kura cache telemetry missing
 
 ```promql
-absent_over_time(up{job="kura"}[15m])
+absent_over_time(up{cluster="tuist-production", job="kura"}[15m])
+or
+absent_over_time(up{cluster="tuist-staging", job="kura"}[15m])
+or
+absent_over_time(up{cluster="tuist-canary", job="kura"}[15m])
 ```
 
 - Pending period: 0 minutes
@@ -582,14 +586,32 @@ threshold rules with **No Data: Normal**, so they cannot distinguish a healthy
 fleet from a scrape configuration that stopped discovering the `kura` namespace
 altogether.
 
+**Enumerate the clusters; do not write the bare selector.** `absent_over_time`
+is absent-or-nothing across everything the selector matches, so
+`absent_over_time(up{job="kura"}[15m])` stays empty while *any* cluster still
+has one Kura target. It cannot see a single cluster's targets disappear, which
+is the case worth alerting on, and on the one occasion it did fire the result
+would carry no `cluster` label for the summary to interpolate. Only equality
+matchers survive into the output, so naming each cluster is also what puts
+`cluster` on the alert. Same shape as **Kubernetes control-plane scrape
+telemetry missing**.
+
+Kura runs in `tuist-production`, `tuist-staging` and `tuist-canary`, and
+deliberately not in `tuist-management`. Add a disjunct when a new cluster
+starts hosting Kura: a cluster that is absent from this list is not covered,
+and nothing will point that out.
+
 **Watch the polarity, which is the reverse of a threshold rule.**
 `absent_over_time` returns `1` when the series has been absent for the whole
 window and returns *nothing* when it is present, so the healthy state here is
 an empty result. **No Data** must therefore be **Normal**, not Alerting;
 setting it to Alerting makes the rule fire continuously while the fleet is
 healthy. Only **Error** goes to **Alerting**, because a failed evaluation does
-mean the safety net is not working. This corrects the general advice in step 8
-of **Create the rules in Grafana** for `absent_over_time` rules specifically.
+mean the safety net is not working. This corrects steps 8 and the Assistant
+prompt below, which said to make **No Data** Alerting for telemetry-missing
+rules; that reads as correct but inverts the semantics of every
+`absent_over_time` rule in this document, so check the deployed configuration
+of the older ones too.
 
 ### Runner host PN VLAN missing
 
@@ -2038,16 +2060,23 @@ min by (cluster, namespace, repo, database) (
 7. Use the explicit telemetry-missing rules in this document to detect absent
    series. They use `absent_over_time` and fire even though threshold rules use
    **No Data: Normal**.
-8. Set **Error** to **Alerting** for the critical availability and
+8. Set **No Data** to **Normal** on the telemetry-missing rules as well.
+   `absent_over_time` returns a series only when the metric is *gone*, so an
+   empty result is the healthy state exactly as it is for a threshold rule.
+   Setting **No Data** to **Alerting** on one of these inverts it and the rule
+   fires continuously while everything is healthy.
+9. Set **Error** to **Alerting** for the critical availability and
    telemetry-missing rules. Use **Keep Last State** for capacity and latency
    warnings so a data-source evaluation error does not fan out into unrelated
-   warnings.
-9. Add the suggested summary, a `severity` label, and the notification contact
+   warnings. Note that **Keep Last State** is reachable from the UI but not
+   from the provisioning API, which accepts only `OK`, `Alerting` and `Error`;
+   use `OK` there for the same intent.
+10. Add the suggested summary, a `severity` label, and the notification contact
    point used by the infrastructure team. Add `affected_service` to
    customer-visible rules as described in **Routing to Grafana IRM** above.
-10. Preview the raw metric selector and the final comparison separately against
+11. Preview the raw metric selector and the final comparison separately against
     recent data before saving it.
-11. For a rule whose healthy state is an empty result *and* whose unhealthy
+12. For a rule whose healthy state is an empty result *and* whose unhealthy
     state depends on the series existing (`Remote processing queue has no
     consumer`, `xcresult processor guest metrics unavailable fleet-wide`),
     confirm the paired telemetry-missing rule exists before relying on it.
@@ -2063,10 +2092,12 @@ infra/helm/k8s-monitoring/alerts.md. Use the Grafana Cloud metrics data source,
 preserve every query and pending period exactly, put the rules in a folder
 named Tuist infrastructure, add the suggested summary as the annotation, and
 route critical and warning severities through our existing infrastructure
-notification policy. Configure No Data and Error as Alerting for every
-explicit telemetry-missing rule. Configure No Data as Normal for every
-threshold rule. Configure Error as Alerting for critical availability and
-telemetry-missing rules, and Keep Last State for warning rules. Group
+notification policy. Configure No Data as Normal for EVERY rule, including the
+telemetry-missing ones: those use absent_over_time, which returns a series only
+when the metric is gone, so an empty result is the healthy state and No Data as
+Alerting would make them fire continuously while healthy. Configure Error as
+Alerting for critical availability and telemetry-missing rules, and Keep Last
+State for warning rules. Group
 notifications by cluster and alert name. Preview each raw metric selector and
 final comparison against the last seven days, report any selector with no
 matching series, and show me the resulting rules before saving.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -512,45 +512,6 @@ separate them because every host, healthy or not, has quiet stretches. Scope thi
 to the runner fleet: `macos-fleet` and `builders-fleet` hosts sit at a couple of
 hundred B/s legitimately, since they run no cache-using VMs.
 
-### Kura cache pod unresponsive
-
-```promql
-avg by (cluster, pod) (
-  avg_over_time(up{job="kura"}[30m])
-) < 0.9
-```
-
-- Pending period: 5 minutes
-- Severity: critical
-- Label: `affected_service` set to the cache component (customer-visible: a
-  node that stops answering fails every cache request routed to it, and the
-  client sees a hang rather than an error)
-- Summary: `Kura cache pod {{ $labels.pod }} is failing scrapes in
-  {{ $labels.cluster }}`
-
-Kura serves `/metrics`, `/up` and `/ready` from the same axum server on the
-same port, so an Alloy scrape timeout and a kubelet probe timeout are the same
-event observed by two collectors. That makes `up` the only signal that sees the
-stall *itself*, independently of whether the kubelet decides to act on it.
-
-The distinction matters because most stalls do not become restarts. On
-2026-08-21 a single production pod accumulated 55 readiness timeouts and 30
-liveness timeouts over 23 hours, of which only 10 crossed the
-three-consecutive-failure liveness threshold. The other stalls dropped
-in-flight requests and left no trace outside these scrape gaps.
-
-**Why a scrape-success ratio and not `up == 0`.** A stall lasts roughly 60
-seconds, which is what three liveness failures at `periodSeconds: 20` costs. A
-rule shaped like the control-plane ones (`min_over_time(up[2m]) == 0`) needs the
-target down continuously for longer than any rollout, so it would never fire on
-this fault. Ten percent of failed scrapes over 30 minutes is about three misses
-at the default interval, the same evidence the kubelet acts on, and one rolling
-restart does not reach it.
-
-Do not scope this to one account. Every tenant runs the same binary on the same
-node pools, and a customer's cache stalling is the more serious version of the
-same fault.
-
 ### Kura cache pod restart loop
 
 ```promql
@@ -558,15 +519,23 @@ sum by (cluster, pod) (
   increase(kube_pod_container_status_restarts_total{
     namespace="kura",
     container="kura"
-  }[1h])
+  }[6h])
 ) >= 2
 ```
 
-- Pending period: 5 minutes
+- Pending period: 10 minutes
 - Severity: critical
-- Label: `affected_service` set to the cache component
+- Label: `affected_service` set to the cache component (customer-visible: a
+  restarting node drops every cache request in flight, and the client sees a
+  hang or a failed build rather than a clean error)
 - Summary: `Kura cache pod {{ $labels.pod }} restarted
-  {{ $value }} times in the last hour in {{ $labels.cluster }}`
+  {{ $value }} times in the last 6 hours in {{ $labels.cluster }}`
+
+**This is the primary rule for the fault.** Backtested over the 7 days to
+2026-08-21 across all 30 production Kura pods, sampled every 10 minutes: it
+held true at 304, 45 and 35 sample points for the three pods of the account
+carrying the heaviest remote-execution traffic, and was never true for any
+other pod. Perfect specificity, no tuning required.
 
 Counts in-place container restarts, so a rollout cannot trigger it: a
 replacement pod starts its counter at zero. Every restart observed on this
@@ -575,17 +544,18 @@ container is killed by the kubelet after `Container kura failed liveness
 probe`, not by the cgroup out-of-memory killer. A rule keyed on `OOMKilled`
 would not have seen any of it.
 
+**Use the 6-hour window, not 1 hour.** The same expression over `[1h]` is
+equally specific but much less sensitive: on the same backtest it held at only
+1 and 3 sample points for two of the three affected pods, which a 10-minute
+pending period may not survive. Restarts on this fault arrive in clusters
+separated by hours, so the shorter window keeps falling back below the
+threshold between clusters.
+
 A restart is not a cheap recovery here. The node loses its place in the mesh,
 its peers log `membership changed: lost peers`, and when it returns every peer
 runs a catch-up backfill pass against it: passes applying 27,716 artifacts and
 545 MB were logged in the minutes after one restart. That write burst is itself
 a trigger for the next stall, so restarts cluster.
-
-For the chronic form, add the same expression over `[24h]` with a `>= 3`
-threshold at severity warning. Healthy tenants sit at exactly zero restarts for
-weeks, so a day with three is already an outlier; in the week to 2026-08-21 the
-three pods of the account carrying the heaviest remote-execution traffic
-recorded 34, 7 and 7 while every other pod recorded none.
 
 ### Kura cache telemetry missing
 
@@ -597,8 +567,8 @@ absent_over_time(up{job="kura"}[15m])
 - Severity: critical
 - Summary: `Kura cache scrape targets have disappeared in {{ $labels.cluster }}`
 
-The paired telemetry rule for **Kura cache pod unresponsive**. That rule is a
-threshold rule with **No Data: Normal**, so it cannot distinguish a healthy
+The paired telemetry rule for the two Kura rules that read `up`. Those are
+threshold rules with **No Data: Normal**, so they cannot distinguish a healthy
 fleet from a scrape configuration that stopped discovering the `kura` namespace
 altogether. Set **No Data** and **Error** to **Alerting** on this one.
 
@@ -1176,6 +1146,41 @@ them and they wait a full catalog rotation for another look. A steady
 rate here is upstream repositories going away or a scope problem on the
 mirror's credential, not a quota problem.
 
+### Kura cache pod failing scrapes
+
+```promql
+sum by (cluster, pod) (
+  count_over_time((up{job="kura"} == 0)[6h:1m])
+) >= 2
+```
+
+- Pending period: 5 minutes
+- Severity: warning
+- Summary: `Kura cache pod {{ $labels.pod }} failed {{ $value }} scrapes in the
+  last 6 hours in {{ $labels.cluster }}`
+
+Kura serves `/metrics`, `/up` and `/ready` from the same axum server on the
+same port, so an Alloy scrape timeout and a kubelet probe timeout are two
+collectors observing the same event. That makes this the only rule that can see
+a stall the kubelet does *not* act on, which matters because most stalls never
+become restarts: one pod logged 55 readiness and 30 liveness timeouts over 23
+hours, of which only 10 crossed the three-consecutive-failure liveness
+threshold.
+
+**Its coverage is partial, and it is a warning for that reason.** Measured over
+the 24 hours to 2026-08-21, three pods restarted 15 times between them but the
+whole production fleet produced only 15 failed scrapes, 13 of them on one pod;
+a pod that restarted three times produced **zero**. A stall costs roughly one
+scrape at the default interval, and the container often comes back before the
+next one lands. Treat this rule as supplementary detail on top of **Kura cache
+pod restart loop**, never as the detector.
+
+Do not reach for a ratio here. An earlier version used
+`avg_over_time(up[30m]) < 0.9`, which the same measurement rules out: a single
+stall plus restart costs about 2 of 30 scrapes in the window, or 0.93, so it
+sits above any threshold loose enough to survive a rolling update. Counting
+absolute failures is what makes a one-scrape event visible.
+
 ### Kura metadata store write buffer saturated
 
 ```promql
@@ -1183,7 +1188,7 @@ max by (cluster, pod) (
   kura_rocksdb_write_buffer_usage_bytes
   /
   kura_rocksdb_write_buffer_capacity_bytes
-) > 0.9
+) > 0.95
 ```
 
 - Pending period: 10 minutes
@@ -1191,9 +1196,8 @@ max by (cluster, pod) (
 - Summary: `Kura metadata store write buffer is {{ $value | humanizePercentage }}
   full on {{ $labels.pod }} in {{ $labels.cluster }}`
 
-The mechanism behind **Kura cache pod unresponsive** and **Kura cache pod
-restart loop**, and the only one of the three visible *before* the pod stops
-answering.
+The mechanism behind the two rules above, and the only one of the three visible
+*before* the pod stops answering.
 
 Kura builds its metadata store with a RocksDB `WriteBufferManager` whose stall
 flag is enabled (`kura/src/store.rs`). Once memtable memory reaches the pool
@@ -1217,10 +1221,19 @@ at `periodSeconds: 20` costs. The cascade size does not predict it: evictions
 cascading 47 and 305 entries stalled the pod exactly as ones cascading 4,555 and
 7,360 did, so treat the eviction itself as the trigger rather than its fanout.
 
+**The threshold is 0.95 because busy is not the same as stalled.** Over the 24
+hours to 2026-08-21 the idle fleet baseline was 0.063, five healthy pods across
+three regions peaked at 0.844 under ordinary load, and exactly one pod exceeded
+the pool size at 1.125. A threshold at 0.9, and certainly one at 0.8, would
+page on the normal peak. Confirm this distribution before tightening it: the
+gauge is unproven as a leading indicator, and 0.95 was chosen to sit between the
+measured normal peak and the one measured excursion rather than from any
+property of RocksDB.
+
 Use **Keep Last State** on **Error** here, as for the other capacity warnings.
-This is a gauge that only exists while the pod is scrapeable, which is
-precisely the window this rule is for: once the stall is underway the series
-stops arriving and the two critical rules above take over.
+This gauge only exists while the pod is scrapeable, which is precisely the
+window this rule is for: once the stall is underway the series stops arriving
+and the restart rule takes over.
 
 ### Worker node pool stuck mid-rollout
 

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -176,9 +176,21 @@ pub const BACKFILL_INDEX_BUILD_CHUNK_ROWS: usize = 4_096;
 // entirely synchronous RocksDB work (a manifest read per artifact, plus a
 // reverse-row prefix scan and an inline-bytes read per cascaded action-cache
 // entry), so without a yield one eviction parks a runtime worker for its whole
-// duration and the process stops answering probes it could otherwise serve
-// from process-local state. Smaller than the snapshot gate's stride because
-// each row here costs several reads rather than one cache hit.
+// duration. Smaller than the snapshot gate's stride because each row here costs
+// several reads rather than one cache hit.
+//
+// Note the different shape from `BACKFILL_INDEX_BUILD_CHUNK_ROWS` above, which
+// answers an overlapping problem the other way. That build chunks and reopens
+// so no iterator outlives a chunk; an eviction yields inside one long-lived
+// `iterator_cf` instead, which pins its implicit snapshot across every yield
+// and so holds it marginally longer than before. That is deliberate, for two
+// reasons. The cascade has to stage every delete into one atomic batch or an
+// entry is left pointing at a blob that is already gone, so resuming from a key
+// cursor is not available here. And the exposure is bounded by one segment's
+// artifact index, tens of thousands of rows, rather than the millions the
+// backfill build walks, so pinning a snapshot for it does not reach the
+// compaction-blocking scale that shaped the constant above. Revisit if segments
+// ever grow far past `MAX_SEGMENT_BYTES` worth of small artifacts.
 pub const SEGMENT_EVICTION_YIELD_ROWS: usize = 256;
 // Byte ceiling of one backfill bodies batch: the sum of body bytes one
 // `POST /_internal/backfill/bodies` response may carry, and the per-entry

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -172,6 +172,14 @@ pub const BACKFILL_SEQ_STAMP_SLACK_SEQS: u64 = 8_000_000;
 // on multi-million-entry nodes), blocking compaction of everything written
 // since it opened.
 pub const BACKFILL_INDEX_BUILD_CHUNK_ROWS: usize = 4_096;
+// How many segment-index rows a CAS eviction scans between yields. The scan is
+// entirely synchronous RocksDB work (a manifest read per artifact, plus a
+// reverse-row prefix scan and an inline-bytes read per cascaded action-cache
+// entry), so without a yield one eviction parks a runtime worker for its whole
+// duration and the process stops answering probes it could otherwise serve
+// from process-local state. Smaller than the snapshot gate's stride because
+// each row here costs several reads rather than one cache hit.
+pub const SEGMENT_EVICTION_YIELD_ROWS: usize = 256;
 // Byte ceiling of one backfill bodies batch: the sum of body bytes one
 // `POST /_internal/backfill/bodies` response may carry, and the per-entry
 // oversized cutoff (entries larger than this route to the per-artifact

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -172,11 +172,15 @@ pub const BACKFILL_SEQ_STAMP_SLACK_SEQS: u64 = 8_000_000;
 // on multi-million-entry nodes), blocking compaction of everything written
 // since it opened.
 pub const BACKFILL_INDEX_BUILD_CHUNK_ROWS: usize = 4_096;
-// How many segment-index rows a CAS eviction scans between yields. The scan is
-// entirely synchronous RocksDB work (a manifest read per artifact, plus a
-// reverse-row prefix scan and an inline-bytes read per cascaded action-cache
-// entry), so without a yield one eviction parks a runtime worker for its whole
-// duration. Smaller than the snapshot gate's stride because each row here costs
+// How many rows a CAS eviction scans between yields, counting BOTH the
+// segment-index rows and the blob-ref rows of every cascade the scan starts
+// against one shared budget. Per-scan budgets were the first attempt and do not
+// bound anything: the cascade counter restarts on each blob, so 255 artifacts
+// each cascading 200 reverse rows walks ~51,000 rows without either scan
+// reaching the stride. The scan is entirely synchronous RocksDB work (a manifest
+// read per artifact, plus a reverse-row prefix scan and an inline-bytes read and
+// decode per cascaded action-cache entry), so without a yield one eviction parks
+// a runtime worker for its whole duration. Smaller than the snapshot gate's stride because each row here costs
 // several reads rather than one cache hit.
 //
 // Note the different shape from `BACKFILL_INDEX_BUILD_CHUNK_ROWS` above, which

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -42,7 +42,7 @@ use crate::{
         ROCKSDB_CF_SEGMENT_STATE, ROCKSDB_CF_USAGE_OUTBOX, ROCKSDB_HARD_PENDING_COMPACTION_BYTES,
         ROCKSDB_LEVEL0_SLOWDOWN_TRIGGER, ROCKSDB_LEVEL0_STOP_TRIGGER,
         ROCKSDB_SOFT_PENDING_COMPACTION_BYTES, ROCKSDB_WAL_BYTES_PER_SYNC,
-        SEGMENT_FREE_SPACE_MARGIN,
+        SEGMENT_EVICTION_YIELD_ROWS, SEGMENT_FREE_SPACE_MARGIN,
     },
     failpoints::{FailpointName, FailpointSet},
     file_cache::{
@@ -2914,11 +2914,16 @@ impl Store {
             IteratorMode::From(prefix.as_bytes(), rocksdb::Direction::Forward),
         );
 
-        for item in iter {
+        for (scanned, item) in iter.enumerate() {
             let (index_key, _) =
                 item.map_err(|error| format!("failed to iterate segment index: {error}"))?;
             if !index_key.starts_with(prefix.as_bytes()) {
                 break;
+            }
+            // Everything below is synchronous RocksDB work, so without this the
+            // whole segment's scan runs in one poll and parks a runtime worker.
+            if scanned % SEGMENT_EVICTION_YIELD_ROWS == SEGMENT_EVICTION_YIELD_ROWS - 1 {
+                tokio::task::yield_now().await;
             }
             saw_entries = true;
             let artifact_id = std::str::from_utf8(&index_key[prefix.len()..])
@@ -2945,7 +2950,8 @@ impl Store {
                             &artifact_id,
                             &mut cascaded_entries,
                             &mut cascaded_namespaces,
-                        )?;
+                        )
+                        .await?;
                     }
                     *removed_artifacts.entry(manifest.producer).or_default() += 1;
                     removed_artifact_ids.push(artifact_id);
@@ -3019,7 +3025,7 @@ impl Store {
     /// orphaned reverse row is reclaimed when its blob is later evicted. This is
     /// the same read-then-delete-without-writer-lock race that
     /// `expire_stale_action_cache_entries` already accepts.
-    fn stage_action_cache_cascade_for_blob(
+    async fn stage_action_cache_cascade_for_blob(
         &self,
         batch: &mut WriteBatch,
         blob_artifact_id: &str,
@@ -3031,11 +3037,14 @@ impl Store {
             self.cf(ROCKSDB_CF_KEY_VALUE),
             IteratorMode::From(prefix.as_bytes(), rocksdb::Direction::Forward),
         );
-        for item in iter {
+        for (scanned, item) in iter.enumerate() {
             let (ref_key, _) =
                 item.map_err(|error| format!("failed to iterate blob refs: {error}"))?;
             if !ref_key.starts_with(prefix.as_bytes()) {
                 break;
+            }
+            if scanned % SEGMENT_EVICTION_YIELD_ROWS == SEGMENT_EVICTION_YIELD_ROWS - 1 {
+                tokio::task::yield_now().await;
             }
             let entry_id = std::str::from_utf8(&ref_key[prefix.len()..])
                 .map_err(|error| format!("invalid blob-ref key: {error}"))?
@@ -10683,6 +10692,91 @@ mod tests {
         );
         assert!(!segment_path.exists());
         assert_eq!(store.segment_handles.lock().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn evict_segment_yields_so_the_runtime_keeps_scheduling() {
+        // Production regression (2026-08-21): `evict_segment` scanned a whole
+        // 512 MiB segment's artifact index with no await anywhere in the loop,
+        // so one eviction parked a runtime worker for the entire scan and
+        // commit. On the production mesh every liveness-probe restart followed
+        // an eviction by 49 to 63 seconds, which is three failed `/up` probes
+        // at `periodSeconds: 20`. `up()` reads nothing but process-local config
+        // and takes no lock, so it can only have been starved of a scheduler
+        // slot. This runs on the single-threaded test runtime, where a task
+        // that never yields is the only way a concurrent task can starve.
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        let mut artifact_ids = Vec::new();
+        for index in 0..(SEGMENT_EVICTION_YIELD_ROWS + 64) {
+            let manifest = store
+                .persist_artifact_from_bytes(
+                    ArtifactProducer::Gradle,
+                    "android",
+                    &format!("artifact-{index}"),
+                    "application/octet-stream",
+                    b"hello",
+                )
+                .await
+                .expect("failed to persist artifact");
+            artifact_ids.push(manifest.artifact_id);
+        }
+        let segment_id = store
+            .manifest(&artifact_ids[0])
+            .expect("failed to load manifest")
+            .expect("artifact should exist")
+            .segment_id
+            .expect("artifact should be segment-backed");
+
+        let eviction_started = Arc::new(AtomicBool::new(false));
+        let observed_mid_scan = Arc::new(AtomicBool::new(false));
+        let probe = tokio::spawn({
+            let store = Arc::clone(&store);
+            let artifact_id = artifact_ids[0].clone();
+            let eviction_started = Arc::clone(&eviction_started);
+            let observed_mid_scan = Arc::clone(&observed_mid_scan);
+            async move {
+                loop {
+                    // The eviction commits every deletion in one batch at the
+                    // very end, so seeing the manifest still present after the
+                    // eviction started means this task was scheduled while the
+                    // scan was still running.
+                    if eviction_started.load(Ordering::SeqCst)
+                        && store
+                            .manifest(&artifact_id)
+                            .expect("failed to load manifest")
+                            .is_some()
+                    {
+                        observed_mid_scan.store(true, Ordering::SeqCst);
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+        // Let the probe reach its first yield so it is parked and runnable.
+        tokio::task::yield_now().await;
+
+        eviction_started.store(true, Ordering::SeqCst);
+        store
+            .evict_segment(&segment_id)
+            .await
+            .expect("failed to evict segment");
+        probe.abort();
+
+        assert!(
+            observed_mid_scan.load(Ordering::SeqCst),
+            "evict_segment ran its entire scan without yielding, so nothing \
+             else on the runtime could be scheduled between the eviction \
+             starting and its batch being committed"
+        );
+        assert!(
+            store
+                .manifest(&artifact_ids[0])
+                .expect("failed to load manifest")
+                .is_none(),
+            "the eviction must still remove every artifact in the segment"
+        );
     }
 
     // ---- Action-cache blob-refs reverse index + eviction cascade ----

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2914,7 +2914,8 @@ impl Store {
             IteratorMode::From(prefix.as_bytes(), rocksdb::Direction::Forward),
         );
 
-        for (scanned, item) in iter.enumerate() {
+        let mut scanned_rows = 0;
+        for item in iter {
             let (index_key, _) =
                 item.map_err(|error| format!("failed to iterate segment index: {error}"))?;
             if !index_key.starts_with(prefix.as_bytes()) {
@@ -2922,9 +2923,7 @@ impl Store {
             }
             // Everything below is synchronous RocksDB work, so without this the
             // whole segment's scan runs in one poll and parks a runtime worker.
-            if scanned % SEGMENT_EVICTION_YIELD_ROWS == SEGMENT_EVICTION_YIELD_ROWS - 1 {
-                tokio::task::yield_now().await;
-            }
+            yield_scanned_row(&mut scanned_rows).await;
             saw_entries = true;
             let artifact_id = std::str::from_utf8(&index_key[prefix.len()..])
                 .map_err(|error| format!("invalid segment index key: {error}"))?
@@ -2950,6 +2949,7 @@ impl Store {
                             &artifact_id,
                             &mut cascaded_entries,
                             &mut cascaded_namespaces,
+                            &mut scanned_rows,
                         )
                         .await?;
                     }
@@ -3031,21 +3031,20 @@ impl Store {
         blob_artifact_id: &str,
         cascaded_entries: &mut HashSet<String>,
         cascaded_namespaces: &mut HashSet<String>,
+        scanned_rows: &mut usize,
     ) -> Result<(), String> {
         let prefix = action_cache_blob_ref_prefix(blob_artifact_id);
         let iter = self.db.iterator_cf(
             self.cf(ROCKSDB_CF_KEY_VALUE),
             IteratorMode::From(prefix.as_bytes(), rocksdb::Direction::Forward),
         );
-        for (scanned, item) in iter.enumerate() {
+        for item in iter {
             let (ref_key, _) =
                 item.map_err(|error| format!("failed to iterate blob refs: {error}"))?;
             if !ref_key.starts_with(prefix.as_bytes()) {
                 break;
             }
-            if scanned % SEGMENT_EVICTION_YIELD_ROWS == SEGMENT_EVICTION_YIELD_ROWS - 1 {
-                tokio::task::yield_now().await;
-            }
+            yield_scanned_row(scanned_rows).await;
             let entry_id = std::str::from_utf8(&ref_key[prefix.len()..])
                 .map_err(|error| format!("invalid blob-ref key: {error}"))?
                 .to_owned();
@@ -6901,6 +6900,21 @@ pub fn is_disk_full_error(error: &str) -> bool {
 /// segment that is not yet unlinked, and tmp staging when it shares the
 /// filesystem — the staged source and the segment copy coexist during the
 /// append).
+/// Hands a CAS eviction's synchronous scan back to the scheduler every
+/// `SEGMENT_EVICTION_YIELD_ROWS` rows.
+///
+/// The counter is threaded through the segment scan and every nested cascade
+/// scan it starts, rather than kept per scan. A per-scan budget restarts at
+/// zero for each blob, so a segment holding many small blobs, each referenced
+/// by many action-cache entries, stays under the stride on both scans while
+/// running their product in a single poll.
+async fn yield_scanned_row(scanned_rows: &mut usize) {
+    *scanned_rows += 1;
+    if (*scanned_rows).is_multiple_of(SEGMENT_EVICTION_YIELD_ROWS) {
+        tokio::task::yield_now().await;
+    }
+}
+
 fn segment_rotation_required_bytes(incoming_size: u64) -> u64 {
     MAX_SEGMENT_BYTES
         .max(incoming_size)
@@ -10776,6 +10790,95 @@ mod tests {
                 .expect("failed to load manifest")
                 .is_none(),
             "the eviction must still remove every artifact in the segment"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_segment_shares_its_yield_budget_with_the_cascade_scan() {
+        // A per-scan budget is not enough: `scanned` restarting at zero for
+        // every blob means a segment of many small blobs, each referenced by
+        // many action-cache entries, never reaches the stride on either scan
+        // while running their product in one poll. The shape below is under
+        // the stride on both scans individually (8 segment rows, 40 reverse
+        // rows per blob) and well over it in total, so it only yields if the
+        // two scans share one budget.
+        const BLOBS: usize = 8;
+        const ENTRIES_PER_BLOB: u8 = 40;
+        const { assert!(BLOBS < SEGMENT_EVICTION_YIELD_ROWS) };
+        const { assert!((ENTRIES_PER_BLOB as usize) < SEGMENT_EVICTION_YIELD_ROWS) };
+        const { assert!(BLOBS * (ENTRIES_PER_BLOB as usize) > SEGMENT_EVICTION_YIELD_ROWS) };
+
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        let mut blob_ids = Vec::new();
+        for blob in 0..BLOBS {
+            // One namespace per blob so every entry can keep a low marker: the
+            // marker is a byte and the artifact id is namespaced, so this is
+            // what keeps 320 distinct entries addressable.
+            let namespace_id = format!("cascade-{blob}");
+            let digest = reapi_digest(blob as u8, 5);
+            let manifest = persist_reapi_blob(&store, &namespace_id, &digest, b"hello").await;
+            for marker in 0..ENTRIES_PER_BLOB {
+                persist_action_cache_entry(
+                    &store,
+                    &namespace_id,
+                    marker,
+                    &action_result_referencing(&[&digest]),
+                    1,
+                )
+                .await;
+            }
+            blob_ids.push(manifest.artifact_id);
+        }
+        let segment_id = store
+            .manifest(&blob_ids[0])
+            .expect("failed to load manifest")
+            .expect("blob should exist")
+            .segment_id
+            .expect("blob should be segment-backed");
+
+        let eviction_started = Arc::new(AtomicBool::new(false));
+        let observed_mid_scan = Arc::new(AtomicBool::new(false));
+        let probe = tokio::spawn({
+            let store = Arc::clone(&store);
+            let blob_id = blob_ids[0].clone();
+            let eviction_started = Arc::clone(&eviction_started);
+            let observed_mid_scan = Arc::clone(&observed_mid_scan);
+            async move {
+                loop {
+                    if eviction_started.load(Ordering::SeqCst)
+                        && store
+                            .manifest(&blob_id)
+                            .expect("failed to load manifest")
+                            .is_some()
+                    {
+                        observed_mid_scan.store(true, Ordering::SeqCst);
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+        tokio::task::yield_now().await;
+
+        eviction_started.store(true, Ordering::SeqCst);
+        store
+            .evict_segment(&segment_id)
+            .await
+            .expect("failed to evict segment");
+        probe.abort();
+
+        assert!(
+            observed_mid_scan.load(Ordering::SeqCst),
+            "the cascade scan restarted the yield budget per blob, so the \
+             eviction ran every reverse row of every blob in one poll"
+        );
+        assert!(
+            store
+                .manifest(&blob_ids[0])
+                .expect("failed to load manifest")
+                .is_none(),
+            "the eviction must still remove every blob in the segment"
         );
     }
 


### PR DESCRIPTION
## What changed

Two things, in five commits:

1. **A partial fix for the fault** (`kura/src/store.rs`): CAS segment eviction now yields to the runtime instead of monopolising a tokio worker for its whole scan. Written test-first.
2. **Alerting for it** (`infra/helm/k8s-monitoring/alerts.md`): four rules, **already created in Grafana**, backtested against production before being written.

**This does not on its own close out the restarts.** See *The other half* below; #12556 tracks it.

## The fault

Tuist's own production Kura pods are killed and restarted in place by the kubelet on liveness-probe timeouts several times a day. In the week to 2026-08-21, the three pods of the account carrying the heaviest remote-execution traffic recorded 34, 7 and 7 restarts while every other tenant's pod recorded none. Nothing paged. The first anyone noticed was a CI build failing when the cache vanished mid-run, fixed separately on the build side.

The signature is identical every time, including two instances caught live during the investigation:

| pod | eviction log | SIGUSR1 (the kill) | gap |
| --- | --- | --- | --- |
| eu-central-1-1 | 11:18:50 (7360 entries) | 11:19:53 | 63 s |
| scw-fr-par-0 | 16:36:09 (4555) | 16:37:05 | 56 s |
| eu-central-1-1 | 16:52:03 (**47**) | 16:52:53 | 49 s |
| eu-central-1-0 | 16:53:33 (**305**) | 16:54:26 | 52 s |

49 to 63 seconds is exactly three failed `/up` probes at `periodSeconds: 20`. Cascade size does not predict it, so the cost is the segment scan rather than its fanout.

## Root cause: two contributors, one fixed here

`up()` reads nothing but process-local config and takes no lock, which #12473 established, so a `/up` timeout can only be scheduler starvation. Confirmed from the other side: the action-cache snapshot timer, which ticks every 75 seconds, fired **28 seconds late** across one stall.

**What starves it takes two things, and this PR addresses one.**

**Contributor 1, fixed here.** `Store::evict_segment` was an `async fn` whose body had no await anywhere in its scan. One call iterated a whole 512 MiB segment's artifact index, read a manifest per artifact, and for every REAPI blob ran a reverse-row prefix scan plus a manifest read, an inline-bytes read and a protobuf decode per cascaded action-cache entry, then committed all of it in one batch. All of that ran in a single poll, monopolising one worker.

**Contributor 2, not fixed here, and the one that scales it to the whole process.** `resolve_worker_threads()` clamps `available_parallelism()` to `2..16`; the hosting nodes have 32 CPUs and the pods carry no CPU limit, only a 0.5 request, so there is no CFS quota to shrink it. Production runs **16 workers**, and one parked worker out of 16 does not stop a process answering `/up` for 50 to 60 seconds.

What does is the write-buffer stall. `store.rs` builds `WriteBufferManager::new_write_buffer_manager_with_cache(bytes, true, block_cache)` — `allow_stall = true`, on a 32 MiB pool shared with the block cache. On saturation RocksDB blocks *every* thread inside `db.write` in FFI, and those calls run directly on tokio worker threads, so all 16 park together.

Two pieces of evidence, both from @esnunes, make this concrete rather than inferred:

- On `kura-tuist-eu-central-1-0` a scrape recorded `up = 0` at **16:25:00** while its `Killing` event is at **16:25:26**. The failed scrape sits *inside the stall, before the restart*, so `/metrics` was failing while the process was still running. The whole listener was down, not one route. One parked worker does not explain that; sixteen blocked does.
- Over the 24 h to 2026-08-21T18:00Z the write-buffer ratio peaked at **1.126** on `kura-tuist-scw-fr-par-0` and `kura-tuist-eu-central-1-0` — the same two pods that produced those `up = 0` scrapes — against a 0.844 healthy peak elsewhere.

The eviction feeds the stall it then waits inside: its 20k–30k-delete `WriteBatch` is one large charge against that same 32 MiB pool. Leaving the batch unchunked is correct, because the cascade must stay atomic, but it does mean **yielding during the scan does not reduce the charge**.

## The fix

Yields every `SEGMENT_EVICTION_YIELD_ROWS` rows in both the segment-index scan and the per-blob cascade scan, sharing one counter across the two, matching the idiom `collect_dead_snapshot_entries` already uses. A per-scan budget resets on each blob, so 255 blobs × 255 reverse rows would run 65,025 reads in one poll while neither scan reaches the stride.

**It deliberately does not chunk the `WriteBatch`.** The cascade must land in the same atomic batch as the blob deletion or an entry is left pointing at a blob that no longer exists, which is the invariant #12152 added it for.

`SEGMENT_EVICTION_YIELD_ROWS` carries a comment on why it yields in place rather than chunking and reopening like its neighbour `BACKFILL_INDEX_BUILD_CHUNK_ROWS`: the atomic batch rules out cursor-resume, and one segment's index is not the multi-million-row walk that made snapshot pinning matter there.

Rollout-safe under a half-rolled fleet: it changes only *when* the task is polled, never what is written.

## TDD, and what the test does and does not prove

Two tests, each red on the commit before its fix:

- `evict_segment_yields_so_the_runtime_keeps_scheduling` — the outer scan. Red: *"evict_segment ran its entire scan without yielding"*.
- `evict_segment_shares_its_yield_budget_with_the_cascade_scan` — the shared budget, built to the shape that defeats a per-scan one (8 segment rows, 40 reverse rows per blob: under the stride on both scans, over it in total). Red: *"the cascade scan restarted the yield budget per blob"*. The earlier test used Gradle artifacts, which have no action-cache entries and never entered the cascade at all.

Both run on the single-threaded runtime, which is the only place one non-yielding task can starve everything. **They prove the change does what it claims; they are not a reproduction of the production failure**, which needs all 16 workers blocked in `db.write` and is not reachable in a unit test.

712 tests pass. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean. Note that CI itself has not run: every job in `.github/workflows/kura.yml` is gated on `draft == false`.

## Alerting

Created in Grafana in folder `Alerts`, group `Cache`, alongside the existing Kura rules:

| Rule | uid | Severity | State |
| --- | --- | --- | --- |
| Kura - cache pod restart loop | `efvvcl6qu3tvkc` | critical | **firing** |
| Kura - cache telemetry missing | `ffvvcpp359qm8d` | critical | normal |
| Kura - cache pod failing scrapes | `cfvvcmpw0wqv4f` | warning | **firing** |
| Kura - metadata store write buffer saturated | `dfvvcp2lfgb9cd` | warning | normal |

**Why nothing paged before.** Two generic restart rules already existed and neither could fire: `Pod restarts (possible overload)` is scoped `namespace="tuist"` and never covered `namespace="kura"`, and both it and `Pod CrashLoop / Frequent Restarts` use thresholds (>2 in 15m, >5 in 1h) far above this fault's rate.

**Backtesting changed the design.** Two originally-written expressions were close to useless:

- **`up` is a weak detector here.** Over 24 hours, three pods restarted 15 times between them while the whole production fleet produced only 15 failed scrapes, 13 on one pod, and the pod that restarted three times produced zero. The original `avg_over_time(up[30m]) < 0.9` never leaves 0.93 on a single stall. Demoted to a supplementary warning counting absolute failures. (Its rare hits are still valuable as *mechanism* evidence, as the 16:25:00 scrape above shows.)
- **The restart counter is what works.** `increase(...[6h]) >= 2`, sampled every 10 minutes over 7 days across all 30 production pods, held true at 304/45/35 sample points for the three affected pods and **never for the other 27**.
- **Write-buffer threshold 0.9 → 0.95**, to sit between the measured 0.844 healthy peak and the 1.126 excursion.

Also corrected: the telemetry rule now enumerates each Kura-hosting cluster. `absent_over_time` is absent-or-nothing across its whole selector, so the bare form stayed empty while any cluster had a target and carried no `cluster` label for its own summary. And the document's step 8 and Assistant prompt said to set **No Data: Alerting** for telemetry-missing rules, which inverts `absent_over_time` and would make them fire continuously while healthy — fixed, and flagged that the older rules in that file may be misconfigured the same way.

## The other half, still open

**Do not read a merge here as closure.** This removes one contributor. The 32 MiB write-buffer pool, shared with the block cache and stalling with `allow_stall = true`, is untouched, and yielding cannot break up a stall inside a single `db.write`. The restarts may well persist.

*Kura - metadata store write buffer saturated* is the instrument that decides: if the restart-loop alert keeps firing after this lands and that warning fires alongside, the pool is why.

Pool sizing is a fleet-wide memory decision (up to ~96 MiB more per pod across ~30 pods, on nodes where one already sits at 152% memory-limit commit), so it gets its own change: **#12556**.

## How to test locally

```bash
cd kura && mise exec -- cargo test --lib store::tests::evict_segment
```

Revert either `yield_scanned_row` call site to see the matching test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
