### PR TITLE
docs(handbook): require reviews to name the separation limitation, not a second signature

### DIFF
--- a/handbook/handbook/security/secure-development-and-operations/logging-and-monitoring-policy.md
+++ b/handbook/handbook/security/secure-development-and-operations/logging-and-monitoring-policy.md
@@ -97,7 +97,7 @@ Logs shall be reviewed periodically. Review frequency is driven by the risk of t
 | Internal tooling and collaboration systems | Restricted | Quarterly |
 | Public-facing marketing and documentation systems | Public | Annually |
 
-Reviews shall be performed by a person other than the primary operator of the system under review wherever staffing allows. Where the size of the team makes full separation impractical, the review shall be documented and countersigned by a second reviewer.
+Reviews shall be performed by a person other than the primary operator of the system under review wherever staffing allows. At the current team size that separation is not achievable for most production systems, so where the reviewer is also an operator of a system under review, the review shall state that limitation explicitly alongside its findings. Naming the limitation in each record is what a reader needs in order to weigh the review, and it is a requirement this team can actually meet, which a second signature on every monthly review is not.
 
 Each review shall be recorded with the reviewer, the date, the period covered, the sources examined, and the findings. Records of reviews shall be retained for at least one year and serve as evidence of compliance.
 


### PR DESCRIPTION
The log review clause in the Logging and monitoring policy required that, where full separation of duties is impractical, the review be countersigned by a second reviewer.

At four people the reviewer is an operator of nearly every system under review, so that fallback is not the exception, it is the normal case. It applies to essentially every monthly review, and a second signature on each one is not something this team will sustain.

That leaves the worst of both outcomes: the control does not get performed, and every completed review reads as non-compliant against our own policy. The first log review under this policy hit exactly that, and the record went out with the limitation described in prose but no second signature.

## What changed

The requirement is now that the review states the limitation explicitly alongside its findings, rather than carrying a second signature.

That is checkable from the record itself, it is what a reader needs in order to weigh the review, and it is met by the reviews we actually complete rather than aspired to.

Separation of duties is still preferred wherever staffing allows. Only the fallback changed.

## Validation

`mise run build` in `handbook/` completes, which also verifies no dead links.
