### PR TITLE
fix(kura): select the egress metrics firewall by pool only, not os label

### DIFF
--- a/infra/helm/tuist/templates/egress-tree-agent.yaml
+++ b/infra/helm/tuist/templates/egress-tree-agent.yaml
@@ -178,14 +178,18 @@ metadata:
     app.kubernetes.io/component: egress-tree-agent
 spec:
   nodeSelector:
-    # Mirror the DaemonSet scope (kubernetes.io/os: linux + the same
-    # nodeSelector/nodePools): the policy must select exactly the nodes the
-    # agent runs on, never a non-linux node in a shared pool.
+    # A host policy matches against the HOST endpoint's labels, which Cilium's
+    # default label filter strips down to node.cluster.x-k8s.io/* (+ reserved)
+    # — kubernetes.io/os is NOT present on the host endpoint. So the policy
+    # selects by pool only; a kubernetes.io/os: linux matchLabel here never
+    # matches, leaving the host endpoint unenforced and the metrics port open
+    # (observed on canary/production). The DaemonSet keeps os: linux because
+    # pod scheduling does see full node labels. The kura pools are linux-only
+    # bare metal, so pool alone is exact.
+    {{- with .Values.egressTreeAgent.nodeSelector }}
     matchLabels:
-      kubernetes.io/os: linux
-      {{- with .Values.egressTreeAgent.nodeSelector }}
       {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- end }}
     {{- with .Values.egressTreeAgent.nodePools }}
     matchExpressions:
       - key: node.cluster.x-k8s.io/pool


### PR DESCRIPTION
## Problem

The egress-tree-agent's `CiliumClusterwideNetworkPolicy` (metrics-port firewall) is **not enforcing on canary or production** — the metrics port (`9469`, carrying per-tenant classids and traffic volumes) is reachable from the internet. Staging enforces correctly.

## Root cause

The CCNP `nodeSelector.matchLabels` required `kubernetes.io/os: linux`. A Cilium **host policy** matches against the **host endpoint's** labels, which Cilium's default label filter strips down to `node.cluster.x-k8s.io/*` (+ `reserved:`). `kubernetes.io/os` is **not** on the host endpoint, so the `os: linux` matchLabel never matches → the host endpoint stays unenforced → port open.

Confirmed by inspecting host endpoints on the live clusters:
- **production** `reserved:host`: `POLICY (ingress) = Disabled`, labels `{instance-type, pool}`, no os.
- **staging** `reserved:host`: `POLICY (ingress) = Enabled`, identical label set (also no os) — it enforces only because its live CCNP predates the `os: linux` addition and selects by pool alone.
- `cilium-config.labels` is empty (default filter) on all three clusters, so the behavior is uniform; the difference was purely which CCNP selector was deployed.

The `os: linux` matchLabel was added in #12525 (review fix, to mirror the DaemonSet scope). It's correct for the DaemonSet — pod scheduling *does* see full node labels — but wrong for a host policy.

## Fix

Select the CCNP by the `node.cluster.x-k8s.io/pool` matchExpressions **only** (the label that survives Cilium's filter and is on the host endpoint). The DaemonSet keeps `kubernetes.io/os: linux`. The kura pools are linux-only bare metal, so pool alone is exact.

## Validation

`helm template` on the production value set: the CCNP renders with `matchExpressions{pool In [...]}` and no os matchLabel; the DaemonSet still carries `kubernetes.io/os: linux`.

After deploy, the host endpoint on the kura nodes will select the policy and enter ingress enforcement (CR change triggers recomputation — no cilium restart needed), and `9469` becomes unreachable from `world` while in-cluster scrapes and everything else stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
