### PR TITLE
fix(cli): stabilize the release build's DerivedData path so it hits the compilation cache

### DIFF
--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -23,7 +23,11 @@ APPLE_PASSWORD=$(op read "op://tuist/App Specific Password/password")
 TEAM_ID='U6LC622NKF'
 ASC_PROVIDER=PedroPieraBuendia211042238 # Obtained with xcrun altool -list-providers
 CERTIFICATE_NAME="Developer ID Application: Tuist GmbH (U6LC622NKF)"
-DERIVED_DATA_PATH=$TMP_DIR/derived-data
+# Until Xcode 27's prefix mapping lands, a compilation-cache key embeds the
+# DerivedData path, so a per-run temporary path gives every task a key no other
+# run can match and the build misses the cache entirely. Keep this stable and
+# repo-relative; $TMP_DIR stays for the keychain and certificate material.
+DERIVED_DATA_PATH=$BUILD_DIRECTORY/derived-data
 export TUIST_EE=1
 KEYCHAIN_PATH=$TMP_DIR/keychain.keychain
 KEYCHAIN_PASSWORD=$(uuidgen)


### PR DESCRIPTION
> Describe here the purpose of your PR.

The CLI release build compiles roughly 9,450 cacheable tasks and hits 108 of them (1.1%). It takes about 16 minutes on every run, 4 to 6 times a day on main. This makes it hit the Xcode compilation cache instead.

### Root cause

The compilation-cache key embeds absolute paths, DerivedData's above all. `XcodeCacheSettingsProjectMapper` only enables the prefix mappings that make keys path-independent when the selected Xcode is 27 or newer, and release CI pins 26.0.1 (`.xcode-version-releases`), so keys are path-dependent today.

`mise/tasks/cli/bundle.sh` set `DERIVED_DATA_PATH` under a per-run `mktemp -d`. A fresh random path on every run means a fresh key for every task on every run, so no run can ever match another. The cache was not misconfigured and it was not unreachable: on the last release build all 9,344 misses carry a `read_duration` (a remote query that came back empty) and 8,537 carry a `write_duration`. Every run queried kura, missed everything, and then uploaded about 8,500 entries under keys nothing would ever request again.

The 108 tasks that did hit are all `Compiling Clang module <toolchain module>` (SwiftShims, ptrauth, _Builtin_stdarg and friends), which is the same PCM recompiled several times inside a single run, not reuse across runs.

### Why this fix rather than the obvious alternatives

The local CAS store is machine-level, at `<machine DerivedData root>/CompilationCache.noindex` (see `CacheWarmCommandService.compilationCacheCASArgument`), not inside whatever `-derivedDataPath` receives. So "the throwaway DerivedData empties the store" is not what was happening, and preserving DerivedData contents between runs is not what fixes it. The store was always fine. Only the key was poisoned, so only the path string needs to change.

Pointing `DERIVED_DATA_PATH` at a stable repo-relative path is what `mise/tasks/app/bundle.sh` already does, and the contrast is measurable across the last 14 days of Release builds on the same fleet through the same `tuist xcodebuild` wrapper:

| scheme | DerivedData path | hit rate | avg duration |
| --- | --- | --- | --- |
| TuistApp | `$BUILD_DIRECTORY/app/derived` (stable, repo-relative) | 67.2% | 112s |
| tuist | `$TMP_DIR/derived-data` (random per run) | 1.1% | 1004s |
| ProjectDescription | same random path, built first in the same script | 0.0% | 26s |

Hit rate tracks path stability and nothing else.

### Impact and constraints

`$TMP_DIR` keeps holding the keychain and `certificate.p12`, so the `trap` that removes secret material on exit is unchanged. `rm -rf $BUILD_DIRECTORY` still runs before the builds, so each run starts from an empty DerivedData exactly as it did before. Only the path string changes.

While CI is on Xcode 26 the keys stay path-dependent, so this pays off only as long as the checkout path is identical across release runners. TuistApp demonstrates that holds on the fleet today. Xcode 27's prefix mapping removes the constraint. Note also that the Release and whole-module-optimization key space never overlaps the debug and test builds, so it warms only from previous release builds, which is fine at 4 to 6 runs a day on main.

### Validation

The release build itself cannot be exercised locally: it needs 1Password credentials, the Developer ID certificate, and Apple notarization. What was checked instead:

- `bash -n mise/tasks/cli/bundle.sh` passes.
- Every `$BUILD_DIRECTORY` consumer was audited. Nothing packages the directory wholesale: both `zip` invocations name their entries explicitly, the release workflow uploads explicit file paths, and the SHASUMS loop guards on `[ -f "$file" ]`, so the new `derived-data/` directory is skipped.
- `/build/` is already covered by `.gitignore`, so `build/derived-data` is ignored locally too.

The real signal is the cache hit rate on the next canary. The first post-merge run should still miss, since it is what establishes the keys at the new path. From the second run onward, `cacheable_task_local_hits_count` on `tuist`-scheme build runs should move off 1.1% toward something like TuistApp's 67%, with build duration dropping well below the current 16 minutes.

### How to test locally

Not reproducible locally end to end, for the credential reasons above. To confirm the mechanism on any project on a pre-27 Xcode, build once, build again with an unchanged tree, and compare the reported cache hit rate when `-derivedDataPath` is held constant versus pointed at a fresh `mktemp -d` each time.

After merge, watch the next `tuist`-scheme build run on the Build Runs dashboard for `tuist/tuist` and check `cacheable_task_local_hits_count` against `cacheable_tasks_count`.
