### PR TITLE
fix(cli): preserve package access build settings

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -2436,12 +2436,7 @@ extension ProjectDescription.Settings {
         }
 
         if swiftToolsVersion >= Version(5, 9, 0) {
-            result.base.ensurePackageName(packageName)
-            for index in result.configurations.indices
-                where result.configurations[index].settings["OTHER_SWIFT_FLAGS"] != nil
-            {
-                result.configurations[index].settings.ensurePackageName(packageName)
-            }
+            result.base.setSwiftPackageName(packageName)
         }
 
         return result
@@ -2533,26 +2528,8 @@ extension ProjectDescription.SettingsDictionary {
         }
     }
 
-    fileprivate mutating func ensurePackageName(_ packageName: String) {
-        let packageName = packageName.quotedIfContainsSpaces
-        var swiftFlags: [String] = switch self["OTHER_SWIFT_FLAGS"] {
-        case let .array(values):
-            values
-        case let .string(value):
-            value.split(separator: " ").map(String.init)
-        case nil:
-            ["$(inherited)"]
-        @unknown default:
-            ["$(inherited)"]
-        }
-
-        let containsPackageName = swiftFlags.indices.dropLast().contains { index in
-            swiftFlags[index] == "-package-name" && swiftFlags[index + 1] == packageName
-        }
-        guard !containsPackageName else { return }
-
-        swiftFlags.append(contentsOf: ["-package-name", packageName])
-        self["OTHER_SWIFT_FLAGS"] = .array(swiftFlags)
+    fileprivate mutating func setSwiftPackageName(_ packageName: String) {
+        self["SWIFT_PACKAGE_NAME"] = .string(packageName)
     }
 }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -557,6 +557,35 @@ struct GenerateAcceptanceTestCommandLineToolWithNativePackageTraits {
     }
 }
 
+struct GenerateAcceptanceTestCommandLineToolWithPackageAccessAndModuleMap {
+    @Test(.withFixture("generated_command_line_tool_with_package_access_and_module_map"), .inTemporaryDirectory)
+    func command_line_tool_with_package_access_and_module_map() async throws {
+        let fixturePath = try fixtureDirectory()
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        let xcodeproj = try XcodeProj(
+            pathString: fixturePath.appending(components: "Package", "repro.xcodeproj").pathString
+        )
+        let reproCoreTarget = try TuistAcceptanceTest.requireTarget("ReproCore", in: xcodeproj)
+        let buildConfigurations = try #require(reproCoreTarget.buildConfigurationList?.buildConfigurations)
+
+        for buildConfiguration in buildConfigurations {
+            let buildSettings = buildConfiguration.buildSettings
+            #expect(buildSettings["SWIFT_PACKAGE_NAME"]?.stringValue == "repro")
+
+            let otherSwiftFlags = try #require(buildSettings["OTHER_SWIFT_FLAGS"]?.arrayValue)
+            #expect(otherSwiftFlags.contains("-module-abi-name"))
+            #expect(otherSwiftFlags.contains("-Xcc"))
+            #expect(otherSwiftFlags.contains(where: { $0.contains("ReproCore-deps.modulemap") }))
+            #expect(!otherSwiftFlags.contains("-package-name"))
+        }
+
+        try await run(BuildCommand.self)
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     @Test(.withFixture("generated_ios_app_with_objc_static_framework_package"), .inTemporaryDirectory)
     func ios_app_with_objc_static_framework_package() async throws {

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4082,8 +4082,6 @@ struct PackageInfoMapperTests {
                                             "CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1"),
                                             "OTHER_SWIFT_FLAGS": .array([
                                                 "-DDEBUG",
-                                                "-package-name",
-                                                "Package",
                                             ]),
                                         ],
                                         xcconfig: "Sources/Target1/Config.xcconfig"
@@ -6271,7 +6269,7 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_other_swift_flags_whenSwiftToolsVersionIs_5_9_0() async throws {
+    ) func map_swift_package_name_whenSwiftToolsVersionIs_5_9_0() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "Package/Sources/Product")))
@@ -6304,15 +6302,16 @@ struct PackageInfoMapperTests {
         // Then
         #expect(
             project?.targets.first?.settings?.base["OTHER_SWIFT_FLAGS"] ==
-                .array(["$(inherited)", "-package-name", "Package"])
+                .array(["$(inherited)"])
         )
+        #expect(project?.targets.first?.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         #expect(project?.settings?.base["OTHER_SWIFT_FLAGS"] == nil)
     }
 
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenPackageUsesPackageAccessAndCustomSwiftSettings_addsPackageNameToTargetFlags() async throws {
+    ) func map_whenPackageUsesPackageAccessAndCustomSwiftSettings_addsPackageNameToTargetSettings() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         try await fileSystem.makeDirectory(
             at: basePath.appending(try RelativePath(validating: "SwiftProtobuf/Sources/SwiftProtobuf"))
@@ -6351,10 +6350,9 @@ struct PackageInfoMapperTests {
             target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
                 "$(inherited)",
                 "-enable-upcoming-feature \"ExistentialAny\"",
-                "-package-name",
-                "SwiftProtobuf",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("SwiftProtobuf"))
     }
 
     @Test(
@@ -8098,10 +8096,9 @@ struct PackageInfoMapperTests {
                 prebuiltPath.appending(component: "Modules").pathString,
                 "-I",
                 checkoutPath.appending(try RelativePath(validating: "Sources/_SwiftSyntaxCShims/include")).pathString,
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         #expect(
             target.settings?.base["LIBRARY_SEARCH_PATHS"] == .array([
                 "$(inherited)",
@@ -8170,10 +8167,9 @@ struct PackageInfoMapperTests {
             target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
                 "$(inherited)",
                 "-enable-experimental-feature \"Lifetimes\"",
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         let projectFlags: [String]
         switch project?.settings?.base["OTHER_SWIFT_FLAGS"] {
         case let .array(flags):
@@ -8238,10 +8234,9 @@ struct PackageInfoMapperTests {
                 "$(inherited)",
                 "-enable-experimental-feature \"Lifetimes\"",
                 "-DSTAGING",
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
     }
 
     @Test(
@@ -8380,10 +8375,9 @@ struct PackageInfoMapperTests {
         #expect(
             target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
                 "$(inherited)",
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
         #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
     }
@@ -8451,10 +8445,9 @@ struct PackageInfoMapperTests {
                 prebuiltPath.appending(component: "Modules").pathString,
                 "-I",
                 prebuiltPath.appending(components: "include", "_SwiftSyntaxCShims").pathString,
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         #expect(
             target.settings?.base["LIBRARY_SEARCH_PATHS"] == .array([
                 "$(inherited)",
@@ -8585,10 +8578,9 @@ struct PackageInfoMapperTests {
         #expect(
             target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
                 "$(inherited)",
-                "-package-name",
-                "Package",
             ])
         )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
         #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
         #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
     }
@@ -8874,19 +8866,7 @@ extension ProjectDescription.Target {
                 ])
         }
 
-        let swiftFlags: [String] = switch customSettings["OTHER_SWIFT_FLAGS"] {
-        case let .array(values):
-            values
-        case let .string(value):
-            value.split(separator: " ").map(String.init)
-        case nil:
-            ["$(inherited)"]
-        @unknown default:
-            ["$(inherited)"]
-        }
-        customSettings["OTHER_SWIFT_FLAGS"] = .array(
-            swiftFlags + ["-package-name", (swiftPackageName ?? packageName).quotedIfContainsSpaces]
-        )
+        customSettings["SWIFT_PACKAGE_NAME"] = .string(swiftPackageName ?? packageName)
 
         return ProjectDescription.Target.target(
             name: name,

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "repro",
+    products: [
+        .library(name: "ReproCore", targets: ["ReproCore"]),
+    ],
+    targets: [
+        .target(name: "CShim", publicHeadersPath: "include"),
+        .target(
+            name: "ReproCore",
+            dependencies: ["CShim"],
+            swiftSettings: [
+                .unsafeFlags(["-module-abi-name", "repro"]),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/CShim/CShim.c
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/CShim/CShim.c
@@ -1,0 +1,5 @@
+#include "CShim.h"
+
+int cShimValue(void) {
+    return 42;
+}

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/CShim/include/CShim.h
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/CShim/include/CShim.h
@@ -1,0 +1,1 @@
+int cShimValue(void);

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/ReproCore/ReproCore.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Package/Sources/ReproCore/ReproCore.swift
@@ -1,0 +1,5 @@
+import CShim
+
+public func reproValue() -> Int {
+    Int(cShimValue())
+}

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Project.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Project.swift
@@ -1,0 +1,17 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "dev.tuist.package-access-module-map",
+            sources: ["Sources/**"],
+            dependencies: [
+                .external(name: "ReproCore"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Sources/main.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Sources/main.swift
@@ -1,0 +1,3 @@
+import ReproCore
+
+print(reproValue())

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Tuist.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Tuist/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_package_access_and_module_map/Tuist/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(
+    productTypes: [
+        "ReproCore": .framework,
+    ]
+)
+#endif
+
+let package = Package(
+    name: "Dependencies",
+    dependencies: [
+        .package(path: "../Package"),
+    ]
+)


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12562>

## What changed

Tuist now records a package access identity in `SWIFT_PACKAGE_NAME` instead of adding `-package-name <value>` to `OTHER_SWIFT_FLAGS`. The mapper tests now expect that representation.

A self-contained acceptance fixture reproduces the unsafe `-module-abi-name repro` setting alongside a generated module map. It checks the generated settings and builds the resulting macOS command-line tool.

## Why

Projects with a package name that also appears as the argument of another compiler option could lose the `-package-name` value while Tuist merged compiler flags. The following argument was then interpreted as the package name, causing the build to fail.

## Root cause

Package access identity was represented in the generic compiler-flag collection. That collection removes duplicate values without preserving argument ownership, so a repeated package name could remove the value required by `-package-name`.

## Approach

This follows [Swift Package Manager's build-setting model](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift): set `SWIFT_PACKAGE_NAME` and let the build system emit the compiler argument. Keeping the identity outside `OTHER_SWIFT_FLAGS` preserves the unsafe compiler arguments unchanged.

## Impact

Generated projects with package access and compiler options that repeat the package name retain valid argument ordering and build successfully.

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace '-only-testing:TuistGeneratorAcceptanceTests/GenerateAcceptanceTestCommandLineToolWithPackageAccessAndModuleMap/command_line_tool_with_package_access_and_module_map()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace '-only-testing:TuistLoaderTests/PackageInfoMapperTests' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`
- `mise run cli:lint`

### How to test locally

Run the focused acceptance test from the Validation section. It installs only the fixture's local package, generates the project, verifies the package build settings, and builds the command-line tool.
