### PR TITLE
fix(infra): collapse repeated blocks out of the macOS runner guest log tail

### DIFF
--- a/infra/tart-kubelet/internal/podagent/runner_log.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log.go
@@ -1,15 +1,17 @@
 package podagent
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
 
 // runnerLogScanBytes / runnerLogScanLines bound the window that is read
-// and collapsed down to runnerLogTailLines / runnerLogTailBytes. The
-// line cap binds only below ~16 bytes per line, which no runner log
-// reaches; it is there to bound collapseRepeatedBlocks on a file the
-// guest chose the shape of.
+// and collapsed down to runnerLogTailLines / runnerLogTailBytes. Both
+// caps are needed: the guest picks the file's size and its line count
+// independently, and a line costs a slice header whether or not it
+// holds anything. The line cap binds only below ~16 bytes per line,
+// which no runner log reaches.
 const (
 	runnerLogScanBytes  = 16 << 20
 	runnerLogScanLines  = 1 << 20
@@ -20,13 +22,15 @@ const (
 // runnerLogTail reduces a scanned window to the published tail.
 // partialFirstLine reports that the window began mid-file, so its first
 // line is a fragment.
-func runnerLogTail(window string, partialFirstLine bool) string {
-	lines := strings.Split(strings.TrimRight(window, "\n"), "\n")
+func runnerLogTail(window []byte, partialFirstLine bool) string {
+	window = bytes.TrimRight(window, "\n")
+	if start := scanLinesStart(window); start > 0 {
+		window = window[start:]
+		partialFirstLine = false
+	}
+	lines := strings.Split(string(window), "\n")
 	if partialFirstLine && len(lines) > 1 {
 		lines = lines[1:]
-	}
-	if len(lines) > runnerLogScanLines {
-		lines = lines[len(lines)-runnerLogScanLines:]
 	}
 	lines = collapseRepeatedBlocks(lines)
 	if len(lines) > runnerLogTailLines {
@@ -35,10 +39,30 @@ func runnerLogTail(window string, partialFirstLine bool) string {
 	return strings.Join(boundToTailBytes(lines), "\n")
 }
 
+// scanLinesStart returns where the last runnerLogScanLines records of
+// window begin, or 0 when window holds no more than that many. Selected
+// before the split, so a file the guest filled with newlines costs one
+// backward pass rather than a slice header per line.
+func scanLinesStart(window []byte) int {
+	end := len(window)
+	for range runnerLogScanLines {
+		i := bytes.LastIndexByte(window[:end], '\n')
+		if i < 0 {
+			return 0
+		}
+		end = i
+	}
+	return end + 1
+}
+
 // collapseRepeatedBlocks rewrites each consecutively repeating block of
 // lines as one copy followed by a count. Blocks rather than single
 // lines: the supervisor loop that floods these logs cycles three
 // distinct lines, so no line there ever follows itself.
+//
+// Keeps only the most recent runnerLogTailLines it has produced, since
+// that is all the caller can publish; a window that collapses to
+// nothing would otherwise cost a header per line of it.
 func collapseRepeatedBlocks(lines []string) []string {
 	var out []string
 	for i := 0; i < len(lines); {
@@ -46,11 +70,14 @@ func collapseRepeatedBlocks(lines []string) []string {
 		if period == 0 {
 			out = append(out, lines[i])
 			i++
-			continue
+		} else {
+			out = append(out, lines[i:i+period]...)
+			out = append(out, repeatMarker(period, repeats))
+			i += period * repeats
 		}
-		out = append(out, lines[i:i+period]...)
-		out = append(out, repeatMarker(period, repeats))
-		i += period * repeats
+		if len(out) > 2*runnerLogTailLines {
+			out = append(out[:0], out[len(out)-runnerLogTailLines:]...)
+		}
 	}
 	return out
 }

--- a/infra/tart-kubelet/internal/podagent/runner_log.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log.go
@@ -1,0 +1,110 @@
+package podagent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// runnerLogScanBytes / runnerLogScanLines bound the window that is read
+// and collapsed down to runnerLogTailLines / runnerLogTailBytes. The
+// line cap binds only below ~16 bytes per line, which no runner log
+// reaches; it is there to bound collapseRepeatedBlocks on a file the
+// guest chose the shape of.
+const (
+	runnerLogScanBytes  = 16 << 20
+	runnerLogScanLines  = 1 << 20
+	runnerLogMaxPeriod  = 8
+	runnerLogMinRepeats = 3
+)
+
+// runnerLogTail reduces a scanned window to the published tail.
+// partialFirstLine reports that the window began mid-file, so its first
+// line is a fragment.
+func runnerLogTail(window string, partialFirstLine bool) string {
+	lines := strings.Split(strings.TrimRight(window, "\n"), "\n")
+	if partialFirstLine && len(lines) > 1 {
+		lines = lines[1:]
+	}
+	if len(lines) > runnerLogScanLines {
+		lines = lines[len(lines)-runnerLogScanLines:]
+	}
+	lines = collapseRepeatedBlocks(lines)
+	if len(lines) > runnerLogTailLines {
+		lines = lines[len(lines)-runnerLogTailLines:]
+	}
+	return strings.Join(boundToTailBytes(lines), "\n")
+}
+
+// collapseRepeatedBlocks rewrites each consecutively repeating block of
+// lines as one copy followed by a count. Blocks rather than single
+// lines: the supervisor loop that floods these logs cycles three
+// distinct lines, so no line there ever follows itself.
+func collapseRepeatedBlocks(lines []string) []string {
+	var out []string
+	for i := 0; i < len(lines); {
+		period, repeats := repeatedBlockAt(lines, i)
+		if period == 0 {
+			out = append(out, lines[i])
+			i++
+			continue
+		}
+		out = append(out, lines[i:i+period]...)
+		out = append(out, repeatMarker(period, repeats))
+		i += period * repeats
+	}
+	return out
+}
+
+// repeatedBlockAt returns the shortest block starting at i that repeats
+// consecutively at least runnerLogMinRepeats times, and how many times
+// it occurs in total. period is 0 when nothing at i repeats that often.
+func repeatedBlockAt(lines []string, i int) (period, repeats int) {
+	for p := 1; p <= runnerLogMaxPeriod && i+p*runnerLogMinRepeats <= len(lines); p++ {
+		n := 1
+		for j := i + p; j+p <= len(lines) && blocksEqual(lines, i, j, p); j += p {
+			n++
+		}
+		if n >= runnerLogMinRepeats {
+			return p, n
+		}
+	}
+	return 0, 0
+}
+
+func blocksEqual(lines []string, a, b, n int) bool {
+	for k := range n {
+		if lines[a+k] != lines[b+k] {
+			return false
+		}
+	}
+	return true
+}
+
+func repeatMarker(period, repeats int) string {
+	if period == 1 {
+		return fmt.Sprintf("... (previous line repeated %d more times)", repeats-1)
+	}
+	return fmt.Sprintf("... (previous %d lines repeated %d more times)", period, repeats-1)
+}
+
+// boundToTailBytes caps the published size. Applied last, because the
+// rewrites above shrink guest-chosen input without bounding it. Whole
+// lines go first, oldest first; a line left over the cap on its own
+// keeps its end, for the same reason the tail is preferred to the head.
+func boundToTailBytes(lines []string) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	total := len(lines) - 1
+	for _, l := range lines {
+		total += len(l)
+	}
+	for total > runnerLogTailBytes && len(lines) > 1 {
+		total -= len(lines[0]) + 1
+		lines = lines[1:]
+	}
+	if l := lines[0]; len(l) > runnerLogTailBytes {
+		lines = []string{l[len(l)-runnerLogTailBytes:]}
+	}
+	return lines
+}

--- a/infra/tart-kubelet/internal/podagent/runner_log_test.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log_test.go
@@ -135,3 +135,171 @@ func TestReadRunnerLogRejectsDirectory(t *testing.T) {
 		t.Errorf("got %q, want \"\"", got)
 	}
 }
+
+// hotLoopBlock is the shape that floods these logs: the supervisor
+// retries a refused stale-lock removal with no backoff, many times per
+// second. Three lines, and no line follows itself, so collapsing equal
+// adjacent lines finds nothing here.
+const hotLoopBlock = "runner-shell-agent-supervisor: removing stale lock at /tmp/tuist-runner-shell-agent.lock\n" +
+	"rm: /tmp/tuist-runner-shell-agent.lock/pid: Permission denied\n" +
+	"rm: /tmp/tuist-runner-shell-agent.lock: Permission denied\n"
+
+func hotLoopLog(t *testing.T, prefix []string, bytes int) string {
+	t.Helper()
+	var b strings.Builder
+	for _, l := range prefix {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	for b.Len() < bytes {
+		b.WriteString(hotLoopBlock)
+	}
+	return writeRunnerLog(t, b.String())
+}
+
+func TestReadRunnerLogKeepsHistoryBehindARepeatingBlock(t *testing.T) {
+	// The runner's own trail sits behind more than a byte window's worth
+	// of one repeating block, and that trail is what the capture exists
+	// to carry.
+	var prefix []string
+	for i := range 20 {
+		prefix = append(prefix, fmt.Sprintf("dispatch-poll: runner-said-%d", i))
+	}
+	dir := hotLoopLog(t, prefix, runnerLogTailBytes*4)
+
+	published := map[string]bool{}
+	for _, l := range strings.Split(readRunnerLog(dir), "\n") {
+		published[l] = true
+	}
+
+	for _, want := range prefix {
+		if !published[want] {
+			t.Errorf("published tail lost %q", want)
+		}
+	}
+}
+
+func TestReadRunnerLogReportsHowOftenABlockRepeated(t *testing.T) {
+	// The repetition is itself the finding, so the count survives even
+	// though the instances do not.
+	dir := hotLoopLog(t, nil, runnerLogTailBytes*4)
+
+	got := readRunnerLog(dir)
+
+	repeats := strings.Count(got, hotLoopBlock)
+	if repeats != 1 {
+		t.Errorf("block appears %d times, want 1 copy plus a count", repeats)
+	}
+	if !strings.Contains(got, "... (previous 3 lines repeated ") {
+		t.Errorf("got %q, want a marker naming the repeat count", got)
+	}
+}
+
+func TestReadRunnerLogBoundsARepeatingBlock(t *testing.T) {
+	// Collapsing runs before the budgets are applied, so the budgets
+	// still have to hold on the input that motivated it.
+	dir := hotLoopLog(t, nil, runnerLogScanBytes*2)
+
+	got := readRunnerLog(dir)
+
+	if len(got) > runnerLogTailBytes {
+		t.Errorf("got %d bytes, want at most %d", len(got), runnerLogTailBytes)
+	}
+	if n := len(strings.Split(got, "\n")); n > runnerLogTailLines {
+		t.Errorf("got %d lines, want at most %d", n, runnerLogTailLines)
+	}
+}
+
+func TestReadRunnerLogDropsPartialFirstLineAtScanBoundary(t *testing.T) {
+	// The mid-line start moved with the window: it is the scan budget,
+	// not the published byte budget, that the read now lands inside.
+	const width = 4095
+	var b strings.Builder
+	for i := 0; b.Len() <= runnerLogScanBytes+width; i++ {
+		fmt.Fprintf(&b, "%04d%s\n", i, strings.Repeat("z", width-4))
+	}
+	dir := writeRunnerLog(t, b.String())
+
+	for _, l := range strings.Split(readRunnerLog(dir), "\n") {
+		if len(l) != width {
+			t.Fatalf("published a %d-byte line, want whole %d-byte lines only", len(l), width)
+		}
+	}
+}
+
+func TestCollapseRepeatedBlocks(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "a run of one line collapses",
+			in:   []string{"a", "a", "a", "a", "b"},
+			want: []string{"a", "... (previous line repeated 3 more times)", "b"},
+		},
+		{
+			name: "a doubled line is left alone",
+			in:   []string{"a", "a", "b"},
+			want: []string{"a", "a", "b"},
+		},
+		{
+			// Below the floor the marker costs more lines than it saves.
+			name: "a doubled block is left alone",
+			in:   []string{"a", "b", "a", "b", "c"},
+			want: []string{"a", "b", "a", "b", "c"},
+		},
+		{
+			name: "the shortest period wins",
+			in:   []string{"a", "a", "a", "a", "a", "a"},
+			want: []string{"a", "... (previous line repeated 5 more times)"},
+		},
+		{
+			name: "lines between runs survive",
+			in:   []string{"x", "a", "b", "a", "b", "a", "b", "y"},
+			want: []string{"x", "a", "b", "... (previous 2 lines repeated 2 more times)", "y"},
+		},
+		{
+			name: "nothing repeating is untouched",
+			in:   []string{"a", "b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			// A block longer than the cap is not a loop worth chasing.
+			name: "a period over the cap is left alone",
+			in:   append(append(longBlock(), longBlock()...), longBlock()...),
+			want: append(append(longBlock(), longBlock()...), longBlock()...),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collapseRepeatedBlocks(tt.in)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func longBlock() []string {
+	b := make([]string, runnerLogMaxPeriod+1)
+	for i := range b {
+		b[i] = fmt.Sprintf("l%d", i)
+	}
+	return b
+}
+
+func TestReadRunnerLogKeepsTheEndOfAFileWithoutNewlines(t *testing.T) {
+	// Nothing to split on, so the fragment published is chosen by the
+	// byte cap alone, and it has to be the end of the file.
+	body := strings.Repeat("q", runnerLogScanBytes+1<<20) + "last-thing-it-said"
+	dir := writeRunnerLog(t, body)
+
+	got := readRunnerLog(dir)
+
+	if len(got) > runnerLogTailBytes {
+		t.Fatalf("got %d bytes, want at most %d", len(got), runnerLogTailBytes)
+	}
+	if !strings.HasSuffix(got, "last-thing-it-said") {
+		t.Error("published a fragment from somewhere other than the end of the file")
+	}
+}

--- a/infra/tart-kubelet/internal/podagent/runner_log_test.go
+++ b/infra/tart-kubelet/internal/podagent/runner_log_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-func writeRunnerLog(t *testing.T, body string) string {
-	t.Helper()
-	dir := t.TempDir()
+func writeRunnerLog(tb testing.TB, body string) string {
+	tb.Helper()
+	dir := tb.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, runnerLogFile), []byte(body), 0o644); err != nil {
-		t.Fatalf("write runner log: %v", err)
+		tb.Fatalf("write runner log: %v", err)
 	}
 	return dir
 }
@@ -144,8 +144,8 @@ const hotLoopBlock = "runner-shell-agent-supervisor: removing stale lock at /tmp
 	"rm: /tmp/tuist-runner-shell-agent.lock/pid: Permission denied\n" +
 	"rm: /tmp/tuist-runner-shell-agent.lock: Permission denied\n"
 
-func hotLoopLog(t *testing.T, prefix []string, bytes int) string {
-	t.Helper()
+func hotLoopLog(tb testing.TB, prefix []string, bytes int) string {
+	tb.Helper()
 	var b strings.Builder
 	for _, l := range prefix {
 		b.WriteString(l)
@@ -154,7 +154,7 @@ func hotLoopLog(t *testing.T, prefix []string, bytes int) string {
 	for b.Len() < bytes {
 		b.WriteString(hotLoopBlock)
 	}
-	return writeRunnerLog(t, b.String())
+	return writeRunnerLog(tb, b.String())
 }
 
 func TestReadRunnerLogKeepsHistoryBehindARepeatingBlock(t *testing.T) {
@@ -302,4 +302,80 @@ func TestReadRunnerLogKeepsTheEndOfAFileWithoutNewlines(t *testing.T) {
 	if !strings.HasSuffix(got, "last-thing-it-said") {
 		t.Error("published a fragment from somewhere other than the end of the file")
 	}
+}
+
+func TestScanLinesStart(t *testing.T) {
+	if got := scanLinesStart([]byte("a\nb\nc")); got != 0 {
+		t.Errorf("window within the cap: got %d, want 0", got)
+	}
+
+	var b strings.Builder
+	for i := range runnerLogScanLines + 5 {
+		fmt.Fprintf(&b, "%d\n", i)
+	}
+	b.WriteString("last")
+	window := []byte(b.String())
+
+	start := scanLinesStart(window)
+
+	if start == 0 {
+		t.Fatal("over-long window not capped")
+	}
+	kept := strings.Split(string(window[start:]), "\n")
+	if len(kept) != runnerLogScanLines {
+		t.Errorf("kept %d lines, want %d", len(kept), runnerLogScanLines)
+	}
+	// Dropping from the wrong side would discard the tail the capture
+	// exists for.
+	if kept[len(kept)-1] != "last" {
+		t.Errorf("last kept line = %q, want the end of the window", kept[len(kept)-1])
+	}
+}
+
+func TestCollapseRepeatedBlocksKeepsItsTail(t *testing.T) {
+	var in []string
+	for i := range runnerLogTailLines * 10 {
+		in = append(in, fmt.Sprintf("line-%d", i))
+	}
+
+	got := collapseRepeatedBlocks(in)
+
+	if len(got) > 2*runnerLogTailLines {
+		t.Errorf("kept %d lines, want at most %d", len(got), 2*runnerLogTailLines)
+	}
+	if got[len(got)-1] != in[len(in)-1] {
+		t.Errorf("last line = %q, want %q", got[len(got)-1], in[len(in)-1])
+	}
+}
+
+// The guest picks this file's byte size and its line count independently,
+// so the shapes that cost the most are measured separately from the one
+// that actually shows up.
+func benchmarkReadRunnerLog(b *testing.B, body string) {
+	dir := writeRunnerLog(b, body)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = readRunnerLog(dir)
+	}
+}
+
+func BenchmarkReadRunnerLogHotLoop(b *testing.B) {
+	var s strings.Builder
+	for s.Len() < runnerLogScanBytes+1<<20 {
+		s.WriteString(hotLoopBlock)
+	}
+	benchmarkReadRunnerLog(b, s.String())
+}
+
+func BenchmarkReadRunnerLogMostlyNewlines(b *testing.B) {
+	benchmarkReadRunnerLog(b, strings.Repeat("\n", runnerLogScanBytes+1<<20)+"x")
+}
+
+func BenchmarkReadRunnerLogShortDistinctLines(b *testing.B) {
+	var s strings.Builder
+	for i := 0; s.Len() < runnerLogScanBytes+1<<20; i++ {
+		fmt.Fprintf(&s, "aaaaaaaaaaaa%d\n", i)
+	}
+	benchmarkReadRunnerLog(b, s.String())
 }

--- a/infra/tart-kubelet/internal/podagent/volume_reconcile.go
+++ b/infra/tart-kubelet/internal/podagent/volume_reconcile.go
@@ -140,9 +140,8 @@ func readRunnerExit(statusDir string) (int32, bool) {
 // own stdout before teardown deletes the share.
 //
 // Tail rather than head: the interesting part of a runner that gave up
-// is what it said last. Bounded twice because the file is guest-written
-// — by bytes first so a single pathological line cannot blow up the log
-// record, then by lines.
+// is what it said last. runnerLogTail reduces the scanned window to the
+// published line and byte budgets.
 //
 // Opened O_NOFOLLOW and required to be a regular file, because the guest
 // writes this path and the guest runs untrusted customer CI. A job that
@@ -171,24 +170,14 @@ func readRunnerLog(statusDir string) string {
 		return ""
 	}
 	offset := int64(0)
-	if fi.Size() > runnerLogTailBytes {
-		offset = fi.Size() - runnerLogTailBytes
+	if fi.Size() > runnerLogScanBytes {
+		offset = fi.Size() - runnerLogScanBytes
 	}
 	b := make([]byte, fi.Size()-offset)
 	if _, err := f.ReadAt(b, offset); err != nil {
 		return ""
 	}
-
-	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
-	// A byte-bounded read almost certainly starts mid-line; drop that
-	// fragment so the tail begins on a real record.
-	if offset > 0 && len(lines) > 1 {
-		lines = lines[1:]
-	}
-	if len(lines) > runnerLogTailLines {
-		lines = lines[len(lines)-runnerLogTailLines:]
-	}
-	return strings.Join(lines, "\n")
+	return runnerLogTail(string(b), offset > 0)
 }
 
 // readRunnerExitTime returns when the guest wrote its exit report, which

--- a/infra/tart-kubelet/internal/podagent/volume_reconcile.go
+++ b/infra/tart-kubelet/internal/podagent/volume_reconcile.go
@@ -177,7 +177,7 @@ func readRunnerLog(statusDir string) string {
 	if _, err := f.ReadAt(b, offset); err != nil {
 		return ""
 	}
-	return runnerLogTail(string(b), offset > 0)
+	return runnerLogTail(b, offset > 0)
 }
 
 // readRunnerExitTime returns when the guest wrote its exit report, which


### PR DESCRIPTION
`readRunnerLog` publishes a bounded tail of the guest's mirrored log so macOS runner deaths can be diagnosed (#12492). It bounds by bytes (64 KiB) first, then by lines (200).

A supervisor bug retries a refused stale-lock removal with no backoff, emitting the same three lines many times per second. On 11-71% of captured runner logs per 6h bucket (median ~38%, 2026-08-22..24) the **entire** 64 KiB window is that one loop, so the published tail carries the loop and nothing about what the runner actually did.

Measured on datasource `grafanacloud-logs`:

```
sum(count_over_time({job="tuist-macos-tart-kubelet"} |= "runner log" |= "removing stale lock" [6h]))
/ sum(count_over_time({job="tuist-macos-tart-kubelet"} |= "runner log" [6h]))
```

The supervisor loop is being fixed separately. This is the capture side, so that one chatty process cannot make the capture useless on its own.

## What changed

`readRunnerLog` now reads a 16 MiB window, and a new `runnerLogTail` (`internal/podagent/runner_log.go`) reduces it to the published tail: drop the partial first line, cap scanned lines, collapse consecutively repeating blocks to one copy plus a count, apply the 200-line budget, then apply the 64 KiB byte cap.

## Blocks, not adjacent equal lines

Collapsing adjacent equal lines is the obvious shape and it fixes nothing here. The loop is a three-line cycle:

```
runner-shell-agent-supervisor: removing stale lock at /tmp/tuist-runner-shell-agent.lock
rm: /tmp/tuist-runner-shell-agent.lock/pid: Permission denied
rm: /tmp/tuist-runner-shell-agent.lock: Permission denied
```

No line ever follows itself, so single-line dedup finds zero to collapse. The collapse therefore detects a repeating *block*: the shortest period up to 8 lines wins, and a run needs 3 repeats before it is rewritten, below which the marker costs more lines than the repetition does. Shape-based matching that ignores timestamps was rejected as guessy, and it would destroy the count fidelity.

A collapsed run reads:

```
2026-08-24T02:05:52Z runner-shell-agent-supervisor: removing stale lock at /tmp/...
rm: /tmp/tuist-runner-shell-agent.lock/pid: Permission denied
rm: /tmp/tuist-runner-shell-agent.lock: Permission denied
... (previous 3 lines repeated 1499 more times)
```

Keeping the count matters: the repetition is itself the finding, and a tail that hid it would send the next reader looking for a quiet runner.

## Why 16 MiB

Sized to the line budget, not to the file. `runner-shell-agent-supervisor.sh` stamps `$(date -u +%FT%TZ)` on its own line, so the block changes once a second and the loop costs about 4 published lines per second. 200 lines therefore buys roughly 50 seconds of wall clock, which at observed loop rates is about 16 MiB of log. A wider window buys nothing, because the 200-line budget binds first.

The cost is one sequential read plus a linear pass, paid once per VM teardown (`readRunnerLog` runs only on the two teardown paths), not per reconcile tick. Measured on 17 MiB inputs: about 9 ms on the production shape, about 150 ms worst case on adversarial input built to defeat the period search.

Verified end to end on a synthetic 131 MiB log at 1500 iterations/s with the real timestamped block: 197 lines / 13.7 KB spanning about 49 seconds of wall clock, against about 0.2 seconds today.

## Bounds

The file is guest-written by untrusted customer CI, so what reaches Loki stays hard bounded:

- 200 lines and 64 KiB, unchanged, and the byte cap now runs **last**. The rewrites above it only shrink guest-chosen input, they do not bound it, so the cap has to be the final step.
- A new scanned-line cap bounds the collapse's work. It binds only below about 16 bytes per line, which no real runner log reaches.
- `O_RDONLY|O_NOFOLLOW|O_NONBLOCK` and the `fi.Mode().IsRegular()` check are untouched (19329b21b7). The diff to `volume_reconcile.go` is 11 net lines and starts below the guards.

One behaviour preserved deliberately: a lone over-long line keeps its end rather than its head, so a log with no newlines at all still publishes the bytes nearest EOF, as it does today.

## Relationship to #12496

#12496 refactored these same guards into `openGuestFile`. It merged while this was in review (`a27c490e3e`), and `main` is merged in here: the two compose as expected, with its `openGuestFile` prologue keeping `O_NOFOLLOW`, `O_NONBLOCK` and the regular-file check, and this change owning the window below it. `gofmt`, `go vet`, `go build` and the podagent suite pass on the merged result.

## Bounding the scan (review follow-up)

Review caught that the scanned-line cap was applied *after* `strings.Split` had already allocated a header per line, so it bounded nothing that mattered. `ff43eb7ce8` selects the last `runnerLogScanLines` records with a backward pass before splitting, takes the window as `[]byte` so the discarded prefix is never copied into a string, and stops `collapseRepeatedBlocks` accumulating more than it can publish.

Peak allocation for one `readRunnerLog` call, on 17 MiB inputs:

| shape | before | after |
| --- | --- | --- |
| mostly newlines | 302 MB / 436 ms | 34.6 MB / 17 ms |
| short distinct lines | 118 MB / 70 ms | 47.7 MB / 48 ms |
| production hot loop | | 37.4 MB / 14 ms |

Reproduce with `go test ./internal/podagent/ -run XXX -bench BenchmarkReadRunnerLog -benchmem`. What gets published is unchanged.

## Limitation

Because the supervisor stamps its own line per second, coverage caps around 50 seconds regardless of window size. That is a large gain over the roughly 0.2 seconds spanned today, but only fixing the loop itself recovers more.

## Impact

Host side only. No runner-image rebuild: this is tart-kubelet, which rides the CAPI operator image and reaches hosts on an SSH drift roll. The guest half of the capture is already live.

### How to test locally

```bash
cd infra/tart-kubelet && gofmt -l internal/ && go vet ./... && go build ./... && go test ./...
```

`TestReadRunnerLogKeepsHistoryBehindARepeatingBlock` is the production case: a log whose last bytes are one repeated block preceded by distinct earlier lines. It fails on `main` (every earlier line is lost) and passes here. The eight pre-existing `readRunnerLog` tests are unmodified.

