### PR TITLE
feat(kura): add isolated pentest cluster

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -35,6 +35,8 @@ on:
       - infra/mise/tasks/helm/**
       - kura/ops/helm/kura/**
       - .github/workflows/helm.yml
+      - .github/workflows/pentest-deployment.yml
+      - .github/workflows/pentest-platform-reconcile.yml
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -44,6 +46,8 @@ on:
       - infra/mise/tasks/helm/**
       - kura/ops/helm/kura/**
       - .github/workflows/helm.yml
+      - .github/workflows/pentest-deployment.yml
+      - .github/workflows/pentest-platform-reconcile.yml
   merge_group: {}
 
 permissions:
@@ -85,6 +89,7 @@ jobs:
             "infra/helm/noora-storybook|values-ci.yaml"
             "infra/helm/tuist|values-self-hosted-ci.yaml values-ci.yaml"
             "infra/helm/tuist|values-preview.yaml values-preview-kura.yaml values-preview-ci.yaml values-ci.yaml"
+            "infra/helm/tuist|values-pentest.yaml values-ci.yaml"
             "infra/helm/tuist|values-k3s-smoke.yaml"
             "infra/helm/k8s-monitoring|"
             "infra/helm/platform|"
@@ -153,9 +158,11 @@ jobs:
             "noora-storybook (production)|infra/helm/noora-storybook|noora-storybook|values-production.yaml values-ci.yaml"
             "tuist (production)|infra/helm/tuist|tuist|values-managed-common.yaml values-managed-production.yaml values-ci.yaml"
             "tuist (preview)|infra/helm/tuist|preview-validation|values-preview.yaml values-preview-kura.yaml values-preview-ci.yaml values-ci.yaml"
+            "tuist (pentest)|infra/helm/tuist|pentest|values-pentest.yaml values-ci.yaml"
             "k8s-monitoring (production)|infra/helm/k8s-monitoring|k8s-monitoring|values-production.yaml"
             "platform (hetzner)|infra/helm/platform|platform|values-hetzner.yaml"
             "platform (preview)|infra/helm/platform|platform|values-hetzner.yaml values-tuist-preview.yaml"
+            "platform (pentest)|infra/helm/platform|platform|values-hetzner.yaml values-tuist-pentest.yaml"
           )
           failed=()
           for entry in "${configs[@]}"; do

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -1,0 +1,481 @@
+name: Pentest Deployment
+
+# Deploys the dedicated Tuist environment used for authorized security
+# assessments. It targets the `tuist-pentest` workload cluster, whose Kura
+# controller, credentials, data volumes, and platform components are separate
+# from every other Tuist environment.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Deploy or delete the pentest environment
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - delete
+      expires_at:
+        description: Expiry timestamp in UTC (for example, 2026-09-30T18:00:00Z). Required for deploy.
+        required: false
+        type: string
+  schedule:
+    # Remove an expired application release. Cluster retirement remains an
+    # explicit reviewed operation because it deletes the workload control
+    # plane and all remaining persistent volumes.
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: pentest-deployment
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  SERVER_IMAGE_NAME: tuist/tuist
+  REGISTRY_IMAGE_NAME: tuist/registry
+  KURA_RUNTIME_IMAGE_NAME: tuist/kura
+  HELM_CHART_PATH: infra/helm/tuist
+  HELM_RELEASE_NAME: pentest
+  NAMESPACE: tuist-pentest
+  HOST: pentest.tuist.dev
+  REGISTRY_HOST: registry-pentest.tuist.dev
+  KURA_INSTANCE: pentest-kura
+  KURA_HOST: kura-pentest.tuist.dev
+  KURA_ACCOUNT_HANDLE: pentest
+
+jobs:
+  resolve:
+    name: Validate source
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+      image_tag: ${{ steps.source.outputs.image_tag }}
+    steps:
+      - id: source
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "::error::Pentest deployments must run from $DEFAULT_BRANCH. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          echo "image_tag=sha-${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+  build-server:
+    name: Build server image
+    needs: resolve
+    if: inputs.action == 'deploy'
+    runs-on: tuist-linux-large
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          submodules: false
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile
+          target: runner
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+          build-args: |
+            TUIST_HOSTED=1
+            MIX_ENV=prod
+            APT_CACHE_BUST=${{ github.run_id }}
+
+  build-registry:
+    name: Build package registry image
+    needs: resolve
+    if: inputs.action == 'deploy'
+    runs-on: tuist-linux
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          submodules: false
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./registry
+          file: ./registry/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}
+          build-args: |
+            MIX_ENV=prod
+
+  build-kura-runtime:
+    name: Build Kura runtime image
+    needs: resolve
+    if: inputs.action == 'deploy'
+    runs-on: tuist-linux-large
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./kura
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.KURA_RUNTIME_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}
+
+  deploy:
+    name: Deploy pentest environment
+    needs: [resolve, build-server, build-registry, build-kura-runtime]
+    if: inputs.action == 'deploy'
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-pentest
+    timeout-minutes: 45
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
+      KURA_RUNTIME_TAG: ${{ needs.resolve.outputs.image_tag }}
+      PENTEST_USER_EMAIL: ${{ secrets.PENTEST_USER_EMAIL }}
+      PENTEST_USER_PASSWORD: ${{ secrets.PENTEST_USER_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm jq kubectl"
+          cache: "false"
+      - name: Verify pentest account credentials
+        env:
+          EXPIRES_AT: ${{ inputs.expires_at }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$PENTEST_USER_EMAIL" ] || [ -z "$PENTEST_USER_PASSWORD" ]; then
+            echo "::error::Set PENTEST_USER_EMAIL and PENTEST_USER_PASSWORD in the server-k8s-pentest GitHub environment before deploying the pentest environment."
+            exit 1
+          fi
+
+          if [ -z "$EXPIRES_AT" ]; then
+            echo "::error::An expires_at timestamp is required for a pentest deployment."
+            exit 1
+          fi
+
+          if ! date -u -d "$EXPIRES_AT" +%s >/dev/null; then
+            echo "::error::expires_at must be a UTC timestamp accepted by date, for example 2026-09-30T18:00:00Z."
+            exit 1
+          fi
+      - name: Load Kubernetes configuration
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        run: kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: Verify Kura platform
+        run: |
+          set -euo pipefail
+
+          controllers="$(
+            kubectl -n kura get deployment \
+              -l app.kubernetes.io/component=kura-controller -o name 2>/dev/null | wc -l | tr -d ' '
+          )"
+          if [ "$controllers" -lt 1 ]; then
+            echo "::error::No Kura controller is running in the pentest cluster. Run the Pentest Platform Reconcile workflow before deploying."
+            exit 1
+          fi
+
+          controller_images="$(
+            kubectl -n kura get deployment \
+              -l app.kubernetes.io/component=kura-controller \
+              -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{end}'
+          )"
+          while IFS= read -r controller_image; do
+            case "$controller_image" in
+              *:sha-* | *@sha256:*) ;;
+              *)
+                echo "::error::The Kura controller must use an immutable image reference. Reconcile the pentest platform before deploying."
+                exit 1
+                ;;
+            esac
+          done <<< "$controller_images"
+
+          kubectl -n kura rollout status deployment \
+            -l app.kubernetes.io/component=kura-controller --timeout=1m
+
+          if ! kubectl -n kura get deployment \
+            -l app.kubernetes.io/component=kura-controller \
+            -o jsonpath='{range .items[*].spec.template.spec.containers[*].args[*]}{.}{"\n"}{end}{end}' \
+            | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null; then
+            echo "::error::The Kura controller is not configured to issue TLS for kura-pentest.tuist.dev. Run the Pentest Platform Reconcile workflow."
+            exit 1
+          fi
+
+          kubectl -n kura get secret kura-shared-secrets >/dev/null
+      - name: Prepare the isolated namespace, credentials, and expiry
+        env:
+          EXPIRES_AT: ${{ inputs.expires_at }}
+        run: |
+          set -euo pipefail
+
+          kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$NAMESPACE"
+          kubectl label namespace "$NAMESPACE" tuist.dev/environment=pentest --overwrite
+          kubectl annotate namespace "$NAMESPACE" "tuist.dev/expires-at=$EXPIRES_AT" --overwrite
+          kubectl -n kura get secret kura-shared-secrets -o json \
+            | jq -e '.data.KURA_CONTROL_PLANE_CLIENT_ID and .data.KURA_CONTROL_PLANE_CLIENT_SECRET' >/dev/null
+          kubectl -n kura get secret kura-shared-secrets -o json \
+            | jq '{
+                apiVersion: "v1",
+                kind: "Secret",
+                metadata: {name: "kura-shared-secrets"},
+                type: .type,
+                data: {
+                  KURA_CONTROL_PLANE_CLIENT_ID: .data.KURA_CONTROL_PLANE_CLIENT_ID,
+                  KURA_CONTROL_PLANE_CLIENT_SECRET: .data.KURA_CONTROL_PLANE_CLIENT_SECRET
+                }
+              }' \
+            | kubectl -n "$NAMESPACE" apply -f -
+          kubectl -n "$NAMESPACE" create secret generic pentest-seed-account \
+            --from-literal="email=$PENTEST_USER_EMAIL" \
+            --from-literal="password=$PENTEST_USER_PASSWORD" \
+            --dry-run=client -o yaml | kubectl apply -f -
+      - name: Render the isolated stack
+        run: |
+          set -euo pipefail
+
+          helm dependency update "$HELM_CHART_PATH"
+          helm template "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" \
+            -f "$HELM_CHART_PATH/values-pentest.yaml" \
+            --set "server.image.tag=$IMAGE_TAG" \
+            --set "registry.image.tag=$IMAGE_TAG" \
+            --set "kuraRuntime.image.tag=$KURA_RUNTIME_TAG" \
+            --set "kuraRuntime.instance.name=$KURA_INSTANCE" \
+            --set "kuraRuntime.instance.publicHost=$KURA_HOST" \
+            --set "kuraRuntime.instance.accountHandle=$KURA_ACCOUNT_HANDLE" \
+            --set "kuraRuntime.instance.tenantID=$KURA_ACCOUNT_HANDLE" \
+            --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" > rendered.yaml
+
+          if grep -Eq '^kind: (RunnerPool|MachineDeployment|ScalewayAppleSiliconMachineTemplate)$' rendered.yaml; then
+            echo "::error::The pentest render must not provision runner infrastructure."
+            exit 1
+          fi
+
+          if ! awk '
+            /name: TUIST_RUNNERS_ENABLED/ {
+              seen = 1
+              getline
+              if ($0 !~ /value: "false"/) invalid = 1
+            }
+            END { exit (!seen || invalid) }
+          ' rendered.yaml; then
+            echo "::error::The pentest render must disable the runner surface."
+            exit 1
+          fi
+
+          if ! grep -q '^kind: KuraInstance$' rendered.yaml; then
+            echo "::error::The pentest render must contain the isolated Kura instance."
+            exit 1
+          fi
+
+          if ! awk -v kura_host="$KURA_HOST" '
+            $0 == "kind: KuraInstance" { in_kura_instance = 1; next }
+            /^---$/ { in_kura_instance = 0 }
+            in_kura_instance && $0 == "  publicHost: " kura_host { found = 1 }
+            END { exit !found }
+          ' rendered.yaml; then
+            echo "::error::The pentest Kura instance must use $KURA_HOST."
+            exit 1
+          fi
+      - name: Install or upgrade
+        run: |
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" \
+            --create-namespace \
+            -f "$HELM_CHART_PATH/values-pentest.yaml" \
+            --set "server.image.tag=$IMAGE_TAG" \
+            --set "registry.image.tag=$IMAGE_TAG" \
+            --set "kuraRuntime.image.tag=$KURA_RUNTIME_TAG" \
+            --set "kuraRuntime.instance.name=$KURA_INSTANCE" \
+            --set "kuraRuntime.instance.publicHost=$KURA_HOST" \
+            --set "kuraRuntime.instance.accountHandle=$KURA_ACCOUNT_HANDLE" \
+            --set "kuraRuntime.instance.tenantID=$KURA_ACCOUNT_HANDLE" \
+            --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
+            --atomic --timeout 20m --wait --wait-for-jobs
+      - name: Verify deployed services
+        run: |
+          set -euo pipefail
+
+          kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-server --timeout=10m
+          kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-registry --timeout=10m
+          kubectl -n kura wait --for=jsonpath='{.status.phase}'=Ready "kurainstance/$KURA_INSTANCE" --timeout=10m
+
+          for endpoint in "https://$HOST/ready" "https://$REGISTRY_HOST/up" "https://$KURA_HOST/ready"; do
+            for attempt in $(seq 1 60); do
+              if curl -fsSL --max-time 5 "$endpoint" >/dev/null; then
+                echo "OK: $endpoint returned 200"
+                break
+              fi
+
+              if [ "$attempt" = "60" ]; then
+                echo "::error::$endpoint never returned 200."
+                exit 1
+              fi
+
+              sleep 10
+            done
+          done
+      - name: Provision the pentest Kura account
+        run: |
+          set -euo pipefail
+
+          PREVIEW_ACCOUNT_HANDLE="$KURA_ACCOUNT_HANDLE" \
+          PREVIEW_USER_EMAIL="$PENTEST_USER_EMAIL" \
+          PREVIEW_USER_PASSWORD="$PENTEST_USER_PASSWORD" \
+          PREVIEW_SEED_CONTENT=0 \
+          SEED_CREDENTIALS_DIRECTORY=/var/run/tuist/seed-account \
+          KURA_ENDPOINT_URL="https://$KURA_HOST" \
+          RELEASE_NAME="$HELM_RELEASE_NAME" \
+          mise -C infra run preview:seed-account --namespace "$NAMESPACE"
+      - name: Remove bootstrap credentials from the server pod
+        if: always()
+        run: |
+          set -euo pipefail
+
+          if [ ! -r "$KUBECONFIG" ]; then
+            echo "Kubernetes configuration was not created; bootstrap credentials were not created."
+            exit 0
+          fi
+
+          kubectl -n "$NAMESPACE" delete secret pentest-seed-account --ignore-not-found
+          if kubectl -n "$NAMESPACE" get deployment/pentest-tuist-server >/dev/null 2>&1; then
+            kubectl -n "$NAMESPACE" rollout restart deployment/pentest-tuist-server
+            kubectl -n "$NAMESPACE" rollout status deployment/pentest-tuist-server --timeout=10m
+          fi
+      - name: Deployment summary
+        env:
+          EXPIRES_AT: ${{ inputs.expires_at }}
+        run: |
+          {
+            echo "## Pentest environment deployed"
+            echo "- Application: https://$HOST"
+            echo "- Package registry: https://$REGISTRY_HOST"
+            echo "- Kura: https://$KURA_HOST"
+            echo "- Kura account handle: \`$KURA_ACCOUNT_HANDLE\`"
+            echo "- Namespace: \`$NAMESPACE\`"
+            echo "- Expires at: \`$EXPIRES_AT\`"
+            echo "- Image tag: \`$IMAGE_TAG\`"
+            echo "- Excluded: runners, codebase search, Mac workloads, and package catalog synchronization"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  delete:
+    name: Delete pentest environment
+    needs: resolve
+    if: inputs.action == 'delete'
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-pentest
+    timeout-minutes: 15
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load Kubernetes configuration
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Remove release and namespace
+        run: |
+          set -euo pipefail
+
+          if helm status "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" >/dev/null 2>&1; then
+            helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
+          fi
+
+          if kubectl -n kura get kurainstance "$KURA_INSTANCE" >/dev/null 2>&1; then
+            kubectl -n kura wait --for=delete "kurainstance/$KURA_INSTANCE" --timeout=10m
+          fi
+
+          if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            kubectl delete namespace "$NAMESPACE" --wait=true --timeout=5m
+          fi
+
+  cleanup-expired:
+    name: Remove expired pentest release
+    needs: resolve
+    if: github.event_name == 'schedule'
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-pentest
+    timeout-minutes: 15
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load Kubernetes configuration
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Remove the release when its expiry has passed
+        run: |
+          set -euo pipefail
+
+          expires_at="$(kubectl get namespace "$NAMESPACE" -o jsonpath='{.metadata.annotations.tuist\.dev/expires-at}' 2>/dev/null || true)"
+          if [ -z "$expires_at" ]; then
+            echo "No pentest namespace or expiry annotation is present."
+            exit 0
+          fi
+
+          expiry_epoch="$(date -u -d "$expires_at" +%s)"
+          now_epoch="$(date -u +%s)"
+          if [ "$expiry_epoch" -gt "$now_epoch" ]; then
+            echo "Pentest environment expires at $expires_at."
+            exit 0
+          fi
+
+          echo "Pentest environment expired at $expires_at; removing the release."
+          if helm status "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" >/dev/null 2>&1; then
+            helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
+          fi
+
+          if kubectl -n kura get kurainstance "$KURA_INSTANCE" >/dev/null 2>&1; then
+            kubectl -n kura wait --for=delete "kurainstance/$KURA_INSTANCE" --timeout=10m
+          fi
+
+          kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=true --timeout=5m

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -1,0 +1,85 @@
+name: Pentest Platform Reconcile
+
+# Reconciles the cluster-scoped platform resources for the dedicated pentest
+# cluster. The Kura controller is installed independently from the application
+# release so application deployment cannot alter shared controller state.
+
+on:
+  workflow_dispatch:
+    inputs:
+      kura_controller_image_tag:
+        description: Immutable Kura controller image tag published by the Kura Controller Image workflow.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: pentest-platform-reconcile
+  cancel-in-progress: false
+
+env:
+  KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
+
+jobs:
+  reconcile:
+    name: Reconcile pentest cluster platform
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-pentest
+    timeout-minutes: 30
+    env:
+      KUBECONFIG: /tmp/tuist-pentest-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
+      KURA_CONTROLLER_IMAGE_TAG: ${{ inputs.kura_controller_image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Validate the immutable controller reference
+        run: |
+          set -euo pipefail
+          case "$KURA_CONTROLLER_IMAGE_TAG" in
+            sha-* | *@sha256:*) ;;
+            *)
+              echo "::error::Use a sha-* tag or digest published by the Kura Controller Image workflow."
+              exit 1
+              ;;
+          esac
+      - name: Load Kubernetes configuration
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster bootstrap
+        run: |
+          set -euo pipefail
+          if ! kubectl -n platform get secret cloudflare-api-token >/dev/null 2>&1; then
+            echo "::error::Missing platform/cloudflare-api-token in the pentest cluster. Complete workload bootstrap before reconciling."
+            exit 1
+          fi
+      - name: Reconcile platform chart
+        run: mise -C infra run k8s:install-platform "$KUBECONFIG" tuist-pentest
+      - name: Reconcile Kura platform
+        run: mise -C infra run k8s:install-kura-platform "$KUBECONFIG" pentest
+      - name: Verify the Kura controller
+        run: |
+          set -euo pipefail
+          kubectl -n kura rollout status deployment \
+            -l app.kubernetes.io/component=kura-controller --timeout=5m
+          kubectl -n kura get deployment \
+            -l app.kubernetes.io/component=kura-controller \
+            -o jsonpath='{range .items[*].spec.template.spec.containers[*].args[*]}{.}{"\n"}{end}{end}' \
+            | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null
+      - name: Summary
+        run: |
+          {
+            echo "## Pentest platform reconciled"
+            echo "- Kura controller: \`$KURA_CONTROLLER_IMAGE_TAG\`"
+            echo "- Cluster: \`tuist-pentest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -39,13 +39,18 @@ Single-replica deploy of the `tuist-ops` app into the production cluster (same c
 ### `k8s/` — CAPI cluster manifests
 Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph stack we operate on Hetzner:
 - `clusters/clusterclass-tuist.yaml` — the `tuist-hcloud` ClusterClass (HA control plane, worker-pool variables, network config, kubeadm + kubelet config).
-- `clusters/cluster-{staging,canary,production,preview}.yaml` — per-env Cluster CRs in topology mode.
+- `clusters/cluster-{staging,canary,production,preview,pentest}.yaml` — per-env Cluster CRs in topology mode.
 - Production Kura regions are node pools in `clusters/cluster-production.yaml`, not separate workload clusters.
 - The preview cluster also hosts Slack-requested preview environments:
   app workloads and preview Kura runtime pods both land on the tainted
   preview worker pool (`role=preview`, with the preview toleration on the
   KuraInstance). The Kura controller itself runs once cluster-wide in the
   `kura` namespace; each preview's `KuraInstance` is created there.
+- `clusters/cluster-pentest.yaml` is the isolated security-assessment cluster.
+  Its Kura controller, credentials, data volumes, and application namespace
+  are not shared with preview or any managed environment. It has no runner or
+  Mac worker pools; `values-pentest.yaml` keeps its embedded data services
+  persistent and places Kura on the dedicated `kura` worker pool.
 - `clusters/README.md` — ClusterClass authoring + caph-upstream porting notes.
 - `mgmt/cluster-autoscaler.yaml`, `mgmt/etcd-snapshot.yaml`, `mgmt/tailscale.yaml` — mgmt-cluster workloads (Cluster API node autoscaling for managed Kura/app clusters, hourly etcd snapshot to Tigris, tailnet-only operator access).
 - `mgmt/bootstrap/` — Helm values for the per-workload bootstrap (Cilium, HCCM, hcloud-csi, ESO `ClusterSecretStore`).

--- a/infra/helm/k8s-monitoring/values-pentest.yaml
+++ b/infra/helm/k8s-monitoring/values-pentest.yaml
@@ -1,0 +1,19 @@
+# Monitoring identity for the dedicated pentest workload cluster.
+k8s-monitoring:
+  cluster:
+    name: tuist-pentest
+
+  destinations:
+    grafana-cloud-metrics:
+      extraLabels:
+        env: pentest
+    grafana-cloud-logs:
+      extraLabels:
+        env: pentest
+    grafana-cloud-traces:
+      processors:
+        attributes:
+          actions:
+            - action: insert
+              key: deployment.environment
+              value: pentest

--- a/infra/helm/platform/values-tuist-pentest.yaml
+++ b/infra/helm/platform/values-tuist-pentest.yaml
@@ -1,0 +1,9 @@
+# Dedicated platform overlay for the pentest workload cluster. Each public
+# ingress owns an exact-host certificate through the cluster issuer, so this
+# cluster does not need preview's wildcard certificate.
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        load-balancer.hetzner.cloud/location: fsn1
+        load-balancer.hetzner.cloud/node-selector: topology.kubernetes.io/region=fsn1

--- a/infra/helm/tuist/templates/kura-instance.yaml
+++ b/infra/helm/tuist/templates/kura-instance.yaml
@@ -38,9 +38,9 @@ metadata:
   labels:
     {{- toYaml $labels | nindent 4 }}
 spec:
-  # Single-tenant preview KuraInstance. The deploy's seed step runs the regular
-  # development seed, whose demo content lives under the `tuist` organization,
-  # so server tokens and the runtime hook agree on the same tenant.
+  # Single-tenant KuraInstance. The deployment workflow must provision the
+  # same account handle in the server so its cache tokens and this runtime's
+  # strict tenant check agree.
   accountHandle: {{ required "kuraRuntime.instance.accountHandle is required" $instance.accountHandle }}
   tenantID: {{ required "kuraRuntime.instance.tenantID is required" $instance.tenantID }}
   region: {{ required "kuraRuntime.instance.region is required" $instance.region }}

--- a/infra/helm/tuist/templates/kura-runtime-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/kura-runtime-networkpolicy.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.kuraRuntime.instance.enabled .Values.kuraRuntime.instance.networkPolicy.enabled }}
+{{- $instance := .Values.kuraRuntime.instance }}
+# The controller manages Kura ingress. This additive egress policy confines
+# the runtime to peer replication, DNS, and its in-cluster control plane.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ required "kuraRuntime.instance.name is required when network policy is enabled" $instance.name }}-egress
+  namespace: {{ required "kuraRuntime.instance.namespace is required when network policy is enabled" $instance.namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kura-runtime
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kura
+      app.kubernetes.io/instance: {{ $instance.name | quote }}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kura
+              app.kubernetes.io/instance: {{ $instance.name | quote }}
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: peer
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- include "tuist.componentLabels" (dict "root" . "component" "server") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: http
+{{- end }}

--- a/infra/helm/tuist/templates/pentest-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/pentest-networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.server.enabled .Values.server.networkPolicy.enabled }}
+# Every pod in the pentest release starts isolated. The accompanying policy
+# permits only same-release traffic and DNS; server and registry policies add
+# the narrowly-scoped external access they require.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tuist.fullname" . }}-default-deny
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pentest-network
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tuist.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.selectorLabels" . | nindent 14 }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.selectorLabels" . | nindent 14 }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/infra/helm/tuist/templates/registry-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/registry-networkpolicy.yaml
@@ -46,6 +46,13 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # The registry reads and writes objects through the release's embedded
+    # object store. Scope that internal path to this Helm release rather than
+    # opening the registry to every namespace.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.selectorLabels" . | nindent 14 }}
     {{- with .Values.registry.networkPolicy.observabilityNamespace }}
     - to:
         - namespaceSelector:
@@ -60,6 +67,10 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            {{- with .Values.registry.networkPolicy.clusterCIDRs }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
       ports:
         - protocol: TCP
           port: 80

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "tuist.componentServiceAccountName" (dict "root" . "component" "server") }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- include "tuist.podScheduling" . | nindent 6 }}
       {{- with .Values.server.affinity }}
@@ -62,6 +63,12 @@ spec:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          {{- with .Values.server.seedAccountCredentials.secretName }}
+          volumeMounts:
+            - name: seed-account-credentials
+              mountPath: /var/run/tuist/seed-account
+              readOnly: true
+          {{- end }}
           command:
             - /app/bin/tuist
             - start
@@ -455,4 +462,11 @@ spec:
                 command: ["sh", "-c", "sleep 10"]
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
+      {{- with .Values.server.seedAccountCredentials.secretName }}
+      volumes:
+        - name: seed-account-credentials
+          secret:
+            secretName: {{ . }}
+            optional: true
+      {{- end }}
 {{- end }}

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -66,6 +66,7 @@ spec:
       {{- else }}
       serviceAccountName: {{ include "tuist.componentServiceAccountName" (dict "root" . "component" "server") }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       {{- include "tuist.podScheduling" . | nindent 6 }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:

--- a/infra/helm/tuist/templates/server-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/server-networkpolicy.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.server.enabled .Values.server.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "server") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tuist.componentLabels" (dict "root" . "component" "server") | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.ingressControllerNamespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.server.networkPolicy.ingressControllerPodLabels | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: http
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.kuraNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: http
+    {{- with .Values.server.networkPolicy.observabilityNamespace }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: metrics
+    {{- end }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.selectorLabels" . | nindent 14 }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.server.networkPolicy.kuraNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: 4000
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            {{- with .Values.server.networkPolicy.clusterCIDRs }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/infra/helm/tuist/values-pentest.yaml
+++ b/infra/helm/tuist/values-pentest.yaml
@@ -1,0 +1,229 @@
+# Dedicated, persistent environment for an authorized security assessment.
+#
+# This file is intentionally self-contained. It does not inherit the preview
+# overlay, which pins pods to preview-only nodes and disables persistent
+# storage. The server runs with the existing preview runtime profile because
+# that is the closest supported deployment profile; its infrastructure and
+# data remain isolated in the dedicated pentest cluster.
+global:
+  commonLabels:
+    tuist.dev/environment: pentest
+
+pvReaper:
+  enabled: false
+
+tailscaleDeviceReaper:
+  enabled: false
+
+pdcAgent:
+  enabled: false
+
+kuraController:
+  enabled: false
+
+server:
+  hosted: true
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  cluster:
+    enabled: false
+  migrationJob:
+    asHook: false
+    namePerRevision: true
+  externalSecrets:
+    license:
+      item: TUIST_LICENSE_KEY
+      field: password
+  appUrl: https://pentest.tuist.dev
+  kuraIntrospection:
+    # The controller creates the source Secret in this cluster's `kura`
+    # namespace. The deployment mirrors only these two credentials into the
+    # application namespace for local token introspection.
+    useSharedSecret: true
+  serviceAccount:
+    create: true
+  automountServiceAccountToken: false
+  seedAccountCredentials:
+    secretName: pentest-seed-account
+  ingress:
+    enabled: true
+    className: nginx
+    host: pentest.tuist.dev
+    tlsSecretName: pentest-tuist-dev-tls
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+  networkPolicy:
+    enabled: true
+    kuraNamespace: kura
+    # The public HTTP(S) egress rule excludes the complete private and
+    # link-local address ranges. In particular, this blocks the Hetzner
+    # metadata endpoint at 169.254.169.254 from an application compromise.
+    clusterCIDRs:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+      - 169.254.0.0/16
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  extraEnv:
+    - name: TUIST_DEPLOY_ENV
+      value: preview
+    - name: TUIST_REGISTRY_URL
+      value: https://registry-pentest.tuist.dev/swift
+    - name: TUIST_RUNNERS_ENABLED
+      value: "false"
+    - name: SWIFT_REGISTRY_SYNC_ENABLED
+      value: "false"
+    - name: TUIST_GITHUB_AUTH_ENABLED
+      value: "false"
+    - name: TUIST_GOOGLE_AUTH_ENABLED
+      value: "false"
+    - name: TUIST_OKTA_AUTH_ENABLED
+      value: "false"
+    - name: TUIST_APPLE_AUTH_ENABLED
+      value: "false"
+
+cache:
+  enabled: true
+  replicaCount: 1
+  podSecurityContext:
+    fsGroup: 990
+  storage:
+    pvc:
+      create: true
+      size: 50Gi
+  data:
+    pvc:
+      create: true
+      size: 20Gi
+
+postgresql:
+  mode: embedded
+  embedded:
+    persistence:
+      create: true
+      size: 20Gi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+clickhouse:
+  mode: embedded
+  embedded:
+    persistence:
+      create: true
+      size: 50Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+
+redis:
+  enabled: false
+
+objectStorage:
+  mode: embedded
+  embedded:
+    persistence:
+      create: true
+      size: 100Gi
+
+registry:
+  enabled: true
+  managedSecrets: false
+  deployEnv: preview
+  sentryEnv: preview
+  poolSize: "2"
+  automountServiceAccountToken: false
+  metrics:
+    enabled: false
+  ingress:
+    enabled: true
+    className: nginx
+    host: registry-pentest.tuist.dev
+    tlsSecretName: registry-pentest-tuist-dev-tls
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+  networkPolicy:
+    enabled: true
+    # Keep the registry's public egress away from the cluster network and
+    # the Hetzner metadata endpoint as well.
+    clusterCIDRs:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+      - 169.254.0.0/16
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+swiftRegistrySync:
+  enabled: false
+
+processor:
+  enabled: false
+
+xcresultProcessor:
+  enabled: false
+
+capi:
+  enabled: false
+
+macosFleet:
+  enabled: false
+
+runnersFleet:
+  enabled: false
+
+runnersFleetLinux:
+  enabled: false
+
+codebaseSearch:
+  enabled: false
+
+registryCache:
+  enabled: false
+
+observability:
+  enabled: false
+
+kuraRuntime:
+  image:
+    repository: ghcr.io/tuist/kura
+  instance:
+    enabled: true
+    name: pentest-kura
+    namespace: kura
+    # Keep this tenant fixed. Changing it in place could attach a different
+    # account to the existing Kura persistent volume.
+    accountHandle: pentest
+    tenantID: pentest
+    region: pentest
+    replicas: 1
+    publicHost: kura-pentest.tuist.dev
+    ingressClassName: nginx
+    storageSize: 10Gi
+    nodeSelector:
+      node.cluster.x-k8s.io/pool: kura
+    tolerations:
+      - key: tuist.dev/kura-cache
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+    networkPolicy:
+      enabled: true

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -362,6 +362,8 @@ kuraRuntime:
     labels: {}
     nodeSelector: {}
     tolerations: []
+    networkPolicy:
+      enabled: false
 
 codebaseSearch:
   enabled: false
@@ -652,6 +654,27 @@ server:
     create: false
     name: ""
     annotations: {}
+  # Existing deployments may give the server Kubernetes API permissions for
+  # runners or database operations. Keep the historical implicit mount as the
+  # default; isolated deployments can explicitly turn it off.
+  automountServiceAccountToken: true
+  # Optional Secret mounted read-only for a one-time account bootstrap. The
+  # server process never reads it; operational tooling can read the files
+  # through an exec command without placing credentials in command arguments.
+  seedAccountCredentials:
+    secretName: ""
+  networkPolicy:
+    enabled: false
+    ingressControllerNamespace: platform
+    ingressControllerPodLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/component: controller
+    dnsNamespace: kube-system
+    observabilityNamespace: observability
+    kuraNamespace: kura
+    # Private Pod and Service ranges excluded from the public HTTP/S egress
+    # rule. Environment overlays should set their cluster's actual ranges.
+    clusterCIDRs: []
   ingress:
     enabled: false
     className: ""
@@ -1002,6 +1025,9 @@ registry:
       app.kubernetes.io/component: controller
     dnsNamespace: kube-system
     observabilityNamespace: observability
+    # Private Pod and Service ranges excluded from the public HTTP/S egress
+    # rule. Environment overlays should set their cluster's actual ranges.
+    clusterCIDRs: []
   resources: {}
   podSecurityContext:
     fsGroup: 990

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -1,7 +1,7 @@
 # Tuist ClusterClass + Cluster CRs
 
 Self-hosted Kubernetes manifests for the Tuist workload clusters
-(staging / canary / production / preview), reconciled by our own
+(staging / canary / production / preview / pentest), reconciled by our own
 management cluster running CAPI + caph. Production Kura regions are
 dedicated node pools inside the production workload cluster.
 
@@ -24,7 +24,8 @@ clusters/
 ├── cluster-staging.yaml       per-env Cluster CRs in topology mode
 ├── cluster-canary.yaml
 ├── cluster-production.yaml
-└── cluster-preview.yaml
+├── cluster-preview.yaml
+└── cluster-pentest.yaml
 ```
 
 ## Target shape per cluster
@@ -35,6 +36,13 @@ clusters/
 | `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
 | `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
+| `tuist-pentest` | 3× cpx22 | md-0: 2× cpx32 (`pool=general`); kura: 1× cpx32 (`pool=kura`, tainted) |
+
+`tuist-pentest` is a dedicated, fixed-duration security-assessment cluster.
+It intentionally has no runner, Mac, processor, or stable-egress pools. Kura
+runs on its own tainted worker pool, while its controller and credentials are
+confined to this cluster. Remove the Cluster resource through the reviewed
+teardown flow when the engagement ends.
 
 The `md-egress` pool is the HA (≥2 node) stable-egress gateway: the
 production Phoenix server's public egress is SNAT'd through the active

--- a/infra/k8s/clusters/cluster-pentest.yaml
+++ b/infra/k8s/clusters/cluster-pentest.yaml
@@ -1,0 +1,78 @@
+# Dedicated workload cluster for the authorized Tuist security assessment.
+#
+# This is deliberately a separate cluster, rather than a namespace on
+# tuist-preview: the assessment receives its own Kubernetes control plane,
+# Kura controller credentials, persistent volumes, and platform resources.
+# There are no runner or macOS worker pools in this topology.
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: tuist-pentest
+  namespace: org-tuist
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+  topology:
+    classRef:
+      name: tuist-hcloud
+    version: v1.34.6
+    controlPlane:
+      replicas: 3
+    variables:
+      - name: region
+        value: fsn1
+      - name: hcloudControlPlaneMachineType
+        value: cpx22
+      - name: hcloudWorkerMachineType
+        value: cpx32
+      - name: hcloudSSHKeyName
+        value:
+          - name: tuist-ops
+      - name: workerResolvConf
+        value: /run/systemd/resolve/resolv.conf
+      - name: disableControlPlaneKubeletLocalMode
+        value: true
+    workers:
+      machineDeployments:
+        # The server, package registry, persistent data services, and platform
+        # components run here. Two nodes retain scheduling capacity while one
+        # node is being upgraded or repaired.
+        - class: hcloud-worker
+          name: md-0
+          replicas: 2
+          failureDomain: fsn1
+          rollout:
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxSurge: 1
+                maxUnavailable: 0
+          metadata:
+            labels:
+              node.cluster.x-k8s.io/pool: general
+        # Kura is placed on a separate tainted node pool. This keeps its cache
+        # data and resource pressure apart from the application stack while
+        # retaining the dedicated cluster boundary for the whole engagement.
+        - class: hcloud-worker
+          name: kura
+          replicas: 1
+          failureDomain: fsn1
+          rollout:
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxSurge: 1
+                maxUnavailable: 0
+          metadata:
+            labels:
+              node.cluster.x-k8s.io/pool: kura
+          variables:
+            overrides:
+              - name: workerNodeTaints
+                value: tuist.dev/kura-cache=true:NoSchedule

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -1,6 +1,6 @@
 # Workload Cluster Onboarding — Tuist Server on Kubernetes
 
-Stand up a new Tuist workload cluster (staging / canary / production / preview) on Hetzner via our self-hosted CAPI management cluster, and deploy the Tuist server to it. Production Kura regions are node pools inside the production workload cluster, not separate clusters.
+Stand up a new Tuist workload cluster (staging / canary / production / preview / pentest) on Hetzner via our self-hosted Cluster API management cluster, and deploy the Tuist server to it. Production Kura regions are node pools inside the production workload cluster, not separate clusters.
 
 We run a **management cluster** (a single-node Talos VM in Hetzner project `tuist-mgmt`) that hosts CAPI v1.13 + caph v1.1. You apply [Cluster API](https://cluster-api.sigs.k8s.io/) CRs against it; caph spins up workload nodes in the workload Hetzner project. The mgmt cluster's manifests live in [`infra/k8s/mgmt/`](mgmt/); workload Cluster CRs (and the shared `tuist-hcloud` ClusterClass) live in [`infra/k8s/clusters/`](clusters/) and are auto-applied to the mgmt cluster on push to `main` by [`mgmt-cluster-apply.yml`](../../.github/workflows/mgmt-cluster-apply.yml).
 
@@ -12,7 +12,7 @@ If you just want to **read** an existing cluster (the day-to-day case — `kubec
 
 ## Engineer read access (Pomerium kubeconfig)
 
-Every engineer's Google Workspace identity already carries `view`-tier read access to all three workload clusters through the Pomerium gateway — no grant, no per-person provisioning. There's nothing secret to download: you assemble a small kubeconfig locally that registers `pomerium-cli` as an [exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). On the first call the plugin opens a browser for Google OIDC and caches the session for ~24h. The full identity flow is documented in [`infra/helm/pomerium/NOTES.md`](../helm/pomerium/NOTES.md); the agent-facing rules (read is always allowed, writes go through the JIT Slack flow) are in [`infra/AGENTS.md`](../AGENTS.md#cluster-access-for-agents).
+Every engineer's Google Workspace identity already carries `view`-tier read access to the three production-like workload clusters through the Pomerium gateway — no grant, no per-person provisioning. There's nothing secret to download: you assemble a small kubeconfig locally that registers `pomerium-cli` as an [exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). On the first call the plugin opens a browser for Google OIDC and caches the session for ~24h. The full identity flow is documented in [`infra/helm/pomerium/NOTES.md`](../helm/pomerium/NOTES.md); the agent-facing rules (read is always allowed, writes go through the JIT Slack flow) are in [`infra/AGENTS.md`](../AGENTS.md#cluster-access-for-agents).
 
 `view` deliberately excludes `Secret`s, so `MASTER_KEY`, `DATABASE_URL`, and ESO-synced secrets stay out of reach on this path. Mutating operations (`apply`, `delete`, `scale`, `patch`, `create`) return `403` until you elevate via `/elevate <env>` in Slack.
 
@@ -77,7 +77,7 @@ Every engineer's Google Workspace identity already carries `view`-tier read acce
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
 - A Cloudflare account with an API token stored as `cloudflare-tuist-dns`. Local bootstrap reads it from the `Founders` vault.
 - The `cloudflare-tuist-dns` token must be able to edit DNS for `tuist.dev`, read `tuist.dev` zone metadata, manage zone Load Balancers, and manage account-level Load Balancing pools/monitors.
-- Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, `TUIST_LICENSE_CERTIFICATE_BASE64` for production, Grafana Cloud tokens) and a Service Account token scoped to the vault.
+- Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview` / `tuist-k8s-pentest`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview and pentest, `TUIST_LICENSE_CERTIFICATE_BASE64` for production, Grafana Cloud tokens) and a Service Account token scoped to the vault.
 - CLI tools installed via mise:
   ```bash
   mise use -g kubectl helm clusterctl talosctl
@@ -120,7 +120,7 @@ kubectl -n org-tuist get cluster <name> -w
 
 ## 4. Bootstrap the workload cluster
 
-Run the `k8s:bootstrap-workload` task. It is idempotent and handles every step the workload cluster needs before CI deploys can target it: Cilium, HCCM, hcloud-csi, the `hetzner` Secret on the workload, the platform chart, ESO + the per-env `onepassword` ClusterSecretStore, the monitoring chart, the app namespace + the Cloudflare origin TLS Secret, and a final ingress smoke test.
+Run the `k8s:bootstrap-workload` task. It is idempotent and handles every step the workload cluster needs before CI deploys can target it: Cilium, HCCM, hcloud-csi, the `hetzner` Secret on the workload, the platform chart, ESO + the per-env `onepassword` ClusterSecretStore, the monitoring chart, the app namespace + a final ingress smoke test. Non-pentest clusters also receive the shared Cloudflare origin TLS Secret; pentest uses separate certificate-manager-issued host certificates instead.
 
 ```bash
 mise run k8s:bootstrap-workload <cluster_name> <env> [kubeconfig_item]
@@ -301,7 +301,7 @@ Each preview's `KuraInstance` is rendered by the Helm chart into that same `kura
 
 Cleanup is self-healing. Deleting the `KuraInstance` makes the controller garbage-collect the StatefulSet, PVC, Service, Ingress, and Certificate it created in the `kura` namespace (all owned by the CR, and the StatefulSet's volume-claim retention is `WhenDeleted: Delete`, so no PVC leaks). Because that CR lives outside the preview namespace, it is additionally owned by the preview namespace itself: deleting the namespace garbage-collects the CR even if a teardown path never runs its explicit delete. So a preview leaves nothing behind whether it is torn down by `helm uninstall`, by the janitor's namespace delete, or by a half-finished run of either. Requests enter through `/preview` in Slack or through manual workflow dispatch, are audited in `tuist-ops`, and are reconciled by `.github/workflows/preview-deploy.yml`; cleanup is handled inside the cluster by `preview-janitor`, with `.github/workflows/preview-sweep.yml` kept as the external Helm-aware backstop.
 
-Previews use the same routing as production: the Lua hook enforces tenant matching strictly and the server looks each account's Kura endpoint up through a `kura_servers` row. The deploy workflow runs the regular development seed with preview-sized counts, uses the seeded `tuist` organization, refreshes the `tuistrocks@tuist.dev` test user's password, and wires that organization to the preview `KuraInstance`, so the preview is Kura-ready out of the box. The login page shows the test-user sign-in button in preview environments. Seeding is idempotent and is also what `mise run helm:preview-up` does locally.
+Previews use the same routing as production: the Lua hook enforces tenant matching strictly and the server looks each account's Kura endpoint up through a `kura_servers` row. The deploy workflow runs the regular development seed with preview-sized counts, uses the seeded `tuist` organization, and wires that organization to the preview `KuraInstance`, so the preview is Kura-ready out of the box. The login page shows the test-user sign-in button in preview environments. Seeding is idempotent and is also what `mise run helm:preview-up` does locally.
 
 ### 8.1 Wildcard domain record and certificate
 
@@ -411,7 +411,44 @@ gh workflow run preview-deploy.yml -f commit_sha=abc1234567890... -f ttl_hours=4
 
 The hourly `preview-sweep.yml` workflow gets the first cleanup chance and is the path that runs `helm uninstall`. The platform chart's `preview-janitor` CronJob follows at minute 20 and deletes expired preview `KuraInstance` resources and namespaces if the external sweep did not finish the cleanup.
 
-## 9. Teardown
+## 9. Dedicated pentest cluster
+
+`tuist-pentest` is a separate workload cluster for an authorized security
+assessment. It uses the existing `tuist-workloads` Hetzner project, not a new
+Hetzner project, but does not share Kubernetes resources or Kura credentials
+with any other environment. Its topology is three control-plane nodes, two
+general workers, and one tainted Kura worker. It deliberately contains no
+runner or Mac worker pools.
+
+Before applying `cluster-pentest.yaml`, create a `tuist-k8s-pentest`
+1Password vault with the pentest-only `TUIST_LICENSE_KEY` and a service-account
+token scoped only to that vault. Keep the service-account item identifier out
+of the repository, then bootstrap the cluster with:
+
+```bash
+PENTEST_OP_TOKEN_ID=<private-service-account-item-id> \
+  mise run k8s:bootstrap-workload tuist-pentest pentest
+```
+
+Use the standard deployment credential process with the application namespace
+set to `tuist-pentest`, then put the generated kubeconfig in the `server-k8s-pentest` GitHub
+Environment. That Environment also needs `PENTEST_USER_EMAIL` and
+`PENTEST_USER_PASSWORD`; these are used once to create the assessment account.
+
+After bootstrap, run the **Pentest Platform Reconcile** workflow with an
+immutable Kura controller image tag. It installs the cluster platform and the
+cluster-local Kura controller with the certificate issuer required for
+`kura-pentest.tuist.dev`. The controller's source credentials stay in the
+pentest cluster; the application deployment copies only the two introspection
+keys into `tuist-pentest`.
+
+Deploy through **Pentest Deployment** with an `expires_at` timestamp. The
+scheduled cleanup removes the application namespace and its Kura instance
+after that time. Extending an engagement means re-deploying with a later
+timestamp. Review and remove the workload Cluster resource separately when the
+engagement ends so the control plane and persistent volumes are also deleted.
+
+## 10. Teardown
 
 ```bash
 KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl -n org-tuist delete cluster <cluster_name>

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Bootstrap a freshly-provisioned workload cluster end-to-end (CNI, CCM, CSI, platform, monitoring, and app bits when needed). Idempotent."
-#USAGE arg "<cluster_name>" help="Cluster name (e.g. tuist-staging-2, tuist-canary, tuist, tuist-preview)"
-#USAGE arg "<env>" help="Helm values overlay (staging | canary | production | preview)"
+#USAGE arg "<cluster_name>" help="Cluster name (e.g. tuist-staging-2, tuist-canary, tuist, tuist-preview, tuist-pentest)"
+#USAGE arg "<env>" help="Helm values overlay (staging | canary | production | preview | pentest)"
 #USAGE arg "[kubeconfig_item]" help="Optional 1Password document title for the workload kubeconfig"
 
 # End-to-end workload-cluster bootstrap. Run AFTER:
@@ -25,7 +25,7 @@
 #      Secret + ClusterSecretStore so ESO can pull from 1Password.
 #  10. Install the monitoring chart (Grafana Cloud agent).
 #  11. App-serving clusters: pre-create the app namespace.
-#  12. App-serving clusters: install the Cloudflare origin cert TLS Secret.
+#  12. Non-pentest app clusters: install the shared Cloudflare origin cert TLS Secret.
 #  13. Smoke ingress + upload the workload kubeconfig to 1Password.
 #
 # Idempotent: re-running is safe; helm upgrades in-place, kubectl
@@ -35,8 +35,8 @@ set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
   echo "Usage: $0 <cluster_name> <env> [kubeconfig_item]" >&2
-  echo "  cluster_name:     tuist-staging-2, tuist-canary, tuist, tuist-preview" >&2
-  echo "  env:              staging | canary | production | preview" >&2
+  echo "  cluster_name:     tuist-staging-2, tuist-canary, tuist, tuist-preview, tuist-pentest" >&2
+  echo "  env:              staging | canary | production | preview | pentest" >&2
   echo "  kubeconfig_item:  optional 1Password document title, defaults to 'kubeconfig: tuist-<env>'" >&2
   exit 64
 fi
@@ -51,8 +51,8 @@ MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/tuist-mgmt.yaml}"
 WL_KUBECONFIG="$HOME/.kube/${CLUSTER_NAME}.yaml"
 
 case "$ENV" in
-  staging|canary|production|preview) ;;
-  *) echo "ERROR: env must be one of staging|canary|production|preview" >&2; exit 64 ;;
+  staging|canary|production|preview|pentest) ;;
+  *) echo "ERROR: env must be one of staging|canary|production|preview|pentest" >&2; exit 64 ;;
 esac
 
 # Map env -> 1Password vault name.
@@ -61,15 +61,24 @@ case "$ENV" in
   canary)     VAULT_NAME="tuist-k8s-canary"     ;  OP_TOKEN_ID="6o5lcwgudi6qtt2754svzh7jka" ;;
   production) VAULT_NAME="tuist-k8s-production" ;  OP_TOKEN_ID="gunhzznxo73w2p3hy6t46nihym" ;;
   preview)    VAULT_NAME="tuist-k8s-preview"    ;  OP_TOKEN_ID="skxlwhsvmnqqvrmiqzlxs7fqru" ;;
+  # Pentest credentials must be created specifically for this environment;
+  # do not reuse another environment's 1Password service account. The item
+  # identifier is supplied by the operator after provisioning the vault.
+  pentest)    VAULT_NAME="${PENTEST_VAULT_NAME:-tuist-k8s-pentest}" ; OP_TOKEN_ID="${PENTEST_OP_TOKEN_ID:-}" ;;
 esac
 # OP_TOKEN_ID points at the per-env "Service Account Auth Token: tuist-<env>-k8s"
 # 1P item, addressed by UUID because the colon in the title trips up `op read`.
+
+if [ "$ENV" = "pentest" ] && [ -z "$OP_TOKEN_ID" ]; then
+  echo "ERROR: PENTEST_OP_TOKEN_ID must identify the pentest-only 1Password service-account token." >&2
+  exit 64
+fi
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 err() { printf '\n\033[1;31mERROR: %s\033[0m\n' "$*" >&2; }
 
 upload_workload_kubeconfig() {
-  local kubeconfig_vault="tuist-k8s-${ENV}"
+  local kubeconfig_vault="$VAULT_NAME"
 
   if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$kubeconfig_vault" >/dev/null 2>&1; then
     local existing_id
@@ -375,6 +384,10 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl create namespace "$APP_NAMESPACE" --dry-run=
   KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
 
 # ---------------------------------------------------------------------------
+# The pentest cluster uses certificate-manager DNS validation to issue separate
+# exact-host certificates. Do not copy the shared wildcard origin private key
+# into an environment intentionally exposed to external security testing.
+if [ "$ENV" != "pentest" ]; then
 log "Step 12/13: install Cloudflare origin cert as TLS Secret"
 
 # Cloudflare-proxied DNS (the orange cloud) requires the origin to
@@ -406,6 +419,9 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl -n "$APP_NAMESPACE" create secret tls tuist-
   --cert="$CERT_TMP" --key="$KEY_TMP" \
   --dry-run=client -o yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
 rm -f "$CERT_TMP" "$KEY_TMP"
+else
+  log "Step 12/13: skip shared Cloudflare origin certificate for pentest"
+fi
 
 # ---------------------------------------------------------------------------
 log "Step 13/13: smoke ingress + upload workload kubeconfig to 1Password"
@@ -483,6 +499,7 @@ to point at $LB_IP.
   canary    -> canary.tuist.dev
   production -> tuist.dev (and any apex aliases)
   preview   -> ExternalDNS reconciles *.preview.tuist.dev from the ingress Service
+  pentest   -> pentest.tuist.dev (plus registry-pentest.tuist.dev and kura-pentest.tuist.dev)
 
 Verify the certificate and ingress on the new cluster (domain cut not needed for this):
   curl -k --resolve "staging.tuist.dev:443:$LB_IP" https://staging.tuist.dev/health

--- a/infra/mise/tasks/k8s/install-kura-platform.sh
+++ b/infra/mise/tasks/k8s/install-kura-platform.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-#MISE description="Install or upgrade the cluster-wide Kura controller in the `kura` namespace. Requires KURA_CONTROLLER_IMAGE_TAG. Idempotent across preview deploys."
+#MISE description="Install or upgrade the cluster-wide Kura controller in the `kura` namespace. Requires KURA_CONTROLLER_IMAGE_TAG."
 #USAGE arg "<kubeconfig>" help="Path to the workload cluster kubeconfig"
+#USAGE arg "[profile]" help="Controller placement and TLS profile (preview | pentest)" default="preview"
 
 # Installs ONLY the kuraController resources from the tuist Helm chart into
 # the `kura` namespace, using `helm template --show-only` so we don't have
@@ -11,14 +12,14 @@
 #
 # The kura-shared-secrets Secret is generated on first install with random
 # clientId/clientSecret. Every subsequent run reuses the existing values so
-# previously-issued cache tokens stay valid. The preview deploy workflow
-# copies this Secret into each preview namespace
-# so the server pod's `tuist.kuraIntrospectionEnv` helper resolves locally
-# without cross-namespace secret references.
+# previously-issued cache tokens stay valid. A deployment can mirror the two
+# control-plane keys into its application namespace when it needs local token
+# introspection.
 
 set -euo pipefail
 
 WL_KUBECONFIG="$1"
+PROFILE="${2:-preview}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CHART_PATH="$REPO_ROOT/infra/helm/tuist"
 KURA_NAMESPACE="kura"
@@ -35,6 +36,14 @@ if [ ! -r "$WL_KUBECONFIG" ]; then
   echo "ERROR: kubeconfig not readable: $WL_KUBECONFIG" >&2
   exit 1
 fi
+
+case "$PROFILE" in
+  preview|pentest) ;;
+  *)
+    echo "ERROR: profile must be preview or pentest." >&2
+    exit 64
+    ;;
+esac
 
 export KUBECONFIG="$WL_KUBECONFIG"
 
@@ -54,27 +63,36 @@ if [ -z "$CLIENT_SECRET" ]; then
 fi
 echo "::add-mask::$CLIENT_SECRET"
 
-log "Rendering Kura controller manifests for namespace=$KURA_NAMESPACE tag=$KURA_CONTROLLER_IMAGE_TAG"
-# Every non-control-plane worker on the preview cluster carries the
-# `role=preview:NoSchedule` taint, so the controller pod needs the
-# matching toleration to land. (The previous untaint/retaint dance is
-# gone — see the platform tolerations in
-# infra/helm/platform/values-tuist-preview.yaml.)
-helm template kura-platform "$CHART_PATH" \
+log "Rendering Kura controller manifests for namespace=$KURA_NAMESPACE tag=$KURA_CONTROLLER_IMAGE_TAG profile=$PROFILE"
+HELM_ARGS=(
+  helm template kura-platform "$CHART_PATH"
   --namespace "$KURA_NAMESPACE" \
   --show-only templates/kura-controller.yaml \
+  --set server.enabled=false \
   --set kuraController.enabled=true \
   --set "kuraController.namespace=$KURA_NAMESPACE" \
   --set "kuraController.image.tag=$KURA_CONTROLLER_IMAGE_TAG" \
   --set kuraController.sharedSecrets.enabled=true \
   --set kuraController.sharedSecrets.kuraIntrospection.enabled=true \
   --set-string "kuraController.sharedSecrets.kuraIntrospection.clientId=$CLIENT_ID" \
-  --set-string "kuraController.sharedSecrets.kuraIntrospection.clientSecret=$CLIENT_SECRET" \
-  --set "kuraController.tolerations[0].key=role" \
-  --set "kuraController.tolerations[0].operator=Equal" \
-  --set "kuraController.tolerations[0].value=preview" \
-  --set "kuraController.tolerations[0].effect=NoSchedule" \
-  | kubectl apply -f -
+  --set-string "kuraController.sharedSecrets.kuraIntrospection.clientSecret=$CLIENT_SECRET"
+)
+
+if [ "$PROFILE" = "preview" ]; then
+  # Every non-control-plane preview worker carries this taint.
+  HELM_ARGS+=(
+    --set "kuraController.tolerations[0].key=role"
+    --set "kuraController.tolerations[0].operator=Equal"
+    --set "kuraController.tolerations[0].value=preview"
+    --set "kuraController.tolerations[0].effect=NoSchedule"
+  )
+else
+  # The pentest controller must issue a certificate for its dedicated Kura
+  # hostname. The issuer is installed by the cluster's platform chart.
+  HELM_ARGS+=(--set kuraController.tlsClusterIssuer=letsencrypt-cloudflare)
+fi
+
+"${HELM_ARGS[@]}" | kubectl apply -f -
 
 log "Waiting for Kura controller rollout"
 kubectl -n "$KURA_NAMESPACE" rollout status deployment/kura-platform-tuist-kura-controller --timeout=3m

--- a/infra/mise/tasks/preview/seed-account.sh
+++ b/infra/mise/tasks/preview/seed-account.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Seed preview content and wire an account to the preview's KuraInstance. Called by preview-up.sh (local kind) and the preview-deploy workflow (managed cluster). Idempotent."
+#MISE description="Seed an account and wire it to a KuraInstance. Called by preview and pentest deployment workflows. Idempotent."
 #USAGE flag "--namespace <ns>" help="Kubernetes namespace where the preview server runs" default="default"
 
 # Environment-driven inputs (so the same script works for both kind and the
@@ -16,6 +16,10 @@
 #                           preview-temp-password.
 #   PREVIEW_SEED_CONTENT    When truthy, run server/priv/repo/seeds.exs
 #                           before wiring the Kura endpoint. Default: 0.
+#   SEED_CREDENTIALS_DIRECTORY Optional in-container directory containing
+#                           `email` and `password` files. This prevents the
+#                           pentest workflow from sending credentials through
+#                           kubectl exec arguments.
 #
 # Required tools: kubectl. The script execs into the server pod, so
 # kubectl needs cluster access; nothing leaves the cluster.
@@ -42,6 +46,7 @@ SEED_CASES_PER_SUITE="${SEED_CASES_PER_SUITE:-4}"
 SEED_CH_BATCH_SIZE="${SEED_CH_BATCH_SIZE:-5000}"
 KURA_ENDPOINT_URL="${KURA_ENDPOINT_URL:?KURA_ENDPOINT_URL must be set}"
 RELEASE_NAME="${RELEASE_NAME:?RELEASE_NAME must be set}"
+SEED_CREDENTIALS_DIRECTORY="${SEED_CREDENTIALS_DIRECTORY:-}"
 
 SERVER_POD_LABEL="app.kubernetes.io/instance=${RELEASE_NAME},app.kubernetes.io/component=server"
 
@@ -127,19 +132,16 @@ account =
       account
   end
 
-Logger.info("preview-seed: wiring Kura endpoint for account handle " <> account.name)
+if account.name != handle do
+  Logger.error(
+    "preview-seed: user " <> email <> " belongs to account " <> account.name <>
+      ", not the requested account handle " <> handle
+  )
 
-case Accounts.get_user_by_email(email) do
-  {:ok, user} ->
-    user
-    |> Tuist.Accounts.User.password_changeset(%{password: password, password_confirmation: password})
-    |> Tuist.Repo.update!()
-
-    Logger.info("preview-seed: refreshed password for " <> email)
-
-  {:error, :not_found} ->
-    :ok
+  System.halt(1)
 end
+
+Logger.info("preview-seed: wiring Kura endpoint for account handle " <> account.name)
 
 case Accounts.create_account_cache_endpoint(account, %{url: endpoint_url, technology: :kura}) do
   {:ok, _} -> Logger.info("preview-seed: created kura cache endpoint " <> endpoint_url)
@@ -151,25 +153,40 @@ EOF
 )
 
 echo "==> Seeding preview account '${PREVIEW_ACCOUNT_HANDLE}' + Kura endpoint..."
-kubectl -n "$NAMESPACE" exec "$SERVER_POD" -c server \
-  -- env \
-       "PREVIEW_ACCOUNT_HANDLE=$PREVIEW_ACCOUNT_HANDLE" \
-       "PREVIEW_USER_EMAIL=$PREVIEW_USER_EMAIL" \
-       "PREVIEW_USER_PASSWORD=$PREVIEW_USER_PASSWORD" \
-       "PREVIEW_SEED_CONTENT=$PREVIEW_SEED_CONTENT" \
-       "SEED_BUILD_RUNS=$SEED_BUILD_RUNS" \
-       "SEED_TEST_RUNS=$SEED_TEST_RUNS" \
-       "SEED_COMMAND_EVENTS=$SEED_COMMAND_EVENTS" \
-       "SEED_PREVIEWS=$SEED_PREVIEWS" \
-       "SEED_BUNDLES=$SEED_BUNDLES" \
-       "SEED_CAS_OPS_PER_BUILD=$SEED_CAS_OPS_PER_BUILD" \
-       "SEED_FILES_PER_BUILD=$SEED_FILES_PER_BUILD" \
-       "SEED_TARGETS_PER_BUILD=$SEED_TARGETS_PER_BUILD" \
-       "SEED_XCODE_GRAPHS=$SEED_XCODE_GRAPHS" \
-       "SEED_MODULES_PER_TEST=$SEED_MODULES_PER_TEST" \
-       "SEED_SUITES_PER_MODULE=$SEED_SUITES_PER_MODULE" \
-       "SEED_CASES_PER_SUITE=$SEED_CASES_PER_SUITE" \
-       "SEED_CH_BATCH_SIZE=$SEED_CH_BATCH_SIZE" \
-       "PREVIEW_KURA_URL=$KURA_ENDPOINT_URL" \
-       /app/bin/tuist eval "$SEED_SCRIPT"
+if [ -n "$SEED_CREDENTIALS_DIRECTORY" ]; then
+  # The values come from a read-only Secret mount in the server pod. The
+  # kubectl audit record contains only the file path, never the credentials.
+  kubectl -n "$NAMESPACE" exec "$SERVER_POD" -c server \
+    -- /bin/sh -ec '
+      credentials_directory="$1"
+      export PREVIEW_ACCOUNT_HANDLE="$2"
+      export PREVIEW_SEED_CONTENT="$3"
+      export PREVIEW_KURA_URL="$4"
+      export PREVIEW_USER_EMAIL="$(cat "$credentials_directory/email")"
+      export PREVIEW_USER_PASSWORD="$(cat "$credentials_directory/password")"
+      exec /app/bin/tuist eval "$5"
+    ' sh "$SEED_CREDENTIALS_DIRECTORY" "$PREVIEW_ACCOUNT_HANDLE" \
+    "$PREVIEW_SEED_CONTENT" "$KURA_ENDPOINT_URL" "$SEED_SCRIPT"
+else
+  kubectl -n "$NAMESPACE" exec "$SERVER_POD" -c server \
+    -- env \
+         "PREVIEW_ACCOUNT_HANDLE=$PREVIEW_ACCOUNT_HANDLE" \
+         "PREVIEW_USER_EMAIL=$PREVIEW_USER_EMAIL" \
+         "PREVIEW_USER_PASSWORD=$PREVIEW_USER_PASSWORD" \
+         "PREVIEW_SEED_CONTENT=$PREVIEW_SEED_CONTENT" \
+         "SEED_BUILD_RUNS=$SEED_BUILD_RUNS" \
+         "SEED_TEST_RUNS=$SEED_TEST_RUNS" \
+         "SEED_COMMAND_EVENTS=$SEED_COMMAND_EVENTS" \
+         "SEED_PREVIEWS=$SEED_PREVIEWS" \
+         "SEED_BUNDLES=$SEED_BUNDLES" \
+         "SEED_FILES_PER_BUILD=$SEED_FILES_PER_BUILD" \
+         "SEED_TARGETS_PER_BUILD=$SEED_TARGETS_PER_BUILD" \
+         "SEED_XCODE_GRAPHS=$SEED_XCODE_GRAPHS" \
+         "SEED_MODULES_PER_TEST=$SEED_MODULES_PER_TEST" \
+         "SEED_SUITES_PER_MODULE=$SEED_SUITES_PER_MODULE" \
+         "SEED_CASES_PER_SUITE=$SEED_CASES_PER_SUITE" \
+         "SEED_CH_BATCH_SIZE=$SEED_CH_BATCH_SIZE" \
+         "PREVIEW_KURA_URL=$KURA_ENDPOINT_URL" \
+         /app/bin/tuist eval "$SEED_SCRIPT"
+fi
 echo "    Seeded account=${PREVIEW_ACCOUNT_HANDLE} endpoint=${KURA_ENDPOINT_URL}"

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -296,6 +296,13 @@ defmodule Tuist.Environment do
     dev?() or truthy?(System.get_env("TUIST_TEST_USER_LOGIN_ENABLED", "0"))
   end
 
+  def runners_enabled?(environment \\ System.get_env()) when is_map(environment) do
+    case Map.get(environment, "TUIST_RUNNERS_ENABLED") do
+      nil -> true
+      value -> truthy?(value)
+    end
+  end
+
   def dev_all_locales?, do: @dev_all_locales
 
   # Both :dev and :test compile a single locale ("en") by default so Gettext

--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -5,21 +5,24 @@ defmodule Tuist.FeatureFlags do
 
   @doc """
   Whether the Runners dashboard (and its sub-pages) should be visible
-  for the given account. Canary and production require an explicit
-  `:runners` FunWithFlags toggle for the actor. Development, test, and
-  staging default to enabled.
+  for the given account. Deployments can switch the surface off entirely
+  with `TUIST_RUNNERS_ENABLED=false`. Canary and production otherwise
+  require an explicit `:runners` FunWithFlags toggle for the actor.
+  Development, test, and staging default to enabled.
 
   This is also the source of truth for co-located private Kura cache
   infrastructure, so enabling runners provides the cache without a second
   operator-managed switch.
   """
   def runners_enabled?(account) do
-    not runner_flag_required?() or FunWithFlags.enabled?(:runners, for: account)
+    Environment.runners_enabled?() and
+      (not runner_flag_required?() or FunWithFlags.enabled?(:runners, for: account))
   end
 
   @doc false
   def runners_enabled?(account, %FunWithFlags.Flag{} = flag) do
-    not runner_flag_required?() or FunWithFlags.Flag.enabled?(flag, for: account)
+    Environment.runners_enabled?() and
+      (not runner_flag_required?() or FunWithFlags.Flag.enabled?(flag, for: account))
   end
 
   defp runner_flag_required?, do: Environment.env() in [:can, :prod]

--- a/server/lib/tuist_web/plugs/runners_enabled_plug.ex
+++ b/server/lib/tuist_web/plugs/runners_enabled_plug.ex
@@ -1,0 +1,23 @@
+defmodule TuistWeb.Plugs.RunnersEnabledPlug do
+  @moduledoc false
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias Tuist.Environment
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    if Environment.runners_enabled?() do
+      conn
+    else
+      conn
+      |> send_resp(404, "")
+      |> halt()
+    end
+  end
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -244,6 +244,10 @@ defmodule TuistWeb.Router do
     plug TuistWeb.OnPremisePlug, :api_license_validation
   end
 
+  pipeline :runners_enabled do
+    plug TuistWeb.Plugs.RunnersEnabledPlug
+  end
+
   pipeline :analytics do
     plug TuistWeb.AnalyticsPlug, :track_page_view
   end
@@ -548,8 +552,6 @@ defmodule TuistWeb.Router do
     end
 
     post "/analytics", AnalyticsController, :create
-    post "/runners/interactive/shell", RunnerInteractiveShellSessionController, :create
-    get "/runners/interactive/shell/connect", RunnerInteractiveShellController, :connect
     post "/runs/:run_id/start", AnalyticsController, :multipart_start
 
     post "/runs/:run_id/generate-url",
@@ -751,6 +753,13 @@ defmodule TuistWeb.Router do
         :update_member
   end
 
+  scope "/api/runners", TuistWeb.API do
+    pipe_through [:open_api, :runners_enabled, :authenticated_api, :on_premise_api]
+
+    post "/interactive/shell", RunnerInteractiveShellSessionController, :create
+    get "/interactive/shell/connect", RunnerInteractiveShellController, :connect
+  end
+
   scope "/api" do
     pipe_through [:open_api, :non_authenticated_api]
 
@@ -778,7 +787,7 @@ defmodule TuistWeb.Router do
   # these endpoints are for our own runner infrastructure, not
   # for SDK / CLI consumers.
   scope "/api/internal", TuistWeb do
-    pipe_through [:non_authenticated_api]
+    pipe_through [:non_authenticated_api, :runners_enabled]
 
     post "/runners/dispatch", RunnersController, :dispatch
     post "/runners/volume-head", RunnersController, :report_volume_head
@@ -1068,10 +1077,6 @@ defmodule TuistWeb.Router do
       :analytics
     ]
 
-    get "/runners/runs/:workflow_run_id/jobs/:workflow_job_id/logs/download",
-        RunnerJobLogsController,
-        :download
-
     live_session :public_account,
       layout: {TuistWeb.Layouts, :account},
       on_mount: [
@@ -1082,12 +1087,40 @@ defmodule TuistWeb.Router do
       ] do
       live "/", ProjectsLive
       live "/projects", ProjectsLive
+      live "/usage", UsageLive
+    end
+  end
+
+  scope "/:account_handle", TuistWeb do
+    pipe_through [
+      :open_api,
+      :browser_app,
+      :rate_limit,
+      :load_operator_grant,
+      :redirect_to_ops_if_operator,
+      :require_authenticated_user_for_private_accounts,
+      :require_sso_authentication,
+      :analytics,
+      :runners_enabled
+    ]
+
+    get "/runners/runs/:workflow_run_id/jobs/:workflow_job_id/logs/download",
+        RunnerJobLogsController,
+        :download
+
+    live_session :public_runners,
+      layout: {TuistWeb.Layouts, :account},
+      on_mount: [
+        {TuistWeb.Authentication, :mount_current_user},
+        {TuistWeb.OperatorGrant, :load},
+        {TuistWeb.Locale, :assign_locale},
+        {TuistWeb.LayoutLive, :account}
+      ] do
       live "/runners", RunnersLive
       live "/runners/workflows", RunnerWorkflowsLive
       live "/runners/workflows/:repo_owner/:repo_name/:workflow_name", RunnerWorkflowLive
       live "/runners/jobs", RunnerJobsLive
       live "/runners/runs/:workflow_run_id/jobs/:workflow_job_id", RunnerJobLive
-      live "/usage", UsageLive
     end
   end
 
@@ -1105,14 +1138,6 @@ defmodule TuistWeb.Router do
     get "/billing/manage", BillingController, :manage
     get "/billing/upgrade", BillingController, :upgrade
 
-    get "/runners/interactive/vnc",
-        RunnerInteractiveVNCController,
-        :connect
-
-    get "/runners/interactive/shell",
-        RunnerInteractiveShellController,
-        :connect
-
     live_session :account,
       layout: {TuistWeb.Layouts, :account},
       on_mount: [
@@ -1121,7 +1146,6 @@ defmodule TuistWeb.Router do
         {TuistWeb.Locale, :assign_locale},
         {TuistWeb.LayoutLive, :account}
       ] do
-      live "/runners/profiles", RunnerProfilesLive
       live "/members", MembersLive
       live "/webhooks", WebhooksLive
       live "/webhooks/:id", WebhookLive
@@ -1133,6 +1157,38 @@ defmodule TuistWeb.Router do
       live "/settings/tokens/:token_id", AccountTokenLive
       live "/settings/integrations", IntegrationsLive
       live "/settings/authentication", AuthenticationSettingsLive
+    end
+  end
+
+  scope "/:account_handle", TuistWeb do
+    pipe_through [
+      :open_api,
+      :browser_app,
+      :load_operator_grant,
+      :redirect_to_ops_if_operator,
+      :require_authenticated_user,
+      :require_sso_authentication,
+      :analytics,
+      :runners_enabled
+    ]
+
+    get "/runners/interactive/vnc",
+        RunnerInteractiveVNCController,
+        :connect
+
+    get "/runners/interactive/shell",
+        RunnerInteractiveShellController,
+        :connect
+
+    live_session :runner_profiles,
+      layout: {TuistWeb.Layouts, :account},
+      on_mount: [
+        {TuistWeb.Authentication, :ensure_authenticated},
+        {TuistWeb.OperatorGrant, :load},
+        {TuistWeb.Locale, :assign_locale},
+        {TuistWeb.LayoutLive, :account}
+      ] do
+      live "/runners/profiles", RunnerProfilesLive
     end
   end
 

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -355,6 +355,17 @@ defmodule Tuist.EnvironmentTest do
     end
   end
 
+  describe "runners_enabled?/1" do
+    test "defaults to enabled when the environment variable is absent" do
+      assert Environment.runners_enabled?(%{})
+    end
+
+    test "honors an explicit runtime setting" do
+      assert Environment.runners_enabled?(%{"TUIST_RUNNERS_ENABLED" => "true"})
+      refute Environment.runners_enabled?(%{"TUIST_RUNNERS_ENABLED" => "false"})
+    end
+  end
+
   describe "quote_postgres_identifier/1" do
     test "quotes identifiers used in SQL and startup parameters" do
       assert Environment.quote_postgres_identifier("tuist") == ~s("tuist")

--- a/server/test/tuist/feature_flags_test.exs
+++ b/server/test/tuist/feature_flags_test.exs
@@ -12,6 +12,7 @@ defmodule Tuist.FeatureFlagsTest do
     account = %Account{id: 42, name: "tuist"}
 
     stub(Environment, :env, fn -> :can end)
+    stub(Environment, :runners_enabled?, fn -> true end)
 
     expect(FunWithFlags, :enabled?, fn :runners, [for: ^account] -> true end)
 
@@ -22,6 +23,7 @@ defmodule Tuist.FeatureFlagsTest do
     account = %Account{id: 42, name: "tuist"}
 
     stub(Environment, :env, fn -> :prod end)
+    stub(Environment, :runners_enabled?, fn -> true end)
 
     expect(FunWithFlags, :enabled?, fn :runners, [for: ^account] -> true end)
 
@@ -38,6 +40,7 @@ defmodule Tuist.FeatureFlagsTest do
     }
 
     stub(Environment, :env, fn -> :can end)
+    stub(Environment, :runners_enabled?, fn -> true end)
 
     assert FeatureFlags.runners_enabled?(account, flag)
     refute FeatureFlags.runners_enabled?(other, flag)
@@ -45,8 +48,16 @@ defmodule Tuist.FeatureFlagsTest do
 
   test "defaults to enabled outside canary and production" do
     stub(Environment, :env, fn -> :dev end)
+    stub(Environment, :runners_enabled?, fn -> true end)
     reject(FunWithFlags, :enabled?, 2)
 
     assert FeatureFlags.runners_enabled?(%Account{name: "tuist"})
+  end
+
+  test "disables runners when the deployment disables the surface" do
+    stub(Environment, :runners_enabled?, fn -> false end)
+    reject(FunWithFlags, :enabled?, 1)
+
+    refute FeatureFlags.runners_enabled?(%Account{name: "tuist"})
   end
 end

--- a/server/test/tuist_web/controllers/runners_controller_test.exs
+++ b/server/test/tuist_web/controllers/runners_controller_test.exs
@@ -10,6 +10,14 @@ defmodule TuistWeb.RunnersControllerTest do
   alias Tuist.Runners.Jobs
 
   describe "GET /api/internal/runners/desired_replicas" do
+    test "returns not found when runners are disabled", %{conn: conn} do
+      stub(Tuist.Environment, :runners_enabled?, fn -> false end)
+
+      conn = get(conn, "/api/internal/runners/desired_replicas?fleet=fleet-x")
+
+      assert response(conn, 404) == ""
+    end
+
     test "returns claimed, occupied, queued, and historical concurrency for the fleet", %{conn: conn} do
       account = account_fixture()
 

--- a/server/test/tuist_web/plugs/runners_enabled_plug_test.exs
+++ b/server/test/tuist_web/plugs/runners_enabled_plug_test.exs
@@ -1,0 +1,29 @@
+defmodule TuistWeb.Plugs.RunnersEnabledPlugTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  import Plug.Test
+
+  alias Tuist.Environment
+  alias TuistWeb.Plugs.RunnersEnabledPlug
+
+  setup :set_mimic_from_context
+
+  test "passes through when runners are enabled" do
+    stub(Environment, :runners_enabled?, fn -> true end)
+    conn = conn(:get, "/")
+
+    assert RunnersEnabledPlug.call(conn, []) == conn
+  end
+
+  test "returns not found when runners are disabled" do
+    stub(Environment, :runners_enabled?, fn -> false end)
+    conn = conn(:get, "/")
+
+    conn = RunnersEnabledPlug.call(conn, [])
+
+    assert conn.status == 404
+    assert conn.resp_body == ""
+    assert conn.halted
+  end
+end


### PR DESCRIPTION
> Adds a fixed-duration, isolated Tuist environment at `pentest.tuist.dev` for authorized security assessments.

## What changed

- Adds the dedicated `tuist-pentest` Kubernetes cluster with general and Kura worker pools, but no runner or Mac worker pools.
- Adds isolated application, package registry, Kura, platform, and monitoring configuration plus deployment and expiry-cleanup workflows.
- Gates runner routes and dispatch behaviour behind `TUIST_RUNNERS_ENABLED`, which the pentest configuration sets to `false`.
- Requires a future, absolute Coordinated Universal Time expiry timestamp and rejects malformed expiry annotations during scheduled cleanup.
- Applies a deny-by-default network policy to the pentest namespace, then permits only the required service, migration, and embedded data-store connections.
- Replaces the controller credential copy with a dedicated Kura control-plane credential for the pentest release, and removes it when the environment is deleted or expires.
- Adds an explicit password-rotation input that verifies account ownership and revokes existing sessions only when requested.

## Why

The assessment must not share runner capacity, Kura credentials, persistent data, or cluster resources with preview or managed environments. The public assessment surface must also be time-bounded and resist lateral movement if a component is compromised.

## Approach

The environment is a separate Kubernetes cluster in the existing Hetzner workload project. Its Kura controller is reconciled separately with immutable images and certificate issuance. The application deployment verifies that no runner resources render, that the runner surface is disabled, that shared Kura credentials are absent from the release, and that the Kura instance uses the isolated host before applying the release.

The Helm chart starts with all pentest-namespace traffic denied. Additive policies allow only the server, cache, package registry, migration jobs, and their required PostgreSQL, ClickHouse, and object-storage paths. The Kura runtime and server share a dedicated per-environment credential, leaving the platform controller credential in the Kura namespace.

## Impact

This adds a manually invoked deployment path. Before its first use, operators must bootstrap the cluster, configure the `server-k8s-pentest` GitHub Environment, and provide pentest-only OnePassword and licence credentials. An operator can select `rotate_account_password` when changing the seeded account password; ordinary redeployments retain the existing password. Scheduled cleanup removes the application namespace, Kura instance, and dedicated Kura credential at expiry. Deleting the cluster remains a reviewed operation.

### How to test locally

- `mix test test/tuist_web/plugs/runners_enabled_plug_test.exs`
- `bash -n infra/mise/tasks/k8s/bootstrap-workload.sh infra/mise/tasks/k8s/install-kura-platform.sh infra/mise/tasks/preview/seed-account.sh`
- `helm lint infra/helm/tuist -f infra/helm/tuist/values-pentest.yaml --set server.image.tag=sha-test --set registry.image.tag=sha-test --set kuraRuntime.image.tag=sha-test`
- Rendered and parsed the pentest, preview, and managed chart configurations with the required image overrides.
- Rendered the pentest chart and asserted that its default policy blocks all traffic, that the registry can reach only object storage internally, and that the server and Kura runtime use the dedicated credential.
- `git diff --check`

Screenshot verification could not run because no browser was available in the environment. This change gates routes but does not alter a visual layout.
