### PR TITLE
docs(server): document the SwifterPM global cache in CI

### DIFF
--- a/server/priv/docs/en/guides/features/projects/dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/dependencies.md
@@ -163,6 +163,11 @@ tuist install
 # Installing Swift Package Manager dependencies. {#installing-swift-package-manager-dependencies}
 ```
 
+> [!TIP]
+> **Caching on CI**
+>
+> `tuist install` restores packages from a global cache at `~/.cache/swifterpm`. Persist that directory across CI runs to keep restores warm, as described in the <.localized_link href="/guides/integrations/continuous-integration#caching-dependencies">Continuous Integration guide</.localized_link>.
+
 As you might have noticed, we take an approach similar to [CocoaPods](https://cocoapods.org)', where the resolution of dependencies is its own command. This gives control to the users over when they'd like dependencies to be resolved and updated, and allows opening the Xcode in project and have it ready to compile. This is an area where we believe the developer experience provided by Apple's integration with the Swift Package Manager degrades over time as the project grows.
 
 From your project targets you can then reference those dependencies using the `TargetDependency.external` dependency type:

--- a/server/priv/docs/en/guides/integrations/continuous-integration.md
+++ b/server/priv/docs/en/guides/integrations/continuous-integration.md
@@ -321,6 +321,25 @@ workflows:
 >
 > Create an <.localized_link href="/guides/server/authentication#account-tokens">account token</.localized_link> and add it as a secret environment variable named `TUIST_TOKEN`.
 
+## Caching dependencies {#caching-dependencies}
+
+`tuist install` resolves and restores Swift package dependencies with [SwifterPM](https://github.com/tuist/tuist/tree/main/swifterpm), which stores package archives and extracted source trees once in a global cache at `~/.cache/swifterpm`, or `$XDG_CACHE_HOME/swifterpm` when that variable is set. Persist that directory across runs:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.cache/swifterpm
+    key: swifterpm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+    restore-keys: swifterpm-${{ runner.os }}-
+```
+
+The cache is content-addressed by package identity, version, and revision, so a stale restore is safe: entries that no longer match go unused, and `restore-keys` lets a run start from the closest previous cache instead of from nothing.
+
+> [!IMPORTANT]
+> **Cache the global cache, not the scratch directory**
+>
+> The package scratch directory (`Tuist/.build`) lives in the freshly checked out workspace and is restored from the global cache on every run. Caching it instead of `~/.cache/swifterpm` leaves every run cold.
+
 ## Run report {#run-report}
 
 When Tuist uploads a run, the dashboard URLs for it are printed to the logs. To get them without scraping the logs — for example to post the test report link to Slack when a job fails, or to feed a run into your own tooling — pass `--run-report-path` (or set `TUIST_RUN_REPORT_PATH`) to `tuist test`, `tuist xcodebuild test`, or `tuist xcodebuild build`. Tuist writes a JSON report to that path once the run has been uploaded:

--- a/server/priv/docs/en/guides/integrations/continuous-integration.md
+++ b/server/priv/docs/en/guides/integrations/continuous-integration.md
@@ -340,6 +340,14 @@ The cache is content-addressed by package identity, version, and revision, so a 
 >
 > The package scratch directory (`Tuist/.build`) lives in the freshly checked out workspace and is restored from the global cache on every run. Caching it instead of `~/.cache/swifterpm` leaves every run cold.
 
+When `Package.resolved` is committed, pass `--force-resolved-versions` to skip dependency solving and restore exactly the pinned versions:
+
+```bash
+tuist install --force-resolved-versions
+```
+
+The command fails when `Package.resolved` is out of date with `Package.swift`, so re-resolve and commit the lockfile whenever you change dependencies.
+
 ## Run report {#run-report}
 
 When Tuist uploads a run, the dashboard URLs for it are printed to the logs. To get them without scraping the logs — for example to post the test report link to Slack when a job fails, or to feed a run into your own tooling — pass `--run-report-path` (or set `TUIST_RUN_REPORT_PATH`) to `tuist test`, `tuist xcodebuild test`, or `tuist xcodebuild build`. Tuist writes a JSON report to that path once the run has been uploaded:


### PR DESCRIPTION
Adds documentation for the one thing a CI pipeline has to do to get SwifterPM's speedups, which until now was documented only outside the product docs.

## What changed

- `server/priv/docs/en/guides/integrations/continuous-integration.md`: a new `Caching dependencies` section covering the `~/.cache/swifterpm` global cache, an `actions/cache` snippet keyed on `Package.resolved`, why a stale restore is safe, an `[!IMPORTANT]` callout that the thing to cache is the global cache and not the package scratch directory, and the `--force-resolved-versions` fast path for skipping dependency solving when the lockfile is committed.
- `server/priv/docs/en/guides/features/projects/dependencies.md`: a short `[!TIP]` under the `tuist install` code block linking to that section.

English only. Other locales go through the usual translation flow.

## Why

Since `tuist install` started using SwifterPM by default, whether a pipeline gets the warm speedup or a cold restore on every run comes down to a single operational detail: persisting `~/.cache/swifterpm`. That guidance lived only in `swifterpm/README.md`, which is the README of a separately published tool that Tuist users have no reason to open, and the product docs never mentioned SwifterPM at all. `grep -rin swifterpm server/priv/docs` returned zero hits across every locale, while the CI integrations guide carries worked examples for GitHub Actions, Xcode Cloud, CircleCI, Bitrise and Codemagic without a single cache step in any of them.

The gap is not theoretical. While investigating a customer's build this week, their workflow caches `Tuist/.build` (1.51 GB, 41.1s to restore) and `tuist install` then pulls roughly another 1.6 GB into a cold `~/.cache/swifterpm`, because SwifterPM materializes the scratch directory from the global cache rather than from whatever `.build` already contains. That is about 3.1 GB fetched per run with roughly half of it wasted, on every build, and nothing in the docs would have told them.

It is not only customers. We were not caching the global store in our own CLI pipelines either, where `tuist install` costs a mean of ~47s in each of five macOS jobs per run. #12584 fixes that and measures the result.

## Notes for reviewers

- The callout names `Tuist/.build` explicitly on purpose. Caching the scratch directory is the intuitive wrong answer and it is the one showing up in real pipelines.
- The `actions/cache` snippet is kept identical to the one in `swifterpm/README.md` so the two do not drift.
- `--force-resolved-versions` is documented as a plain command-line flag because that is what it is: `InstallCommand` declares `@Argument(parsing: .captureForPassthrough)`, so unrecognized arguments reach SwifterPM directly, and every one of our own workflows already runs `tuist install --force-resolved-versions`.

### How to test locally

Run the docs tests:

```
cd server && mix test test/tuist/docs_test.exs test/tuist/docs/html_test.exs
```

Then start the server and check both pages render and the cross-link resolves:

```
mise run dev
```

- `/guides/integrations/continuous-integration#caching-dependencies`
- `/guides/features/projects/dependencies`

Validation already run on this branch: both docs test files pass, 16 tests, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
