### PR TITLE
fix(infra): roll local-path-provisioner when its helper Pod template changes

### DIFF
--- a/infra/helm/tuist/templates/kura-fleet-storage.yaml
+++ b/infra/helm/tuist/templates/kura-fleet-storage.yaml
@@ -191,6 +191,57 @@ want_kb=$(( bytes / 1024 ))
 log "project $projid bounds $dir at $want_kb KiB / $inodes inodes"
 {{- end }}
 
+{{- /*
+tuist.kuraHelperPodTemplate is the helper Pod the provisioner runs on the target
+node. It is defined here rather than inline in the ConfigMap so the Deployment
+can checksum it: the provisioner reads this template ONCE at startup and holds
+it in memory, so a change to it does nothing until the Deployment rolls.
+*/ -}}
+{{- define "tuist.kuraHelperPodTemplate" -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: helper-pod
+spec:
+  # The helper Pod runs on the target cache node to create/remove the PV
+  # directory, so it has to tolerate whatever taint that node carries:
+  # runner-cache (Elastic Metal) or kura-cache (the public Dedibox/OVH cache
+  # pools, which also provision scw-local-nvme PVCs).
+  tolerations:
+    - key: tuist.dev/runner-cache
+      operator: Exists
+      effect: NoSchedule
+    - key: tuist.dev/kura-cache
+      operator: Exists
+      effect: NoSchedule
+  # The setup/teardown hooks nsenter into PID 1's namespaces to run the
+  # node's xfs_quota against the node's own view of /data. Both are needed:
+  # hostPID to address PID 1 at all, privileged for the CAP_SYS_ADMIN that
+  # quotactl requires. The busybox image supplies only nsenter; every tool
+  # the hooks actually run comes from the host.
+  #
+  # `--root` is deliberately NOT passed, and is not needed. Entering a mount
+  # namespace already moves the process root: setns(CLONE_NEWNS) dispatches
+  # to mntns_install() in fs/namespace.c, which ends with set_fs_pwd() and
+  # set_fs_root() onto the target namespace's root. So `findmnt` and
+  # `xfs_quota` resolve from the host, not from busybox, which has neither.
+  # This is the same mechanism `kubectl node-shell` relies on.
+  #
+  # It reads like a bug and has been raised as one twice, so it is settled
+  # empirically rather than by argument: the rendered hook has been run
+  # verbatim inside a busybox container with --pid=host against a real XFS
+  # filesystem, and applied a working ceiling. Reproduce by running the
+  # ConfigMap's `setup` under `docker run --privileged --pid=host busybox sh`
+  # on a host with an xfs /data mounted with prjquota.
+  hostPID: true
+  containers:
+    - name: helper-pod
+      image: busybox
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        privileged: true
+{{- end }}
+
 {{- if and .Values.capi.enabled .Values.kuraFleet.enabled }}
 {{- /*
 local-path-provisioner for the kura runner-cache Elastic Metal pool. Elastic
@@ -281,6 +332,12 @@ spec:
       app: local-path-provisioner
   template:
     metadata:
+      annotations:
+        # The provisioner reads helperPod.yaml once at startup and keeps it in
+        # memory, so a change to it takes effect only when this Deployment rolls.
+        # setup/teardown reach the helper Pod through the ConfigMap volume mount
+        # and stay in sync on their own, so without this the two can drift.
+        checksum/helper-pod: {{ include "tuist.kuraHelperPodTemplate" . | sha256sum }}
       labels:
         app: local-path-provisioner
     spec:
@@ -396,48 +453,7 @@ data:
       || echo "tuist-kura-quota: could not clear the quota for $VOL_DIR; removing it anyway" >&2
     rm -rf "$VOL_DIR"
   helperPod.yaml: |-
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: helper-pod
-    spec:
-      # The helper Pod runs on the target cache node to create/remove the PV
-      # directory, so it has to tolerate whatever taint that node carries:
-      # runner-cache (Elastic Metal) or kura-cache (the public Dedibox/OVH cache
-      # pools, which also provision scw-local-nvme PVCs).
-      tolerations:
-        - key: tuist.dev/runner-cache
-          operator: Exists
-          effect: NoSchedule
-        - key: tuist.dev/kura-cache
-          operator: Exists
-          effect: NoSchedule
-      # The setup/teardown hooks nsenter into PID 1's namespaces to run the
-      # node's xfs_quota against the node's own view of /data. Both are needed:
-      # hostPID to address PID 1 at all, privileged for the CAP_SYS_ADMIN that
-      # quotactl requires. The busybox image supplies only nsenter; every tool
-      # the hooks actually run comes from the host.
-      #
-      # `--root` is deliberately NOT passed, and is not needed. Entering a mount
-      # namespace already moves the process root: setns(CLONE_NEWNS) dispatches
-      # to mntns_install() in fs/namespace.c, which ends with set_fs_pwd() and
-      # set_fs_root() onto the target namespace's root. So `findmnt` and
-      # `xfs_quota` resolve from the host, not from busybox, which has neither.
-      # This is the same mechanism `kubectl node-shell` relies on.
-      #
-      # It reads like a bug and has been raised as one twice, so it is settled
-      # empirically rather than by argument: the rendered hook has been run
-      # verbatim inside a busybox container with --pid=host against a real XFS
-      # filesystem, and applied a working ceiling. Reproduce by running the
-      # ConfigMap's `setup` under `docker run --privileged --pid=host busybox sh`
-      # on a host with an xfs /data mounted with prjquota.
-      hostPID: true
-      containers:
-        - name: helper-pod
-          image: busybox
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
+{{ include "tuist.kuraHelperPodTemplate" . | indent 4 }}
 ---
 {{- /*
 Per-volume quota usage as metrics. The setup hook installs a ceiling; without


### PR DESCRIPTION
## What changed

`local-path-provisioner`'s Deployment carried no pod-template annotations, so a change to the `local-path-config` ConfigMap never rolled it. The helper Pod spec is now extracted into a named template, `tuist.kuraHelperPodTemplate`, that the ConfigMap and the Deployment both read from, and its sha256 is stamped onto the pod template as `checksum/helper-pod`. A change to the helper Pod now rolls the provisioner.

## Why

The provisioner reads `helperPod.yaml` from the ConfigMap **once at process start** and holds it in memory for the life of the process. The `setup`/`teardown` hooks reach the helper Pod by a completely different route: a ConfigMap volume mount, which kubelet keeps in sync on its own.

So the two halves of a helper Pod drift apart. The hooks update themselves; the Pod spec that has to run them does not. Nothing about this is visible in the ConfigMap, which reads as correct the whole time.

## Root cause of the incident this came from

On 2026-08-25 four Kura cache PVCs were stuck Pending across two regions, leaving two accounts with no serving instance in their region. Kura is terminal storage, so those accounts were running fully uncached rather than degraded.

#12522 landed the nsenter-based quota hooks together with the `hostPID` and `privileged` the helper Pod needs to run them, and Helm updated the ConfigMap on 2026-08-21T18:19:35Z. The provisioner pod had been running since 2026-07-01T09:14:30Z with 0 restarts, so it was still serving the pre-#12522 template. Helper Pods got the new hooks inside the old unprivileged Pod spec and died in under a second:

```
nsenter: setns(): can't reassociate to namespace 'ipc': Operation not permitted
```

The live helper Pod confirmed it directly: pre-#12522 tolerations present, but `securityContext: {}` and no `hostPID`, while the ConfigMap had both.

Two things made this hard to see, and both are worth knowing:

1. **Upstream never detects a failed helper Pod.** v0.0.31's wait loop breaks only on `PodSucceeded`. A Pod that fails in one second is polled for the full 120s `CmdTimeoutSeconds` and then reported as `create process timeout after 120 seconds`, with the provisioner's own log fetch coming back empty. That message reads like slow filesystem or quota work and points the investigation at node disk, xfs_quota, and flock, none of which were involved.
2. **The failure looked node-specific but was total.** The last successful `scw-local-nvme` provision was 2026-07-31, three weeks before the hooks shipped. The four Pending claims were the only ones created after the deploy, so every provisioning attempt since had failed. Any new Kura volume on any node in any region would have failed identically; those two accounts were simply the first to need one.

## Why this approach

A `checksum/config` over the whole rendered file is the conventional fix, but it cannot be used here: the file contains the Deployment that carries the annotation, so `include` of the same file recurses. Checksumming a named `define` avoids that and also scopes the roll to the content that actually needs it. `config.json` is re-read by the provisioner's config watcher and `setup`/`teardown` ride the volume mount, so neither needs to force a restart.

The alternative of deleting and recreating the stuck PVCs was rejected on two counts: it destroys the instance's cache directory, and it does not work, because the recreated claim fails in exactly the same way.

## Impact

No behaviour change in the rendered manifests beyond the new annotation. The next deploy rolls the provisioner once as the checksum is stamped for the first time, which is a single restart of a stateless controller and does not disturb bound volumes.

Going forward, editing the helper Pod template is enough on its own; it no longer needs a remembered manual restart to take effect.

## Validation

- `helm template` before and after, rendered from the production fleet values: the only difference in the entire output is the added annotation.
- The rendered `helperPod.yaml` diffed byte-for-byte against the live production ConfigMap: identical, so the extraction into a `define` is behaviour-preserving.
- Checksum sensitivity confirmed by mutating `hostPID` in the template and observing the annotation change (`d5c1d900...` to `9428b417...`), and reverting.
- The live fix was verified separately by restarting the provisioner in production: all four volumes reported `ProvisioningSucceeded`, every PVC bound, and both regions returned to Ready with 2/2 replicas and completed catch-up. Zero Pending PVCs cluster-wide afterwards.

## Follow-up, not in this PR

`infra/cluster-api-provider-tuist/AGENTS.md` already prescribes provisioning a throwaway PVC to confirm a box can enforce. Run at deploy time rather than by hand, that check would have caught this within minutes of #12522 rather than three days later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
