### PR TITLE
fix(server): persist run destinations for sharded test runs

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -312,6 +312,7 @@ defmodule Tuist.Tests do
               test
               |> Repo.preload(pg_preloads)
               |> ClickHouseRepo.preload(ch_preloads)
+              |> dedupe_run_destinations()
 
             {:ok, test}
         end
@@ -320,6 +321,15 @@ defmodule Tuist.Tests do
         {:error, :not_found}
     end
   end
+
+  # `test_run_destinations` has no uniqueness constraint, and a row is written
+  # per shard report and per reprocessing attempt. Collapse them to the
+  # distinct destinations the run executed on.
+  defp dedupe_run_destinations(%Test{run_destinations: destinations} = test) when is_list(destinations) do
+    %{test | run_destinations: Enum.uniq_by(destinations, &{&1.name, &1.platform, &1.os_version})}
+  end
+
+  defp dedupe_run_destinations(test), do: test
 
   def get_latest_test_by_build_run_id(build_run_id) do
     query =
@@ -665,6 +675,11 @@ defmodule Tuist.Tests do
           # uniqueness, so an error hit by several shards is deduplicated on
           # read instead of here.
           create_run_errors(merged_test, Map.get(attrs, :run_errors, []))
+
+          # Every shard reports the destination it executed on, so a merged run
+          # that never takes the branch above would carry none at all. Same
+          # concurrency story as the errors: duplicates are collapsed on read.
+          create_run_destinations(merged_test, Map.get(attrs, :run_destinations, []))
 
           insert_shard_run(
             shard_plan_id,

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -62,14 +62,6 @@ defmodule TuistWeb.TestRunLive do
 
     project = Tuist.Repo.preload(project, vcs_connection: :github_app_installation)
 
-    # A run that was processed across multiple retries (e.g. before a fix) can
-    # carry duplicate identical destination rows, since create_run_destinations
-    # inserts a fresh row per attempt. Collapse them to distinct devices.
-    run = %{
-      run
-      | run_destinations: Enum.uniq_by(run.run_destinations, &{&1.name, &1.platform, &1.os_version})
-    }
-
     ci_run_url = Tests.test_ci_run_url(run)
     ci_context = test_ci_context(run, socket.assigns.selected_account, ci_run_url)
     run = Map.put(run, :project, project)

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -604,7 +604,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:1228
 #: lib/tuist_web/live/run_detail_live.ex:336
 #: lib/tuist_web/live/run_detail_live.ex:369
-#: lib/tuist_web/live/test_run_live.ex:1226
+#: lib/tuist_web/live/test_run_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
@@ -643,7 +643,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:1231
 #: lib/tuist_web/live/run_detail_live.ex:341
 #: lib/tuist_web/live/run_detail_live.ex:374
-#: lib/tuist_web/live/test_run_live.ex:1231
+#: lib/tuist_web/live/test_run_live.ex:1223
 #: lib/tuist_web/live/xcode_builds_live.ex:387
 #: lib/tuist_web/live/xcode_builds_live.ex:390
 #: lib/tuist_web/live/xcode_builds_live.html.heex:127
@@ -670,7 +670,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:1243
 #: lib/tuist_web/live/run_detail_live.ex:342
 #: lib/tuist_web/live/run_detail_live.ex:375
-#: lib/tuist_web/live/test_run_live.ex:1232
+#: lib/tuist_web/live/test_run_live.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -838,7 +838,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:1237
 #: lib/tuist_web/live/run_detail_live.ex:340
 #: lib/tuist_web/live/run_detail_live.ex:373
-#: lib/tuist_web/live/test_run_live.ex:1230
+#: lib/tuist_web/live/test_run_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -96,8 +96,8 @@ msgstr ""
 msgid "Average duration of test runs during a given period."
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.ex:1101
-#: lib/tuist_web/live/test_run_live.ex:1158
+#: lib/tuist_web/live/test_run_live.ex:1093
+#: lib/tuist_web/live/test_run_live.ex:1150
 #: lib/tuist_web/live/test_run_live.html.heex:391
 #: lib/tuist_web/live/test_run_live.html.heex:1328
 #: lib/tuist_web/live/test_run_live.html.heex:1357
@@ -247,9 +247,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:921
 #: lib/tuist_web/live/test_case_live.html.heex:997
 #: lib/tuist_web/live/test_case_run_live.html.heex:149
-#: lib/tuist_web/live/test_run_live.ex:1047
-#: lib/tuist_web/live/test_run_live.ex:1109
-#: lib/tuist_web/live/test_run_live.ex:1166
+#: lib/tuist_web/live/test_run_live.ex:1039
+#: lib/tuist_web/live/test_run_live.ex:1101
+#: lib/tuist_web/live/test_run_live.ex:1158
 #: lib/tuist_web/live/test_run_live.html.heex:285
 #: lib/tuist_web/live/test_run_live.html.heex:497
 #: lib/tuist_web/live/test_run_live.html.heex:1139
@@ -334,9 +334,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1044
 #: lib/tuist_web/live/test_cases_live.ex:45
 #: lib/tuist_web/live/test_cases_live.html.heex:686
-#: lib/tuist_web/live/test_run_live.ex:1060
-#: lib/tuist_web/live/test_run_live.ex:1122
-#: lib/tuist_web/live/test_run_live.ex:1179
+#: lib/tuist_web/live/test_run_live.ex:1052
+#: lib/tuist_web/live/test_run_live.ex:1114
+#: lib/tuist_web/live/test_run_live.ex:1171
 #: lib/tuist_web/live/test_run_live.html.heex:251
 #: lib/tuist_web/live/test_run_live.html.heex:521
 #: lib/tuist_web/live/test_run_live.html.heex:662
@@ -440,7 +440,7 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:40
 #: lib/tuist_web/live/test_cases_live.ex:74
 #: lib/tuist_web/live/test_cases_live.html.heex:579
-#: lib/tuist_web/live/test_run_live.ex:1074
+#: lib/tuist_web/live/test_run_live.ex:1066
 #: lib/tuist_web/live/test_run_live.html.heex:55
 #: lib/tuist_web/live/test_run_live.html.heex:1197
 #: lib/tuist_web/live/test_run_live.html.heex:1398
@@ -493,7 +493,7 @@ msgid "Hash"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:137
-#: lib/tuist_web/live/test_run_live.ex:1245
+#: lib/tuist_web/live/test_run_live.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
@@ -605,7 +605,7 @@ msgid "Load more"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.ex:217
-#: lib/tuist_web/live/test_run_live.ex:1410
+#: lib/tuist_web/live/test_run_live.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
@@ -615,7 +615,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:18
 #: lib/tuist_web/live/test_cases_live.ex:391
 #: lib/tuist_web/live/test_cases_live.html.heex:18
-#: lib/tuist_web/live/test_run_live.ex:1250
+#: lib/tuist_web/live/test_run_live.ex:1242
 #: lib/tuist_web/live/test_runs_live.ex:357
 #: lib/tuist_web/live/tests_live.ex:432
 #: lib/tuist_web/live/tests_live.ex:435
@@ -650,7 +650,7 @@ msgid "Marked as flaky"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:152
-#: lib/tuist_web/live/test_run_live.ex:1251
+#: lib/tuist_web/live/test_run_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -678,7 +678,7 @@ msgid "Most occurring flaky tests"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:47
-#: lib/tuist_web/live/test_run_live.ex:1073
+#: lib/tuist_web/live/test_run_live.ex:1065
 #: lib/tuist_web/live/test_run_live.html.heex:1204
 #, elixir-autogen, elixir-format
 msgid "New"
@@ -799,9 +799,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1037
 #: lib/tuist_web/live/test_cases_live.ex:44
 #: lib/tuist_web/live/test_cases_live.html.heex:682
-#: lib/tuist_web/live/test_run_live.ex:1059
-#: lib/tuist_web/live/test_run_live.ex:1121
-#: lib/tuist_web/live/test_run_live.ex:1178
+#: lib/tuist_web/live/test_run_live.ex:1051
+#: lib/tuist_web/live/test_run_live.ex:1113
+#: lib/tuist_web/live/test_run_live.ex:1170
 #: lib/tuist_web/live/test_run_live.html.heex:244
 #: lib/tuist_web/live/test_run_live.html.heex:516
 #: lib/tuist_web/live/test_run_live.html.heex:714
@@ -891,7 +891,7 @@ msgid "Recent Test Runs"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:140
-#: lib/tuist_web/live/test_run_live.ex:1249
+#: lib/tuist_web/live/test_run_live.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
@@ -988,8 +988,8 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.ex:76
 #: lib/tuist_web/live/test_cases_live.html.heex:593
 #: lib/tuist_web/live/test_cases_live.html.heex:689
-#: lib/tuist_web/live/test_run_live.ex:1061
-#: lib/tuist_web/live/test_run_live.ex:1123
+#: lib/tuist_web/live/test_run_live.ex:1053
+#: lib/tuist_web/live/test_run_live.ex:1115
 #: lib/tuist_web/live/test_run_live.html.heex:265
 #: lib/tuist_web/live/test_run_live.html.heex:1273
 #: lib/tuist_web/live/test_run_live.html.heex:1460
@@ -1022,9 +1022,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:965
 #: lib/tuist_web/live/test_case_run_live.html.heex:119
 #: lib/tuist_web/live/test_case_run_live.html.heex:845
-#: lib/tuist_web/live/test_run_live.ex:1055
-#: lib/tuist_web/live/test_run_live.ex:1117
-#: lib/tuist_web/live/test_run_live.ex:1174
+#: lib/tuist_web/live/test_run_live.ex:1047
+#: lib/tuist_web/live/test_run_live.ex:1109
+#: lib/tuist_web/live/test_run_live.ex:1166
 #: lib/tuist_web/live/test_run_live.html.heex:241
 #: lib/tuist_web/live/test_run_live.html.heex:513
 #: lib/tuist_web/live/test_run_live.html.heex:1447
@@ -1061,7 +1061,7 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.html.heex:495
 #: lib/tuist_web/live/test_cases_live.html.heex:515
 #: lib/tuist_web/live/test_cases_live.html.heex:566
-#: lib/tuist_web/live/test_run_live.ex:1069
+#: lib/tuist_web/live/test_run_live.ex:1061
 #, elixir-autogen, elixir-format
 msgid "Test Case"
 msgstr ""
@@ -1114,7 +1114,7 @@ msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:4
 #: lib/tuist_web/live/test_case_run_live.html.heex:212
-#: lib/tuist_web/live/test_run_live.ex:99
+#: lib/tuist_web/live/test_run_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Test Run"
 msgstr ""
@@ -1171,8 +1171,8 @@ msgstr ""
 
 #: lib/tuist_web/live/test_cases_live.ex:329
 #: lib/tuist_web/live/test_cases_live.html.heex:220
-#: lib/tuist_web/live/test_run_live.ex:1093
-#: lib/tuist_web/live/test_run_live.ex:1150
+#: lib/tuist_web/live/test_run_live.ex:1085
+#: lib/tuist_web/live/test_run_live.ex:1142
 #: lib/tuist_web/live/test_run_live.html.heex:371
 #: lib/tuist_web/live/test_run_live.html.heex:1325
 #: lib/tuist_web/live/test_run_live.html.heex:1349
@@ -1534,7 +1534,7 @@ msgid "Pending"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:197
-#: lib/tuist_web/live/test_run_live.ex:1212
+#: lib/tuist_web/live/test_run_live.ex:1204
 #: lib/tuist_web/live/test_run_live.html.heex:481
 #: lib/tuist_web/live/test_run_live.html.heex:1236
 #: lib/tuist_web/live/test_run_live.html.heex:1410
@@ -1544,7 +1544,7 @@ msgid "Shard"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:201
-#: lib/tuist_web/live/test_run_live.ex:1206
+#: lib/tuist_web/live/test_run_live.ex:1198
 #: lib/tuist_web/live/test_run_live.html.heex:483
 #: lib/tuist_web/live/test_run_live.html.heex:1239
 #: lib/tuist_web/live/test_run_live.html.heex:1413

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2143,6 +2143,89 @@ defmodule Tuist.TestsTest do
       assert error.module_name == "AboutUserTests"
     end
 
+    test "persists run destinations reported by a shard that merges into an existing run" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      shard_attrs = fn shard_index, extra ->
+        Map.merge(
+          %{
+            id: UUIDv7.generate(),
+            project_id: project.id,
+            account_id: account.id,
+            duration: 500,
+            status: "success",
+            model_identifier: "Mac15,6",
+            macos_version: "14.0",
+            xcode_version: "15.0",
+            git_branch: "main",
+            git_commit_sha: "abc123",
+            ran_at: NaiveDateTime.utc_now(),
+            is_ci: true,
+            shard_plan_id: plan.id,
+            shard_index: shard_index
+          },
+          extra
+        )
+      end
+
+      # The placeholder row the CLI uploads lands before the xcresult worker
+      # parses anything, so the merge branch is the one every sharded run takes
+      # by the time destinations are known.
+      {:ok, first_test} = Tests.create_test(shard_attrs.(0, %{status: "processing"}))
+
+      {:ok, _} =
+        Tests.create_test(
+          shard_attrs.(1, %{
+            run_destinations: [%{name: "iPhone SE Test", platform: "ios_simulator", os_version: "26.1"}]
+          })
+        )
+
+      assert [destination] =
+               ClickHouseRepo.all(from(d in TestRunDestination, where: d.test_run_id == ^first_test.id))
+
+      assert destination.name == "iPhone SE Test"
+      assert destination.platform == "ios_simulator"
+      assert destination.os_version == "26.1"
+    end
+
+    test "collapses a run destination reported by every shard into one" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      run_destinations = [%{name: "iPhone SE Test", platform: "ios_simulator", os_version: "26.1"}]
+
+      shard_attrs = fn shard_index ->
+        %{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: shard_index,
+          run_destinations: run_destinations
+        }
+      end
+
+      {:ok, first_test} = Tests.create_test(shard_attrs.(0))
+      {:ok, _} = Tests.create_test(shard_attrs.(1))
+
+      {:ok, run} = Tests.get_test(first_test.id, preload: [:run_destinations])
+
+      assert [%TestRunDestination{name: "iPhone SE Test", platform: "ios_simulator", os_version: "26.1"}] =
+               run.run_destinations
+    end
+
     test "uses the shard-run mapping instead of scanning test runs for later shards" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account


### PR DESCRIPTION
### What changed

`Tuist.Tests.create_or_update_sharded_test/1` now writes `test_run_destinations` from its merge branch, alongside the existing `create_run_errors/2` call.

Duplicates are collapsed on read, and that dedup moved from an inline `Enum.uniq_by` in `TestRunLive.mount/3` into `Tests.get_test/2` so it covers every read of the association.

### Why

The function branches on whether a `Test` row already exists for the merged run id. Only the `nil` branch, via `create_new_test/3`, wrote run destinations. A placeholder `Test` row with status "processing" is inserted when the CLI uploads the result bundle, before the xcresult worker runs, so `existing` is non-nil for effectively every sharded run and the branch that writes destinations is never taken.

Measured on production ClickHouse over a 7-day window:

| | runs with destinations |
| --- | --- |
| sharded | 0 of 1108 |
| unsharded | 52377 of 55087 (95.1%) |

The dashboard therefore never shows a device, platform, or OS version for a sharded test run.

### Root cause

This is not a parser bug. Verified by extracting the result bundle for an affected run and reading it back with `xcresulttool get test-results tests`: it returns a fully populated `devices` entry (device name, platform "iOS Simulator", OS version). The CLI parser's compactMap over `output.devices` requires exactly those three fields, so run destinations left the parser non-empty and were dropped on the Elixir side.

### Why dedup on read rather than gating the write

Every shard reports the destination it executed on and ClickHouse has no uniqueness constraint, so writing from the merge branch produces one row per shard. Two alternatives were considered:

- **Only insert when the run has none yet.** This does not hold. A read-before-write cannot see rows a concurrent shard is inserting, and the same function already documents that a row written earlier in the request is not reliably read back. It would also keep whichever shard won the race when shards genuinely run on different devices, instead of merging to the union.
- **Deduplicate on read.** Follows the precedent set by the adjacent `create_run_errors/2` call, which documents this exact tradeoff, and merges correctly across differing destinations.

The dedup previously lived inline in `TestRunLive.mount/3`, which left the poll path (`reload_run_state/1`) showing duplicates for in-progress runs. Centralizing it in `Tests.get_test/2` fixes that too, since both call sites go through it.

### Impact

Sharded test runs show their run destination on the test run page, matching unsharded runs. No schema change, no backfill: rows are written from the next report of each run onward, so historical sharded runs stay empty.

### Validation

- Two regression tests in `test/tuist/tests_test.exs`, both verified to bite:
  - "persists run destinations reported by a shard that merges into an existing run" covers the placeholder-first shape. Red before the fix, green after.
  - "collapses a run destination reported by every shard into one" guards the duplicate concern. With the write added but the read dedup removed, it fails with two identical rows.
- `mix test test/tuist/tests_test.exs test/tuist/tests/test_run_destination_test.exs test/tuist_web/live/test_run_live_test.exs`: 323 passed.
- `mix format` and `mix credo` clean; no new compiler warnings under `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
