### PR TITLE
fix(server,cli): stop shard plans scheduling suites a test plan skips

### DIFF
--- a/cli/Sources/TuistAutomation/XcodeBuild/XCTestRun.swift
+++ b/cli/Sources/TuistAutomation/XcodeBuild/XCTestRun.swift
@@ -14,20 +14,28 @@ public struct XCTestRun: Decodable, Equatable {
     public struct TestTarget: Decodable, Equatable {
         public let blueprintName: String
         public let onlyTestIdentifiers: [String]?
+        public let skipTestIdentifiers: [String]?
         /// Whether xcodebuild runs this target's tests across multiple runner processes. Absent in
         /// the legacy format and in bundles produced before Xcode wrote the key, which is why it is
         /// optional rather than defaulted: a missing value means "not stated", not "disabled".
         public let parallelizationEnabled: Bool?
 
-        public init(blueprintName: String, onlyTestIdentifiers: [String]?, parallelizationEnabled: Bool? = nil) {
+        public init(
+            blueprintName: String,
+            onlyTestIdentifiers: [String]?,
+            skipTestIdentifiers: [String]? = nil,
+            parallelizationEnabled: Bool? = nil
+        ) {
             self.blueprintName = blueprintName
             self.onlyTestIdentifiers = onlyTestIdentifiers
+            self.skipTestIdentifiers = skipTestIdentifiers
             self.parallelizationEnabled = parallelizationEnabled
         }
 
         enum CodingKeys: String, CodingKey {
             case blueprintName = "BlueprintName"
             case onlyTestIdentifiers = "OnlyTestIdentifiers"
+            case skipTestIdentifiers = "SkipTestIdentifiers"
             case parallelizationEnabled = "ParallelizationEnabled"
         }
     }
@@ -44,14 +52,32 @@ public struct XCTestRun: Decodable, Equatable {
     /// limited to nothing contributes no entries and is left to be resolved from history.
     ///
     /// Identifiers naming a single test are collapsed to the suite that holds it, since a plan
-    /// distributes suites.
+    /// distributes suites. Suites the products also skip are left out: xcodebuild applies the skips
+    /// after the selection, so a selected suite that is skipped runs nothing.
     public func selectedTestSuiteIdentifiers() -> [String] {
+        let skipped = Set(skippedTestSuiteIdentifiers())
         let identifiers = testConfigurations
             .flatMap { $0.testTargets ?? [] }
             .flatMap { target in
                 (target.onlyTestIdentifiers ?? []).map { identifier in
                     let suite = identifier.split(separator: "/").first.map(String.init) ?? identifier
                     return "\(target.blueprintName)/\(suite)"
+                }
+            }
+        return Set(identifiers).subtracting(skipped).sorted()
+    }
+
+    /// The suites the built products take out of a module's run, as `Module/Suite`. Only skips that
+    /// name a whole suite are reported: xcodebuild applies them to everything under that name, so
+    /// the suite is known not to run. A skip naming a single test says nothing about its suite,
+    /// which may still have tests left, and the xctestrun holds no inventory to check against.
+    public func skippedTestSuiteIdentifiers() -> [String] {
+        let identifiers = testConfigurations
+            .flatMap { $0.testTargets ?? [] }
+            .flatMap { target in
+                (target.skipTestIdentifiers ?? []).compactMap { identifier -> String? in
+                    guard !identifier.contains("/") else { return nil }
+                    return "\(target.blueprintName)/\(identifier)"
                 }
             }
         return Set(identifiers).sorted()

--- a/cli/Sources/TuistAutomation/XcodeBuild/XCTestRun.swift
+++ b/cli/Sources/TuistAutomation/XcodeBuild/XCTestRun.swift
@@ -52,10 +52,14 @@ public struct XCTestRun: Decodable, Equatable {
     /// limited to nothing contributes no entries and is left to be resolved from history.
     ///
     /// Identifiers naming a single test are collapsed to the suite that holds it, since a plan
-    /// distributes suites. Suites the products also skip are left out: xcodebuild applies the skips
-    /// after the selection, so a selected suite that is skipped runs nothing.
+    /// distributes suites.
+    ///
+    /// Suites the products also skip stay in: this is what tells a consumer which modules the
+    /// products restrict at all, and it has to be read before the skips are applied. Narrowing it
+    /// here would leave a module whose every selected suite is skipped looking unrestricted, which
+    /// is the one state that invites resolving it from history and planning suites the selection
+    /// already ruled out.
     public func selectedTestSuiteIdentifiers() -> [String] {
-        let skipped = Set(skippedTestSuiteIdentifiers())
         let identifiers = testConfigurations
             .flatMap { $0.testTargets ?? [] }
             .flatMap { target in
@@ -64,20 +68,28 @@ public struct XCTestRun: Decodable, Equatable {
                     return "\(target.blueprintName)/\(suite)"
                 }
             }
-        return Set(identifiers).subtracting(skipped).sorted()
+        return Set(identifiers).sorted()
     }
 
-    /// The suites the built products take out of a module's run, as `Module/Suite`. Only skips that
-    /// name a whole suite are reported: xcodebuild applies them to everything under that name, so
-    /// the suite is known not to run. A skip naming a single test says nothing about its suite,
-    /// which may still have tests left, and the xctestrun holds no inventory to check against.
+    /// The suites the built products take out of a module's run, as `Module/Suite`.
+    ///
+    /// A skip identifier names the innermost thing it disables, and a nested suite is named by its
+    /// whole path, so the suite is the last component rather than the first: skipping
+    /// `ParentSuite/NestedSuite` takes out `NestedSuite`, which is also the name a run reports it
+    /// under. An identifier ending in a function only reduces the suite holding it, which may still
+    /// have tests left to run, and the xctestrun carries no inventory to check that against, so
+    /// those are left out. A trailing `()` and a lowercase first character each mark a function
+    /// rather than a type.
     public func skippedTestSuiteIdentifiers() -> [String] {
         let identifiers = testConfigurations
             .flatMap { $0.testTargets ?? [] }
             .flatMap { target in
                 (target.skipTestIdentifiers ?? []).compactMap { identifier -> String? in
-                    guard !identifier.contains("/") else { return nil }
-                    return "\(target.blueprintName)/\(identifier)"
+                    guard let suite = identifier.split(separator: "/").last.map(String.init),
+                          !suite.hasSuffix("()"),
+                          suite.first?.isLowercase != true
+                    else { return nil }
+                    return "\(target.blueprintName)/\(suite)"
                 }
             }
         return Set(identifiers).sorted()

--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -131,6 +131,7 @@
             let modules = xcTestRun.testModules
             let parallelizableModules = xcTestRun.parallelizableTestModules
             let selectedTestSuites = xcTestRun.selectedTestSuiteIdentifiers()
+            let skippedTestSuites = xcTestRun.skippedTestSuiteIdentifiers()
 
             guard !modules.isEmpty else {
                 throw ShardPlanServiceError.noTestModulesFound
@@ -142,6 +143,10 @@
             // large plans — it could take an hour) and sends only the module universe from the
             // deterministic `.xctestrun`, plus the suites that bundle limits a module to, which are
             // known exactly and don't need inferring.
+            //
+            // The suites the bundle skips go with them. A test plan that disables tests still builds
+            // the target, so it stays in the module universe, and without the skips the server would
+            // resolve its suites from history and plan work the products cannot run.
             Logger.current.notice("Creating shard plan with \(modules.count) test module(s)", metadata: .section)
 
             let shardPlan = try await createShardPlanService.createShardPlan(
@@ -151,6 +156,7 @@
                 modules: modules,
                 parallelizableModules: parallelizableModules,
                 testSuites: selectedTestSuites.isEmpty ? nil : selectedTestSuites,
+                skippedTestSuites: skippedTestSuites.isEmpty ? nil : skippedTestSuites,
                 shardMin: shardMin,
                 shardMax: shardMax,
                 shardTotal: shardTotal,

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -2456,6 +2456,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .unprocessableContent(.init(body: body))
+                case 500:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.updateAutomationAlert.Output.InternalServerError.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .internalServerError(.init(body: body))
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
@@ -2709,15 +2731,15 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "page",
-                    value: input.query.page
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
+                    name: "page",
+                    value: input.query.page
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
@@ -15887,6 +15909,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .unprocessableContent(.init(body: body))
+                case 500:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.createAutomationAlert.Output.InternalServerError.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .internalServerError(.init(body: body))
                 default:
                     return .undocumented(
                         statusCode: response.status.code,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -5228,6 +5228,10 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/CreateShardPlanParams/shard_total`.
             public var shard_total: Swift.Int?
+            /// Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
+            ///
+            /// - Remark: Generated from `#/components/schemas/CreateShardPlanParams/skipped_test_suites`.
+            public var skipped_test_suites: [Swift.String]?
             /// Test suite names (for suite-level granularity).
             ///
             /// - Remark: Generated from `#/components/schemas/CreateShardPlanParams/test_suites`.
@@ -5246,6 +5250,7 @@ public enum Components {
             ///   - shard_max_duration: Target maximum duration per shard in milliseconds.
             ///   - shard_min: Minimum number of shards.
             ///   - shard_total: Exact number of shards. With suite granularity, the final shard is the catch-all.
+            ///   - skipped_test_suites: Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
             ///   - test_suites: Test suite names (for suite-level granularity).
             public init(
                 build_run_id: Swift.String? = nil,
@@ -5259,6 +5264,7 @@ public enum Components {
                 shard_max_duration: Swift.Int? = nil,
                 shard_min: Swift.Int? = nil,
                 shard_total: Swift.Int? = nil,
+                skipped_test_suites: [Swift.String]? = nil,
                 test_suites: [Swift.String]? = nil
             ) {
                 self.build_run_id = build_run_id
@@ -5272,6 +5278,7 @@ public enum Components {
                 self.shard_max_duration = shard_max_duration
                 self.shard_min = shard_min
                 self.shard_total = shard_total
+                self.skipped_test_suites = skipped_test_suites
                 self.test_suites = test_suites
             }
             public enum CodingKeys: String, CodingKey {
@@ -5286,6 +5293,7 @@ public enum Components {
                 case shard_max_duration
                 case shard_min
                 case shard_total
+                case skipped_test_suites
                 case test_suites
             }
         }
@@ -18674,6 +18682,57 @@ public enum Operations {
                     }
                 }
             }
+            public struct InternalServerError: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/PUT/responses/500/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/PUT/responses/500/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateAutomationAlert.Output.InternalServerError.Body
+                /// Creates a new `InternalServerError`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.updateAutomationAlert.Output.InternalServerError.Body) {
+                    self.body = body
+                }
+            }
+            /// An internal server error occurred
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/put(updateAutomationAlert)/responses/500`.
+            ///
+            /// HTTP response code: `500 internalServerError`.
+            case internalServerError(Operations.updateAutomationAlert.Output.InternalServerError)
+            /// The associated value of the enum case if `self` is `.internalServerError`.
+            ///
+            /// - Throws: An error if `self` is not `.internalServerError`.
+            /// - SeeAlso: `.internalServerError`.
+            public var internalServerError: Operations.updateAutomationAlert.Output.InternalServerError {
+                get throws {
+                    switch self {
+                    case let .internalServerError(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "internalServerError",
+                            response: self
+                        )
+                    }
+                }
+            }
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
@@ -19253,14 +19312,14 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
-                /// Page number for pagination.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
-                public var page: Swift.Int?
                 /// Filter bundles by git branch.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
                 public var git_branch: Swift.String?
+                /// Page number for pagination.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
+                public var page: Swift.Int?
                 /// Number of items per page.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
@@ -19268,16 +19327,16 @@ public enum Operations {
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
-                ///   - page: Page number for pagination.
                 ///   - git_branch: Filter bundles by git branch.
+                ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
                 public init(
-                    page: Swift.Int? = nil,
                     git_branch: Swift.String? = nil,
+                    page: Swift.Int? = nil,
                     page_size: Swift.Int? = nil
                 ) {
-                    self.page = page
                     self.git_branch = git_branch
+                    self.page = page
                     self.page_size = page_size
                 }
             }
@@ -42929,6 +42988,10 @@ public enum Operations {
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/shards/POST/requestBody/json/shard_total`.
                     public var shard_total: Swift.Int?
+                    /// Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/shards/POST/requestBody/json/skipped_test_suites`.
+                    public var skipped_test_suites: [Swift.String]?
                     /// Test suite names (for suite-level granularity).
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/shards/POST/requestBody/json/test_suites`.
@@ -42947,6 +43010,7 @@ public enum Operations {
                     ///   - shard_max_duration: Target maximum duration per shard in milliseconds.
                     ///   - shard_min: Minimum number of shards.
                     ///   - shard_total: Exact number of shards. With suite granularity, the final shard is the catch-all.
+                    ///   - skipped_test_suites: Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
                     ///   - test_suites: Test suite names (for suite-level granularity).
                     public init(
                         build_run_id: Swift.String? = nil,
@@ -42960,6 +43024,7 @@ public enum Operations {
                         shard_max_duration: Swift.Int? = nil,
                         shard_min: Swift.Int? = nil,
                         shard_total: Swift.Int? = nil,
+                        skipped_test_suites: [Swift.String]? = nil,
                         test_suites: [Swift.String]? = nil
                     ) {
                         self.build_run_id = build_run_id
@@ -42973,6 +43038,7 @@ public enum Operations {
                         self.shard_max_duration = shard_max_duration
                         self.shard_min = shard_min
                         self.shard_total = shard_total
+                        self.skipped_test_suites = skipped_test_suites
                         self.test_suites = test_suites
                     }
                     public enum CodingKeys: String, CodingKey {
@@ -42987,6 +43053,7 @@ public enum Operations {
                         case shard_max_duration
                         case shard_min
                         case shard_total
+                        case skipped_test_suites
                         case test_suites
                     }
                 }
@@ -57492,6 +57559,57 @@ public enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct InternalServerError: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/POST/responses/500/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/POST/responses/500/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.createAutomationAlert.Output.InternalServerError.Body
+                /// Creates a new `InternalServerError`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.createAutomationAlert.Output.InternalServerError.Body) {
+                    self.body = body
+                }
+            }
+            /// An internal server error occurred
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/post(createAutomationAlert)/responses/500`.
+            ///
+            /// HTTP response code: `500 internalServerError`.
+            case internalServerError(Operations.createAutomationAlert.Output.InternalServerError)
+            /// The associated value of the enum case if `self` is `.internalServerError`.
+            ///
+            /// - Throws: An error if `self` is not `.internalServerError`.
+            /// - SeeAlso: `.internalServerError`.
+            public var internalServerError: Operations.createAutomationAlert.Output.InternalServerError {
+                get throws {
+                    switch self {
+                    case let .internalServerError(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "internalServerError",
                             response: self
                         )
                     }

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -1868,6 +1868,15 @@ components:
           type: integer
           x-struct:
           x-validate:
+        skipped_test_suites:
+          description: Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
+          items:
+            type: string
+            x-struct:
+            x-validate:
+          type: array
+          x-struct:
+          x-validate:
         test_suites:
           description: Test suite names (for suite-level granularity).
           items:
@@ -8766,6 +8775,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Validation error
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: An internal server error occurred
       summary: Update an automation alert.
       tags:
         - Automation Alerts
@@ -8840,14 +8855,6 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: Page number for pagination.
-          in: query
-          name: page
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
         - description: Filter bundles by git branch.
           in: query
           name: git_branch
@@ -8856,9 +8863,25 @@ paths:
             type: string
             x-struct:
             x-validate:
+        - description: Page number for pagination.
+          in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
         - description: The handle of the account.
           in: path
           name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
           required: true
           schema:
             type: string
@@ -8870,14 +8893,6 @@ paths:
           required: false
           schema:
             type: integer
-            x-struct:
-            x-validate:
-        - description: The handle of the project.
-          in: path
-          name: project_handle
-          required: true
-          schema:
-            type: string
             x-struct:
             x-validate:
       responses:
@@ -16559,6 +16574,15 @@ paths:
                   type: integer
                   x-struct:
                   x-validate:
+                skipped_test_suites:
+                  description: Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history.
+                  items:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  type: array
+                  x-struct:
+                  x-validate:
                 test_suites:
                   description: Test suite names (for suite-level granularity).
                   items:
@@ -21405,6 +21429,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Validation error
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: An internal server error occurred
       summary: Create an automation alert.
       tags:
         - Automation Alerts

--- a/cli/Sources/TuistServer/Services/CreateShardPlanService.swift
+++ b/cli/Sources/TuistServer/Services/CreateShardPlanService.swift
@@ -11,6 +11,7 @@ public protocol CreateShardPlanServicing {
         modules: [String]?,
         parallelizableModules: [String]?,
         testSuites: [String]?,
+        skippedTestSuites: [String]?,
         shardMin: Int?,
         shardMax: Int?,
         shardTotal: Int?,
@@ -55,6 +56,7 @@ public struct CreateShardPlanService: CreateShardPlanServicing {
         modules: [String]?,
         parallelizableModules: [String]?,
         testSuites: [String]?,
+        skippedTestSuites: [String]?,
         shardMin: Int?,
         shardMax: Int?,
         shardTotal: Int?,
@@ -83,6 +85,7 @@ public struct CreateShardPlanService: CreateShardPlanServicing {
                     shard_max_duration: shardMaxDuration,
                     shard_min: shardMin,
                     shard_total: shardTotal,
+                    skipped_test_suites: skippedTestSuites,
                     test_suites: testSuites
                 )
             )

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,8 +63,8 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
-                    page: page,
                     git_branch: gitBranch,
+                    page: page,
                     page_size: pageSize
                 )
             )

--- a/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestRunTests.swift
+++ b/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestRunTests.swift
@@ -130,7 +130,7 @@
         }
 
         @Test
-        func decode_v2_skippedSuitesAreExcludedFromSelectedSuites() throws {
+        func decode_v2_selectedSuitesAreReportedWholeAlongsideTheSkips() throws {
             let plist = try makePlist([
                 "TestConfigurations": [
                     [
@@ -147,10 +147,64 @@
 
             let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
 
-            // xcodebuild applies the skips after the selection, so a selected suite that is also
-            // skipped runs nothing.
-            #expect(xcTestRun.selectedTestSuiteIdentifiers() == ["AppUITests/CheckoutFlowTests"])
+            // The selection is reported in full even where the skips cancel it out. It is what tells
+            // the consumer which modules the products restrict at all, and narrowing it here would
+            // make a module whose every selected suite is skipped look unrestricted.
+            #expect(
+                xcTestRun.selectedTestSuiteIdentifiers() == [
+                    "AppUITests/CheckoutFlowTests",
+                    "AppUITests/OnboardingFlowTests",
+                ]
+            )
             #expect(xcTestRun.skippedTestSuiteIdentifiers() == ["AppUITests/OnboardingFlowTests"])
+        }
+
+        @Test
+        func decode_v2_parsesNestedSuiteSkips() throws {
+            let plist = try makePlist([
+                "TestConfigurations": [
+                    [
+                        "TestTargets": [
+                            [
+                                "BlueprintName": "AppUITests",
+                                "SkipTestIdentifiers": ["OnboardingFlowTests/NestedFlowTests"],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
+
+            // A nested Swift Testing suite is skipped by its path, and a suite is named by its
+            // innermost component, matching how a run reports it.
+            #expect(xcTestRun.skippedTestSuiteIdentifiers() == ["AppUITests/NestedFlowTests"])
+        }
+
+        @Test
+        func decode_v2_ignoresSkipsNamingASingleTest() throws {
+            let plist = try makePlist([
+                "TestConfigurations": [
+                    [
+                        "TestTargets": [
+                            [
+                                "BlueprintName": "AppUITests",
+                                "SkipTestIdentifiers": [
+                                    "OnboardingFlowTests/testExample",
+                                    "CheckoutFlowTests/testExample()",
+                                    "SettingsFlowTests/NestedFlowTests/testExample()",
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
+
+            // Skips naming a single test leave their suite with tests that may still run. A trailing
+            // "()" and a lowercase first character both mark a function rather than a type.
+            #expect(xcTestRun.skippedTestSuiteIdentifiers().isEmpty)
         }
 
         @Test

--- a/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestRunTests.swift
+++ b/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestRunTests.swift
@@ -105,6 +105,71 @@
             #expect(xcTestRun.parallelizableTestModules == ["ParallelTests"])
         }
 
+        // MARK: - Skipped tests
+
+        @Test
+        func decode_v2_parsesSkippedTestSuiteIdentifiers() throws {
+            let plist = try makePlist([
+                "TestConfigurations": [
+                    [
+                        "TestTargets": [
+                            [
+                                "BlueprintName": "AppUITests",
+                                "SkipTestIdentifiers": ["OnboardingFlowTests", "SettingsFlowTests/testExample"],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
+
+            // A skip naming a whole suite takes it out of the run. A skip naming a single test
+            // doesn't, because the suite holding it may still have tests left to run.
+            #expect(xcTestRun.skippedTestSuiteIdentifiers() == ["AppUITests/OnboardingFlowTests"])
+        }
+
+        @Test
+        func decode_v2_skippedSuitesAreExcludedFromSelectedSuites() throws {
+            let plist = try makePlist([
+                "TestConfigurations": [
+                    [
+                        "TestTargets": [
+                            [
+                                "BlueprintName": "AppUITests",
+                                "OnlyTestIdentifiers": ["OnboardingFlowTests", "CheckoutFlowTests/testExample()"],
+                                "SkipTestIdentifiers": ["OnboardingFlowTests"],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
+
+            // xcodebuild applies the skips after the selection, so a selected suite that is also
+            // skipped runs nothing.
+            #expect(xcTestRun.selectedTestSuiteIdentifiers() == ["AppUITests/CheckoutFlowTests"])
+            #expect(xcTestRun.skippedTestSuiteIdentifiers() == ["AppUITests/OnboardingFlowTests"])
+        }
+
+        @Test
+        func decode_v2_noSkippedIdentifiers() throws {
+            let plist = try makePlist([
+                "TestConfigurations": [
+                    [
+                        "TestTargets": [
+                            ["BlueprintName": "AppUITests"],
+                        ],
+                    ],
+                ],
+            ])
+
+            let xcTestRun = try PropertyListDecoder().decode(XCTestRun.self, from: plist)
+
+            #expect(xcTestRun.skippedTestSuiteIdentifiers().isEmpty)
+        }
+
         // MARK: - Format v1 (Legacy top-level keys)
 
         @Test

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
@@ -730,7 +730,11 @@ struct ShardPlanServiceTests {
                         testTargets: [
                             TestTargetFixture(
                                 blueprintName: "AppUITests",
-                                skipTestIdentifiers: ["OnboardingFlowTests", "CheckoutFlowTests/testExample()"]
+                                skipTestIdentifiers: [
+                                    "OnboardingFlowTests",
+                                    "SettingsFlowTests/NestedFlowTests",
+                                    "CheckoutFlowTests/testExample()",
+                                ]
                             ),
                             TestTargetFixture(blueprintName: "SmokeTests"),
                         ]
@@ -798,13 +802,103 @@ struct ShardPlanServiceTests {
             archivePath: temporaryDirectory.appending(components: "artifacts", "bundle.aar")
         )
 
-        // Only the whole-suite skip is reported: a skip naming a single test leaves its suite with
-        // work that may still run.
-        #expect(sentSkippedTestSuites.value == ["AppUITests/OnboardingFlowTests"])
+        // A nested suite is skipped by its path and reported under its innermost name, which is how
+        // a run reports it. A skip naming a single test is left out, since its suite may still have
+        // work that runs.
+        #expect(sentSkippedTestSuites.value == ["AppUITests/NestedFlowTests", "AppUITests/OnboardingFlowTests"])
 
         // The module universe is untouched. A skipped module's products still have to be downloaded
         // for the bundle to load, and whether its skips cover everything isn't knowable here.
         #expect(sentModules.value == ["AppUITests", "SmokeTests"])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func plan_sendsTheWholeSelectionWhenEverySelectedSuiteIsSkipped() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+        try await fileSystem.writeAsPlist(
+            XCTestRunFixture(
+                testConfigurations: [
+                    .init(
+                        testTargets: [
+                            TestTargetFixture(
+                                blueprintName: "AppUITests",
+                                onlyTestIdentifiers: ["OnboardingFlowTests/testExample()"],
+                                skipTestIdentifiers: ["OnboardingFlowTests"]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            at: testProductsPath.appending(component: "MyApp.xctestrun"),
+            encoder: plistEncoder()
+        )
+
+        let sentTestSuites = LockedValue<[String]?>(nil)
+        let sentSkippedTestSuites = LockedValue<[String]?>(nil)
+        let createShardPlanService = MockCreateShardPlanServicing()
+        given(createShardPlanService)
+            .createShardPlan(
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                modules: .any,
+                parallelizableModules: .any,
+                testSuites: .any,
+                skippedTestSuites: .any,
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .any,
+                shardMaxDuration: .any,
+                shardGranularity: .any,
+                buildRunId: .any,
+                gitBranch: .any
+            )
+            .willProduce { _, _, _, _, _, testSuites, skippedTestSuites, _, _, _, _, _, _, _ in
+                sentTestSuites.mutate { $0 = testSuites }
+                sentSkippedTestSuites.mutate { $0 = skippedTestSuites }
+                return Components.Schemas.ShardPlan(
+                    id: "plan-id",
+                    reference: "ref",
+                    shard_count: 1,
+                    shards: [],
+                    upload_url: "https://tuist.dev/api/projects/tuist/tuist/tests/shards/upload/start"
+                )
+            }
+
+        let shardMatrixOutputService = MockShardMatrixOutputServicing()
+        given(shardMatrixOutputService).output(.any).willReturn()
+
+        let subject = ShardPlanService(
+            createShardPlanService: createShardPlanService,
+            fileSystem: fileSystem,
+            shardMatrixOutputService: shardMatrixOutputService
+        )
+
+        _ = try await subject.plan(
+            xctestproductsPath: testProductsPath,
+            projectPath: temporaryDirectory,
+            reference: "ref",
+            shardGranularity: .suite,
+            shardMin: nil,
+            shardMax: nil,
+            shardTotal: 1,
+            shardMaxDuration: nil,
+            fullHandle: "tuist/tuist",
+            serverURL: try #require(URL(string: "https://tuist.dev")),
+            buildRunId: nil,
+            skipUpload: true,
+            archivePath: temporaryDirectory.appending(components: "artifacts", "bundle.aar")
+        )
+
+        // The selection still has to be sent, even though the skips cancel it out. Sending nothing
+        // would leave the module looking unrestricted, and it would be resolved from history into
+        // suites that `OnlyTestIdentifiers` never let run.
+        #expect(sentTestSuites.value == ["AppUITests/OnboardingFlowTests"])
+        #expect(sentSkippedTestSuites.value == ["AppUITests/OnboardingFlowTests"])
     }
 
     private func writeXCTestProducts(modules: [String], at testProductsPath: AbsolutePath, fileSystem: FileSystem) async throws {

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
@@ -46,6 +46,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -140,6 +141,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -288,6 +290,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -443,6 +446,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -451,7 +455,7 @@ struct ShardPlanServiceTests {
                 buildRunId: .any,
                 gitBranch: .any
             )
-            .willProduce { _, _, _, _, _, testSuites, _, _, _, _, _, _, _ in
+            .willProduce { _, _, _, _, _, testSuites, _, _, _, _, _, _, _, _ in
                 capture(testSuites)
                 return Components.Schemas.ShardPlan(
                     id: "plan-id",
@@ -496,6 +500,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -504,7 +509,7 @@ struct ShardPlanServiceTests {
                 buildRunId: .any,
                 gitBranch: .any
             )
-            .willProduce { _, _, _, _, parallelizableModules, _, _, _, _, _, _, _, _ in
+            .willProduce { _, _, _, _, parallelizableModules, _, _, _, _, _, _, _, _, _ in
                 sentParallelizableModules.mutate { $0 = parallelizableModules }
                 return Components.Schemas.ShardPlan(
                     id: "plan-id",
@@ -563,6 +568,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -571,7 +577,7 @@ struct ShardPlanServiceTests {
                 buildRunId: .any,
                 gitBranch: .any
             )
-            .willProduce { _, _, _, _, _, _, _, _, _, _, _, _, gitBranch in
+            .willProduce { _, _, _, _, _, _, _, _, _, _, _, _, _, gitBranch in
                 sentGitBranch.mutate { $0 = gitBranch }
                 return Components.Schemas.ShardPlan(
                     id: "plan-id",
@@ -660,6 +666,7 @@ struct ShardPlanServiceTests {
                 modules: .any,
                 parallelizableModules: .any,
                 testSuites: .any,
+                skippedTestSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -668,7 +675,7 @@ struct ShardPlanServiceTests {
                 buildRunId: .any,
                 gitBranch: .any
             )
-            .willProduce { _, _, _, _, _, testSuites, _, _, _, _, _, _, _ in
+            .willProduce { _, _, _, _, _, testSuites, _, _, _, _, _, _, _, _ in
                 sentTestSuites.mutate { $0 = testSuites }
                 return Components.Schemas.ShardPlan(
                     id: "plan-id",
@@ -709,6 +716,97 @@ struct ShardPlanServiceTests {
         #expect(sentTestSuites.value == ["SmokeTests/CartSuite", "SmokeTests/CheckoutSuite"])
     }
 
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func plan_sendsTheSuitesTheXCTestRunSkips() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+        try await fileSystem.writeAsPlist(
+            XCTestRunFixture(
+                testConfigurations: [
+                    .init(
+                        testTargets: [
+                            TestTargetFixture(
+                                blueprintName: "AppUITests",
+                                skipTestIdentifiers: ["OnboardingFlowTests", "CheckoutFlowTests/testExample()"]
+                            ),
+                            TestTargetFixture(blueprintName: "SmokeTests"),
+                        ]
+                    ),
+                ]
+            ),
+            at: testProductsPath.appending(component: "MyApp.xctestrun"),
+            encoder: plistEncoder()
+        )
+
+        let sentModules = LockedValue<[String]?>(nil)
+        let sentSkippedTestSuites = LockedValue<[String]?>(nil)
+        let createShardPlanService = MockCreateShardPlanServicing()
+        given(createShardPlanService)
+            .createShardPlan(
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                modules: .any,
+                parallelizableModules: .any,
+                testSuites: .any,
+                skippedTestSuites: .any,
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .any,
+                shardMaxDuration: .any,
+                shardGranularity: .any,
+                buildRunId: .any,
+                gitBranch: .any
+            )
+            .willProduce { _, _, _, modules, _, _, skippedTestSuites, _, _, _, _, _, _, _ in
+                sentModules.mutate { $0 = modules }
+                sentSkippedTestSuites.mutate { $0 = skippedTestSuites }
+                return Components.Schemas.ShardPlan(
+                    id: "plan-id",
+                    reference: "ref",
+                    shard_count: 1,
+                    shards: [],
+                    upload_url: "https://tuist.dev/api/projects/tuist/tuist/tests/shards/upload/start"
+                )
+            }
+
+        let shardMatrixOutputService = MockShardMatrixOutputServicing()
+        given(shardMatrixOutputService).output(.any).willReturn()
+
+        let subject = ShardPlanService(
+            createShardPlanService: createShardPlanService,
+            fileSystem: fileSystem,
+            shardMatrixOutputService: shardMatrixOutputService
+        )
+
+        _ = try await subject.plan(
+            xctestproductsPath: testProductsPath,
+            projectPath: temporaryDirectory,
+            reference: "ref",
+            shardGranularity: .suite,
+            shardMin: nil,
+            shardMax: nil,
+            shardTotal: 1,
+            shardMaxDuration: nil,
+            fullHandle: "tuist/tuist",
+            serverURL: try #require(URL(string: "https://tuist.dev")),
+            buildRunId: nil,
+            skipUpload: true,
+            archivePath: temporaryDirectory.appending(components: "artifacts", "bundle.aar")
+        )
+
+        // Only the whole-suite skip is reported: a skip naming a single test leaves its suite with
+        // work that may still run.
+        #expect(sentSkippedTestSuites.value == ["AppUITests/OnboardingFlowTests"])
+
+        // The module universe is untouched. A skipped module's products still have to be downloaded
+        // for the bundle to load, and whether its skips cover everything isn't knowable here.
+        #expect(sentModules.value == ["AppUITests", "SmokeTests"])
+    }
+
     private func writeXCTestProducts(modules: [String], at testProductsPath: AbsolutePath, fileSystem: FileSystem) async throws {
         try await fileSystem.makeDirectory(at: testProductsPath)
         try await fileSystem.writeAsPlist(
@@ -743,11 +841,13 @@ private struct TestTargetFixture: Encodable {
     let blueprintName: String
     var parallelizationEnabled: Bool?
     var onlyTestIdentifiers: [String]?
+    var skipTestIdentifiers: [String]?
 
     enum CodingKeys: String, CodingKey {
         case blueprintName = "BlueprintName"
         case parallelizationEnabled = "ParallelizationEnabled"
         case onlyTestIdentifiers = "OnlyTestIdentifiers"
+        case skipTestIdentifiers = "SkipTestIdentifiers"
     }
 }
 

--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -425,12 +425,22 @@ defmodule Tuist.Shards do
   # those suites are used as given. Modules it selected nothing for are still resolved from history:
   # a selection usually covers part of a plan, and dropping the rest would hand whole modules to the
   # catch-all shard.
+  #
+  # Suites the products skip are then dropped from both. A skipped suite cannot run, so planning it
+  # gives a shard work that executes nothing, and history is where that happens silently: a suite a
+  # test plan disabled stays in the inventory until it ages out of the lookback window. Modules are
+  # matched against the pre-skip selection, so a module whose every selected suite is skipped is not
+  # resolved from history either: the products limit it to suites that no longer run, and history
+  # would answer with ones outside that limit.
   defp resolve_units(project, params, "suite") do
+    skipped = MapSet.new(Map.get(params, :skipped_test_suites) || [])
     selected = Map.get(params, :test_suites) || []
     selected_modules = MapSet.new(selected, &suite_module/1)
     unselected_modules = Enum.reject(params_modules(params), &MapSet.member?(selected_modules, &1))
 
-    selected ++ latest_branch_suite_units(project, params, unselected_modules)
+    units = selected ++ latest_branch_suite_units(project, params, unselected_modules)
+
+    Enum.reject(units, &MapSet.member?(skipped, &1))
   end
 
   defp params_modules(params), do: Map.get(params, :modules) || []

--- a/server/lib/tuist_web/controllers/api/shards_controller.ex
+++ b/server/lib/tuist_web/controllers/api/shards_controller.ex
@@ -59,6 +59,12 @@ defmodule TuistWeb.API.ShardsController do
              items: %Schema{type: :string},
              description: "Test suite names (for suite-level granularity)."
            },
+           skipped_test_suites: %Schema{
+             type: :array,
+             items: %Schema{type: :string},
+             description:
+               "Test suite names the built products take out of the run, as `Module/Suite`. They are excluded from the plan, including when a module's suites would otherwise be resolved from run history."
+           },
            parallelizable_modules: %Schema{
              type: :array,
              items: %Schema{type: :string},
@@ -112,6 +118,7 @@ defmodule TuistWeb.API.ShardsController do
       reference: body_params.reference,
       modules: Map.get(body_params, :modules),
       test_suites: Map.get(body_params, :test_suites),
+      skipped_test_suites: Map.get(body_params, :skipped_test_suites),
       parallelizable_modules: Map.get(body_params, :parallelizable_modules),
       shard_min: Map.get(body_params, :shard_min),
       shard_max: Map.get(body_params, :shard_max),

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -312,6 +312,59 @@ defmodule Tuist.ShardsTest do
       assert planned_targets(result) == MapSet.new([])
     end
 
+    test "collapses to a single catch-all shard when every suite is skipped" do
+      project = ProjectsFixtures.project_fixture()
+      account = project.account
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: project.default_branch,
+        test_modules: [
+          %{
+            name: "AppUITests",
+            status: "success",
+            duration: 10_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "OnboardingFlowTests", status: "success", duration: 6_000},
+              %{name: "CheckoutFlowTests", status: "success", duration: 4_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      stub(Tuist.Storage, :object_exists?, fn _key, _account -> true end)
+      stub(Tuist.Storage, :generate_download_url, fn key, _account -> key end)
+
+      params = %{
+        reference: "all-skipped-1",
+        modules: ["AppUITests"],
+        skipped_test_suites: ["AppUITests/OnboardingFlowTests", "AppUITests/CheckoutFlowTests"],
+        granularity: "suite",
+        shard_total: 4
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      # Nothing is left to distribute, so the requested shard count is ignored rather than spreading
+      # an empty plan over four shards, three of which would resolve to nothing at all.
+      assert result.shard_count == 1
+      assert planned_targets(result) == MapSet.new([])
+
+      # The one shard is the catch-all, and it still runs. An empty unit set means "nothing to
+      # distribute", which is also what a project with no recorded suites produces, so it cannot be
+      # read as "nothing to run". The shard carries no -only-testing and no skip list, which leaves
+      # the decision to the bundle's own SkipTestIdentifiers.
+      assert {:ok, shard} = Shards.get_shard(project, account, "all-skipped-1", 0, suite_catch_all?: true)
+      assert shard.modules == []
+      assert shard.suites == %{}
+      assert shard.skip == []
+      assert Enum.any?(shard.download_urls, &String.ends_with?(&1, "/modules/AppUITests.aar"))
+    end
+
     test "does not append a catch-all shard for module granularity" do
       project = ProjectsFixtures.project_fixture()
 

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -218,6 +218,100 @@ defmodule Tuist.ShardsTest do
       refute Enum.any?(regular.download_urls, &String.ends_with?(&1, "/modules/NewTests.aar"))
     end
 
+    test "does not plan a suite the built products skip, even when history still has it" do
+      project = ProjectsFixtures.project_fixture()
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: project.default_branch,
+        test_modules: [
+          %{
+            name: "AppUITests",
+            status: "success",
+            duration: 10_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "OnboardingFlowTests", status: "success", duration: 6_000},
+              %{name: "CheckoutFlowTests", status: "success", duration: 4_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      params = %{
+        reference: "skipped-history-1",
+        modules: ["AppUITests"],
+        skipped_test_suites: ["AppUITests/OnboardingFlowTests"],
+        granularity: "suite",
+        shard_total: 2
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      # The test plan disabled the suite, so the built products cannot run it. Resolving the module
+      # from history would resurrect it and hand a shard work that executes nothing.
+      assert planned_targets(result) == MapSet.new(["AppUITests/CheckoutFlowTests"])
+    end
+
+    test "does not plan a suite the built products both select and skip" do
+      project = ProjectsFixtures.project_fixture()
+
+      params = %{
+        reference: "skipped-selected-1",
+        modules: ["AppUITests"],
+        test_suites: ["AppUITests/OnboardingFlowTests", "AppUITests/CheckoutFlowTests"],
+        skipped_test_suites: ["AppUITests/OnboardingFlowTests"],
+        granularity: "suite",
+        shard_total: 2
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      assert planned_targets(result) == MapSet.new(["AppUITests/CheckoutFlowTests"])
+    end
+
+    test "leaves a module whose every selected suite is skipped to the catch-all rather than history" do
+      project = ProjectsFixtures.project_fixture()
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: project.default_branch,
+        test_modules: [
+          %{
+            name: "AppUITests",
+            status: "success",
+            duration: 10_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "OnboardingFlowTests", status: "success", duration: 6_000},
+              %{name: "CheckoutFlowTests", status: "success", duration: 4_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      params = %{
+        reference: "skipped-selected-2",
+        modules: ["AppUITests"],
+        test_suites: ["AppUITests/OnboardingFlowTests"],
+        skipped_test_suites: ["AppUITests/OnboardingFlowTests"],
+        granularity: "suite",
+        shard_total: 2
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      # The products limit the module to a suite that is then skipped, so it runs nothing. History
+      # must not step in: CheckoutFlowTests is outside what the products would run.
+      assert planned_targets(result) == MapSet.new([])
+    end
+
     test "does not append a catch-all shard for module granularity" do
       project = ProjectsFixtures.project_fixture()
 

--- a/server/test/tuist_web/controllers/api/shards_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/shards_controller_test.exs
@@ -4,6 +4,7 @@ defmodule TuistWeb.API.ShardsControllerTest do
 
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.RunsFixtures
   alias TuistWeb.Authentication
   alias TuistWeb.Headers
 
@@ -61,6 +62,48 @@ defmodule TuistWeb.API.ShardsControllerTest do
       assert response["reference"] == "github-123-suite"
       assert is_integer(response["shard_count"])
       assert is_list(response["shards"])
+    end
+
+    test "excludes the suites the client reports as skipped", %{conn: conn, user: user, project: project} do
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: project.default_branch,
+        test_modules: [
+          %{
+            name: "AppUITests",
+            status: "success",
+            duration: 10_000,
+            test_cases: [],
+            test_suites: [
+              %{name: "OnboardingFlowTests", status: "success", duration: 6_000},
+              %{name: "CheckoutFlowTests", status: "success", duration: 4_000}
+            ]
+          }
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/api/projects/#{project.account.name}/#{project.name}/tests/shards",
+          %{
+            reference: "github-123-skipped",
+            modules: ["AppUITests"],
+            skipped_test_suites: ["AppUITests/OnboardingFlowTests"],
+            granularity: "suite",
+            shard_total: 2
+          }
+        )
+
+      response = json_response(conn, :ok)
+      planned = Enum.flat_map(response["shards"], & &1["test_targets"])
+
+      assert planned == ["AppUITests/CheckoutFlowTests"]
     end
 
     test "returns upload start URL", %{conn: conn, user: user, project: project} do


### PR DESCRIPTION
Shard plans were scheduling test suites that a test plan had disabled, producing shards that run zero tests.

`XCTestRun` decoded the xctestrun's `OnlyTestIdentifiers` but had no counterpart for `SkipTestIdentifiers`. A test plan that disables tests still builds the target, so the target stays in the xctestrun and therefore in the module universe the CLI sends to the planner. It contributes nothing to `test_suites`, so the server fell back to inferring the module's suites from run history and planned work the built products cannot execute.

That plays out two ways. A module with stale history gets assigned a suite that no longer runs. A module with no history resolves nothing but is still carried in the plan's module inventory. When a shard ends up holding only such suites, the run executes no tests, the parsed xcresult has no test modules, and the server labels the result `failed_processing` through the `run_status(_parsed_data, [])` clause in `Tuist.Tests.Workers.ProcessXCResultWorker`. This was observed in production, where targets that had produced no results for over a week were still receiving shard slots several times a day.

### Verifying the premise first

The whole approach depends on `SkipTestIdentifiers` actually reaching the xctestrun, rather than the skips being resolved at test time from the `.xctestplan`. That was checked before any code was written, by building a fixture project with a test plan, unticking tests, running `xcodebuild build-for-testing` on Xcode 26.5, and reading the generated plist.

| Test plan input | Result in the generated xctestrun |
| --- | --- |
| A whole suite unticked | `SkipTestIdentifiers: ["OnboardingFlowTests"]` |
| A nested Swift Testing suite unticked | `SkipTestIdentifiers: ["ParentSuite/NestedSuite"]` |
| A single XCTest case unticked | `SkipTestIdentifiers: ["OnboardingFlowTests/testExample"]` |
| A single Swift Testing case unticked | `SkipTestIdentifiers: ["AppTests/secondExample()"]` |
| Every test in a target unticked | The target is still present in `TestTargets`, carrying its skips |
| The target itself unticked (`enabled: false`) | The target is absent from the xctestrun entirely |

Identifiers are suite-relative and carry no module prefix, the same shape as `OnlyTestIdentifiers`. Two findings shaped the implementation. A target disabled outright already drops out of the xctestrun on its own, so only the skip case needed fixing. And when a plan target carries `selectedTests`, Xcode emits `OnlyTestIdentifiers` alone and discards the skips, so the both-keys case does not arise from a `.xctestplan` in practice, though the format permits it and it is handled.

### Which end of a skip identifier names the suite

A slash in a skip identifier does not mean the identifier names a single test. `ParentSuite/NestedSuite` is a nested Swift Testing suite and `OnboardingFlowTests/testExample` is an XCTest case, and the two are textually indistinguishable in the xctestrun.

Which component names the suite was settled against the run side rather than guessed. `XCResultParser.extractSuiteName` takes the second-to-last component of a test node identifier, and dumping a real xcresult from the fixture shows the nested case arrives as `ParentSuite/NestedSuite/nestedExample()`. So a run reports that suite as `NestedSuite`, and a skip has to resolve to its innermost component rather than its first, or it would never match the history inventory it exists to subtract from.

Single tests are excluded by two markers that separate a function from a type: a trailing `()`, and a lowercase first character, which every XCTest method has because discovery requires the `test` prefix. The residual ambiguity is a two component identifier whose tail is a type-cased name that is really a test, which Swift naming makes pathological, and it stays recoverable: the catch-all shard skips only the suites assigned to earlier shards, so a suite dropped from the plan still runs there.

### What changed

`XCTestRun` now decodes `SkipTestIdentifiers` and exposes `skippedTestSuiteIdentifiers()`, which reports each skipped suite as `Module/Suite` using the innermost component. `ShardPlanService` sends these in a new `skipped_test_suites` field alongside the module universe it already sends.

`selectedTestSuiteIdentifiers()` deliberately does not subtract the skips. That selection is what tells the server which modules the products restrict at all, and it has to be read before the skips are applied. Narrowing it would leave a module whose every selected suite is skipped looking unrestricted, which is the one state that sends the server back to history for suites `OnlyTestIdentifiers` never let run, recreating the very zero-test shard this change removes.

Server-side, `resolve_units/3` drops skipped suites from both the client's selection and the history-resolved inventory. Modules are matched against the pre-skip selection, so a module whose every selected suite is skipped is not resolved from history either.

### Why there is no skipped-modules counterpart

`test_suites` gained a `skipped_test_suites` pair and `modules` did not, which is deliberate rather than an oversight. The two fields are not the same kind of thing. `test_suites` is a selection, so there is something to subtract from. `modules` is the universe the bundle contains, and the catch-all shard needs it intact: the shared `.xctestrun` references every target, so a module's products are downloaded whether or not its tests run.

The deeper reason is that no client could populate such a field. There is no reachable xctestrun state that proves a module runs nothing:

- A target disabled outright in the plan (`enabled: false`) is absent from the xctestrun entirely, so it never reaches `modules` in the first place. That case is already handled by Xcode.
- A target carrying skips exposes the skip list but no suite inventory, so whether those skips cover everything is not decidable from the file.
- A target whose `OnlyTestIdentifiers` are all skipped would be decidable, but Xcode emits `OnlyTestIdentifiers` alone and discards the skips whenever a plan target has `selectedTests`, so that combination does not arise from a `.xctestplan`.

Deriving it server-side does not work either. Comparing the skip set against a module's historical suites needs that history to be complete, and it frequently is not. A module with five suites whose history recorded only the two that are skipped would be dropped while three runnable suites remain.

That leaves one honest gap, worth stating plainly: module-granularity plans get no benefit from this change, so a fully-skipped target there still receives a shard slot that runs nothing. Fixing it would mean guessing at completeness, and module granularity is exactly where guessing wrong is unrecoverable, because those plans have no catch-all shard (asserted by the existing `does not append a catch-all shard for module granularity` test). A suite wrongly dropped from a suite plan still runs on the catch-all; a module wrongly dropped from a module plan simply never runs. Silently skipping real tests is a worse failure than an idle shard, so the module universe is left alone.

### Impact

Suite-granularity shard plans stop allocating work for suites a test plan has disabled, which removes the empty runs and the `failed_processing` results that follow them. Module-granularity plans are unaffected, since a module is only excluded when its skip set is provably complete, which is not decidable. Older CLIs simply omit the new field and keep their current behaviour.

Two incidental changes came along with the OpenAPI regeneration, which also flushed unrelated pending spec drift, namely two `500` response entries and a reordering of the `listBundles` query parameters. The argument order in `ListBundlesService` was corrected to match the regenerated client.

Note for reviewers: [#12599](https://github.com/tuist/tuist/pull/12599) covers a neighbouring issue, a suite plan collapsing to a single shard that discards its own assignment. That is a separate representation problem and is not what causes the empty runs addressed here.

### How to test locally

Server tests, run from `server/`:

```
mix test test/tuist/shards_test.exs test/tuist_web/controllers/api/shards_controller_test.exs --warnings-as-errors
```

This covers three cases in `shards_test.exs`, a suite that history still holds but the products skip, a suite that is both selected and skipped, and a module whose every selected suite is skipped, plus a controller test asserting the field survives the request schema. The existing catch-all download test is in the same file and still passes. 85 tests pass.

CLI tests, run from the repository root after `tuist generate tuist ProjectDescription TuistAutomationTests TuistKitTests --no-open`:

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistAutomationTests/XCTestRunTests -only-testing TuistKitTests/ShardPlanServiceTests -only-testing TuistKitTests/ShardServiceTests -only-testing TuistKitTests/ShardMatrixOutputServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

`ShardPlanServiceTests.plan_sendsTheWholeSelectionWhenEverySelectedSuiteIsSkipped` is the guard for the selection behaviour above. It was confirmed to be a real guard by restoring the subtraction, watching it fail, and reverting.

To reproduce the premise checks, add a test plan to an Xcode project with two test targets and a nested Swift Testing suite, untick a whole suite and the nested suite, run `xcodebuild build-for-testing -destination 'generic/platform=iOS Simulator'`, and read the generated xctestrun:

```
plutil -convert json -o - <DerivedData>/Build/Products/*.xctestrun
```

For the naming side, run the tests once with no skips and read the node identifiers back:

```
xcrun xcresulttool get test-results tests --path probe.xcresult
```

The nested test case appears as `ParentSuite/NestedSuite/nestedExample()`.

