### PR TITLE
fix(infra): wait for the k3s apiserver before the smoke test queries it

### DIFF
--- a/infra/mise/tasks/helm/k3s-smoke.sh
+++ b/infra/mise/tasks/helm/k3s-smoke.sh
@@ -34,14 +34,36 @@ fi
 
 created_cluster=0
 
+apiserver_ready() {
+    "$KUBECTL_BIN" api-resources >/dev/null 2>&1
+}
+
+wait_for_apiserver() {
+    local deadline=$((SECONDS + 120))
+
+    while ((SECONDS < deadline)); do
+        if apiserver_ready && [[ -n "$("$KUBECTL_BIN" get nodes -o name 2>/dev/null)" ]]; then
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "The Kubernetes API server did not start serving its API group list within 120s." >&2
+    return 1
+}
+
 collect_diagnostics() {
     local exit_code=$?
     rm -f "$rendered"
 
     if [[ "$exit_code" -ne 0 ]]; then
-        "$KUBECTL_BIN" -n "$NAMESPACE" get all,pvc || true
-        "$KUBECTL_BIN" -n "$NAMESPACE" get events --sort-by=.lastTimestamp || true
-        "$KUBECTL_BIN" -n "$NAMESPACE" describe pods || true
+        if apiserver_ready; then
+            "$KUBECTL_BIN" -n "$NAMESPACE" get all,pvc || true
+            "$KUBECTL_BIN" -n "$NAMESPACE" get events --sort-by=.lastTimestamp || true
+            "$KUBECTL_BIN" -n "$NAMESPACE" describe pods || true
+        else
+            echo "Skipping cluster diagnostics: the Kubernetes API server is unreachable." >&2
+        fi
     fi
 
     if [[ "$created_cluster" == "1" && "$KEEP_CLUSTER" != "1" ]]; then
@@ -71,6 +93,7 @@ if [[ "$USE_CURRENT_CONTEXT" != "1" ]]; then
     KUBECONFIG="$(k3d kubeconfig write "$CLUSTER")"
 fi
 
+wait_for_apiserver
 "$KUBECTL_BIN" wait --for=condition=Ready nodes --all --timeout=120s
 node_versions="$("$KUBECTL_BIN" get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}')"
 if ! grep -qi "k3s" <<< "$node_versions"; then


### PR DESCRIPTION
## What changed

`infra/mise/tasks/helm/k3s-smoke.sh` now polls the Kubernetes apiserver for readiness before running any `kubectl` command against a freshly created k3d cluster, and the `collect_diagnostics` EXIT trap skips its dumps when the apiserver is unreachable.

## Why

The **K3s Smoke Install** check (`.github/workflows/helm.yml`, job `k3s`) fails intermittently on PRs that touch no chart or script files at all. Observed on [run 32729488783](https://github.com/tuist/tuist/actions/runs/32729488783/job/97438248811) for #12573 — a PR whose diff is confined to `kura/src/*.rs`, kura docs, a Grafana dashboard and `alerts.md`. Re-running the identical commit passed, confirming a race rather than a real chart failure.

The job died 48s in, immediately after k3d logged `Cluster 'tuist-helm-smoke' created successfully!`, with four consecutive kubectl invocations returning:

```
Error from server (ServiceUnavailable): the server is currently unable to handle the request
couldn't get current server API group list: the server is currently unable to handle the request
```

## Root cause

The script ran `k3d cluster create ... --wait` and then went straight into `kubectl wait --for=condition=Ready nodes --all --timeout=120s`.

`--wait` returns once the server *container* is up. That does not mean the k3s apiserver is serving its API group list yet. `kubectl wait` treats an API-level `ServiceUnavailable` as a hard error and exits non-zero straight away rather than retrying, so its own `--timeout=120s` never got a chance to absorb the gap — the timeout only governs waiting for the *condition*, not for the API to become answerable.

The three further errors in the log were the `collect_diagnostics` EXIT trap running `get all,pvc`, `get events` and `describe pods` against the same not-yet-ready apiserver, burying the actual first error under three identical dumps.

## The fix

Poll `kubectl api-resources` every 2s (up to 120s) before the node wait. That is the exact call that was failing — discovery of the API group list — so it is the right readiness probe rather than a proxy for one.

The poll additionally requires at least one registered node. This goes slightly beyond a bare API-reachability check, and deliberately: `kubectl wait --all` with zero matching resources fails just as eagerly, with `no matching resources found`. Probing only API reachability would have closed the reported race while leaving a second, narrower one on the same line. The existing `kubectl wait --for=condition=Ready nodes` stays in place for actual node readiness — the new poll is strictly a precondition, not a replacement.

`collect_diagnostics` reuses the same `apiserver_ready` helper and prints one explanatory line instead of three more `ServiceUnavailable` dumps when the cluster never came up, so a bootstrap failure keeps the real error visible at the bottom of the log. A failure *after* the apiserver is healthy (e.g. a `helm upgrade` failure) still collects the full diagnostics, so the guard costs nothing in the case where those dumps matter.

An alternative considered and rejected: wrapping the existing `kubectl wait` in a retry loop. That would paper over the symptom on one line while leaving every later `kubectl` call in the script exposed to the same window, and it would conflate "API not answering yet" with "node genuinely not Ready" — two conditions that deserve different timeouts and different error messages.

No workflow change is needed; `helm.yml` is a thin wrapper around this script, and its 25-minute job timeout leaves ample headroom for a 120s poll.

## Impact

CI only. Removes a spurious red check that blocks unrelated PRs and costs a full re-run of a ~25-minute-budget job. No change to the chart, to what the smoke test asserts, or to behaviour on a cluster that is already up — on a healthy apiserver the poll returns on its first iteration.

## Validation

- `shellcheck` and `bash -n` clean.
- Stubbed `kubectl` returning the verbatim `ServiceUnavailable` pair for its first four calls, then healthy: the poll recovers and returns success after 8s. The old code died on call one against the same stub.
- Stubbed `kubectl` that never recovers: returns non-zero at the deadline with a clear message, and the EXIT trap prints a single `Skipping cluster diagnostics: the Kubernetes API server is unreachable.` — no duplicate dumps.
- Simulated post-bootstrap failure against a healthy apiserver: all three diagnostic dumps still collected.
- `mise run helm:k3s-smoke --render-only` passes end to end (lint clean, 3577 lines rendered).

**Not validated locally:** the full cluster path. Docker was not running on the dev machine, so a real k3d bootstrap against the new poll was not exercised — the logic above was verified with stubs only. This PR's own CI run of the `k3s` job covers that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)