### PR TITLE
feat(server): validate licenses with Atlas

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35d76794b53a6a0577a17df5267c01f210145ab4a6b9a5b58b67a72d4f5ee17f",
+  "originHash" : "4c6897375e79ffa718a691c19c62ba3ee61dfadb9540342f26fdb8e3ff19f36b",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -528,8 +528,10 @@ License env vars. Resolves to one mutually exclusive source:
 {{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
 {{- $useEsoKey := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
 {{- $useEsoCertificate := ne (.Values.server.externalSecrets.license.certificateItem | default "") "" -}}
+{{- $useEsoVerifyKey := ne (.Values.server.externalSecrets.license.verifyKeyItem | default "") "" -}}
 {{- $useInlineKey := ne (.Values.server.license.key | default "") "" -}}
 {{- $useInlineCertificate := ne (.Values.server.license.certificateBase64 | default "") "" -}}
+{{- $useInlineVerifyKey := ne (.Values.server.license.verifyKey | default "") "" -}}
 {{- if and $useEsoKey $useEsoCertificate -}}
 {{- fail "server.externalSecrets.license.item and server.externalSecrets.license.certificateItem are mutually exclusive; pick one license source." -}}
 {{- end -}}
@@ -555,6 +557,13 @@ License env vars. Resolves to one mutually exclusive source:
     secretKeyRef:
       name: {{ ternary $esoSecret $appSecret $useEsoCertificate | quote }}
       key: server-license-certificate-base64
+{{- end }}
+{{- if or $useEsoVerifyKey $useInlineVerifyKey }}
+- name: TUIST_LICENSE_VERIFY_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ ternary $esoSecret $appSecret $useEsoVerifyKey | quote }}
+      key: server-license-verify-key
 {{- end }}
 {{- end -}}
 

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -38,6 +38,9 @@ stringData:
   {{- if .Values.server.license.certificateBase64 }}
   server-license-certificate-base64: {{ .Values.server.license.certificateBase64 | quote }}
   {{- end }}
+  {{- if .Values.server.license.verifyKey }}
+  server-license-verify-key: {{ .Values.server.license.verifyKey | quote }}
+  {{- end }}
   {{- if and .Values.processor.enabled (not .Values.processor.managedSecrets) .Values.processor.databaseUrl }}
   processor-database-url: {{ .Values.processor.databaseUrl | quote }}
   {{- end }}

--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -1,6 +1,7 @@
 {{- $syncLicenseKey := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
 {{- $syncLicenseCertificate := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.certificateItem | default "") "") -}}
-{{- $syncLicense := or $syncLicenseKey $syncLicenseCertificate -}}
+{{- $syncLicenseVerifyKey := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.verifyKeyItem | default "") "") -}}
+{{- $syncLicense := or $syncLicenseKey $syncLicenseCertificate $syncLicenseVerifyKey -}}
 {{- $syncCacheGrant := and .Values.server.enabled (ne (.Values.server.externalSecrets.cacheGrant.item | default "") "") -}}
 {{- $serverKuraIntrospection := .Values.server.externalSecrets.kuraIntrospection -}}
 {{- $kuraSharedSecrets := .Values.kuraController.sharedSecrets -}}
@@ -59,6 +60,9 @@ spec:
         {{- if $syncLicenseCertificate }}
         server-license-certificate-base64: "{{ `{{ .server_license_certificate_base64 | trim }}` }}"
         {{- end }}
+        {{- if $syncLicenseVerifyKey }}
+        server-license-verify-key: "{{ `{{ .server_license_verify_key | trim }}` }}"
+        {{- end }}
         {{- if $syncCacheGrant }}
         cache-grant-private-key: "{{ `{{ .cache_grant_private_key | trim }}` }}"
         {{- end }}
@@ -83,6 +87,11 @@ spec:
     - secretKey: server_license_certificate_base64
       remoteRef:
         key: "{{ .Values.server.externalSecrets.license.certificateItem }}/{{ .Values.server.externalSecrets.license.certificateField | default "password" }}"
+    {{- end }}
+    {{- if $syncLicenseVerifyKey }}
+    - secretKey: server_license_verify_key
+      remoteRef:
+        key: "{{ .Values.server.externalSecrets.license.verifyKeyItem }}/{{ .Values.server.externalSecrets.license.verifyKeyField | default "password" }}"
     {{- end }}
     {{- if $syncCacheGrant }}
     - secretKey: cache_grant_private_key

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -70,6 +70,9 @@ server:
   externalSecrets:
     # The offline-certificate license config is now the shared default in
     # values-managed-common.yaml, so production no longer overrides it here.
+    license:
+      verifyKeyItem: TUIST_LICENSE_VERIFY_KEY
+      verifyKeyField: password
     cacheGrant:
       item: TUIST_CACHE_GRANT_PRIVATE_KEY
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -437,12 +437,15 @@ server:
       name: onepassword
     # Sync either the online Tuist license key or the air-gapped license
     # certificate from the external store. These sources are mutually
-    # exclusive. Leave both item names empty to skip license sync.
+    # exclusive. The optional verify key lets air-gapped certificates signed
+    # by an additional issuer validate during a key rotation.
     license:
       item: ""
       field: password
       certificateItem: ""
       certificateField: password
+      verifyKeyItem: ""
+      verifyKeyField: password
     # Cache-signing grant private key: a PEM Ed25519 key the
     # server signs runner cache grants with. Leave item empty to disable
     # grant minting (dispatch omits the grant; CLI falls back to the MAC
@@ -600,6 +603,7 @@ server:
   license:
     key: ""
     certificateBase64: ""
+    verifyKey: ""
     selfHostingDevelopmentMode: false
   database:
     ssl: false

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -486,6 +486,10 @@ defmodule Tuist.Environment do
       get([:license, :certificate, :base64], secrets)
   end
 
+  def license_verify_key(secrets \\ secrets()) do
+    System.get_env("TUIST_LICENSE_VERIFY_KEY") || get([:license, :verify_key], secrets)
+  end
+
   def use_ipv6?(secrets \\ secrets()) do
     get([:use_ipv6], secrets)
   end

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -237,9 +237,7 @@ defmodule Tuist.License do
         {:ok, license}
 
       {:fallback, reason} ->
-        Logger.warning(
-          "Atlas did not validate the license (#{inspect(reason)}); falling back to Keygen."
-        )
+        Logger.warning("Atlas did not validate the license (#{inspect(reason)}); falling back to Keygen.")
 
         resolve_license_from_keygen(key)
     end

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -7,13 +7,18 @@ defmodule Tuist.License do
 
   require Logger
 
-  @validation_url "https://api.keygen.sh/v1/accounts/cce51171-9339-4430-8441-73bb5abd9a5c/licenses/actions/validate-key"
+  @atlas_validation_url "https://atlas.tuist.dev/api/licenses/actions/validate-key"
+  @keygen_validation_url "https://api.keygen.sh/v1/accounts/cce51171-9339-4430-8441-73bb5abd9a5c/licenses/actions/validate-key"
 
   @enforce_keys [:id, :features, :expiration_date, :valid]
   defstruct [:id, :features, :expiration_date, :valid, :signing_key]
 
   def get_validation_url do
-    @validation_url
+    @atlas_validation_url
+  end
+
+  def get_keygen_validation_url do
+    @keygen_validation_url
   end
 
   def sign(value) when is_binary(value) do
@@ -59,6 +64,12 @@ defmodule Tuist.License do
     "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
   end
 
+  def ed25519_verify_keys do
+    [Tuist.Environment.license_verify_key(), ed25519_verify_key()]
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> Enum.uniq()
+  end
+
   def certificate(encoded \\ Tuist.Environment.license_certificate_base64()) do
     Base.decode64!(encoded, ignore: :whitespace)
   end
@@ -70,7 +81,7 @@ defmodule Tuist.License do
 
   Supports Keygen offline license format with Ed25519 signatures.
   """
-  def resolve_certificate(verify_key \\ ed25519_verify_key(), certificate \\ certificate()) do
+  def resolve_certificate(verify_keys \\ ed25519_verify_keys(), certificate \\ certificate()) do
     cert_content =
       certificate
       |> String.replace(~r/-----.*?-----/s, "")
@@ -81,10 +92,10 @@ defmodule Tuist.License do
          {:ok, payload} <- JSON.decode(decoded) do
       case payload do
         %{"enc" => enc_data, "sig" => sig_data, "alg" => alg} ->
-          verify_and_build_license(verify_key, enc_data, sig_data, alg)
+          verify_and_build_license(verify_keys, enc_data, sig_data, alg)
 
         %{"data" => data, "sig" => sig, "alg" => alg} ->
-          verify_and_build_license(verify_key, data, sig, alg)
+          verify_and_build_license(verify_keys, data, sig, alg)
 
         _ ->
           {:error, "Invalid certificate format - missing required fields"}
@@ -98,10 +109,10 @@ defmodule Tuist.License do
     end
   end
 
-  defp verify_and_build_license(verify_key, enc_data, signature, _algorithm) do
-    with {:ok, public_key} <- Base.decode16(verify_key, case: :lower),
+  defp verify_and_build_license(verify_keys, enc_data, signature, _algorithm) do
+    with {:ok, public_keys} <- decode_verify_keys(verify_keys),
          {:ok, sig_binary} <- Base.decode64(signature),
-         :ok <- verify_license_signature(public_key, enc_data, sig_binary),
+         :ok <- verify_license_signature(public_keys, enc_data, sig_binary),
          {:ok, decoded} <- decode_license_data(enc_data),
          {:ok, license_data} <- decode_license_json(decoded) do
       build_license_struct(license_data)
@@ -120,8 +131,23 @@ defmodule Tuist.License do
     end
   end
 
-  defp verify_license_signature(public_key, enc_data, signature) do
-    if :crypto.verify(:eddsa, :none, "license/" <> enc_data, signature, [public_key, :ed25519]) do
+  defp decode_verify_keys(verify_keys) do
+    public_keys =
+      verify_keys
+      |> List.wrap()
+      |> Enum.map(&Base.decode16(&1, case: :lower))
+
+    if Enum.all?(public_keys, &match?({:ok, _}, &1)) do
+      {:ok, Enum.map(public_keys, fn {:ok, public_key} -> public_key end)}
+    else
+      :error
+    end
+  end
+
+  defp verify_license_signature(public_keys, enc_data, signature) do
+    if Enum.any?(public_keys, fn public_key ->
+         :crypto.verify(:eddsa, :none, "license/" <> enc_data, signature, [public_key, :ed25519])
+       end) do
       :ok
     else
       {:error, :invalid_signature}
@@ -206,29 +232,49 @@ defmodule Tuist.License do
   end
 
   def resolve_license(key) when not is_nil(key) do
-    Logger.debug("Validating the license against the Keygen API...")
+    case resolve_license_from_atlas(key) do
+      {:ok, license} ->
+        {:ok, license}
 
-    url =
-      "https://api.keygen.sh/v1/accounts/cce51171-9339-4430-8441-73bb5abd9a5c/licenses/actions/validate-key"
+      {:fallback, reason} ->
+        Logger.warning(
+          "Atlas did not validate the license (#{inspect(reason)}); falling back to Keygen."
+        )
 
+        resolve_license_from_keygen(key)
+    end
+  end
+
+  defp resolve_license_from_atlas(key) do
+    Logger.debug("Validating the license against Atlas...")
+
+    case validate_license(@atlas_validation_url, key) do
+      {:ok, %{"data" => nil}} ->
+        {:fallback, :license_not_found}
+
+      {:ok, payload} ->
+        case build_license(payload) do
+          {:ok, license} -> {:ok, license}
+          {:error, reason} -> {:fallback, reason}
+        end
+
+      {:error, reason} ->
+        {:fallback, reason}
+    end
+  end
+
+  defp resolve_license_from_keygen(key) do
+    Logger.debug("Validating the license against Keygen...")
+
+    with {:ok, payload} <- validate_license(@keygen_validation_url, key) do
+      build_license(payload)
+    end
+  end
+
+  defp validate_license(url, key) do
     case Req.post(url, json: %{meta: %{key: key}}) do
       {:ok, %{body: payload, status: status}} when status in 200..299 ->
-        # When the license doesn't exist, keygen's API returns a 2xx response with "data" set to nil in the payload.
-        if is_nil(payload["data"]) do
-          {:ok, nil}
-        else
-          signing_key =
-            (payload["data"]["attributes"]["metadata"] || %{})["signingKey"]
-
-          {:ok,
-           %__MODULE__{
-             valid: payload["meta"]["valid"],
-             id: payload["data"]["id"],
-             features: [],
-             expiration_date: Timex.parse!(payload["data"]["attributes"]["expiry"], "{RFC3339}"),
-             signing_key: signing_key
-           }}
-        end
+        {:ok, payload}
 
       {:ok, %{status: status}} when status in 400..599 ->
         {:error, "The server to validate the license responded with a #{status} status code."}
@@ -237,4 +283,24 @@ defmodule Tuist.License do
         {:error, inspect(error)}
     end
   end
+
+  defp build_license(%{"data" => nil}), do: {:ok, nil}
+
+  defp build_license(%{
+         "data" => %{"id" => id, "attributes" => %{"expiry" => expiry} = attributes},
+         "meta" => %{"valid" => valid}
+       }) do
+    signing_key = (attributes["metadata"] || %{})["signingKey"]
+
+    {:ok,
+     %__MODULE__{
+       valid: valid,
+       id: id,
+       features: [],
+       expiration_date: Timex.parse!(expiry, "{RFC3339}"),
+       signing_key: signing_key
+     }}
+  end
+
+  defp build_license(_payload), do: {:error, :invalid_license_response}
 end

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -46,10 +46,15 @@ defmodule Tuist.LicenseTest do
 
     test "returns nil when API returns nil data" do
       validation_url = License.get_validation_url()
+      keygen_validation_url = License.get_keygen_validation_url()
       license_key = UUIDv7.generate()
 
-      stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
-        {:ok, %{status: 200, body: %{"data" => nil}}}
+      stub(Req, :post, fn
+        ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 200, body: %{"data" => nil}}}
+
+        ^keygen_validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 200, body: %{"data" => nil}}}
       end)
 
       result = License.resolve_license(license_key)
@@ -86,30 +91,113 @@ defmodule Tuist.LicenseTest do
       assert license.id == "1234"
     end
 
-    test "returns error when the server responds with error status" do
+    test "falls back to Keygen when Atlas does not recognize the license" do
       validation_url = License.get_validation_url()
+      keygen_validation_url = License.get_keygen_validation_url()
+      expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
       license_key = UUIDv7.generate()
 
-      stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
-        {:ok, %{status: 500}}
+      stub(Req, :post, fn
+        ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 200, body: %{"data" => nil}}}
+
+        ^keygen_validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok,
+           %{
+             status: 200,
+             body: %{
+               "data" => %{
+                 "id" => "1234",
+                 "attributes" => %{"expiry" => expiry}
+               },
+               "meta" => %{"valid" => true}
+             }
+           }}
       end)
 
-      result = License.resolve_license(license_key)
+      {:ok, license} = License.resolve_license(license_key)
 
-      assert {:error, "The server to validate the license responded with a 500 status code."} = result
+      assert license.valid == true
+      assert license.id == "1234"
     end
 
-    test "returns error when the Req errors" do
+    test "falls back to Keygen when Atlas responds with an error status" do
       validation_url = License.get_validation_url()
+      keygen_validation_url = License.get_keygen_validation_url()
+      expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
       license_key = UUIDv7.generate()
 
-      stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
-        {:error, "req error."}
+      stub(Req, :post, fn
+        ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 500}}
+
+        ^keygen_validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok,
+           %{
+             status: 200,
+             body: %{
+               "data" => %{
+                 "id" => "1234",
+                 "attributes" => %{"expiry" => expiry}
+               },
+               "meta" => %{"valid" => true}
+             }
+           }}
+      end)
+
+      {:ok, license} = License.resolve_license(license_key)
+
+      assert license.valid == true
+      assert license.id == "1234"
+    end
+
+    test "returns an error when Keygen also responds with an error status" do
+      validation_url = License.get_validation_url()
+      keygen_validation_url = License.get_keygen_validation_url()
+      license_key = UUIDv7.generate()
+
+      stub(Req, :post, fn
+        ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 500}}
+
+        ^keygen_validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok, %{status: 500}}
       end)
 
       result = License.resolve_license(license_key)
 
-      assert {:error, "\"req error.\""} = result
+      assert {:error, "The server to validate the license responded with a 500 status code."} =
+               result
+    end
+
+    test "falls back to Keygen when the Atlas request errors" do
+      validation_url = License.get_validation_url()
+      keygen_validation_url = License.get_keygen_validation_url()
+      expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
+      license_key = UUIDv7.generate()
+
+      stub(Req, :post, fn
+        ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:error, "atlas error"}
+
+        ^keygen_validation_url, [json: %{meta: %{key: ^license_key}}] ->
+          {:ok,
+           %{
+             status: 200,
+             body: %{
+               "data" => %{
+                 "id" => "1234",
+                 "attributes" => %{"expiry" => expiry}
+               },
+               "meta" => %{"valid" => true}
+             }
+           }}
+      end)
+
+      {:ok, license} = License.resolve_license(license_key)
+
+      assert license.valid == true
+      assert license.id == "1234"
     end
   end
 
@@ -158,6 +246,39 @@ defmodule Tuist.LicenseTest do
       assert license.id == "test-license-id"
       assert license.valid == true
       assert license.signing_key == "test-signing-key-base64"
+    end
+
+    test "returns valid license when certificate is signed by one of the trusted verify keys" do
+      {trusted_public_key, _trusted_private_key} = :crypto.generate_key(:eddsa, :ed25519)
+      {atlas_public_key, atlas_private_key} = :crypto.generate_key(:eddsa, :ed25519)
+
+      verify_keys = [
+        Base.encode16(atlas_public_key, case: :lower),
+        Base.encode16(trusted_public_key, case: :lower)
+      ]
+
+      license_payload = %{
+        "data" => %{
+          "id" => "test-license-id",
+          "attributes" => %{
+            "expiry" => DateTime.utc_now() |> DateTime.shift(day: 1) |> DateTime.to_iso8601(),
+            "metadata" => %{"signingKey" => "test-signing-key-base64"}
+          }
+        }
+      }
+
+      encoded_data = license_payload |> JSON.encode!() |> Base.encode64()
+
+      signature =
+        :crypto.sign(:eddsa, :none, "license/" <> encoded_data, [atlas_private_key, :ed25519])
+
+      certificate =
+        %{"enc" => encoded_data, "sig" => Base.encode64(signature), "alg" => "base64+ed25519"}
+        |> JSON.encode!()
+        |> Base.encode64()
+
+      assert {:ok, license} = License.resolve_certificate(verify_keys, certificate)
+      assert license.id == "test-license-id"
     end
 
     test "returns error when signature is invalid" do


### PR DESCRIPTION
## What changed

- Validate online license keys with Atlas before falling back to Keygen.
- Accept air-gapped certificates signed by Atlas while retaining the existing Keygen verification key.
- Synchronize the additional verification key from 1Password into the production server deployment.

## Why

Atlas now issues Tuist licenses. The server needs to validate Atlas licenses online and in air-gapped environments without invalidating the deployed Keygen certificate.

## Approach

The server treats the Atlas verification key as an additional trusted signer rather than replacing the Keygen signer. This permits a staged certificate rotation while preserving the current production certificate.

## Impact

Online validation uses Atlas when it recognizes the license and retains Keygen as a fallback. Air-gapped validation accepts certificates signed by either trusted signer during the migration.

## Validation

- `mix test test/tuist/license_test.exs` (15 passed)
- Rendered the production Helm chart with `values-managed-common.yaml`, `values-managed-production.yaml`, and `values-ci.yaml`.
- Generated a disposable certificate with the production Atlas signer and validated it with Tuist without exposing key material.
