### PR TITLE
fix(server): serve the runner queue gauge from Postgres, not ClickHouse

### DIFF
--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -869,6 +869,25 @@ defmodule Tuist.Runners.Jobs do
   end
 
   @doc """
+  Queue depth and oldest-arrival per fleet, for the queue gauges.
+
+  Served from the Postgres lifecycle table — the same rows
+  `pick_queued_top_k/5` selects from and under the same
+  `@queued_lookback_seconds` floor, so the gauge and dispatch can never
+  disagree about what is queued. They used to: the gauge scanned the
+  ClickHouse `runner_jobs` replica, which since #12031 is fed only by
+  the transition outbox and therefore holds `queued` for any job whose
+  terminal transition never replayed. Those rows are unreachable to
+  dispatch and never age out on their own, so the tile read a backlog
+  that no Pod could ever drain.
+
+  Returns `%{fleet_name => %{count: n, oldest_enqueued_at: dt}}`.
+  """
+  def queue_stats_by_fleet do
+    WorkflowJobs.queue_stats_by_fleet(queued_lookback_floor())
+  end
+
+  @doc """
   Queued workflow_job counts for `fleet_name`, broken down by account.
 
   Same rows `queued_count_by_fleet/1` totals, grouped so the caller can

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -18,7 +18,7 @@ defmodule Tuist.Runners.PromExPlugin do
 
     * **Polling metrics.** Four poll loops at a coarse 30s cadence
       query authoritative state and emit gauges: queue length per
-      fleet from ClickHouse, inflight claim counts per fleet /
+      fleet from Postgres, inflight claim counts per fleet /
       lifecycle state from Postgres, open sessions past the six-hour
       safety bound per fleet from Postgres, RunnerPool desired /
       observed / capacity-ceiling replica counts from the K8s
@@ -36,14 +36,13 @@ defmodule Tuist.Runners.PromExPlugin do
 
   use PromEx.Plugin
 
-  import Ecto.Query, only: [from: 2, subquery: 1]
+  import Ecto.Query, only: [from: 2]
 
   alias Tuist.ClickHouseRepo
   alias Tuist.Environment
   alias Tuist.Kubernetes.Client, as: K8sClient
   alias Tuist.Repo
   alias Tuist.Runners.Claim
-  alias Tuist.Runners.Job
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Telemetry
@@ -284,12 +283,12 @@ defmodule Tuist.Runners.PromExPlugin do
           last_value(
             @metric_prefix ++ [:queue, :length],
             event_name: Telemetry.event_name_queue_length(),
-            description: "Queued workflow jobs per fleet (ClickHouse runner_jobs).",
+            description: "Queued workflow jobs per fleet (Postgres runner_workflow_jobs).",
             measurement: :count,
             tags: [:fleet]
           ),
           # Rides the `queue_length` event: both values come out of one
-          # ClickHouse scan. Depth alone can't distinguish a queue that
+          # Postgres scan. Depth alone can't distinguish a queue that
           # is never empty because arrivals are served promptly from one
           # job wedged for hours — both sit at 1.
           last_value(
@@ -392,18 +391,18 @@ defmodule Tuist.Runners.PromExPlugin do
 
   @doc false
   def execute_queue_length_telemetry_event do
-    if PoolMetrics.running?(ClickHouseRepo) do
+    if PoolMetrics.running?(Repo) do
       now = DateTime.utc_now()
-      stats = fetch_queue_stats(now)
+      stats = Jobs.queue_stats_by_fleet()
       current_fleets = stats |> universe_fleets() |> MapSet.new()
 
       Enum.each(current_fleets, fn fleet ->
-        %{count: count, oldest_age_seconds: age} =
-          Map.get(stats, fleet, %{count: 0, oldest_age_seconds: 0})
+        %{count: count, oldest_enqueued_at: oldest_enqueued_at} =
+          Map.get(stats, fleet, %{count: 0, oldest_enqueued_at: nil})
 
         :telemetry.execute(
           Telemetry.event_name_queue_length(),
-          %{count: count, oldest_age_seconds: age},
+          %{count: count, oldest_age_seconds: age_seconds(now, oldest_enqueued_at)},
           %{fleet: fleet}
         )
       end)
@@ -423,46 +422,14 @@ defmodule Tuist.Runners.PromExPlugin do
     end
   end
 
-  # Avoid `FINAL` — at scale it forces ClickHouse to merge across
-  # every part of `runner_jobs` on every 30s poll. Instead, collapse
-  # per workflow_job via `argMax(updated_at)` in a subquery, then
-  # filter the *current* state to `queued` and group by fleet.
-  #
-  # The `enqueued_at >= cutoff` prunes partitions (the table is
+  # Horizon for the ClickHouse side of the divergence scan. The
+  # `enqueued_at >= cutoff` prunes partitions (the table is
   # `PARTITION BY toYYYYMM(enqueued_at)` and every state-transition
   # INSERT carries the original `enqueued_at` forward, so all rows
-  # for a workflow_job live in the same partition). Seven days is
-  # well past any realistic queue lifetime — GitHub's own queue
-  # timeout is ~24h — so any row still queued beyond the cutoff is
-  # a system-wide outage where a slightly low gauge is the least
-  # of our problems.
+  # for a workflow_job live in the same partition). Seven days matches
+  # `Jobs`' own queued floor, so a row old enough to fall out of this
+  # scan is also one nothing will ever dispatch.
   @queue_lookback_days 7
-
-  defp fetch_queue_stats(now) do
-    cutoff = DateTime.add(now, -@queue_lookback_days, :day)
-
-    latest =
-      from(j in Job,
-        where: j.enqueued_at >= ^cutoff,
-        group_by: j.workflow_job_id,
-        select: %{
-          workflow_job_id: j.workflow_job_id,
-          fleet_name: fragment("argMax(?, ?)", j.fleet_name, j.updated_at),
-          status: fragment("argMax(?, ?)", j.status, j.updated_at),
-          enqueued_at: min(j.enqueued_at)
-        }
-      )
-
-    from(s in subquery(latest),
-      where: s.status == "queued",
-      group_by: s.fleet_name,
-      select: {s.fleet_name, count(s.workflow_job_id), min(s.enqueued_at)}
-    )
-    |> ClickHouseRepo.all()
-    |> Map.new(fn {fleet, count, oldest_enqueued_at} ->
-      {fleet || "", %{count: count, oldest_age_seconds: age_seconds(now, oldest_enqueued_at)}}
-    end)
-  end
 
   # Clamped at 0 so clock skew between the pod that wrote `enqueued_at`
   # and the pod polling can't report a negative age, which would read as

--- a/server/lib/tuist/runners/workflow_jobs.ex
+++ b/server/lib/tuist/runners/workflow_jobs.ex
@@ -380,6 +380,29 @@ defmodule Tuist.Runners.WorkflowJobs do
   end
 
   @doc """
+  Postgres twin of `Tuist.Runners.Jobs.queue_stats_by_fleet/0`: the same
+  rows `queued_count_by_fleet/2` totals for one fleet, but for every
+  fleet at once and carrying the oldest `enqueued_at` alongside the
+  count. Both values come from one scan so the depth and the age the
+  gauges report are always the same queue.
+
+  Returns `%{fleet_name => %{count: n, oldest_enqueued_at: dt}}`. A fleet
+  with nothing queued is absent, not zero — the caller unions this
+  against the live RunnerPool set to decide what to drain.
+  """
+  def queue_stats_by_fleet(%DateTime{} = enqueued_floor) do
+    from(j in WorkflowJob,
+      where: j.status == "queued" and j.enqueued_at > ^enqueued_floor,
+      group_by: j.fleet_name,
+      select: {j.fleet_name, count(j.workflow_job_id), min(j.enqueued_at)}
+    )
+    |> Repo.all()
+    |> Map.new(fn {fleet_name, count, oldest_enqueued_at} ->
+      {fleet_name || "", %{count: count, oldest_enqueued_at: oldest_enqueued_at}}
+    end)
+  end
+
+  @doc """
   Postgres twin of `Tuist.Runners.Jobs.queued_count_by_fleet_and_account/1`.
   """
   def queued_count_by_fleet_and_account(fleet_name, %DateTime{} = enqueued_floor) when is_binary(fleet_name) do

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -67,7 +67,6 @@ defmodule Tuist.Runners.PromExPluginTest do
           head_sha: "deadbeef"
         })
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 1}, %{fleet: "fleet-poll"}},
@@ -78,12 +77,11 @@ defmodule Tuist.Runners.PromExPluginTest do
       attach_collector(handler_id, Telemetry.event_name_queue_length())
 
       # Fleet is declared in the cluster but has no queued rows in
-      # ClickHouse. Without the drain-to-zero path, `last_value`
+      # Postgres. Without the drain-to-zero path, `last_value`
       # would keep whatever the last non-zero sample was; this
       # asserts we emit an explicit `0` instead.
       stub_pool_list(["fleet-empty"])
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0}, %{fleet: "fleet-empty"}},
@@ -123,7 +121,6 @@ defmodule Tuist.Runners.PromExPluginTest do
           })
       end
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length],
@@ -137,7 +134,6 @@ defmodule Tuist.Runners.PromExPluginTest do
       attach_collector(handler_id, Telemetry.event_name_queue_length())
       stub_pool_list(["fleet-empty-age"])
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{oldest_age_seconds: 0},
@@ -169,7 +165,6 @@ defmodule Tuist.Runners.PromExPluginTest do
           head_sha: "deadbeef"
         })
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 1}, %{fleet: "fleet-gone"}},
@@ -181,11 +176,48 @@ defmodule Tuist.Runners.PromExPluginTest do
       # last_value would hold the stale non-zero age forever.
       {:ok, _} = Jobs.complete(999_020, "success")
 
-      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
       PromExPlugin.execute_queue_length_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0, oldest_age_seconds: 0},
                       %{fleet: "fleet-gone"}},
+                     500
+    end
+
+    test "ignores a ClickHouse row still queued after Postgres reached a terminal state",
+         %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+      stub_pool_list(["fleet-diverged"])
+
+      account = account_fixture()
+
+      :ok =
+        Jobs.enqueue(%{
+          workflow_job_id: 999_030,
+          account_id: account.id,
+          fleet_name: "fleet-diverged",
+          repository: "acme/cli",
+          workflow_run_id: 9030,
+          run_attempt: 1,
+          job_name: "build",
+          head_branch: "main",
+          head_sha: "deadbeef"
+        })
+
+      # Flush only the `queued` transition, so ClickHouse holds a
+      # `queued` row, then complete the job WITHOUT flushing again. That
+      # is the shape production ended up in: the outbox dropped a batch
+      # of terminal transitions and the replica froze mid-lifecycle. A
+      # terminal job emits no further events, so nothing ever corrects
+      # those rows — a gauge reading ClickHouse reports them as a
+      # backlog forever, while dispatch, which reads Postgres, cannot
+      # see them at all.
+      :ok = perform_job(FlushJobTransitionEventsWorker, %{})
+      {:ok, _} = Jobs.complete(999_030, "success")
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0, oldest_age_seconds: 0},
+                      %{fleet: "fleet-diverged"}},
                      500
     end
   end

--- a/server/test/tuist/runners/workflow_jobs_test.exs
+++ b/server/test/tuist/runners/workflow_jobs_test.exs
@@ -380,6 +380,28 @@ defmodule Tuist.Runners.WorkflowJobsTest do
                other_account.id => 1
              }
     end
+
+    test "queue_stats_by_fleet groups every fleet with its depth and oldest arrival" do
+      account = account_fixture()
+      now = DateTime.utc_now()
+      floor = DateTime.add(now, -7 * 86_400, :second)
+      oldest = DateTime.add(now, -3600, :second)
+
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_110, enqueued_at: oldest))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_111))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_112, fleet: "fleet-b"))
+      # Left the queue, so it counts for neither fleet.
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_113))
+      :ok = WorkflowJobs.transition_claimed(910_113, "pod-1", now)
+      # Older than the floor — unreachable to dispatch, so invisible here too.
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_114, enqueued_at: DateTime.add(now, -8 * 86_400, :second)))
+
+      stats = WorkflowJobs.queue_stats_by_fleet(floor)
+
+      assert %{"fleet-a" => %{count: 2, oldest_enqueued_at: reported}, "fleet-b" => %{count: 1}} = stats
+      assert DateTime.compare(reported, oldest) == :eq
+      refute Map.has_key?(stats, "fleet-c")
+    end
   end
 
   describe "transition outbox" do


### PR DESCRIPTION
## What changed

`tuist_runners_queue_length` (and its sibling `queue_oldest_age_seconds`) now read the Postgres lifecycle table `runner_workflow_jobs` instead of the ClickHouse `runner_jobs` replica.

- New `WorkflowJobs.queue_stats_by_fleet/1` — one grouped scan returning `%{fleet => %{count, oldest_enqueued_at}}`.
- New `Jobs.queue_stats_by_fleet/0` wrapper applying the same `@queued_lookback_seconds` floor that `pick_queued_top_k/5` uses.
- `PromExPlugin.execute_queue_length_telemetry_event/0` calls it and gates on `PoolMetrics.running?(Repo)`; the ClickHouse `fetch_queue_stats/1` scan is deleted.

Reporting only. Dispatch is untouched — it was already reading Postgres.

## Why

On 2026-08-24 the Runners dashboard showed **78 queued jobs** (62 macOS + 16 Linux). The real backlog was **3**.

The gauge and the dispatcher were reading different databases:

| Path | Store |
| --- | --- |
| `pick_queued_top_k` (dispatch) | Postgres `runner_workflow_jobs` |
| `queued_count_by_fleet` (autoscaler) | Postgres |
| **`tuist_runners_queue_length`** | **ClickHouse `runner_jobs`** |

## Root cause

Postgres became the control-plane store in #12031, and #12050 made ClickHouse a replica fed solely by the transition outbox. The queue-length poller was never migrated with it.

The outbox then lost a batch of terminal transitions on **2026-08-19..21**, freezing **~2078 rows** mid-lifecycle in ClickHouse: 2006 at `running`, 75 at `queued`, nothing after Aug 21. A terminal job emits no further events, so nothing corrects them — the gauge reported a backlog no Pod could ever drain, while dispatch could not see those rows at all.

The arithmetic confirms the source: Postgres held **0** queued rows; ClickHouse held 16 frozen Linux rows against a gauge of exactly **16**, and 59 frozen macOS rows + 3 real against a gauge of **62**.

`tuist_runners_replica_divergence_count` already measures this and had been flat at 2078 for a full week. Its own description says the quiet part: *"nothing will correct it on its own because a terminal job emits no further events."*

## Why this fix over the alternatives

Repairing the ClickHouse rows would clear today's number but leave the gauge measuring a replica that can drift again on the next outbox gap. Pointing the poll at the store dispatch actually selects from makes the two structurally unable to disagree — a queue tile that reads N means N jobs a Pod can claim.

## Impact

The queue tile becomes truthful, and the "Runner queue age" alert stops being anchored to rows nothing can dispatch. Real waits were never caused by this — the same day's 19-minute pickup was the account concurrency cap (4 concurrent macOS jobs at 32 vCPU / 64 GB against a 6 vCPU / 14 GB shape) plus the known dispatch→register shuffle.

## Not fixed here

The ~2006 rows still frozen at `running` in ClickHouse feed `in_progress_count` on the customer-facing Workflows rollup, so those jobs read as perpetually in-flight. That needs a separate one-off reconciliation from Postgres. Nothing alerts on `replica_divergence_count` either.

## Validation

- New `prom_ex_plugin_test` case flushes only the `queued` transition, then completes the job **without** flushing again — reproducing the frozen-replica shape exactly. Verified it fails with `count: 1` against the old ClickHouse path and passes on Postgres.
- New `workflow_jobs_test` case covers grouping, the oldest-arrival value, rows that left `queued`, and the lookback floor.
- Existing queue-poll tests keep passing; their now-irrelevant outbox-flush calls were dropped so they no longer imply ClickHouse is involved.
- `mix test` across `runners_test`, `jobs_test`, `workflow_jobs_test`, `prom_ex_plugin_test`: **193 passed**. `mix credo --strict` and `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)