### PR TITLE
fix(infra): stop the runner shell-agent supervisor spinning on a foreign-uid lock

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -248,6 +248,15 @@ added to catch that failed on `admin`'s unwritable cache instead.
   shell bridge while the single-shot runner VM is alive. It runs as root
   from a LaunchDaemon so terminal access does not depend on an unlocked
   Aqua session, then drops PTY child shells to the `runner` user.
+  `/tmp/tuist-runner-shell-agent.lock` keeps it a singleton, and both uids
+  share that one path, so probe the holder with `ps -p` and never with
+  `kill -0`: from `runner`, `kill -0` fails with EPERM against the live
+  root-owned daemon exactly as it fails with ESRCH against a dead pid.
+  An unreadable pid file or a refused `rm` means the lock is held, not
+  stale; clearing it there starts a second bridge against the same
+  dispatch URL and claim marker. `dispatch-poll.sh`'s
+  `shell_agent_lock_active` implements the same protocol and must stay in
+  step with it.
 - `/Library/LaunchDaemons/dev.tuist.runner-shell-agent.plist` — the
   boot-time LaunchDaemon for the shell supervisor. `dispatch-poll.sh`
   still has a singleton-lock guarded fallback start path for older or

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -172,6 +172,12 @@ SHELL_CLAIM_MARKER="${TUIST_RUNNER_SHELL_CLAIM_MARKER:-/tmp/tuist-runner-shell-c
 export TUIST_RUNNER_SHELL_CLAIM_MARKER="${SHELL_CLAIM_MARKER}"
 rm -f "${SHELL_CLAIM_MARKER}" 2>/dev/null || true
 
+# Mirrors the lock protocol in runner-shell-agent-supervisor.sh. The lock is
+# shared across uids: the supervisor holds it as root from its LaunchDaemon,
+# this script runs as `runner`. Liveness therefore goes through ps, not
+# kill -0, which from `runner` fails with EPERM against a live root-owned
+# holder exactly as it fails with ESRCH against a dead pid. Reading a healthy
+# daemon as stale is what started the redundant second supervisor.
 shell_agent_lock_active() {
   local lock_dir=/tmp/tuist-runner-shell-agent.lock
   local pid_file="${lock_dir}/pid"
@@ -181,17 +187,31 @@ shell_agent_lock_active() {
     return 1
   fi
 
+  if [ -e "${pid_file}" ] && [ ! -r "${pid_file}" ]; then
+    echo "$(date -u +%FT%TZ) dispatch-poll: cannot read ${pid_file}; assuming the supervisor lock is held"
+    return 0
+  fi
+
   if [ -f "${pid_file}" ]; then
     read -r lock_pid <"${pid_file}" || lock_pid=""
   fi
 
-  if [ -n "${lock_pid}" ] && kill -0 "${lock_pid}" 2>/dev/null; then
-    return 0
-  fi
+  case "${lock_pid}" in
+    '' | *[!0-9]*) ;;
+    *)
+      if ps -p "${lock_pid}" -o pid= >/dev/null 2>&1; then
+        return 0
+      fi
+      ;;
+  esac
 
   echo "$(date -u +%FT%TZ) dispatch-poll: removing stale runner-shell-agent lock"
-  rm -rf "${lock_dir}"
-  return 1
+  if rm -rf "${lock_dir}"; then
+    return 1
+  fi
+
+  echo "$(date -u +%FT%TZ) dispatch-poll: cannot remove ${lock_dir}; assuming the supervisor lock is held"
+  return 0
 }
 
 if shell_agent_lock_active; then

--- a/infra/runner-image/runner-shell-agent-supervisor.sh
+++ b/infra/runner-image/runner-shell-agent-supervisor.sh
@@ -12,25 +12,75 @@ echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: starting"
 
 LOCK_DIR=/tmp/tuist-runner-shell-agent.lock
 LOCK_PID_FILE="${LOCK_DIR}/pid"
+
+# The lock is deliberately shared across uids: this script runs as root from
+# /Library/LaunchDaemons, while dispatch-poll.sh starts its fallback copy as
+# `runner`. Both must see the same lock, so the path stays in /tmp.
+#
+# kill -0 cannot arbitrate that. From `runner` it fails with EPERM against a
+# live root-owned holder exactly as it fails with ESRCH against a dead pid, so
+# a healthy daemon reads as stale. ps reports every uid, so it can tell the
+# two apart.
+lock_holder_alive() {
+  case "${1}" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  ps -p "${1}" -o pid= >/dev/null 2>&1
+}
+
+# Sets lock_pid. Returns 1 when the pid file exists but cannot be read, which
+# is not evidence that the holder died.
+lock_pid=""
+read_lock_pid() {
+  lock_pid=""
+  [ -r "${LOCK_PID_FILE}" ] || return 1
+  read -r lock_pid <"${LOCK_PID_FILE}" || lock_pid=""
+  return 0
+}
+
+LOCK_REMOVAL_ATTEMPT_LIMIT=5
+lock_removal_failures=0
+
 while ! mkdir "${LOCK_DIR}" 2>/dev/null; do
   lock_pid=""
-  if [ -f "${LOCK_PID_FILE}" ]; then
-    read -r lock_pid <"${LOCK_PID_FILE}" || lock_pid=""
-  else
+  # The holder writes its pid just after mkdir; give it a beat to appear.
+  if [ ! -e "${LOCK_PID_FILE}" ]; then
     sleep 1
-    if [ -f "${LOCK_PID_FILE}" ]; then
-      read -r lock_pid <"${LOCK_PID_FILE}" || lock_pid=""
-    fi
   fi
 
-  if [ -z "${lock_pid}" ] || ! kill -0 "${lock_pid}" 2>/dev/null; then
-    echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: removing stale lock at ${LOCK_DIR}"
-    rm -rf "${LOCK_DIR}"
+  if [ -e "${LOCK_PID_FILE}" ] && ! read_lock_pid; then
+    echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: cannot read ${LOCK_PID_FILE}; assuming the lock is held"
+    sleep 30
     continue
   fi
 
-  echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: another supervisor is active; waiting"
-  sleep 30
+  if lock_holder_alive "${lock_pid}"; then
+    echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: another supervisor is active (pid=${lock_pid}); waiting"
+    sleep 30
+    continue
+  fi
+
+  echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: removing stale lock at ${LOCK_DIR}"
+  if rm -rf "${LOCK_DIR}"; then
+    lock_removal_failures=0
+    continue
+  fi
+
+  # Refused removal means the lock belongs to another uid, and the only other
+  # uid reaching this path is the one running the other supervisor copy. Retry
+  # bounded and backed off, then exit rather than run unlocked: starting a
+  # second runner-shell-agent against the same dispatch URL and claim marker is
+  # what the lock exists to prevent. Exiting is safe for both callers. The
+  # LaunchDaemon copy is KeepAlive=true, so launchd respawns it under its own
+  # 10s throttle and reclaims the lock once the holder is gone; the
+  # dispatch-poll.sh fallback copy is redundant while the daemon holds it.
+  lock_removal_failures=$((lock_removal_failures + 1))
+  if [ "${lock_removal_failures}" -ge "${LOCK_REMOVAL_ATTEMPT_LIMIT}" ]; then
+    echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: cannot remove ${LOCK_DIR} after ${LOCK_REMOVAL_ATTEMPT_LIMIT} attempts; another uid owns it, giving up"
+    exit 1
+  fi
+  echo "$(date -u +%FT%TZ) runner-shell-agent-supervisor: lock removal refused (attempt ${lock_removal_failures}/${LOCK_REMOVAL_ATTEMPT_LIMIT}); retrying"
+  sleep $((lock_removal_failures * 5))
 done
 echo "$$" >"${LOCK_PID_FILE}"
 trap 'rm -rf "${LOCK_DIR}" 2>/dev/null || true' EXIT

--- a/infra/runner-image/runner-shell-agent-supervisor.sh
+++ b/infra/runner-image/runner-shell-agent-supervisor.sh
@@ -28,11 +28,20 @@ lock_holder_alive() {
   ps -p "${1}" -o pid= >/dev/null 2>&1
 }
 
-# Sets lock_pid. Returns 1 when the pid file exists but cannot be read, which
-# is not evidence that the holder died.
+# Sets lock_pid. Returns 1 only when the pid file is a regular file that cannot
+# be read, which is not evidence that the holder died.
+#
+# The -f test carries weight beyond -r: -r is an access(2) permission check and
+# passes on a FIFO or a blocking device node, and the redirect below would then
+# hang in open(2), before any of the bounded handling downstream gets to run.
+# A non-regular path is never a live holder's doing either, since the holder
+# publishes its pid with a plain `echo >` that would block on the same FIFO, so
+# anything that is not a regular file falls through to the stale path where
+# removal is bounded and refusal exits.
 lock_pid=""
 read_lock_pid() {
   lock_pid=""
+  [ -f "${LOCK_PID_FILE}" ] || return 0
   [ -r "${LOCK_PID_FILE}" ] || return 1
   read -r lock_pid <"${LOCK_PID_FILE}" || lock_pid=""
   return 0


### PR DESCRIPTION
## What changed

`runner-shell-agent-supervisor.sh` could retry an impossible operation with no
delay, spinning at roughly 135 iterations per second inside macOS runner VMs.
The loop is now unable to spin, and the condition that drove it into that state
is fixed at its source in `dispatch-poll.sh`.

Two separable defects:

1. **The loop had no backoff on a failing removal.** `rm -rf "${LOCK_DIR}"` was
   issued and its result discarded, then `continue` retried immediately. `-f`
   suppresses missing-file errors but not permission errors, so a refused
   removal left the lock in place, `mkdir` failed again, the same branch was
   taken again, and nothing broke the cycle. The `sleep 1` sat only in the
   pid-file-absent branch, so the hot path had no sleep at all.
2. **`kill -0` cannot decide liveness across a uid boundary**, and that is what
   routed a healthy VM into the destructive branch in the first place.

## Root cause

The lock at `/tmp/tuist-runner-shell-agent.lock` is reached by two uids by
design:

- `runner-shell-agent-supervisor.sh` runs as **root**, started from
  `/Library/LaunchDaemons/dev.tuist.runner-shell-agent.plist`, so terminal
  access does not depend on an unlocked Aqua session.
- `dispatch-poll.sh` runs as **`runner`** (the LaunchAgent deliberately keeps
  the GitHub runner non-root) and carries a singleton-guarded fallback start
  path for older or partially-built images.

From `runner`, `kill -0 <root pid>` fails with `EPERM`. Bash surfaces that
identically to the `ESRCH` of a genuinely dead pid, so the **live** root daemon
read as stale. Verified directly:

```
$ id -u
501
$ kill -0 1        # launchd, uid 0
kill 1 failed: operation not permitted     (rc=1)
$ ps -p 1 -o pid=  # same pid, cross-uid
rc=0
```

That single misread produced the whole failure:

1. `dispatch-poll.sh`'s `shell_agent_lock_active` sees the live daemon as dead,
   its own `rm -rf` is refused, and it starts a **second** supervisor as
   `runner`.
2. That second supervisor enters the lock loop, reads the same live root pid,
   reaches the same wrong conclusion, and tries to remove the lock.
3. `/tmp` is `1777` (sticky), so uid 501 cannot unlink the root-owned lock
   directory; the lock directory is `0755` root-owned, so uid 501 cannot unlink
   `pid` inside it. Both denials appear, matching the guest logs exactly.
4. `continue`, no sleep, forever.

## The fix

**Liveness via `ps -p`, in both scripts.** `ps` reports every uid, so a live
holder on the other side of a uid boundary is recognised as live and the
destructive branch is never entered. This also means `dispatch-poll.sh` stops
starting the redundant second supervisor, which removes the spin at its source
rather than only surviving it.

**Bounded, backed-off removal.** A refused `rm` now backs off (5s, 10s, 15s,
20s) and exits non-zero after five attempts.

Exiting rather than proceeding without the lock, because a lock that cannot be
removed belongs to another uid, and the only other uid reaching this path is
the one running the other supervisor copy. Running unlocked would start a
second `runner-shell-agent` against the same dispatch URL and claim marker,
which is precisely what the lock exists to prevent, and a worse outcome than
not starting. Exiting is safe for both callers: the LaunchDaemon copy is
`KeepAlive=true`, so launchd respawns it under its own 10 second throttle and
reclaims the lock once the holder is gone; the `dispatch-poll.sh` fallback copy
is redundant for as long as the daemon holds it.

**An unreadable pid file is no longer treated as a dead holder.** "I cannot
read this" is not "the owner is dead", and conflating them is what let an
unreadable lock reach the destructive branch. It now waits instead.

## Why the lock was not relocated

A uid-scoped or daemon-private directory would remove the permission error, but
it would also break what the lock is for. The two copies are *supposed* to see
each other across the uid boundary; give them separate paths and both start a
bridge, every time. The ownership turned out to be the benign case the
relocation argument allows for: a correctly shared, correctly root-owned lock,
misjudged by a uid-blind liveness probe. Fixing the probe keeps the mutual
exclusion and removes the class of problem. The lock stays in `/tmp`, and
`AGENTS.md` now records `ps -p`-not-`kill -0` as a constraint on both scripts so
the protocol does not drift back.

## Prevalence

11% to 71% of captured macOS runner logs per 6h bucket, median around 38%, over
2026-08-22..24 (`grafanacloud-logs`):

```
sum(count_over_time({job="tuist-macos-tart-kubelet"} |= "runner log" |= "removing stale lock" [6h]))
/ sum(count_over_time({job="tuist-macos-tart-kubelet"} |= "runner log" [6h]))
```

## Impact

A busy-loop burning a core inside a VM whose whole job is to run someone's
build. It also drowns the guest-log tail: the repro below produced 2032 log
lines in 5 seconds, so the useful boot and dispatch lines are pushed out by
noise from a loop that cannot make progress. That interacts with the guest log
capture added in #12492 and is a real second-order cost of leaving it in place.

This deliberately makes no claim about runner strandings. In-VM CPU starvation
is a plausible contributor, but that is untested and a separate investigation
into stranding causes is ongoing. The loop is fixed because an unbounded
no-backoff retry on an operation that cannot succeed is wrong on its own terms.

## Validation

`bash -n` passes on both scripts. `shellcheck` reports an identical set of
findings before and after, with only line numbers shifted: SC2154 on
`dispatch-poll.sh`'s EXIT trap, SC2164 on a `cd`, and SC2012 on an `ls`, all
pre-existing and unrelated to this loop. The supervisor is shellcheck-clean.

The failure was reproduced locally in a sandbox that recreates the VM
conditions (a lock directory the caller may not unlink from, holding a pid
owned by a uid the caller may not signal), running the real scripts
unprivileged.

Against the current code, with pid 1 (launchd, alive, uid 0) as the holder:

```
677 'removing stale lock' iterations in 5s
1354 'Permission denied' lines
2032 log lines total
```

After the fix, same scenario: **0 iterations, 0 permission errors, 2 log lines
in 6 seconds**, holder correctly identified as active, lock left intact.

Scenarios covered, all passing:

| Scenario | Behaviour |
| --- | --- |
| Live foreign-uid holder, removal refused | recognised as active, waits, lock intact |
| Dead holder, removal refused | 5 bounded attempts with backoff, exits 1, lock intact |
| Pid file present but unreadable | treated as held, destructive branch not entered |
| Genuinely stale lock, removal permitted | cleared once, lock acquired, proceeds (regression) |

`dispatch-poll.sh`'s `shell_agent_lock_active` was extracted and exercised over
the same cases. Before: live root-owned holder, unreadable pid file, and
refused-removal all returned "not active", which is what spawned the duplicate
supervisor. After: all three correctly return "active", while a genuinely stale
and removable lock is still cleared and a missing lock still reports inactive.

## Shipping

`runner-shell-agent-supervisor.sh` is baked into the macOS runner image, which
is built and released by the "Build runner image (Xcode …)" and "Release runner
image" jobs inside `server-production-deployment.yml`, not by the standalone
`runner-image.yml` workflow. Those jobs are gated on changes under
`infra/runner-image/**`, which this PR touches, so merging rebuilds and
republishes the image and moves the chart pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
