### PR TITLE
fix(server,infra): catch a wedged Oban consumer, restore guest telemetry, stabilise parse-error grouping

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1069,27 +1069,43 @@ queue genuinely was being drained, just not by both consumers. It was
 found by hand, from `oban_jobs.attempted_by`.
 
 ```promql
-(
-  time() - max by (cluster, env, queue, node) (
-    tuist_oban_node_last_attempt_timestamp_seconds{
-      queue=~"process_xcresult|process_build"
-    }
-  ) < 900
-)
-unless
-(
-  time() - max by (cluster, env, queue, node) (
-    tuist_oban_node_last_completion_timestamp_seconds{
-      queue=~"process_xcresult|process_build"
-    }
-  ) < 900
-)
+count by (cluster, env, queue, node) (
+  (
+    time() - max by (cluster, env, queue, node) (
+      tuist_oban_node_last_attempt_timestamp_seconds{
+        cluster="tuist-production",
+        queue=~"process_xcresult|process_build"
+      }
+    ) < 900
+  )
+  unless
+  (
+    time() - max by (cluster, env, queue, node) (
+      tuist_oban_node_last_completion_timestamp_seconds{
+        cluster="tuist-production",
+        queue=~"process_xcresult|process_build"
+      }
+    ) < 900
+  )
+) > 0
 ```
 
 - Pending period: 5 minutes
+- Keep firing for: 5 minutes
 - Severity: critical
 - Summary: `{{ $labels.node }} has been taking {{ $labels.queue }} jobs
-  without completing any for over 15 minutes in {{ $labels.cluster }}`
+  without completing any for over 15 minutes`
+
+The `count by` wrapper exists to give the threshold something to compare.
+The inner expression's own value is seconds since the node's last
+attempt, which is bounded by the `< 900` filter and can legitimately be
+`0`, so thresholding it directly would need a negative bound to mean
+"any series at all". Wrapping yields exactly `1` per wedged consumer and
+`> 0` then reads as what it is.
+
+Production only, unlike the queue rule above, because this one pages.
+A wedged consumer on canary or staging is worth knowing about and is not
+worth waking someone for; neither serves customer traffic.
 
 Read it as: this node started a job recently, and did not finish one
 recently. Both halves are load-bearing. Without the attempt clause an

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1050,6 +1050,73 @@ plugin, the scrape, or the queue's registration went away, not that the
 queue is idle. Production only: staging and canary can legitimately run
 with no processor deployment at all.
 
+### Remote processing queue consumer takes work but completes none
+
+The rule above keys on the queue, which is the right shape when *every*
+consumer is gone. It is blind when one of several is broken: the healthy
+peers keep `available` at zero, so queue depth, queue age and every
+readiness signal read perfectly normal while a fraction of jobs is
+quietly destroyed.
+
+On 2026-08-25 one of the two production xcresult processors entered a
+state where every parse blocked for the full 600s NIF deadline. It
+completed zero jobs for fourteen hours while its sibling completed 84 to
+218 an hour. Nothing fired. Host CPU was flat at 2.5 of 10 cores (a
+wedged parse burns none, which is what distinguishes it from a slow
+one), the Pod stayed `1/1 Running` with zero restarts, and
+`queue_oldest_available_age_seconds` sat at zero throughout because the
+queue genuinely was being drained, just not by both consumers. It was
+found by hand, from `oban_jobs.attempted_by`.
+
+```promql
+(
+  time() - max by (cluster, env, queue, node) (
+    tuist_oban_node_last_attempt_timestamp_seconds{
+      queue=~"process_xcresult|process_build"
+    }
+  ) < 900
+)
+unless
+(
+  time() - max by (cluster, env, queue, node) (
+    tuist_oban_node_last_completion_timestamp_seconds{
+      queue=~"process_xcresult|process_build"
+    }
+  ) < 900
+)
+```
+
+- Pending period: 5 minutes
+- Severity: critical
+- Summary: `{{ $labels.node }} has been taking {{ $labels.queue }} jobs
+  without completing any for over 15 minutes in {{ $labels.cluster }}`
+
+Read it as: this node started a job recently, and did not finish one
+recently. Both halves are load-bearing. Without the attempt clause an
+idle node on a quiet queue looks identical to a wedged one, because
+"time since last completion" climbs in both cases. `unless` rather than
+a second comparison is what makes the rule cover a node that wedges
+*before* its first completion: that node has no completion series at
+all, and an `and` against a missing series matches nothing.
+
+Both gauges are absolute unix timestamps rather than elapsed seconds, so
+they need no state between events and no scan of `oban_jobs`, which
+matters: the table is multi-gigabyte and neither `attempted_by` nor
+`completed_at` is indexed, so the per-node question cannot be answered
+from the polling side at all. `node` is Oban's own node name, the value
+it writes into `oban_jobs.attempted_by`, so the alert names the row to
+go and query.
+
+Unlike the queue rules, these are emitted by the consumer about itself,
+so a consumer that stops serving metrics entirely produces no series
+rather than a firing alert. That gap is deliberately left to the
+`xcresult processor guest metrics unavailable` rules below, which key on
+`up` and already cover it.
+
+15 minutes for the same reason as the queue rule: the NIF's own parse
+deadline is 600s plus a 30s cancellation grace, so a single legitimately
+slow job cannot reach it.
+
 ### Swift registry catalog coverage deferred
 
 Same shape as the queue rule above, for the writer rather than a

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -661,8 +661,15 @@ xcresultProcessor:
     # was being dropped before it left the VM. This is the tailnet hostname of
     # the Tailscale-operator proxy in front of the same receiver Service, set
     # up in the k8s-monitoring chart's production values.
+    #
+    # Fully qualified, not the bare MagicDNS label. The bare form only
+    # resolves when the tailnet search domain is in the guest's resolver,
+    # and on these VMs it is not: tailscaled sets DNS up at boot, so a
+    # short name resolves for the first few minutes and then stops. That
+    # is what the host-side `macosFleet.hostLogs.url` below has always
+    # used, and why host logs kept flowing while the guest's did not.
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://tuist-alloy-receiver-production:4317
+      value: http://tuist-alloy-receiver-production.taild6d7bb.ts.net:4317
     # Push logs to the same tailnet-fronted Alloy. Setting this attaches the
     # in-process handler in Tuist.Application.start_loki_logger/0, which is
     # the only way these pods can ship logs: Alloy cannot tail a Tart guest
@@ -671,7 +678,7 @@ xcresultProcessor:
     # k8s-monitoring chart exposes on 3100. No credentials here: Alloy
     # forwards to Grafana Cloud with the ones it already holds.
     - name: TUIST_LOKI_URL
-      value: http://tuist-alloy-receiver-production:3100
+      value: http://tuist-alloy-receiver-production.taild6d7bb.ts.net:3100
 
 # Declarative Scaleway Elastic Metal kura runner-cache node, co-located with the
 # Mac fleet in fr-par. The provider orders the bare-metal server, attaches it to

--- a/server/lib/tuist/oban/prom_ex_plugin.ex
+++ b/server/lib/tuist/oban/prom_ex_plugin.ex
@@ -11,6 +11,12 @@ defmodule Tuist.Oban.PromExPlugin do
   node that runs this plugin. That is deliberate: it makes "the only
   consumer of this queue is gone" observable from a node that is
   itself healthy.
+
+  Those queue-level gauges answer "is this queue being drained at all".
+  They cannot answer "is every consumer of it healthy": one broken
+  consumer beside a working one leaves the queue draining normally. The
+  `node_last_attempt/completion_timestamp_seconds` pair covers that case
+  from the opposite direction, reported by each consumer about itself.
   """
   use PromEx.Plugin
 
@@ -18,6 +24,7 @@ defmodule Tuist.Oban.PromExPlugin do
 
   alias Tuist.Environment
 
+  @job_start_event [:oban, :job, :start]
   @job_complete_event [:oban, :job, :stop]
   @job_exception_event [:oban, :job, :exception]
   @producer_complete_event [:oban, :producer, :stop]
@@ -100,6 +107,27 @@ defmodule Tuist.Oban.PromExPlugin do
             reporter_options: [buckets: @job_attempt_buckets],
             tag_values: &job_exception_tag_values/1,
             tags: [:name, :queue, :state, :worker]
+          )
+        ]
+      ),
+      Event.build(
+        :oban_node_liveness_metrics,
+        [
+          last_value(
+            @metric_prefix ++ [:node, :last, :attempt, :timestamp, :seconds],
+            event_name: @job_start_event,
+            measurement: &current_unix_second/2,
+            description: "Unix timestamp of the last job this node started on the queue.",
+            tag_values: &node_liveness_tag_values/1,
+            tags: [:name, :queue, :node]
+          ),
+          last_value(
+            @metric_prefix ++ [:node, :last, :completion, :timestamp, :seconds],
+            event_name: @job_complete_event,
+            measurement: &current_unix_second/2,
+            description: "Unix timestamp of the last job this node completed on the queue.",
+            tag_values: &node_liveness_tag_values/1,
+            tags: [:name, :queue, :node]
           )
         ]
       ),
@@ -281,6 +309,34 @@ defmodule Tuist.Oban.PromExPlugin do
 
   defp age_seconds(now, %NaiveDateTime{} = scheduled_at),
     do: age_seconds(now, DateTime.from_naive!(scheduled_at, "Etc/UTC"))
+
+  # Absolute timestamps rather than a "seconds since" gauge, so the pair
+  # needs no state between events and no scan of `oban_jobs`. The elapsed
+  # time is `time() - <gauge>` at query time, which is also what makes a
+  # node that stops reporting fall out of the alert as absent rather than
+  # as a stale healthy-looking sample.
+  #
+  # Reported per node because the failure this pair exists to catch is
+  # per-consumer, not per-queue: on 2026-08-25 one of two xcresult
+  # processors took jobs for 14 hours and completed none, while its
+  # sibling kept `available` at 0. Every queue-level gauge, including
+  # `queue_oldest_available_age_seconds`, read perfectly healthy
+  # throughout.
+  #
+  # `node` is Oban's own node name, the same value it writes into
+  # `oban_jobs.attempted_by`, so a firing alert names the row you can go
+  # and query.
+  defp node_liveness_tag_values(metadata) do
+    config = config_from_metadata(metadata)
+
+    %{
+      name: normalize_module_name(config.name),
+      queue: metadata.job.queue,
+      node: config.node
+    }
+  end
+
+  defp current_unix_second(_measurements, _metadata), do: System.system_time(:second)
 
   defp job_complete_tag_values(metadata) do
     config = config_from_metadata(metadata)

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -151,10 +151,53 @@ defmodule Tuist.Processor.XCResultProcessor do
 
   defp parse_xcresult(xcresult_path, root_dir) do
     :telemetry.span([:tuist, :processor, :xcresult, :parse], %{}, fn ->
-      result = XCResultNIF.parse(xcresult_path, root_dir)
+      result =
+        xcresult_path
+        |> XCResultNIF.parse(root_dir)
+        |> normalize_parse_error(xcresult_path)
+
       status = if match?({:ok, _}, result), do: :ok, else: :error
       {result, %{status: status}}
     end)
+  end
+
+  # The NIF reports a failure as a JSON blob whose message embeds the
+  # absolute bundle path, which carries both a `System.tmp_dir!()` directory
+  # named with an `:erlang.unique_integer` and the customer's own bundle
+  # filename. Both are unique per job, so Sentry fingerprints every failure
+  # as a brand new issue: the fleet-wide parse stall on 2026-08-25 arrived
+  # as fifteen separate "new issue" alerts, each looking like a harmless
+  # one-off, rather than one issue with a rate worth paging on.
+  #
+  # Collapse the volatile path out of the term Oban reports so the grouping
+  # is stable, and log the original so the path stays one query away.
+  defp normalize_parse_error({:ok, _} = result, _xcresult_path), do: result
+
+  defp normalize_parse_error({:error, reason}, xcresult_path) do
+    message = parse_error_message(reason)
+    Logger.error("xcresult parse failed at #{xcresult_path}: #{message}")
+    {:error, stable_parse_error(message, xcresult_path)}
+  end
+
+  defp parse_error_message(reason) when is_binary(reason) do
+    case JSON.decode(reason) do
+      {:ok, %{"error" => message}} when is_binary(message) -> message
+      _ -> reason
+    end
+  end
+
+  defp parse_error_message(reason), do: inspect(reason)
+
+  # A dedicated atom rather than a sanitized string: the timeout is the one
+  # failure mode with its own alert, and an atom is what a queue-consumer
+  # rule and a `grep` can both key on unambiguously. The elapsed seconds it
+  # replaces are a compile-time constant in the NIF, not information.
+  defp stable_parse_error(message, xcresult_path) do
+    if String.starts_with?(message, "xcresult parsing timed out") do
+      :parse_timeout
+    else
+      {:parse_failed, String.replace(message, xcresult_path, "<xcresult>")}
+    end
   end
 
   defp read_quarantined_tests(xcresult_path) do

--- a/server/test/tuist/oban/prom_ex_plugin_test.exs
+++ b/server/test/tuist/oban/prom_ex_plugin_test.exs
@@ -107,4 +107,58 @@ defmodule Tuist.Oban.PromExPluginTest do
                Enum.find(lengths, fn {_, meta} -> meta.queue == "process_xcresult" and meta.state == "available" end)
     end
   end
+
+  describe "node liveness metrics" do
+    defp node_liveness_metric(suffix) do
+      []
+      |> PromExPlugin.event_metrics()
+      |> Enum.flat_map(& &1.metrics)
+      |> Enum.find(fn metric -> Enum.take(metric.name, -3) == suffix end)
+    end
+
+    defp job_metadata(queue, node) do
+      %{job: %{queue: queue}, conf: %{name: Oban, node: node}}
+    end
+
+    test "tags the last-completion gauge with the queue and Oban's node name" do
+      metric = node_liveness_metric([:completion, :timestamp, :seconds])
+
+      assert metric
+      assert metric.tags == [:name, :queue, :node]
+
+      tags = metric.tag_values.(job_metadata("process_xcresult", "tuist-xcresult-processor-abc"))
+
+      assert tags.queue == "process_xcresult"
+      assert tags.node == "tuist-xcresult-processor-abc"
+    end
+
+    test "tags the last-attempt gauge with the queue and Oban's node name" do
+      metric = node_liveness_metric([:attempt, :timestamp, :seconds])
+
+      assert metric
+      tags = metric.tag_values.(job_metadata("process_build", "tuist-processor-xyz"))
+
+      assert tags.queue == "process_build"
+      assert tags.node == "tuist-processor-xyz"
+    end
+
+    test "measures the current unix second rather than any job measurement" do
+      metric = node_liveness_metric([:completion, :timestamp, :seconds])
+
+      # The job's own duration must not leak into a timestamp gauge: the
+      # alert computes `time() - gauge`, so a duration here would read as
+      # a completion in 1970.
+      value = metric.measurement.(%{duration: 123_456}, job_metadata("process_xcresult", "node-a"))
+
+      assert_in_delta value, System.system_time(:second), 5
+    end
+
+    test "the two gauges are driven by different Oban events" do
+      completion = node_liveness_metric([:completion, :timestamp, :seconds])
+      attempt = node_liveness_metric([:attempt, :timestamp, :seconds])
+
+      assert completion.event_name == [:oban, :job, :stop]
+      assert attempt.event_name == [:oban, :job, :start]
+    end
+  end
 end

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -79,7 +79,50 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         {:error, "parse failed"}
       end)
 
-      assert {:error, "parse failed"} = XCResultProcessor.process_local(fixture_zip)
+      assert {:error, {:parse_failed, "parse failed"}} =
+               XCResultProcessor.process_local(fixture_zip)
+    end
+
+    test "collapses a parse timeout to a stable reason regardless of bundle path" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error, JSON.encode!(%{"error" => "xcresult parsing timed out after 600s at #{xcresult_path}"})}
+      end)
+
+      assert {:error, :parse_timeout} = XCResultProcessor.process_local(fixture_zip)
+    end
+
+    test "strips the bundle path out of a non-timeout parse failure" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error,
+         JSON.encode!(%{
+           "error" => "Failed to decode xcresult test-results at #{xcresult_path}: dataCorrupted"
+         })}
+      end)
+
+      assert {:error, {:parse_failed, message}} = XCResultProcessor.process_local(fixture_zip)
+
+      assert message == "Failed to decode xcresult test-results at <xcresult>: dataCorrupted"
+      refute message =~ "xcresult_test_fixture_"
+    end
+
+    test "logs the original message with the path it stripped" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error, JSON.encode!(%{"error" => "xcresult parsing timed out after 600s at #{xcresult_path}"})}
+      end)
+
+      log = capture_log(fn -> XCResultProcessor.process_local(fixture_zip) end)
+
+      assert log =~ "xcresult parse failed at"
+      assert log =~ "Test.xcresult"
     end
 
     @tag :tmp_dir


### PR DESCRIPTION
## What changed

Three independent observability gaps, all of which had to be open at once for a production xcresult-processor replica to claim jobs and complete none of them for fourteen hours with nothing firing.

1. A per-consumer liveness signal for remote Oban queues, plus the alert rule that uses it.
2. The macOS guests' OTLP and Loki endpoints, which were pointed at a hostname that stops resolving a few minutes after boot.
3. Sentry fingerprinting for xcresult parse failures.

## Why

On 2026-08-25 one of the two production xcresult processors entered a state where every parse blocked for the full 600s NIF deadline. It completed zero jobs for fourteen hours. Its sibling completed 84 to 218 an hour, so the queue kept draining and the backlog never grew.

Every signal we had read healthy. The Pod was `1/1 Running` with zero restarts, `up` was 1, the PDB was satisfied, and `tuist_oban_queue_oldest_available_age_seconds` sat at zero the entire time, because the queue genuinely was being drained, just not by both consumers. Host CPU was flat at 2.5 of 10 cores, which is the tell that separates a wedged parse from a slow one: a wedged one burns no CPU. It was eventually found by hand, by grouping `oban_jobs` on `attempted_by`.

Root cause of the wedge itself is still unknown. The VM was replaced to restore capacity and the evidence went with it. This PR is about the fourteen hours, not the wedge.

## Per-consumer liveness

The existing `Remote processing queue has no consumer` rule is the right shape when every consumer is gone, and blind when one of several is broken. This adds the complementary signal:

- `tuist_oban_node_last_attempt_timestamp_seconds{queue, node}`
- `tuist_oban_node_last_completion_timestamp_seconds{queue, node}`

The alert reads as "this node started a job recently and did not finish one recently". Both halves are load-bearing: without the attempt clause, an idle node on a quiet queue is indistinguishable from a wedged one, since time-since-last-completion climbs in both cases.

Two design choices worth reviewing:

**Absolute timestamps, not an elapsed-seconds gauge.** The obvious metric is `seconds_since_last_completion`, but producing it needs either state carried between telemetry events or a query over `oban_jobs`. The table is currently 8.3 GB across 109k rows with neither `attempted_by` nor `completed_at` indexed, so grouping by node from the polling side would heap-scan the whole thing on every poll, on a table that has already caused DB saturation once. Timestamp gauges need neither, and the elapsed time is `time() - gauge` at query time.

**`unless`, not `and`.** A node that wedges before its first completion has no completion series at all, and an `and` against a missing series matches nothing. `unless` covers that case.

These are emitted by the consumer about itself, so a consumer that stops serving metrics produces no series rather than a firing alert. That gap is deliberately left to the existing `up`-based guest metrics rules rather than duplicated here.

## Guest telemetry egress

The processor VMs reach Alloy over Tailscale only. Their OTLP and Loki endpoints used the bare MagicDNS label, while the host-side log shipper on the same minis used the FQDN. The bare form resolves only while the tailnet search domain is in the guest's resolver, which tailscaled sets up at boot, so guest logs flowed for a few minutes after each boot and then stopped.

Measured over three hours during the incident: the host shipper delivered 686 KB, the guest delivered 716 bytes. That is why there were no processor logs for the entire incident.

This also restores traces, which matters more than the logs. The parse path is already instrumented with spans carrying archive size, test case count and a per-phase breakdown, written specifically to answer "where is this job spending its time". None of it was arriving. With traces the parse-versus-download question is one query instead of an inference from host CPU.

Production only. Canary and staging do not set these two variables.

## Parse-error grouping

The NIF reports failures as JSON whose message embeds the absolute bundle path, which carries a temp directory named with `:erlang.unique_integer` plus the bundle filename. Both are unique per job, so Sentry fingerprinted every single failure as a brand new issue. The stall surfaced as roughly fifteen separate "new issue" Slack alerts, each individually looking like a harmless one-off, rather than one issue with a rate worth paging on.

Parse failures now collapse to a stable reason with the volatile path removed, and the original message is logged so the path stays one query away. A timeout gets its own atom since it is the failure mode with a dedicated alert.

## Impact

No behaviour change to job processing: the same failures still retry the same way. `process_local/2` now returns `{:error, :parse_timeout}` or `{:error, {:parse_failed, message}}` where it previously returned the raw NIF string; nothing outside the module matched on that value.

## Validation

- 28 tests pass with `--warnings-as-errors`, including new coverage for the tag values, the measurement source, the event wiring, and all three error-normalisation paths.
- Credo clean on the changed files.
- Values YAML re-parsed to confirm all three receiver endpoints now agree.
- The alert expression is written against metric names this PR introduces; it has not been exercised against live data yet, because the series do not exist until this ships.

## Follow-ups not in this PR

- **Adaptive Metrics.** `instance` and `pod` are currently aggregated away on `tuist_oban_*` (the datasource rejects a per-instance query on `tuist_oban_queue_length_count` for exactly this reason). The new series need an aggregation exclusion or the alert will have nothing to group by. That is Grafana Cloud config, not repo state, and has to be done by hand before the rule is created.
- **The alert rule itself** must be created in Grafana; rules are not provisioned from this repo. The expression, pending period, severity and summary are in `alerts.md`.
- Root cause of the wedge. Still open.
- Auto-remediation was considered and deliberately not included: alert first, decide later whether a wedged consumer should pause its own queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
