### PR TITLE
test(cli): cover local macro package access

### DIFF
--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -586,6 +586,33 @@ struct GenerateAcceptanceTestCommandLineToolWithPackageAccessAndModuleMap {
     }
 }
 
+struct GenerateAcceptanceTestCommandLineToolWithLocalMacroPackage {
+    @Test(.withFixture("generated_command_line_tool_with_local_macro_package"), .inTemporaryDirectory)
+    func command_line_tool_with_local_macro_package() async throws {
+        let fixturePath = try fixtureDirectory()
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        let xcodeproj = try XcodeProj(
+            pathString: fixturePath.appending(components: "Package", "MacroPackage.xcodeproj").pathString
+        )
+        let macroTarget = try TuistAcceptanceTest.requireTarget("ReproMacro", in: xcodeproj)
+        let buildConfigurations = try #require(macroTarget.buildConfigurationList?.buildConfigurations)
+
+        for buildConfiguration in buildConfigurations {
+            let buildSettings = buildConfiguration.buildSettings
+            #expect(buildSettings["SWIFT_PACKAGE_NAME"]?.stringValue == "MacroPackage")
+
+            let otherSwiftFlags = try #require(buildSettings["OTHER_SWIFT_FLAGS"]?.stringValue)
+            #expect(otherSwiftFlags.contains("-Xfrontend -disable-sil-ownership-verifier"))
+            #expect(!otherSwiftFlags.contains("-package-name"))
+        }
+
+        try await run(BuildCommand.self)
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     @Test(.withFixture("generated_ios_app_with_objc_static_framework_package"), .inTemporaryDirectory)
     func ios_app_with_objc_and_c_static_framework_package() async throws {

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -6358,6 +6358,46 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_macroTarget_withCustomSwiftFlags_addsPackageNameToTargetSettings() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/MyMacro"))
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [],
+                    targets: [
+                        .test(name: "MyMacro", type: .macro),
+                    ],
+                    platforms: [.macos],
+                    toolsVersion: Version(5, 9, 0)
+                ),
+            ],
+            packageSettings: .test(
+                baseSettings: .default.with(
+                    base: ["OTHER_SWIFT_FLAGS": ["-Xfrontend", "-disable-sil-ownership-verifier"]]
+                )
+            )
+        )
+
+        let target = try #require(project?.targets.first(where: { $0.name == "MyMacro" }))
+        #expect(
+            target.settings?.base["OTHER_SWIFT_FLAGS"] == .array([
+                "-Xfrontend",
+                "-disable-sil-ownership-verifier",
+            ])
+        )
+        #expect(target.settings?.base["SWIFT_PACKAGE_NAME"] == .string("Package"))
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenSourcesDirectlyInSourcesDirectory_SE0162Support() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let packagePath = basePath.appending(try RelativePath(validating: "Package"))

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "MacroPackage",
+    products: [
+        .library(name: "ReproCore", targets: ["ReproCore"]),
+    ],
+    targets: [
+        .macro(name: "ReproMacro"),
+        .target(
+            name: "ReproCore",
+            dependencies: ["ReproMacro"]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Sources/ReproCore/ReproCore.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Sources/ReproCore/ReproCore.swift
@@ -1,0 +1,3 @@
+public func reproValue() -> Int {
+    42
+}

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Sources/ReproMacro/ReproMacro.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Package/Sources/ReproMacro/ReproMacro.swift
@@ -1,0 +1,4 @@
+@main
+struct ReproMacro {
+    static func main() {}
+}

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Project.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Project.swift
@@ -1,0 +1,17 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "dev.tuist.local-macro-package",
+            sources: ["Sources/**"],
+            dependencies: [
+                .external(name: "ReproCore"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Sources/main.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Sources/main.swift
@@ -1,0 +1,3 @@
+import ReproCore
+
+print(reproValue())

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Tuist.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_command_line_tool_with_local_macro_package/Tuist/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_macro_package/Tuist/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(
+    baseSettings: .settings(
+        base: [
+            "OTHER_SWIFT_FLAGS": ["-Xfrontend -disable-sil-ownership-verifier"],
+        ]
+    )
+)
+#endif
+
+let package = Package(
+    name: "Dependencies",
+    dependencies: [
+        .package(path: "../Package"),
+    ]
+)


### PR DESCRIPTION
## What changed

- Add a local macro-package fixture and acceptance test that generates and builds its command-line tool.
- Assert that the macro target retains its custom compiler flag, uses `SWIFT_PACKAGE_NAME`, and does not receive `-package-name` through `OTHER_SWIFT_FLAGS`.
- Add a focused mapper regression test for the same macro-target settings path.

## Why

This adds end-to-end coverage for [#12592](https://github.com/tuist/tuist/issues/12592) without relying on remotely fetched dependencies.

## Root cause

Package identity was previously carried in the general compiler-flags setting. Macro targets with package-level compiler settings need that identity to remain separate from the flags and their arguments.

## Approach

The fixture uses path-based packages only. Its library depends on a macro target, so the acceptance test confirms the generated macro target settings and builds the macro, library, and application together.

## Impact

Future changes to package-settings mapping will be checked against a local macro package before release.

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace '-only-testing:TuistGeneratorAcceptanceTests/GenerateAcceptanceTestCommandLineToolWithLocalMacroPackage/command_line_tool_with_local_macro_package()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`
- `mise run cli:lint`
- `git diff --check`
