### PR TITLE
fix(server): make the claim override stick, and apply plan upgrades to running instances

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -14,6 +14,7 @@ defmodule Tuist.Billing do
   alias Tuist.Billing.Subscription
   alias Tuist.Billing.TokenUsage
   alias Tuist.CommandEvents
+  alias Tuist.Kura
   alias Tuist.Repo
   alias Tuist.Runners.Billing, as: RunnerBilling
 
@@ -582,6 +583,10 @@ defmodule Tuist.Billing do
         })
         |> Repo.update!()
     end
+
+    # A Kura instance carries the claim it is built at rather than resolving one
+    # per render, so a plan change reaches it from here or not at all.
+    Kura.refresh_storage_claims_for_plan(account)
 
     :ok
   end

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -23,6 +23,7 @@ defmodule Tuist.Kura do
   alias Tuist.Accounts
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
+  alias Tuist.Kura.AccountPolicies
   alias Tuist.Kura.Demand
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
@@ -338,6 +339,53 @@ defmodule Tuist.Kura do
     end
   end
 
+  @doc """
+  Re-pins an account's running instances after its plan changed.
+
+  The claim is carried on the row rather than resolved per render, so a plan
+  change would otherwise not reach an instance until its volumes were next
+  built. This is what applies it: an account that upgrades gets the ring its new
+  plan pays for, on the rolling rebuild the controller does for a grown claim.
+
+  A move to `:air` never re-pins, and that is the whole safety property rather
+  than a detail. `Tuist.Billing.effective_plan/1` reads `:air` whenever an
+  account has no `active` or `trialing` subscription, which is a state real
+  accounts pass through on the way between two paid subscriptions rather than a
+  statement that they downgraded. Measured across the accounts holding an
+  instance in a per-account region, four of seven have done it, with the gap
+  lasting anywhere from six minutes to four and a half days. Sizing on that
+  would drop an enterprise claim to air's, evict a 40 GiB ring down to 3.4 GiB,
+  and then rebuild the volumes on the way back up -- destroying the cache twice
+  over for a billing round trip that changed nothing about the account.
+
+  So air is only ever reached by provisioning, where it describes an account
+  that is actually on that plan. The cost of ignoring it here is that a genuine
+  permanent downgrade keeps its larger claim until its volumes are next built,
+  which reserves disk we could have taken back. That is the cheaper mistake.
+  """
+  def refresh_storage_claims_for_plan(%Account{id: account_id}) do
+    # Read the account back rather than trusting the caller's copy: this runs
+    # from the subscription write that just changed the answer.
+    with {:ok, account} <- Accounts.get_account_by_id(account_id, preload: [:subscriptions]),
+         true <- AccountPolicies.sizing_plan(account) != :air,
+         {:ok, result} <- repin_for_plan(account) do
+      Enum.each(result.raised ++ result.lowered, &broadcast_server(&1, :updated))
+      :ok
+    else
+      _ -> :ok
+    end
+  end
+
+  defp repin_for_plan(account) do
+    Repo.transaction(fn ->
+      lock_account(account.id)
+
+      claim_size = StorageClaims.effective_claim_size(account)
+
+      repin_storage_claims(account, claim_size, claim_size)
+    end)
+  end
+
   defp write_storage_claim_override(account, override) do
     Repo.transaction(fn ->
       # Taken before anything is read, and paired with the shared lock every path
@@ -376,19 +424,31 @@ defmodule Tuist.Kura do
   # A row already rendering `claim_size` is left alone: re-pinning it would
   # produce no manifest change, and reporting it as rebuilt would tell an
   # operator a cache was dropped that never was.
+  # Pins every governed row that still holds volumes, and reports only the ones
+  # whose rendered claim actually moved.
+  #
+  # Pinning is unconditional on purpose. It used to happen only when the value
+  # moved, which left the case that reads as a no-op and is not one: an override
+  # set to exactly what the account's plan already gives it pinned nothing, so
+  # the row went on resolving from the plan and a later plan change moved it off
+  # the override that was supposed to govern it. Every live instance in
+  # production carries no pin today, so that was the default shape rather than a
+  # corner. Writing the claim onto the row is what makes the override stick, and
+  # a row already carrying this claim produces an empty changeset and no write.
   defp repin_storage_claims(%Account{id: account_id}, previous, claim_size) do
     {raised, lowered} =
       Server
       |> where([server], server.account_id == ^account_id)
       |> where([server], server.status not in ^@volumeless_statuses)
       |> Repo.all()
-      |> Enum.filter(&storage_claim_moves?(&1, previous, claim_size))
+      |> Enum.filter(&storage_governed_instance?/1)
       |> Enum.map(fn server ->
-        raised? = claim_grows?(instance_storage_claim(server, previous), claim_size)
+        held = instance_storage_claim(server, previous)
 
-        {server |> Server.lifecycle_changeset(%{storage_claim_size: claim_size}) |> Repo.update!(), raised?}
+        {server |> Server.lifecycle_changeset(%{storage_claim_size: claim_size}) |> Repo.update!(), held}
       end)
-      |> Enum.split_with(fn {_server, raised?} -> raised? end)
+      |> Enum.filter(fn {_server, held} -> held != claim_size end)
+      |> Enum.split_with(fn {_server, held} -> claim_grows?(held, claim_size) end)
 
     %{raised: Enum.map(raised, &elem(&1, 0)), lowered: Enum.map(lowered, &elem(&1, 0))}
   end
@@ -416,13 +476,10 @@ defmodule Tuist.Kura do
   # today. Pinning such a row is the point rather than a side effect, since it
   # stops resolving with the account and holds what its volumes were built at,
   # which is what every row created in a governed region already does.
-  defp storage_claim_moves?(%Server{} = server, previous, claim_size) do
+  defp storage_governed_instance?(%Server{} = server) do
     case Regions.fetch(server.region) do
-      {:ok, region} ->
-        Regions.storage_governed?(region) and instance_storage_claim(server, previous) != claim_size
-
-      {:error, _reason} ->
-        false
+      {:ok, region} -> Regions.storage_governed?(region)
+      {:error, _reason} -> false
     end
   end
 

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -1,11 +1,13 @@
 defmodule Tuist.KuraTest do
   use TuistTestSupport.Cases.DataCase, async: true
 
+  import Ecto.Query, only: [from: 2]
   import Mimic
 
   alias Tuist.Accounts
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
+  alias Tuist.Billing.Subscription
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
@@ -714,6 +716,24 @@ defmodule Tuist.KuraTest do
       assert Repo.get!(Server, server.id).storage_claim_size == "40Gi"
     end
 
+    # The case that reads as a no-op and is not one. Setting an override to what
+    # the plan already gives pins nothing under the old rule, so the row went on
+    # resolving from the plan and a later plan change moved it off the override.
+    test "pins the override even when it matches the claim the plan already gives", %{account: account} do
+      {:ok, server} = Kura.create_server(%{account_id: account.id, region: "us-east", image_tag: "0.5.2"})
+
+      # Provisioned rows pin at creation, so clear it to reproduce the shape
+      # every instance in production is actually in.
+      Repo.update_all(from(s in Server, where: s.id == ^server.id), set: [storage_claim_size: nil])
+
+      assert {:ok, %{claim_size: "8Gi", raised: [], lowered: []}} =
+               Kura.update_storage_claim_override(account, %{"kura_storage_claim_size" => "8Gi"})
+
+      # Nothing moved, so nothing is reported, but the claim is now carried on
+      # the row: that is what makes it survive a later plan change.
+      assert Repo.get!(Server, server.id).storage_claim_size == "8Gi"
+    end
+
     test "reports nothing moved when the claim it renders does not move", %{account: account} do
       {:ok, _server} = Kura.create_server(%{account_id: account.id, region: "us-east", image_tag: "0.5.2"})
 
@@ -786,6 +806,59 @@ defmodule Tuist.KuraTest do
       {:ok, server} = Kura.begin_drain(server)
       {:ok, server} = Kura.archive_server(server)
       server
+    end
+  end
+
+  describe "refresh_storage_claims_for_plan/1" do
+    setup do
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :kura_available_region_ids, fn -> ["us-east"] end)
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      %{account: account}
+    end
+
+    test "applies an upgrade to a running instance", %{account: account} do
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
+      {:ok, server} = Kura.create_server(%{account_id: account.id, region: "us-east", image_tag: "0.5.2"})
+      assert server.storage_claim_size == "30Gi"
+
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+
+      assert :ok = Kura.refresh_storage_claims_for_plan(account)
+
+      # Without this the upgrade would sit unapplied until the volumes were next
+      # built, which for a serving instance is indefinitely.
+      assert Repo.get!(Server, server.id).storage_claim_size == "50Gi"
+    end
+
+    # The safety property. An account between two paid subscriptions reads as air
+    # for anywhere from minutes to days, and sizing on that would evict the ring
+    # down to air's and then rebuild the volumes on the way back up.
+    test "ignores a move to air rather than sizing on a billing gap", %{account: account} do
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, server} = Kura.create_server(%{account_id: account.id, region: "us-east", image_tag: "0.5.2"})
+      assert server.storage_claim_size == "50Gi"
+
+      Repo.update_all(from(s in Subscription, where: s.account_id == ^account.id), set: [status: "canceled"])
+      account = Repo.preload(account, :subscriptions, force: true)
+      assert Tuist.Billing.effective_plan(account) == :air
+
+      assert :ok = Kura.refresh_storage_claims_for_plan(account)
+
+      assert Repo.get!(Server, server.id).storage_claim_size == "50Gi"
+    end
+
+    test "leaves an account that is genuinely on air where provisioning put it", %{account: account} do
+      {:ok, server} = Kura.create_server(%{account_id: account.id, region: "us-east", image_tag: "0.5.2"})
+      assert server.storage_claim_size == "8Gi"
+
+      assert :ok = Kura.refresh_storage_claims_for_plan(account)
+
+      assert Repo.get!(Server, server.id).storage_claim_size == "8Gi"
     end
   end
 


### PR DESCRIPTION
Follow-up to #12533, which shipped the per-account Kura disk claim override. Both fixes come from reading production after it deployed rather than from new requirements.

> Makes a claim override stick when it matches the plan's claim, and applies plan upgrades to instances that are already running.

### What production showed

Every live Kura instance carries **no pinned claim at all** — `storage_claim_size` is NULL on all 20 — because the backfill onto existing instances was deliberately dropped just before the override landed. So the unpinned path is not a corner case, it is the default shape, and two gaps in it matter.

### An override equal to the plan's claim pinned nothing

Re-pinning only happened when the rendered claim moved, so setting an override to exactly what the account already resolves to was treated as a no-op. The row kept resolving from the plan, and a later plan change would move it off the override that was meant to govern it.

Pinning is now unconditional on an override write. Writing the claim onto the row is what makes it stick; a row already carrying that claim produces an empty changeset and no write, so this costs nothing where it changes nothing. Reporting stays keyed on movement, so no cache warning is raised for an instance that is not being rebuilt.

### A plan upgrade never reached a running instance

Because the claim is carried on the row rather than resolved per render, an upgrade sat unapplied until the volumes were next built — which, for an instance that keeps serving, is indefinitely. `refresh_storage_claims_for_plan/1` applies it from the subscription write. What makes that safe to do to a live instance is the rolling rebuild #12533 added for a grown claim: one replica at a time, behind the standby, refilling from it.

### Why a move to air never re-pins

This is the safety property, not a detail.

`Billing.effective_plan/1` returns `:air` whenever an account has no `active` or `trialing` subscription. That is a state real accounts pass through **between two paid subscriptions**, not a statement that they downgraded. Measured on the accounts holding an instance in a per-account region:

- four of seven have done it,
- gaps of 6 minutes, 11.8h, 14h, 44h and 108h,
- every one of them enterprise on both sides of the gap.

Sizing on that would cut the claim from 50Gi to air's 8Gi, evict a 40.25 GiB ring down to 3.39 GiB, and then rebuild the volumes on the way back up — losing the cache twice over for a billing round trip that changed nothing about the account. Note the eviction happens on the *shrink*, which the one-directional rebuild trigger treats as free; that trigger protects the volume, not the cache.

So air is only ever reached by provisioning, where it describes an account actually on that plan. The cost is that a genuine permanent downgrade keeps its larger claim until its volumes are next built, reserving disk we could have taken back. Against the alternative, that is the cheaper mistake.

### On the pin itself

The note left when the backfill was removed said the pin's justification — a grown claim wedging Reconcile because the PVC could not be patched upward — would be redundant once a claim change could rebuild volumes. That did land in #12533, so the original reason is gone.

The pin stays anyway, on a different and now measured basis: subscription state is too noisy to size storage from directly. Damping it instead of pinning would need more than 4.5 days of hysteresis to bridge the observed gaps, which is the pin again with a timer instead of a value.

### Reviewer notes

- `Billing → Kura` is a new call direction, but `Tuist` is a single Boundary with `deps: []` and Billing already calls `Accounts`, `CommandEvents` and `Runners.Billing`, so it matches existing structure. Kura already depends on Billing via `AccountPolicies`.
- `refresh_storage_claims_for_plan/1` re-reads the account rather than trusting the caller's copy, because it runs from the subscription write that just changed the answer.
- The override test was checked red against the previous behaviour before being made green.
- Not included: the ops flash messages still are not rendered by any layout, so an operator setting an override sees the table update and no message. Pre-existing and affects all flashes on that page, so it is left for its own change.

### How to test locally

```bash
cd server && mix test test/tuist/kura test/tuist/kura_test.exs test/tuist/billing_test.exs test/tuist_web/live/ops_account_live_test.exs
```

```bash
cd server && mix format --check-formatted && mix credo
```

Validation for this change: 555 tests across the Kura, billing and ops account suites, `mix format`, `mix credo` (no issues).
