### PR TITLE
fix(swifterpm): retry transient HTTP statuses and report the URL that failed

### DIFF
--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -330,17 +330,21 @@ enum HTTPClient {
             return min(seconds, maximumRetryAfter)
         }
 
-        /// Recipients must accept all three historic HTTP-date formats (RFC 9110 section 5.6.7).
+        /// The three formats a recipient must accept (RFC 9110 section 5.6.7). Foundation
+        /// ships no HTTP-date constant, so they are spelled out here.
+        private enum HTTPDateFormat {
+            static let imfFixdate = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            static let rfc850 = "EEEE, dd-MMM-yy HH:mm:ss zzz"
+            static let asctime = "EEE MMM d HH:mm:ss yyyy"
+
+            static let all = [imfFixdate, rfc850, asctime]
+        }
+
         private static func httpDate(from value: String) -> Date? {
             let normalized = value.split(separator: " ", omittingEmptySubsequences: true)
                 .joined(separator: " ")
-            let formats = [
-                "EEE, dd MMM yyyy HH:mm:ss zzz",
-                "EEEE, dd-MMM-yy HH:mm:ss zzz",
-                "EEE MMM d HH:mm:ss yyyy",
-            ]
 
-            for format in formats {
+            for format in HTTPDateFormat.all {
                 let formatter = DateFormatter()
                 formatter.locale = Locale(identifier: "en_US_POSIX")
                 formatter.timeZone = TimeZone(secondsFromGMT: 0)

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -269,7 +269,9 @@ enum HTTPClient {
 }
 
 /// A non-2xx HTTP response. `url` is the URL that produced the status, which after a
-/// redirect is not the URL that was requested.
+/// redirect is not the URL that was requested. Rendering goes through
+/// `redactingCredentials`, since a redirect target is routinely a presigned URL whose
+/// query string carries a signature.
 struct HTTPStatusError: Error, CustomStringConvertible {
     /// Bounds a hostile or mistaken `Retry-After` so a restore cannot stall on it.
     static let maximumRetryAfter: TimeInterval = 30
@@ -278,14 +280,14 @@ struct HTTPStatusError: Error, CustomStringConvertible {
     let url: URL
     let retryAfter: TimeInterval?
 
-    init?(response: URLResponse, requestedURL: URL) {
+    init?(response: URLResponse, requestedURL: URL, now: Date = Date()) {
         guard let httpResponse = response as? HTTPURLResponse,
               !(200 ..< 300).contains(httpResponse.statusCode)
         else { return nil }
 
         statusCode = httpResponse.statusCode
         url = httpResponse.url ?? requestedURL
-        retryAfter = Self.retryAfter(from: httpResponse)
+        retryAfter = Self.retryAfter(from: httpResponse, now: now)
     }
 
     var isRetryable: Bool {
@@ -293,15 +295,62 @@ struct HTTPStatusError: Error, CustomStringConvertible {
     }
 
     var description: String {
-        "HTTP \(statusCode) for \(url.absoluteString)"
+        "HTTP \(statusCode) for \(Self.redactingCredentials(url))"
     }
 
-    private static func retryAfter(from response: HTTPURLResponse) -> TimeInterval? {
-        guard let value = response.value(forHTTPHeaderField: "Retry-After"),
-              let seconds = TimeInterval(value.trimmingCharacters(in: .whitespaces)),
-              seconds > 0
-        else { return nil }
+    /// Keeps scheme, host, port and path; drops user info, query and fragment.
+    static func redactingCredentials(_ url: URL) -> String {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.user = nil
+        components?.password = nil
+        components?.query = nil
+        components?.fragment = nil
+        if let string = components?.string, !string.isEmpty {
+            return string
+        }
+        let scheme = url.scheme.map { "\($0)://" } ?? ""
+        let port = url.port.map { ":\($0)" } ?? ""
+        return "\(scheme)\(url.host ?? "")\(port)\(url.path)"
+    }
+
+    /// `Retry-After` is either delay-seconds or an HTTP-date (RFC 9110 section 10.2.3).
+    private static func retryAfter(from response: HTTPURLResponse, now: Date) -> TimeInterval? {
+        guard let raw = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+        let value = raw.trimmingCharacters(in: .whitespaces)
+
+        let seconds: TimeInterval?
+        if let delay = TimeInterval(value) {
+            seconds = delay
+        } else if let date = httpDate(from: value) {
+            seconds = date.timeIntervalSince(now)
+        } else {
+            seconds = nil
+        }
+
+        guard let seconds, seconds > 0 else { return nil }
         return min(seconds, maximumRetryAfter)
+    }
+
+    /// Recipients must accept all three historic HTTP-date formats (RFC 9110 section 5.6.7).
+    private static func httpDate(from value: String) -> Date? {
+        let normalized = value.split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+        let formats = [
+            "EEE, dd MMM yyyy HH:mm:ss zzz",
+            "EEEE, dd-MMM-yy HH:mm:ss zzz",
+            "EEE MMM d HH:mm:ss yyyy",
+        ]
+
+        for format in formats {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = format
+            if let date = formatter.date(from: normalized) {
+                return date
+            }
+        }
+        return nil
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -227,7 +227,7 @@ enum HTTPClient {
     }
 
     private static func ensureSuccessfulStatus(_ response: URLResponse, url: URL) throws {
-        if let error = HTTPStatusError(response: response, requestedURL: url) {
+        if let error = StatusError(response: response, requestedURL: url) {
             throw error
         }
     }
@@ -245,7 +245,7 @@ enum HTTPClient {
             } catch let error as URLError where attempt < maxAttempts && isRetryable(error) {
                 try? await Task.sleep(nanoseconds: backoff(attempt: attempt, retryAfter: nil))
                 attempt += 1
-            } catch let error as HTTPStatusError where attempt < maxAttempts && error.isRetryable {
+            } catch let error as StatusError where attempt < maxAttempts && error.isRetryable {
                 try? await Task.sleep(
                     nanoseconds: backoff(attempt: attempt, retryAfter: error.retryAfter))
                 attempt += 1
@@ -266,91 +266,91 @@ enum HTTPClient {
             return false
         }
     }
-}
 
-/// A non-2xx HTTP response. `url` is the URL that produced the status, which after a
-/// redirect is not the URL that was requested. Rendering goes through
-/// `redactingCredentials`, since a redirect target is routinely a presigned URL whose
-/// query string carries a signature.
-struct HTTPStatusError: Error, CustomStringConvertible {
-    /// Bounds a hostile or mistaken `Retry-After` so a restore cannot stall on it.
-    static let maximumRetryAfter: TimeInterval = 30
+    /// A non-2xx HTTP response. `url` is the URL that produced the status, which after a
+    /// redirect is not the URL that was requested. Rendering goes through
+    /// `redactingCredentials`, since a redirect target is routinely a presigned URL whose
+    /// query string carries a signature.
+    struct StatusError: Error, CustomStringConvertible {
+        /// Bounds a hostile or mistaken `Retry-After` so a restore cannot stall on it.
+        static let maximumRetryAfter: TimeInterval = 30
 
-    let statusCode: Int
-    let url: URL
-    let retryAfter: TimeInterval?
+        let statusCode: Int
+        let url: URL
+        let retryAfter: TimeInterval?
 
-    init?(response: URLResponse, requestedURL: URL, now: Date = Date()) {
-        guard let httpResponse = response as? HTTPURLResponse,
-              !(200 ..< 300).contains(httpResponse.statusCode)
-        else { return nil }
+        init?(response: URLResponse, requestedURL: URL, now: Date = Date()) {
+            guard let httpResponse = response as? HTTPURLResponse,
+                  !(200 ..< 300).contains(httpResponse.statusCode)
+            else { return nil }
 
-        statusCode = httpResponse.statusCode
-        url = httpResponse.url ?? requestedURL
-        retryAfter = Self.retryAfter(from: httpResponse, now: now)
-    }
-
-    var isRetryable: Bool {
-        statusCode == 408 || statusCode == 429 || (500 ..< 600).contains(statusCode)
-    }
-
-    var description: String {
-        "HTTP \(statusCode) for \(Self.redactingCredentials(url))"
-    }
-
-    /// Keeps scheme, host, port and path; drops user info, query and fragment.
-    static func redactingCredentials(_ url: URL) -> String {
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        components?.user = nil
-        components?.password = nil
-        components?.query = nil
-        components?.fragment = nil
-        if let string = components?.string, !string.isEmpty {
-            return string
-        }
-        let scheme = url.scheme.map { "\($0)://" } ?? ""
-        let port = url.port.map { ":\($0)" } ?? ""
-        return "\(scheme)\(url.host ?? "")\(port)\(url.path)"
-    }
-
-    /// `Retry-After` is either delay-seconds or an HTTP-date (RFC 9110 section 10.2.3).
-    private static func retryAfter(from response: HTTPURLResponse, now: Date) -> TimeInterval? {
-        guard let raw = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
-        let value = raw.trimmingCharacters(in: .whitespaces)
-
-        let seconds: TimeInterval?
-        if let delay = TimeInterval(value) {
-            seconds = delay
-        } else if let date = httpDate(from: value) {
-            seconds = date.timeIntervalSince(now)
-        } else {
-            seconds = nil
+            statusCode = httpResponse.statusCode
+            url = httpResponse.url ?? requestedURL
+            retryAfter = Self.retryAfter(from: httpResponse, now: now)
         }
 
-        guard let seconds, seconds > 0 else { return nil }
-        return min(seconds, maximumRetryAfter)
-    }
+        var isRetryable: Bool {
+            statusCode == 408 || statusCode == 429 || (500 ..< 600).contains(statusCode)
+        }
 
-    /// Recipients must accept all three historic HTTP-date formats (RFC 9110 section 5.6.7).
-    private static func httpDate(from value: String) -> Date? {
-        let normalized = value.split(separator: " ", omittingEmptySubsequences: true)
-            .joined(separator: " ")
-        let formats = [
-            "EEE, dd MMM yyyy HH:mm:ss zzz",
-            "EEEE, dd-MMM-yy HH:mm:ss zzz",
-            "EEE MMM d HH:mm:ss yyyy",
-        ]
+        var description: String {
+            "HTTP \(statusCode) for \(Self.redactingCredentials(url))"
+        }
 
-        for format in formats {
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(secondsFromGMT: 0)
-            formatter.dateFormat = format
-            if let date = formatter.date(from: normalized) {
-                return date
+        /// Keeps scheme, host, port and path; drops user info, query and fragment.
+        static func redactingCredentials(_ url: URL) -> String {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            components?.user = nil
+            components?.password = nil
+            components?.query = nil
+            components?.fragment = nil
+            if let string = components?.string, !string.isEmpty {
+                return string
             }
+            let scheme = url.scheme.map { "\($0)://" } ?? ""
+            let port = url.port.map { ":\($0)" } ?? ""
+            return "\(scheme)\(url.host ?? "")\(port)\(url.path)"
         }
-        return nil
+
+        /// `Retry-After` is either delay-seconds or an HTTP-date (RFC 9110 section 10.2.3).
+        private static func retryAfter(from response: HTTPURLResponse, now: Date) -> TimeInterval? {
+            guard let raw = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+            let value = raw.trimmingCharacters(in: .whitespaces)
+
+            let seconds: TimeInterval?
+            if let delay = TimeInterval(value) {
+                seconds = delay
+            } else if let date = httpDate(from: value) {
+                seconds = date.timeIntervalSince(now)
+            } else {
+                seconds = nil
+            }
+
+            guard let seconds, seconds > 0 else { return nil }
+            return min(seconds, maximumRetryAfter)
+        }
+
+        /// Recipients must accept all three historic HTTP-date formats (RFC 9110 section 5.6.7).
+        private static func httpDate(from value: String) -> Date? {
+            let normalized = value.split(separator: " ", omittingEmptySubsequences: true)
+                .joined(separator: " ")
+            let formats = [
+                "EEE, dd MMM yyyy HH:mm:ss zzz",
+                "EEEE, dd-MMM-yy HH:mm:ss zzz",
+                "EEE MMM d HH:mm:ss yyyy",
+            ]
+
+            for format in formats {
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.dateFormat = format
+                if let date = formatter.date(from: normalized) {
+                    return date
+                }
+            }
+            return nil
+        }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -227,17 +227,14 @@ enum HTTPClient {
     }
 
     private static func ensureSuccessfulStatus(_ response: URLResponse, url: URL) throws {
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200 ..< 300).contains(httpResponse.statusCode)
-        {
-            throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
+        if let error = HTTPStatusError(response: response, requestedURL: url) {
+            throw error
         }
     }
 
-    // Retries transient transport failures (timeouts, dropped or half-open
-    // connections) on a fresh connection with linear backoff. HTTP status
-    // failures are not retried: a non-2xx response is deterministic for an
-    // artifact URL, so a retry would only delay the surfaced error.
+    /// Retries transient transport failures (timeouts, dropped or half-open
+    /// connections) and transient HTTP statuses on a fresh connection with
+    /// linear backoff.
     private static func withRetry<T>(
         _ operation: @Sendable () async throws -> T
     ) async throws -> T {
@@ -246,10 +243,18 @@ enum HTTPClient {
             do {
                 return try await operation()
             } catch let error as URLError where attempt < maxAttempts && isRetryable(error) {
-                try? await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: backoff(attempt: attempt, retryAfter: nil))
+                attempt += 1
+            } catch let error as HTTPStatusError where attempt < maxAttempts && error.isRetryable {
+                try? await Task.sleep(
+                    nanoseconds: backoff(attempt: attempt, retryAfter: error.retryAfter))
                 attempt += 1
             }
         }
+    }
+
+    private static func backoff(attempt: Int, retryAfter: TimeInterval?) -> UInt64 {
+        UInt64((retryAfter ?? TimeInterval(attempt)) * 1_000_000_000)
     }
 
     private static func isRetryable(_ error: URLError) -> Bool {
@@ -260,6 +265,43 @@ enum HTTPClient {
         default:
             return false
         }
+    }
+}
+
+/// A non-2xx HTTP response. `url` is the URL that produced the status, which after a
+/// redirect is not the URL that was requested.
+struct HTTPStatusError: Error, CustomStringConvertible {
+    /// Bounds a hostile or mistaken `Retry-After` so a restore cannot stall on it.
+    static let maximumRetryAfter: TimeInterval = 30
+
+    let statusCode: Int
+    let url: URL
+    let retryAfter: TimeInterval?
+
+    init?(response: URLResponse, requestedURL: URL) {
+        guard let httpResponse = response as? HTTPURLResponse,
+              !(200 ..< 300).contains(httpResponse.statusCode)
+        else { return nil }
+
+        statusCode = httpResponse.statusCode
+        url = httpResponse.url ?? requestedURL
+        retryAfter = Self.retryAfter(from: httpResponse)
+    }
+
+    var isRetryable: Bool {
+        statusCode == 408 || statusCode == 429 || (500 ..< 600).contains(statusCode)
+    }
+
+    var description: String {
+        "HTTP \(statusCode) for \(url.absoluteString)"
+    }
+
+    private static func retryAfter(from response: HTTPURLResponse) -> TimeInterval? {
+        guard let value = response.value(forHTTPHeaderField: "Retry-After"),
+              let seconds = TimeInterval(value.trimmingCharacters(in: .whitespaces)),
+              seconds > 0
+        else { return nil }
+        return min(seconds, maximumRetryAfter)
     }
 }
 

--- a/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
+++ b/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import SwifterPMCore
+
+struct HTTPClientTests {
+    @Test
+    func retriesRequestTimeoutUntilItSucceeds() async throws {
+        try await withLocalHTTPServer { server in
+            server.respond(
+                to: "/archive.zip",
+                with: [.status(408), .status(408), .ok("payload")]
+            )
+
+            let data = try await HTTPClient.data(url: server.url(path: "/archive.zip"))
+
+            #expect(String(data: data, encoding: .utf8) == "payload")
+            #expect(server.requestedPaths == ["/archive.zip", "/archive.zip", "/archive.zip"])
+        }
+    }
+
+    @Test
+    func retriesServiceUnavailableAndTooManyRequests() async throws {
+        for status in [429, 503] {
+            try await withLocalHTTPServer { server in
+                server.respond(to: "/archive.zip", with: [.status(status), .ok("payload")])
+
+                let data = try await HTTPClient.data(url: server.url(path: "/archive.zip"))
+
+                #expect(String(data: data, encoding: .utf8) == "payload")
+                #expect(server.requestedPaths.count == 2)
+            }
+        }
+    }
+
+    @Test
+    func doesNotRetryClientErrors() async throws {
+        try await withLocalHTTPServer { server in
+            server.respond(to: "/archive.zip", with: [.status(404)])
+
+            await #expect(throws: (any Error).self) {
+                try await HTTPClient.data(url: server.url(path: "/archive.zip"))
+            }
+            #expect(server.requestedPaths == ["/archive.zip"])
+        }
+    }
+
+    @Test
+    func reportsTheURLThatActuallyFailedAfterARedirect() async throws {
+        try await withLocalHTTPServer { server in
+            server.respond(to: "/registry.zip", with: [.redirect(to: "/storage.zip")])
+            server.respond(to: "/storage.zip", with: [.status(408)])
+
+            let error = await #expect(throws: (any Error).self) {
+                try await HTTPClient.data(url: server.url(path: "/registry.zip"))
+            }
+
+            let message = String(describing: try #require(error))
+            #expect(message.contains("/storage.zip"))
+            #expect(!message.contains("/registry.zip"))
+        }
+    }
+
+    @Test
+    func surfacesTheStatusCodeInTheMessage() async throws {
+        try await withLocalHTTPServer { server in
+            server.respond(to: "/archive.zip", with: [.status(404)])
+
+            let error = await #expect(throws: (any Error).self) {
+                try await HTTPClient.data(url: server.url(path: "/archive.zip"))
+            }
+
+            let message = String(describing: try #require(error))
+            #expect(message.contains("HTTP 404"))
+        }
+    }
+
+    @Test
+    func successfulResponsesProduceNoError() throws {
+        #expect(makeStatusError(statusCode: 200) == nil)
+        #expect(makeStatusError(statusCode: 204) == nil)
+    }
+
+    @Test
+    func classifiesTransientStatusesAsRetryable() throws {
+        for statusCode in [408, 429, 500, 502, 503, 504] {
+            let error = try #require(makeStatusError(statusCode: statusCode))
+            #expect(error.isRetryable, "expected \(statusCode) to be retryable")
+        }
+
+        for statusCode in [400, 401, 403, 404, 410, 422] {
+            let error = try #require(makeStatusError(statusCode: statusCode))
+            #expect(!error.isRetryable, "expected \(statusCode) not to be retryable")
+        }
+    }
+
+    @Test
+    func readsRetryAfterAndBoundsIt() throws {
+        let honoured = try #require(
+            makeStatusError(statusCode: 429, headers: ["Retry-After": " 5 "]))
+        #expect(honoured.retryAfter == 5)
+
+        let bounded = try #require(
+            makeStatusError(statusCode: 429, headers: ["Retry-After": "86400"]))
+        #expect(bounded.retryAfter == HTTPStatusError.maximumRetryAfter)
+
+        let absent = try #require(makeStatusError(statusCode: 429))
+        #expect(absent.retryAfter == nil)
+
+        let unparsable = try #require(
+            makeStatusError(statusCode: 429, headers: ["Retry-After": "Wed, 26 Aug 2026 01:19:31 GMT"]))
+        #expect(unparsable.retryAfter == nil)
+    }
+
+    private func makeStatusError(
+        statusCode: Int,
+        headers: [String: String] = [:],
+        respondingURL: URL? = nil,
+        requestedURL: URL = URL(string: "https://tuist.dev/registry.zip")!
+    ) -> HTTPStatusError? {
+        let response = HTTPURLResponse(
+            url: respondingURL ?? requestedURL,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+        return HTTPStatusError(response: response, requestedURL: requestedURL)
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
+++ b/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
@@ -103,7 +103,7 @@ struct HTTPClientTests {
         let url = try #require(
             URL(string: "https://user:pass@storage.example/a/b.zip?token=secret#frag"))
 
-        let redacted = HTTPStatusError.redactingCredentials(url)
+        let redacted = HTTPClient.StatusError.redactingCredentials(url)
 
         #expect(redacted == "https://storage.example/a/b.zip")
     }
@@ -135,7 +135,7 @@ struct HTTPClientTests {
 
         let bounded = try #require(
             makeStatusError(statusCode: 429, headers: ["Retry-After": "86400"]))
-        #expect(bounded.retryAfter == HTTPStatusError.maximumRetryAfter)
+        #expect(bounded.retryAfter == HTTPClient.StatusError.maximumRetryAfter)
 
         let absent = try #require(makeStatusError(statusCode: 429))
         #expect(absent.retryAfter == nil)
@@ -163,7 +163,7 @@ struct HTTPClientTests {
                 headers: ["Retry-After": "Thu, 27 Aug 2026 01:19:31 GMT"],
                 now: now
             ))
-        #expect(bounded.retryAfter == HTTPStatusError.maximumRetryAfter)
+        #expect(bounded.retryAfter == HTTPClient.StatusError.maximumRetryAfter)
 
         let past = try #require(
             makeStatusError(
@@ -188,13 +188,13 @@ struct HTTPClientTests {
         respondingURL: URL? = nil,
         requestedURL: URL = URL(string: "https://tuist.dev/registry.zip")!,
         now: Date = Date()
-    ) -> HTTPStatusError? {
+    ) -> HTTPClient.StatusError? {
         let response = HTTPURLResponse(
             url: respondingURL ?? requestedURL,
             statusCode: statusCode,
             httpVersion: "HTTP/1.1",
             headerFields: headers
         )!
-        return HTTPStatusError(response: response, requestedURL: requestedURL, now: now)
+        return HTTPClient.StatusError(response: response, requestedURL: requestedURL, now: now)
     }
 }

--- a/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
+++ b/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
@@ -2,6 +2,10 @@ import Foundation
 import Testing
 @testable import SwifterPMCore
 
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
 struct HTTPClientTests {
     @Test
     func retriesRequestTimeoutUntilItSucceeds() async throws {
@@ -75,6 +79,36 @@ struct HTTPClientTests {
     }
 
     @Test
+    func doesNotLeakRedirectCredentialsIntoTheMessage() async throws {
+        try await withLocalHTTPServer { server in
+            let signed = "/storage.zip?X-Amz-Credential=AKIAEXAMPLE&X-Amz-Signature=deadbeefsecret"
+            server.respond(to: "/registry.zip", with: [.redirect(to: signed)])
+            server.respond(to: "/storage.zip", with: [.status(408)])
+
+            let error = await #expect(throws: (any Error).self) {
+                try await HTTPClient.data(url: server.url(path: "/registry.zip"))
+            }
+
+            let message = String(describing: try #require(error))
+            #expect(message.contains("HTTP 408"))
+            #expect(message.contains("/storage.zip"))
+            #expect(!message.contains("deadbeefsecret"))
+            #expect(!message.contains("X-Amz-Signature"))
+            #expect(!message.contains("AKIAEXAMPLE"))
+        }
+    }
+
+    @Test
+    func redactsUserInfoQueryAndFragment() throws {
+        let url = try #require(
+            URL(string: "https://user:pass@storage.example/a/b.zip?token=secret#frag"))
+
+        let redacted = HTTPStatusError.redactingCredentials(url)
+
+        #expect(redacted == "https://storage.example/a/b.zip")
+    }
+
+    @Test
     func successfulResponsesProduceNoError() throws {
         #expect(makeStatusError(statusCode: 200) == nil)
         #expect(makeStatusError(statusCode: 204) == nil)
@@ -107,15 +141,53 @@ struct HTTPClientTests {
         #expect(absent.retryAfter == nil)
 
         let unparsable = try #require(
-            makeStatusError(statusCode: 429, headers: ["Retry-After": "Wed, 26 Aug 2026 01:19:31 GMT"]))
+            makeStatusError(statusCode: 429, headers: ["Retry-After": "not-a-delay"]))
         #expect(unparsable.retryAfter == nil)
+    }
+
+    @Test
+    func readsRetryAfterExpressedAsAnHTTPDate() throws {
+        let now = Date(timeIntervalSince1970: 1_787_707_171)
+
+        let imfFixdate = try #require(
+            makeStatusError(
+                statusCode: 503,
+                headers: ["Retry-After": "Wed, 26 Aug 2026 01:19:41 GMT"],
+                now: now
+            ))
+        #expect(imfFixdate.retryAfter == 10)
+
+        let bounded = try #require(
+            makeStatusError(
+                statusCode: 503,
+                headers: ["Retry-After": "Thu, 27 Aug 2026 01:19:31 GMT"],
+                now: now
+            ))
+        #expect(bounded.retryAfter == HTTPStatusError.maximumRetryAfter)
+
+        let past = try #require(
+            makeStatusError(
+                statusCode: 503,
+                headers: ["Retry-After": "Tue, 25 Aug 2026 01:19:31 GMT"],
+                now: now
+            ))
+        #expect(past.retryAfter == nil)
+
+        let asctime = try #require(
+            makeStatusError(
+                statusCode: 503,
+                headers: ["Retry-After": "Wed Aug 26 01:19:41 2026"],
+                now: now
+            ))
+        #expect(asctime.retryAfter == 10)
     }
 
     private func makeStatusError(
         statusCode: Int,
         headers: [String: String] = [:],
         respondingURL: URL? = nil,
-        requestedURL: URL = URL(string: "https://tuist.dev/registry.zip")!
+        requestedURL: URL = URL(string: "https://tuist.dev/registry.zip")!,
+        now: Date = Date()
     ) -> HTTPStatusError? {
         let response = HTTPURLResponse(
             url: respondingURL ?? requestedURL,
@@ -123,6 +195,6 @@ struct HTTPClientTests {
             httpVersion: "HTTP/1.1",
             headerFields: headers
         )!
-        return HTTPStatusError(response: response, requestedURL: requestedURL)
+        return HTTPStatusError(response: response, requestedURL: requestedURL, now: now)
     }
 }

--- a/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
+++ b/swifterpm/Tests/swifterpmTests/HTTPClientTests.swift
@@ -173,6 +173,14 @@ struct HTTPClientTests {
             ))
         #expect(past.retryAfter == nil)
 
+        let rfc850 = try #require(
+            makeStatusError(
+                statusCode: 503,
+                headers: ["Retry-After": "Wednesday, 26-Aug-26 01:19:41 GMT"],
+                now: now
+            ))
+        #expect(rfc850.retryAfter == 10)
+
         let asctime = try #require(
             makeStatusError(
                 statusCode: 503,

--- a/swifterpm/Tests/swifterpmTests/LocalHTTPServer.swift
+++ b/swifterpm/Tests/swifterpmTests/LocalHTTPServer.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+#if canImport(Glibc)
+    import Glibc
+#else
+    import Darwin
+#endif
+
+/// A single-threaded loopback HTTP/1.1 server that replays a scripted sequence of
+/// responses, so tests can drive redirect and status-code handling without a network.
+final class LocalHTTPServer: @unchecked Sendable {
+    struct Response {
+        let statusCode: Int
+        let headers: [String: String]
+        let body: String
+
+        init(statusCode: Int, headers: [String: String] = [:], body: String = "") {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.body = body
+        }
+
+        static func ok(_ body: String) -> Response {
+            Response(statusCode: 200, body: body)
+        }
+
+        static func status(_ statusCode: Int, headers: [String: String] = [:]) -> Response {
+            Response(statusCode: statusCode, headers: headers)
+        }
+
+        static func redirect(to location: String) -> Response {
+            Response(statusCode: 303, headers: ["Location": location])
+        }
+    }
+
+    private let listeningSocket: Int32
+    private let lock = NSLock()
+    private var routes: [String: [Response]] = [:]
+    private var fallback: [Response] = []
+    private var recordedPaths: [String] = []
+    private var stopped = false
+
+    let port: UInt16
+
+    init() throws {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw Failure.socketUnavailable }
+
+        var reuse: Int32 = 1
+        setsockopt(
+            descriptor, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size)
+        )
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(descriptor, 16) == 0 else {
+            close(descriptor)
+            throw Failure.bindFailed
+        }
+
+        var boundAddress = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(descriptor, $0, &length)
+            }
+        }
+        guard named == 0 else {
+            close(descriptor)
+            throw Failure.bindFailed
+        }
+
+        listeningSocket = descriptor
+        port = UInt16(bigEndian: boundAddress.sin_port)
+    }
+
+    enum Failure: Error {
+        case socketUnavailable
+        case bindFailed
+    }
+
+    /// Queues the responses served for `path`, in order. The last one repeats once exhausted.
+    func respond(to path: String, with responses: [Response]) {
+        lock.lock()
+        routes[path] = responses
+        lock.unlock()
+    }
+
+    func respondToEverything(with responses: [Response]) {
+        lock.lock()
+        fallback = responses
+        lock.unlock()
+    }
+
+    func url(path: String) -> URL {
+        URL(string: "http://127.0.0.1:\(port)\(path)")!
+    }
+
+    /// Paths of every request served so far, in order, so tests can assert retry counts.
+    var requestedPaths: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedPaths
+    }
+
+    func start() {
+        let thread = Thread { [weak self] in self?.acceptLoop() }
+        thread.stackSize = 512 * 1024
+        thread.start()
+    }
+
+    func stop() {
+        lock.lock()
+        guard !stopped else {
+            lock.unlock()
+            return
+        }
+        stopped = true
+        lock.unlock()
+        shutdown(listeningSocket, SHUT_RDWR)
+        close(listeningSocket)
+    }
+
+    private func acceptLoop() {
+        while true {
+            lock.lock()
+            let isStopped = stopped
+            lock.unlock()
+            if isStopped { return }
+
+            let connection = accept(listeningSocket, nil, nil)
+            guard connection >= 0 else { return }
+            serve(connection: connection)
+            close(connection)
+        }
+    }
+
+    private func serve(connection: Int32) {
+        guard let path = readRequestPath(connection: connection) else { return }
+
+        lock.lock()
+        recordedPaths.append(path)
+        let response: Response
+        if var queued = routes[path], !queued.isEmpty {
+            response = queued.removeFirst()
+            routes[path] = queued.isEmpty ? [response] : queued
+        } else if var queued = fallback as [Response]?, !queued.isEmpty {
+            response = queued.removeFirst()
+            fallback = queued.isEmpty ? [response] : queued
+        } else {
+            response = Response(statusCode: 404)
+        }
+        lock.unlock()
+
+        write(response: response, to: connection)
+    }
+
+    private func readRequestPath(connection: Int32) -> String? {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let received = recv(connection, &buffer, buffer.count, 0)
+        guard received > 0 else { return nil }
+
+        let request = String(bytes: buffer[0 ..< received], encoding: .utf8) ?? ""
+        let requestLine = request.split(separator: "\r\n", maxSplits: 1).first ?? ""
+        let components = requestLine.split(separator: " ")
+        guard components.count >= 2 else { return nil }
+        return String(components[1])
+    }
+
+    private func write(response: Response, to connection: Int32) {
+        let body = Array(response.body.utf8)
+        var head = "HTTP/1.1 \(response.statusCode) \(Self.reason(for: response.statusCode))\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n"
+        for (name, value) in response.headers {
+            head += "\(name): \(value)\r\n"
+        }
+        head += "\r\n"
+
+        var payload = Array(head.utf8)
+        payload.append(contentsOf: body)
+        payload.withUnsafeBufferPointer { buffer in
+            var sent = 0
+            while sent < buffer.count {
+                let written = send(connection, buffer.baseAddress! + sent, buffer.count - sent, 0)
+                guard written > 0 else { return }
+                sent += written
+            }
+        }
+    }
+
+    private static func reason(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200: return "OK"
+        case 303: return "See Other"
+        case 404: return "Not Found"
+        case 408: return "Request Timeout"
+        case 429: return "Too Many Requests"
+        case 503: return "Service Unavailable"
+        default: return "Status"
+        }
+    }
+}
+
+func withLocalHTTPServer<T>(_ body: (LocalHTTPServer) async throws -> T) async throws -> T {
+    let server = try LocalHTTPServer()
+    server.start()
+    do {
+        let result = try await body(server)
+        server.stop()
+        return result
+    } catch {
+        server.stop()
+        throw error
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/LocalHTTPServer.swift
+++ b/swifterpm/Tests/swifterpmTests/LocalHTTPServer.swift
@@ -1,15 +1,18 @@
 import Foundation
+import Synchronization
 
 #if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 
-/// A single-threaded loopback HTTP/1.1 server that replays a scripted sequence of
-/// responses, so tests can drive redirect and status-code handling without a network.
-final class LocalHTTPServer: @unchecked Sendable {
-    struct Response {
+/// A loopback HTTP/1.1 server that replays a scripted sequence of responses, so tests can
+/// drive redirect, retry and status-code handling without a network.
+final class LocalHTTPServer: Sendable {
+    struct Response: Sendable {
         let statusCode: Int
         let headers: [String: String]
         let body: String
@@ -33,17 +36,30 @@ final class LocalHTTPServer: @unchecked Sendable {
         }
     }
 
+    private struct State {
+        var routes: [String: [Response]] = [:]
+        var recordedPaths: [String] = []
+        var stopped = false
+    }
+
+    private let state = Mutex(State())
     private let listeningSocket: Int32
-    private let lock = NSLock()
-    private var routes: [String: [Response]] = [:]
-    private var fallback: [Response] = []
-    private var recordedPaths: [String] = []
-    private var stopped = false
 
     let port: UInt16
 
+    enum Failure: Error {
+        case socketUnavailable
+        case bindFailed
+    }
+
     init() throws {
-        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        #if canImport(Glibc)
+            let streamType = Int32(SOCK_STREAM.rawValue)
+        #else
+            let streamType = SOCK_STREAM
+        #endif
+
+        let descriptor = socket(AF_INET, streamType, 0)
         guard descriptor >= 0 else { throw Failure.socketUnavailable }
 
         var reuse: Int32 = 1
@@ -82,22 +98,9 @@ final class LocalHTTPServer: @unchecked Sendable {
         port = UInt16(bigEndian: boundAddress.sin_port)
     }
 
-    enum Failure: Error {
-        case socketUnavailable
-        case bindFailed
-    }
-
     /// Queues the responses served for `path`, in order. The last one repeats once exhausted.
     func respond(to path: String, with responses: [Response]) {
-        lock.lock()
-        routes[path] = responses
-        lock.unlock()
-    }
-
-    func respondToEverything(with responses: [Response]) {
-        lock.lock()
-        fallback = responses
-        lock.unlock()
+        state.withLock { $0.routes[path] = responses }
     }
 
     func url(path: String) -> URL {
@@ -106,36 +109,28 @@ final class LocalHTTPServer: @unchecked Sendable {
 
     /// Paths of every request served so far, in order, so tests can assert retry counts.
     var requestedPaths: [String] {
-        lock.lock()
-        defer { lock.unlock() }
-        return recordedPaths
+        state.withLock { $0.recordedPaths }
     }
 
     func start() {
-        let thread = Thread { [weak self] in self?.acceptLoop() }
+        let thread = Thread { [self] in acceptLoop() }
         thread.stackSize = 512 * 1024
         thread.start()
     }
 
     func stop() {
-        lock.lock()
-        guard !stopped else {
-            lock.unlock()
-            return
+        let alreadyStopped = state.withLock { state -> Bool in
+            let wasStopped = state.stopped
+            state.stopped = true
+            return wasStopped
         }
-        stopped = true
-        lock.unlock()
-        shutdown(listeningSocket, SHUT_RDWR)
+        guard !alreadyStopped else { return }
+        shutdown(listeningSocket, Int32(SHUT_RDWR))
         close(listeningSocket)
     }
 
     private func acceptLoop() {
-        while true {
-            lock.lock()
-            let isStopped = stopped
-            lock.unlock()
-            if isStopped { return }
-
+        while !state.withLock({ $0.stopped }) {
             let connection = accept(listeningSocket, nil, nil)
             guard connection >= 0 else { return }
             serve(connection: connection)
@@ -146,23 +141,21 @@ final class LocalHTTPServer: @unchecked Sendable {
     private func serve(connection: Int32) {
         guard let path = readRequestPath(connection: connection) else { return }
 
-        lock.lock()
-        recordedPaths.append(path)
-        let response: Response
-        if var queued = routes[path], !queued.isEmpty {
-            response = queued.removeFirst()
-            routes[path] = queued.isEmpty ? [response] : queued
-        } else if var queued = fallback as [Response]?, !queued.isEmpty {
-            response = queued.removeFirst()
-            fallback = queued.isEmpty ? [response] : queued
-        } else {
-            response = Response(statusCode: 404)
+        let response = state.withLock { state -> Response in
+            state.recordedPaths.append(path)
+            guard var queued = state.routes[path], !queued.isEmpty else {
+                return Response(statusCode: 404)
+            }
+            let next = queued.removeFirst()
+            state.routes[path] = queued.isEmpty ? [next] : queued
+            return next
         }
-        lock.unlock()
 
         write(response: response, to: connection)
     }
 
+    /// Routes are keyed on the path alone, so a redirect target carrying a query string
+    /// still matches the route registered for its path.
     private func readRequestPath(connection: Int32) -> String? {
         var buffer = [UInt8](repeating: 0, count: 4096)
         let received = recv(connection, &buffer, buffer.count, 0)
@@ -172,7 +165,7 @@ final class LocalHTTPServer: @unchecked Sendable {
         let requestLine = request.split(separator: "\r\n", maxSplits: 1).first ?? ""
         let components = requestLine.split(separator: " ")
         guard components.count >= 2 else { return nil }
-        return String(components[1])
+        return String(components[1].split(separator: "?", maxSplits: 1)[0])
     }
 
     private func write(response: Response, to connection: Int32) {


### PR DESCRIPTION
## What changed

`swifterpm`'s `HTTPClient` now retries transient HTTP statuses (408, 429, 5xx) alongside the transport errors it already retried, honouring a bounded `Retry-After` in either of its legal forms. It also reports the URL that actually produced the status rather than the URL that was requested, with credentials stripped.

## Why

Registry archive fetches were failing with:

```
HTTP 408 for https://tuist.dev/api/registry/swift/<scope>/<name>/<version>.zip
```

The failures were package-agnostic, arrived in concentrated bursts rather than as a steady drip, and cleared on their own. During a burst they were frequent enough to fail a meaningful share of CI runs.

## Root cause

Two separate defects, and the second is what made the first hard to find.

**The URL in the message was wrong.** `ensureSuccessfulStatus` reported the `url` argument that was requested. The session has no delegate, so URLSession transparently follows the registry's 303 to object storage, and `httpResponse.url` holds the URL that actually answered. Every one of these failures was reported against `tuist.dev` when the request that returned 408 was to object storage.

The registry was never involved in the failure. Cross-referencing each failure against the ingress access log, every one has a matching `.zip` request answered **303 in 3 to 7 milliseconds**. Origin request time stayed under 3s, the Finch pool sat at 0 to 1 in-use connections, and S3 HEAD p99 was 200ms to 1s with spikes both inside and outside the affected window. ingress-nginx serves roughly 335k `/api/registry/swift` requests a day with zero 408s.

**Transient statuses were treated as permanent.** The retry loop caught only `URLError`, with a comment asserting that a non-2xx is deterministic for an artifact URL. True for 404, false for 408, 429, and 5xx. Because archive downloads run inside a `ConcurrentTasks.map` group of up to 32, one unretried transient status cancels every sibling still in flight, which is visible on our side as bursts of exactly 32 same-second 499s at the ingress.

## Why this approach

Retrying transient statuses restores parity with the rest of the CLI. `TuistHTTP/RetryMiddleware` and `TuistServer/ServerErrorClassifier` already classify `408 || 429 || 5xx` as retryable; swifterpm was the outlier.

The failing status is now modelled as `HTTPStatusError` rather than a stringly-typed `ToolError.message`, which is what lets the retry loop make the decision without parsing its own error text. The user-visible message keeps its existing `HTTP <code> for <url>` shape.

Two details worth calling out:

- **Credentials are stripped from the rendered URL.** Printing the post-redirect URL is only safe once redacted: a redirect target is routinely a presigned URL whose query string carries a signature, which would otherwise reach CI logs and command-event telemetry. Rendering keeps scheme, host, port and path, and drops user info, query and fragment.
- **`Retry-After` accepts both legal forms.** It is either delay-seconds or an HTTP-date (RFC 9110 section 10.2.3). Dates resolve against an injectable clock, then the 30 second bound applies so a mistaken or hostile value cannot stall a restore.

I also considered adding a retry to the registry Worker in `infra/registry-router`, which only treats `>= 500` as an origin failure and passes 408 straight through. That turned out to be unnecessary: the Worker leg is not the one failing, and it answers in single-digit milliseconds.

## Impact

A transient object-storage blip now costs a retry instead of a red CI build, and the error names the host that actually failed. That last part is the difference between the next report being diagnosed in minutes and being investigated as a registry outage.

This does not address why object storage returned 408 in the first place. The registry bucket is single-region (`X-Tigris-Regions: fra`), so any client far from that region pulls every archive cross-region and is the most exposed. That is being followed up separately with the storage provider.

## Validation

Red before green, using a new loopback HTTP server test helper.

Against the pre-fix code the behavioural tests fail, including the misattribution reproduced exactly:

```
✘ reportsTheURLThatActuallyFailedAfterARedirect
  Expectation failed: ("HTTP 408 for http://127.0.0.1:51250/registry.zip").contains("/storage.zip")
✘ retriesRequestTimeoutUntilItSucceeds
  Caught error: HTTP 408 for http://127.0.0.1:51251/archive.zip
✘ retriesServiceUnavailableAndTooManyRequests
  Caught error: HTTP 429 for http://127.0.0.1:51253/archive.zip
```

The credential leak reproduces the same way, against a redirect target carrying a signed query string:

```
✘ doesNotLeakRedirectCredentialsIntoTheMessage
  Expectation failed: !((message → "HTTP 408 for http://127.0.0.1:62320/storage.zip
  ?X-Amz-Credential=AKIAEXAMPLE&X-Amz-Signature=deadbeefsecret").contains("deadbeefsecret") → true)
```

Control tests (404 not retried, status code present in the message) pass before and after.

After the fix:

- `swift test`: 182 tests in 22 suites pass
- `bazel test //:swifterpm_tests`: PASSED, matching what CI runs
- `swiftformat` clean; `swiftlint` clean on the changed files (the one remaining `no_grouping_extension` warning in `Support.swift` is pre-existing on `extension PathLock` and only moved line number)
- `swift build --build-tests` emits no warnings

Coverage added: retry-until-success on 408, retry on 429 and 503, no retry on 4xx, correct URL reported after a redirect, credentials stripped from a signed redirect target, status code present in the message, plus unit coverage of the retryable classification, `Retry-After` in both seconds and HTTP-date form, and its bounding.

The test server uses `Synchronization.Mutex` rather than `@unchecked Sendable`, per the repository's Swift review guidance.

**Not verified on Linux.** `Support.swift` is compiled by `cli-linux-build` via the root package, but `swifterpm/Tests/` lives only in the standalone package, whose workflow is macOS-only, so the test helper's Glibc and Musl branches are correct by inspection and unverified. The Linux jobs are also gated on the PR being non-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
