### PR TITLE
fix(cli): use native Objective-C resource accessors

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
@@ -4,8 +4,8 @@ import Path
 import TuistConstants
 import XcodeGraph
 
-/// A file Tuist writes into a target's Derived directory to expose `Bundle.module` (and the
-/// SwiftPM-compatible C entry point) to the target's own sources.
+/// A file Tuist writes into a target's Derived directory to expose `Bundle.module` to the target's
+/// own sources.
 public struct SynthesizedBundleAccessorFile {
     public let path: AbsolutePath
     public let contents: Data?
@@ -16,13 +16,11 @@ public struct SynthesizedBundleAccessorFile {
     }
 }
 
-/// Renders the Swift / Objective-C accessor files Tuist injects so that user code can reach the
-/// companion resource bundle via `Bundle.module` — mirroring the shape SwiftPM produces.
+/// Renders the Swift accessor files Tuist injects so that user code can reach the companion
+/// resource bundle via `Bundle.module` — mirroring the shape Swift Package Manager produces.
 @Mockable
 public protocol BundleAccessorTemplating {
     func swiftAccessor(target: Target, bundleName: String, project: Project) -> SynthesizedBundleAccessorFile
-    func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile
-    func objcAccessorImplementation(target: Target, bundleName: String, project: Project) -> SynthesizedBundleAccessorFile
 }
 
 public struct BundleAccessorTemplate: BundleAccessorTemplating {
@@ -38,26 +36,6 @@ public struct BundleAccessorTemplate: BundleAccessorTemplating {
             .appending(components: Constants.DerivedDirectory.sources, filename)
         let contents = Self.swiftAccessorContents(target: target, bundleName: bundleName, project: project)
         return SynthesizedBundleAccessorFile(path: path, contents: contents.data(using: .utf8))
-    }
-
-    public func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile {
-        let path = Self.objcAccessorPath(target: target, project: project, fileExtension: "h")
-        return SynthesizedBundleAccessorFile(
-            path: path,
-            contents: Self.objcHeaderContents(targetName: target.name).data(using: .utf8)
-        )
-    }
-
-    public func objcAccessorImplementation(
-        target: Target,
-        bundleName: String,
-        project: Project
-    ) -> SynthesizedBundleAccessorFile {
-        let path = Self.objcAccessorPath(target: target, project: project, fileExtension: "m")
-        return SynthesizedBundleAccessorFile(
-            path: path,
-            contents: Self.objcImplementationContents(targetName: target.name, bundleName: bundleName).data(using: .utf8)
-        )
     }
 
     // MARK: - Rendering
@@ -85,86 +63,7 @@ public struct BundleAccessorTemplate: BundleAccessorTemplating {
         """
     }
 
-    static func objcHeaderContents(targetName: String) -> String {
-        let identifier = targetName.toValidSwiftIdentifier()
-        return """
-        #import <Foundation/Foundation.h>
-
-        #if __cplusplus
-        extern "C" {
-        #endif
-
-        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
-
-        #define SWIFTPM_MODULE_BUNDLE \(identifier)_SWIFTPM_MODULE_BUNDLE()
-
-        #if __cplusplus
-        }
-        #endif
-        """
-    }
-
-    static func objcImplementationContents(targetName: String, bundleName: String) -> String {
-        let identifier = targetName.toValidSwiftIdentifier()
-        return """
-        #import <Foundation/Foundation.h>
-        #import "TuistBundle+\(targetName).h"
-
-        @interface \(identifier)BundleFinder : NSObject
-        @end
-
-        @implementation \(identifier)BundleFinder
-        @end
-
-        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) {
-            NSString *bundleName = @"\(bundleName)";
-
-            NSURL *bundleURL = [[NSBundle bundleForClass:\(identifier)BundleFinder.self] resourceURL];
-            NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
-                                          [[NSBundle mainBundle] resourceURL],
-                                          bundleURL,
-                                          [[NSBundle mainBundle] bundleURL],
-                                          nil];
-
-            NSString* override = [[[NSProcessInfo processInfo] environment] objectForKey:@"PACKAGE_RESOURCE_BUNDLE_PATH"];
-            if (override) {
-                [candidates addObject:override];
-
-                NSString *subpaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:override error:nil];
-                if (subpaths) {
-                    for (NSString *subpath in subpaths) {
-                        if ([subpath hasSuffix:@".framework"]) {
-                            [candidates addObject:[NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@", override, subpath]]];
-                        }
-                    }
-                }
-            }
-
-            #if __has_include(<XCTest/XCTest.h>)
-            [candidates addObject:[bundleURL URLByAppendingPathComponent:@".."]];
-            #endif
-
-            for (NSURL *candidate in candidates) {
-                NSURL *bundlePath = [candidate URLByAppendingPathComponent:[NSString stringWithFormat:@"%@%@", bundleName, @".bundle"]];
-                NSBundle *bundle = [NSBundle bundleWithURL:bundlePath];
-
-                if (bundle) {
-                    return bundle;
-                }
-            }
-
-            [NSException raise:@"BundleNotFound" format:nil];
-        }
-        """
-    }
-
     // MARK: - Helpers
-
-    private static func objcAccessorPath(target: Target, project: Project, fileExtension: String) -> AbsolutePath {
-        let filename = "TuistBundle+\(target.name.uppercasingFirst).\(fileExtension)"
-        return project.derivedDirectoryPath(for: target)
-            .appending(components: Constants.DerivedDirectory.sources, filename)
-    }
 
     private static func swiftAccessorPreamble(
         target: Target,

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -58,13 +58,15 @@ public struct ResourcesProjectMapper: ProjectMapping {
             return ([target], [])
         }
 
+        let objcResourceAccessorNeeded = targetNeedsObjcResourceAccessor(target)
         let bundleName = "\(project.name)_\(target.name.sanitizedModuleName)"
+        let resourceBundleName = objcResourceAccessorNeeded ? bundleName.asLegalCIdentifier : bundleName
         var modifiedTarget = target
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 
         if targetNeedsCompanionBundle(target) {
-            let companion = synthesizeCompanionBundle(for: target, bundleName: bundleName)
+            let companion = synthesizeCompanionBundle(for: target, bundleName: resourceBundleName)
             modifiedTarget = companion.modifiedTarget
             additionalTargets.append(companion.bundleTarget)
         }
@@ -75,14 +77,14 @@ public struct ResourcesProjectMapper: ProjectMapping {
                 sideEffects: &sideEffects,
                 target: target,
                 project: project,
-                bundleName: bundleName
+                bundleName: resourceBundleName
             )
             if targetNeedsCompanionBundle(target) {
                 modifiedTarget = addingModuleResourceBundleAvailableCondition(to: modifiedTarget)
             }
         }
 
-        if targetNeedsObjcResourceAccessor(target) {
+        if objcResourceAccessorNeeded {
             modifiedTarget = addingObjcResourceAccessorGeneration(to: modifiedTarget)
         }
 

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -14,8 +14,8 @@ import XcodeGraph
 ///      cannot host their own resources).
 ///   2. Writes a `TuistBundle+<Target>.swift` accessor into the target's Derived directory so
 ///      that user code can call `Bundle.module`.
-///   3. For Objective-C targets generated from Swift packages, also emits
-///      Swift Package Manager-shaped C bridging files.
+///   3. For Objective-C targets generated from Swift packages, asks Xcode to generate resource
+///      accessors with the same build setting as Swift Package Manager.
 public struct ResourcesProjectMapper: ProjectMapping {
     private let contentHasher: ContentHashing
     private let buildableFolderChecker: BuildableFolderChecking
@@ -82,14 +82,8 @@ public struct ResourcesProjectMapper: ProjectMapping {
             }
         }
 
-        if targetNeedsObjcAccessor(target) {
-            try appendObjcBundleAccessor(
-                to: &modifiedTarget,
-                sideEffects: &sideEffects,
-                target: target,
-                project: project,
-                bundleName: bundleName
-            )
+        if targetNeedsObjcResourceAccessor(target) {
+            modifiedTarget = addingObjcResourceAccessorGeneration(to: modifiedTarget)
         }
 
         return ([modifiedTarget] + additionalTargets, sideEffects)
@@ -120,7 +114,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
         return containsSwift || containsSourcesInBuildableFolders
     }
 
-    private func targetNeedsObjcAccessor(_ target: Target) -> Bool {
+    private func targetNeedsObjcResourceAccessor(_ target: Target) -> Bool {
         guard target.metadata.tags.contains(TargetTags.swiftPackage) else { return false }
         let containsObjc = target.sources.contains {
             $0.path.extension == "m" || $0.path.extension == "mm"
@@ -329,32 +323,13 @@ public struct ResourcesProjectMapper: ProjectMapping {
         return target
     }
 
-    private func appendObjcBundleAccessor(
-        to modifiedTarget: inout Target,
-        sideEffects: inout [SideEffectDescriptor],
-        target: Target,
-        project: Project,
-        bundleName: String
-    ) throws {
-        let header = bundleAccessorTemplate.objcAccessorHeader(target: target, project: project)
-        let implementation = bundleAccessorTemplate.objcAccessorImplementation(
-            target: target,
-            bundleName: bundleName,
-            project: project
-        )
-
-        // Point the target's prefix header at the synthesised .h so every Obj-C file picks up
-        // `SWIFTPM_MODULE_BUNDLE` without an explicit `#import`.
-        let prefixHeaderPath = "$(SRCROOT)/\(header.path.relative(to: project.path).pathString)"
-        var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
-        settings["GCC_PREFIX_HEADER"] = .string(prefixHeaderPath)
-        modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)
-
-        let implementationHash = try implementation.contents.map(contentHasher.hash)
-        modifiedTarget.sources.append(SourceFile(path: implementation.path, contentHash: implementationHash))
-
-        sideEffects.append(.file(.init(path: header.path, contents: header.contents, state: .present)))
-        sideEffects.append(.file(.init(path: implementation.path, contents: implementation.contents, state: .present)))
+    private func addingObjcResourceAccessorGeneration(to target: Target) -> Target {
+        var target = target
+        var settings = target.settings?.base ?? SettingsDictionary()
+        settings["GENERATE_RESOURCE_ACCESSORS"] = .string("YES")
+        target.settings = target.settings?.with(base: settings)
+            ?? Settings(base: settings, configurations: [:])
+        return target
     }
 
     private func appendUniqueSourceFiles(paths: [AbsolutePath], to target: inout Target) {

--- a/cli/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -243,6 +243,20 @@ extension String {
         replacingOccurrences(of: "-", with: "_")
             .replacingOccurrences(of: "/", with: "_")
     }
+
+    /// Formats the string as a legal C identifier.
+    public var asLegalCIdentifier: String {
+        decomposedStringWithCanonicalMapping.enumerated().map { index, character in
+            switch character {
+            case "A" ... "Z", "a" ... "z", "_":
+                String(character)
+            case "0" ... "9" where index != 0:
+                String(character)
+            default:
+                "_"
+            }
+        }.joined()
+    }
 }
 
 extension Array where Element: CustomStringConvertible {

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -559,7 +559,7 @@ struct GenerateAcceptanceTestCommandLineToolWithNativePackageTraits {
 
 struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     @Test(.withFixture("generated_ios_app_with_objc_static_framework_package"), .inTemporaryDirectory)
-    func ios_app_with_objc_static_framework_package() async throws {
+    func ios_app_with_objc_and_c_static_framework_package() async throws {
         let fixturePath = try fixtureDirectory()
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1206,14 +1206,20 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
-    func mapWhenProjectNameHasDashesInItBundleNameIncludeDashForProjectNameAndUnderscoreForTargetName() async throws {
+    func mapWhenSwiftPackageProjectAndTargetNamesRequireCIdentifierSanitization() async throws {
         // Given
-        let projectName = "sdk-with-dash"
+        let projectName = "3sdk-with.dash"
         let targetName = "target-with-dash"
-        let expectedBundleName = "sdk-with-dash_target_with_dash"
-        let sources: [SourceFile] = ["/ViewController.m", "/ViewController2.swift"]
+        let expectedBundleName = "_sdk_with_dash_target_with_dash"
+        let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
-        let target = Target.test(name: targetName, product: .staticLibrary, sources: sources, resources: .init(resources))
+        let target = Target.test(
+            name: targetName,
+            product: .staticLibrary,
+            sources: sources,
+            resources: .init(resources),
+            metadata: .test(tags: [TargetTags.swiftPackage])
+        )
         let project = Project.test(
             path: try AbsolutePath(validating: "/AbsolutePath/Project"),
             name: projectName,
@@ -1223,12 +1229,15 @@ struct ResourcesProjectMapperTests {
         given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // When
-        let (gotProject, _) = try await subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
+        let gotTarget = try #require(gotProject.targets.values.first(where: { $0.name == targetName }))
         let bundleTarget = try #require(gotProject.targets.values.sorted().first(where: { $0.product == .bundle }))
 
         // Then
         #expect(bundleTarget.name == expectedBundleName)
         #expect(bundleTarget.productName == expectedBundleName)
+        #expect(gotTarget.settings?.base["PACKAGE_RESOURCE_BUNDLE_NAME"] == .string(expectedBundleName))
+        verifyObjcResourceAccessorGeneration(for: target, gotTarget: gotTarget, gotSideEffects: gotSideEffects)
         #expect(gotProject.targets.count == 2)
     }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -133,12 +133,7 @@ struct ResourcesProjectMapperTests {
 
         // Then
         let gotTarget = try #require(gotProject.targets.values.sorted().last)
-        verifyObjcBundleAccessor(
-            for: target,
-            gotTarget: gotTarget,
-            gotSideEffects: gotSideEffects,
-            project: project
-        )
+        verifyObjcResourceAccessorGeneration(for: target, gotTarget: gotTarget, gotSideEffects: gotSideEffects)
     }
 
     @Test
@@ -160,12 +155,7 @@ struct ResourcesProjectMapperTests {
 
         // Then
         let gotTarget = try #require(gotProject.targets.values.sorted().last)
-        verifyObjcBundleAccessor(
-            for: target,
-            gotTarget: gotTarget,
-            gotSideEffects: gotSideEffects,
-            project: project
-        )
+        verifyObjcResourceAccessorGeneration(for: target, gotTarget: gotTarget, gotSideEffects: gotSideEffects)
     }
 
     @Test
@@ -1161,9 +1151,9 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
-    func mapWhenProjectIsExternalTargetHasObjcSourceFiles() async throws {
+    func mapWhenSwiftPackageTargetHasObjcAndCSourceFiles() async throws {
         // Given
-        let sources: [SourceFile] = ["/ViewController.m"]
+        let sources: [SourceFile] = ["/ViewController.m", "/ViewController.c"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(
             product: .staticLibrary,
@@ -1184,12 +1174,7 @@ struct ResourcesProjectMapperTests {
 
         // Then
         let gotTarget = try #require(gotProject.targets.values.sorted().last)
-        verifyObjcBundleAccessor(
-            for: target,
-            gotTarget: gotTarget,
-            gotSideEffects: gotSideEffects,
-            project: project
-        )
+        verifyObjcResourceAccessorGeneration(for: target, gotTarget: gotTarget, gotSideEffects: gotSideEffects)
     }
 
     @Test
@@ -1512,37 +1497,6 @@ struct ResourcesProjectMapperTests {
         #expect(gotTarget.settings?.base["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] == nil)
     }
 
-    @Test
-    func objcImplementationFileContentSanitizesTargetNameWithHyphens() {
-        // Given
-        let targetName = "YoutubePlayer-in-WKWebView"
-
-        // When
-        let got = BundleAccessorTemplate.objcImplementationContents(
-            targetName: targetName,
-            bundleName: "MyProject_YoutubePlayer-in-WKWebView"
-        )
-
-        // Then
-        #expect(!got.contains("YoutubePlayer-in-WKWebViewBundleFinder"))
-        #expect(got.contains("YoutubePlayerInWKWebViewBundleFinder"))
-        #expect(got.contains("YoutubePlayerInWKWebView_SWIFTPM_MODULE_BUNDLE"))
-        #expect(!got.contains("YoutubePlayer-in-WKWebView_SWIFTPM_MODULE_BUNDLE"))
-    }
-
-    @Test
-    func objcHeaderFileContentSanitizesTargetNameWithHyphens() {
-        // Given
-        let targetName = "YoutubePlayer-in-WKWebView"
-
-        // When
-        let got = BundleAccessorTemplate.objcHeaderContents(targetName: targetName)
-
-        // Then
-        #expect(got.contains("YoutubePlayerInWKWebView_SWIFTPM_MODULE_BUNDLE"))
-        #expect(!got.contains("YoutubePlayer-in-WKWebView_SWIFTPM_MODULE_BUNDLE"))
-    }
-
     // MARK: - Helpers
 
     private func verifySideEffects(
@@ -1574,48 +1528,14 @@ struct ResourcesProjectMapperTests {
         }
     }
 
-    private func verifyObjcBundleAccessor(
+    private func verifyObjcResourceAccessorGeneration(
         for target: Target,
         gotTarget: Target,
-        gotSideEffects: [SideEffectDescriptor],
-        project: Project
+        gotSideEffects: [SideEffectDescriptor]
     ) {
-        #expect(
-            gotTarget.settings?.base["GCC_PREFIX_HEADER"] ==
-                .string(
-                    "$(SRCROOT)/\(Constants.DerivedDirectory.name)/\(Constants.DerivedDirectory.sources)/TuistBundle+\(target.name).h"
-                )
-        )
-        #expect(gotTarget.sources.count == 2)
-        #expect(gotSideEffects.count == 2)
-        let generatedFiles = gotSideEffects.compactMap {
-            if case let .file(file) = $0 {
-                return file
-            } else {
-                return nil
-            }
-        }
-
-        let expectedBasePath = project.derivedDirectoryPath(for: target)
-            .appending(component: Constants.DerivedDirectory.sources)
-        #expect(
-            generatedFiles == [
-                FileDescriptor(
-                    path: expectedBasePath.appending(component: "TuistBundle+\(target.name).h"),
-                    contents: BundleAccessorTemplate
-                        .objcHeaderContents(targetName: target.name)
-                        .data(using: .utf8)
-                ),
-                FileDescriptor(
-                    path: expectedBasePath.appending(component: "TuistBundle+\(target.name).m"),
-                    contents: BundleAccessorTemplate
-                        .objcImplementationContents(
-                            targetName: target.name,
-                            bundleName: "\(project.name)_\(target.name)"
-                        )
-                        .data(using: .utf8)
-                ),
-            ]
-        )
+        #expect(gotTarget.settings?.base["GENERATE_RESOURCE_ACCESSORS"] == .string("YES"))
+        #expect(gotTarget.settings?.base["GCC_PREFIX_HEADER"] == nil)
+        #expect(gotTarget.sources.count == target.sources.count)
+        #expect(gotSideEffects.isEmpty)
     }
 }

--- a/cli/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
+++ b/cli/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
@@ -116,6 +116,17 @@ final class StringExtrasTests: TuistUnitTestCase {
         XCTAssertEqual(got, "test--bundle--identifier")
     }
 
+    func test_as_legal_c_identifier() {
+        // Given
+        let subject = "3sdk-with.dash/target"
+
+        // When
+        let got = subject.asLegalCIdentifier
+
+        // Then
+        XCTAssertEqual(got, "_sdk_with_dash_target")
+    }
+
     func test_string_doesnt_match_GitURL_regex() {
         // Given
         let stringToEvaluate = "not a url string"

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "ObjCPlayerSupport",
+    name: "ObjCPlayer-Support",
     platforms: [
         .iOS(.v16),
     ],
@@ -16,6 +16,7 @@ let package = Package(
     targets: [
         .target(
             name: "ObjCPlayerSupport",
+            resources: [.process("Resources")],
             publicHeadersPath: "."
         ),
     ]

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerSupport.c
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerSupport.c
@@ -1,0 +1,4 @@
+const char *ObjCPlayerSupportName(void)
+{
+    return "ObjCPlayerSupport";
+}

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
@@ -4,7 +4,7 @@
 
 + (NSString *)playerName
 {
-    return @"PlayerView";
+    return [SWIFTPM_MODULE_BUNDLE bundlePath];
 }
 
 @end

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/Resources/player.txt
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/Resources/player.txt
@@ -1,0 +1,1 @@
+ObjCPlayerSupport


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/12559

Tuist now asks Xcode to generate resource accessors for Objective-C targets originating from Swift Package Manager, instead of generating and injecting a target-wide prefix header itself. This keeps the generated accessor available to Objective-C sources without exposing Foundation to plain C sources.

### How to test locally

- `tuist generate tuist TuistGenerator TuistGeneratorTests ProjectDescription --no-open`
- `xcodebuild -quiet test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ResourcesProjectMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`
- `mise run cli:lint --fix`
- Build a resource-bearing mixed Objective-C and C target with Xcode.
