### PR TITLE
fix(infra): request RAID 10 for OVH disk groups of four or more disks

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -495,7 +495,7 @@ node-local volume is lost and the host key rotates, so the next claim re-TOFUs i
 
 ### Disk layout, and why it is an install-time decision
 
-Every install these kinds start lays down a mirrored root plus a **separate XFS
+Every install these kinds start lays down a redundant root plus a **separate XFS
 `/data`**, and the self-join then mounts `/data` with `prjquota` and refuses to
 join a box where it cannot (`dataProjectQuotaScript` in
 `controllers/linux/linux_cloudinit.go`).
@@ -523,8 +523,18 @@ the box crosses kubelet's eviction line and takes down every tenant on it.
 
 The layout comes from the box's real disk groups (`ovh.PlanStorage`,
 `GET /dedicated/server/{name}/specifications/hardware`), so one code path covers
-every shape in the fleet: `/boot` + a capped `/` + `/data` filling the rest,
-mirrored, on the box's LARGEST disk group.
+every shape in the fleet: `/boot` + a capped `/` + `/data` filling the rest, on
+the box's LARGEST disk group.
+
+The RAID level comes from that group's disk count (`DiskGroup.raidLevel`): RAID
+10 on an even group of four or more disks, RAID 1 on two or three, none on one.
+This decides usable capacity, not just redundancy. A layout installed at RAID 1
+mirrors across every disk the partitioning covers, so a four-disk group installed
+that way carries ONE disk of `/data` and the extra disks buy nothing. Order a box
+with the larger disk option and it is RAID 10 that turns those disks into space.
+Odd counts above three fall back to RAID 1 rather than parity: RAID 5/6 is a
+different durability and rebuild trade to pick deliberately, and no box in the
+fleet has that shape.
 
 It is deliberately ONE storage entry. OVH documents storage customization for a
 single disk group per install, so a box with a small OS mirror plus a larger data

--- a/infra/cluster-api-provider-tuist/internal/ovh/client.go
+++ b/infra/cluster-api-provider-tuist/internal/ovh/client.go
@@ -19,10 +19,10 @@
 //     left intact, so there is no DeleteServer here.
 //
 // Every install goes out with an explicit storage block (see PlanStorage): a
-// mirrored root plus a separate XFS /data. Partitioning is an install-time
-// decision (a box adopted on OVH's default single-root layout cannot grow a
-// /data without another wipe), and /data is what makes a per-account cache
-// quota enforceable at all.
+// redundant root plus a separate XFS /data, at the RAID level the box's disk
+// count supports. Partitioning is an install-time decision (a box adopted on
+// OVH's default single-root layout cannot grow a /data without another wipe),
+// and /data is what makes a per-account cache quota enforceable at all.
 package ovh
 
 import (
@@ -263,9 +263,9 @@ const (
 	bootPartitionMiB = 1024
 
 	// rootPartitionMiB caps / on a single-disk-group box so the rest of the
-	// mirror can become /data. The node keeps almost nothing on root: the
-	// self-join relocates containerd's image store and bind-mounts the kubelet
-	// root onto /data, so this holds the base OS and its logs.
+	// group's usable capacity can become /data. The node keeps almost nothing
+	// on root: the self-join relocates containerd's image store and bind-mounts
+	// the kubelet root onto /data, so this holds the base OS and its logs.
 	rootPartitionMiB = 64 * 1024
 
 	// fillRemainingMiB is the size value OVH reads as "give this partition the
@@ -331,10 +331,30 @@ func (g DiskGroup) capacityMiB() int64 {
 	return size * disks
 }
 
-// raidLevel is 1 (mirror) wherever the group has disks to mirror across. Every
-// box in the fleet does; a single-disk group degrades to no RAID rather than
-// failing the install.
+// raidLevel is the software RAID level every partition of the group's layout is
+// installed at. RAID 10 on an EVEN group of four or more disks, RAID 1 on two
+// or three, no RAID on one.
+//
+// The distinction is the group's usable capacity, not just its redundancy. A
+// layout installed at RAID 1 mirrors across ALL the disks the partitioning
+// covers, so a four-disk group installed that way yields ONE disk of usable
+// space: ordering a box with twice the disks buys nothing. RAID 10 stripes over
+// mirrored pairs instead, so the same four disks yield two disks of space at
+// the same single-disk-failure tolerance. Below four there is nothing to stripe
+// and RAID 1 is the only mirror available.
+//
+// An ODD count above three (5, 7) falls back to RAID 1 rather than reaching for
+// RAID 5 or 6: parity is a different durability, write-cost and rebuild story
+// that should be chosen deliberately for a shape that exists, no box in the
+// fleet has one, and a rejected payload is discovered by wiping a machine.
+//
+// 10 is a value dedicated.server.reinstall.storage.partitioning.layout accepts
+// for soft RAID (its RaidLevelEnum is 0/1/5/6/7/10), so this is a level the
+// install honours rather than one it fails on.
 func (g DiskGroup) raidLevel() int64 {
+	if g.NumberOfDisks >= 4 && g.NumberOfDisks%2 == 0 {
+		return 10
+	}
 	if g.NumberOfDisks >= 2 {
 		return 1
 	}
@@ -355,6 +375,12 @@ type Partition struct {
 
 // Partitioning is the layout applied to one disk group.
 type Partitioning struct {
+	// Disks is how many of the group's disks the layout is built across. OVH
+	// defaults it to the whole group; it is sent explicitly because the layout's
+	// RaidLevel is derived from the same count, and the two only describe a
+	// valid array together. A RAID 10 layout needs all four of a four-disk group
+	// to have its two mirrored pairs, so a Disks that disagreed with the count
+	// raidLevel was chosen from would ask for an array that cannot be built.
 	Disks  int64       `json:"disks,omitempty"`
 	Layout []Partition `json:"layout"`
 }
@@ -379,9 +405,10 @@ func (c *Client) DiskGroups(ctx context.Context, serviceName string) ([]DiskGrou
 }
 
 // PlanStorage derives the reinstall storage block from a server's disk groups:
-// one mirrored group carrying /boot, a capped /, and a separate XFS /data
+// one redundant group carrying /boot, a capped /, and a separate XFS /data
 // filling what is left. It is a pure function of the reported hardware so the
-// same code covers every shape in the fleet without an offer-keyed table.
+// same code covers every shape in the fleet without an offer-keyed table,
+// including the RAID level, which the group's disk count decides (raidLevel).
 //
 // Deliberately a SINGLE storage entry, on the largest disk group. OVH documents
 // storage customization for one disk group per install, so a box with a small OS

--- a/infra/cluster-api-provider-tuist/internal/ovh/client_test.go
+++ b/infra/cluster-api-provider-tuist/internal/ovh/client_test.go
@@ -315,18 +315,76 @@ func TestPlanStorageAlwaysFormatsDataAsXFS(t *testing.T) {
 	}
 }
 
-// A mirror is only a mirror if the layout asks for one. OVH defaults an absent
-// raidLevel to 1, but the plan states it so a disk loss on these boxes stays a
-// degraded array rather than a lost cache region.
-func TestPlanStorageMirrorsEveryPartition(t *testing.T) {
-	plan, err := PlanStorage([]DiskGroup{group(1, 2, 1920)})
-	if err != nil {
-		t.Fatalf("PlanStorage: %v", err)
-	}
-	for _, part := range plan[0].Partitioning.Layout {
-		if part.RaidLevel != 1 {
-			t.Fatalf("partition %s raidLevel = %d, want 1", part.MountPoint, part.RaidLevel)
+// A RAID level is only applied if the layout asks for one. OVH defaults an
+// absent raidLevel to 1, but the plan states it on every partition so a disk
+// loss on these boxes stays a degraded array rather than a lost cache region,
+// and so a group large enough to stripe mirrored pairs is not silently
+// installed as a mirror across all of its disks.
+func TestPlanStorageRaidLevelFollowsDiskCount(t *testing.T) {
+	for _, tc := range []struct {
+		disks int64
+		want  int64
+	}{
+		{disks: 1, want: 0},
+		{disks: 2, want: 1},
+		{disks: 3, want: 1},
+		{disks: 4, want: 10},
+		{disks: 5, want: 1},
+		{disks: 6, want: 10},
+		{disks: 7, want: 1},
+		{disks: 8, want: 10},
+	} {
+		plan, err := PlanStorage([]DiskGroup{group(1, tc.disks, 960)})
+		if err != nil {
+			t.Fatalf("PlanStorage(%d disks): %v", tc.disks, err)
 		}
+		if got := plan[0].Partitioning.Disks; got != tc.disks {
+			t.Fatalf("%d-disk group: partitioning disks = %d, want every disk in the group", tc.disks, got)
+		}
+		for _, part := range plan[0].Partitioning.Layout {
+			if part.RaidLevel != tc.want {
+				t.Fatalf("%d-disk group: partition %s raidLevel = %d, want %d",
+					tc.disks, part.MountPoint, part.RaidLevel, tc.want)
+			}
+		}
+	}
+}
+
+// The reason the whole rule exists, asserted on the wire: a four-disk group
+// installed as RAID 1 mirrors across ALL FOUR disks, so a box ordered with the
+// 4-disk storage option comes up with one disk's worth of /data and the extra
+// two disks buy nothing. RAID 10 over the same four is what makes them usable
+// capacity. disks: 4 alongside raidLevel: 10 is the internally consistent pair:
+// the whole group participates, striped over two mirrored pairs.
+func TestStartInstallRequestsRaid10ForAFourDiskGroup(t *testing.T) {
+	api := &fakeAPI{get: map[string]any{
+		"/dedicated/server/srv/specifications/hardware": hardwareSpec{DiskGroups: []DiskGroup{group(1, 4, 960)}},
+	}}
+	c := &Client{API: api}
+	if err := c.StartInstall(context.Background(), "srv", InstallParams{
+		TemplateName: "ubuntu2404-server_64",
+		Hostname:     "host1",
+		SSHKey:       "ssh-ed25519 AAAA...",
+	}); err != nil {
+		t.Fatalf("StartInstall: %v", err)
+	}
+	if len(api.posts) != 1 || api.posts[0].url != "/dedicated/server/srv/reinstall" {
+		t.Fatalf("expected one POST to /dedicated/server/srv/reinstall, got %+v", api.posts)
+	}
+	body, ok := api.posts[0].body.(map[string]any)
+	if !ok {
+		t.Fatalf("reinstall body is not an object: %+v", api.posts[0].body)
+	}
+	wire, err := json.Marshal(body["storage"])
+	if err != nil {
+		t.Fatalf("marshal storage: %v", err)
+	}
+	want := `[{"diskGroupId":1,"partitioning":{"disks":4,"layout":[` +
+		`{"fileSystem":"ext4","mountPoint":"/boot","size":1024,"raidLevel":10},` +
+		`{"fileSystem":"ext4","mountPoint":"/","size":65536,"raidLevel":10},` +
+		`{"fileSystem":"xfs","mountPoint":"/data","size":0,"raidLevel":10}]}}]`
+	if string(wire) != want {
+		t.Fatalf("storage block =\n%s\nwant\n%s", wire, want)
 	}
 }
 


### PR DESCRIPTION
## What changed

`DiskGroup.raidLevel()` in `infra/cluster-api-provider-tuist/internal/ovh/client.go` now returns **10 for an even disk count of four or more**, keeping 1 for two or three disks and 0 for one. `PlanStorage` puts that level on every partition of the reinstall payload, so a box ordered with the larger disk option is installed as RAID 10 instead of a mirror across all of its disks.

## Why

The old rule returned 1 for any group with two or more disks and could never return 10. A four-disk group therefore went out as a **four-way mirror**: usable capacity of one disk. Concretely, for the Advance-2 sizing this came out of:

| Storage | Layout as it stood | `/data` |
|---|---|---|
| 2 x 960 GB | RAID 1 | ~829 GiB |
| 4 x 960 GB | RAID 1 across all four | ~829 GiB |
| 4 x 960 GB | RAID 10 | ~1,723 GiB |

The 4-disk option is $100/month over the included 2-disk one and, as the code stood, would have bought zero additional `/data`. At `replicas: 2` an Enterprise instance reserves 100 GiB, so the difference is machine counts, not headroom: roughly three machines across the pools being sized.

The old comment is the reason this stayed invisible. It said RAID 1 applies "wherever the group has disks to mirror across. Every box in the fleet does" — true, and it hid the question of *how many*. It reads as a considered decision about redundancy when the real consequence is capacity. It is rewritten to state the rule, and to say that the level decides usable capacity and not only redundancy.

## Odd counts are a deliberate non-decision

5 and 7 disks fall back to RAID 1 rather than reaching for RAID 5. Parity is a different durability, write-cost and rebuild story that should be picked deliberately for a shape that actually exists; no box in the fleet has one; and a payload OVH rejects is discovered by wiping a machine. The comment says so, so the next reader does not have to re-derive that it was a choice.

## RAID 10 is verified accepted, not assumed

Checked against OVH's own schema for the endpoint this code posts to, on `api.us.ovhcloud.com` — the exact entity every fleet box lives on, since all OVH boxes sit on the US subsidiary:

```
dedicated.server.reinstall.storage.partitioning.layout.RaidLevelEnum
  description: "Software raid type"
  enum: [0, 1, 5, 6, 7, 10]
```

`POST /dedicated/server/{serviceName}/reinstall` takes `dedicated.server.Reinstall`, whose `storage[].partitioning.layout[].raidLevel` is that enum. OVH's [partitioning guide](https://docs.ovhcloud.com/en/guides/bare-metal-cloud/dedicated-servers/partitioning-ovh) agrees and adds the minimum of 4 disks in mirrored pairs, which is what the even-count guard enforces.

## `disks` and `raidLevel` are consistent by construction

`Partitioning.Disks` is documented by OVH as "total number of disks in the disk group involved in the partitioning configuration (all disks of the disk group by default)". The planner already sent the group's full count, which is exactly what RAID 10 needs: all four disks of a four-disk group participate, striped over two mirrored pairs. Both values derive from the same `NumberOfDisks`, so they cannot drift into a payload that asks for an array which cannot be built. That coupling was undocumented and is now stated on the field, since it is the thing that breaks if someone later makes `Disks` a subset.

## Blast radius: zero, and measured rather than assumed

Only groups of 4+ disks change, and a storage payload only takes effect on install or reinstall, so nothing re-partitions on its own. Beyond that argument, every box was checked against the live provider APIs.

The OVH account holds **exactly four servers**, and every one reports a single 2-disk group:

| Box | Role | Disk groups |
|---|---|---|
| `ns1034936.ip-40-160-72.us` | production us-east (Advance-1, VIN) | 1 group, 2 x 960 GB NVMe |
| `ns1032829.ip-40-160-129.us` | production us-west (Advance-1, HIL) | 1 group, 2 x 960 GB NVMe |
| `ns552702.ip-142-44-139.net` | canary ca-east (BHS) | 1 group, 2 x 1920 GB NVMe |
| `ns543284.ip-144-217-252.net` | staging ca-east (BHS) | 1 group, 2 x 512 GB NVMe |

The full account listing was swept, not just the adopted boxes, so an unadopted spare with more disks would have shown up. For all four, the payload `PlanStorage` emits is byte-identical before and after this change.

The other two Linux kinds were checked too, and both report two disks: the eu-central Dedibox (`fr-par-2/184798`, Pro-9-XS) reports 2 x 1 TB NVMe, and the Elastic Metal kura box (`fr-par-1/9e70ce89...`, EM-I220E-NVME) reports 2 x 960 GB NVMe. Neither number can matter here in any case: `internal/dedibox` passes the provider's own default-layout `RaidLevel` through untouched, and `internal/scaleway/partitioning.go` copies `rootRaid.Level` from the offer's default schema. Only `controllers/linux/ovhdedicatedmachine_controller.go` imports this package, so no Dedibox or Elastic Metal reinstall payload can change as a result of this diff.

## What was actually exercised

Stated plainly because a wrong storage payload wipes a machine.

**Unit-tested.** The emitted payload for a 4-disk group, asserted on the marshalled wire JSON against the fake OVH API alongside the existing 2-disk case, because `size: 0` (fill the group) and `raidLevel` are values whose zero is meaningful and has to survive marshalling:

```json
[{"diskGroupId":1,"partitioning":{"disks":4,"layout":[
  {"fileSystem":"ext4","mountPoint":"/boot","size":1024,"raidLevel":10},
  {"fileSystem":"ext4","mountPoint":"/","size":65536,"raidLevel":10},
  {"fileSystem":"xfs","mountPoint":"/data","size":0,"raidLevel":10}]}}]
```

Plus a table over disk counts 1 through 8 asserting the level on every partition and that `disks` still covers the whole group. Both tests were written first and observed failing against the old `raidLevel` (the 4-disk case emitted `raidLevel: 1`), so they are pinned to the real behaviour rather than to the new code.

`gofmt -l .`, `go vet ./...` and `go test ./...` all pass for the provider, which is exactly what CI runs.

**NOT exercised end to end, and it cannot be yet.** No reinstall was posted; every API call made while preparing this was a read. RAID 10 has never been laid down on a real box, and there is no way to change that today: the account holds no spare, and no box anywhere in the fleet has more than two disks, so even reinstalling the staging ca-east box would exercise the RAID 1 branch and prove nothing about the new one. The first real exercise of this path will be the first 4-disk box delivered. Worth confirming `/data` on that box before the region takes traffic.

## Coordination

The unmerged Asia-Pacific region branch (#12596) carries a warning about exactly this bug in its PR body: a callout that the 4x960 upgrade may not fix its day-one capacity pressure because `raidLevel()` never asks for RAID 10, flagged as an adoption-time check and a decision to make before the box order. Once this lands, that paragraph can be reduced to a note that the provider now selects RAID 10, and the open question there narrows to confirming the delivered box's `/data`. The two should not drift.
