### PR TITLE
fix(slack): copy noora web-component sources into the image build

### DIFF
--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -13,6 +13,8 @@ RUN npm install -g --ignore-scripts=false @endevco/aube@1.6.2
 COPY noora/package.json noora/aube-lock.yaml /app/noora/
 COPY noora/js/ /app/noora/js/
 COPY noora/css/ /app/noora/css/
+COPY noora/components/ /app/noora/components/
+COPY noora/scripts/ /app/noora/scripts/
 COPY noora/lib/ /app/noora/lib/
 COPY noora/mix.exs noora/README.md /app/noora/
 


### PR DESCRIPTION
## What changed

`slack/Dockerfile` now copies `noora/components/` and `noora/scripts/` into the `npm-deps` stage.

## Why

The Slack Deployment workflow has failed on every run since 2026-07-27 ([run 32716797643](https://github.com/tuist/tuist/actions/runs/32716797643) is the latest), with:

```
Error: Cannot find module '/app/noora/scripts/generate-web-components.js'
ERROR: process "/bin/sh -c aube run build" did not complete successfully: exit code: 1
```

### Root cause

`slack/Dockerfile` copies a hand-picked subset of `noora/` (`package.json`, `aube-lock.yaml`, `js/`, `css/`, `lib/`, `mix.exs`, `README.md`) rather than the whole directory. That subset was correct until [#12079](https://github.com/tuist/tuist/pull/12079) made noora's `build` script run `generate:web-components` first:

```json
"build": "aube run generate:web-components && aube run build:js && ..."
```

The generator lives in `noora/scripts/` and reads its component contracts from `noora/components/` — neither of which the Slack image ever copied. So the very first step of `aube run build` failed on a missing module. Since the workflow triggers on `noora/**` as well as `slack/**`, unrelated noora changes have been kicking off — and failing — this deploy for a month.

The other two consumers of these sources were already correct: `server/Dockerfile` copies the whole `noora` directory, and `noora/storybook/Dockerfile` explicitly copies `scripts/`.

### Why this fix over the alternatives

Copying just the two missing directories keeps the existing narrow-copy approach, which exists so unrelated noora churn doesn't bust the Docker layer cache. Switching Slack to `COPY noora /noora` like the server does would also work, but would widen cache invalidation for no benefit here.

The generator's remaining input, `lib/noora/icons`, is already covered by the existing `noora/lib/` copy. Everything it writes (`types/`, `docs/`, `js/web-components/`, `custom-elements.json`, `storybook/`) is emitted with `mkdir -p` semantics, so no output directories need to pre-exist.

## Impact

The Slack invitation app has not shipped a new image since 2026-07-24; production is running that build. Merging this unblocks the deploy pipeline. No runtime behavior changes — only which files reach the asset-build stage.

## Validation

Built the full image locally from a clean context:

```
docker build -f slack/Dockerfile .
```

It now runs `aube run build` successfully (all five esbuild bundles emitted, including `noora-web-components.js`) and completes through `mix assets.deploy`, `mix compile --warnings-as-errors`, and `mix release`. On `main` the same command fails at the same step CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)