### PR TITLE
feat(kura): record per-artifact write size so module uploads have a measurable distribution

### DIFF
--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -41,6 +41,7 @@ pub struct Metrics {
     artifact_writes: Family<ArtifactOpLabels, Counter>,
     artifact_read_bytes: Family<ArtifactOpLabels, Counter>,
     artifact_write_bytes: Family<ArtifactOpLabels, Counter>,
+    artifact_write_size_bytes: Family<ArtifactRouteLabels, Histogram>,
     artifact_egress_completions: Family<ArtifactOpLabels, Counter>,
     artifact_egress_bytes: Family<ArtifactOpLabels, Counter>,
     artifact_egress_duration: Family<ArtifactRouteLabels, Histogram>,
@@ -272,6 +273,10 @@ impl Metrics {
         let action_cache_cascade_removed = Counter::default();
         let artifact_read_bytes = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_write_bytes = Family::<ArtifactOpLabels, Counter>::default();
+        let artifact_write_size_bytes =
+            Family::<ArtifactRouteLabels, Histogram>::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(4096.0, 2.0, 20))
+            });
         let artifact_egress_completions = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_egress_bytes = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_egress_duration =
@@ -521,6 +526,11 @@ impl Metrics {
             "kura_artifact_write_bytes_total",
             "Artifact write throughput by producer and result",
             artifact_write_bytes.clone(),
+        );
+        registry.register(
+            "kura_artifact_write_size_bytes",
+            "Size of each stored artifact by producer. For producer=\"module\" this is the per-upload payload that stages to the tmp dir, so its upper quantiles size the staging reserve and the TmpBudget::try_reserve floor",
+            artifact_write_size_bytes.clone(),
         );
         registry.register(
             "kura_artifact_egress_completions_total",
@@ -1261,6 +1271,7 @@ impl Metrics {
             action_cache_cascade_removed,
             artifact_read_bytes,
             artifact_write_bytes,
+            artifact_write_size_bytes,
             artifact_egress_completions,
             artifact_egress_bytes,
             artifact_egress_duration,
@@ -1522,6 +1533,11 @@ impl Metrics {
             self.artifact_write_bytes
                 .get_or_create(&labels)
                 .inc_by(bytes);
+            self.artifact_write_size_bytes
+                .get_or_create(&ArtifactRouteLabels {
+                    producer: producer.as_str().to_owned(),
+                })
+                .observe(bytes as f64);
         }
     }
 
@@ -2801,6 +2817,35 @@ mod tests {
     }
 
     #[test]
+    fn module_write_sizes_are_bucketed_by_producer_alone() {
+        let metrics = Metrics::new("eu-west".into(), "acme".into());
+        metrics.record_artifact_write(ArtifactProducer::Module, "ok", 21 * 1024 * 1024);
+        metrics.record_artifact_write(ArtifactProducer::Module, "error", 0);
+
+        let rendered = metrics.render();
+        let lines: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with("kura_artifact_write_size_bytes"))
+            .collect();
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("producer=\"module\""))
+        );
+        // A failed write carries no payload, so it must not land in the zero
+        // bucket and drag the quantiles that size the staging reserve down.
+        assert!(lines.iter().any(
+            |line| line.starts_with("kura_artifact_write_size_bytes_count") && line.ends_with(" 1")
+        ));
+        // The June 2026 series blowup came from a high-cardinality label on a
+        // Kura histogram; the size distribution stays producer-scoped.
+        assert!(lines.iter().all(|line| !line.contains("tenant")
+            && !line.contains("namespace")
+            && !line.contains("result=")));
+    }
+
+    #[test]
     fn render_includes_recorded_metrics() {
         let metrics = Metrics::new("eu-west".into(), "acme".into());
         metrics.record_http("/up".into(), StatusCode::OK, Duration::from_millis(10));
@@ -2941,6 +2986,7 @@ mod tests {
         );
         assert!(rendered.contains("kura_artifact_reads_total"));
         assert!(rendered.contains("kura_artifact_write_bytes_total"));
+        assert!(rendered.contains("kura_artifact_write_size_bytes_bucket"));
         assert!(rendered.contains("kura_artifact_egress_completions_total"));
         assert!(rendered.contains("kura_artifact_egress_bytes_total"));
         assert!(rendered.contains("kura_artifact_egress_duration_seconds"));


### PR DESCRIPTION
## What changed

Adds `kura_artifact_write_size_bytes`, a histogram of the size of each stored artifact, observed inside `Metrics::record_artifact_write` in `kura/src/metrics.rs`. Buckets run 4 KiB to 2 GiB and the only label is `producer`.

## Why

The upload staging reserve shares the data volume with the artifact ring, so every byte reserved for staging is cache an account cannot hold. [PR #12606](https://github.com/tuist/tuist/pull/12606) cut that reserve from half the disk claim to an eighth, floored at 2 GiB.

That floor is not measured, it is inferred. `MAX_MODULE_TOTAL_BYTES` (`kura/src/constants.rs`) is 2 GiB and `TmpBudget::try_reserve` (`kura/src/utils.rs`) rejects an oversized request outright rather than queuing it, so the floor has to cover the largest thing that can stage. Module uploads are that thing, and their size distribution was the one input nobody could measure:

- `kura_tmp_dir_bytes` covers every lane in aggregate and does not isolate modules.
- `kura_artifact_write_bytes_total` is a counter, so it yields a mean but never a tail.
- The telemetry that was meant to answer this, the ClickHouse table `module_cache_outputs`, has **0 rows in production and always has**.

## Root cause of the empty table

Worth recording, because the table looks fully wired and is not.

The server half is fine: the controller reads the field (`analytics_controller.ex:533`), `CommandEvents.create_module_cache_outputs/2` builds the rows, the buffer is started in `application.ex:320`, and the migration ran. **No CLI has ever sent the field.**

The producer is `RunMetadataStorage.current.add(moduleCacheOutput:)` in `Sources/Storage/ModuleCacheRemoteStorage.swift` in the TuistCacheEE submodule, and it exists only on `origin/feat/module-cache-transfer-instrumentation` (commits `9c7b715`, `d56a89f`, `0ac4af6`, 2026-07-02). That branch was never merged: `git merge-base --is-ancestor 0ac4af6 HEAD` returns false. EE main instead took `650dc80` (AppleArchive/LZFSE compression, EE #69) on 2026-07-03, which rewrote the same upload and download functions, and the instrumentation branch was never rebased onto it. The same day, the open source half merged here as `cf7ce0b854` ([#11619](https://github.com/tuist/tuist/pull/11619)): server, migration, buffer, dashboard tab, OpenAPI, CLI core types.

So a change split across two repos landed only on the open side. In open source `cli/`, `add(moduleCacheOutput:)` has zero callers, which is the fast way to confirm it.

No user visible breakage: every widget in `server/lib/tuist_web/components/runs/module_cache_tab.ex` is `:if` guarded on `> 0`, so the tab degrades to invisible rather than rendering zeros. The cost is a per run page ClickHouse query that always returns zeros.

## Why measure at the node instead of restoring the CLI path

Restoring the EE emission reaches the fleet only at CLI adoption speed, which cannot answer a capacity question now. It would also need rewriting rather than reviving: the branch set `size` and `compressedSize` to the same value, and after the compression rewrite the payload is no longer the on disk size, so a straight revive would be wrong twice over.

`record_artifact_write` already receives the completed size on every client write path, and it is the only place module uploads are counted. The module lane has no single shot PUT, every upload goes `start_module_upload` to multipart completion (`http.rs:2218`), so one histogram there covers 100% of module uploads for the whole fleet regardless of CLI version, at deploy speed.

## What production already shows

`kura_usage_events` (ClickHouse, schema `Tuist.Kura.UsageEvent`) already isolates modules as `artifact_kind = 'module'`. Rollups are per window sums, so they give a mean and not a tail, but windows containing exactly one upload yield exact per upload sizes.

Last 7 days, module lane:

| direction | requests | total bytes | mean |
| --- | --- | --- | --- |
| upload | 45,631 | 206.5 GB | 4.3 MiB |
| download | 6,737,800 | 17.66 TB | 2.5 MiB |

Exact single upload samples, last 30 days (n = 70): p50 108.5 MiB, p90 527.7 MiB, p99 529.1 MiB, max 529.1 MiB. The largest per window mean across all 853 windows is the same 529.1 MiB.

Two things follow. First, module uploads really are the large stager: the observed 529 MiB tail is roughly 25x the 21.6 MiB largest single CAS upload that #12606 measured, so a reserve sized from CAS traffic alone would be badly undersized. Second, nothing observed comes close to 2 GiB, so the floor looks conservative by roughly 4x. That single upload sample is biased, though, since a window with one upload skews toward slow or quiet accounts, which is exactly why the unbiased histogram is worth having before anyone moves the floor.

## Cardinality

Labelled by `producer` alone, so 6 producers times 22 series. The June 2026 billable series spike came from a high cardinality label on a Kura histogram (`kura_http_request_duration_seconds_bucket` reached 180k active series), so there is a test asserting the size histogram carries no tenant or namespace label.

`result` is deliberately dropped as well. Failed writes pass `bytes = 0` and would otherwise pile into the zero bucket and drag down the very quantiles the reserve is sized from. The existing `bytes > 0` guard keeps them out, and a test pins that.

No monitoring change is needed. Kura is scraped wholesale under `job_name "kura"` and no allow list or `write_relabel` rule in `infra/helm/k8s-monitoring/values.yaml` matches the new name.

## How to test locally

From `kura/`:

```
mise exec -- cargo test --lib metrics::
mise exec -- cargo clippy --all-targets -- -D warnings
mise run format -- --check
```

Validated here: 6 metrics tests pass, including the new `module_write_sizes_are_bucketed_by_producer_alone`; clippy is clean with warnings as errors; formatting applied.

Once deployed, the floor question is answered by:

```
histogram_quantile(0.99, sum by (le) (rate(kura_artifact_write_size_bytes_bucket{producer="module"}[7d])))
```

and the `_count` / `_sum` pair cross checks against the `kura_usage_events` mean above.

## Follow up, not in this PR

`module_cache_outputs` is unfed rather than obsolete, so I would keep it and its `server/data-export.md` entry. Making the per run module cache tab work again needs a fresh EE implementation against the post compression code, with `size` and `compressedSize` genuinely distinguished this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
