### PR TITLE
feat(server): enable the egress-tree-agent on canary and production kura pools

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -242,6 +242,16 @@ kuraController:
       enabled: true
       item: kura-sentry
 
+# Only the shared mesh cache pools are listed. The runner-cache pool
+# (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
+# and its traffic is node-local runner reads that must not be shaped.
+# betaPodPrefix keeps the first enforcement step on kura-tuist-* pods.
+egressTreeAgent:
+  enabled: true
+  image: ghcr.io/tuist/egress-tree-agent@sha256:b0e324e95d04cee3a63e536a7a0eb00acebcd365ae475c513741572b50f7a75d
+  nodePools: [kura-dedibox, kura-ca-east]
+  betaPodPrefix: "kura-tuist-"
+
 # CloudNativePG cluster — canary shape. 2 instances (primary + 1 sync
 # replica), 10Gi per instance. Matches the cluster's general-purpose
 # hcloud-worker pool (md-0, replicas: 2) — hard pod anti-affinity

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -280,6 +280,16 @@ kuraController:
       enabled: true
       item: kura-sentry
 
+# Only the shared mesh cache pools are listed. The runner-cache pool
+# (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
+# and its traffic is node-local runner reads that must not be shaped.
+# betaPodPrefix keeps the first enforcement step on kura-tuist-* pods.
+egressTreeAgent:
+  enabled: true
+  image: ghcr.io/tuist/egress-tree-agent@sha256:b0e324e95d04cee3a63e536a7a0eb00acebcd365ae475c513741572b50f7a75d
+  nodePools: [kura-dedibox, kura-us-east, kura-us-west]
+  betaPodPrefix: "kura-tuist-"
+
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
 # sync replicas), 100Gi per instance. Each instance is a streaming
 # replica holding the whole DB, so the size is per-replica capacity,


### PR DESCRIPTION
## What

Enables the shared per-node egress HTB tree (the egress-tree-agent, merged in #12525 and shipped disabled) on **canary** and **production**, gated to `kura-tuist-*` pods for the first enforcement step.

## Node pools

Scoped to the shared mesh cache pools that advertise a `tuist.dev/egress-mbps` budget (so the tree actually shapes rather than fail-open), verified against the live clusters:

| Env | nodePools | Budgets |
|---|---|---|
| canary | `kura-dedibox`, `kura-ca-east` | 1000 / 1000 Mbps |
| production | `kura-dedibox`, `kura-us-east`, `kura-us-west` | 1000 / 3000 / 3000 Mbps |

**`kura-scw-fr-par` (runner-cache) is deliberately excluded** on both. It advertises no egress budget (the agent would fail open there with a privileged pod for no benefit), and its traffic is node-local runner reads that must not be shaped — the runner-cache pool is intentionally outside egress governance. If you want the DaemonSet to run there too, add the pool to `nodePools`, but shaping won't engage until that pool advertises a budget.

## Beta gate

`betaPodPrefix: "kura-tuist-"` limits program attachment to pods whose name starts with `kura-tuist-` — the tuist account's own instances first. Every other annotated pod stays on the unshaped Cilium-only path and is counted in `kura_egress_tree_beta_excluded_pods` (separate from the alerting `skipped_pods`). Sibling allowlists are still computed over all annotated pods, so widening the prefix later converges within one reconcile cycle.

## Why this is safe to roll

- The controller half (annotations, classids) has been live fleet-wide since #12525 with no incident; this only turns on the agent that consumes them.
- The image is pinned by digest from the main build (`sha-dfc8646bcffa`).
- The metrics port is dropped from `world` by the bundled `CiliumClusterwideNetworkPolicy` (allow-all baseline + `ingressDeny`), scoped to the same pools.
- Enforcement is a floor/ceiling on egress the tenant already has; the beta prefix keeps the blast radius to `kura-tuist-*`.

## Validation

`helm template` on both env value sets renders the DaemonSet and the `CiliumClusterwideNetworkPolicy` on exactly the intended pools, with `kubernetes.io/os: linux`, `BETA_POD_PREFIX=kura-tuist-`, the digest-pinned image, and TCP 9469 denied from `world`. The agent behaviour itself was validated end-to-end on staging (30-scenario matrix + a controller-driven churn run + packet-rate runs) in #12525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
