### PR TITLE
Fix XcodeGraphMapper trap on duplicate local package

### DIFF
--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -235,7 +235,8 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
         projects.compactMapValues { project in
             guard !project.packages.isEmpty else { return nil }
             return Dictionary(
-                uniqueKeysWithValues: project.packages.map { ($0.url, $0) }
+                project.packages.map { ($0.url, $0) },
+                uniquingKeysWith: { first, _ in first }
             )
         }
     }


### PR DESCRIPTION
Fixes #12546

### Problem

`XcodeGraphMapper.map(at:)` trapped with:

```
Fatal error: Duplicate values for key: '/path/to/App/Packages/MyPackage'
  _NativeDictionary.merge → Dictionary.init(uniqueKeysWithValues:)
  at XcodeGraphMapper.swift:237 in extractPackages(from:)
```

Local packages are collected from two independent places in `PBXProjectMapper` (local packages + folder references). When a project contains a local Swift package that is also present as a folder reference in the navigator, the same package appears twice and `Dictionary(uniqueKeysWithValues:)` aborts the process. The consumer cannot recover from a trap.

### Change

Deduplicate by keeping the first occurrence:

```swift
Dictionary(
    project.packages.map { ($0.url, $0) },
    uniquingKeysWith: { first, _ in first }
)
```

instead of `uniqueKeysWithValues:`.

### Validation

- `git diff --check` clean
- Change is isolated to `extractPackages(from:)`; existing `XcodeGraphMapperTests` expected to be unaffected (deduplication preserves first-seen package, matching the previous non-duplicate behavior)
