### PR TITLE
fix(infra): ship kura pod logs from the scw-fr-par cache pool to Loki

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -1395,6 +1395,11 @@ k8s-monitoring:
           - key: tuist.dev/stable-egress
             operator: Exists
             effect: NoSchedule
+          # Scaleway Elastic Metal cache pool (kura-scw-fr-par), which
+          # registers with tuist.dev/runner-cache=true:NoSchedule.
+          - key: tuist.dev/runner-cache
+            operator: Exists
+            effect: NoSchedule
     # Kubernetes Events must come from exactly one replica — otherwise
     # every pod watches the event stream and emits duplicate log lines.
     alloy-singleton:


### PR DESCRIPTION
Every `kura-*-scw-fr-par-0` pod has been invisible in Loki. A query over the last 6h returns 20 kura pods, all `eu-central` / `us-east` / `us-west`; all ten on the Scaleway Elastic Metal pool are absent. `kura/manager` from the same namespace ships fine, so the namespace itself was being discovered.

```
sum by (pod) (count_over_time({job="kura/kura", cluster="tuist-production"}[6h]))
```

### Root cause

A toleration gap, not a discovery problem.

The `kura-scw-fr-par` nodes register with `--register-with-taints=tuist.dev/runner-cache=true:NoSchedule` (see `infra/cluster-api-provider-tuist/docs/scaleway-elastic-metal-support.md`). The `alloy-logs` DaemonSet tolerated only `tuist.dev/runner-tier`, `tuist.dev/kura-cache` and `tuist.dev/stable-egress`, so it never scheduled a pod onto that pool. `podLogsViaLoki` tails `/var/log/pods` from the node it runs on, which makes a pool with no collector pod a total blind spot — for pod logs **and** for the node's journald (`nodeLogs`).

Every consumer that actually needs to run on those nodes already carries this toleration (`kura-fleet.yaml`, `kura-fleet-storage.yaml`, `scaleway-csi-values.yaml`, `Tuist.Kura.Regions`). The log collector was the one that did not.

### Why it stayed hidden

Metrics kept working the whole time. `alloy-metrics` runs `clustered` and scrapes over the network, so it needs no pod on the node — `job="kura"` series were present and healthy for exactly the pods that were producing no log lines at all. Metric coverage is not evidence of log coverage on a tainted pool.

The DaemonSet replica counts show it plainly: `alloy-logs` desired **12** against `node-exporter` desired **16**, the latter inheriting the upstream subchart's broad `operator: Exists`.

### Why not broaden to `operator: Exists`

That would fix this class of bug permanently — this is the fourth taint-specific entry in the list and the failure mode is always silent — but it would also newly schedule the log DaemonSet onto the three control-plane nodes. That is a larger scheduling change than this fix needs, so the taint is tolerated explicitly. Control-plane nodes remain a separate, pre-existing pod-log gap (they account for the other 3 of the 4 missing DaemonSet pods).

### Impact

On 2026-08-24 `kura-tuist-scw-fr-par-0` was killed twice by its liveness probe, and the only crash evidence available was `kubectl logs --previous`, which retains exactly one generation — a third restart would have destroyed it. After this lands, those pods are queryable in Loki like every other region, and the node's `containerd` / `kubelet` / kernel journal ships too, which is where a host-side kill leaves its trail.

Log-volume impact is small: that node runs only the ten kura StatefulSet pods plus `cilium`, `local-path-provisioner` and the quota exporter. No `kura-*-ingress-nginx` pods live there, so the existing ingress sampling stages are not involved.

Deploys through the `observability-install` job in `server-deployment.yml`, so it reaches the clusters on the next `main` deploy.

### How to test locally

Render the chart and confirm the new toleration lands in the `alloy-logs` Alloy CR's `controller.tolerations`:

```
helm dependency update infra/helm/k8s-monitoring
helm template k8s-monitoring infra/helm/k8s-monitoring -n observability \
  -f infra/helm/k8s-monitoring/values-production.yaml \
  | grep -A 14 'tolerations:'
```

Verified against `tuist-k8s-production` before the change:

- `kubectl get nodes -l node.cluster.x-k8s.io/pool=kura-scw-fr-par -o custom-columns='NAME:.metadata.name,TAINTS:.spec.taints'` → the taint is exactly `tuist.dev/runner-cache=true:NoSchedule`.
- `kubectl -n observability get ds` → `alloy-logs` 12 desired vs `node-exporter` 16.
- `kubectl get pods -A --field-selector spec.nodeName=tuist-tuist-kura-fleet-6vx2l-plpvc` → `node-exporter` present, `alloy-logs` absent, all ten kura pods Running.

`helm template` renders clean for the staging, canary, production and management overlays.

After deploy, the same Loki query should return 30 pods instead of 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
