### PR TITLE
feat(server): marketing-wide dropdown animation defaults and navbar mega menu sizing

### DIFF
--- a/server/assets/marketing/css/new/layouts/components/dropdown.css
+++ b/server/assets/marketing/css/new/layouts/components/dropdown.css
@@ -1,0 +1,97 @@
+/* Marketing-wide Noora dropdown defaults: the dashboard's open/close
+   animation (same recipe as the breadcrumbs project switcher), applied to
+   every dropdown on the redesigned marketing pages.
+
+   zag sets `hidden` + `data-state="closed"` on the content the instant it
+   closes, and dropdown.css hides `.noora-dropdown-content` when not open —
+   both force `display: none` immediately and kill the exit transition. The
+   positioner (which zag never hides) is the single presence gate via
+   `allow-discrete`, so keep the content rendered and let opacity/transform
+   animate out underneath it. */
+[id^="marketing-"] .noora-dropdown {
+  & > [data-part="positioner"] {
+    transition: display 150ms allow-discrete;
+  }
+
+  & .noora-dropdown-content {
+    display: block;
+    opacity: 0;
+    transform: translateY(-0.25rem);
+    transition:
+      opacity 150ms var(--ease-out-cubic),
+      transform 150ms var(--ease-out-cubic);
+  }
+
+  & > [data-part="trigger"][data-state="open"] + [data-part="positioner"] > [data-part="content"] {
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      opacity 200ms var(--ease-out-cubic),
+      transform 200ms var(--ease-out-cubic);
+
+    @starting-style {
+      opacity: 0;
+      transform: translateY(-0.25rem);
+    }
+  }
+
+  /* zag focuses the menu container on open; when the last input wasn't a
+     pointer (e.g. right after a window resize) browsers mark that
+     programmatic focus :focus-visible and the site-wide ring wraps the
+     whole menu. The container isn't a keyboard target — items carry their
+     own roving focus — so keep the ring off it. */
+  & .noora-dropdown-content:focus-visible {
+    outline: none;
+  }
+
+  /* One chevron that rotates on open, instead of Noora's two-icon
+     display swap. */
+  & [data-part="indicator"] {
+    & [data-part="indicator-up"] {
+      display: none;
+    }
+
+    & [data-part="indicator-down"] {
+      display: inline-flex;
+      transition: rotate 200ms var(--ease-out-cubic);
+    }
+
+    &[data-state="open"] [data-part="indicator-down"] {
+      display: inline-flex;
+      rotate: 180deg;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    & > [data-part="positioner"],
+    & .noora-dropdown-content,
+    & > [data-part="trigger"][data-state="open"] + [data-part="positioner"] > [data-part="content"],
+    & [data-part="indicator"] [data-part="indicator-down"] {
+      transition: none;
+    }
+  }
+}
+
+/* Phone tray variant shared by the filter/plan selects (blog, changelog,
+   pricing): the menu slides up from the bottom edge instead of fading in
+   place, and the tray gets breathing room around the items. */
+@media (max-width: 767px) {
+  [id^="marketing-"] .noora-dropdown[data-part="category-select"],
+  [id^="marketing-"] .noora-dropdown[data-part="plan-select"] {
+    & .noora-dropdown-content {
+      box-sizing: border-box;
+      transform: translateY(100%);
+      padding: var(--noora-spacing-4) var(--noora-spacing-4)
+        max(var(--noora-spacing-6), env(safe-area-inset-bottom));
+    }
+
+    & > [data-part="trigger"][data-state="open"] + [data-part="positioner"] > [data-part="content"] {
+      transform: translateY(0);
+
+      @starting-style {
+        opacity: 0;
+        transform: translateY(100%);
+      }
+    }
+  }
+}

--- a/server/assets/marketing/css/new/layouts/components/dropdown.css
+++ b/server/assets/marketing/css/new/layouts/components/dropdown.css
@@ -15,23 +15,23 @@
 
   & .noora-dropdown-content {
     display: block;
-    opacity: 0;
     transform: translateY(-0.25rem);
+    opacity: 0;
     transition:
       opacity 150ms var(--ease-out-cubic),
       transform 150ms var(--ease-out-cubic);
   }
 
   & > [data-part="trigger"][data-state="open"] + [data-part="positioner"] > [data-part="content"] {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
     transition:
       opacity 200ms var(--ease-out-cubic),
       transform 200ms var(--ease-out-cubic);
 
     @starting-style {
-      opacity: 0;
       transform: translateY(-0.25rem);
+      opacity: 0;
     }
   }
 
@@ -79,18 +79,17 @@
   [id^="marketing-"] .noora-dropdown[data-part="category-select"],
   [id^="marketing-"] .noora-dropdown[data-part="plan-select"] {
     & .noora-dropdown-content {
-      box-sizing: border-box;
       transform: translateY(100%);
-      padding: var(--noora-spacing-4) var(--noora-spacing-4)
-        max(var(--noora-spacing-6), env(safe-area-inset-bottom));
+      box-sizing: border-box;
+      padding: var(--noora-spacing-4) var(--noora-spacing-4) max(var(--noora-spacing-6), env(safe-area-inset-bottom));
     }
 
     & > [data-part="trigger"][data-state="open"] + [data-part="positioner"] > [data-part="content"] {
       transform: translateY(0);
 
       @starting-style {
-        opacity: 0;
         transform: translateY(100%);
+        opacity: 0;
       }
     }
   }

--- a/server/assets/marketing/css/new/layouts/components/navbar.css
+++ b/server/assets/marketing/css/new/layouts/components/navbar.css
@@ -875,10 +875,16 @@
         );
     border-radius: var(--noora-radius-4);
     background: var(--noora-surface-background-primary);
-    /* Figma: every dropdown is a 1200x360 frame (width = the page container). */
+    /* Figma: every dropdown is a 1200-wide frame (width = the page
+       container). The height comes from the open content (the closed ones
+       are absolutely stacked for the crossfade), so a menu taller than the
+       360px baseline grows the panel instead of scrolling inside it.
+       interpolate-size lets the auto height animate between menus. */
     width: min(var(--marketing-page-width), calc(100vw - 64px));
-    height: 360px;
+    min-height: 360px;
     overflow: hidden;
+    interpolate-size: allow-keywords;
+    transition: height 250ms ease;
   }
 
   & > [data-part="panel"] > [data-part="content"] {
@@ -890,10 +896,10 @@
     /* Stay visible while the exit animation plays, then hide. */
     transition: visibility 0s linear 250ms;
     inset: 0;
-    overflow-y: auto;
     pointer-events: none;
 
     &[data-state="open"] {
+      position: relative;
       visibility: visible;
       opacity: 1;
       transition: none;
@@ -1202,6 +1208,10 @@
       flex-direction: column;
       gap: var(--noora-spacing-2);
       box-sizing: border-box;
+      /* Lets the 1fr tracks shrink below the nowrap subtitle's intrinsic
+         width, so the ellipsis engages instead of the panel growing a
+         horizontal scrollbar. */
+      min-width: 0;
       padding: var(--noora-spacing-7);
       text-decoration: none;
 

--- a/server/assets/marketing/css/new/layouts/components/navbar.css
+++ b/server/assets/marketing/css/new/layouts/components/navbar.css
@@ -1208,11 +1208,11 @@
       flex-direction: column;
       gap: var(--noora-spacing-2);
       box-sizing: border-box;
+      padding: var(--noora-spacing-7);
       /* Lets the 1fr tracks shrink below the nowrap subtitle's intrinsic
          width, so the ellipsis engages instead of the panel growing a
          horizontal scrollbar. */
       min-width: 0;
-      padding: var(--noora-spacing-7);
       text-decoration: none;
 
       & > [data-part="title"] {

--- a/server/assets/marketing/marketing_new.css
+++ b/server/assets/marketing/marketing_new.css
@@ -29,6 +29,8 @@
 @import "css/new/routes/page.css";
 @import "css/new/routes/brand.css";
 @import "css/new/routes/cache.css";
+@import "css/new/routes/pricing.css";
+@import "css/new/layouts/components/dropdown.css";
 @import "css/new/layouts/components/navbar.css";
 @import "css/new/layouts/components/footer.css";
 @import "css/layouts/components/banner.css";

--- a/server/assets/marketing/marketing_new.css
+++ b/server/assets/marketing/marketing_new.css
@@ -29,7 +29,6 @@
 @import "css/new/routes/page.css";
 @import "css/new/routes/brand.css";
 @import "css/new/routes/cache.css";
-@import "css/new/routes/pricing.css";
 @import "css/new/layouts/components/dropdown.css";
 @import "css/new/layouts/components/navbar.css";
 @import "css/new/layouts/components/footer.css";


### PR DESCRIPTION
## What changed

- A new shared stylesheet (`css/new/layouts/components/dropdown.css`, imported into the marketing bundle) gives every Noora dropdown on the redesigned marketing pages the dashboard's open/close animation: 200ms fade-and-settle enter via `@starting-style`, a 150ms exit, a single rotating chevron instead of the two-icon display swap, and a suppressed focus ring on the menu container. On phones the blog/changelog/pricing filter trays slide up from the bottom edge and get item padding plus a home-indicator safe-area inset.
- The navbar mega menu no longer scrolls: the open menu content sits in normal flow and defines the panel height (`min-height` keeps the 360px Figma baseline, `interpolate-size` animates height between menus), and the resources grid cells get `min-width: 0` so the nowrap subtitles ellipsize instead of forcing a horizontal scrollbar.

## Why

The redesigned marketing dropdowns opened instantly while the dashboard's menus animate; this makes the dashboard treatment the default site-wide instead of per-page copies. The mega menu's hard 1200×360 frame grew scrollbars whenever a menu was taller than the baseline (the resources menu with larger font settings) or its nowrap subtitles exceeded the column width.

## Non-obvious details

- zag stamps `hidden` + `data-state=closed` on dropdown content the instant it closes, which kills exit animations. The positioner (which zag never hides) is used as the single presence gate via `display … allow-discrete`, with the content kept rendered underneath — the same recipe as the dashboard's breadcrumbs switcher.
- The focus ring suppression exists because zag focuses the menu container on open; after non-pointer input (e.g. a window resize) browsers mark that programmatic focus `:focus-visible` and the site-wide purple ring wrapped the whole menu. Items keep their own roving focus, so keyboard a11y is unaffected.

## Validation

Verified interactively on the local dev server across the blog, changelog, and pricing pages in light/dark, desktop/tab/phone widths: popover and tray animations, chevron rotation, scrim dismissal, and mega menu growth without scrollbars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)