### PR TITLE
feat(server): redesigned pricing page behind the new_marketing_pricing flag

### DIFF
--- a/server/assets/marketing/css/new/routes/pricing.css
+++ b/server/assets/marketing/css/new/routes/pricing.css
@@ -1,0 +1,619 @@
+/* Pricing page (/pricing): centered hero card followed by the plans frame
+   (intro text + 3-up hairline card row), the feature comparison table, and
+   the FAQ — all on the 1200px page frame with 2px seams. The legacy design
+   lives in routes/pricing (legacy bundle). */
+#marketing-pricing {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--noora-spacing-1);
+
+  @media (min-width: 1024px) {
+    align-items: center;
+  }
+
+  /* All frames share the page shell: stroke border, primary surface, the
+     same margin/width override that beats pages.css. */
+  & > header[data-part="header"],
+  & > section {
+    box-sizing: border-box;
+    margin: 0 var(--noora-spacing-1);
+    border: 1px solid var(--marketing-stroke-default);
+    background: var(--noora-surface-background-primary);
+
+    @media (min-width: 1024px) {
+      margin: 0;
+      width: 100%;
+      max-width: 1200px;
+    }
+  }
+
+  /* Hero header card: centered display title + subtitle, same type ramp as
+     the about page header. */
+  & > header[data-part="header"] {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--noora-spacing-6);
+    padding: var(--noora-spacing-13) var(--noora-spacing-13) var(--noora-spacing-10);
+    text-align: center;
+
+    @media (max-width: 720px) {
+      padding: var(--noora-spacing-10);
+    }
+
+    & > [data-part="title"] {
+      color: var(--noora-surface-label-primary);
+      font: var(--noora-font-weight-regular) var(--noora-font-display-large);
+      letter-spacing: -0.035em;
+      text-wrap: balance;
+    }
+
+    & > [data-part="subtitle"] {
+      max-width: 540px;
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-weight-regular) var(--noora-font-body-large);
+      text-wrap: pretty;
+    }
+  }
+
+  /* Plans + comparison share one continuous card (no page seam between
+     them — a single hairline separates the two frames, per the design).
+     Each frame follows the shared convention: intro text below the frame's
+     top edge (72px for plans, 96px for the comparison) at 8px sides, with
+     the same eyebrow → h2 → p ramp as the cache and brand pages. */
+  & > section[data-part="pricing"] {
+    display: flex;
+    flex-direction: column;
+
+    & > [data-part="plans"],
+    & > [data-part="compare"],
+    & > [data-part="faq"] {
+      display: flex;
+      flex-direction: column;
+      gap: var(--noora-spacing-11);
+      padding-top: var(--noora-spacing-14);
+
+      & > [data-part="text"] {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 0 var(--noora-spacing-4);
+
+        & > [data-part="eyebrow"] {
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-code-large);
+          text-transform: uppercase;
+        }
+
+        & > [data-part="title"] {
+          margin-top: var(--noora-spacing-7);
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-regular) var(--noora-font-display-small);
+        }
+
+        & > [data-part="description"] {
+          margin-top: var(--noora-spacing-4);
+          max-width: 720px;
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-large);
+        }
+      }
+    }
+
+    & > [data-part="compare"] {
+      border-top: 1px solid var(--marketing-stroke-default);
+      padding-top: var(--noora-spacing-16);
+      /* The big gap before the FAQ divider belongs to this frame. */
+      padding-bottom: var(--noora-spacing-16);
+
+      /* Tab/mobile tighten the text → plan picker → table rhythm. */
+      @media (max-width: 1023px) {
+        gap: var(--noora-spacing-8);
+      }
+
+      & > [data-part="text"] > [data-part="description"] {
+        max-width: none;
+      }
+    }
+
+    /* FAQ frame: the comparison table's bottom hairline already closes
+       the frame above, so no divider of its own. */
+    & > [data-part="faq"] {
+      padding-top: var(--noora-spacing-7);
+    }
+  }
+
+  /* 3-up plan card row. Hairlines close each card: one above the row and
+     one between the columns. Figma card: 400 wide, 20px padding all
+     around, name →4px→ description →12px→ price, 24px between the card's
+     sections, 16px between traits. */
+  & > section[data-part="pricing"] > [data-part="plans"] > [data-part="grid"] {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+
+    @media (max-width: 1023px) {
+      grid-template-columns: 1fr;
+    }
+
+    & > [data-part="plan"] {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      box-sizing: border-box;
+      border-top: 1px solid var(--marketing-stroke-default);
+      padding: var(--noora-spacing-7);
+
+      @media (min-width: 1024px) {
+        &:not(:first-child) {
+          border-left: 1px solid var(--marketing-stroke-default);
+        }
+      }
+
+      /* Stacked tab/mobile cards breathe more vertically. */
+      @media (max-width: 1023px) {
+        padding-top: var(--noora-spacing-9);
+        padding-bottom: var(--noora-spacing-9);
+      }
+
+      & > [data-part="head"] {
+        display: flex;
+        align-items: center;
+        gap: var(--noora-spacing-5);
+
+        & > [data-part="name"] {
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-medium) var(--noora-font-heading-medium);
+        }
+      }
+
+      & > [data-part="description"] {
+        margin-top: var(--noora-spacing-2);
+        color: var(--noora-surface-label-secondary);
+        font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+        text-wrap: pretty;
+      }
+
+      & > [data-part="price"] {
+        display: flex;
+        align-items: baseline;
+        gap: var(--noora-spacing-3);
+        margin-top: var(--noora-spacing-5);
+
+        & > [data-part="value"] {
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-regular) var(--noora-font-display-small);
+          letter-spacing: -0.025em;
+        }
+
+        & > [data-part="extra"] {
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+        }
+      }
+
+      /* The traits list opens with the hairline that closes the price
+         block in the design, and flexes so the CTA sits at the bottom
+         edge regardless of trait count. */
+      & > [data-part="traits"] {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        align-self: stretch;
+        gap: var(--noora-spacing-6);
+        margin: var(--noora-spacing-8) 0 0;
+        border-top: 1px solid var(--marketing-stroke-default);
+        padding: var(--noora-spacing-8) 0 0;
+        list-style: none;
+
+        & > [data-part="trait"] {
+          display: flex;
+          align-items: center;
+          gap: var(--noora-spacing-4);
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+
+          & > svg {
+            flex-shrink: 0;
+            width: 16px;
+            height: 16px;
+            color: var(--noora-purple-500);
+          }
+        }
+      }
+
+      & > .noora-button {
+        margin-top: var(--noora-spacing-8);
+      }
+    }
+  }
+
+  /* Feature comparison table: hairline rows, vertical hairlines between
+     the plan value columns, centered values. Scrolls sideways on narrow
+     viewports instead of squeezing the feature column. */
+  /* Plan picker: the tab/mobile stand-in for the hidden table columns —
+     same recipe as the blog/customers filter dropdowns. Hidden on
+     desktop. */
+  & > section[data-part="pricing"] > [data-part="compare"] > [data-part="plan-select"] {
+    position: relative;
+    align-self: flex-start;
+    margin: 0 var(--noora-spacing-4);
+
+    @media (min-width: 1024px) {
+      display: none;
+    }
+
+    /* Zag normally positions the open menu with inline styles; the
+       hand-rolled dropdown anchors it below the trigger instead, with the
+       dashboard's 8px trigger gap. */
+    & > [data-part="positioner"] {
+      position: absolute;
+      top: calc(100% + var(--noora-spacing-4));
+      left: 0;
+      z-index: var(--noora-z-index-9);
+      min-width: 240px;
+    }
+
+    /* On phones the menu is a tray pinned to the bottom of the viewport
+       behind a modal scrim, instead of a popover anchored to the trigger.
+       Zag positions the popover with inline styles, so overriding its
+       placement needs !important. */
+    @media (max-width: 767px) {
+      & > [data-part="positioner"] {
+        position: fixed !important;
+        transform: none !important;
+        z-index: var(--noora-z-index-12);
+        inset: auto 0 0 0 !important;
+        padding: 0;
+
+        &::before {
+          position: fixed;
+          backdrop-filter: blur(2.5px);
+          inset: 0;
+          background: var(--noora-surface-overlay);
+          content: "";
+        }
+      }
+
+      & .noora-dropdown-content {
+        position: relative;
+        box-shadow: var(--noora-border-light-default);
+        border-radius: var(--noora-radius-4) var(--noora-radius-4) 0 0;
+        width: 100%;
+        max-height: 60vh;
+      }
+    }
+  }
+
+  & > section[data-part="pricing"] > [data-part="compare"] > [data-part="table-frame"] {
+    /* The sideways-scroll wrapper only exists on narrow viewports: an
+       overflow container would trap the sticky header row, so on desktop
+       the table overflows nothing and the header sticks to the page. */
+    @media (max-width: 1023px) {
+      overflow-x: auto;
+    }
+
+    & > [data-part="table"] {
+      /* Separate borders, not collapse: collapsed borders stay behind when
+         the sticky header row sticks (Chrome), separate ones travel with
+         the cell. Border-spacing 0 keeps the hairlines single-width. */
+      border-collapse: separate;
+      border-spacing: 0;
+      width: 100%;
+
+      @media (min-width: 1024px) {
+        min-width: 720px;
+      }
+
+      /* Tab/mobile: only the plan column picked in the dropdown renders,
+         next to the feature column, and the two columns split the width
+         in exact halves (the widths live on the header cells below). */
+      @media (max-width: 1023px) {
+        table-layout: fixed;
+
+        & [data-part="cell-plan"]:not(.active),
+        & [data-part="cell-value"]:not(.active),
+        & [data-part="cell-cta"]:not(.active) {
+          display: none;
+        }
+      }
+
+      & th,
+      & td {
+        /* Table cells default to content-box, which would add each cell's
+           padding on top of the fixed-layout 50% column widths. */
+        box-sizing: border-box;
+        border-top: 1px solid var(--marketing-stroke-default);
+        padding: var(--noora-spacing-7) var(--noora-spacing-6);
+      }
+
+      /* The stuck header paints its own bottom hairline (there's no row
+         underneath it while floating), so the first body row drops its
+         top one to avoid doubling in normal flow. */
+      & > [data-part="head"] th,
+      & > [data-part="head"] td {
+        border-bottom: 1px solid var(--marketing-stroke-default);
+      }
+
+      & > [data-part="body"] > tr:first-child > th,
+      & > [data-part="body"] > tr:first-child > td {
+        border-top: none;
+      }
+
+      /* The CTA row closes the table with its own hairline. */
+      & > [data-part="body"] > tr:last-child > th,
+      & > [data-part="body"] > tr:last-child > td {
+        border-bottom: 1px solid var(--marketing-stroke-default);
+      }
+
+      /* Plan header cells (Figma: 270 wide, 96 Hug): 32px vertical
+         padding, hairline above the whole header row. 3×270 + the 390
+         feature column = the 1200 card. The header row sticks below the
+         navbar while the table scrolls under it; the opaque background
+         keeps the rows from showing through. */
+      & [data-part="cell-blank"],
+      & [data-part="cell-plan"] {
+        position: sticky;
+        top: var(--sticky-top);
+        z-index: var(--noora-z-index-1);
+        background: var(--noora-surface-background-primary);
+
+        /* Tab/mobile: the table sits in the overflow-x wrapper, whose
+           scrollport the sticky offset resolves against — the cells pin
+           48px into the table and cover the first body row. No sticky
+           header inside a scroll container. */
+        @media (max-width: 1023px) {
+          position: static;
+        }
+      }
+
+      & [data-part="cell-plan"] {
+        border-left: 1px solid var(--marketing-stroke-default);
+        width: 270px;
+        padding: var(--noora-spacing-9) 0;
+        color: var(--noora-surface-label-primary);
+        font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
+        text-align: center;
+
+        @media (max-width: 1023px) {
+          width: 50%;
+        }
+      }
+
+      /* The blank corner sizes the feature column in the fixed layout. */
+      & [data-part="cell-blank"] {
+        @media (max-width: 1023px) {
+          width: 50%;
+        }
+      }
+
+      /* Feature cell (Figma: 390 Fill × Hug): 24px vertical / 8px
+         horizontal padding, name → description → hint stacked with an 8px
+         gap. */
+      & [data-part="cell-feature"] {
+        padding: var(--noora-spacing-8) var(--noora-spacing-4);
+        text-align: left;
+        vertical-align: middle;
+
+        & > [data-part="feature-name"] {
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-medium) var(--noora-font-body-large);
+        }
+
+        & > [data-part="feature-description"] {
+          margin-top: var(--noora-spacing-4);
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+          text-wrap: pretty;
+        }
+
+        & [data-part="feature-description"] + * {
+          display: block;
+          margin-top: var(--noora-spacing-4);
+        }
+      }
+
+      /* Closing CTA row: one button per plan column, empty feature cell. */
+      & [data-part="cell-cta"] {
+        border-left: 1px solid var(--marketing-stroke-default);
+        padding: var(--noora-spacing-9) 0;
+        text-align: center;
+      }
+
+      & [data-part="cell-value"] {
+        border-left: 1px solid var(--marketing-stroke-default);
+        color: var(--noora-surface-label-primary);
+        font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+        text-align: center;
+        vertical-align: middle;
+
+        & > [data-part="description"] {
+          margin-top: var(--noora-spacing-2);
+          color: var(--noora-surface-label-secondary);
+        }
+
+        & svg {
+          width: 16px;
+          height: 16px;
+          vertical-align: middle;
+        }
+
+        &[data-available="true"] svg {
+          color: var(--noora-purple-500);
+        }
+
+        &[data-available="false"] svg {
+          color: var(--noora-surface-label-secondary);
+        }
+      }
+    }
+  }
+
+  /* Dithered divider bands framing the closing CTA — same recipe as the
+     cache and home pages. */
+  & > [data-part="features-divider"] {
+    position: relative;
+    z-index: var(--noora-z-index-2);
+    box-sizing: border-box;
+    margin: 0 var(--noora-spacing-1);
+    border: 1px solid var(--marketing-stroke-default);
+    height: 120px;
+    overflow: hidden;
+
+    @media (min-width: 1024px) {
+      margin: 0;
+      width: 100%;
+      max-width: 1200px;
+    }
+
+    & > [data-part="dither"] {
+      display: block;
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+    }
+  }
+
+  /* CTA box: exact replica of the home/cache CTA shell and text ramp. */
+  & > [data-part="cta"] {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+    margin: 0 var(--noora-spacing-1);
+    border: 1px solid var(--marketing-stroke-default);
+    background: var(--noora-surface-background-primary);
+    padding: var(--noora-spacing-14) var(--noora-spacing-4);
+
+    @media (min-width: 1024px) {
+      margin: 0;
+      width: 100%;
+      max-width: 1200px;
+    }
+
+    & > [data-part="eyebrow"] {
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-weight-regular) var(--noora-font-code-large);
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    & > h2 {
+      margin-top: var(--noora-spacing-7);
+      color: var(--noora-surface-label-primary);
+      font: var(--noora-font-weight-regular) var(--noora-font-display-small);
+      text-align: center;
+    }
+
+    & > [data-part="actions"] {
+      display: flex;
+      gap: var(--noora-spacing-4);
+      margin-top: var(--noora-spacing-9);
+    }
+  }
+
+  & > section[data-part="pricing"] > [data-part="faq"] {
+    /* Question rows run edge to edge of the card; each box carries its
+       own 20px padding. */
+    & > [data-part="questions"] {
+      display: flex;
+      flex-direction: column;
+
+      /* Question box: 20px padding all around, the chevron 16px to the
+         right of the text column. The answer reuses the question's column
+         width — nothing renders below the chevron. */
+      & > [data-part="question"] {
+        border-top: 1px solid var(--marketing-stroke-default);
+        transition: background 0.15s ease;
+
+        &:not([open]):hover {
+          background: var(--noora-surface-background-secondary);
+        }
+        /* Lets block-size animate to `auto` so the disclosure opens
+           smoothly; browsers without ::details-content support just
+           toggle instantly. */
+        interpolate-size: allow-keywords;
+
+        &::details-content {
+          opacity: 0;
+          block-size: 0;
+          overflow-y: clip;
+          transition:
+            content-visibility 0.25s allow-discrete,
+            opacity 0.25s ease,
+            block-size 0.25s ease;
+
+          @media (prefers-reduced-motion: reduce) {
+            transition: none;
+          }
+        }
+
+        &[open]::details-content {
+          opacity: 1;
+          block-size: auto;
+        }
+
+        /* The 20px box padding sits on the summary so the whole row —
+           padding included — is the click/hover target. */
+        & > [data-part="summary"] {
+          display: flex;
+          align-items: center;
+          gap: var(--noora-spacing-6);
+          padding: var(--noora-spacing-7);
+          cursor: pointer;
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-medium) var(--noora-font-body-large);
+          list-style: none;
+
+          &::-webkit-details-marker {
+            display: none;
+          }
+
+          & > [data-part="label"] {
+            flex: 1;
+          }
+
+          & > [data-part="chevron"] {
+            flex-shrink: 0;
+
+            & svg {
+              transition: rotate 0.2s ease;
+            }
+          }
+        }
+
+        &[open] > [data-part="summary"] > [data-part="chevron"] svg {
+          rotate: 180deg;
+        }
+
+        /* Open state: the summary's bottom padding becomes the 16px
+           question → answer gap; the answer carries the box's bottom
+           and side padding. */
+        &[open] > [data-part="summary"] {
+          padding-bottom: var(--noora-spacing-6);
+        }
+
+        & > [data-part="answer"] {
+          /* Keep clear of the chevron column: the 28px neutral button +
+             16px gap. */
+          margin-right: calc(28px + var(--noora-spacing-6));
+          padding: 0 var(--noora-spacing-7) var(--noora-spacing-7);
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-large);
+
+          & p + p {
+            margin-top: var(--noora-spacing-4);
+          }
+
+          & a {
+            color: var(--noora-surface-label-primary);
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/assets/marketing/css/new/routes/pricing.css
+++ b/server/assets/marketing/css/new/routes/pricing.css
@@ -198,8 +198,8 @@
          edge regardless of trait count. */
       & > [data-part="traits"] {
         display: flex;
-        flex-direction: column;
         flex-grow: 1;
+        flex-direction: column;
         align-self: stretch;
         gap: var(--noora-spacing-6);
         margin: var(--noora-spacing-8) 0 0;
@@ -370,8 +370,8 @@
 
       & [data-part="cell-plan"] {
         border-left: 1px solid var(--marketing-stroke-default);
-        width: 270px;
         padding: var(--noora-spacing-9) 0;
+        width: 270px;
         color: var(--noora-surface-label-primary);
         font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
         text-align: center;
@@ -392,9 +392,9 @@
          horizontal padding, name → description → hint stacked with an 8px
          gap. */
       & [data-part="cell-feature"] {
+        vertical-align: middle;
         padding: var(--noora-spacing-8) var(--noora-spacing-4);
         text-align: left;
-        vertical-align: middle;
 
         & > [data-part="feature-name"] {
           color: var(--noora-surface-label-primary);
@@ -422,11 +422,11 @@
       }
 
       & [data-part="cell-value"] {
+        vertical-align: middle;
         border-left: 1px solid var(--marketing-stroke-default);
         color: var(--noora-surface-label-primary);
         font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
         text-align: center;
-        vertical-align: middle;
 
         & > [data-part="description"] {
           margin-top: var(--noora-spacing-2);
@@ -434,9 +434,9 @@
         }
 
         & svg {
+          vertical-align: middle;
           width: 16px;
           height: 16px;
-          vertical-align: middle;
         }
 
         &[data-available="true"] svg {
@@ -526,25 +526,25 @@
          right of the text column. The answer reuses the question's column
          width — nothing renders below the chevron. */
       & > [data-part="question"] {
-        border-top: 1px solid var(--marketing-stroke-default);
         transition: background 0.15s ease;
-
-        &:not([open]):hover {
-          background: var(--noora-surface-background-secondary);
-        }
+        border-top: 1px solid var(--marketing-stroke-default);
         /* Lets block-size animate to `auto` so the disclosure opens
            smoothly; browsers without ::details-content support just
            toggle instantly. */
         interpolate-size: allow-keywords;
 
+        &:not([open]):hover {
+          background: var(--noora-surface-background-secondary);
+        }
+
         &::details-content {
           opacity: 0;
-          block-size: 0;
-          overflow-y: clip;
           transition:
             content-visibility 0.25s allow-discrete,
             opacity 0.25s ease,
             block-size 0.25s ease;
+          block-size: 0;
+          overflow-y: clip;
 
           @media (prefers-reduced-motion: reduce) {
             transition: none;
@@ -562,8 +562,8 @@
           display: flex;
           align-items: center;
           gap: var(--noora-spacing-6);
-          padding: var(--noora-spacing-7);
           cursor: pointer;
+          padding: var(--noora-spacing-7);
           color: var(--noora-surface-label-primary);
           font: var(--noora-font-weight-medium) var(--noora-font-body-large);
           list-style: none;

--- a/server/assets/marketing/js/hooks.js
+++ b/server/assets/marketing/js/hooks.js
@@ -31,6 +31,7 @@ import { CustomersDitherLine } from "./hooks/customers-dither-line.js";
 import { DitherBlocks } from "./hooks/dither-blocks.js";
 import { LogoContextMenu } from "./hooks/logo-context-menu.js";
 import { BlogViewPreference } from "./hooks/blog-view-preference.js";
+import { PricingPlanSelect } from "./hooks/pricing-plan-select.js";
 
 const Hooks = {
   PlatformBackground,
@@ -66,6 +67,7 @@ const Hooks = {
   CounterAnimation,
   KaTeX,
   BlogViewPreference,
+  PricingPlanSelect,
 };
 
 export { Hooks };

--- a/server/assets/marketing/js/hooks/pricing-plan-select.js
+++ b/server/assets/marketing/js/hooks/pricing-plan-select.js
@@ -1,0 +1,75 @@
+/**
+ * PricingPlanSelect Hook
+ *
+ * Drives the pricing page's tab/mobile plan picker — a hand-rolled Noora
+ * dropdown (the real component teleports its label/menu through LiveView
+ * portals, which never mount on this dead-rendered page).
+ *
+ * Open state lives in `data-state` on the trigger, which Noora's dropdown
+ * CSS keys on for the menu and the chevron indicator. Picking a plan swaps
+ * the `.active` column in the comparison table, writes the plan name into
+ * the trigger label, and closes the menu.
+ */
+export const PricingPlanSelect = {
+  mounted() {
+    this.trigger = this.el.querySelector('[data-part="trigger"]');
+    this.content = this.el.querySelector('[data-part="content"]');
+    this.indicator = this.el.querySelector('[data-part="indicator"]');
+    this.label = this.el.querySelector('[data-part="label"] > span');
+    this.items = Array.from(this.el.querySelectorAll('[data-part="item"]'));
+
+    if (!this.trigger || !this.content || !this.label) {
+      console.error("Pricing plan select: missing trigger, content, or label element");
+      return;
+    }
+
+    this.onTriggerClick = (e) => {
+      e.preventDefault();
+      this.setOpen(this.trigger.getAttribute("data-state") !== "open");
+    };
+
+    this.onDocumentClick = (e) => {
+      // Close on any click that lands outside the trigger and the menu
+      // itself — including on the phone tray's scrim, whose click target
+      // is the positioner (the ::before pseudo-element belongs to it).
+      if (this.trigger.contains(e.target) || this.content.contains(e.target)) return;
+      this.setOpen(false);
+    };
+
+    this.onKeydown = (e) => {
+      if (e.key === "Escape") this.setOpen(false);
+    };
+
+    this.trigger.addEventListener("click", this.onTriggerClick);
+    document.addEventListener("click", this.onDocumentClick);
+    document.addEventListener("keydown", this.onKeydown);
+
+    this.items.forEach((item, index) => {
+      item.addEventListener("click", () => this.select(item, index));
+    });
+  },
+
+  setOpen(open) {
+    const state = open ? "open" : "closed";
+    // Noora's CSS keys the positioner off the trigger, the menu box off
+    // the content element, and the chevron swap off the indicator — zag
+    // stamps data-state on all three.
+    this.trigger.setAttribute("data-state", state);
+    this.content.setAttribute("data-state", state);
+    if (this.indicator) this.indicator.setAttribute("data-state", state);
+    this.trigger.setAttribute("aria-expanded", open ? "true" : "false");
+  },
+
+  select(item, index) {
+    document.querySelectorAll("[data-plan-index]").forEach((cell) => {
+      cell.classList.toggle("active", cell.getAttribute("data-plan-index") === String(index));
+    });
+    this.label.textContent = item.getAttribute("data-label");
+    this.setOpen(false);
+  },
+
+  destroyed() {
+    document.removeEventListener("click", this.onDocumentClick);
+    document.removeEventListener("keydown", this.onKeydown);
+  },
+};

--- a/server/assets/marketing/marketing_new.css
+++ b/server/assets/marketing/marketing_new.css
@@ -29,6 +29,7 @@
 @import "css/new/routes/page.css";
 @import "css/new/routes/brand.css";
 @import "css/new/routes/cache.css";
+@import "css/new/routes/pricing.css";
 @import "css/new/layouts/components/dropdown.css";
 @import "css/new/layouts/components/navbar.css";
 @import "css/new/layouts/components/footer.css";

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -928,65 +928,87 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   def pricing(conn, _params) do
     faqs = [
-      {dgettext(
-         "marketing",
-         "Why is your pricing model more accessible compared to traditional enterprise models?"
-       ),
+      {dgettext("marketing", "Do you support a seat-based pricing model?"),
        dgettext(
          "marketing",
-         ~S"""
-         <p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with "contact sales" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>
-         <p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>
-         """,
-         read_more: "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{dgettext("marketing", "read more")}</a>"
+         "Yes, we do. Please contact us at contact@tuist.dev to discuss your team's needs and we'll set up a custom plan that works for you."
        )},
-      {dgettext("marketing", "How can I estimate the cost of my project?"),
+      {dgettext("marketing", "What payment methods do you accept?"),
+       dgettext("marketing", "We accept credit card payments and wire transfers.")},
+      {dgettext("marketing", "Can I change or cancel my plan at any time?"),
+       dgettext("marketing", "Yes, you can manage your plan at any time through our management interface.")},
+      {dgettext("marketing", "What happens if I exceed my plan limits?"),
        dgettext(
          "marketing",
-         "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
+         "You'll be warned before reaching your plan limits. Once reached, the plan will cap interactions to prevent unexpected charges."
        )},
-      {dgettext("marketing", "Is there a free trial on paid plans?"),
+      {dgettext("marketing", "Do you offer annual billing discounts?"),
+       dgettext(
+         "marketing",
+         "Yes, we offer discounts for yearly subscriptions. Please contact us at contact@tuist.dev to learn more."
+       )},
+      {dgettext("marketing", "Is there a minimum contract length?"),
+       dgettext("marketing", "No, there's no minimum contract length. You're free to cancel at any time.")},
+      {dgettext("marketing", "What support is included with each plan?"),
+       dgettext(
+         "marketing",
+         "Tuist Pro includes support through our community forum and GitHub issues. Enterprise plans include dedicated support via Slack channels with high priority response times."
+       )},
+      {dgettext("marketing", "How can I estimate the cost for my project?"),
+       dgettext(
+         "marketing",
+         "You can set up the Air plan and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
+       )},
+      {dgettext("marketing", "Is there a free trial for paid plans?"),
        dgettext(
          "marketing",
          "We have a generous free tier on every paid plan so you can try out the features before paying any money."
        )},
       {dgettext("marketing", "Do you offer discounts for non-profits and open-source?"),
-       dgettext("marketing", "Yes, we do. Please reach out to oss@tuist.io for more information.")}
+       dgettext("marketing", "Yes, we do. Please reach out to contact@tuist.dev for more information.")}
     ]
 
     plans = Tuist.Billing.get_plans()
 
-    conn
-    |> assign(:head_title, "Pricing · Plans for every developer · Tuist")
-    |> assign(:faqs, faqs)
-    |> assign(:plans, plans)
-    |> assign(
-      :head_image,
-      Tuist.Environment.app_url(
-        path:
-          OpenGraph.image_path(:marketing,
-            title: dgettext("marketing", "Pricing"),
-            icon: "static/marketing/images/pricing/logo-og.svg"
-          )
+    conn =
+      conn
+      |> assign(:head_title, "Pricing · Plans for every developer · Tuist")
+      |> assign(:faqs, faqs)
+      |> assign(:plans, plans)
+      |> assign(
+        :head_image,
+        Tuist.Environment.app_url(
+          path:
+            OpenGraph.image_path(:marketing,
+              title: dgettext("marketing", "Pricing"),
+              icon: "static/marketing/images/pricing/logo-og.svg"
+            )
+        )
       )
-    )
-    |> assign(:head_twitter_card, "summary_large_image")
-    |> assign_structured_data(get_faq_structured_data(faqs))
-    |> assign_structured_data(get_pricing_plans_structured_data(plans))
-    |> assign_structured_data(
-      get_breadcrumbs_structured_data([
-        {dgettext("marketing", "Tuist"), Tuist.Environment.app_url(path: ~p"/")},
-        {dgettext("marketing", "Pricing"), Tuist.Environment.app_url(path: ~p"/pricing")}
-      ])
-    )
-    |> assign(
-      :head_description,
-      dgettext(
-        "marketing",
-        "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
+      |> assign(:head_twitter_card, "summary_large_image")
+      |> assign_structured_data(get_faq_structured_data(faqs))
+      |> assign_structured_data(get_pricing_plans_structured_data(plans))
+      |> assign_structured_data(
+        get_breadcrumbs_structured_data([
+          {dgettext("marketing", "Tuist"), Tuist.Environment.app_url(path: ~p"/")},
+          {dgettext("marketing", "Pricing"), Tuist.Environment.app_url(path: ~p"/pricing")}
+        ])
       )
-    )
-    |> render(:pricing, layout: false)
+      |> assign(
+        :head_description,
+        dgettext(
+          "marketing",
+          "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
+        )
+      )
+
+    if Design.new?(conn, :pricing) do
+      conn
+      |> assign(:new_design, true)
+      |> render(:pricing_new, layout: false)
+    else
+      render(conn, :pricing, layout: false)
+    end
   end
 
   def page(conn, _params) do

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
@@ -1,0 +1,485 @@
+<% signed_in? = not is_nil(TuistWeb.Authentication.current_user(assigns))
+
+plans = [
+  %{
+    id: "air",
+    name: dgettext("marketing", "Air"),
+    description: dgettext("marketing", "Get started with no credit card required"),
+    price: dgettext("marketing", "Free"),
+    price_extra: nil,
+    cta_label:
+      if(signed_in?,
+        do: dgettext("marketing", "Current plan"),
+        else: dgettext("marketing", "Get started")
+      ),
+    cta_href: ~p"/users/register",
+    cta_variant: "secondary",
+    popular: false,
+    traits: [
+      dgettext("marketing", "Free under tier limits"),
+      dgettext("marketing", "All features, no credit card required"),
+      dgettext("marketing", "Community support via forum")
+    ]
+  },
+  %{
+    id: "pro",
+    name: dgettext("marketing", "Pro"),
+    description: dgettext("marketing", "Usage-based pricing after free tier"),
+    price: "$0",
+    price_extra: dgettext("marketing", "and up"),
+    cta_label:
+      if(signed_in?,
+        do: dgettext("marketing", "Upgrade now"),
+        else: dgettext("marketing", "Upgrade on the go")
+      ),
+    cta_href: ~p"/users/register",
+    cta_variant: "primary",
+    popular: true,
+    traits: [
+      dgettext("marketing", "Pay nothing if below free tier limits"),
+      dgettext("marketing", "Pay only for what you use per feature"),
+      dgettext("marketing", "Standard support via Slack and email")
+    ]
+  },
+  %{
+    id: "enterprise",
+    name: dgettext("marketing", "Enterprise"),
+    description: dgettext("marketing", "Create your plan or self-host your instance"),
+    price: dgettext("marketing", "Custom"),
+    price_extra: nil,
+    cta_label: dgettext("marketing", "Contact us"),
+    cta_href: "https://cal.tuist.dev/team/tuist/tuist",
+    cta_variant: "secondary",
+    popular: false,
+    traits: [
+      dgettext("marketing", "Tailored agreement for specific needs"),
+      dgettext("marketing", "Self-host your instance of Tuist"),
+      dgettext("marketing", "Priority support via Slack channel")
+    ]
+  }
+]
+
+features = [
+  %{
+    name: dgettext("marketing", "Base price"),
+    description: nil,
+    hint: nil,
+    values: [
+      dgettext("marketing", "Free"),
+      %{
+        price: "$0 " <> dgettext("marketing", "and up"),
+        description: dgettext("marketing", "Price per unit above free tier")
+      },
+      %{
+        price: dgettext("marketing", "Custom"),
+        description: dgettext("marketing", "Usage/seat based pricing")
+      }
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Cache"),
+    description:
+      dgettext(
+        "marketing",
+        "Speed up clean compilations by using binaries for graph targets (including external dependencies)."
+      ),
+    hint: dgettext("marketing", "How do we calculate units?"),
+    hint_text:
+      dgettext(
+        "marketing",
+        "A Tuist command execution that interacts with the server to pull module binaries. As an estimate, this is roughly equivalent to the number of clean builds on CI, plus local project generations that aren't cached locally."
+      ),
+    values: [
+      "200",
+      %{value: "200", description: "+ $0.5 " <> dgettext("marketing", "per additional unit")},
+      dgettext("marketing", "Custom")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Tests"),
+    description:
+      dgettext(
+        "marketing",
+        "Speed up test runs by skipping test suites (test targets) whose tests are not impacted by the changes."
+      ),
+    hint: dgettext("marketing", "How do we calculate units?"),
+    hint_text:
+      dgettext(
+        "marketing",
+        "A Tuist command execution that interacts with the server pull test result information. As an estimate, this is roughly equivalent to the number of test runs on CI."
+      ),
+    values: [
+      "200",
+      %{value: "200", description: "+ $0.5 " <> dgettext("marketing", "per additional unit")},
+      dgettext("marketing", "Custom")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Generated Projects"),
+    description:
+      dgettext(
+        "marketing",
+        "Turn projects defined with a Swift-DSL into Xcode workspaces and projects."
+      ),
+    hint: nil,
+    values: [
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Previews"),
+    description:
+      dgettext(
+        "marketing",
+        "Preview your project apps in simulator or devices with one click/command."
+      ),
+    hint: nil,
+    values: [
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Registry"),
+    description:
+      dgettext(
+        "marketing",
+        "Download only what you need — faster, lighter builds locally and on CI."
+      ),
+    hint: nil,
+    values: [
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Build Insights"),
+    description:
+      dgettext(
+        "marketing",
+        "Explore what is making your builds slow and speed up your builds."
+      ),
+    hint: nil,
+    values: [
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Bundle Insights"),
+    description:
+      dgettext(
+        "marketing",
+        "Track and reduce app size by spotting duplicate assets and bloated resources."
+      ),
+    hint: nil,
+    values: [
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited"),
+      dgettext("marketing", "Unlimited")
+    ]
+  },
+  %{
+    name: dgettext("marketing", "Self-hosting Tuist instance"),
+    description:
+      dgettext(
+        "marketing",
+        "Host Tuist server on your own infrastructure for complete control and data sovereignty."
+      ),
+    hint: nil,
+    values: [:unavailable, :unavailable, :available]
+  },
+  %{
+    name: dgettext("marketing", "Tailored legal terms"),
+    description:
+      dgettext(
+        "marketing",
+        "Custom legal agreements and terms of service tailored to your organization's needs."
+      ),
+    hint: nil,
+    values: [:unavailable, :unavailable, :available]
+  },
+  %{
+    name: dgettext("marketing", "Support"),
+    description: dgettext("marketing", "Get help when you need it through various support channels."),
+    hint: nil,
+    values: [
+      %{
+        level: dgettext("marketing", "Community support"),
+        description: dgettext("marketing", "via Discourse forum")
+      },
+      %{
+        level: dgettext("marketing", "Standard support"),
+        description: dgettext("marketing", "via Slack and email")
+      },
+      %{
+        level: dgettext("marketing", "Priority support"),
+        description: dgettext("marketing", "via Slack and email")
+      }
+    ]
+  }
+] %>
+<%!-- Redesigned pricing page (styles in css/new/routes/pricing.css). --%>
+<TuistWeb.Marketing.Layouts.marketing {assigns}>
+  <main id="marketing-pricing">
+    <header data-part="header">
+      <h1 data-part="title">
+        {dgettext("marketing", "Start for free, pay as you go")}
+      </h1>
+      <p data-part="subtitle">
+        {dgettext(
+          "marketing",
+          "Get started with Tuist at no cost, and only invest more when you're ready for higher limits or personalized support."
+        )}
+      </p>
+    </header>
+
+    <section data-part="pricing" aria-labelledby="pricing-plans-title">
+      <div data-part="plans">
+        <div data-part="text">
+          <span data-part="eyebrow">{dgettext("marketing", "Plans")}</span>
+          <h2 data-part="title" id="pricing-plans-title">{dgettext("marketing", "Pricing plans")}</h2>
+        </div>
+        <div data-part="grid">
+          <article :for={plan <- plans} data-part="plan" data-plan={plan.id} data-popular={plan.popular}>
+            <div data-part="head">
+              <h3 data-part="name">{plan.name}</h3>
+              <.badge :if={plan.popular} label={dgettext("marketing", "Popular")} color="primary" style="light-fill" />
+            </div>
+            <p data-part="description">{plan.description}</p>
+            <div data-part="price">
+              <span data-part="value">{plan.price}</span>
+              <span :if={plan.price_extra} data-part="extra">{plan.price_extra}</span>
+            </div>
+            <ul data-part="traits">
+              <li :for={trait <- plan.traits} data-part="trait">
+                <.system_check />
+                <span>{trait}</span>
+              </li>
+            </ul>
+            <.button variant={plan.cta_variant} size="large" label={plan.cta_label} href={plan.cta_href} />
+          </article>
+        </div>
+      </div>
+
+      <div data-part="compare">
+        <div data-part="text">
+          <span data-part="eyebrow">{dgettext("marketing", "Features")}</span>
+          <h2 data-part="title" id="pricing-compare-title">
+            {dgettext("marketing", "Compare features across plans")}
+          </h2>
+          <p data-part="description">
+            {dgettext(
+              "marketing",
+              "You're only charged for the features you use, based on your usage, and only after you exceed a free threshold."
+            )}
+          </p>
+        </div>
+        <%!-- Tab/mobile collapse the table to a single plan column, picked
+        here. Renders as a bottom tray with a modal scrim on phones, same
+        pattern as the blog and customers filters (see pricing.css).
+
+        The markup mirrors Noora's dropdown but is hand-rolled: the Noora
+        component teleports its label and menu with LiveView portals, which
+        only mount inside connected LiveViews — on this dead view the
+        trigger rendered empty. Open state lives in data-state on the
+        trigger, which Noora's CSS already keys on. --%>
+        <div
+          id="pricing-plan-select"
+          class="noora-dropdown"
+          data-part="plan-select"
+          data-size="large"
+          phx-hook="PricingPlanSelect"
+          phx-update="ignore"
+        >
+          <button type="button" data-part="trigger" data-state="closed" aria-expanded="false">
+            <div data-part="label-wrapper">
+              <span data-part="label">
+                <span id="pricing-plan-select-label-target">{dgettext("marketing", "Air")}</span>
+              </span>
+            </div>
+            <div data-part="indicator">
+              <div data-part="indicator-down"><.chevron_down /></div>
+              <div data-part="indicator-up"><.chevron_up /></div>
+            </div>
+          </button>
+          <div data-part="positioner">
+            <div class="noora-dropdown-content" data-part="content">
+              <.dropdown_item :for={plan <- plans} value={plan.id} label={plan.name} />
+            </div>
+          </div>
+        </div>
+        <div data-part="table-frame">
+        <table data-part="table">
+          <thead data-part="head">
+            <tr data-part="row">
+              <td data-part="cell-blank"></td>
+              <th
+                :for={{plan, index} <- Enum.with_index(plans)}
+                data-part="cell-plan"
+                data-popular={plan.popular}
+                data-plan-index={index}
+                class={if index == 0, do: "active"}
+                scope="col"
+              >
+                {plan.name}
+              </th>
+            </tr>
+          </thead>
+          <tbody data-part="body">
+            <tr :for={feature <- features} data-part="row">
+              <th data-part="cell-feature" scope="row">
+                <div data-part="feature-name">{feature.name}</div>
+                <div :if={feature.description} data-part="feature-description">
+                  {feature.description}
+                </div>
+                <.tooltip
+                  :if={not is_nil(feature.hint) and not is_nil(feature[:hint_text])}
+                  id={"#{feature.name}-hint"}
+                  size="large"
+                  description={feature.hint_text}
+                  title={dgettext("marketing", "Hits")}
+                >
+                  <:trigger :let={attrs}>
+                    <span {attrs}>
+                      <.hint_text label={feature.hint} />
+                    </span>
+                  </:trigger>
+                </.tooltip>
+              </th>
+              <td
+                :for={{value, index} <- Enum.with_index(feature.values)}
+                data-part="cell-value"
+                data-plan-index={index}
+                class={if index == 0, do: "active"}
+                data-available={
+                  cond do
+                    value == :available -> true
+                    value == :unavailable -> false
+                    true -> nil
+                  end
+                }
+              >
+                <%= cond do %>
+                  <% value == :available -> %>
+                    <.system_check />
+                  <% value == :unavailable -> %>
+                    <.math_x />
+                  <% is_map(value) and Map.has_key?(value, :price) -> %>
+                    <div data-part="value">{value.price}</div>
+                    <div data-part="description">{value.description}</div>
+                  <% is_map(value) and Map.has_key?(value, :value) -> %>
+                    <div data-part="value">{value.value}</div>
+                    <div data-part="description">{value.description}</div>
+                  <% is_map(value) and Map.has_key?(value, :level) -> %>
+                    <div data-part="value">{value.level}</div>
+                    <div data-part="description">{value.description}</div>
+                  <% true -> %>
+                    {value}
+                <% end %>
+              </td>
+            </tr>
+            <tr data-part="row">
+              <td data-part="cell-feature"></td>
+              <td
+                :for={{plan, index} <- Enum.with_index(plans)}
+                data-part="cell-cta"
+                data-plan-index={index}
+                class={if index == 0, do: "active"}
+              >
+                <.button variant={plan.cta_variant} size="large" label={plan.cta_label} href={plan.cta_href} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+
+      <div data-part="faq">
+        <div data-part="text">
+          <span data-part="eyebrow">{dgettext("marketing", "FAQs")}</span>
+          <h2 data-part="title" id="pricing-faq-title">
+            {dgettext("marketing", "Frequently asked questions")}
+          </h2>
+        </div>
+        <div data-part="questions">
+          <details :for={{question, answer} <- @faqs} data-part="question">
+            <summary data-part="summary">
+              <span data-part="label">{question}</span>
+              <span
+                data-part="chevron"
+                class="noora-neutral-button"
+                data-size="medium"
+                data-icon-only
+                aria-hidden="true"
+              ><.chevron_down /></span>
+            </summary>
+            <div data-part="answer">{raw(answer)}</div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <%!-- CTA framed by dithered divider bands, same recipe as the home
+    and cache pages' closing CTA. --%>
+    <div data-part="features-divider" aria-hidden="true">
+      <canvas
+        data-part="dither"
+        id="pricing-cta-divider-top-dither"
+        phx-hook="DitherTexture"
+        data-pitch="2"
+        data-dot="2"
+        data-top="0"
+        data-bottom="0.95"
+        data-wave="0.335"
+        data-wave-scale="2.5"
+        data-levels="0"
+        data-speed="1"
+        data-phase="22.1"
+        data-dither="on"
+        data-opacity="0.3"
+      >
+      </canvas>
+    </div>
+
+    <section data-part="cta" aria-labelledby="cta-title">
+      <span data-part="eyebrow">{dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste!")}</span>
+      <h2 id="cta-title">{dgettext("marketing", "Unlock your team's full potential")}</h2>
+      <nav data-part="actions" aria-label="Primary actions">
+        <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
+        <.button
+          href="https://cal.tuist.dev/team/tuist/tuist?overlayCalendar=true"
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="secondary"
+          label={dgettext("marketing", "Talk to us")}
+        />
+      </nav>
+    </section>
+
+    <div data-part="features-divider" aria-hidden="true">
+      <canvas
+        data-part="dither"
+        id="pricing-cta-divider-bottom-dither"
+        phx-hook="DitherTexture"
+        data-pitch="2"
+        data-dot="2"
+        data-top="0"
+        data-bottom="0.95"
+        data-wave="0.335"
+        data-wave-scale="2.5"
+        data-levels="0"
+        data-speed="1"
+        data-phase="29.6"
+        data-dither="on"
+        data-opacity="0.3"
+      >
+      </canvas>
+    </div>
+  </main>
+</TuistWeb.Marketing.Layouts.marketing>

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
@@ -206,7 +206,8 @@ features = [
   },
   %{
     name: dgettext("marketing", "Support"),
-    description: dgettext("marketing", "Get help when you need it through various support channels."),
+    description:
+      dgettext("marketing", "Get help when you need it through various support channels."),
     hint: nil,
     values: [
       %{
@@ -243,13 +244,25 @@ features = [
       <div data-part="plans">
         <div data-part="text">
           <span data-part="eyebrow">{dgettext("marketing", "Plans")}</span>
-          <h2 data-part="title" id="pricing-plans-title">{dgettext("marketing", "Pricing plans")}</h2>
+          <h2 data-part="title" id="pricing-plans-title">
+            {dgettext("marketing", "Pricing plans")}
+          </h2>
         </div>
         <div data-part="grid">
-          <article :for={plan <- plans} data-part="plan" data-plan={plan.id} data-popular={plan.popular}>
+          <article
+            :for={plan <- plans}
+            data-part="plan"
+            data-plan={plan.id}
+            data-popular={plan.popular}
+          >
             <div data-part="head">
               <h3 data-part="name">{plan.name}</h3>
-              <.badge :if={plan.popular} label={dgettext("marketing", "Popular")} color="primary" style="light-fill" />
+              <.badge
+                :if={plan.popular}
+                label={dgettext("marketing", "Popular")}
+                color="primary"
+                style="light-fill"
+              />
             </div>
             <p data-part="description">{plan.description}</p>
             <div data-part="price">
@@ -262,7 +275,12 @@ features = [
                 <span>{trait}</span>
               </li>
             </ul>
-            <.button variant={plan.cta_variant} size="large" label={plan.cta_label} href={plan.cta_href} />
+            <.button
+              variant={plan.cta_variant}
+              size="large"
+              label={plan.cta_label}
+              href={plan.cta_href}
+            />
           </article>
         </div>
       </div>
@@ -315,88 +333,93 @@ features = [
           </div>
         </div>
         <div data-part="table-frame">
-        <table data-part="table">
-          <thead data-part="head">
-            <tr data-part="row">
-              <td data-part="cell-blank"></td>
-              <th
-                :for={{plan, index} <- Enum.with_index(plans)}
-                data-part="cell-plan"
-                data-popular={plan.popular}
-                data-plan-index={index}
-                class={if index == 0, do: "active"}
-                scope="col"
-              >
-                {plan.name}
-              </th>
-            </tr>
-          </thead>
-          <tbody data-part="body">
-            <tr :for={feature <- features} data-part="row">
-              <th data-part="cell-feature" scope="row">
-                <div data-part="feature-name">{feature.name}</div>
-                <div :if={feature.description} data-part="feature-description">
-                  {feature.description}
-                </div>
-                <.tooltip
-                  :if={not is_nil(feature.hint) and not is_nil(feature[:hint_text])}
-                  id={"#{feature.name}-hint"}
-                  size="large"
-                  description={feature.hint_text}
-                  title={dgettext("marketing", "Hits")}
+          <table data-part="table">
+            <thead data-part="head">
+              <tr data-part="row">
+                <td data-part="cell-blank"></td>
+                <th
+                  :for={{plan, index} <- Enum.with_index(plans)}
+                  data-part="cell-plan"
+                  data-popular={plan.popular}
+                  data-plan-index={index}
+                  class={if index == 0, do: "active"}
+                  scope="col"
                 >
-                  <:trigger :let={attrs}>
-                    <span {attrs}>
-                      <.hint_text label={feature.hint} />
-                    </span>
-                  </:trigger>
-                </.tooltip>
-              </th>
-              <td
-                :for={{value, index} <- Enum.with_index(feature.values)}
-                data-part="cell-value"
-                data-plan-index={index}
-                class={if index == 0, do: "active"}
-                data-available={
-                  cond do
-                    value == :available -> true
-                    value == :unavailable -> false
-                    true -> nil
-                  end
-                }
-              >
-                <%= cond do %>
-                  <% value == :available -> %>
-                    <.system_check />
-                  <% value == :unavailable -> %>
-                    <.math_x />
-                  <% is_map(value) and Map.has_key?(value, :price) -> %>
-                    <div data-part="value">{value.price}</div>
-                    <div data-part="description">{value.description}</div>
-                  <% is_map(value) and Map.has_key?(value, :value) -> %>
-                    <div data-part="value">{value.value}</div>
-                    <div data-part="description">{value.description}</div>
-                  <% is_map(value) and Map.has_key?(value, :level) -> %>
-                    <div data-part="value">{value.level}</div>
-                    <div data-part="description">{value.description}</div>
-                  <% true -> %>
-                    {value}
-                <% end %>
-              </td>
-            </tr>
-            <tr data-part="row">
-              <td data-part="cell-feature"></td>
-              <td
-                :for={{plan, index} <- Enum.with_index(plans)}
-                data-part="cell-cta"
-                data-plan-index={index}
-                class={if index == 0, do: "active"}
-              >
-                <.button variant={plan.cta_variant} size="large" label={plan.cta_label} href={plan.cta_href} />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                  {plan.name}
+                </th>
+              </tr>
+            </thead>
+            <tbody data-part="body">
+              <tr :for={feature <- features} data-part="row">
+                <th data-part="cell-feature" scope="row">
+                  <div data-part="feature-name">{feature.name}</div>
+                  <div :if={feature.description} data-part="feature-description">
+                    {feature.description}
+                  </div>
+                  <.tooltip
+                    :if={not is_nil(feature.hint) and not is_nil(feature[:hint_text])}
+                    id={"#{feature.name}-hint"}
+                    size="large"
+                    description={feature.hint_text}
+                    title={dgettext("marketing", "Hits")}
+                  >
+                    <:trigger :let={attrs}>
+                      <span {attrs}>
+                        <.hint_text label={feature.hint} />
+                      </span>
+                    </:trigger>
+                  </.tooltip>
+                </th>
+                <td
+                  :for={{value, index} <- Enum.with_index(feature.values)}
+                  data-part="cell-value"
+                  data-plan-index={index}
+                  class={if index == 0, do: "active"}
+                  data-available={
+                    cond do
+                      value == :available -> true
+                      value == :unavailable -> false
+                      true -> nil
+                    end
+                  }
+                >
+                  <%= cond do %>
+                    <% value == :available -> %>
+                      <.system_check />
+                    <% value == :unavailable -> %>
+                      <.math_x />
+                    <% is_map(value) and Map.has_key?(value, :price) -> %>
+                      <div data-part="value">{value.price}</div>
+                      <div data-part="description">{value.description}</div>
+                    <% is_map(value) and Map.has_key?(value, :value) -> %>
+                      <div data-part="value">{value.value}</div>
+                      <div data-part="description">{value.description}</div>
+                    <% is_map(value) and Map.has_key?(value, :level) -> %>
+                      <div data-part="value">{value.level}</div>
+                      <div data-part="description">{value.description}</div>
+                    <% true -> %>
+                      {value}
+                  <% end %>
+                </td>
+              </tr>
+              <tr data-part="row">
+                <td data-part="cell-feature"></td>
+                <td
+                  :for={{plan, index} <- Enum.with_index(plans)}
+                  data-part="cell-cta"
+                  data-plan-index={index}
+                  class={if index == 0, do: "active"}
+                >
+                  <.button
+                    variant={plan.cta_variant}
+                    size="large"
+                    label={plan.cta_label}
+                    href={plan.cta_href}
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
 
@@ -443,8 +466,7 @@ features = [
         data-phase="22.1"
         data-dither="on"
         data-opacity="0.3"
-      >
-      </canvas>
+      ></canvas>
     </div>
 
     <section data-part="cta" aria-labelledby="cta-title">
@@ -478,8 +500,7 @@ features = [
         data-phase="29.6"
         data-dither="on"
         data-opacity="0.3"
-      >
-      </canvas>
+      ></canvas>
     </div>
   </main>
 </TuistWeb.Marketing.Layouts.marketing>

--- a/server/priv/gettext/errors.pot
+++ b/server/priv/gettext/errors.pot
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:76
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:998
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr ""

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -47,11 +47,6 @@ msgstr ""
 msgid "9+"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:935
-#, elixir-autogen, elixir-format
-msgid "<p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with \"contact sales\" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>\n<p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>\n"
-msgstr ""
-
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "A newsletter from the Tuist team sharing product updates, our perspective on modern app development, and what's on the horizon. Stay in the loop with where we're headed and why."
@@ -114,6 +109,7 @@ msgstr ""
 msgid "Bluesky"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:160
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:166
 #: lib/tuist_web/marketing/live/marketing_build_insights_live.ex:43
 #: lib/tuist_web/marketing/live/marketing_build_insights_live.ex:48
@@ -149,6 +145,7 @@ msgstr ""
 msgid "Bumble solved key issues without changing the core dev experience"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:174
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Bundle Insights"
@@ -168,6 +165,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:201
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:220
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:105
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:80
 #: lib/tuist_web/marketing/live/marketing_cache_live.ex:63
 #: lib/tuist_web/marketing/live/marketing_cache_live.ex:68
 #: lib/tuist_web/marketing/live/marketing_cache_live/cache.html.heex:10
@@ -175,6 +173,7 @@ msgstr ""
 msgid "Cache"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:938
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Can I change or cancel my plan at any time?"
@@ -251,11 +250,13 @@ msgstr ""
 msgid "Community forum"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:214
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "Community support"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:21
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Community support via forum"
@@ -284,6 +285,7 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:50
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Contact us"
@@ -305,6 +307,7 @@ msgstr ""
 msgid "Create your plan or self-host your instance."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:200
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Custom legal agreements and terms of service tailored to your organization's needs."
@@ -338,22 +341,24 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:984
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:999
 #, elixir-autogen, elixir-format
 msgid "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:945
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Do you offer annual billing discounts?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:953
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:967
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Do you offer discounts for non-profits and open-source?"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:931
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "Do you support a seat-based pricing model?"
@@ -403,6 +408,7 @@ msgstr ""
 msgid "Enhance your development environment with actionable insights."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:46
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Enterprise"
@@ -426,6 +432,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:3
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:239
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:514
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:290
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:311
 #: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:58
 #, elixir-autogen, elixir-format
@@ -442,6 +449,7 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:19
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Free under tier limits"
@@ -456,6 +464,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:473
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:479
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:614
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:118
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Generated Projects"
@@ -474,6 +483,7 @@ msgstr ""
 msgid "Get Support"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:210
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "Get help when you need it through various support channels."
@@ -486,6 +496,8 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:125
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:29
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1019
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:13
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:476
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:10
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:28
 #: lib/tuist_web/marketing/live/marketing_blog_post_live/new/blog_post.html.heex:98
@@ -535,21 +547,20 @@ msgstr ""
 msgid "Hear from our community about their experience with Tuist"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:190
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Host Tuist server on your own infrastructure for complete control and data sovereignty."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:957
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "How can I estimate the cost for my project?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:943
-#, elixir-autogen, elixir-format
-msgid "How can I estimate the cost of my project?"
-msgstr ""
-
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:86
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:105
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:82
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:115
 #, elixir-autogen, elixir-format
@@ -587,16 +598,13 @@ msgstr ""
 msgid "Invalid verification link. Please try signing up again."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:962
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "Is there a free trial for paid plans?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:948
-#, elixir-autogen, elixir-format
-msgid "Is there a free trial on paid plans?"
-msgstr ""
-
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:950
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "Is there a minimum contract length?"
@@ -710,12 +718,12 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:68
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:130
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:529
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1058
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1067
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1089
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Newsletter Verification Failed"
@@ -726,6 +734,7 @@ msgstr ""
 msgid "Newsletter issues are sent every 6 weeks and you can unsubscribe at any time."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:951
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "No, there's no minimum contract length. You're free to cancel at any time."
@@ -766,11 +775,13 @@ msgstr ""
 msgid "Our cache solution integrates with Xcode 26's build system cache capabilities."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:39
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Pay nothing if below free tier limits"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:40
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Pay only for what you use per feature"
@@ -800,6 +811,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:418
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:438
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:598
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:132
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:142
 #: lib/tuist_web/marketing/live/marketing_previews_live.ex:37
 #: lib/tuist_web/marketing/live/marketing_previews_live.ex:42
@@ -808,6 +820,7 @@ msgstr ""
 msgid "Previews"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:71
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Price per unit above free tier"
@@ -821,17 +834,19 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:43
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:282
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:576
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:968
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:979
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:983
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:994
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:222
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "Priority support"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:57
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Priority support via Slack channel"
@@ -843,6 +858,7 @@ msgstr ""
 msgid "Privacy policy"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:26
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Pro"
@@ -881,6 +897,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:498
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:504
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:630
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:146
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Registry"
@@ -912,11 +929,13 @@ msgstr ""
 msgid "Selective testing"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:56
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Self-host your instance of Tuist"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:188
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Self-hosting Tuist instance"
@@ -1056,6 +1075,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:499
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:504
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:208
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:214
 #: lib/tuist_web/marketing/controllers/marketing_html/support.html.heex:2
 #, elixir-autogen, elixir-format
@@ -1067,11 +1087,13 @@ msgstr ""
 msgid "Swift Stories Newsletter"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:55
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Tailored agreement for specific needs"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:198
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Tailored legal terms"
@@ -1084,6 +1106,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:131
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:36
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1025
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:482
 #: lib/tuist_web/marketing/live/marketing_blog_post_live/new/blog_post.html.heex:104
 #: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:356
 #: lib/tuist_web/marketing/live/marketing_customers_live/customers.html.heex:35
@@ -1128,6 +1151,7 @@ msgstr ""
 msgid "There was an error signing you up on the newsletter"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:176
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Track and reduce app size by spotting duplicate assets and bloated resources."
@@ -1149,8 +1173,8 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:520
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:852
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:910
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:978
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1015
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:993
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1037
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:75
 #: lib/tuist_web/marketing/live/marketing_changelog_entry_live.ex:52
 #, elixir-autogen, elixir-format
@@ -1185,6 +1209,7 @@ msgstr ""
 msgid "Tuist Icon"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:953
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Tuist Pro includes support through our community forum and GitHub issues. Enterprise plans include dedicated support via Slack channels with high priority response times."
@@ -1228,11 +1253,27 @@ msgstr ""
 msgid "Tuist's changelog"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:120
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Turn projects defined with a Swift-DSL into Xcode workspaces and projects."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:126
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:127
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:128
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:140
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:141
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:142
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:154
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:155
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:156
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:168
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:169
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:170
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:182
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:183
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:184
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:103
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:104
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:105
@@ -1271,6 +1312,7 @@ msgstr ""
 msgid "Usage-based pricing after free tier."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:75
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Usage/seat based pricing"
@@ -1315,6 +1357,7 @@ msgstr ""
 msgid "Visit the forum"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:937
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "We accept credit card payments and wire transfers."
@@ -1330,7 +1373,7 @@ msgstr ""
 msgid "We embrace standards for long-term success while respecting freedom of choice."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:949
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:963
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "We have a generous free tier on every paid plan so you can try out the features before paying any money."
@@ -1367,16 +1410,19 @@ msgstr ""
 msgid "We’ve sent a confirmation email to your inbox. Please check your spam or promotions folder and confirm your subscription."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:940
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "What happens if I exceed my plan limits?"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:936
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:466
 #, elixir-autogen, elixir-format
 msgid "What payment methods do you accept?"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:952
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "What support is included with each plan?"
@@ -1385,11 +1431,6 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/about.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "What we believe in"
-msgstr ""
-
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:931
-#, elixir-autogen, elixir-format
-msgid "Why is your pricing model more accessible compared to traditional enterprise models?"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:394
@@ -1407,41 +1448,37 @@ msgstr ""
 msgid "Years of building OSS Foundation"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:932
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please contact us at contact@tuist.dev to discuss your team's needs and we'll set up a custom plan that works for you."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:968
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please reach out to contact@tuist.dev for more information."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:954
-#, elixir-autogen, elixir-format
-msgid "Yes, we do. Please reach out to oss@tuist.io for more information."
-msgstr ""
-
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:946
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer discounts for yearly subscriptions. Please contact us at contact@tuist.dev to learn more."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:939
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Yes, you can manage your plan at any time through our management interface."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:958
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "You can set up the Air plan and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:944
-#, elixir-autogen, elixir-format
-msgid "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
-msgstr ""
-
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:941
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "You'll be warned before reaching your plan limits. Once reached, the plan will cap interactions to prevent unexpected charges."
@@ -1452,6 +1489,7 @@ msgstr ""
 msgid "You'll receive newsletter issues every 6 weeks with the most important work happening in Tuist and our vision for the future of app development at scale."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:295
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "You're only charged for the features you use, based on your usage, and only after you exceed a free threshold."
@@ -1484,11 +1522,6 @@ msgstr ""
 msgid "pay as you go"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:941
-#, elixir-autogen, elixir-format
-msgid "read more"
-msgstr ""
-
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:221
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:225
 #, elixir-autogen, elixir-format
@@ -1500,6 +1533,10 @@ msgstr ""
 msgid "via dedicated Slack"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:48
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:74
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:95
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:114
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:44
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:70
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:91
@@ -1508,34 +1545,43 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:8
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:68
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:8
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:29
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:70
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:27
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "and up"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:94
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:113
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:90
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "per additional unit"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:107
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "A Tuist command execution that interacts with the server pull test result information. As an estimate, this is roughly equivalent to the number of test runs on CI."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:88
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "A Tuist command execution that interacts with the server to pull module binaries. As an estimate, this is roughly equivalent to the number of clean builds on CI, plus local project generations that aren't cached locally."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:364
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Hits"
@@ -1718,12 +1764,14 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:24
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:271
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:536
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Tests"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:507
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:632
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Download only what you need — faster, lighter builds locally and on CI."
 msgstr ""
@@ -2360,6 +2408,8 @@ msgstr ""
 msgid "Stop chasing flaky tests manually"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:6
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:321
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Air"
@@ -2377,6 +2427,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:20
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "All features, no credit card required"
@@ -2415,6 +2466,7 @@ msgstr ""
 msgid "Automatically detect flaky tests that fail without code changes and reduce time spent investigating false failures."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:64
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "Base price"
@@ -2485,11 +2537,13 @@ msgstr ""
 msgid "Speeds up builds by reusing compiled binaries, cutting down build times in both local development and CI."
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:218
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Standard support"
 msgstr ""
 
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:41
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Standard support via Slack and email"
@@ -2507,13 +2561,13 @@ msgstr ""
 msgid "Track test performance, catch slow tests early, and debug CI failures without digging through logs."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1078
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1100
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Your mobile platform team,"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1079
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1101
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:21
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:13
 #, elixir-autogen, elixir-format
@@ -3154,6 +3208,7 @@ msgid "Tuist · Build infrastructure for productive teams"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:188
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:473
 #: lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Hola! Hello! Hallo! Olá! Namaste!"
@@ -3418,4 +3473,110 @@ msgstr ""
 #: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "same thing twice."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:292
+#, elixir-autogen, elixir-format
+msgid "Compare features across plans"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Create your plan or self-host your instance"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "Current plan"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:162
+#, elixir-autogen, elixir-format
+msgid "Explore what is making your builds slow and speed up your builds."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:428
+#, elixir-autogen, elixir-format
+msgid "FAQs"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:430
+#, elixir-autogen, elixir-format
+msgid "Frequently asked questions"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:236
+#, elixir-autogen, elixir-format
+msgid "Get started with Tuist at no cost, and only invest more when you're ready for higher limits or personalized support."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:7
+#, elixir-autogen, elixir-format
+msgid "Get started with no credit card required"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:246
+#, elixir-autogen, elixir-format
+msgid "Plans"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:262
+#, elixir-autogen, elixir-format
+msgid "Popular"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:134
+#, elixir-autogen, elixir-format
+msgid "Preview your project apps in simulator or devices with one click/command."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:248
+#, elixir-autogen, elixir-format
+msgid "Pricing plans"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:82
+#, elixir-autogen, elixir-format
+msgid "Speed up clean compilations by using binaries for graph targets (including external dependencies)."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:101
+#, elixir-autogen, elixir-format
+msgid "Speed up test runs by skipping test suites (test targets) whose tests are not impacted by the changes."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:233
+#, elixir-autogen, elixir-format
+msgid "Start for free, pay as you go"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:474
+#, elixir-autogen, elixir-format
+msgid "Unlock your team's full potential"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:32
+#, elixir-autogen, elixir-format
+msgid "Upgrade now"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Upgrade on the go"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Usage-based pricing after free tier"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:215
+#, elixir-autogen, elixir-format
+msgid "via Discourse forum"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:219
+#: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:223
+#, elixir-autogen, elixir-format
+msgid "via Slack and email"
 msgstr ""


### PR DESCRIPTION
## What changed

The /pricing route joins the marketing redesign rollout. The controller branches on `Design.new?(conn, :pricing)` like the other migrated pages, so the legacy page keeps rendering until the `:new_marketing_pricing` FunWithFlags boolean flips (previewable per-user before the global flip).

<img width="1502" height="737" alt="Screenshot 2026-08-25 at 19 17 42" src="https://github.com/user-attachments/assets/e1f49e99-a2b0-4402-8626-a0a77ce0fea4" />
<img width="1301" height="588" alt="Screenshot 2026-08-25 at 19 17 53" src="https://github.com/user-attachments/assets/d408fdf8-5c54-4a5f-a37e-60518a77939c" />
<img width="1248" height="641" alt="Screenshot 2026-08-25 at 19 18 04" src="https://github.com/user-attachments/assets/18355a8a-2ace-492c-bc3b-520456ba4599" />
<img width="1408" height="414" alt="Screenshot 2026-08-25 at 19 18 17" src="https://github.com/user-attachments/assets/02a93a65-927d-43ca-a7a2-04332157f37f" />
<img width="1295" height="635" alt="Screenshot 2026-08-25 at 19 18 29" src="https://github.com/user-attachments/assets/c14c04cd-2df9-4b80-9dbc-2b349fdefd6b" />
