### PR TITLE
feat(server): add a 12 vCPU macOS runner shape sized to the M4-XL

### DIFF
--- a/.staging-check/pools-before.txt
+++ b/.staging-check/pools-before.txt
@@ -1,0 +1,5 @@
+tuist-tuist-runner-pool-macos-26-0-1|6000|14336|shape-macos-26-0-1|1|1
+tuist-tuist-runner-pool-macos-26-3|6000|14336|shape-macos-26-3|1|1
+tuist-tuist-runner-pool-macos-26-4-1|6000|14336|shape-macos-26-4-1|1|1
+tuist-tuist-runner-pool-macos-26-5|6000|14336|shape-macos-26-5|1|0
+tuist-tuist-runner-pool-macos-26-6|6000|14336|shape-macos-26-6|1|1

--- a/.staging-check/pools-before.txt
+++ b/.staging-check/pools-before.txt
@@ -1,5 +1,0 @@
-tuist-tuist-runner-pool-macos-26-0-1|6000|14336|shape-macos-26-0-1|1|1
-tuist-tuist-runner-pool-macos-26-3|6000|14336|shape-macos-26-3|1|1
-tuist-tuist-runner-pool-macos-26-4-1|6000|14336|shape-macos-26-4-1|1|1
-tuist-tuist-runner-pool-macos-26-5|6000|14336|shape-macos-26-5|1|0
-tuist-tuist-runner-pool-macos-26-6|6000|14336|shape-macos-26-6|1|1

--- a/infra/helm/tuist/templates/runner-pool.yaml
+++ b/infra/helm/tuist/templates/runner-pool.yaml
@@ -82,14 +82,22 @@ spec:
 {{- end }}
 
 {{- /*
-Per-Xcode macOS pools (Runner Profiles backend). Each entry in
-`runnersFleet.xcodeVersions` renders a RunnerPool CR with a
-deterministic name (`<release>-runner-pool-macos-<xcode-dashes>`)
-mirroring how `runnersFleetLinux.shapes` produces per-shape pools.
+Per-Xcode, per-shape macOS pools (Runner Profiles backend). Every
+`runnersFleet.xcodeVersions` entry crossed with every
+`runnersFleet.shapes` entry renders a RunnerPool CR, mirroring how
+`runnersFleetLinux.shapes` produces per-shape pools.
 Customers don't reference these labels directly; they create
 account-scoped Profiles in the Tuist UI, and the server's dispatch
 path resolves (account, requested-label) → profile → pool, with
 the pool name formed via `Catalog.pool_name/1`.
+
+Naming: the DEFAULT shape's pools keep the shape-free
+`<release>-runner-pool-macos-<xcode-dashes>` name they had before the
+catalog gained a second shape, and every other shape appends
+`-<vcpus>vcpu-<gb>gb`. Renaming the existing pools instead would
+strand `queued` runner_jobs rows pointing at the old `fleet_name`
+(a runner only claims work for its own pool) and split fleet
+analytics at the deploy. `Catalog.pool_name/1` applies the same rule.
 
 The `runnerImage` for each pool is derived from a shared
 `runnerImageRepository` + per-semver tag computed as
@@ -114,10 +122,17 @@ chart defaults (replicas: 0, the long-standing pod sizing).
 */}}
 {{- $overrides := .Values.runnersFleet.xcodeOverrides | default dict }}
 {{- /*
-Pod sizing defaults follow the catalog's default shape so a pool
-inherits 6 vCPU / 14 GB from the M2-L catalog without each env
-re-stating it. An override can still pin custom pod sizing if a
-future shape moves off the default.
+Pod sizing for the default shape's pools follows the catalog's
+`default: true` entry, so a pool inherits 6 vCPU / 14 GB without each
+env re-stating it. An `xcodeOverrides` entry can still pin custom pod
+sizing. Non-default shapes size their Pods from the shape itself
+(that is what makes them a distinct shape) and take their scaling
+knobs from the shape entry's own `autoscaling` block.
+
+An empty `shapes` list, or one with no `default: true` entry, keeps
+rendering exactly the one pool per Xcode this template rendered before
+shapes were crossed in, at the long-standing 8000 milli / 14336 MB
+sizing.
 */}}
 {{- $defaultShape := dict }}
 {{- range $.Values.runnersFleet.shapes | default list }}
@@ -127,6 +142,16 @@ future shape moves off the default.
 {{- end }}
 {{- $defaultCPU := mul (dig "vcpus" 8 $defaultShape) 1000 }}
 {{- $defaultMem := mul (dig "memoryGb" 14 $defaultShape) 1024 }}
+{{- /*
+The rendered set is the default shape (always, even when the catalog
+declares none) plus every non-default shape.
+*/}}
+{{- $extraShapes := list }}
+{{- range $.Values.runnersFleet.shapes | default list }}
+  {{- if not .default }}
+    {{- $extraShapes = append $extraShapes . }}
+  {{- end }}
+{{- end }}
 {{- range $xcode := $xcodeVersions }}
 {{- $xcodeVersion := required "runnersFleet.xcodeVersions[].xcodeVersion required" $xcode.xcodeVersion | toString }}
 {{- $xcodeTag := $xcodeVersion | replace "." "-" }}
@@ -158,6 +183,10 @@ metadata:
     tuist.dev/runner-pool: {{ $poolName | quote }}
     tuist.dev/managed-by: helm
     tuist.dev/xcode-version: {{ $xcodeVersion | quote }}
+    tuist.dev/shape: {{ printf "%dvcpu-%dgb" (div $defaultCPU 1000) (div $defaultMem 1024) | quote }}
+    tuist.dev/shape-vcpus: {{ div $defaultCPU 1000 | quote }}
+    tuist.dev/shape-memory-gb: {{ div $defaultMem 1024 | quote }}
+    tuist.dev/shape-default: "true"
     {{- if $xcode.default }}
     tuist.dev/xcode-default: "true"
     {{- end }}
@@ -189,6 +218,74 @@ spec:
   rollout:
     maxConcurrentPercent: {{ dig "maxConcurrentPercent" 5 . }}
   {{- end }}
+{{- /*
+Non-default shapes on this same Xcode. They share the Xcode's image,
+runner labels and idle timeout, which are properties of the image rather
+than of the machine, and take their sizing and scaling from the shape
+entry.
+
+A shape only runs on host SKUs whose advertised hostCPU/hostMemoryMB fit
+it, and the fleet allocator's budget is the fleet's TOTAL advertised
+memory, which counts hosts too small to place this shape at all. So a
+shape larger than the smallest host in the fleet MUST carry an
+`autoscaling.maxReplicas` no greater than the number of hosts that can
+host it; that ceiling, not the shared budget, is what keeps the pool from
+targeting slots it can never fill. Omitting the block leaves the pool
+static at replicas 0, which is the safe cold default.
+*/}}
+{{- range $shape := $extraShapes }}
+{{- $vcpus := required "runnersFleet.shapes[].vcpus required" $shape.vcpus | int }}
+{{- $memoryGb := required "runnersFleet.shapes[].memoryGb required" $shape.memoryGb | int }}
+{{- $shapeKey := printf "%dvcpu-%dgb" $vcpus $memoryGb }}
+{{- $shapeAutoscaling := $shape.autoscaling }}
+{{- $shapePoolName := printf "%s-%s-%s" (include "tuist.componentName" (dict "root" $ "component" "runner-pool-macos")) $xcodeTag $shapeKey }}
+---
+apiVersion: tuist.dev/v1alpha1
+kind: RunnerPool
+metadata:
+  name: {{ $shapePoolName | quote }}
+  namespace: {{ $namespace | quote }}
+  labels:
+    {{- $labels | nindent 4 }}
+    app.kubernetes.io/component: runners-controller
+    tuist.dev/runner-pool: {{ $shapePoolName | quote }}
+    tuist.dev/managed-by: helm
+    tuist.dev/xcode-version: {{ $xcodeVersion | quote }}
+    tuist.dev/shape: {{ $shapeKey | quote }}
+    tuist.dev/shape-vcpus: {{ $vcpus | quote }}
+    tuist.dev/shape-memory-gb: {{ $memoryGb | quote }}
+    {{- if $xcode.default }}
+    tuist.dev/xcode-default: "true"
+    {{- end }}
+spec:
+  labels: []
+  replicas: {{ dig "minWarmPoolFloor" 0 (default dict $shapeAutoscaling) }}
+  image: {{ $image | quote }}
+  os: darwin
+  fleetSelector: {{ $hostFleetName | quote }}
+  dispatchLabel: {{ printf "shape-macos-%s-%s" $xcodeTag $shapeKey | quote }}
+  runnerLabels:
+    {{- range $runnerLabels }}
+    - {{ . | quote }}
+    {{- end }}
+  podCPUMilli: {{ mul $vcpus 1000 }}
+  podMemoryMB: {{ mul $memoryGb 1024 }}
+  {{- $shapeIdleTimeout := dig "idleTimeoutSeconds" ($.Values.runnersFleet.idleTimeoutSeconds | default 0) $shape }}
+  {{- if gt (int $shapeIdleTimeout) 0 }}
+  idleTimeoutSeconds: {{ $shapeIdleTimeout }}
+  {{- end }}
+  {{- if $shapeAutoscaling }}
+  autoscaling:
+    enabled: {{ dig "enabled" false $shapeAutoscaling }}
+    minWarmPoolFloor: {{ dig "minWarmPoolFloor" 0 $shapeAutoscaling }}
+    maxReplicas: {{ dig "maxReplicas" 0 $shapeAutoscaling }}
+    scaleDownCooldownSeconds: {{ dig "scaleDownCooldownSeconds" 300 $shapeAutoscaling }}
+  {{- end }}
+  {{- with $shape.rollout }}
+  rollout:
+    maxConcurrentPercent: {{ dig "maxConcurrentPercent" 5 . }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/infra/helm/tuist/templates/runner-pool.yaml
+++ b/infra/helm/tuist/templates/runner-pool.yaml
@@ -134,20 +134,39 @@ rendering exactly the one pool per Xcode this template rendered before
 shapes were crossed in, at the long-standing 8000 milli / 14336 MB
 sizing.
 */}}
+{{- $macosShapes := .Values.runnersFleet.shapes | default list }}
 {{- $defaultShape := dict }}
-{{- range $.Values.runnersFleet.shapes | default list }}
+{{- $defaultShapeCount := 0 }}
+{{- range $macosShapes }}
   {{- if .default }}
     {{- $defaultShape = . }}
+    {{- $defaultShapeCount = add1 $defaultShapeCount }}
   {{- end }}
+{{- end }}
+{{- /*
+A non-empty catalog must tag exactly one default, and the render fails
+rather than guessing. The default shape is what owns the shape-free pool
+name, and `Catalog.pool_name/1` answers `nil` from `default_shape/1` by
+routing EVERY shape to that one name — so a catalog with no default
+would have the server sending 12 vCPU profiles at a 6 vCPU pool, while
+this template rendered a suffixed pool for each shape that nothing ever
+dispatches to. Two defaults are equally ambiguous: the server takes the
+first match and this loop keeps the last.
+
+An EMPTY list stays legal and renders one pool per Xcode at the
+long-standing 8000 milli / 14336 MB sizing, which is what this template
+did before shapes were crossed in.
+*/}}
+{{- if and $macosShapes (ne (int $defaultShapeCount) 1) }}
+  {{- fail (printf "runnersFleet.shapes must tag exactly one entry `default: true` (found %d); the default shape owns the shape-free pool name that Catalog.pool_name/1 resolves to" (int $defaultShapeCount)) }}
 {{- end }}
 {{- $defaultCPU := mul (dig "vcpus" 8 $defaultShape) 1000 }}
 {{- $defaultMem := mul (dig "memoryGb" 14 $defaultShape) 1024 }}
 {{- /*
-The rendered set is the default shape (always, even when the catalog
-declares none) plus every non-default shape.
+The rendered set is the default shape plus every non-default shape.
 */}}
 {{- $extraShapes := list }}
-{{- range $.Values.runnersFleet.shapes | default list }}
+{{- range $macosShapes }}
   {{- if not .default }}
     {{- $extraShapes = append $extraShapes . }}
   {{- end }}

--- a/infra/helm/tuist/templates/runners-controller-deployment.yaml
+++ b/infra/helm/tuist/templates/runners-controller-deployment.yaml
@@ -39,9 +39,19 @@ rules:
   # is replacing are retired instead of holding the drain open. Nodes
   # are cluster-scoped, so this read can't live in the namespaced Role
   # below.
+  #
+  # `patch` is for node reservation: a macOS shape that needs more than
+  # one guest slot on a host (12 vCPU on an M4-XL) can otherwise never
+  # accumulate them, because each slot that frees is taken by a smaller
+  # Pod that fits. The reconciler taints one eligible host
+  # `tuist.dev/reserved-for=<pool>:NoSchedule`, lets its running jobs
+  # finish, retires only its idle Pods, and removes the taint once the
+  # Pod lands or the reservation times out. Scoped to `patch` rather than
+  # `update` so the controller can only merge the taint and its
+  # timestamp, never rewrite a Node object wholesale.
   - apiGroups: [""]
     resources: [nodes]
-    verbs: [get, list, watch]
+    verbs: [get, list, watch, patch]
   # RuntimeClass podFixed memory is part of the scheduler's per-Pod
   # cost. The autoscaler reads it directly so its fleet allocation
   # cannot drift from the admission-time scheduling calculation.

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -485,11 +485,20 @@ observability:
   # the platform chart. The chart's embedded observability stack stays off.
   enabled: false
 
-# macOS Profile catalog — shared across every managed env. The
-# catalog (which shapes / Xcode versions exist) doesn't differ per
-# env today; per-env files only declare `xcodeOverrides` keyed by
+# macOS Profile catalog: the baseline shared across every managed
+# env. `xcodeVersions` is an image-matrix fact and is the same
+# everywhere; per-env files declare `xcodeOverrides` keyed by
 # `xcodeVersion`, where they tune `replicas`, pod sizing, and
 # autoscaling for the local fleet.
+#
+# `shapes` is the baseline that EVERY env can run, because a shape is
+# only runnable where a host SKU can fit it and the fleets differ:
+# staging and canary are M2-L only, production also has M4-XL hosts.
+# An env with the bigger SKU overrides this list wholesale (Helm
+# replaces lists rather than merging them). See
+# `values-managed-production.yaml`. Leaving a shape here that an env
+# cannot host would offer it in that env's Profiles dropdown and queue
+# any job picking it forever.
 #
 # - `runner-pool.yaml` iterates `xcodeVersions` here and merges the
 #   matching per-env `xcodeOverrides[<version>]` to render each pool.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1033,13 +1033,25 @@ runnersFleet:
         # M4 Pro is 14 CPU / 64 GB. Leave the host 2 cores and Apple
         # Virtualization.framework its reserve, as on the M2-L.
         #
-        # hostMemoryMB is 2x the pool's 14336 MB podMemoryMB, not the
-        # ~60 GB the SKU could advertise, so BOTH dimensions bind at
+        # hostMemoryMB is 2x the 6 vCPU pool's 14336 MB podMemoryMB, not
+        # the ~60 GB the SKU could advertise, so BOTH dimensions bind at
         # exactly two guests. On CPU alone 12/6 already caps at two,
         # but that would make the cap an accident of the current shape:
-        # a future 4-vCPU macOS shape would let memory admit four and
-        # leave maxPods — which also counts system Pods — as the only
-        # thing between the fleet and an SLA violation.
+        # a 4-vCPU macOS shape would let memory admit four and leave
+        # maxPods — which also counts system Pods — as the only thing
+        # between the fleet and an SLA violation.
+        #
+        # These two numbers are also what every macOS shape is sized
+        # against. 28672/12 is 2389 MB per vCPU, the same proportion as
+        # the 6 vCPU / 14 GB shape, so the 12 vCPU / 28 GB shape in
+        # `shapes` above binds at one guest on BOTH dimensions here and
+        # at zero on an M2-L. Keeping that proportion is what lets
+        # `macosFleetAllocatableMemory` keep dividing advertised memory
+        # by podMemoryMB and agree with kube-scheduler; a shape with
+        # more memory per vCPU would force hostMemoryMB up, CPU would
+        # start binding instead, and the 6 vCPU pools' budget would
+        # over-count. Size a new shape from these numbers, not the
+        # other way round.
         #
         # Advertising only 28 of 64 GB looks like a lot left on the
         # table. It isn't reclaimable, and the measurements say it also
@@ -1065,9 +1077,12 @@ runnersFleet:
         # disk images and a 240 GiB cache volume on a 2 TB disk. That is
         # the best available use of it.
         #
-        # If the M4's headroom is ever worth monetizing, the data says
-        # sell CORES, not RAM: a larger-CPU shape would measurably help
-        # 78% of jobs, a larger-memory one would help none of them.
+        # That is also why the M4's headroom is monetized as CORES and
+        # not RAM: the 12 vCPU shape in `shapes` above measurably helps
+        # the 78% of jobs that peg all 6 vCPUs, where a larger-memory
+        # shape would help none of them. A 12 vCPU guest takes the whole
+        # advertised CPU budget, so a host runs one of those OR two 6
+        # vCPU guests, never a mix.
         # Caveat on the numbers: 15s sampling can miss a sub-15s spike,
         # though compressed pages are counted so sustained pressure
         # would show.
@@ -1117,8 +1132,60 @@ runnersFleet:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
-  # macOS catalog (shapes + xcodeVersions) is shared across managed
-  # envs via `values-managed-common.yaml`. Per-env tuning lives in
+  # Shape catalog. Overrides the common baseline because production is
+  # the only managed env with an M4-XL group, and 12 vCPU only fits
+  # there. Helm replaces lists rather than merging, so the 6 vCPU
+  # baseline is restated here.
+  #
+  # 12 vCPU / 28 GB is the M4-XL sold whole: 12 of its 14 cores, and
+  # memory in the SAME 2389 MB-per-vCPU proportion the 6 vCPU shape
+  # uses. That proportion is the point. `hostMemoryMB: 28672` below
+  # stays as it is, so memory keeps binding guest count on every host
+  # for BOTH shapes (M4: 1 of these or 2 of those; M2-L: 0 or 1), which
+  # is the invariant `macosFleetAllocatableMemory` divides against. A 56
+  # GB variant would force `hostMemoryMB` to 57344, and the 6 vCPU pools,
+  # which carry all of today's traffic, would then be handed a 15-slot
+  # budget against 11 placeable ones.
+  #
+  # It is also exactly 2x the baseline shape in both dimensions, so
+  # `Catalog.billing_multiplier/3` meters it at precisely 2.0000 compute
+  # units with no rounding.
+  #
+  # Memory is not what this shape sells and the numbers say so: over
+  # 3,251 macOS jobs in the 7 days to 2026-08-25 peak RSS was p50 7.6 /
+  # p90 8.8 / p99 10.0 GiB, max ever 10.2, with ZERO jobs above 85% of
+  # the 14 GiB ceiling, while peak CPU was p50 100% and 78% of jobs
+  # pegged all 6 vCPUs. Cores are the constraint; 28 GB is already 2.7x
+  # the largest working set ever measured.
+  #
+  # NO PRICE ATTACHED YET. A 12 vCPU guest takes the whole M4-XL
+  # (12 of 12 advertised cores), so it costs EUR 0.49/h against EUR
+  # 0.245 for a 6 vCPU slot on the same host: 2x the cost for 2x the
+  # billing multiplier, which is coincidence, not a pricing decision.
+  # Settle the rate card before this is offered to accounts.
+  shapes:
+    - vcpus: 6
+      memoryGb: 14
+      default: true
+    - vcpus: 12
+      memoryGb: 28
+      # maxReplicas is the M4-XL HOST count, not a fleet slot count.
+      # The allocator's budget is the fleet's total advertised memory,
+      # which includes the 7 M2-L hosts that cannot place a 28 GB Pod at
+      # all, so 157696 / 28672 reads as 5 where only 2 are real. This
+      # ceiling is what makes that safe, so it moves with
+      # `machineGroups[m4].hostCount`, not with the 11-slot totals the
+      # `xcodeOverrides` below use.
+      #
+      # Cold: no warm floor. A 12 vCPU Pod parks a whole M4-XL, and idle
+      # it would halve the fleet's dual-guest capacity to keep one
+      # speculative runner warm. Jobs pay cold start until demand
+      # justifies otherwise.
+      autoscaling:
+        enabled: true
+        minWarmPoolFloor: 0
+        maxReplicas: 2
+  # Per-env tuning for the default shape's pools lives in
   # `xcodeOverrides`, a map keyed by `xcodeVersion`; the chart
   # template merges each catalog entry with its override at render
   # time. Every active profile runs through the runners-controller's

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1158,11 +1158,19 @@ runnersFleet:
   # pegged all 6 vCPUs. Cores are the constraint; 28 GB is already 2.7x
   # the largest working set ever measured.
   #
-  # NO PRICE ATTACHED YET. A 12 vCPU guest takes the whole M4-XL
-  # (12 of 12 advertised cores), so it costs EUR 0.49/h against EUR
-  # 0.245 for a 6 vCPU slot on the same host: 2x the cost for 2x the
-  # billing multiplier, which is coincidence, not a pricing decision.
-  # Settle the rate card before this is offered to accounts.
+  # Priced at 2x the baseline, which is exactly what that multiplier
+  # already produces: $0.15 per machine-minute on demand and $0.12
+  # prepaid, against $0.075 / $0.06 for the 6 vCPU shape. No Stripe
+  # work is needed for it. Usage is reported gross into the single
+  # macOS meter weighted by `Catalog.billing_multiplier/3`, and prepaid
+  # is a money-denominated credit grant rather than a minutes ledger,
+  # so a new shape prices itself and the 1.25x funding ratio is
+  # untouched (see `Tuist.Runners.Prepaid`).
+  #
+  # Cost tracks it: a 12 vCPU guest takes the whole M4-XL, EUR 0.49/h
+  # against EUR 0.245 for a 6 vCPU slot on the same host. Revenue and
+  # cost both double, so the margin matches the baseline shape's on
+  # this SKU.
   shapes:
     - vcpus: 6
       memoryGb: 14

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1177,13 +1177,20 @@ runnersFleet:
       default: true
     - vcpus: 12
       memoryGb: 28
-      # maxReplicas is the M4-XL HOST count, not a fleet slot count.
-      # The allocator's budget is the fleet's total advertised memory,
-      # which includes the 7 M2-L hosts that cannot place a 28 GB Pod at
-      # all, so 157696 / 28672 reads as 5 where only 2 are real. This
-      # ceiling is what makes that safe, so it moves with
-      # `machineGroups[m4].hostCount`, not with the 11-slot totals the
-      # `xcodeOverrides` below use.
+      # maxReplicas is a PER-POOL ceiling and is NOT what keeps the
+      # fleet honest: this shape renders one pool per Xcode version, and
+      # five pools each allowed 2 compose to 10. The fleet-wide bound
+      # comes from the runners-controller, which counts each node's own
+      # min(cpu, memory) quotient for a shape and caps every pool sharing
+      # it at that sum (2 today, both on M4-XL). It has to be derived
+      # there rather than written here because the byte budget cannot see
+      # it: 157696 / 28672 reads as 5, pooling memory from M2-L hosts
+      # that cannot seat one of these Pods at all.
+      #
+      # Set it to the M4-XL host count regardless, as the per-pool bound
+      # it is: no single Xcode version should be able to take the whole
+      # shape. It moves with `machineGroups[m4].hostCount`, not with the
+      # 11-slot totals the `xcodeOverrides` below use.
       #
       # Cold: no warm floor. A 12 vCPU Pod parks a whole M4-XL, and idle
       # it would halve the fleet's dual-guest capacity to keep one

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2017,9 +2017,13 @@ runnersFleet:
   #      consistent way to sell an M4-XL's cores.
   #   2. A shape larger than the smallest host in the fleet is
   #      over-promised by that same fleet-wide sum, since it counts
-  #      memory on hosts too small to place it. Give such a shape an
-  #      `autoscaling.maxReplicas` no greater than the number of hosts
-  #      that can actually host it.
+  #      memory on hosts too small to place it. The runners-controller
+  #      corrects for this by counting each node's own min(cpu, memory)
+  #      quotient and capping every pool sharing the shape at that sum,
+  #      which `autoscaling.maxReplicas` cannot do on its own — it is
+  #      per pool, and a shape renders one pool per Xcode version. Still
+  #      set `maxReplicas` to the number of hosts that can seat the
+  #      shape, as the per-pool bound.
   #
   # Which SKUs a given environment owns is therefore part of what its
   # catalog can offer, so managed envs override this list per env rather

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1991,10 +1991,54 @@ runnersFleet:
   # to `machineGroups` therefore changes capacity, not the catalog —
   # and `memoryGb` here is the divisor the autoscaler uses to turn a
   # host's advertised memory into guest slots.
+  #
+  # Every entry renders one pool per `xcodeVersions` entry. Exactly one
+  # entry must carry `default: true`. That one keeps the shape-free pool
+  # name `<release>-runner-pool-macos-<xcode-dashes>`; the others append
+  # `-<vcpus>vcpu-<gb>gb`. So the default shape is not just a preselect
+  # in the profile form: changing which entry carries it renames live
+  # pools, and a `queued` job's `fleet_name` names the pool a runner
+  # claims it from. Don't move it on a fleet with traffic.
+  #
+  # Two constraints bound what can go in this list, and neither is
+  # enforced by the chart:
+  #
+  #   1. Keep `memoryGb / vcpus` equal across shapes, and equal to a
+  #      host group's `hostMemoryMB / hostCPU`. The autoscaler's macOS
+  #      budget is the fleet's advertised memory divided by a pool's
+  #      `podMemoryMB`, which only equals what kube-scheduler will place
+  #      when memory is the dimension that binds guest count on every
+  #      host. A shape with more memory per vCPU than the host
+  #      advertises forces `hostMemoryMB` up, at which point CPU binds
+  #      instead and the budget over-counts every SMALLER shape's slots,
+  #      producing Pods the allocator keeps asking for and the scheduler
+  #      never places. At the M2-L's 6 vCPU / 14 GB that ratio is
+  #      2389 MB per vCPU, which is what makes 12 vCPU / 28 GB the
+  #      consistent way to sell an M4-XL's cores.
+  #   2. A shape larger than the smallest host in the fleet is
+  #      over-promised by that same fleet-wide sum, since it counts
+  #      memory on hosts too small to place it. Give such a shape an
+  #      `autoscaling.maxReplicas` no greater than the number of hosts
+  #      that can actually host it.
+  #
+  # Which SKUs a given environment owns is therefore part of what its
+  # catalog can offer, so managed envs override this list per env rather
+  # than sharing one. See `values-managed-common.yaml`.
   shapes:
     - vcpus: 6
       memoryGb: 14
       default: true
+    # A non-default entry may carry its own `autoscaling` block, which
+    # is the only place a shape's scaling is configured (`xcodeOverrides`
+    # tunes the default shape's pools). Without one the pool renders
+    # static at replicas 0.
+    #
+    # - vcpus: 12
+    #   memoryGb: 28
+    #   autoscaling:
+    #     enabled: true
+    #     minWarmPoolFloor: 0
+    #     maxReplicas: 2          # hosts that can fit it, not fleet slots
   # macOS Xcode catalog. Each entry renders a `RunnerPool` CR named
   # `<release>-runner-pool-macos-<xcode-dashes>` with image
   # `<runnerImageRepository>:macos-<xcode-dashes>-<runnerImageSemver>`.

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -89,6 +89,60 @@ independent workqueues:
     construction rather than via a second number kept in sync by hand.
     Apple's SLA caps any single host at 2 guests and Tart enforces it.
 
+    **Shape placement caps.** The byte budget above answers "how much
+    fleet is there", which over-counts as soon as a shape does not fit
+    every host. A 12 vCPU / 28 GB guest fits only an M4-XL, yet a fleet
+    advertising 157696 MB divides to five such slots when two are real,
+    because the sum pools memory from M2-L hosts that cannot seat one at
+    all. It also cannot see CPU, which binds a guest whose memory-per-
+    vCPU is richer than its host's. So the autoscaler additionally
+    computes, per shape, the sum over Ready nodes of each node's OWN
+    `min(cpu, memory)` quotient, and `AllocateFleet` caps every pool
+    sharing that shape at it.
+
+    This has to be a shared cap rather than `maxReplicas`, because a
+    macOS shape renders one pool per Xcode version: five pools each
+    capped at the two M4-XL hosts compose to ten. Inside the cap, seats
+    go load first, then warm floor, then headroom, one Pod per pool per
+    round (so contenders do not both lose a seat) in name order (so the
+    split is stable across reconciles). darwin only — Linux kata pins
+    memory and oversubscribes CPU by design, and those hosts are
+    homogeneous, so the byte budget is already exact there.
+
+    **Node reservation.** A shape needing more than one guest slot on a
+    single host cannot accumulate them on its own. kube-scheduler does
+    not hold its queue on an unschedulable Pod, so each slot that frees
+    is taken by the next smaller Pod that fits, and the large Pod waits
+    for a coincidence of two simultaneously-free slots that a steady
+    trickle of small jobs prevents. The cross-pool reclaim does not help
+    either: it reclaims speculative warm capacity, and the Pod winning
+    the race is backed by real queued work, the one tier that never
+    yields.
+
+    When a Pod has sat unscheduled past `reservationGrace` (2m), the
+    RunnerPool reconciler taints one eligible host
+    `tuist.dev/reserved-for=<pool>:NoSchedule`. Every runner Pod
+    tolerates that key at its OWN pool's value, so the host stops
+    admitting everyone else while its seats accumulate. Running jobs are
+    waited out, never evicted; only idle Pods of other pools are
+    retired. The taint is removed when the Pod lands or after
+    `reservationTimeout` (15m), and at most one host is held fleet-wide
+    (`maxFleetReservations`), since a reservation is capacity withdrawn
+    from the small shapes while it converges.
+
+    A dedicated taint, not a cordon: a cordoned node is indistinguishable
+    from one Cluster API is replacing, and `reapIdlePodsOnCordonedNodes`
+    would retire the reserved pool's own Pod the moment it landed and was
+    still warm-polling.
+
+    PriorityClass preemption cannot substitute. The scheduler picks
+    victims by priority, `spec.priority` is immutable after admission,
+    and a runner Pod becomes job-owning in place — so a priority high
+    enough to evict for the large Pod would also kill customer builds.
+    The signal that separates them (`isIdle`) reads init-container
+    status the scheduler never sees, which is why this lives in the
+    controller.
+
   Only nodes that report `Ready=True`, remain schedulable, and have no
   memory, disk, or process identifier pressure contribute to either
   budget. A fleet filtered to zero capacity still takes the existing

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -157,6 +157,32 @@ independent workqueues:
     would retire the reserved pool's own Pod the moment it landed and was
     still warm-polling.
 
+    Three properties the taint being pool-named forces:
+
+      - **Orphans must be swept.** Only the pool named in a taint can
+        find and release its own reservation, so a deleted or renamed
+        pool would strand the host out of the fleet forever and keep its
+        reservation counting against `maxFleetReservations`. The delete
+        path releases explicitly (`reconcileDelete` returns before
+        reservation reconciliation), and every reconcile sweeps taints
+        naming a pool that no longer exists as a backstop.
+      - **The fleet limit is confirmed uncached.** `MaxConcurrentReconciles: 1`
+        serializes the workers but not their reads; the informer cache
+        can lag a taint another pool wrote moments ago. The one path that
+        takes the fleet's reservation re-reads nodes through the
+        `APIReader` before committing.
+      - **Node writes are optimistically locked.** Taints are a plain
+        list, so a merge patch replaces the whole array with the one
+        computed from our copy. Without a resourceVersion precondition a
+        taint added since the read — a kubelet pressure taint, Cluster
+        API's cordon, a sibling reservation — is silently dropped.
+
+    Candidate selection subtracts the pool's OWN Pods from a host's
+    usable seats. The reaper never retires own-pool Pods, so a host
+    already holding one cannot be cleared for a second; ranking on
+    occupancy alone made exactly that host look ideal, since its own idle
+    Pod counts as zero occupancy.
+
     PriorityClass preemption cannot substitute. The scheduler picks
     victims by priority, `spec.priority` is immutable after admission,
     and a runner Pod becomes job-owning in place — so a priority high

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -119,8 +119,19 @@ independent workqueues:
     the race is backed by real queued work, the one tier that never
     yields.
 
-    When a Pod has sat unscheduled past `reservationGrace` (2m), the
-    RunnerPool reconciler taints one eligible host
+    A reservation is only taken for a shape that is LARGE relative to
+    the fleet: this shape must get fewer seats on the candidate host
+    than the fleet's most granular shape does. That is exactly the case
+    where the seats it needs are the ones smaller Pods keep taking. On a
+    homogeneous fleet whose hosts hold one guest (staging, canary) the
+    test never passes, so the mechanism is inert there — nothing can
+    accumulate when the shape already fits a single seat, and reserving
+    a one-host fleet would take every pool out of service until it
+    cleared. Waiting is correct there, and the allocator's cross-pool
+    reclaim already arranges it.
+
+    When a qualifying Pod has sat unscheduled past `reservationGrace`
+    (2m), the RunnerPool reconciler taints one eligible host
     `tuist.dev/reserved-for=<pool>:NoSchedule`. Every runner Pod
     tolerates that key at its OWN pool's value, so the host stops
     admitting everyone else while its seats accumulate. Running jobs are

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -141,6 +141,17 @@ independent workqueues:
     (`maxFleetReservations`), since a reservation is capacity withdrawn
     from the small shapes while it converges.
 
+    A timed-out release rests the host for `reservationCooldown` (15m)
+    via a `tuist.dev/reservation-cooldown-until` annotation. Without it
+    the timeout does nothing: `starvedPod` measures a Pod's own age, so
+    the Pod that triggered the reservation is still far past the grace
+    period the moment the taint lifts, and the next reconcile would
+    re-reserve the same host immediately. The cooldown is on the NODE
+    rather than the pool because the host is what is being rested — a
+    pool blocked on one host stays free to reserve a different eligible
+    one. A release because the Pod landed sets no cooldown; it achieved
+    what it was for.
+
     A dedicated taint, not a cordon: a cordoned node is indistinguishable
     from one Cluster API is replacing, and `reapIdlePodsOnCordonedNodes`
     would retire the reserved pool's own Pod the moment it landed and was

--- a/infra/runners-controller/cmd/manager/main.go
+++ b/infra/runners-controller/cmd/manager/main.go
@@ -116,6 +116,7 @@ func main() {
 
 	if err := (&controllers.RunnerPoolReconciler{
 		Client:              mgr.GetClient(),
+		APIReader:           mgr.GetAPIReader(),
 		Scheme:              mgr.GetScheme(),
 		SessionsClient:      sessionsClient,
 		DispatchURL:         dispatchURL,

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -271,7 +271,7 @@ func (r *AutoscalerReconciler) allocate(
 		return perPool
 	}
 
-	demands, err := r.gatherFleetDemands(ctx, pool, signals, knobs)
+	demands, shapes, err := r.gatherFleetDemands(ctx, pool, signals, knobs)
 	if err != nil {
 		if errors.Is(err, errPodCostUnavailable) {
 			logger.Error(err, "per-Pod scheduling cost unknown; leaving replicas unchanged",
@@ -298,11 +298,112 @@ func (r *AutoscalerReconciler) allocate(
 		return perPool
 	}
 
-	alloc := scaling.AllocateFleet(demands, capacity)
+	// A cap read failure degrades to the byte budget alone rather than
+	// freezing the pool: the budget is never LOWER than the true
+	// placeable count, so the worst case is the over-scheduling this cap
+	// exists to prevent — which is where the fleet already was.
+	shapeCaps, err := r.shapePlacementCaps(ctx, pool, shapes)
+	if err != nil {
+		logger.Error(err, "read shape placement caps; allocating on the byte budget alone",
+			"fleetSelector", pool.Spec.FleetSelector)
+	}
+
+	alloc := scaling.AllocateFleet(demands, capacity, shapeCaps)
 	if v, ok := alloc[pool.Name]; ok {
 		return v
 	}
 	return perPool
+}
+
+// podShape is the placement footprint of one pool's Pod. Two pools with
+// the same footprint compete for the same node slots regardless of which
+// runner image they carry, which is what makes it the right grouping key
+// for a placement cap.
+type podShape struct {
+	cpuMilli int32
+	memoryMB int32
+}
+
+func podShapeOf(pool *tuistv1.RunnerPool) podShape {
+	return podShape{cpuMilli: pool.Spec.PodCPUMilli, memoryMB: pool.Spec.PodMemoryMB}
+}
+
+func (s podShape) key() string {
+	return fmt.Sprintf("%dm-%dMi", s.cpuMilli, s.memoryMB)
+}
+
+// shapePlacementCaps returns, per shape, how many Pods of that shape the
+// fleet's Ready nodes can actually seat — summing each node's own
+// `min(cpu, memory)` quotient rather than dividing a fleet-wide total.
+//
+// The distinction is the whole point. Summing first and dividing after
+// answers "how much fleet is there", which over-counts twice over on a
+// mixed fleet: it pools memory from hosts too small to seat the shape at
+// all, and it ignores CPU, which is what actually binds a guest whose
+// memory-per-vCPU is richer than its host's. Per-node `min` answers the
+// question kube-scheduler will actually be asked.
+//
+// darwin only, deliberately. Linux runner Pods are kata microVMs that
+// pin memory per sandbox while CPU is intentionally oversubscribed, so a
+// CPU quotient there would cap a fleet that is not CPU-bound; and those
+// hosts are homogeneous, so the byte budget is already exact.
+//
+// An empty result (no nodes, or a non-darwin pool) disables the cap.
+func (r *AutoscalerReconciler) shapePlacementCaps(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	shapes map[string]podShape,
+) (map[string]int32, error) {
+	if pool.Spec.OS != macosNodeOSDarwin || len(shapes) == 0 {
+		return nil, nil
+	}
+
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes, client.MatchingLabels{
+		macosFleetLabel:  pool.Spec.FleetSelector,
+		macosNodeOSLabel: macosNodeOSDarwin,
+	}); err != nil {
+		return nil, fmt.Errorf("list macOS fleet nodes for shape caps: %w", err)
+	}
+
+	caps := make(map[string]int32, len(shapes))
+	for key, shape := range shapes {
+		if shape.cpuMilli <= 0 || shape.memoryMB <= 0 {
+			continue
+		}
+		var seats int32
+		for i := range nodes.Items {
+			if nodeFilterReason(&nodes.Items[i]) != "" {
+				continue
+			}
+			seats += nodeSeatsForShape(&nodes.Items[i], shape)
+		}
+		caps[key] = seats
+	}
+	return caps, nil
+}
+
+// nodeSeatsForShape is how many Pods of `shape` one node could hold if
+// it were empty: the smaller of its CPU and memory quotients. Current
+// occupancy is deliberately not subtracted — the allocator sizes a
+// steady-state target, and the Pods already running are themselves part
+// of that target.
+func nodeSeatsForShape(node *corev1.Node, shape podShape) int32 {
+	cpu := node.Status.Allocatable.Cpu()
+	memory := node.Status.Allocatable.Memory()
+	if cpu == nil || memory == nil {
+		return 0
+	}
+
+	byCPU := cpu.MilliValue() / int64(shape.cpuMilli)
+	byMemory := memory.Value() / (int64(shape.memoryMB) * 1024 * 1024)
+	if byMemory < byCPU {
+		byCPU = byMemory
+	}
+	if byCPU < 0 {
+		return 0
+	}
+	return int32(byCPU)
 }
 
 // fleetCapacity returns the shared budget `pool` competes for with
@@ -388,13 +489,14 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 	pool *tuistv1.RunnerPool,
 	signals scaling.Signals,
 	knobs scaling.PolicyKnobs,
-) ([]scaling.PoolDemand, error) {
+) ([]scaling.PoolDemand, map[string]podShape, error) {
 	var pools tuistv1.RunnerPoolList
 	if err := r.List(ctx, &pools, client.InNamespace(pool.Namespace)); err != nil {
-		return nil, fmt.Errorf("list runner pools: %w", err)
+		return nil, nil, fmt.Errorf("list runner pools: %w", err)
 	}
 
 	var demands []scaling.PoolDemand
+	shapes := map[string]podShape{}
 	for i := range pools.Items {
 		p := &pools.Items[i]
 		if p.Spec.OS != pool.Spec.OS || p.Spec.FleetSelector != pool.Spec.FleetSelector {
@@ -409,7 +511,7 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 		if p.Name != pool.Name {
 			fetched, err := r.SignalsClient.Signals(ctx, p.Name)
 			if err != nil {
-				return nil, fmt.Errorf("signals for sibling %q: %w", p.Name, err)
+				return nil, nil, fmt.Errorf("signals for sibling %q: %w", p.Name, err)
 			}
 			sig = *fetched
 			k = scaling.PolicyKnobs{
@@ -420,7 +522,7 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 
 		cost, err := r.perPodCost(ctx, p)
 		if err != nil {
-			return nil, fmt.Errorf("calculate per-Pod cost for %q: %w", p.Name, err)
+			return nil, nil, fmt.Errorf("calculate per-Pod cost for %q: %w", p.Name, err)
 		}
 
 		// A costless Pod would consume none of the shared budget, so
@@ -450,16 +552,20 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 			continue
 		}
 
+		shape := podShapeOf(p)
+		shapes[shape.key()] = shape
+
 		demands = append(demands, scaling.PoolDemand{
 			Name:       p.Name,
 			PerPodCost: cost,
 			Floor:      k.MinWarmPoolFloor,
 			Load:       sig.Load(),
 			Target:     scaling.DesiredReplicas(sig, k),
+			ShapeKey:   shape.key(),
 		})
 	}
 
-	return demands, nil
+	return demands, shapes, nil
 }
 
 // fleetAllocatableMemory sums allocatable memory across nodes in the

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -922,3 +922,99 @@ func TestAutoscaler_PerPodCostCountsRuntimeClassOverheadOnZeroRequest(t *testing
 		t.Fatalf("perPodCost = %d, want the RuntimeClass overhead %d", cost, want)
 	}
 }
+
+// macosNodeWithResources is a Mac mini advertising both dimensions, as
+// tart-kubelet does (hostCPU / hostMemoryMB verbatim, no reserve). The
+// memory-only helper above predates the shape cap, which needs CPU too.
+func macosNodeWithResources(name, fleetSelector string, cpu int64, memoryMB int64) *corev1.Node {
+	node := macosNodeWithGuests(name, fleetSelector, 1)
+	node.Status.Allocatable = corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewQuantity(cpu, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(memoryMB*1024*1024, resource.BinarySI),
+	}
+	return node
+}
+
+// The production topology: 7 M2-L (8 CPU / 14336 MB) + 2 M4-XL
+// (12 CPU / 28672 MB). The 6 vCPU shape seats 11, the 12 vCPU shape
+// seats 2 — and the second number is the one no fleet-wide division can
+// produce, since 157696 MB / 28672 reads as 5.
+func TestAutoscaler_ShapePlacementCapsCountSeatsPerNode(t *testing.T) {
+	const fleet = "runners-macos"
+
+	objects := []client.Object{}
+	for i := 0; i < 7; i++ {
+		objects = append(objects, macosNodeWithResources(fmt.Sprintf("m2-%d", i), fleet, 8, 14336))
+	}
+	for i := 0; i < 2; i++ {
+		objects = append(objects, macosNodeWithResources(fmt.Sprintf("m4-%d", i), fleet, 12, 28672))
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	small := podShape{cpuMilli: 6000, memoryMB: 14336}
+	large := podShape{cpuMilli: 12000, memoryMB: 28672}
+	pool := &tuistv1.RunnerPool{Spec: tuistv1.RunnerPoolSpec{OS: "darwin", FleetSelector: fleet}}
+
+	caps, err := r.shapePlacementCaps(context.Background(), pool, map[string]podShape{
+		small.key(): small,
+		large.key(): large,
+	})
+	if err != nil {
+		t.Fatalf("shapePlacementCaps: %v", err)
+	}
+
+	if got := caps[small.key()]; got != 11 {
+		t.Fatalf("6 vCPU seats = %d, want 11 (7 M2-L at one + 2 M4-XL at two)", got)
+	}
+	if got := caps[large.key()]; got != 2 {
+		t.Fatalf("12 vCPU seats = %d, want 2 (M4-XL only, one guest each)", got)
+	}
+}
+
+// CPU binds a shape whose memory-per-vCPU is richer than its host's.
+// Dividing advertised memory alone would report four seats on a host
+// whose twelve cores can only run two.
+func TestAutoscaler_ShapePlacementCapsBindOnCPUNotOnlyMemory(t *testing.T) {
+	const fleet = "runners-macos"
+	node := macosNodeWithResources("m4", fleet, 12, 57344)
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	shape := podShape{cpuMilli: 6000, memoryMB: 14336}
+	pool := &tuistv1.RunnerPool{Spec: tuistv1.RunnerPoolSpec{OS: "darwin", FleetSelector: fleet}}
+
+	caps, err := r.shapePlacementCaps(context.Background(), pool, map[string]podShape{shape.key(): shape})
+	if err != nil {
+		t.Fatalf("shapePlacementCaps: %v", err)
+	}
+	if got := caps[shape.key()]; got != 2 {
+		t.Fatalf("seats = %d, want 2 (12 cores / 6), not the 4 that 57344/14336 would suggest", got)
+	}
+}
+
+// Linux opts out: kata pins memory per sandbox and oversubscribes CPU,
+// so a CPU quotient would cap a fleet that is not CPU-bound.
+func TestAutoscaler_ShapePlacementCapsSkipLinux(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	shape := podShape{cpuMilli: 2000, memoryMB: 8192}
+	pool := &tuistv1.RunnerPool{Spec: tuistv1.RunnerPoolSpec{OS: "linux", FleetSelector: "runners-linux"}}
+
+	caps, err := r.shapePlacementCaps(context.Background(), pool, map[string]podShape{shape.key(): shape})
+	if err != nil {
+		t.Fatalf("shapePlacementCaps: %v", err)
+	}
+	if caps != nil {
+		t.Fatalf("Linux must not be capped, got %v", caps)
+	}
+}

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -62,6 +62,25 @@ const (
 	// back in general circulation than spent waiting.
 	reservationTimeout = 15 * time.Minute
 
+	// reservationCooldownAnnotation is when a timed-out host may be
+	// reserved again, and reservationCooldown is how long that is.
+	//
+	// Without it the timeout above does nothing. `starvedPod` measures a
+	// Pod's own age, so the Pod that triggered a reservation is still
+	// long past the grace period the instant the reservation releases —
+	// the next reconcile would re-reserve the same host immediately and
+	// the small shapes would never actually get it back. The timeout
+	// would read as a safety valve and behave like an indefinite hold.
+	//
+	// It is stamped on the NODE rather than the pool, because that is
+	// the resource being rested: a pool blocked on one host should still
+	// be free to reserve a different eligible one. Only a timed-out
+	// release sets it. A reservation that ended because the Pod landed
+	// achieved what it was for, and a later starved Pod deserves a fresh
+	// attempt with no penalty.
+	reservationCooldownAnnotation = "tuist.dev/reservation-cooldown-until"
+	reservationCooldown           = 15 * time.Minute
+
 	// maxFleetReservations is how many hosts may be held across the whole
 	// fleet at once. Every reservation is capacity withdrawn from the
 	// small shapes while it converges, so this stays at one: a second
@@ -104,11 +123,12 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		switch {
 		case starved == nil:
 			logger.Info("releasing node reservation; pool is served", "node", held.Name, "pool", pool.Name)
-			return r.releaseReservation(ctx, held)
+			return r.releaseReservation(ctx, held, time.Time{})
 		case reservationAge(held, now) > reservationTimeout:
 			logger.Info("releasing node reservation; timed out waiting for jobs to finish",
-				"node", held.Name, "pool", pool.Name, "timeout", reservationTimeout)
-			return r.releaseReservation(ctx, held)
+				"node", held.Name, "pool", pool.Name, "timeout", reservationTimeout,
+				"cooldown", reservationCooldown)
+			return r.releaseReservation(ctx, held, now.Add(reservationCooldown))
 		default:
 			return r.retireIdlePodsOnReservedNode(ctx, held, pool)
 		}
@@ -121,7 +141,7 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		return nil
 	}
 
-	target, err := r.pickReservationTarget(ctx, pool, nodes)
+	target, err := r.pickReservationTarget(ctx, pool, nodes, now)
 	if err != nil {
 		return err
 	}
@@ -173,6 +193,7 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 	ctx context.Context,
 	pool *tuistv1.RunnerPool,
 	nodes []corev1.Node,
+	now time.Time,
 ) (*corev1.Node, error) {
 	shape := podShape{cpuMilli: pool.Spec.PodCPUMilli, memoryMB: pool.Spec.PodMemoryMB}
 	if shape.cpuMilli <= 0 || shape.memoryMB <= 0 {
@@ -204,6 +225,9 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 	for i := range nodes {
 		node := &nodes[i]
 		if nodeFilterReason(node) != "" || isReserved(node) {
+			continue
+		}
+		if inReservationCooldown(node, now) {
 			continue
 		}
 		seats := nodeSeatsForShape(node, shape)
@@ -305,7 +329,14 @@ func (r *RunnerPoolReconciler) reserveNode(
 	return nil
 }
 
-func (r *RunnerPoolReconciler) releaseReservation(ctx context.Context, node *corev1.Node) error {
+// releaseReservation lifts the taint. A non-zero `cooldownUntil` rests
+// the host until that time, which is what a timed-out release wants; the
+// zero value releases it straight back into circulation.
+func (r *RunnerPoolReconciler) releaseReservation(
+	ctx context.Context,
+	node *corev1.Node,
+	cooldownUntil time.Time,
+) error {
 	patched := node.DeepCopy()
 	taints := make([]corev1.Taint, 0, len(patched.Spec.Taints))
 	for _, taint := range patched.Spec.Taints {
@@ -316,6 +347,12 @@ func (r *RunnerPoolReconciler) releaseReservation(ctx context.Context, node *cor
 	}
 	patched.Spec.Taints = taints
 	delete(patched.Annotations, reservationAtAnnotation)
+	if !cooldownUntil.IsZero() {
+		if patched.Annotations == nil {
+			patched.Annotations = map[string]string{}
+		}
+		patched.Annotations[reservationCooldownAnnotation] = cooldownUntil.UTC().Format(time.RFC3339)
+	}
 
 	if err := r.Patch(ctx, patched, client.MergeFrom(node)); err != nil {
 		return fmt.Errorf("release reservation on node %s: %w", node.Name, err)
@@ -373,6 +410,21 @@ func maxSeatsOnNode(node *corev1.Node, shapes []podShape) int32 {
 		}
 	}
 	return most
+}
+
+// inReservationCooldown reports whether a host is resting after a
+// timed-out reservation. An unparseable stamp reads as expired: a
+// malformed annotation must not take a host out of the pool forever.
+func inReservationCooldown(node *corev1.Node, now time.Time) bool {
+	stamp, ok := node.Annotations[reservationCooldownAnnotation]
+	if !ok {
+		return false
+	}
+	until, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return false
+	}
+	return now.Before(until)
 }
 
 func isReserved(node *corev1.Node) bool {

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -179,6 +179,11 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 		return nil, nil
 	}
 
+	siblings, err := r.fleetShapes(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+
 	var fleetPods corev1.PodList
 	if err := r.List(ctx, &fleetPods, client.InNamespace(pool.Namespace)); err != nil {
 		return nil, fmt.Errorf("list pods for reservation target: %w", err)
@@ -201,7 +206,23 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 		if nodeFilterReason(node) != "" || isReserved(node) {
 			continue
 		}
-		if nodeSeatsForShape(node, shape) < 1 {
+		seats := nodeSeatsForShape(node, shape)
+		if seats < 1 {
+			continue
+		}
+		// Reserve only where a reservation can actually achieve
+		// something: this shape must occupy more of the host than the
+		// fleet's most granular shape does, which is precisely the case
+		// where the seats it needs are the ones smaller Pods keep taking.
+		//
+		// Without this a homogeneous single-slot fleet would reserve for
+		// an ordinary Pod that is merely queued behind one other Pod.
+		// Nothing accumulates (the shape already fits one seat), and on a
+		// one-host fleet the taint takes every pool out of service until
+		// the reservation clears. Waiting for the seat is the correct
+		// behaviour there, and it is what the allocator's cross-pool
+		// reclaim already arranges.
+		if seats >= maxSeatsOnNode(node, siblings) {
 			continue
 		}
 		candidates = append(candidates, node)
@@ -313,6 +334,45 @@ func (r *RunnerPoolReconciler) fleetNodes(ctx context.Context, pool *tuistv1.Run
 		return nil, fmt.Errorf("list fleet nodes: %w", err)
 	}
 	return nodes.Items, nil
+}
+
+// fleetShapes is every Pod footprint in play on this pool's fleet. The
+// reservation needs it to know what "large" means here: a shape is only
+// large relative to the smallest thing competing for the same hosts.
+func (r *RunnerPoolReconciler) fleetShapes(ctx context.Context, pool *tuistv1.RunnerPool) ([]podShape, error) {
+	var pools tuistv1.RunnerPoolList
+	if err := r.List(ctx, &pools, client.InNamespace(pool.Namespace)); err != nil {
+		return nil, fmt.Errorf("list runner pools for fleet shapes: %w", err)
+	}
+
+	shapes := make([]podShape, 0, len(pools.Items))
+	for i := range pools.Items {
+		sibling := &pools.Items[i]
+		if sibling.Spec.OS != pool.Spec.OS || sibling.Spec.FleetSelector != pool.Spec.FleetSelector {
+			continue
+		}
+		if sibling.Spec.PodCPUMilli <= 0 || sibling.Spec.PodMemoryMB <= 0 {
+			continue
+		}
+		shapes = append(shapes, podShape{
+			cpuMilli: sibling.Spec.PodCPUMilli,
+			memoryMB: sibling.Spec.PodMemoryMB,
+		})
+	}
+	return shapes, nil
+}
+
+// maxSeatsOnNode is how many Pods the most granular shape on the fleet
+// would get from this node — the yardstick a reservation candidate is
+// measured against.
+func maxSeatsOnNode(node *corev1.Node, shapes []podShape) int32 {
+	var most int32
+	for _, shape := range shapes {
+		if seats := nodeSeatsForShape(node, shape); seats > most {
+			most = seats
+		}
+	}
+	return most
 }
 
 func isReserved(node *corev1.Node) bool {

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -115,6 +115,17 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		return err
 	}
 
+	// Orphan sweep first. A reservation is discoverable only by the pool
+	// named in its taint, so once that pool's CR is gone nothing can
+	// release it: the host stays tainted out of the fleet forever AND
+	// its reservation keeps counting against maxFleetReservations, which
+	// blocks every future one. Deleting or renaming a pool in a helm
+	// upgrade is enough to reach this, because a deleting pool returns
+	// through reconcileDelete before it ever gets here.
+	if err := r.releaseOrphanedReservations(ctx, pool, nodes); err != nil {
+		return err
+	}
+
 	value := podtemplate.ReservationValue(pool.Name)
 	held := reservedNode(nodes, value)
 	starved := starvedPod(pods, now)
@@ -141,7 +152,21 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		return nil
 	}
 
-	target, err := r.pickReservationTarget(ctx, pool, nodes, now)
+	// About to take the fleet's one reservation, so re-read the nodes
+	// straight from the apiserver. MaxConcurrentReconciles 1 serializes
+	// the workers but not their reads: the List above is served from the
+	// informer cache, which can still be missing a taint another pool's
+	// reconcile wrote moments ago. Confirming against the cache would
+	// hand out a second reservation and drain two hosts at once.
+	fresh, err := r.fleetNodesFrom(ctx, r.apiReader(), pool)
+	if err != nil {
+		return err
+	}
+	if reservationCount(fresh) >= maxFleetReservations {
+		return nil
+	}
+
+	target, err := r.pickReservationTarget(ctx, pool, fresh, now)
 	if err != nil {
 		return err
 	}
@@ -211,9 +236,19 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 	}
 
 	owned := map[string]int{}
+	ownPool := map[string]int32{}
 	for i := range fleetPods.Items {
 		pod := &fleetPods.Items[i]
 		if pod.Spec.NodeName == "" || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		// This pool's own Pods are never retired by the reaper, so for
+		// the purposes of this reservation they are permanent occupants
+		// and have to come off the candidate's usable seats. Other
+		// pools' Pods do not: idle ones are retired immediately and
+		// running ones are waited out.
+		if pod.Labels["tuist.dev/runner-pool"] == pool.Name {
+			ownPool[pod.Spec.NodeName]++
 			continue
 		}
 		if !isIdle(pod) {
@@ -231,6 +266,13 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 			continue
 		}
 		seats := nodeSeatsForShape(node, shape)
+		// Seats this reservation could actually end up with. A host
+		// already holding one of this pool's own Pods cannot be cleared
+		// for a second one, and ranking on occupancy alone would make it
+		// look like the BEST candidate — its own idle Pod counts as zero
+		// occupancy — so the reservation would settle on a host it can
+		// never clear and burn the fleet's one slot until the timeout.
+		seats -= ownPool[node.Name]
 		if seats < 1 {
 			continue
 		}
@@ -323,7 +365,7 @@ func (r *RunnerPoolReconciler) reserveNode(
 	}
 	patched.Annotations[reservationAtAnnotation] = now.UTC().Format(time.RFC3339)
 
-	if err := r.Patch(ctx, patched, client.MergeFrom(node)); err != nil {
+	if err := r.Patch(ctx, patched, optimisticPatch(node)); err != nil {
 		return fmt.Errorf("reserve node %s: %w", node.Name, err)
 	}
 	return nil
@@ -354,23 +396,111 @@ func (r *RunnerPoolReconciler) releaseReservation(
 		patched.Annotations[reservationCooldownAnnotation] = cooldownUntil.UTC().Format(time.RFC3339)
 	}
 
-	if err := r.Patch(ctx, patched, client.MergeFrom(node)); err != nil {
+	if err := r.Patch(ctx, patched, optimisticPatch(node)); err != nil {
 		return fmt.Errorf("release reservation on node %s: %w", node.Name, err)
 	}
 	return nil
 }
 
 // fleetNodes lists the macOS hosts behind a pool's fleet selector, the
-// same set the autoscaler sizes its budget from.
+// same set the autoscaler sizes its budget from. Cached read: fine for
+// deciding whether this pool already holds a reservation, and for
+// releasing one.
 func (r *RunnerPoolReconciler) fleetNodes(ctx context.Context, pool *tuistv1.RunnerPool) ([]corev1.Node, error) {
+	return r.fleetNodesFrom(ctx, r.Client, pool)
+}
+
+func (r *RunnerPoolReconciler) fleetNodesFrom(
+	ctx context.Context,
+	reader client.Reader,
+	pool *tuistv1.RunnerPool,
+) ([]corev1.Node, error) {
 	var nodes corev1.NodeList
-	if err := r.List(ctx, &nodes, client.MatchingLabels{
+	if err := reader.List(ctx, &nodes, client.MatchingLabels{
 		macosFleetLabel:  pool.Spec.FleetSelector,
 		macosNodeOSLabel: macosNodeOSDarwin,
 	}); err != nil {
 		return nil, fmt.Errorf("list fleet nodes: %w", err)
 	}
 	return nodes.Items, nil
+}
+
+// apiReader is the uncached client, used on the one path where a stale
+// read is not survivable. Falls back to the cached client when unset so
+// tests (and any caller that has not wired one) still work.
+func (r *RunnerPoolReconciler) apiReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// releaseOrphanedReservations lifts reservation taints that name a pool
+// which no longer exists, or is on its way out. Both the per-pool
+// release in reconcileDelete and this sweep are needed: the release
+// handles the ordinary delete promptly, and the sweep is the backstop
+// for a controller that died mid-reservation, a pool force-deleted past
+// its finalizer, or a taint left by an earlier version.
+//
+// Deliberately no cooldown on these: an orphan was never a considered
+// decision about this host, so there is nothing to back off from.
+func (r *RunnerPoolReconciler) releaseOrphanedReservations(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	nodes []corev1.Node,
+) error {
+	logger := log.FromContext(ctx)
+
+	var pools tuistv1.RunnerPoolList
+	if err := r.List(ctx, &pools, client.InNamespace(pool.Namespace)); err != nil {
+		return fmt.Errorf("list runner pools for orphan sweep: %w", err)
+	}
+
+	live := map[string]bool{}
+	for i := range pools.Items {
+		if !pools.Items[i].DeletionTimestamp.IsZero() {
+			continue
+		}
+		live[podtemplate.ReservationValue(pools.Items[i].Name)] = true
+	}
+
+	for i := range nodes {
+		node := &nodes[i]
+		for _, taint := range node.Spec.Taints {
+			if taint.Key != podtemplate.ReservationTaintKey || live[taint.Value] {
+				continue
+			}
+			logger.Info("releasing orphaned node reservation; owning pool is gone",
+				"node", node.Name, "reservedFor", taint.Value)
+			if err := r.releaseReservation(ctx, node, time.Time{}); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// ReleaseReservationsForPool lifts any reservation this pool holds. Called
+// from the delete path, which returns before the ordinary reservation
+// reconciliation and would otherwise strand the taint.
+func (r *RunnerPoolReconciler) ReleaseReservationsForPool(ctx context.Context, pool *tuistv1.RunnerPool) error {
+	if pool.Spec.OS != macosNodeOSDarwin {
+		return nil
+	}
+
+	nodes, err := r.fleetNodes(ctx, pool)
+	if err != nil {
+		return err
+	}
+	held := reservedNode(nodes, podtemplate.ReservationValue(pool.Name))
+	if held == nil {
+		return nil
+	}
+
+	log.FromContext(ctx).Info("releasing node reservation; owning pool is being deleted",
+		"node", held.Name, "pool", pool.Name)
+	return r.releaseReservation(ctx, held, time.Time{})
 }
 
 // fleetShapes is every Pod footprint in play on this pool's fleet. The
@@ -470,4 +600,15 @@ func reservationAge(node *corev1.Node, now time.Time) time.Duration {
 		return 0
 	}
 	return now.Sub(at)
+}
+
+// optimisticPatch carries the base object's resourceVersion as a
+// precondition. Taints are a plain list, so a merge patch REPLACES the
+// whole array with the one computed from our copy of the node. Without
+// the precondition a taint another actor added since we read it — a
+// kubelet pressure taint, Cluster API's cordon, a sibling reservation —
+// would be silently dropped on write. With it the write fails on
+// conflict instead, and the next reconcile recomputes from fresh state.
+func optimisticPatch(base client.Object) client.Patch {
+	return client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
 }

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -1,0 +1,361 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
+	"github.com/tuist/tuist/infra/runners-controller/internal/podtemplate"
+)
+
+// Node reservation: draining one host to fit a Pod that no host can seat.
+//
+// A macOS fleet mixes guest shapes on the same hosts, and the large ones
+// need more than one guest slot on a single host. An M4-XL seats two
+// 6 vCPU guests or one 12 vCPU guest, so a 12 vCPU Pod needs BOTH of a
+// host's slots free at the same instant. Nothing in Kubernetes arranges
+// that on its own:
+//
+//   - kube-scheduler does not hold a queue on an unschedulable Pod. The
+//     large Pod is attempted, fails the CPU filter, and is set aside;
+//     the next 6 vCPU Pod is attempted and binds into the slot that just
+//     freed. Being queued longer earns a first attempt, not the seat.
+//   - The fleet allocator's cross-pool reclaim cannot help either. It
+//     reclaims speculative warm capacity, and the Pod winning the race
+//     here is backed by real queued work, which is the one tier that
+//     never yields.
+//
+// So under a steady trickle of small jobs the large Pod waits for a
+// coincidence that may not arrive. The fix is to stop the leak: take one
+// eligible host out of circulation for everyone else, let its running
+// jobs finish, retire only its idle Pods, and hand the accumulated seats
+// to the pool that was starved.
+//
+// Preemption cannot do this. The scheduler chooses victims by priority,
+// `spec.priority` is immutable after admission, and a runner Pod becomes
+// job-owning in place — so a priority high enough to evict for the large
+// Pod would also evict Pods running customer builds. The signal that
+// separates them, `isIdle`, reads init-container status the scheduler
+// never sees. The controller is the only component that can tell the
+// difference, which is why the reservation lives here.
+const (
+	// reservationAtAnnotation records when a reservation started, so it
+	// can be released on a timeout. Taint objects only carry a timestamp
+	// for NoExecute, and this taint is deliberately NoSchedule.
+	reservationAtAnnotation = "tuist.dev/reserved-at"
+
+	// reservationGrace is how long a Pod must sit unscheduled before it
+	// is treated as starved rather than merely waiting for the scheduler.
+	// Draining a host is expensive, and the ordinary case (a seat is free
+	// somewhere) resolves in well under a second.
+	reservationGrace = 2 * time.Minute
+
+	// reservationTimeout bounds how long one host stays held. The Pods a
+	// reservation waits on are customer jobs, which can legitimately run
+	// for hours; past this point the seats already cleared are worth more
+	// back in general circulation than spent waiting.
+	reservationTimeout = 15 * time.Minute
+
+	// maxFleetReservations is how many hosts may be held across the whole
+	// fleet at once. Every reservation is capacity withdrawn from the
+	// small shapes while it converges, so this stays at one: a second
+	// concurrent drain would take a quarter of an 11-slot fleet offline
+	// to serve two large jobs.
+	maxFleetReservations = 1
+)
+
+// reconcileReservation drives the reservation state machine for one
+// pool. It is called from the RunnerPool reconciler, which runs with
+// MaxConcurrentReconciles 1 — that serialization is what makes the
+// fleet-wide reservation count safe to read and act on without a lease.
+//
+// `pods` are this pool's Pods, already fetched by the caller.
+func (r *RunnerPoolReconciler) reconcileReservation(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	pods []corev1.Pod,
+) error {
+	// darwin only. Linux runner Pods are kata sandboxes on homogeneous
+	// bare-metal hosts an order of magnitude larger than any shape, so a
+	// shape never needs a host drained to fit.
+	if pool.Spec.OS != macosNodeOSDarwin {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	now := r.now()
+
+	nodes, err := r.fleetNodes(ctx, pool)
+	if err != nil {
+		return err
+	}
+
+	value := podtemplate.ReservationValue(pool.Name)
+	held := reservedNode(nodes, value)
+	starved := starvedPod(pods, now)
+
+	if held != nil {
+		switch {
+		case starved == nil:
+			logger.Info("releasing node reservation; pool is served", "node", held.Name, "pool", pool.Name)
+			return r.releaseReservation(ctx, held)
+		case reservationAge(held, now) > reservationTimeout:
+			logger.Info("releasing node reservation; timed out waiting for jobs to finish",
+				"node", held.Name, "pool", pool.Name, "timeout", reservationTimeout)
+			return r.releaseReservation(ctx, held)
+		default:
+			return r.retireIdlePodsOnReservedNode(ctx, held, pool)
+		}
+	}
+
+	if starved == nil {
+		return nil
+	}
+	if reservationCount(nodes) >= maxFleetReservations {
+		return nil
+	}
+
+	target, err := r.pickReservationTarget(ctx, pool, nodes)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		// No host in the fleet could seat this shape even empty. That is
+		// a capacity or catalog problem, not something a drain can fix,
+		// and the pool's queue-age metric already carries the signal.
+		return nil
+	}
+
+	logger.Info("reserving node to fit a starved runner",
+		"node", target.Name, "pool", pool.Name, "pod", starved.Name)
+	return r.reserveNode(ctx, target, value, now)
+}
+
+// starvedPod returns a Pod that has waited past the grace period with no
+// node assigned. Phase is not the test on its own — an unscheduled Pod
+// and a Pod whose VM is still booting are both Pending — so this asks
+// for an empty `spec.nodeName`, which only an unplaced Pod has.
+func starvedPod(pods []corev1.Pod, now time.Time) *corev1.Pod {
+	var oldest *corev1.Pod
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Spec.NodeName != "" || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodPending {
+			continue
+		}
+		if now.Sub(pod.CreationTimestamp.Time) < reservationGrace {
+			continue
+		}
+		if oldest == nil || pod.CreationTimestamp.Time.Before(oldest.CreationTimestamp.Time) {
+			oldest = pod
+		}
+	}
+	return oldest
+}
+
+// pickReservationTarget chooses the host to drain: one that could seat
+// this pool's shape if it were empty, is not already reserved, and is
+// otherwise healthy.
+//
+// Preference is the host that will converge soonest — fewest Pods
+// running customer jobs, since those are the ones a reservation can only
+// wait for. Idle Pods are not counted; retiring them is immediate. Ties
+// break on name so a reservation does not wander between reconciles.
+func (r *RunnerPoolReconciler) pickReservationTarget(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	nodes []corev1.Node,
+) (*corev1.Node, error) {
+	shape := podShape{cpuMilli: pool.Spec.PodCPUMilli, memoryMB: pool.Spec.PodMemoryMB}
+	if shape.cpuMilli <= 0 || shape.memoryMB <= 0 {
+		return nil, nil
+	}
+
+	var fleetPods corev1.PodList
+	if err := r.List(ctx, &fleetPods, client.InNamespace(pool.Namespace)); err != nil {
+		return nil, fmt.Errorf("list pods for reservation target: %w", err)
+	}
+
+	owned := map[string]int{}
+	for i := range fleetPods.Items {
+		pod := &fleetPods.Items[i]
+		if pod.Spec.NodeName == "" || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if !isIdle(pod) {
+			owned[pod.Spec.NodeName]++
+		}
+	}
+
+	candidates := make([]*corev1.Node, 0, len(nodes))
+	for i := range nodes {
+		node := &nodes[i]
+		if nodeFilterReason(node) != "" || isReserved(node) {
+			continue
+		}
+		if nodeSeatsForShape(node, shape) < 1 {
+			continue
+		}
+		candidates = append(candidates, node)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(candidates, func(a, b int) bool {
+		if owned[candidates[a].Name] != owned[candidates[b].Name] {
+			return owned[candidates[a].Name] < owned[candidates[b].Name]
+		}
+		return candidates[a].Name < candidates[b].Name
+	})
+	return candidates[0], nil
+}
+
+// retireIdlePodsOnReservedNode clears the seats a reservation can clear
+// straight away: idle Pods belonging to OTHER pools. Retiring them costs
+// a cold start and nothing else.
+//
+// This pool's own Pods are left alone — an idle one here is the seat the
+// reservation was taken to produce. Pods running customer jobs are never
+// touched; the reservation waits them out, or times out.
+//
+// Idleness is read through `isIdle`, matching the node-drain path: the
+// owner label alone is best-effort and can be missing on a Pod that is
+// running a job.
+func (r *RunnerPoolReconciler) retireIdlePodsOnReservedNode(
+	ctx context.Context,
+	node *corev1.Node,
+	pool *tuistv1.RunnerPool,
+) error {
+	logger := log.FromContext(ctx)
+
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(pool.Namespace)); err != nil {
+		return fmt.Errorf("list pods on reserved node %s: %w", node.Name, err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName != node.Name || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if pod.Labels["tuist.dev/runner-pool"] == pool.Name {
+			continue
+		}
+		if !isIdle(pod) {
+			continue
+		}
+		if err := r.reapRunner(ctx, pod); err != nil {
+			return fmt.Errorf("retire idle pod %s on reserved node %s: %w", pod.Name, node.Name, err)
+		}
+		logger.Info("retired idle pod to clear a reserved node", "pod", pod.Name, "node", node.Name)
+	}
+	return nil
+}
+
+func (r *RunnerPoolReconciler) reserveNode(
+	ctx context.Context,
+	node *corev1.Node,
+	value string,
+	now time.Time,
+) error {
+	patched := node.DeepCopy()
+	patched.Spec.Taints = append(patched.Spec.Taints, corev1.Taint{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  value,
+		Effect: corev1.TaintEffectNoSchedule,
+	})
+	if patched.Annotations == nil {
+		patched.Annotations = map[string]string{}
+	}
+	patched.Annotations[reservationAtAnnotation] = now.UTC().Format(time.RFC3339)
+
+	if err := r.Patch(ctx, patched, client.MergeFrom(node)); err != nil {
+		return fmt.Errorf("reserve node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+func (r *RunnerPoolReconciler) releaseReservation(ctx context.Context, node *corev1.Node) error {
+	patched := node.DeepCopy()
+	taints := make([]corev1.Taint, 0, len(patched.Spec.Taints))
+	for _, taint := range patched.Spec.Taints {
+		if taint.Key == podtemplate.ReservationTaintKey {
+			continue
+		}
+		taints = append(taints, taint)
+	}
+	patched.Spec.Taints = taints
+	delete(patched.Annotations, reservationAtAnnotation)
+
+	if err := r.Patch(ctx, patched, client.MergeFrom(node)); err != nil {
+		return fmt.Errorf("release reservation on node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+// fleetNodes lists the macOS hosts behind a pool's fleet selector, the
+// same set the autoscaler sizes its budget from.
+func (r *RunnerPoolReconciler) fleetNodes(ctx context.Context, pool *tuistv1.RunnerPool) ([]corev1.Node, error) {
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes, client.MatchingLabels{
+		macosFleetLabel:  pool.Spec.FleetSelector,
+		macosNodeOSLabel: macosNodeOSDarwin,
+	}); err != nil {
+		return nil, fmt.Errorf("list fleet nodes: %w", err)
+	}
+	return nodes.Items, nil
+}
+
+func isReserved(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == podtemplate.ReservationTaintKey {
+			return true
+		}
+	}
+	return false
+}
+
+func reservedNode(nodes []corev1.Node, value string) *corev1.Node {
+	for i := range nodes {
+		for _, taint := range nodes[i].Spec.Taints {
+			if taint.Key == podtemplate.ReservationTaintKey && taint.Value == value {
+				return &nodes[i]
+			}
+		}
+	}
+	return nil
+}
+
+func reservationCount(nodes []corev1.Node) int {
+	count := 0
+	for i := range nodes {
+		if isReserved(&nodes[i]) {
+			count++
+		}
+	}
+	return count
+}
+
+// reservationAge reports how long a node has been held. A missing or
+// unparseable stamp reads as freshly reserved rather than expired, so a
+// hand-applied taint is not torn down on the next tick.
+func reservationAge(node *corev1.Node, now time.Time) time.Duration {
+	stamp, ok := node.Annotations[reservationAtAnnotation]
+	if !ok {
+		return 0
+	}
+	at, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return 0
+	}
+	return now.Sub(at)
+}

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -1,0 +1,329 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
+	"github.com/tuist/tuist/infra/runners-controller/internal/podtemplate"
+)
+
+const reservationFleet = "runners-macos"
+
+var reservationNow = time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+// largePool is the 12 vCPU shape: it needs both of an M4-XL's guest
+// slots, so no host running two 6 vCPU guests can seat it.
+func largePool() *tuistv1.RunnerPool {
+	return &tuistv1.RunnerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "macos-26-6-12vcpu-28gb", Namespace: "runners"},
+		Spec: tuistv1.RunnerPoolSpec{
+			OS:            "darwin",
+			FleetSelector: reservationFleet,
+			PodCPUMilli:   12000,
+			PodMemoryMB:   28672,
+		},
+	}
+}
+
+func m4Node(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				macosFleetLabel:  reservationFleet,
+				macosNodeOSLabel: macosNodeOSDarwin,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewQuantity(12, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(28672*1024*1024, resource.BinarySI),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+// m2Node cannot seat the large shape on either dimension.
+func m2Node(name string) *corev1.Node {
+	node := m4Node(name)
+	node.Status.Allocatable = corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(14336*1024*1024, resource.BinarySI),
+	}
+	return node
+}
+
+func pendingPod(name, pool string, age time.Duration) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "runners",
+			Labels:            map[string]string{"tuist.dev/runner-pool": pool},
+			CreationTimestamp: metav1.NewTime(reservationNow.Add(-age)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+}
+
+func placedPod(name, pool, node string, owner string) *corev1.Pod {
+	pod := pendingPod(name, pool, time.Hour)
+	pod.Spec.NodeName = node
+	pod.Status.Phase = corev1.PodRunning
+	if owner != "" {
+		pod.Labels["tuist.dev/runner-pool-owner"] = owner
+	}
+	return pod
+}
+
+func reservationReconciler(objects ...client.Object) *RunnerPoolReconciler {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = tuistv1.AddToScheme(scheme)
+	return &RunnerPoolReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+		Scheme: scheme,
+		Now:    func() time.Time { return reservationNow },
+	}
+}
+
+func nodeByName(t *testing.T, r *RunnerPoolReconciler, name string) *corev1.Node {
+	t.Helper()
+	node := &corev1.Node{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: name}, node); err != nil {
+		t.Fatalf("get node %s: %v", name, err)
+	}
+	return node
+}
+
+// The scenario the reservation exists for: both M4 guest slots are held
+// by 6 vCPU jobs, a 12 vCPU Pod has waited past the grace period, and no
+// coincidence of two simultaneously-free slots is going to arrive on its
+// own while small jobs keep landing.
+func TestReservation_HoldsAHostForAStarvedShape(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, node, starved,
+		placedPod("small-0", "macos-26-6", "m4-0", "acme"),
+		placedPod("small-1", "macos-26-6", "m4-0", "acme"),
+	)
+
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	got := nodeByName(t, r, "m4-0")
+	if !isReserved(got) {
+		t.Fatalf("node was not reserved: %+v", got.Spec.Taints)
+	}
+	for _, taint := range got.Spec.Taints {
+		if taint.Key == podtemplate.ReservationTaintKey {
+			if taint.Value != podtemplate.ReservationValue(pool.Name) {
+				t.Errorf("taint value = %q, want the starved pool", taint.Value)
+			}
+			if taint.Effect != corev1.TaintEffectNoSchedule {
+				t.Errorf("taint effect = %q, want NoSchedule so running jobs survive", taint.Effect)
+			}
+		}
+	}
+	if got.Annotations[reservationAtAnnotation] == "" {
+		t.Error("reservation must be stamped so it can time out")
+	}
+}
+
+// A Pod that has only just been created is waiting for the scheduler,
+// not starved. Draining a host for it would be expensive and wrong.
+func TestReservation_WaitsOutTheGracePeriod(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	fresh := pendingPod("large-0", pool.Name, 10*time.Second)
+
+	r := reservationReconciler(pool, node, fresh)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*fresh}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("a Pod inside the grace period must not trigger a drain")
+	}
+}
+
+// Only idle Pods are retired, and only those belonging to other pools.
+// A Pod running a customer job is waited out, never evicted.
+func TestReservation_RetiresIdlePodsButNeverRunningJobs(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{reservationAtAnnotation: reservationNow.Format(time.RFC3339)}
+
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+	idle := placedPod("small-idle", "macos-26-6", "m4-0", "")
+	owned := placedPod("small-owned", "macos-26-6", "m4-0", "acme")
+
+	r := reservationReconciler(pool, node, starved, idle, owned)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	remaining := &corev1.PodList{}
+	if err := r.List(context.Background(), remaining, client.InNamespace("runners")); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	names := map[string]bool{}
+	for i := range remaining.Items {
+		names[remaining.Items[i].Name] = true
+	}
+
+	if names["small-idle"] {
+		t.Error("an idle Pod of another pool should have been retired to clear the seat")
+	}
+	if !names["small-owned"] {
+		t.Error("a Pod running a customer job must never be evicted by a reservation")
+	}
+}
+
+// Once the pool is served the host goes back into general circulation.
+func TestReservation_ReleasesWhenThePoolIsServed(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{reservationAtAnnotation: reservationNow.Format(time.RFC3339)}
+
+	placed := placedPod("large-0", pool.Name, "m4-0", "acme")
+
+	r := reservationReconciler(pool, node, placed)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*placed}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("reservation should be released once the pool has its seat")
+	}
+}
+
+// A reservation waiting on a six-hour job must not hold the host
+// forever; the seats already cleared are worth more back in circulation.
+func TestReservation_ReleasesOnTimeout(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{
+		reservationAtAnnotation: reservationNow.Add(-reservationTimeout - time.Minute).Format(time.RFC3339),
+	}
+	starved := pendingPod("large-0", pool.Name, time.Hour)
+
+	r := reservationReconciler(pool, node, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("an expired reservation should have been released")
+	}
+}
+
+// Hosts too small to ever seat the shape are not drained: no amount of
+// waiting makes an M2-L fit a 12 vCPU guest.
+func TestReservation_SkipsHostsThatCouldNeverSeatTheShape(t *testing.T) {
+	pool := largePool()
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, m2Node("m2-0"), m2Node("m2-1"), starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	for _, name := range []string{"m2-0", "m2-1"} {
+		if isReserved(nodeByName(t, r, name)) {
+			t.Fatalf("%s cannot seat the shape and must not be drained", name)
+		}
+	}
+}
+
+// Every reservation is capacity withdrawn from the small shapes, so only
+// one host is held at a time across the whole fleet.
+func TestReservation_HoldsAtMostOneHostFleetWide(t *testing.T) {
+	pool := largePool()
+	held := m4Node("m4-0")
+	held.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  "some-other-pool",
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	free := m4Node("m4-1")
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, held, free, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-1")) {
+		t.Fatal("a second concurrent reservation would take a quarter of the fleet offline")
+	}
+}
+
+// The host that converges soonest is the one with fewest customer jobs
+// to wait out; ties break on name so a reservation does not wander.
+func TestReservation_PrefersTheHostThatConvergesSoonest(t *testing.T) {
+	pool := largePool()
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, m4Node("m4-busy"), m4Node("m4-quiet"), starved,
+		placedPod("job-0", "macos-26-6", "m4-busy", "acme"),
+		placedPod("job-1", "macos-26-6", "m4-busy", "acme"),
+		placedPod("idle-0", "macos-26-6", "m4-quiet", ""),
+	)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if !isReserved(nodeByName(t, r, "m4-quiet")) {
+		t.Error("should reserve the host whose seats are only held by idle Pods")
+	}
+	if isReserved(nodeByName(t, r, "m4-busy")) {
+		t.Error("should not reserve the host with two customer jobs to wait out")
+	}
+}
+
+// Linux fleets opt out: those hosts are far larger than any shape, so a
+// shape never needs one drained to fit.
+func TestReservation_SkipsLinuxPools(t *testing.T) {
+	pool := largePool()
+	pool.Spec.OS = "linux"
+	node := m4Node("m4-0")
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, node, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("Linux pools must not take reservations")
+	}
+}

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -86,6 +86,22 @@ func placedPod(name, pool, node string, owner string) *corev1.Pod {
 	return pod
 }
 
+// smallPool is the 6 vCPU shape the large one competes with. A
+// reservation is only taken for a shape that is large RELATIVE to what
+// else runs on the fleet, so the sibling has to exist for the large
+// shape to qualify.
+func smallPool() *tuistv1.RunnerPool {
+	return &tuistv1.RunnerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "macos-26-6", Namespace: "runners"},
+		Spec: tuistv1.RunnerPoolSpec{
+			OS:            "darwin",
+			FleetSelector: reservationFleet,
+			PodCPUMilli:   6000,
+			PodMemoryMB:   14336,
+		},
+	}
+}
+
 func reservationReconciler(objects ...client.Object) *RunnerPoolReconciler {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -115,7 +131,7 @@ func TestReservation_HoldsAHostForAStarvedShape(t *testing.T) {
 	node := m4Node("m4-0")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, node, starved,
+	r := reservationReconciler(pool, smallPool(), node, starved,
 		placedPod("small-0", "macos-26-6", "m4-0", "acme"),
 		placedPod("small-1", "macos-26-6", "m4-0", "acme"),
 	)
@@ -150,7 +166,7 @@ func TestReservation_WaitsOutTheGracePeriod(t *testing.T) {
 	node := m4Node("m4-0")
 	fresh := pendingPod("large-0", pool.Name, 10*time.Second)
 
-	r := reservationReconciler(pool, node, fresh)
+	r := reservationReconciler(pool, smallPool(), node, fresh)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*fresh}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -176,7 +192,7 @@ func TestReservation_RetiresIdlePodsButNeverRunningJobs(t *testing.T) {
 	idle := placedPod("small-idle", "macos-26-6", "m4-0", "")
 	owned := placedPod("small-owned", "macos-26-6", "m4-0", "acme")
 
-	r := reservationReconciler(pool, node, starved, idle, owned)
+	r := reservationReconciler(pool, smallPool(), node, starved, idle, owned)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -211,7 +227,7 @@ func TestReservation_ReleasesWhenThePoolIsServed(t *testing.T) {
 
 	placed := placedPod("large-0", pool.Name, "m4-0", "acme")
 
-	r := reservationReconciler(pool, node, placed)
+	r := reservationReconciler(pool, smallPool(), node, placed)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*placed}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -236,7 +252,7 @@ func TestReservation_ReleasesOnTimeout(t *testing.T) {
 	}
 	starved := pendingPod("large-0", pool.Name, time.Hour)
 
-	r := reservationReconciler(pool, node, starved)
+	r := reservationReconciler(pool, smallPool(), node, starved)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -252,7 +268,7 @@ func TestReservation_SkipsHostsThatCouldNeverSeatTheShape(t *testing.T) {
 	pool := largePool()
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, m2Node("m2-0"), m2Node("m2-1"), starved)
+	r := reservationReconciler(pool, smallPool(), m2Node("m2-0"), m2Node("m2-1"), starved)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -277,7 +293,7 @@ func TestReservation_HoldsAtMostOneHostFleetWide(t *testing.T) {
 	free := m4Node("m4-1")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, held, free, starved)
+	r := reservationReconciler(pool, smallPool(), held, free, starved)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
@@ -293,7 +309,7 @@ func TestReservation_PrefersTheHostThatConvergesSoonest(t *testing.T) {
 	pool := largePool()
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, m4Node("m4-busy"), m4Node("m4-quiet"), starved,
+	r := reservationReconciler(pool, smallPool(), m4Node("m4-busy"), m4Node("m4-quiet"), starved,
 		placedPod("job-0", "macos-26-6", "m4-busy", "acme"),
 		placedPod("job-1", "macos-26-6", "m4-busy", "acme"),
 		placedPod("idle-0", "macos-26-6", "m4-quiet", ""),
@@ -318,12 +334,50 @@ func TestReservation_SkipsLinuxPools(t *testing.T) {
 	node := m4Node("m4-0")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, node, starved)
+	r := reservationReconciler(pool, smallPool(), node, starved)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
 
 	if isReserved(nodeByName(t, r, "m4-0")) {
 		t.Fatal("Linux pools must not take reservations")
+	}
+}
+
+// A homogeneous fleet whose hosts hold exactly one guest has nothing to
+// accumulate: the shape already fits a single seat, so waiting for it is
+// correct. Reserving there would take a one-host fleet entirely out of
+// service for every other pool until the reservation cleared.
+func TestReservation_SkipsFleetsWhereTheShapeIsNotLarge(t *testing.T) {
+	pool := smallPool()
+	node := m2Node("m2-0")
+	starved := pendingPod("small-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, node, starved,
+		placedPod("other-0", "macos-26-5", "m2-0", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m2-0")) {
+		t.Fatal("a single-seat shape on a single-seat host must not reserve; it should just wait")
+	}
+}
+
+// The 6 vCPU shape is not large on an M4-XL either — it fits any free
+// seat, so it never needs a host drained for it.
+func TestReservation_SkipsTheSmallShapeOnADualSeatHost(t *testing.T) {
+	pool := smallPool()
+	node := m4Node("m4-0")
+	starved := pendingPod("small-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, largePool(), node, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("the fleet's most granular shape must never trigger a reservation")
 	}
 }

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -492,3 +492,101 @@ func TestReservation_CooldownIsPerHostNotPerPool(t *testing.T) {
 		t.Error("a sibling host with no cooldown should have been reserved instead")
 	}
 }
+
+// A reservation names its owning pool, so only that pool can find and
+// release it. Once the pool's CR is gone the taint is unreachable: the
+// host is out of the fleet permanently AND its reservation keeps
+// counting against the fleet-wide limit, blocking every future one.
+func TestReservation_SweepsReservationsWhoseOwningPoolIsGone(t *testing.T) {
+	pool := largePool()
+	orphaned := m4Node("m4-0")
+	orphaned.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue("macos-26-1-12vcpu-28gb"),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+
+	// No Pod is starved, so nothing but the sweep can act here.
+	r := reservationReconciler(pool, smallPool(), orphaned)
+	if err := r.reconcileReservation(context.Background(), pool, nil); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("a reservation whose pool no longer exists must be swept")
+	}
+}
+
+// An orphaned reservation must not keep the fleet's one slot spoken for.
+func TestReservation_OrphanDoesNotBlockANewReservation(t *testing.T) {
+	pool := largePool()
+	orphaned := m4Node("m4-0")
+	orphaned.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue("long-gone-pool"),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, smallPool(), orphaned, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	node := nodeByName(t, r, "m4-0")
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == podtemplate.ReservationTaintKey &&
+			taint.Value != podtemplate.ReservationValue(pool.Name) {
+			t.Fatal("the orphan still holds the host; the starved pool is blocked behind it")
+		}
+	}
+}
+
+// A pool being deleted returns through reconcileDelete without reaching
+// reservation reconciliation, so the delete path has to hand the host
+// back itself.
+func TestReservation_ReleasedWhenTheOwningPoolIsDeleted(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+
+	r := reservationReconciler(pool, smallPool(), node)
+	if err := r.ReleaseReservationsForPool(context.Background(), pool); err != nil {
+		t.Fatalf("ReleaseReservationsForPool: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("a deleting pool must hand its host back")
+	}
+}
+
+// A host already holding one of this pool's own Pods cannot be cleared
+// for a second: the reaper never retires own-pool Pods. Ranking on
+// occupancy alone made that host look ideal, because its own idle Pod
+// counts as zero occupancy.
+func TestReservation_SkipsHostsItsOwnPodAlreadyFills(t *testing.T) {
+	pool := largePool()
+	occupied := m4Node("m4-a") // holds this pool's own idle Pod
+	free := m4Node("m4-b")     // holds two other-pool jobs
+	starved := pendingPod("large-1", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, smallPool(), occupied, free, starved,
+		placedPod("large-0", pool.Name, "m4-a", ""),
+		placedPod("small-0", "macos-26-6", "m4-b", "acme"),
+		placedPod("small-1", "macos-26-6", "m4-b", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-a")) {
+		t.Fatal("reserved a host its own Pod fills; that host can never seat the second Pod")
+	}
+	if !isReserved(nodeByName(t, r, "m4-b")) {
+		t.Fatal("should have reserved the host whose occupants can actually be cleared")
+	}
+}

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -381,3 +381,114 @@ func TestReservation_SkipsTheSmallShapeOnADualSeatHost(t *testing.T) {
 		t.Fatal("the fleet's most granular shape must never trigger a reservation")
 	}
 }
+
+// The timeout is only a safety valve if the host actually goes back
+// into circulation. `starvedPod` measures the Pod's own age, so the Pod
+// that triggered the reservation is still long past the grace period the
+// instant the taint lifts — without a cooldown the next reconcile
+// re-reserves the same host and the small shapes never get it back.
+func TestReservation_TimedOutHostRestsBeforeBeingReservedAgain(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{
+		reservationAtAnnotation: reservationNow.Add(-reservationTimeout - time.Minute).Format(time.RFC3339),
+	}
+	// Pending since well before the grace period, as it would be after
+	// fifteen minutes of waiting.
+	starved := pendingPod("large-0", pool.Name, time.Hour)
+
+	r := reservationReconciler(pool, smallPool(), node, starved)
+	ctx := context.Background()
+
+	// First pass times out and releases.
+	if err := r.reconcileReservation(ctx, pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation (release): %v", err)
+	}
+	released := nodeByName(t, r, "m4-0")
+	if isReserved(released) {
+		t.Fatal("an expired reservation should have been released")
+	}
+	if released.Annotations[reservationCooldownAnnotation] == "" {
+		t.Fatal("a timed-out release must rest the host")
+	}
+
+	// Second pass, same tick: the host must not be taken straight back.
+	if err := r.reconcileReservation(ctx, pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation (retry): %v", err)
+	}
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("host was re-reserved during its cooldown; the timeout is then a no-op")
+	}
+}
+
+// Once the cooldown expires the pool may try again — the job is still
+// queued and the host may since have freed up.
+func TestReservation_ResumesAfterTheCooldownExpires(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Annotations = map[string]string{
+		reservationCooldownAnnotation: reservationNow.Add(-time.Minute).Format(time.RFC3339),
+	}
+	starved := pendingPod("large-0", pool.Name, time.Hour)
+
+	r := reservationReconciler(pool, smallPool(), node, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if !isReserved(nodeByName(t, r, "m4-0")) {
+		t.Fatal("an expired cooldown must not keep blocking the host")
+	}
+}
+
+// A reservation that ended because the Pod landed achieved what it was
+// for, so the host is handed straight back with no penalty.
+func TestReservation_SuccessfulReleaseSetsNoCooldown(t *testing.T) {
+	pool := largePool()
+	node := m4Node("m4-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{reservationAtAnnotation: reservationNow.Format(time.RFC3339)}
+	placed := placedPod("large-0", pool.Name, "m4-0", "acme")
+
+	r := reservationReconciler(pool, smallPool(), node, placed)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*placed}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if got := nodeByName(t, r, "m4-0"); got.Annotations[reservationCooldownAnnotation] != "" {
+		t.Fatal("a successful reservation must not penalise the host")
+	}
+}
+
+// A pool blocked on a resting host is still free to reserve a different
+// eligible one, which is why the cooldown lives on the node.
+func TestReservation_CooldownIsPerHostNotPerPool(t *testing.T) {
+	pool := largePool()
+	resting := m4Node("m4-0")
+	resting.Annotations = map[string]string{
+		reservationCooldownAnnotation: reservationNow.Add(time.Minute).Format(time.RFC3339),
+	}
+	fresh := m4Node("m4-1")
+	starved := pendingPod("large-0", pool.Name, time.Hour)
+
+	r := reservationReconciler(pool, smallPool(), resting, fresh, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "m4-0")) {
+		t.Error("the resting host must stay out of the running")
+	}
+	if !isReserved(nodeByName(t, r, "m4-1")) {
+		t.Error("a sibling host with no cooldown should have been reserved instead")
+	}
+}

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -117,7 +117,7 @@ func (r *RunnerPoolReconciler) now() time.Time {
 // +kubebuilder:rbac:groups=tuist.dev,resources=runnerpools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;delete
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch
 
 func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("pool", req.NamespacedName)
@@ -187,6 +187,17 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	pods.Items = survivors
 	if cordonReaped > 0 {
 		logger.Info("retired idle runner pods for node drain", "count", cordonReaped)
+	}
+
+	// Node reservation. Runs after the drain reap so a Pod already
+	// retired above is not counted as an occupant a reservation must
+	// wait on, and before the accounting below because retiring another
+	// pool's idle Pod here changes what this fleet has free. Failures are
+	// logged and skipped rather than returned: a reservation is an
+	// optimization for a starved shape, and a fleet that cannot take one
+	// must still converge its Pods.
+	if err := r.reconcileReservation(ctx, pool, pods.Items); err != nil {
+		logger.Error(err, "reconcile node reservation; will retry next tick")
 	}
 
 	// Warm capacity is counted here, in the one pass with no early

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -54,7 +54,13 @@ const defaultRollMaxConcurrentPercent = 5
 // the previous Pod freed.
 type RunnerPoolReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+
+	// APIReader is an uncached reader. The reservation path confirms the
+	// fleet-wide reservation limit through it, because the informer
+	// cache can lag a taint written moments earlier by another pool's
+	// reconcile. Optional: falls back to the cached client when unset.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 
 	// SessionsClient closes a Pod's billing session immediately before
 	// the reap deletes it — see reapRunner for why the ordering matters.
@@ -143,6 +149,14 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// finish their single-shot job. Only then is the finalizer
 	// dropped, letting the CR and any remaining terminal Pods/SAs GC.
 	if !pool.DeletionTimestamp.IsZero() {
+		// Before the drain, hand back any host this pool was holding.
+		// reconcileDelete returns without reaching reconcileReservation,
+		// and once the CR is gone nothing can match the taint's value,
+		// so the host would be tainted out of the fleet permanently.
+		if err := r.ReleaseReservationsForPool(ctx, pool); err != nil {
+			logger.Error(err, "release node reservation for a deleting pool; will retry")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
 		return r.reconcileDelete(ctx, pool)
 	}
 	if controllerutil.AddFinalizer(pool, runnerPoolFinalizer) {

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -24,6 +24,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -41,6 +42,25 @@ const (
 	// revision used at creation so the controller can roll old admission
 	// accounting without inspecting mutable cluster state.
 	RuntimeClassRevisionAnnotation = "tuist.dev/runtime-class-revision"
+
+	// ReservationTaintKey is the taint the controller puts on a node it
+	// is draining to make room for a pool whose Pods no node can seat
+	// right now. Its value is the pool the node is being held for, and
+	// every runner Pod tolerates that key at its OWN pool's value — so a
+	// reserved node stops admitting everyone else's Pods while the seat
+	// it is clearing accumulates, and admits the reserved pool's Pod the
+	// moment it fits.
+	//
+	// NoSchedule, never NoExecute: the Pods already on the node are
+	// running customer jobs and must finish. The controller retires the
+	// IDLE ones itself, which is the only eviction a reservation does.
+	//
+	// A dedicated taint rather than a cordon. Cordoning would make the
+	// node indistinguishable from one Cluster API is replacing, and
+	// `reapIdlePodsOnCordonedNodes` would then retire the reserved pool's
+	// own Pod the moment it landed and was still warm-polling — the
+	// reservation would eat its own result.
+	ReservationTaintKey = "tuist.dev/reserved-for"
 
 	// jitMountPath is where the JIT-handoff emptyDir is mounted in
 	// both the poller (rw) and runner (ro) containers. Deliberately
@@ -649,6 +669,7 @@ func schedulingFor(pool *tuistv1.RunnerPool) (map[string]string, []corev1.Tolera
 					Value:    "bare-metal",
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
+				reservationToleration(pool),
 			}
 	default:
 		return map[string]string{
@@ -661,6 +682,39 @@ func schedulingFor(pool *tuistv1.RunnerPool) (map[string]string, []corev1.Tolera
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
+				reservationToleration(pool),
 			}
 	}
 }
+
+// reservationToleration lets a pool's Pods land on a node reserved for
+// that same pool, and only that pool. Every runner Pod carries it, on
+// both platforms, so the reservation mechanism needs no per-pool opt-in
+// and an operator can reserve for any pool without a redeploy.
+//
+// Pods created before this toleration existed keep scheduling normally;
+// they simply cannot use a reservation, and the reservation releases on
+// its timeout if one is held for such a Pod.
+func reservationToleration(pool *tuistv1.RunnerPool) corev1.Toleration {
+	return corev1.Toleration{
+		Key:      ReservationTaintKey,
+		Operator: corev1.TolerationOpEqual,
+		Value:    ReservationValue(pool.Name),
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}
+
+// ReservationValue is the taint/toleration value identifying a pool.
+// Pool names are readable and almost always short enough to use as-is,
+// which keeps `kubectl describe node` self-explanatory; a name too long
+// to be a valid label value falls back to a digest so the mechanism
+// still works rather than producing a node the apiserver rejects.
+func ReservationValue(poolName string) string {
+	if len(poolName) <= 63 && labelValue.MatchString(poolName) {
+		return poolName
+	}
+	sum := sha256.Sum256([]byte(poolName))
+	return fmt.Sprintf("pool-%x", sum[:8])
+}
+
+var labelValue = regexp.MustCompile(`^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$`)

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -53,9 +53,10 @@ func TestBuild_MacOSScheduling(t *testing.T) {
 	if got, want := pod.Spec.NodeSelector["tuist.dev/fleet"], "fleet-x"; got != want {
 		t.Errorf("nodeSelector fleet = %q, want %q", got, want)
 	}
-	if len(pod.Spec.Tolerations) != 1 || pod.Spec.Tolerations[0].Key != "tuist.dev/macos" {
-		t.Errorf("Tolerations = %+v, want one tuist.dev/macos toleration", pod.Spec.Tolerations)
+	if len(pod.Spec.Tolerations) != 2 || pod.Spec.Tolerations[0].Key != "tuist.dev/macos" {
+		t.Errorf("Tolerations = %+v, want tuist.dev/macos plus the reservation toleration", pod.Spec.Tolerations)
 	}
+	assertReservationToleration(t, pod, "pool-1")
 }
 
 func TestBuild_MacOSGoldenAffinity(t *testing.T) {
@@ -131,13 +132,14 @@ func TestBuild_LinuxScheduling(t *testing.T) {
 	if _, present := pod.Spec.NodeSelector["tuist.dev/runtime"]; present {
 		t.Errorf("nodeSelector should NOT carry tuist.dev/runtime on Linux pools")
 	}
-	if len(pod.Spec.Tolerations) != 1 {
-		t.Fatalf("Tolerations = %+v, want exactly 1 (bare-metal runner-tier)", pod.Spec.Tolerations)
+	if len(pod.Spec.Tolerations) != 2 {
+		t.Fatalf("Tolerations = %+v, want the bare-metal runner-tier plus the reservation toleration", pod.Spec.Tolerations)
 	}
 	tol := pod.Spec.Tolerations[0]
 	if tol.Key != "tuist.dev/runner-tier" || tol.Value != "bare-metal" || tol.Effect != "NoSchedule" {
 		t.Errorf("Toleration = %+v, want {Key:tuist.dev/runner-tier Value:bare-metal Effect:NoSchedule}", tol)
 	}
+	assertReservationToleration(t, pod, "pool-1")
 }
 
 func TestBuild_LinuxMetricsSidecar(t *testing.T) {
@@ -745,4 +747,43 @@ func hasVolume(volumes []corev1.Volume, name string) bool {
 		}
 	}
 	return false
+}
+
+// A runner Pod tolerates a reservation held for its OWN pool and no
+// other, which is what makes a reserved node stop admitting everyone
+// else while the seats it is clearing accumulate.
+func assertReservationToleration(t *testing.T, pod *corev1.Pod, poolName string) {
+	t.Helper()
+
+	for _, tol := range pod.Spec.Tolerations {
+		if tol.Key != ReservationTaintKey {
+			continue
+		}
+		if tol.Value != poolName {
+			t.Errorf("reservation toleration value = %q, want the pool's own name %q", tol.Value, poolName)
+		}
+		if tol.Operator != corev1.TolerationOpEqual {
+			t.Errorf("reservation toleration operator = %q, want Equal so it matches only this pool", tol.Operator)
+		}
+		if tol.Effect != corev1.TaintEffectNoSchedule {
+			t.Errorf("reservation toleration effect = %q, want NoSchedule", tol.Effect)
+		}
+		return
+	}
+	t.Errorf("no %s toleration on the Pod: %+v", ReservationTaintKey, pod.Spec.Tolerations)
+}
+
+func TestReservationValueFallsBackToADigestForUnusableNames(t *testing.T) {
+	long := strings.Repeat("a", 80)
+	got := ReservationValue(long)
+
+	if got == long {
+		t.Fatalf("a name too long for a label value must not be used verbatim")
+	}
+	if len(got) > 63 {
+		t.Fatalf("ReservationValue = %q (%d chars), want a valid label value", got, len(got))
+	}
+	if ReservationValue(long) != got {
+		t.Fatalf("ReservationValue must be deterministic")
+	}
 }

--- a/infra/runners-controller/internal/scaling/allocate.go
+++ b/infra/runners-controller/internal/scaling/allocate.go
@@ -1,5 +1,7 @@
 package scaling
 
+import "sort"
+
 // PoolDemand is one pool's input to the fleet-capacity allocation.
 // All pools in a single AllocateFleet call share one capacity budget
 // (the contention domain): the schedulable memory across the fleet's
@@ -34,6 +36,12 @@ type PoolDemand struct {
 	// including the speculative p95 warm buffer, already clamped to
 	// `maxReplicas`.
 	Target int32
+
+	// ShapeKey groups pools whose Pods place identically on a node, so
+	// their grants can be capped against what the fleet's nodes can
+	// actually seat for that shape. Empty opts the pool out of the cap.
+	// See AllocateFleet's `shapeCaps`.
+	ShapeKey string
 }
 
 // AllocateFleet distributes `fleetCapacity` across pools sharing a
@@ -69,7 +77,14 @@ type PoolDemand struct {
 // Result per pool is in `[load_i, Target_i]`. The algorithm is
 // unit-agnostic: `fleetCapacity` and `PerPodCost` just need to be in
 // the same unit (allocatable memory bytes on both platforms today).
-func AllocateFleet(pools []PoolDemand, fleetCapacity int64) map[string]int32 {
+//
+// `shapeCaps` is an optional per-ShapeKey ceiling on the number of Pods
+// the fleet can actually place for that shape, applied before the byte
+// budget. A nil or empty map disables it. See capByShape for why the
+// byte budget cannot express this on its own.
+func AllocateFleet(pools []PoolDemand, fleetCapacity int64, shapeCaps map[string]int32) map[string]int32 {
+	pools = capByShape(pools, shapeCaps)
+
 	out := make(map[string]int32, len(pools))
 
 	type tierWant struct {
@@ -171,4 +186,124 @@ func AllocateFleet(pools []PoolDemand, fleetCapacity int64) map[string]int32 {
 	}
 
 	return out
+}
+
+// capByShape clamps each pool's Target so that the pools sharing a
+// ShapeKey never sum above what the fleet's nodes can actually seat for
+// that shape.
+//
+// `maxReplicas` cannot do this. It is a PER-POOL ceiling, and the pools
+// sharing a shape are siblings: five Xcode pools each capped at the two
+// M4 hosts that can seat a 12 vCPU guest compose to ten, not two. Nor
+// can the shared byte budget catch it, because that budget pools memory
+// across nodes which cannot host the shape at all — a fleet advertising
+// 157 GB reads as five 28 GB slots when only two hosts can seat one.
+// Everything above the real count is a Pod that no node will ever
+// accept, so it is not the transient "add a host" overshoot the load
+// tier deliberately allows; it is permanent.
+//
+// The cap is handed out by the same priority the tiers use — load
+// first, then the warm floor, then headroom — one Pod per pool per
+// round, so two pools contending for a single slot do not both lose it,
+// and in name order so the split is identical on every reconcile.
+//
+// Clamping Target (rather than the tiers directly) is enough: the tier
+// decomposition already clamps load and floor to it.
+func capByShape(pools []PoolDemand, shapeCaps map[string]int32) []PoolDemand {
+	if len(shapeCaps) == 0 {
+		return pools
+	}
+
+	groups := map[string][]int{}
+	for i, pool := range pools {
+		if pool.ShapeKey == "" {
+			continue
+		}
+		if _, capped := shapeCaps[pool.ShapeKey]; !capped {
+			continue
+		}
+		groups[pool.ShapeKey] = append(groups[pool.ShapeKey], i)
+	}
+	if len(groups) == 0 {
+		return pools
+	}
+
+	out := make([]PoolDemand, len(pools))
+	copy(out, pools)
+
+	for key, members := range groups {
+		limit := shapeCaps[key]
+		if limit < 0 {
+			limit = 0
+		}
+
+		var asked int32
+		for _, i := range members {
+			asked += clampMin(out[i].Target, 0)
+		}
+		if asked <= limit {
+			continue
+		}
+
+		sort.Slice(members, func(a, b int) bool { return out[members[a]].Name < out[members[b]].Name })
+
+		granted := make([]int32, len(members))
+		remaining := limit
+		for _, ceiling := range []func(PoolDemand) int32{loadCeiling, floorCeiling, targetCeiling} {
+			for remaining > 0 {
+				progressed := false
+				for j, i := range members {
+					if remaining == 0 {
+						break
+					}
+					if granted[j] < ceiling(out[i]) {
+						granted[j]++
+						remaining--
+						progressed = true
+					}
+				}
+				if !progressed {
+					break
+				}
+			}
+		}
+
+		for j, i := range members {
+			out[i].Target = granted[j]
+			out[i].Load = clampMax(out[i].Load, granted[j])
+			out[i].Floor = clampMax(out[i].Floor, granted[j])
+		}
+	}
+
+	return out
+}
+
+// The three ceilings capByShape fills in priority order, each the top of
+// one tier and each already bounded by the pool's own Target.
+func targetCeiling(p PoolDemand) int32 { return clampMin(p.Target, 0) }
+
+func loadCeiling(p PoolDemand) int32 {
+	return clampMax(clampMin(p.Load, 0), targetCeiling(p))
+}
+
+func floorCeiling(p PoolDemand) int32 {
+	floor := clampMin(p.Floor, 0)
+	if load := loadCeiling(p); floor < load {
+		floor = load
+	}
+	return clampMax(floor, targetCeiling(p))
+}
+
+func clampMin(v, min int32) int32 {
+	if v < min {
+		return min
+	}
+	return v
+}
+
+func clampMax(v, max int32) int32 {
+	if v > max {
+		return max
+	}
+	return v
 }

--- a/infra/runners-controller/internal/scaling/allocate_test.go
+++ b/infra/runners-controller/internal/scaling/allocate_test.go
@@ -2,7 +2,10 @@ package scaling
 
 import "testing"
 
-const gib = int64(1024) * 1024 * 1024
+const (
+	gib = int64(1024) * 1024 * 1024
+	mib = int64(1024) * 1024
+)
 
 func TestAllocateFleet_UncontendedGrantsEveryTarget(t *testing.T) {
 	// 100 GiB fleet, two small shapes — everything fits, each gets its
@@ -11,7 +14,7 @@ func TestAllocateFleet_UncontendedGrantsEveryTarget(t *testing.T) {
 		{Name: "small", PerPodCost: 2 * gib, Floor: 1, Load: 2, Target: 5},
 		{Name: "med", PerPodCost: 4 * gib, Floor: 1, Load: 1, Target: 4},
 	}
-	got := AllocateFleet(pools, 100*gib)
+	got := AllocateFleet(pools, 100*gib, nil)
 
 	if got["small"] != 5 {
 		t.Errorf("small = %d, want 5", got["small"])
@@ -29,7 +32,7 @@ func TestAllocateFleet_RealLoadAlwaysGrantedEvenOverCapacity(t *testing.T) {
 		{Name: "b", PerPodCost: 16 * gib, Floor: 1, Load: 2, Target: 5},
 	}
 	// Only 32 GiB usable — 2 pods — but real load wants 5 pods.
-	got := AllocateFleet(pools, 32*gib)
+	got := AllocateFleet(pools, 32*gib, nil)
 
 	if got["a"] != 3 {
 		t.Errorf("a = %d, want 3 (load honored in full)", got["a"])
@@ -53,7 +56,7 @@ func TestAllocateFleet_SqueezesSpeculativeHeadroomUnderContention(t *testing.T) 
 	// Headroom wants: busy 2, idle 4 (6 total). 1 pod split
 	// proportionally → busy ~0, idle ~0 (rounding down). The point:
 	// idle does NOT get its speculative 5; busy's real load is intact.
-	got := AllocateFleet(pools, 64*gib)
+	got := AllocateFleet(pools, 64*gib, nil)
 
 	if got["busy"] < 6 {
 		t.Errorf("busy = %d, want >= 6 (real load protected)", got["busy"])
@@ -81,7 +84,7 @@ func TestAllocateFleet_SqueezesIdleFloorForAnotherPoolsQueuedLoad(t *testing.T) 
 	}
 	// 200 GiB usable. big's load = 160 GiB granted first, leaving 40 GiB
 	// (5 pods of 8 GiB) for small's floor of 20 → squeezed to 5.
-	got := AllocateFleet(pools, 200*gib)
+	got := AllocateFleet(pools, 200*gib, nil)
 
 	if got["big"] != 10 {
 		t.Errorf("big = %d, want 10 (queued load wins over idle floor)", got["big"])
@@ -100,7 +103,7 @@ func TestAllocateFleet_HeadroomSplitProportionally(t *testing.T) {
 	}
 	// Floors: 2 pods = 8 GiB. Fleet 8 GiB base + 12 GiB (3 pods) left.
 	// Headroom demand: x=4, y=2 (6 total). 3 pods split 2:1 → x≈2, y≈1.
-	got := AllocateFleet(pools, 20*gib)
+	got := AllocateFleet(pools, 20*gib, nil)
 
 	if got["x"] != 3 { // floor 1 + 2 headroom
 		t.Errorf("x = %d, want 3", got["x"])
@@ -114,7 +117,7 @@ func TestAllocateFleet_NeverExceedsTarget(t *testing.T) {
 	pools := []PoolDemand{
 		{Name: "a", PerPodCost: 1 * gib, Floor: 1, Load: 0, Target: 2},
 	}
-	got := AllocateFleet(pools, 1000*gib)
+	got := AllocateFleet(pools, 1000*gib, nil)
 	if got["a"] != 2 {
 		t.Errorf("a = %d, want 2 (capped at target)", got["a"])
 	}
@@ -135,7 +138,7 @@ func TestAllocateFleet_ZeroCapacityHonorsLoadNotFloor(t *testing.T) {
 		{Name: "load", PerPodCost: 4 * gib, Floor: 2, Load: 3, Target: 5},
 		{Name: "floor", PerPodCost: 4 * gib, Floor: 2, Load: 0, Target: 5},
 	}
-	got := AllocateFleet(pools, 0)
+	got := AllocateFleet(pools, 0, nil)
 	if got["load"] != 3 {
 		t.Errorf("load = %d, want 3 (real load honored even at zero capacity)", got["load"])
 	}
@@ -263,7 +266,7 @@ func TestAllocateFleet_WithheldDemand(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := AllocateFleet(tc.pools, tc.capacity)
+			got := AllocateFleet(tc.pools, tc.capacity, nil)
 			for name, want := range tc.want {
 				if got[name] != want {
 					t.Errorf("%s = %d, want %d (full allocation: %v)", name, got[name], want, got)
@@ -274,8 +277,93 @@ func TestAllocateFleet_WithheldDemand(t *testing.T) {
 }
 
 func TestAllocateFleet_EmptyFleet(t *testing.T) {
-	got := AllocateFleet(nil, 100*gib)
+	got := AllocateFleet(nil, 100*gib, nil)
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty", got)
+	}
+}
+
+// The shape cap exists because `maxReplicas` is per pool: five Xcode
+// pools each allowed two 12 vCPU runners compose to ten, and the byte
+// budget cannot catch it because it pools memory from M2-L hosts that
+// cannot seat the shape at all.
+func TestAllocateFleetCapsPoolsSharingAShape(t *testing.T) {
+	const big = 28672 * mib
+
+	pools := []PoolDemand{
+		{Name: "macos-26-6-12vcpu", PerPodCost: big, Load: 1, Target: 2, ShapeKey: "12000m-28672Mi"},
+		{Name: "macos-26-5-12vcpu", PerPodCost: big, Load: 1, Target: 2, ShapeKey: "12000m-28672Mi"},
+		{Name: "macos-26-3-12vcpu", PerPodCost: big, Load: 1, Target: 2, ShapeKey: "12000m-28672Mi"},
+	}
+
+	// The fleet advertises 157696 MiB, which the byte budget alone reads
+	// as five 28 GiB slots. Only two hosts can actually seat one.
+	got := AllocateFleet(pools, 157696*mib, map[string]int32{"12000m-28672Mi": 2})
+
+	var total int32
+	for _, v := range got {
+		total += v
+	}
+	if total != 2 {
+		t.Fatalf("granted %d runners for a shape only two hosts can seat: %v", total, got)
+	}
+}
+
+// Load is granted before floor and headroom inside the cap, so a pool
+// with a queued job beats a sibling that only wants to stay warm.
+func TestAllocateFleetShapeCapPrefersLoadOverWarmth(t *testing.T) {
+	const big = 28672 * mib
+
+	pools := []PoolDemand{
+		{Name: "a-idle", PerPodCost: big, Floor: 1, Target: 1, ShapeKey: "s"},
+		{Name: "b-queued", PerPodCost: big, Load: 1, Target: 1, ShapeKey: "s"},
+	}
+
+	got := AllocateFleet(pools, 1000*gib, map[string]int32{"s": 1})
+
+	if got["b-queued"] != 1 || got["a-idle"] != 0 {
+		t.Fatalf("the one seat should go to real queued work, got %v", got)
+	}
+}
+
+// Two pools contending for a single seat must not both lose it, and the
+// winner must be the same on every reconcile.
+func TestAllocateFleetShapeCapSplitsDeterministically(t *testing.T) {
+	const big = 28672 * mib
+
+	pools := []PoolDemand{
+		{Name: "b", PerPodCost: big, Load: 2, Target: 2, ShapeKey: "s"},
+		{Name: "a", PerPodCost: big, Load: 2, Target: 2, ShapeKey: "s"},
+	}
+
+	first := AllocateFleet(pools, 1000*gib, map[string]int32{"s": 2})
+	second := AllocateFleet(pools, 1000*gib, map[string]int32{"s": 2})
+
+	if first["a"] != 1 || first["b"] != 1 {
+		t.Fatalf("a single round should hand each contender one seat, got %v", first)
+	}
+	if first["a"] != second["a"] || first["b"] != second["b"] {
+		t.Fatalf("allocation is not deterministic: %v then %v", first, second)
+	}
+}
+
+// Pools of other shapes, and pools with no ShapeKey, are untouched.
+func TestAllocateFleetShapeCapLeavesOtherShapesAlone(t *testing.T) {
+	pools := []PoolDemand{
+		{Name: "big", PerPodCost: 28672 * mib, Load: 3, Target: 3, ShapeKey: "big"},
+		{Name: "small", PerPodCost: 14336 * mib, Load: 4, Target: 4, ShapeKey: "small"},
+		{Name: "unkeyed", PerPodCost: 14336 * mib, Load: 2, Target: 2},
+	}
+
+	got := AllocateFleet(pools, 1000*gib, map[string]int32{"big": 2})
+
+	if got["big"] != 2 {
+		t.Fatalf("capped shape: want 2, got %d", got["big"])
+	}
+	if got["small"] != 4 {
+		t.Fatalf("uncapped shape must be untouched, got %d", got["small"])
+	}
+	if got["unkeyed"] != 2 {
+		t.Fatalf("a pool with no ShapeKey must be untouched, got %d", got["unkeyed"])
 	}
 }

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -417,10 +417,6 @@ config :tuist, :blocked_handles, [
 
 config :tuist, :dev_all_locales, System.get_env("TUIST_DEV_ALL_LOCALES") in ~w(1 true TRUE yes YES)
 
-# macOS shape catalog. Same role as `:runner_linux_shapes`. M2-L is the
-# only Scaleway Apple Silicon SKU on the fleet today, so only one shape
-# ships here. Managed deploys override at boot from
-# `TUIST_RUNNER_MACOS_SHAPES` (Helm injects from `runnersFleet.shapes`).
 # Baseline machine-minutes every account gets free per billing period.
 # Must match the first tier of the environment's runner Stripe Price;
 # see `Tuist.Runners.Allowance`.
@@ -445,8 +441,17 @@ config :tuist, :runner_linux_shapes, [
   %{vcpus: 16, memory_gb: 32}
 ]
 
+# macOS shape catalog. Same role as `:runner_linux_shapes`. Managed
+# deploys override at boot from `TUIST_RUNNER_MACOS_SHAPES` (Helm
+# injects from `runnersFleet.shapes`).
+#
+# A macOS shape is only runnable on a host SKU whose advertised
+# `hostCPU`/`hostMemoryMB` fit it, so the catalog is per-environment on
+# the Helm side: the 12 vCPU shape needs an M4-XL and is not offered in
+# environments whose fleet is M2-L only.
 config :tuist, :runner_macos_shapes, [
-  %{vcpus: 6, memory_gb: 14, default: true}
+  %{vcpus: 6, memory_gb: 14, default: true},
+  %{vcpus: 12, memory_gb: 28}
 ]
 
 # macOS Xcode catalog. Each entry is a runnable Xcode version on the

--- a/server/lib/tuist/runners/catalog.ex
+++ b/server/lib/tuist/runners/catalog.ex
@@ -5,7 +5,7 @@ defmodule Tuist.Runners.Catalog do
 
     * `:runner_linux_shapes` — Linux shape catalog.
     * `:runner_linux_pools` — operator-defined Linux pools.
-    * `:runner_macos_shapes` — macOS shape catalog (M2-L only today).
+    * `:runner_macos_shapes` — macOS shape catalog.
     * `:runner_macos_xcode_versions` — Xcode versions runnable on the
       macOS fleet.
 
@@ -227,9 +227,10 @@ defmodule Tuist.Runners.Catalog do
     * `:linux` — `<linux-prefix>-<vcpus>vcpu-<memory_gb>gb` (e.g.
       `tuist-runner-pool-linux-4vcpu-16gb`). Prefix injected via
       `TUIST_RUNNERS_LINUX_POOL_NAME_PREFIX`.
-    * `:macos` — `<macos-prefix>-<xcode-version-dashes>` (e.g.
-      `tuist-runner-pool-macos-26-5`). M2-L is implicit today;
-      when additional shapes ship, the shape suffix joins. Prefix
+    * `:macos` — `<macos-prefix>-<xcode-version-dashes>` for the
+      catalog's default shape (e.g. `tuist-runner-pool-macos-26-5`),
+      with `-<vcpus>vcpu-<memory_gb>gb` appended for any other shape
+      (e.g. `tuist-runner-pool-macos-26-5-12vcpu-28gb`). Prefix
       injected via `TUIST_RUNNERS_MACOS_POOL_NAME_PREFIX`.
 
   Accepts any map with the relevant fields — `%Profile{}` works, as
@@ -240,10 +241,34 @@ defmodule Tuist.Runners.Catalog do
     "#{Tuist.Environment.runners_linux_pool_name_prefix()}-#{vcpus}vcpu-#{memory_gb}gb"
   end
 
-  def pool_name(%{platform: :macos, xcode_version: xcode_version})
+  def pool_name(%{platform: :macos, xcode_version: xcode_version} = profile)
       when is_binary(xcode_version) and xcode_version != "" do
-    "#{Tuist.Environment.runners_macos_pool_name_prefix()}-#{xcode_version_tag(xcode_version)}"
+    base = "#{Tuist.Environment.runners_macos_pool_name_prefix()}-#{xcode_version_tag(xcode_version)}"
+
+    case macos_shape_suffix(profile) do
+      nil -> base
+      suffix -> "#{base}-#{suffix}"
+    end
   end
+
+  # The default shape's pools carry no shape suffix, so every name that
+  # existed before the catalog gained a second macOS shape still resolves
+  # to the same pool. Renaming them would strand `queued` rows whose
+  # `fleet_name` points at the old pool (a runner only claims work for
+  # its own pool) and split the fleet's analytics history at the deploy.
+  #
+  # Non-default shapes therefore carry `-<vcpus>vcpu-<memory_gb>gb`.
+  # `templates/runner-pool.yaml` renders pool names by the same rule, so
+  # the two stay in step.
+  defp macos_shape_suffix(%{vcpus: vcpus, memory_gb: memory_gb}) when is_integer(vcpus) and is_integer(memory_gb) do
+    case default_shape(:macos) do
+      nil -> nil
+      %{vcpus: ^vcpus, memory_gb: ^memory_gb} -> nil
+      _ -> "#{vcpus}vcpu-#{memory_gb}gb"
+    end
+  end
+
+  defp macos_shape_suffix(_), do: nil
 
   @doc """
   `fleet_name` prefixes that identify `platform` jobs in
@@ -290,16 +315,29 @@ defmodule Tuist.Runners.Catalog do
   New lifecycle rows persist resources at webhook enqueue time, so
   this is primarily a rollout fallback for queued rows created before
   resource columns existed. Linux profile and operator-defined pools
-  are matched against their configured resources; macOS pools use the
-  catalog default shape because the current Xcode-keyed pools all run
-  on the same machine shape. Legacy `linux-…` names use the Linux
-  default, while an unconfigured catalog pool is rejected.
+  are matched against their configured resources; macOS pools are
+  matched on the shape suffix `pool_name/1` appends, falling back to
+  the catalog default shape, which is what the unsuffixed pools run.
+  Legacy `linux-…` names use the Linux default, while an unconfigured
+  catalog pool is rejected.
   """
   def resources_for_fleet(fleet_name) when is_binary(fleet_name) do
     case fleet_platform(fleet_name) do
       :linux -> linux_resources_for_fleet(fleet_name)
-      :macos -> default_resources(:macos)
+      :macos -> macos_resources_for_fleet(fleet_name)
       nil -> {:error, :invalid_resources}
+    end
+  end
+
+  defp macos_resources_for_fleet(fleet_name) do
+    shape =
+      Enum.find(shapes(:macos), fn shape ->
+        not shape.default? and String.ends_with?(fleet_name, "-" <> shape.key)
+      end)
+
+    case shape do
+      nil -> default_resources(:macos)
+      shape -> {:ok, %{platform: :macos, vcpus: shape.vcpus, memory_gb: shape.memory_gb}}
     end
   end
 

--- a/server/lib/tuist/runners/profile.ex
+++ b/server/lib/tuist/runners/profile.ex
@@ -12,10 +12,11 @@ defmodule Tuist.Runners.Profile do
     * `:linux` — `(vcpus, memory_gb)`, picked from
       `Tuist.Runners.Catalog.shapes(:linux)`.
     * `:macos` — `(vcpus, memory_gb)` plus an `xcode_version`,
-      picked from `Catalog.shapes(:macos)` (M2-L is the only shape
-      today) and `Catalog.xcode_versions/0`. The Xcode
-      version pins the runner image's `:macos-<dashes>-<semver>`
-      tag.
+      picked from `Catalog.shapes(:macos)` and
+      `Catalog.xcode_versions/0`. The pool is keyed on both, so a
+      profile resolves to the pool running that shape on that Xcode.
+      The Xcode version pins the runner image's
+      `:macos-<dashes>-<semver>` tag.
 
   Backed by [priv/repo/migrations/20260527130000_create_runner_profiles.exs](priv/repo/migrations/20260527130000_create_runner_profiles.exs)
   and [priv/repo/migrations/20260602144624_add_platform_and_xcode_to_runner_profiles.exs](priv/repo/migrations/20260602144624_add_platform_and_xcode_to_runner_profiles.exs).

--- a/server/priv/docs/en/guides/features/runners/profiles.md
+++ b/server/priv/docs/en/guides/features/runners/profiles.md
@@ -37,6 +37,8 @@ Runners are available on macOS (Apple silicon, virtualized on the Mac fleet) and
 
 {{runner_macos_shapes_table}}
 
+Larger macOS shapes run on fewer machines in the fleet, so a job that asks for one can wait longer to start than the same job on a smaller shape. Reach for a larger shape when a job is limited by CPU, and keep the default shape for everything else. If you are not sure, run the job on both and compare the durations in the dashboard.
+
 macOS profiles also pin an **Xcode version**. The version selects a runner image with that Xcode preinstalled, so jobs start with the toolchain already in place. Supported versions today:
 
 {{runner_macos_xcode_versions}}

--- a/server/priv/marketing/changelog/2026.08.26-macos-runner-12-vcpu-shape.md
+++ b/server/priv/marketing/changelog/2026.08.26-macos-runner-12-vcpu-shape.md
@@ -1,0 +1,16 @@
+---
+title: A 12 vCPU macOS runner for CPU-bound builds
+description: "macOS runner profiles can now pick a 12 vCPU / 28 GB machine, double the cores of the standard shape."
+category: "Product"
+pull_request: 12612
+---
+
+Runner profiles have offered one macOS machine shape since launch: 6 vCPU and 14 GB of memory. Looking at what jobs actually do with it, memory was never the thing holding them back. Across several thousand macOS jobs, peak memory use sat around 7.6 GB at the median and never once came close to the 14 GB ceiling. CPU is a different story: half of all jobs pegged every core they were given, and more than three quarters spent time fully saturating all six.
+
+So the new shape adds cores, not memory. **12 vCPU / 28 GB** is now selectable when you create or edit a macOS profile, alongside the existing 6 vCPU / 14 GB shape, which stays the default.
+
+It suits the jobs that were CPU-starved on the smaller shape: large Swift compilations, parallel test suites, and anything that scales with core count. Jobs that were comfortable on 6 vCPU will not get faster on 12, so it is worth measuring rather than switching everything over.
+
+Billing follows the machine, at twice the standard shape's rate: $0.15 per machine-minute on demand and $0.12 prepaid. Your existing profiles keep the shape they were created with, so nothing changes until you pick the new one.
+
+Learn more in the [runner profiles documentation](https://tuist.dev/en/docs/guides/features/runners/profiles#machine-shapes).

--- a/server/priv/marketing/changelog/2026.08.26-macos-runner-12-vcpu-shape.md
+++ b/server/priv/marketing/changelog/2026.08.26-macos-runner-12-vcpu-shape.md
@@ -1,16 +1,12 @@
 ---
-title: A 12 vCPU macOS runner for CPU-bound builds
-description: "macOS runner profiles can now pick a 12 vCPU / 28 GB machine, double the cores of the standard shape."
+title: A larger macOS runner shape
+description: "macOS runner profiles can now pick a 12 vCPU / 28 GB machine alongside the standard 6 vCPU / 14 GB one."
 category: "Product"
 pull_request: 12612
 ---
 
-Runner profiles have offered one macOS machine shape since launch: 6 vCPU and 14 GB of memory. Looking at what jobs actually do with it, memory was never the thing holding them back. Across several thousand macOS jobs, peak memory use sat around 7.6 GB at the median and never once came close to the 14 GB ceiling. CPU is a different story: half of all jobs pegged every core they were given, and more than three quarters spent time fully saturating all six.
+macOS runner profiles have offered a single machine shape since launch: 6 vCPU / 14 GB. There is now a second, **12 vCPU / 28 GB**, running on M4 Pro hardware.
 
-So the new shape adds cores, not memory. **12 vCPU / 28 GB** is now selectable when you create or edit a macOS profile, alongside the existing 6 vCPU / 14 GB shape, which stays the default.
-
-It suits the jobs that were CPU-starved on the smaller shape: large Swift compilations, parallel test suites, and anything that scales with core count. Jobs that were comfortable on 6 vCPU will not get faster on 12, so it is worth measuring rather than switching everything over.
-
-Billing follows the machine, at twice the standard shape's rate: $0.15 per machine-minute on demand and $0.12 prepaid. Your existing profiles keep the shape they were created with, so nothing changes until you pick the new one.
+Pick it when you create or edit a macOS profile. The 6 vCPU shape stays the default, and existing profiles keep the shape they were created with.
 
 Learn more in the [runner profiles documentation](https://tuist.dev/en/docs/guides/features/runners/profiles#machine-shapes).

--- a/server/test/tuist/runners/catalog_test.exs
+++ b/server/test/tuist/runners/catalog_test.exs
@@ -86,6 +86,32 @@ defmodule Tuist.Runners.CatalogTest do
       assert Catalog.pool_name(%{platform: :macos, xcode_version: "26.0.1"}) ==
                "#{Tuist.Environment.runners_macos_pool_name_prefix()}-26-0-1"
     end
+
+    test ":macos default shape keeps the shape-free pool name" do
+      # The pools that existed before the catalog gained a second macOS
+      # shape must not be renamed: a `queued` row's `fleet_name` is what a
+      # runner claims against, so a rename strands in-flight work.
+      default = Catalog.default_shape(:macos)
+
+      assert Catalog.pool_name(%{
+               platform: :macos,
+               xcode_version: "26.5",
+               vcpus: default.vcpus,
+               memory_gb: default.memory_gb
+             }) == "#{Tuist.Environment.runners_macos_pool_name_prefix()}-26-5"
+    end
+
+    test ":macos non-default shapes append the shape key" do
+      shape = non_default_macos_shape()
+
+      assert Catalog.pool_name(%{
+               platform: :macos,
+               xcode_version: "26.5",
+               vcpus: shape.vcpus,
+               memory_gb: shape.memory_gb
+             }) ==
+               "#{Tuist.Environment.runners_macos_pool_name_prefix()}-26-5-#{shape.vcpus}vcpu-#{shape.memory_gb}gb"
+    end
   end
 
   describe "resources_for_fleet/1" do
@@ -107,6 +133,24 @@ defmodule Tuist.Runners.CatalogTest do
 
       assert Catalog.resources_for_fleet("macos-26-5") ==
                {:ok, %{platform: :macos, vcpus: macos.vcpus, memory_gb: macos.memory_gb}}
+    end
+
+    test "resolves a macOS pool name through the configured shape catalog" do
+      default = Catalog.default_shape(:macos)
+      shape = non_default_macos_shape()
+
+      Enum.each([default, shape], fn s ->
+        fleet_name =
+          Catalog.pool_name(%{
+            platform: :macos,
+            xcode_version: "26.5",
+            vcpus: s.vcpus,
+            memory_gb: s.memory_gb
+          })
+
+        assert Catalog.resources_for_fleet(fleet_name) ==
+                 {:ok, %{platform: :macos, vcpus: s.vcpus, memory_gb: s.memory_gb}}
+      end)
     end
 
     test "does not infer resources from an unconfigured Linux pool suffix" do
@@ -231,5 +275,16 @@ defmodule Tuist.Runners.CatalogTest do
       refute Catalog.fleet_on_cluster_network?("linux-amd64")
       refute Catalog.fleet_on_cluster_network?("macos-26-5")
     end
+  end
+
+  # The catalog ships more than one macOS shape (see
+  # `config/config.exs`); the tests above assert on whichever entry is
+  # not the default rather than pinning a specific one.
+  defp non_default_macos_shape do
+    shape = Enum.find(Catalog.shapes(:macos), &(not &1.default?))
+
+    refute is_nil(shape), "the macOS shape catalog needs a non-default shape for this test"
+
+    shape
   end
 end


### PR DESCRIPTION
Adds a second macOS runner shape at 12 vCPU / 28 GB to the Tuist Runners catalog, alongside today's 6 vCPU / 14 GB shape. Production only; the existing shape and its `default: true` flag are untouched.

### Why

macOS jobs are CPU-bound and have never been memory-bound. Measured over the 7 days to 2026-08-25 (`runner_job_machine_metrics`, in-guest `active+wired+compressed`, 3,251 macOS jobs):

| | p50 | p90 | p99 | max ever |
| --- | --- | --- | --- | --- |
| peak RSS | 7.6 GiB | 8.8 GiB | 10.0 GiB | 10.2 GiB |

Zero jobs went above 85% of the 14 GiB ceiling. Peak CPU, meanwhile, is p50 100%, with 78% of jobs pegging all 6 vCPUs. So a larger-core shape measurably helps most jobs and a larger-memory shape helps none of them. This monetizes the M4-XL headroom the dual-guest work in #12595 left on the table.

### Why 28 GB and not 56

The original proposal was 12 vCPU / 56 GB, on the reasoning that a 12 vCPU guest takes the host's whole advertised CPU budget, so only one fits and a 28 GB cap would strand memory for a second guest that cannot exist. Verifying that against the autoscaler showed 56 GB is not safe on our hardware, for a reason that has nothing to do with stranding.

`macosFleetAllocatableMemory` sums the fleet's advertised memory and divides by a pool's `podMemoryMB`. The comment on it says it agrees with kube-scheduler "by construction", and it does, but only while memory is the dimension that binds guest count on every host. `hostCPU` and `hostMemoryMB` become Node allocatable verbatim with no reserve, so the scheduler bin-packs both dimensions.

A 56 GB shape forces the M4 group's `hostMemoryMB` from 28672 to 57344. CPU then binds the M4 at 2 guests (12/6) while memory says 4:

| | M2-L x7 | M4-XL x2 | fleet budget for 6/14 | actually placeable |
| --- | --- | --- | --- | --- |
| today, 28672 | 14336 | 28672 | 157696 / 14336 = 11 | 11 |
| with 57344 | 14336 | 57344 | 215040 / 14336 = 15 | 11 |

That hands the five 6 vCPU pools, which carry all of today's traffic, a shared budget of 15 slots against 11 real ones: up to four warm Pods permanently Pending on `Insufficient cpu`, invisible to the allocator. `maxReplicas: 11` does not prevent it, because that clamps each pool individually while the over-count is in the shared budget. Fixing it properly would mean teaching the macOS path to count `min(mem/podMem, cpu/podCPU)` per node, and `AllocateFleet` is deliberately single-budget and unit-agnostic, so there is nowhere to put a second dimension without redesigning it.

28672 MB / 12 vCPU is 2389 MB per vCPU, exactly the 6/14 shape's ratio. Memory therefore keeps binding at the same count CPU does, for both shapes on both SKUs, and `hostMemoryMB` stays at 28672. The belt-and-braces guard the M4 comment describes survives instead of being removed. 28 GB is also 2.7x the largest working set ever measured, and exactly 2x the baseline shape in both dimensions, so `Catalog.billing_multiplier/3` meters it at precisely 20000 basis points with no rounding.

### What changed

- `infra/helm/tuist/templates/runner-pool.yaml` renders macOS pools per Xcode version crossed with each shape. The `default: true` shape keeps its shape-free pool name; other shapes append `-<vcpus>vcpu-<gb>gb`. Renaming the live pools instead would strand `queued` rows whose `fleet_name` is what a runner claims work from, and split fleet analytics at the deploy. `Catalog.pool_name/1` applies the same rule, so the chart and the server cannot drift.
- `infra/helm/tuist/values-managed-production.yaml` adds the shape with `minWarmPoolFloor: 0` and `maxReplicas: 2`, plus the reasoning above on the M4 machine group.
- `infra/helm/tuist/values-managed-common.yaml` keeps the baseline-only catalog. A shape only runs where a host SKU fits it, and staging and canary are M2-L only, so the catalog is now per-environment the way `runnersFleetLinux.shapes` already is. Leaving 12 vCPU in the shared file would offer it in those envs' Profiles dropdown and queue any job picking it forever.
- `infra/helm/tuist/values.yaml` documents the two sizing constraints. The chart default catalog is unchanged, so self-hosters on the default M2-L are not offered a shape they cannot host.
- `server/lib/tuist/runners/catalog.ex`: `pool_name/1` appends the shape key for non-default macOS shapes, and `resources_for_fleet/1` resolves it back instead of always answering with the default shape.
- `server/config/config.exs` adds the shape to the dev/test/CI catalog.
- A non-empty shape catalog now fails the Helm render unless exactly one entry carries `default: true`. Without one, this template rendered a suffixed pool per shape *plus* an unsuffixed fallback (15 macOS pools instead of 5) while `Catalog.pool_name/1` routed every profile to the fallback, because `default_shape/1` was `nil`. An empty list stays legal and renders as before.
- `infra/runners-controller` gains the shape cap and the reservation described below, and `patch` on nodes in its ClusterRole (scoped to `patch`, not `update`, so it can only merge the taint and its timestamp).
- `server/priv/marketing/changelog/` gains the launch entry.

### What needed no change

- **`macosFleetAllocatableMemory` itself.** The byte budget is unchanged and still correct for the 6 vCPU shape; the shape cap is an additional clamp beside it, not a replacement.
- **Billing.** `@platform_baseline_units` is the platform baseline, not a per-shape value, and the numerator already varies by shape. `catalog_test.exs:17` was already asserting `billing_multiplier(:macos, 12, 28) == 2 * billing_multiplier(:macos, 6, 14)`.
- **`config/runtime.exs`.** `parse_shapes_json/1` and its validation are already list-shaped.
- **Profiles UI and docs.** Both read the catalog generically, so the shape surfaces as "12 vCPU, 28 GB RAM" in the dropdown and in the generated shapes table on its own.
- **`maxPods: 5` and `guestCapacity: 2`** on the M4 group. CPU binds every catalog shape at or below 2 guests, and 2 is still the maximum.

### Scheduling a shape that needs two guest slots

A 12 vCPU guest takes both of an M4-XL's slots, and getting them turned out to need two controller changes. Neither is optional: without them the shape is unusable at any real traffic level.

**Pools sharing a shape are now capped at the seats their fleet can place.** `maxReplicas` is a per-pool ceiling and this shape renders one pool per Xcode version, so five pools each allowed 2 composed to 10 against two M4-XL hosts. The shared byte budget could not catch it either, since it pools memory across M2-L hosts that cannot seat a 28 GB Pod at all: 157,696 / 28,672 reads as 5 where 2 are real. The autoscaler now sums each node's own `min(cpu, memory)` quotient per shape instead of dividing a fleet-wide total, which is the question kube-scheduler is actually asked, and `AllocateFleet` caps every pool sharing a shape at that sum. Seats go load first, then warm floor, then headroom, one Pod per pool per round so contenders do not both lose a seat, in name order so the split is stable. darwin only — Linux kata pins memory and oversubscribes CPU by design.

**A starved shape can now reserve a host.** kube-scheduler does not hold its queue on an unschedulable Pod: the 12 vCPU Pod is attempted, fails the CPU filter, is set aside, and the next 6 vCPU Pod binds into the slot that just freed. Being queued longer earns a first attempt, not the seat, so under a steady trickle of small jobs the coincidence of two simultaneously-free slots may never arrive. The cross-pool reclaim does not help — it reclaims speculative warm capacity, and the Pod winning the race is backed by real queued work, the one tier that never yields.

So when a Pod has sat unscheduled past a grace period, the RunnerPool reconciler taints one eligible host `tuist.dev/reserved-for=<pool>:NoSchedule`. Every runner Pod tolerates that key at its own pool's value, so the host stops admitting everyone else while its seats accumulate. Pods running customer jobs are waited out and never evicted; only idle Pods of other pools are retired. The taint lifts when the Pod lands or the reservation times out, and at most one host is held fleet-wide, since a reservation is capacity withdrawn from the small shapes while it converges.

A dedicated taint rather than a cordon: a cordoned node is indistinguishable from one Cluster API is replacing, and `reapIdlePodsOnCordonedNodes` would retire the reserved pool's own Pod the moment it landed and was still warm-polling.

PriorityClass preemption was the obvious alternative and cannot be made safe here. The scheduler picks victims by priority, `spec.priority` is immutable after admission, and a runner Pod becomes job-owning in place — so a priority high enough to evict for the large Pod would also kill customer builds. The signal that separates the two states (`isIdle`) reads init-container status the scheduler never sees, which is why this lives in the controller. `node_drain.go` already rejected label-based selection for the same reason: the owner label is best-effort and can be missing on a Pod that is running a job.

Queuing stays visible throughout: each pool has its own `fleet_name`, so `queue_length` and `queue_oldest_age_seconds` are separately labelled and the existing queue-age alert names the exact pool.

### Pricing

Priced at 2x the baseline, which is exactly what the multiplier already produces: **$0.15 per machine-minute on demand, $0.12 prepaid**, against $0.075 / $0.06 for the 6 vCPU shape.

That needs no Stripe work. Usage is reported gross into the single macOS meter weighted by `Catalog.billing_multiplier/3`, and prepaid is a money-denominated credit grant rather than a minutes ledger, so a new shape prices itself and the 1.25x funding ratio is untouched. No new Meter, Price, or backfill across existing subscriptions, which is the property `Tuist.Runners.Catalog`'s metering design was chosen for.

Cost tracks revenue: a 12 vCPU guest takes a whole M4-XL at EUR 0.49/h against EUR 0.245 for a 6 vCPU slot on the same host. Both double, so the margin matches the baseline shape's on this SKU.

### How to test locally

Render the chart and confirm the change is additive, i.e. no existing pool is renamed or re-specced:

```bash
helm template t infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --show-only templates/runner-pool.yaml
```

Production renders 18 RunnerPool CRs (10 macOS = 5 Xcode x 2 shapes, plus 8 Linux). Staging and canary stay at 13 with 5 macOS pools. Diffing the full rendered chart against `main` for all three envs shows insertions only, apart from randomly generated secrets. `TUIST_RUNNER_MACOS_SHAPES` injects both shapes.

Server side:

```bash
mix test test/tuist/runners test/tuist_web/live/runner_profiles_live_test.exs test/tuist_web/live/runner_jobs_live_test.exs test/tuist_web/live/runner_job_live_test.exs
```

### Validation run

- 756 tests pass across the runners suites and the runner LiveViews, plus 12 docs tests. Three new cases cover the default shape keeping its pool name, non-default shapes getting the suffix, and `resources_for_fleet/1` round-tripping both.
- `go build`, `go vet`, `gofmt` and the full `go test ./...` are clean in `infra/runners-controller`. New coverage: the shape cap holding three Xcode pools to two seats, preferring load over warmth inside the cap, splitting deterministically; the production topology resolving to 11 seats for 6 vCPU and 2 for 12 vCPU; CPU binding where a memory-only division would say 4; and the reservation state machine (holds a host, respects the grace period, retires idle Pods but never running jobs, releases on success and on timeout, skips hosts that could never seat the shape, one host fleet-wide, prefers the host that converges soonest, skips Linux).
- Helm render checked for the added validation: no default and two defaults both fail with a clear message; an empty catalog still renders 5 pools at the legacy sizing; production still renders 10 macOS pools.
- `mix format --check-formatted` and `mix credo` are clean.
- Full-chart render diffed against `main` for production, staging and canary: additive only. Staging and canary gain nothing but four descriptive labels on existing pools.
- Degenerate chart configs checked: an empty `shapes` list still renders exactly one pool per Xcode at the long-standing sizing.
- The one pre-existing `helm lint` failure (`templates/dedibox-fleet.yaml`) reproduces on `main` and is unrelated.

Not validated here, because it needs the hardware: nothing in this change asks Apple's Virtualization.framework for more memory than the M4 group already advertises, so there is no new `memorySize > maximumAllowedMemorySize` risk to test. The first 12 vCPU guest to boot is still worth watching.

### Follow-ups

- The shape cap now counts CPU per node, so a future shape with a different memory-to-vCPU ratio would be sized correctly by the allocator. The `hostMemoryMB` constraint on `runnersFleet.shapes` in `values.yaml` still stands for the scheduler's sake, and is worth re-reading before adding a shape.

Context: dual-guest M4 work landed in #12595, fleet trim in #12605. The fleet today is 7x M2-L at one guest each plus 2x M4-XL at two = 11 slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


