### PR TITLE
fix(server): stop billing and showing the runner minutes a trial covered

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -225,6 +225,16 @@ defmodule Tuist.Billing do
   # Read locally rather than from Stripe: it is our own record of when
   # the account stopped being on a trial, and the subscription carries no
   # trace of when its runner item was added.
+  #
+  # Like the Stripe boundaries beside it, this one is read live and can
+  # move: restarting a trial clears the end and cancelling again stamps a
+  # new one, just as a renewal moves `current_period_start`. Re-reporting
+  # a day whose boundaries have since moved therefore splits it
+  # differently from the original run, and since the meter identifier is
+  # derived from the window, Stripe reads the result as new usage rather
+  # than as a retry. That belongs to every boundary here rather than to
+  # this one, and closing it means recording the windows a reporting run
+  # used instead of recomputing them.
   defp trial_boundaries(%Account{runner_trial_ended_at: nil}), do: []
   defp trial_boundaries(%Account{runner_trial_ended_at: ended_at}), do: [ended_at]
 

--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -190,6 +190,11 @@ defmodule Tuist.Billing do
   row is no longer active or trialing, yet its final cycle is exactly the
   one being reported.
 
+  The end of a runner trial is a boundary for the same reason. It adds
+  the runner item part-way through a day, and an unsplit day is stamped
+  after that item exists, so Stripe bills the whole day including the
+  minutes the trial still covered. See `trial_boundaries/1`.
+
   Returns `{:ok, windows}`, or `{:error, reason}` when Stripe cannot be
   reached. An unknown boundary is not the same as no boundary: on a
   renewal or cancellation day, treating it as none would permanently
@@ -201,12 +206,27 @@ defmodule Tuist.Billing do
   def usage_windows(%Account{} = account, %DateTime{} = period_start, %DateTime{} = period_end) do
     case service_period_boundaries(account) do
       {:ok, boundaries} ->
-        {:ok, split_window(period_start, period_end, boundaries)}
+        {:ok, split_window(period_start, period_end, boundaries ++ trial_boundaries(account))}
 
       {:error, reason} ->
         {:error, reason}
     end
   end
+
+  # A runner trial ends by adding the runner item to the subscription
+  # mid-day. The day's usage is reported as a single event stamped at the
+  # day's end, which postdates the item, so Stripe invoices the whole day
+  # — including the minutes the trial was still covering when they ran.
+  # Cutting the day here gives those minutes an event of their own,
+  # stamped before the item existed, which is what makes the guarantee in
+  # `Tuist.Runners.Trials` hold on the day a trial ends and not only on
+  # the days before it.
+  #
+  # Read locally rather than from Stripe: it is our own record of when
+  # the account stopped being on a trial, and the subscription carries no
+  # trace of when its runner item was added.
+  defp trial_boundaries(%Account{runner_trial_ended_at: nil}), do: []
+  defp trial_boundaries(%Account{runner_trial_ended_at: ended_at}), do: [ended_at]
 
   defp split_window(period_start, period_end, boundaries) do
     cuts =

--- a/server/lib/tuist/billing/workers/sync_customer_stripe_meters_worker.ex
+++ b/server/lib/tuist/billing/workers/sync_customer_stripe_meters_worker.ex
@@ -69,9 +69,10 @@ defmodule Tuist.Billing.Workers.SyncCustomerStripeMetersWorker do
 
       day_values ->
         # Snapshot each service period the day covers separately. A day that
-        # straddles a subscription renewal or its cancellation produces one set
-        # of jobs per side, each reporting only the usage its own period earned,
-        # so no event ever crosses an invoice boundary.
+        # straddles a subscription renewal, its cancellation, or the end of a
+        # runner trial produces one set of jobs per side, each reporting only
+        # the usage its own period earned, so no event ever crosses an invoice
+        # boundary.
         #
         # A failed boundary lookup fails the whole job rather than snapshotting
         # the day as one window. The snapshot is permanent — a child never

--- a/server/lib/tuist/billing/workers/sync_stripe_meters_worker.ex
+++ b/server/lib/tuist/billing/workers/sync_stripe_meters_worker.ex
@@ -24,7 +24,8 @@ defmodule Tuist.Billing.Workers.SyncStripeMetersWorker do
   A whole closed day is exactly what the cron reports, so a manual request
   deduplicates against it rather than racing it. Narrower windows still
   occur internally when `Billing.usage_windows/3` splits at a subscription
-  boundary; both paths split identically, so the identifiers match.
+  or runner-trial boundary; both paths split identically, so the
+  identifiers match.
 
   Either way the customer jobs are released in per-second batches rather
   than all at once, so the Stripe requests they go on to make arrive at a

--- a/server/lib/tuist/runners/allowance.ex
+++ b/server/lib/tuist/runners/allowance.ex
@@ -29,7 +29,6 @@ defmodule Tuist.Runners.Allowance do
   alias Tuist.KeyValueStore
   alias Tuist.Runners.Billing, as: RunnerBilling
   alias Tuist.Runners.Prepaid
-  alias Tuist.Runners.Trials
 
   # Platforms with an agreed rate. Linux joins when it has one.
   @priced_platforms [:macos]
@@ -130,7 +129,7 @@ defmodule Tuist.Runners.Allowance do
     {period_start, period_end} = period || billing_window(account, now)
     # A closed period is reported whole; the open one only as far as now.
     usage_end = if DateTime.before?(now, period_end), do: now, else: period_end
-    billable_from = billable_from(account, period_start, usage_end)
+    trial_window = trial_window(account, period_start, usage_end)
     free_ms = free_monthly_minutes() * 60_000
 
     # Money is only ever put on usage there is a rate for. Linux runs
@@ -141,14 +140,14 @@ defmodule Tuist.Runners.Allowance do
       |> RunnerBilling.compute_milliseconds_per_bucket(period_start, usage_end, :day, platforms: @priced_platforms)
       |> Enum.sort_by(fn {date, _ms} -> Date.to_erl(date) end)
 
-    billable_per_day = billable_per_day(account_id, billable_from, period_start, usage_end, per_day)
+    covered_per_day = covered_per_day(account_id, trial_window)
 
     {days, _remaining} =
       Enum.map_reduce(per_day, free_ms, fn {date, ms}, remaining_free ->
         # The allowance is spent by billable usage only. Letting a day
         # the trial covered consume it would charge the account for
         # minutes the trial was supposed to pay for, one day later.
-        priced = Map.get(billable_per_day, date, 0)
+        priced = ms - Map.get(covered_per_day, date, 0)
         covered = min(priced, remaining_free)
         billable = priced - covered
 
@@ -166,7 +165,7 @@ defmodule Tuist.Runners.Allowance do
       end)
 
     priced_ms = per_day |> Enum.map(&elem(&1, 1)) |> Enum.sum()
-    billable_ms = billable_per_day |> Map.values() |> Enum.sum()
+    covered_ms = covered_per_day |> Map.values() |> Enum.sum()
 
     # Every minute the account ran, priced or not: it did use them, and
     # the minute count is what it is judged against.
@@ -179,53 +178,64 @@ defmodule Tuist.Runners.Allowance do
       minutes: div(total_ms, 60_000),
       free_minutes: free_monthly_minutes(),
       gross: Prepaid.on_demand_cost_for_milliseconds(priced_ms),
-      trial_covered: Prepaid.on_demand_cost_for_milliseconds(priced_ms - billable_ms),
-      billed: Prepaid.on_demand_cost_for_milliseconds(max(billable_ms - free_ms, 0)),
+      trial_covered: Prepaid.on_demand_cost_for_milliseconds(covered_ms),
+      billed: Prepaid.on_demand_cost_for_milliseconds(max(priced_ms - covered_ms - free_ms, 0)),
       days: Enum.reject(days, &(&1.minutes == 0 and &1.gross == Money.new(0, :USD))),
       by_repository:
         RunnerBilling.compute_milliseconds_per_repository(account_id, period_start, usage_end,
           platforms: @priced_platforms
         ),
       projected_days: projected_days(priced_ms, period_start, period_end, usage_end),
-      platforms: platform_rows(account_id, period_start, period_end, usage_end, billable_from)
+      platforms: platform_rows(account_id, period_start, period_end, usage_end, trial_window)
     }
   end
 
-  # The instant this period's runner usage starts landing on an invoice,
-  # or `nil` when none of it does.
+  # The slice of `[period_start, usage_end]` a runner trial covered, or
+  # `nil` when it covered none of it.
   #
   # A trial is the absence of a runner item on the subscription, so the
   # usage it covered has nothing to be invoiced against, and ending one
   # adds the item with `proration_behavior: "none"` so Stripe bills from
-  # that instant rather than from the period start. A breakdown that
-  # priced the whole period showed a bill no invoice was going to carry
-  # for the rest of the period the trial ended in.
-  defp billable_from(%Account{} = account, period_start, usage_end) do
-    cond do
-      Trials.on_trial?(account) -> nil
-      is_nil(account.runner_trial_ended_at) -> period_start
-      DateTime.after?(account.runner_trial_ended_at, usage_end) -> nil
-      DateTime.after?(account.runner_trial_ended_at, period_start) -> account.runner_trial_ended_at
-      true -> period_start
-    end
+  # that instant on. What the trial covers is therefore an interval, and
+  # a period is covered only where it overlaps that interval: usage that
+  # ran before the trial started was billable, and so is usage after it
+  # ended. The page offers a year of history, so a period that closed
+  # before the trial began has to keep reading as fully billable.
+  #
+  # A restarted trial overwrites both timestamps, so a period covered by
+  # an earlier trial reads as billable. Reconstructing that needs a
+  # record of every transition rather than of the latest one. It is only
+  # ever a display inaccuracy: an account carries no runner item while a
+  # trial runs, so it was not invoiced for those minutes either.
+  defp trial_window(%Account{runner_trial_started_at: nil}, _period_start, _usage_end), do: nil
+
+  defp trial_window(%Account{} = account, period_start, usage_end) do
+    from = latest(account.runner_trial_started_at, period_start)
+    to = earliest(account.runner_trial_ended_at || usage_end, usage_end)
+
+    if DateTime.before?(from, to), do: {from, to}
   end
 
-  # Per-day billable milliseconds, which are the whole period's for
-  # every account that has never been on a trial. Measured a second time
-  # rather than sliced out of `per_day`, because the trial can end
+  # Per-day milliseconds a trial covered. Measured rather than sliced out
+  # of the period's own buckets, because a trial can start or end
   # part-way through a day and only the query knows how much of that
-  # day's runs fell on each side of it.
-  defp billable_per_day(_account_id, nil, _period_start, _usage_end, _per_day), do: %{}
+  # day's runs fell on each side.
+  defp covered_per_day(_account_id, nil), do: %{}
 
-  defp billable_per_day(account_id, billable_from, period_start, usage_end, per_day) do
-    if DateTime.compare(billable_from, period_start) == :eq do
-      Map.new(per_day)
-    else
-      RunnerBilling.compute_milliseconds_per_bucket(account_id, billable_from, usage_end, :day,
-        platforms: @priced_platforms
-      )
-    end
+  defp covered_per_day(account_id, {from, to}) do
+    RunnerBilling.compute_milliseconds_per_bucket(account_id, from, to, :day, platforms: @priced_platforms)
   end
+
+  # True when a trial covered the period end to end, and so the account
+  # cannot reach its allowance anywhere in it.
+  defp fully_covered?(nil, _period_start, _usage_end), do: false
+
+  defp fully_covered?({from, to}, period_start, usage_end) do
+    not DateTime.after?(from, period_start) and not DateTime.before?(to, usage_end)
+  end
+
+  defp latest(a, b), do: if(DateTime.after?(a, b), do: a, else: b)
+  defp earliest(a, b), do: if(DateTime.before?(a, b), do: a, else: b)
 
   # One row per platform there is a rate for, whether or not it ran.
   # An account has an allowance before it runs anything, and a receipt
@@ -237,7 +247,7 @@ defmodule Tuist.Runners.Allowance do
   # far, where that lands by the end of it, what the plan covers, and
   # what the period before it came
   # to.
-  defp platform_rows(account_id, period_start, period_end, usage_end, billable_from) do
+  defp platform_rows(account_id, period_start, period_end, usage_end, trial_window) do
     # The period immediately before this one, the same length, so
     # "previous period" compares like with like whether the window is a
     # subscription cycle or a calendar month.
@@ -248,14 +258,17 @@ defmodule Tuist.Runners.Allowance do
 
     by_platform = milliseconds_by_platform(account_id, period_start, usage_end)
 
-    billable_by_platform =
-      if is_nil(billable_from), do: %{}, else: milliseconds_by_platform(account_id, billable_from, usage_end)
+    covered_by_platform = covered_by_platform(account_id, trial_window)
+    reachable_allowance? = not fully_covered?(trial_window, period_start, usage_end)
 
-    billable_total_ms = billable_by_platform |> Map.take(@priced_platforms) |> Map.values() |> Enum.sum()
+    billable_total_ms =
+      @priced_platforms
+      |> Enum.map(&(Map.get(by_platform, &1, 0) - Map.get(covered_by_platform, &1, 0)))
+      |> Enum.sum()
 
     Enum.map(@priced_platforms, fn platform ->
       ms = Map.get(by_platform, platform, 0)
-      billable_ms = Map.get(billable_by_platform, platform, 0)
+      billable_ms = ms - Map.get(covered_by_platform, platform, 0)
 
       %{
         id: to_string(platform),
@@ -267,7 +280,7 @@ defmodule Tuist.Runners.Allowance do
         # a rate to spend it at. macOS is the only one so far. An
         # account with nothing billable in the period cannot reach it at
         # all, and a line it can never spend is worse than no line.
-        included_minutes: if(platform == :macos and not is_nil(billable_from), do: free_monthly_minutes()),
+        included_minutes: if(platform == :macos and reachable_allowance?, do: free_monthly_minutes()),
         previous_minutes: previous_by_platform |> Map.get(platform, 0) |> div(60_000),
         gross: platform_cost(platform, ms),
         trial_covered: platform_cost(platform, ms - billable_ms),
@@ -296,6 +309,10 @@ defmodule Tuist.Runners.Allowance do
       |> Enum.map(&%{date: &1, total_ms: daily_ms})
     end
   end
+
+  defp covered_by_platform(_account_id, nil), do: %{}
+
+  defp covered_by_platform(account_id, {from, to}), do: milliseconds_by_platform(account_id, from, to)
 
   defp milliseconds_by_platform(account_id, period_start, period_end) do
     account_id

--- a/server/lib/tuist/runners/allowance.ex
+++ b/server/lib/tuist/runners/allowance.ex
@@ -116,18 +116,21 @@ defmodule Tuist.Runners.Allowance do
   carry a gross figure larger than their billed one and the days before
   it bill nothing. That split is the point: it shows where the free tier
   ran out rather than presenting one blended number.
+
+  Usage a runner trial covered is reported and valued but never priced,
+  and never spends the allowance either. `trial_covered` is what the
+  trial took off, so a period the trial ended part-way through reads as
+  minutes run, less what the trial covered, less what the plan includes,
+  leaving what is billed.
   """
   def period_breakdown(account, period \\ nil)
 
   def period_breakdown(%Account{id: account_id} = account, period) do
-    # An account on a trial is billed nothing for runner usage, so the
-    # breakdown must say so too. Reporting what it would otherwise owe
-    # would contradict the bill it is actually going to get.
-    on_trial = Trials.on_trial?(account)
     now = DateTime.utc_now()
     {period_start, period_end} = period || billing_window(account, now)
     # A closed period is reported whole; the open one only as far as now.
     usage_end = if DateTime.before?(now, period_end), do: now, else: period_end
+    billable_from = billable_from(account, period_start, usage_end)
     free_ms = free_monthly_minutes() * 60_000
 
     # Money is only ever put on usage there is a rate for. Linux runs
@@ -138,10 +141,16 @@ defmodule Tuist.Runners.Allowance do
       |> RunnerBilling.compute_milliseconds_per_bucket(period_start, usage_end, :day, platforms: @priced_platforms)
       |> Enum.sort_by(fn {date, _ms} -> Date.to_erl(date) end)
 
+    billable_per_day = billable_per_day(account_id, billable_from, period_start, usage_end, per_day)
+
     {days, _remaining} =
       Enum.map_reduce(per_day, free_ms, fn {date, ms}, remaining_free ->
-        covered = min(ms, remaining_free)
-        billable = ms - covered
+        # The allowance is spent by billable usage only. Letting a day
+        # the trial covered consume it would charge the account for
+        # minutes the trial was supposed to pay for, one day later.
+        priced = Map.get(billable_per_day, date, 0)
+        covered = min(priced, remaining_free)
+        billable = priced - covered
 
         day = %{
           # The table keys rows on `:id`; without one every row shares a
@@ -157,6 +166,7 @@ defmodule Tuist.Runners.Allowance do
       end)
 
     priced_ms = per_day |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+    billable_ms = billable_per_day |> Map.values() |> Enum.sum()
 
     # Every minute the account ran, priced or not: it did use them, and
     # the minute count is what it is judged against.
@@ -169,23 +179,52 @@ defmodule Tuist.Runners.Allowance do
       minutes: div(total_ms, 60_000),
       free_minutes: free_monthly_minutes(),
       gross: Prepaid.on_demand_cost_for_milliseconds(priced_ms),
-      billed:
-        if(on_trial,
-          do: Money.new(0, :USD),
-          else: Prepaid.on_demand_cost_for_milliseconds(max(priced_ms - free_ms, 0))
-        ),
+      trial_covered: Prepaid.on_demand_cost_for_milliseconds(priced_ms - billable_ms),
+      billed: Prepaid.on_demand_cost_for_milliseconds(max(billable_ms - free_ms, 0)),
       days: Enum.reject(days, &(&1.minutes == 0 and &1.gross == Money.new(0, :USD))),
       by_repository:
         RunnerBilling.compute_milliseconds_per_repository(account_id, period_start, usage_end,
           platforms: @priced_platforms
         ),
       projected_days: projected_days(priced_ms, period_start, period_end, usage_end),
-      on_trial: on_trial,
-      platforms:
-        account_id
-        |> platform_rows(period_start, period_end, usage_end, priced_ms)
-        |> zero_billed_on_trial(on_trial)
+      platforms: platform_rows(account_id, period_start, period_end, usage_end, billable_from)
     }
+  end
+
+  # The instant this period's runner usage starts landing on an invoice,
+  # or `nil` when none of it does.
+  #
+  # A trial is the absence of a runner item on the subscription, so the
+  # usage it covered has nothing to be invoiced against, and ending one
+  # adds the item with `proration_behavior: "none"` so Stripe bills from
+  # that instant rather than from the period start. A breakdown that
+  # priced the whole period showed a bill no invoice was going to carry
+  # for the rest of the period the trial ended in.
+  defp billable_from(%Account{} = account, period_start, usage_end) do
+    cond do
+      Trials.on_trial?(account) -> nil
+      is_nil(account.runner_trial_ended_at) -> period_start
+      DateTime.after?(account.runner_trial_ended_at, usage_end) -> nil
+      DateTime.after?(account.runner_trial_ended_at, period_start) -> account.runner_trial_ended_at
+      true -> period_start
+    end
+  end
+
+  # Per-day billable milliseconds, which are the whole period's for
+  # every account that has never been on a trial. Measured a second time
+  # rather than sliced out of `per_day`, because the trial can end
+  # part-way through a day and only the query knows how much of that
+  # day's runs fell on each side of it.
+  defp billable_per_day(_account_id, nil, _period_start, _usage_end, _per_day), do: %{}
+
+  defp billable_per_day(account_id, billable_from, period_start, usage_end, per_day) do
+    if DateTime.compare(billable_from, period_start) == :eq do
+      Map.new(per_day)
+    else
+      RunnerBilling.compute_milliseconds_per_bucket(account_id, billable_from, usage_end, :day,
+        platforms: @priced_platforms
+      )
+    end
   end
 
   # One row per platform there is a rate for, whether or not it ran.
@@ -198,7 +237,7 @@ defmodule Tuist.Runners.Allowance do
   # far, where that lands by the end of it, what the plan covers, and
   # what the period before it came
   # to.
-  defp platform_rows(account_id, period_start, period_end, now, total_ms) do
+  defp platform_rows(account_id, period_start, period_end, usage_end, billable_from) do
     # The period immediately before this one, the same length, so
     # "previous period" compares like with like whether the window is a
     # subscription cycle or a calendar month.
@@ -207,23 +246,32 @@ defmodule Tuist.Runners.Allowance do
 
     previous_by_platform = milliseconds_by_platform(account_id, previous_start, previous_end)
 
-    by_platform = milliseconds_by_platform(account_id, period_start, now)
+    by_platform = milliseconds_by_platform(account_id, period_start, usage_end)
 
-    @priced_platforms
-    |> Enum.map(fn platform -> {platform, Map.get(by_platform, platform, 0)} end)
-    |> Enum.map(fn {platform, ms} ->
+    billable_by_platform =
+      if is_nil(billable_from), do: %{}, else: milliseconds_by_platform(account_id, billable_from, usage_end)
+
+    billable_total_ms = billable_by_platform |> Map.take(@priced_platforms) |> Map.values() |> Enum.sum()
+
+    Enum.map(@priced_platforms, fn platform ->
+      ms = Map.get(by_platform, platform, 0)
+      billable_ms = Map.get(billable_by_platform, platform, 0)
+
       %{
         id: to_string(platform),
         platform: platform,
         minutes: div(ms, 60_000),
-        projected_minutes: project(ms, period_start, period_end, now),
+        projected_minutes: project(ms, period_start, period_end, usage_end),
         # The allowance is one pot for the account rather than one per
         # platform, so it is only meaningful against a platform that has
-        # a rate to spend it at. macOS is the only one so far.
-        included_minutes: if(platform == :macos, do: free_monthly_minutes()),
+        # a rate to spend it at. macOS is the only one so far. An
+        # account with nothing billable in the period cannot reach it at
+        # all, and a line it can never spend is worse than no line.
+        included_minutes: if(platform == :macos and not is_nil(billable_from), do: free_monthly_minutes()),
         previous_minutes: previous_by_platform |> Map.get(platform, 0) |> div(60_000),
         gross: platform_cost(platform, ms),
-        billed: platform_cost(platform, billable_milliseconds(platform, ms, total_ms))
+        trial_covered: platform_cost(platform, ms - billable_ms),
+        billed: platform_cost(platform, billable_milliseconds(billable_ms, billable_total_ms))
       }
     end)
   end
@@ -249,14 +297,6 @@ defmodule Tuist.Runners.Allowance do
     end
   end
 
-  defp zero_billed_on_trial(rows, false), do: rows
-
-  defp zero_billed_on_trial(rows, true) do
-    Enum.map(rows, fn row ->
-      %{row | billed: if(is_nil(row.gross), do: nil, else: Money.new(0, :USD))}
-    end)
-  end
-
   defp milliseconds_by_platform(account_id, period_start, period_end) do
     account_id
     |> RunnerBilling.compute_milliseconds_by_machine(period_start, period_end)
@@ -273,8 +313,8 @@ defmodule Tuist.Runners.Allowance do
 
   # The allowance is spent by the account, not by the platform, so a
   # platform's billable share is what is left of it after the account's
-  # free milliseconds are taken off the whole period.
-  defp billable_milliseconds(_platform, ms, total_ms) do
+  # free milliseconds are taken off the period's billable total.
+  defp billable_milliseconds(ms, total_ms) do
     free_ms = free_monthly_minutes() * 60_000
     billable_total = max(total_ms - free_ms, 0)
 

--- a/server/lib/tuist/runners/trials.ex
+++ b/server/lib/tuist/runners/trials.ex
@@ -32,6 +32,14 @@ defmodule Tuist.Runners.Trials do
   the amount accrued before they existed. Without it the default
   proration can invoice exactly the minutes the trial was covering.
 
+  That holds for whole days, and the day the trial ends needs one thing
+  more. Usage is reported as one meter event per UTC day, stamped at the
+  day's end, which postdates the item a mid-day cancellation adds — so
+  an unsplit day is invoiced entire. `Billing.usage_windows/3` therefore
+  treats `runner_trial_ended_at` as a service-period boundary and cuts
+  that day in two, leaving the trial's own minutes in an event stamped
+  before the item existed.
+
   On `billing_mode=classic` this is belt and braces, since adding a
   meter-priced item mid-cycle already bills only from the date it was
   added. On `flexible`, where Stripe otherwise prices usage at whatever

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -37,20 +37,30 @@ defmodule TuistWeb.UsageLive do
     # nothing.
     periods = Billing.recent_billing_periods(account, 12)
 
+    # Read once and kept, because `handle_params/3` runs on every period
+    # change and `Prepaid.balance/2` does not cache a nil: an account
+    # with no credit would otherwise pay a Stripe round trip each time.
+    prepaid_balance = Prepaid.balance(account)
+
     {:ok,
      socket
      |> assign(:head_title, "#{dgettext("dashboard_usage", "Usage")} · #{account.name} · Tuist")
      |> assign(:periods, periods)
      |> assign(:runner_breakdown, runner_breakdown)
      |> assign(:runners_enabled, runners_enabled)
-     |> assign(:prepaid_coverage, prepaid_coverage(Prepaid.balance(account), runner_breakdown))
+     |> assign(:prepaid_balance, prepaid_balance)
+     |> assign(:prepaid_coverage, prepaid_coverage(prepaid_balance, runner_breakdown))
      |> assign(:kura_enabled, FeatureFlags.kura_enabled?(account))}
   end
 
   @widgets ["egress", "ingress", "requests"]
 
   @impl true
-  def handle_params(params, uri, %{assigns: %{selected_account: account, periods: periods}} = socket) do
+  def handle_params(
+        params,
+        uri,
+        %{assigns: %{selected_account: account, periods: periods, prepaid_balance: prepaid_balance}} = socket
+      ) do
     {start_dt, end_dt} = period = selected_period(periods, params["period"])
     selected_widget = widget_param(params["widget"])
 
@@ -76,7 +86,7 @@ defmodule TuistWeb.UsageLive do
      |> assign(:analytics_selected_widget, selected_widget)
      |> assign(:analytics_trend_label, dgettext("dashboard_usage", "since the previous period"))
      |> assign(:runner_breakdown, runner_breakdown)
-     |> assign(:prepaid_coverage, prepaid_coverage(Prepaid.balance(account), runner_breakdown))
+     |> assign(:prepaid_coverage, period_coverage(prepaid_balance, runner_breakdown, period == hd(periods)))
      |> assign_async(
        [:totals, :egress_series, :ingress_series, :requests_series, :per_region],
        fn ->
@@ -91,6 +101,14 @@ defmodule TuistWeb.UsageLive do
        end
      )}
   end
+
+  # A prepaid balance is what the account holds today, so it describes
+  # only the period still being accrued. The grants that covered a closed
+  # period were drawn down when it was invoiced, and today's balance says
+  # nothing about what that invoice came to, so a closed period reports
+  # its usage charge and no credit at all.
+  defp period_coverage(_balance, _breakdown, false), do: nil
+  defp period_coverage(balance, breakdown, true), do: prepaid_coverage(balance, breakdown)
 
   @doc """
   The period whose start matches the `period` param, or the current one.

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -405,8 +405,14 @@ defmodule TuistWeb.UsageLive do
   """
   def included_credit_label(%{included_minutes: nil}), do: "—"
 
-  def included_credit_label(%{gross: gross, billed: billed}) when not is_nil(gross) do
-    "−" <> CldrHelpers.format_money(Money.subtract(gross, billed))
+  def included_credit_label(%{gross: gross, trial_covered: trial_covered, billed: billed}) when not is_nil(gross) do
+    # What a trial covered has a credit line of its own, so the allowance
+    # only ever takes money off what was left billable after it. Reading
+    # this off gross would subtract the trial twice.
+    gross
+    |> Money.subtract(trial_covered)
+    |> Money.subtract(billed)
+    |> credit_label()
   end
 
   def included_credit_label(_row), do: "—"

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -43,7 +43,7 @@ defmodule TuistWeb.UsageLive do
      |> assign(:periods, periods)
      |> assign(:runner_breakdown, runner_breakdown)
      |> assign(:runners_enabled, runners_enabled)
-     |> assign(:prepaid_balance, Prepaid.balance(account))
+     |> assign(:prepaid_coverage, prepaid_coverage(Prepaid.balance(account), runner_breakdown))
      |> assign(:kura_enabled, FeatureFlags.kura_enabled?(account))}
   end
 
@@ -65,6 +65,8 @@ defmodule TuistWeb.UsageLive do
 
     usage_end = if DateTime.before?(DateTime.utc_now(), end_dt), do: DateTime.utc_now(), else: end_dt
 
+    runner_breakdown = Allowance.period_breakdown(account, period)
+
     {:noreply,
      socket
      |> assign(:uri, URI.parse(uri))
@@ -73,7 +75,8 @@ defmodule TuistWeb.UsageLive do
      |> assign(:bucket, :day)
      |> assign(:analytics_selected_widget, selected_widget)
      |> assign(:analytics_trend_label, dgettext("dashboard_usage", "since the previous period"))
-     |> assign(:runner_breakdown, Allowance.period_breakdown(account, period))
+     |> assign(:runner_breakdown, runner_breakdown)
+     |> assign(:prepaid_coverage, prepaid_coverage(Prepaid.balance(account), runner_breakdown))
      |> assign_async(
        [:totals, :egress_series, :ingress_series, :requests_series, :per_region],
        fn ->
@@ -358,17 +361,23 @@ defmodule TuistWeb.UsageLive do
   """
   def prepaid_coverage(nil, _breakdown), do: nil
 
-  def prepaid_coverage(%{available: available}, %{platforms: platforms}) do
-    billed =
-      platforms
-      |> Enum.map(& &1.billed)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.reduce(Money.new(0, :USD), &Money.add(&2, &1))
-
+  def prepaid_coverage(%{available: available}, %{billed: billed}) do
     covered = if Money.compare(available, billed) == -1, do: available, else: billed
 
     %{available: available, covered: covered, due: Money.subtract(billed, covered)}
   end
+
+  @doc """
+  What the account owes for the period: the usage charge less whatever
+  its prepaid balance would cover today.
+
+  This is the figure a customer reads first, so it has to be the money
+  rather than the line item the money lands on. The receipt below the
+  widget breaks the same number down into balance, drawdown and
+  remainder.
+  """
+  def amount_due(%{billed: billed}, nil), do: billed
+  def amount_due(_breakdown, %{due: due}), do: due
 
   @doc """
   The money a runner trial took off this row, or `nil` when it took

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -49,7 +49,6 @@ defmodule TuistWeb.UsageLive do
      |> assign(:runner_breakdown, runner_breakdown)
      |> assign(:runners_enabled, runners_enabled)
      |> assign(:prepaid_balance, prepaid_balance)
-     |> assign(:prepaid_coverage, prepaid_coverage(prepaid_balance, runner_breakdown))
      |> assign(:kura_enabled, FeatureFlags.kura_enabled?(account))}
   end
 

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -371,6 +371,15 @@ defmodule TuistWeb.UsageLive do
   end
 
   @doc """
+  The money a runner trial took off this row, or `nil` when it took
+  none. A zero credit is a line that explains nothing, and an account
+  that was never on a trial has no business being told about one.
+  """
+  def trial_credit(%{trial_covered: nil}), do: nil
+  def trial_credit(%{trial_covered: %Money{amount: 0}}), do: nil
+  def trial_credit(%{trial_covered: covered}), do: covered
+
+  @doc """
   A credit, signed only when there is something to subtract. A bare
   "−0.00" reads as a rounding artefact rather than as nothing owed.
   """

--- a/server/lib/tuist_web/live/usage_live.html.heex
+++ b/server/lib/tuist_web/live/usage_live.html.heex
@@ -63,8 +63,10 @@
         <.widget
           id="widget-runner-billed"
           title={dgettext("dashboard_usage", "Billed")}
-          description={dgettext("dashboard_usage", "What lands on your invoice")}
-          value={format_money(@runner_breakdown.billed)}
+          description={dgettext("dashboard_usage", "What you'll owe for this period")}
+          value={
+            format_money(TuistWeb.UsageLive.amount_due(@runner_breakdown, @prepaid_coverage))
+          }
         />
       </div>
     </.card_section>
@@ -123,23 +125,22 @@
           <% pace = TuistWeb.UsageLive.pace_label(row) %>
           <p :if={pace} data-part="footnote">{pace}</p>
         </div>
-        <% coverage = TuistWeb.UsageLive.prepaid_coverage(@prepaid_balance, @runner_breakdown) %>
-        <div :if={coverage} data-part="receipt" data-kind="prepaid">
+        <div :if={@prepaid_coverage} data-part="receipt" data-kind="prepaid">
           <div data-part="heading">
             <span data-part="platform">{dgettext("dashboard_usage", "Prepaid credit")}</span>
           </div>
           <dl data-part="lines">
             <div data-part="line">
               <dt>{dgettext("dashboard_usage", "Balance")}</dt>
-              <dd>{TuistWeb.UsageLive.money_label(coverage.available)}</dd>
+              <dd>{TuistWeb.UsageLive.money_label(@prepaid_coverage.available)}</dd>
             </div>
             <div data-part="line" data-kind="credit">
               <dt>{dgettext("dashboard_usage", "Covers this period")}</dt>
-              <dd>{TuistWeb.UsageLive.credit_label(coverage.covered)}</dd>
+              <dd>{TuistWeb.UsageLive.credit_label(@prepaid_coverage.covered)}</dd>
             </div>
             <div data-part="line" data-kind="total">
               <dt>{dgettext("dashboard_usage", "Left to pay")}</dt>
-              <dd>{TuistWeb.UsageLive.money_label(coverage.due)}</dd>
+              <dd>{TuistWeb.UsageLive.money_label(@prepaid_coverage.due)}</dd>
             </div>
           </dl>
           <p data-part="footnote">

--- a/server/lib/tuist_web/live/usage_live.html.heex
+++ b/server/lib/tuist_web/live/usage_live.html.heex
@@ -102,19 +102,12 @@
               </dt>
               <dd>{TuistWeb.UsageLive.money_label(row.gross)}</dd>
             </div>
-            <div
-              :if={@runner_breakdown.on_trial and row.gross}
-              data-part="line"
-              data-kind="credit"
-            >
+            <% trial_credit = TuistWeb.UsageLive.trial_credit(row) %>
+            <div :if={trial_credit} data-part="line" data-kind="credit">
               <dt>{dgettext("dashboard_usage", "Covered by your trial")}</dt>
-              <dd>{TuistWeb.UsageLive.credit_label(row.gross)}</dd>
+              <dd>{TuistWeb.UsageLive.credit_label(trial_credit)}</dd>
             </div>
-            <div
-              :if={row.included_minutes && not @runner_breakdown.on_trial}
-              data-part="line"
-              data-kind="credit"
-            >
+            <div :if={row.included_minutes} data-part="line" data-kind="credit">
               <dt>
                 {dgettext("dashboard_usage", "%{count} minutes included",
                   count: row.included_minutes

--- a/server/priv/gettext/dashboard_usage.pot
+++ b/server/priv/gettext/dashboard_usage.pot
@@ -11,13 +11,13 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:307
+#: lib/tuist_web/live/usage_live.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:211
-#: lib/tuist_web/live/usage_live.html.heex:316
+#: lib/tuist_web/live/usage_live.html.heex:205
+#: lib/tuist_web/live/usage_live.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
@@ -33,52 +33,52 @@ msgstr ""
 msgid "Usage"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:171
-#: lib/tuist_web/live/usage_live.html.heex:310
+#: lib/tuist_web/live/usage_live.html.heex:165
+#: lib/tuist_web/live/usage_live.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Egress"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:191
-#: lib/tuist_web/live/usage_live.html.heex:313
+#: lib/tuist_web/live/usage_live.html.heex:185
+#: lib/tuist_web/live/usage_live.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Ingress"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:339
-#: lib/tuist_web/live/usage_live.ex:340
-#: lib/tuist_web/live/usage_live.ex:447
-#: lib/tuist_web/live/usage_live.ex:448
+#: lib/tuist_web/live/usage_live.ex:342
+#: lib/tuist_web/live/usage_live.ex:343
+#: lib/tuist_web/live/usage_live.ex:465
+#: lib/tuist_web/live/usage_live.ex:466
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:194
+#: lib/tuist_web/live/usage_live.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Bytes received by the cache from clients (cache uploads) in the selected window."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:174
+#: lib/tuist_web/live/usage_live.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Bytes sent from the cache to clients (cache downloads) in the selected window."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:164
+#: lib/tuist_web/live/usage_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Cache traffic"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:455
+#: lib/tuist_web/live/usage_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "No cache traffic in this window yet"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:214
+#: lib/tuist_web/live/usage_live.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Number of cache requests served in the selected window."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:273
+#: lib/tuist_web/live/usage_live.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Traffic by region"
 msgstr ""
@@ -123,57 +123,52 @@ msgstr ""
 msgid "Usage value"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:66
-#, elixir-autogen, elixir-format
-msgid "What lands on your invoice"
-msgstr ""
-
-#: lib/tuist_web/live/usage_live.ex:427
+#: lib/tuist_web/live/usage_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Linux"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:426
+#: lib/tuist_web/live/usage_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "macOS"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:119
+#: lib/tuist_web/live/usage_live.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "%{count} minutes included"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:99
+#: lib/tuist_web/live/usage_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "%{count} minutes run"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:126
+#: lib/tuist_web/live/usage_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Billed this period"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:140
+#: lib/tuist_web/live/usage_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Balance"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:144
+#: lib/tuist_web/live/usage_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Covers this period"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:153
+#: lib/tuist_web/live/usage_live.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Drawn down when the period is invoiced, so this is what your balance would cover today."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:148
+#: lib/tuist_web/live/usage_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Left to pay"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:136
+#: lib/tuist_web/live/usage_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Prepaid credit"
 msgstr ""
@@ -183,42 +178,47 @@ msgstr ""
 msgid "Billing period:"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:402
+#: lib/tuist_web/live/usage_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count} minutes."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:422
+#: lib/tuist_web/live/usage_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count}."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:414
+#: lib/tuist_web/live/usage_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Nothing ran last period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:408
+#: lib/tuist_web/live/usage_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "On track for about %{count} minutes this period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:75
+#: lib/tuist_web/live/usage_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "since the previous period"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:332
+#: lib/tuist_web/live/usage_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Projected"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:435
+#: lib/tuist_web/live/usage_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "Current period %{from} – %{to}"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:110
+#: lib/tuist_web/live/usage_live.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Covered by your trial"
+msgstr ""
+
+#: lib/tuist_web/live/usage_live.html.heex:66
+#, elixir-autogen, elixir-format
+msgid "What you'll owe for this period"
 msgstr ""

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -10,6 +10,7 @@ defmodule Tuist.BillingTest do
   alias Tuist.Billing.Customer
   alias Tuist.Billing.PaymentMethod
   alias Tuist.Environment
+  alias Tuist.Repo
   alias Tuist.Runners.Billing, as: RunnerBilling
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.BillingFixtures
@@ -1124,6 +1125,83 @@ defmodule Tuist.BillingTest do
       assert Billing.usage_windows(account, period_start, period_end) == {:error, error}
     end
 
+    test "splits the window where a runner trial ended inside it", %{account: account} do
+      # The day a trial is cancelled is reported as one event stamped at
+      # the day's end, which postdates the runner item the cancellation
+      # adds — so Stripe billed the whole day, including the minutes the
+      # trial still covered. Splitting puts those in an event of their
+      # own, stamped before the item existed.
+      period_start = ~U[2026-07-16 00:00:00.000000Z]
+      period_end = ~U[2026-07-17 00:00:00.000000Z]
+      trial_end = ~U[2026-07-16 11:15:00Z]
+
+      account = runner_trial_ended(account, trial_end)
+      subscription_with_stripe(account, %{current_period_start: DateTime.to_unix(~U[2026-07-01 00:00:00Z])})
+
+      assert Billing.usage_windows(account, period_start, period_end) ==
+               {:ok,
+                [
+                  {period_start, trial_end},
+                  {trial_end, period_end}
+                ]}
+    end
+
+    test "keeps the window whole when the trial ended outside it", %{account: account} do
+      period_start = ~U[2026-07-16 00:00:00.000000Z]
+      period_end = ~U[2026-07-17 00:00:00.000000Z]
+
+      account = runner_trial_ended(account, ~U[2026-07-12 11:15:00Z])
+      subscription_with_stripe(account, %{current_period_start: DateTime.to_unix(~U[2026-07-01 00:00:00Z])})
+
+      assert Billing.usage_windows(account, period_start, period_end) == {:ok, [{period_start, period_end}]}
+    end
+
+    test "splits at a trial end and a renewal falling in the same window", %{account: account} do
+      period_start = ~U[2026-07-16 00:00:00.000000Z]
+      period_end = ~U[2026-07-17 00:00:00.000000Z]
+      renewal = ~U[2026-07-16 06:00:00Z]
+      trial_end = ~U[2026-07-16 18:00:00Z]
+
+      account = runner_trial_ended(account, trial_end)
+      subscription_with_stripe(account, %{current_period_start: DateTime.to_unix(renewal)})
+
+      assert Billing.usage_windows(account, period_start, period_end) ==
+               {:ok,
+                [
+                  {period_start, renewal},
+                  {renewal, trial_end},
+                  {trial_end, period_end}
+                ]}
+    end
+
+    test "splits at a trial end for an account with no subscription", %{account: account} do
+      # Nothing is invoiced for such an account either way, but the split
+      # is the same one the reporting path takes everywhere else, and a
+      # boundary that appears only for subscribers is a boundary that has
+      # to be reasoned about twice.
+      period_start = ~U[2026-07-16 00:00:00.000000Z]
+      period_end = ~U[2026-07-17 00:00:00.000000Z]
+      trial_end = ~U[2026-07-16 11:15:00Z]
+
+      account = runner_trial_ended(account, trial_end)
+
+      assert Billing.usage_windows(account, period_start, period_end) ==
+               {:ok,
+                [
+                  {period_start, trial_end},
+                  {trial_end, period_end}
+                ]}
+    end
+
+    defp runner_trial_ended(account, at) do
+      account
+      |> Ecto.Changeset.change(
+        runner_trial_started_at: at |> DateTime.add(-30, :day) |> DateTime.truncate(:second),
+        runner_trial_ended_at: DateTime.truncate(at, :second)
+      )
+      |> Repo.update!()
+    end
+
     defp subscription_with_stripe(account, stripe_attrs, opts \\ []) do
       subscription_id = "sub-#{UUIDv7.generate()}"
 
@@ -1206,14 +1284,14 @@ defmodule Tuist.BillingTest do
       period_end = ~U[2025-01-02 00:00:00Z]
 
       org = AccountsFixtures.organization_fixture()
-      account = Tuist.Repo.get_by!(Account, organization_id: org.id)
-      account = Tuist.Repo.update!(Account.billing_changeset(account, %{customer_id: "cust_" <> UUIDv7.generate()}))
+      account = Repo.get_by!(Account, organization_id: org.id)
+      account = Repo.update!(Account.billing_changeset(account, %{customer_id: "cust_" <> UUIDv7.generate()}))
 
       other_org = AccountsFixtures.organization_fixture()
-      other_account = Tuist.Repo.get_by!(Account, organization_id: other_org.id)
+      other_account = Repo.get_by!(Account, organization_id: other_org.id)
 
       other_account =
-        Tuist.Repo.update!(Account.billing_changeset(other_account, %{customer_id: "cust_" <> UUIDv7.generate()}))
+        Repo.update!(Account.billing_changeset(other_account, %{customer_id: "cust_" <> UUIDv7.generate()}))
 
       # Yesterday usage for target account (should be included)
       {:ok, _} =

--- a/server/test/tuist/runners/allowance_test.exs
+++ b/server/test/tuist/runners/allowance_test.exs
@@ -66,9 +66,9 @@ defmodule Tuist.Runners.AllowanceTest do
     |> Repo.update!()
   end
 
-  defp on_trial(account) do
+  defp on_trial_since(account, at) do
     account
-    |> Ecto.Changeset.change(runner_trial_started_at: DateTime.truncate(DateTime.utc_now(), :second))
+    |> Ecto.Changeset.change(runner_trial_started_at: DateTime.truncate(at, :second))
     |> Repo.update!()
   end
 
@@ -446,8 +446,40 @@ defmodule Tuist.Runners.AllowanceTest do
       assert breakdown.billed == Money.new(600, :USD)
     end
 
+    test "prices a period that closed before the trial began", %{account: account} do
+      # The usage page offers a year of history. A trial that starts today
+      # says nothing about a period that was invoiced months ago, and
+      # reading the trial's end alone marked every one of them covered.
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -10, :day), DateTime.add(now, -6, :day)}
+      account = on_trial_since(account, DateTime.add(now, -2, :day))
+
+      ran_minutes(account, DateTime.add(now, -8, :day), 180)
+
+      breakdown = Allowance.period_breakdown(account, period)
+
+      assert breakdown.trial_covered == Money.new(0, :USD)
+      assert breakdown.billed == Money.new(600, :USD)
+    end
+
+    test "covers only what ran after the trial started", %{account: account} do
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+      account = on_trial_since(account, DateTime.add(now, -2, :day))
+
+      ran_minutes(account, DateTime.add(now, -3, :day), 180)
+      ran_minutes(account, DateTime.add(now, -1, :day), 60)
+
+      breakdown = Allowance.period_breakdown(account, period)
+
+      assert breakdown.minutes == 240
+      assert breakdown.gross == Money.new(1800, :USD)
+      assert breakdown.trial_covered == Money.new(450, :USD)
+      assert breakdown.billed == Money.new(600, :USD)
+    end
+
     test "prices nothing at all while the trial is still running", %{account: account} do
-      account = on_trial(account)
+      account = on_trial_since(account, DateTime.add(DateTime.utc_now(), -30, :day))
       ran_minutes(account, DateTime.add(DateTime.utc_now(), -4, :hour), 180)
 
       breakdown = Allowance.period_breakdown(account)

--- a/server/test/tuist/runners/allowance_test.exs
+++ b/server/test/tuist/runners/allowance_test.exs
@@ -34,6 +34,44 @@ defmodule Tuist.Runners.AllowanceTest do
     })
   end
 
+  defp ran_minutes(account, started, minutes) do
+    # Session timestamps are microsecond-precision; callers pass whatever
+    # precision the instant they care about happens to carry.
+    started = %{started | microsecond: {elem(started.microsecond, 0), 6}}
+
+    Repo.insert!(%RunnerSession{
+      account_id: account.id,
+      workflow_job_id: System.unique_integer([:positive]),
+      fleet_name: "tuist-macos",
+      pod_name: "pod-#{System.unique_integer([:positive])}",
+      runner_name: "",
+      platform: :macos,
+      vcpus: 6,
+      memory_gb: 14,
+      billing_multiplier: 10_000,
+      started_at: started,
+      job_started_at: started,
+      job_ended_at: DateTime.add(started, minutes * 60, :second),
+      inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
+      updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+    })
+  end
+
+  defp trial_ended(account, at) do
+    account
+    |> Ecto.Changeset.change(
+      runner_trial_started_at: at |> DateTime.add(-30, :day) |> DateTime.truncate(:second),
+      runner_trial_ended_at: DateTime.truncate(at, :second)
+    )
+    |> Repo.update!()
+  end
+
+  defp on_trial(account) do
+    account
+    |> Ecto.Changeset.change(runner_trial_started_at: DateTime.truncate(DateTime.utc_now(), :second))
+    |> Repo.update!()
+  end
+
   describe "exhausted?/1" do
     test "a free account with room left may still dispatch", %{account: account} do
       stub(Billing, :effective_plan, fn _account -> :air end)
@@ -332,6 +370,114 @@ defmodule Tuist.Runners.AllowanceTest do
       assert row.minutes == 0
       assert row.gross == Money.new(0, :USD)
       assert row.billed == Money.new(0, :USD)
+      assert row.included_minutes == Allowance.free_monthly_minutes()
+    end
+  end
+
+  describe "period_breakdown/1 runner trials" do
+    setup do
+      stub(Billing, :current_billing_period, fn _account -> nil end)
+      :ok
+    end
+
+    test "prices nothing the trial covered when it ended inside the period", %{account: account} do
+      # Stripe bills the runner item from the instant the trial ended, so
+      # a period that straddles the cancellation is part covered and part
+      # billable. Pricing the whole of it showed a bill no invoice was
+      # going to carry.
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+      account = trial_ended(account, DateTime.add(now, -2, :day))
+
+      ran_minutes(account, DateTime.add(now, -3, :day), 60)
+      ran_minutes(account, DateTime.add(now, -1, :day), 180)
+
+      breakdown = Allowance.period_breakdown(account, period)
+
+      # Every minute it ran, priced at the standard rate.
+      assert breakdown.minutes == 240
+      assert breakdown.gross == Money.new(1800, :USD)
+      assert breakdown.trial_covered == Money.new(450, :USD)
+      # 180 billable minutes, 100 of them included. The trial's 60 must
+      # not have eaten the allowance on their way past.
+      assert breakdown.billed == Money.new(600, :USD)
+    end
+
+    test "counts only the part of a run that fell after the trial ended", %{account: account} do
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+      trial_end = now |> DateTime.add(-6, :hour) |> DateTime.truncate(:second)
+      account = trial_ended(account, trial_end)
+
+      ran_minutes(account, DateTime.add(trial_end, -60, :minute), 120)
+
+      breakdown = Allowance.period_breakdown(account, period)
+
+      assert breakdown.minutes == 120
+      assert breakdown.gross == Money.new(900, :USD)
+      assert breakdown.trial_covered == Money.new(450, :USD)
+      assert breakdown.billed == Money.new(0, :USD)
+    end
+
+    test "leaves a day that ran wholly inside the trial with nothing billed", %{account: account} do
+      # Past the allowance, so a day the trial covered has to be zeroed
+      # deliberately rather than by the free tier happening to reach it.
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+      account = trial_ended(account, DateTime.add(now, -2, :day))
+
+      ran_minutes(account, DateTime.add(now, -3, :day), 180)
+
+      assert [day] = Allowance.period_breakdown(account, period).days
+      assert day.gross == Money.new(1350, :USD)
+      assert day.billed == Money.new(0, :USD)
+    end
+
+    test "prices the whole period once the trial ended before it started", %{account: account} do
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -2, :day), DateTime.add(now, 1, :day)}
+      account = trial_ended(account, DateTime.add(now, -10, :day))
+
+      ran_minutes(account, DateTime.add(now, -1, :day), 180)
+
+      breakdown = Allowance.period_breakdown(account, period)
+
+      assert breakdown.trial_covered == Money.new(0, :USD)
+      assert breakdown.billed == Money.new(600, :USD)
+    end
+
+    test "prices nothing at all while the trial is still running", %{account: account} do
+      account = on_trial(account)
+      ran_minutes(account, DateTime.add(DateTime.utc_now(), -4, :hour), 180)
+
+      breakdown = Allowance.period_breakdown(account)
+
+      assert breakdown.gross == Money.new(1350, :USD)
+      assert breakdown.trial_covered == Money.new(1350, :USD)
+      assert breakdown.billed == Money.new(0, :USD)
+
+      # An allowance the account cannot reach yet is not a line worth
+      # showing; the trial already covers everything above it.
+      assert [row] = breakdown.platforms
+      assert row.trial_covered == Money.new(1350, :USD)
+      assert row.billed == Money.new(0, :USD)
+      assert row.included_minutes == nil
+    end
+
+    test "bills a platform row only for what ran after the trial", %{account: account} do
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+      account = trial_ended(account, DateTime.add(now, -2, :day))
+
+      ran_minutes(account, DateTime.add(now, -3, :day), 60)
+      ran_minutes(account, DateTime.add(now, -1, :day), 180)
+
+      assert [row] = Allowance.period_breakdown(account, period).platforms
+
+      assert row.minutes == 240
+      assert row.gross == Money.new(1800, :USD)
+      assert row.trial_covered == Money.new(450, :USD)
+      assert row.billed == Money.new(600, :USD)
       assert row.included_minutes == Allowance.free_monthly_minutes()
     end
   end

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -54,20 +54,23 @@ defmodule TuistWeb.UsageLiveTest do
       minutes: 1_000,
       free_minutes: 100,
       gross: Money.new(7_500, :USD),
+      trial_covered: Money.new(7_500, :USD),
       billed: Money.new(0, :USD),
       days: [],
       by_repository: [],
       projected_days: [],
-      on_trial: true,
       platforms: [
         %{
           id: "macos",
           platform: :macos,
           minutes: 1_000,
           projected_minutes: 1_000,
-          included_minutes: 100,
+          # Nothing is billable while the trial runs, so the allowance
+          # has no line of its own.
+          included_minutes: nil,
           previous_minutes: 0,
           gross: Money.new(7_500, :USD),
+          trial_covered: Money.new(7_500, :USD),
           billed: Money.new(0, :USD)
         }
       ]
@@ -169,6 +172,7 @@ defmodule TuistWeb.UsageLiveTest do
               included_minutes: nil,
               previous_minutes: 0,
               gross: nil,
+              trial_covered: nil,
               billed: nil
             }
           ]

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -267,6 +267,49 @@ defmodule TuistWeb.UsageLiveTest do
     end
   end
 
+  describe "runner usage after a trial ends mid-period" do
+    test "credits the trial and the allowance separately", %{conn: conn, account: account} do
+      # The allowance line was rendered as gross minus billed, which is
+      # the trial's credit and the allowance's added together. A period
+      # part-covered by a trial therefore subtracted the trial twice and
+      # the receipt stopped adding up.
+      disable_kura(account)
+      stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+
+      breakdown = %{
+        billed_breakdown()
+        | trial_covered: Money.new(3_000, :USD),
+          billed: Money.new(3_750, :USD),
+          platforms: [
+            %{
+              id: "macos",
+              platform: :macos,
+              minutes: 1_000,
+              projected_minutes: 1_000,
+              included_minutes: 100,
+              previous_minutes: 0,
+              gross: Money.new(7_500, :USD),
+              trial_covered: Money.new(3_000, :USD),
+              billed: Money.new(3_750, :USD)
+            }
+          ]
+      }
+
+      stub(Allowance, :period_breakdown, fn _account -> breakdown end)
+      stub(Allowance, :period_breakdown, fn _account, _period -> breakdown end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      html = render(lv)
+
+      # 75.00$ run, 30.00$ of it covered by the trial, 7.50$ of the rest
+      # covered by the allowance, 37.50$ billed.
+      assert html =~ "−30.00"
+      assert html =~ "−7.50"
+      assert html =~ "37.50"
+    end
+  end
+
   describe "Kura feature flag gate" do
     test "raises 404 when Kura is not enabled for the account", %{conn: conn, account: account} do
       disable_kura(account)

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -10,6 +10,7 @@ defmodule TuistWeb.UsageLiveTest do
   alias Tuist.IngestRepo
   alias Tuist.Kura.UsageEvent
   alias Tuist.Runners.Allowance
+  alias Tuist.Runners.Prepaid
   alias Tuist.Runners.Trials
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
@@ -23,7 +24,7 @@ defmodule TuistWeb.UsageLiveTest do
     # Keeps the page off the network: the balance comes from Stripe and
     # the period from the subscription, neither of which a render test
     # should depend on.
-    stub(Tuist.Runners.Prepaid, :balance, fn _account -> nil end)
+    stub(Prepaid, :balance, fn _account -> nil end)
     stub(Tuist.Billing, :current_billing_period, fn _account -> nil end)
     :ok
   end
@@ -72,6 +73,35 @@ defmodule TuistWeb.UsageLiveTest do
           gross: Money.new(7_500, :USD),
           trial_covered: Money.new(7_500, :USD),
           billed: Money.new(0, :USD)
+        }
+      ]
+    }
+  end
+
+  defp billed_breakdown do
+    %{
+      period_start: ~D[2026-08-24],
+      period_end: ~D[2026-09-24],
+      usage_through: ~D[2026-08-25],
+      minutes: 1_000,
+      free_minutes: 100,
+      gross: Money.new(7_500, :USD),
+      trial_covered: Money.new(0, :USD),
+      billed: Money.new(6_750, :USD),
+      days: [],
+      by_repository: [],
+      projected_days: [],
+      platforms: [
+        %{
+          id: "macos",
+          platform: :macos,
+          minutes: 1_000,
+          projected_minutes: 1_000,
+          included_minutes: 100,
+          previous_minutes: 0,
+          gross: Money.new(7_500, :USD),
+          trial_covered: Money.new(0, :USD),
+          billed: Money.new(6_750, :USD)
         }
       ]
     }
@@ -197,6 +227,43 @@ defmodule TuistWeb.UsageLiveTest do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
 
       refute has_element?(lv, "[data-part='runner-usage-card']")
+    end
+  end
+
+  describe "runner usage with prepaid credit" do
+    setup %{account: account} do
+      disable_kura(account)
+      stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+      stub(Allowance, :period_breakdown, fn _account -> billed_breakdown() end)
+      stub(Allowance, :period_breakdown, fn _account, _period -> billed_breakdown() end)
+      :ok
+    end
+
+    test "shows what is left to pay once the credit is drawn down", %{conn: conn, account: account} do
+      # The widget read "what lands on your invoice" and gave the usage
+      # charge, while the receipt an inch below said nothing was left to
+      # pay. Both figures were on screen and they disagreed.
+      stub(Prepaid, :balance, fn _account -> %{available: Money.new(22_500, :USD)} end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      assert has_element?(lv, "#widget-runner-billed", "0.00")
+      refute has_element?(lv, "#widget-runner-billed", "67.50")
+    end
+
+    test "shows the shortfall when the balance does not cover the period", %{conn: conn, account: account} do
+      # 67.50$ of usage against a 20.00$ balance.
+      stub(Prepaid, :balance, fn _account -> %{available: Money.new(2_000, :USD)} end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      assert has_element?(lv, "#widget-runner-billed", "47.50")
+    end
+
+    test "shows the usage charge itself for an account with no credit", %{conn: conn, account: account} do
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      assert has_element?(lv, "#widget-runner-billed", "67.50")
     end
   end
 

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -107,6 +107,13 @@ defmodule TuistWeb.UsageLiveTest do
     }
   end
 
+  defp previous_period_path(account) do
+    now = DateTime.utc_now()
+    previous = Timex.shift(%{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 6}}, months: -1)
+
+    "/#{account.name}/usage?period=#{Date.to_iso8601(DateTime.to_date(previous))}"
+  end
+
   defp enable_kura(account) do
     stub(Environment, :dev?, fn -> false end)
     stub_kura_flag(account, true)
@@ -307,6 +314,51 @@ defmodule TuistWeb.UsageLiveTest do
       assert html =~ "−30.00"
       assert html =~ "−7.50"
       assert html =~ "37.50"
+    end
+  end
+
+  describe "runner usage across billing periods" do
+    setup %{account: account} do
+      disable_kura(account)
+      stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+      stub(Allowance, :period_breakdown, fn _account -> billed_breakdown() end)
+      stub(Allowance, :period_breakdown, fn _account, _period -> billed_breakdown() end)
+      :ok
+    end
+
+    test "does not put today's credit against a period that has closed", %{conn: conn, account: account} do
+      # A balance is what the account holds now. The grants that covered a
+      # closed period were drawn down when it was invoiced, so applying
+      # today's balance to it reports an amount owed that has nothing to
+      # do with the invoice that period actually produced.
+      stub(Prepaid, :balance, fn _account -> %{available: Money.new(22_500, :USD)} end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      assert has_element?(lv, "#widget-runner-billed", "0.00")
+      assert has_element?(lv, "[data-kind='prepaid']")
+
+      render_patch(lv, previous_period_path(account))
+
+      assert has_element?(lv, "#widget-runner-billed", "67.50")
+      refute has_element?(lv, "[data-kind='prepaid']")
+    end
+
+    test "does not read the prepaid balance again when the period changes", %{conn: conn, account: account} do
+      # `Prepaid.balance/2` does not cache a nil, so an account with no
+      # credit pays a Stripe round trip for every read.
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
+
+      test_pid = self()
+
+      stub(Prepaid, :balance, fn _account ->
+        send(test_pid, :balance_read)
+        nil
+      end)
+
+      render_patch(lv, previous_period_path(account))
+
+      refute_received :balance_read
     end
   end
 


### PR DESCRIPTION
Four fixes to how runner usage is billed, and to what the usage page says about it, once a runner trial ends. The first three were planned; the fourth surfaced while checking what the fixed page would actually render.

### 1. The usage page priced minutes the trial had covered

`Allowance.period_breakdown/2` decided billability with a boolean, `Trials.on_trial?/1`, applied to the whole billing period. Stripe does not work that way: ending a trial adds the runner item with `proration_behavior: "none"`, so the invoice starts at the instant the trial ended, not at the period start.

An account cancelled mid-period therefore saw its bill jump to the whole period's usage while the invoice it was going to get covered only the remainder. On the account that prompted this, 1,019 minutes read as $68.93 billed against an invoice of roughly nothing.

The boolean becomes an instant. `billable_from/3` is the moment the period's usage starts landing on an invoice, or nil when none of it does. Money is measured over `[billable_from, usage_end]` while minutes and gross keep covering the whole period, and the free allowance is spent by billable usage only, so a day the trial covered can no longer eat it and charge the account a day later.

`trial_covered` carries what the trial took off, per period and per platform, so the receipt reads minutes run, less the trial, less the plan's included minutes, leaving what is billed. That replaces `zero_billed_on_trial/2` and the `included_minutes` line the template was hiding by hand. The `on_trial` field is gone from the breakdown map, since nothing reads it now.

### 2. Stripe billed the day the trial ended, entire

Usage is reported as one meter event per UTC day, stamped at the day's end by `usage_timestamp/3`. That stamp postdates the runner item a mid-day cancellation adds, so Stripe invoiced the whole day including the minutes the trial was still covering when they ran. `proration_behavior: "none"` does not cover this: those minutes do not read as accrued before the change, they read as usage after it.

Small in money, but exactly the wrong shape: a trial promising its minutes are free, billing the last few hours of them, with the only workaround being to cancel just after 00:00 UTC.

`usage_windows/3` now treats `runner_trial_ended_at` as a service-period boundary alongside the subscription's own, so the cancellation day is reported as two events. The pre-cancellation window is stamped a second before the trial ended, which predates the item and is free; the remainder is stamped at the day's end and billed. Every other day stays one event.

The boundary is read locally rather than from Stripe: it is our own record of when the account stopped being on a trial, and the subscription carries no trace of when its runner item was added. It applies to accounts with no subscription too. Nothing is invoiced for them either way, but a boundary that appears only for subscribers is one that has to be reasoned about twice.

### 3. The page carried two bill-shaped figures that disagreed

The "Billed" widget said "what lands on your invoice" and gave the usage charge, while the prepaid receipt an inch below said "Left to pay 0.00$". Both were true of something, neither was what a customer wants to know, and the widget is the one read first.

The credit was already computed and simply never reached the widget: `prepaid_coverage/2` ran inline in the template, below the widgets that needed it. It moves into an assign, and the widget renders `amount_due/2`, the usage charge less whatever the balance would cover today, under a caption that says so. `prepaid_coverage/2` now derives from the breakdown's own billed figure rather than re-summing the platform rows; two derivations of one charge is how the widget and the receipt drifted apart to begin with.

The per-platform receipt is untouched. "Billed this period" stays the usage charge, because that is the line the credit is applied to.

### 4. The receipt subtracted the trial twice

The allowance line rendered gross minus billed, which is the trial's credit and the allowance's added together. It went unnoticed while a trial was all or nothing, because the template hid the allowance line outright for an account on one. With the first fix, a period can be part covered and part billed, the two credits coexist, and each has to describe only its own share. The allowance line is now what it takes off the charge left after the trial, and renders through `credit_label/1` so a period with nothing billable yet reads 0.00$ rather than a signed zero.

### Why this way

The cheap alternative to fix 2 was to leave the reporting path alone and align the page to the start of the UTC day the trial ended. One line, matches what Stripe bills today, no billing-path risk. Rejected because it makes the page truthful by making the promise false: both the ops panel and the `Tuist.Runners.Trials` moduledoc state that trial minutes stay free, and that variant bills the ones from the cancellation day.

### Impact

Accounts whose trial ends mid-period are no longer invoiced for the tail of that day, and their usage page no longer shows a bill several times larger than the invoice they will receive. Ops can cancel a trial at any hour rather than waiting for a UTC midnight. Accounts holding prepaid credit see what they owe rather than the line item the credit is applied to.

One caveat worth a reviewer's eye: the pre-cancellation meter event lands one second before `runner_trial_ended_at`, while the Stripe item is created a round trip after it. That is about a second of headroom against clock skew. It is the same margin the existing `current_period_start` split already relies on, but it is the tight part of fix 2.

### How to test locally

Server suites:

```
mix test test/tuist/runners/allowance_test.exs test/tuist/billing_test.exs test/tuist_web/live/usage_live_test.exs
```

For the page itself, on a dev account with runner sessions in the current period:

1. Start a runner trial from `/ops/accounts/:id`, then load `/:account/usage`. Every minute reads as covered by the trial, nothing billed, and no allowance line.
2. Cancel the trial and reload. The minutes already run stay under "Covered by your trial", the allowance is intact, and "Billed" reads what is owed once prepaid credit is drawn down.
3. Run another job and reload. Only the new minutes move into the billed column.

### Validation

1,516 tests pass across the live-view, runners and billing suites with `--warnings-as-errors`, including 13 new cases: a trial ending inside the period, a run straddling the cancellation, a fully covered day past the allowance, a trial that ended before the period, one still running, the platform row, the four `usage_windows/3` boundary cases, a prepaid balance that covers the period, one that falls short, an account with no credit, and the two credits listed separately. Each new case was written failing first.

Credo is clean on every file touched and `mix format --check-formatted` passes. `mix gettext.extract` updated `dashboard_usage.pot` only; no `.po` file is touched.
