### PR TITLE
feat(server): trim the M2-L runner fleet to 7 now the M4s carry 4 slots

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -933,8 +933,16 @@ macosFleet:
     name: tuist-runner-cache
     cidr: 172.16.0.0/22
 
-# Customer-runner Mac mini fleet. 9 M2-L hosts at one guest each plus
-# 2 M4-XL hosts at two = 13 concurrent customer runs.
+# Customer-runner Mac mini fleet. 7 M2-L hosts at one guest each plus
+# 2 M4-XL hosts at two = 11 concurrent customer runs.
+#
+# Sized against measured demand, not host count. macOS job concurrency
+# over the 7 days to 2026-08-25 ran p50 3 / p95 5 / p99 6 with a peak of
+# 8, so 11 keeps a margin above the observed peak while the M4s absorb
+# what the retired M2-Ls used to hold. The M2-L count came down from 9
+# when the second M4 landed: 2 M4 hosts add 4 slots, so keeping all 9
+# M2-Ls would have meant 13 slots against a workload that has never
+# asked for 9.
 #
 # Apple's SLA permits two guests per host and Tart enforces it; whether
 # a host runs two is purely a function of how much CPU/RAM tart-kubelet
@@ -947,7 +955,20 @@ macosFleet:
 # releases can safely bump all enabled managed environments.
 runnersFleet:
   enabled: true
-  hostCount: 9
+  # 7, down from 9, offset by the 4 slots the two M4-XL hosts add.
+  #
+  # Scaling this DOWN does not stop the bill. On Machine deletion the
+  # controller renames the host back into the `tuist-pool-` pool and
+  # reinstalls it — the mini stays alive and keeps billing, deliberately,
+  # so Apple's 24h floor never leaks into a deploy flow. Releasing the
+  # hardware is a separate, operator-owned step in the Scaleway console.
+  # Leave the host parked instead if you want it back as burst capacity.
+  #
+  # CAPI deletes the most-recently-created Machines and this fleet sets
+  # no nodeDrainTimeout, so an evicted Pod is not waited on: retire while
+  # the target hosts hold no owned (job-running) runner Pod, or a
+  # customer job dies with the node.
+  hostCount: 7
   # Pre-ordered pool. Operator orders M2-L hosts in the Scaleway
   # console with names starting with `tuist-pool-` ahead of
   # bringing this block live (Mac mini lead times can stretch
@@ -1104,19 +1125,19 @@ runnersFleet:
   # fleet allocator, which apportions the fleet's GUEST-slot budget
   # across all macOS pools using the three-tier (floor / load /
   # headroom) policy. `minWarmPoolFloor` is the always-on warm
-  # guarantee; `maxReplicas: 13` lets either pool absorb the whole
+  # guarantee; `maxReplicas: 11` lets either pool absorb the whole
   # fleet under skewed demand and the allocator caps the joint sum
   # so the pools don't double-book.
   #
   # The budget is slots, not minis: the allocator divides the fleet's
-  # advertised memory by this shape's 14336 MB, so the 9 M2-L hosts are
-  # 9 slots and the 2 M4-XL hosts are 2 each, for 13. These ceilings must
+  # advertised memory by this shape's 14336 MB, so the 7 M2-L hosts are
+  # 7 slots and the 2 M4-XL hosts are 2 each, for 11. These ceilings must
   # move with that number — the allocator never exceeds a pool's
   # maxReplicas, so leaving them behind would let an M4 boot but keep
   # every pool clamped below the capacity it adds, and its second guest
   # would sit idle.
   #
-  # Floors sum to 1 of the 13-slot budget; the remaining 12 slots are
+  # Floors sum to 1 of the 11-slot budget; the remaining 10 slots are
   # dynamically apportioned by queue depth across the pools. Older
   # Xcodes sit cold (floor 0) so an unused runner doesn't tie up a host.
   #
@@ -1133,27 +1154,27 @@ runnersFleet:
       autoscaling:
         enabled: true
         minWarmPoolFloor: 1
-        maxReplicas: 13
+        maxReplicas: 11
     "26.5":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 11
     "26.4.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 11
     "26.3":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 11
     "26.0.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 11
   # Resolved at deploy time from the latest `runner-image@` git tag.
   runnerImageSemver: ""
   pools: []


### PR DESCRIPTION
## What

Takes the M2-L runner fleet from 9 hosts to 7, now that two M4-XL hosts carry 4 slots between them.

```
runnersFleet.hostCount           9  →  7
xcodeOverrides[*].maxReplicas   13  →  11
```

11 slots = 7 M2-L at one guest + 2 M4-XL at two.

## Why

The M4s landed in #12595 and **nothing had scheduled onto them at all**. Not a bug — I checked the obvious suspects and ruled them out: the fleet Node label is correct (`tuist-tuist-runners-fleet`, shared with the M2-Ls), taints are identical, neither node reports images so `ImageLocality` isn't steering, and the runner Pods carry no affinity. Two Pods were even created 8 minutes *after* the M4s joined and still went to M2-Ls.

The reason is demand. macOS job concurrency over the 7 days to 2026-08-25 (`runner_job_machine_metrics`, overlapping job spans):

| p50 | p95 | p99 | **peak** |
|---|---|---|---|
| 3 | 5 | 6 | **8** |

**Zero observations above 9.** The nine M2-Ls have never been saturated, so the M4s were slots 10–13 of a fleet whose first 9 are never all busy. Capacity is a ceiling, not a target — extra slots don't generate demand.

11 keeps a margin above the observed peak of 8 while letting the M4s take the traffic the retired hosts used to, which is also where it's worth having: an M4 host gets 240 GiB of cache volume against the M2-L's 80, so ~9 resident cache masters instead of 1–3.

Both numbers move together, as always: the allocator never exceeds a pool's `maxReplicas`, so a stale ceiling would clamp the pools below the capacity the fleet actually has.

## Two things worth knowing before this is applied

Both are recorded next to `hostCount` in the values file, because neither is obvious and both cost either real money or real jobs.

**Scaling down does not stop the bill.** On Machine deletion the controller renames the host back into the `tuist-pool-` pool and reinstalls it — the mini stays alive and keeps billing. That's deliberate, so Apple's 24h floor never leaks into a deploy flow ([`scalewayapplesiliconmachine_types.go`](https://github.com/tuist/tuist/blob/main/infra/cluster-api-provider-tuist/api/v1alpha1/scalewayapplesiliconmachine_types.go#L232-L239)). Releasing the hardware is a separate operator step in the Scaleway console. Alternatively leave them parked and they become burst capacity the next scale-up adopts for free — which given the demand numbers is a reasonable choice.

**Retire while the target hosts are idle.** CAPI deletes the most-recently-created Machines, and this fleet sets no `nodeDrainTimeout`, so an evicted Pod isn't waited on — a customer job on a deleted host dies with the node. All 9 runner Pods were idle (`owner=<none>`) when this was written, and the two newest Machines are `mndbc-8n9bz` and one of `mndbc-hvcl6` / `mndbc-jl28k`. Worth a re-check at apply time:

```bash
kubectl get pods -n tuist-runners -o custom-columns=NODE:.spec.nodeName,OWNER:.metadata.labels.tuist\.dev/runner-pool-owner --no-headers | grep mndbc
```

## Validation

- `helm lint` plus full render of staging, canary and production
- Renders confirm MD replicas 7 (M2-L) and 2 (M4), and all five macOS pools at `maxReplicas: 11`
- Live state cross-checked: 11 macOS Nodes advertising 182 Gi total, which the autoscaler divides by the 14336 MB Pod shape to 13 slots today — 11 after this lands

Not doing anything to force traffic onto the M4s; per the sizing above they'll pick up work the first time demand passes 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
