### PR TITLE
perf(infra): reuse macOS build caches for the xcresult processor image

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1017,21 +1017,43 @@ jobs:
 
           git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../../" --tag "${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}" -o CHANGELOG.md 2>/dev/null
 
+      # `actions/checkout` runs `git clean -ffdx` on this host's persistent
+      # workspace, which deletes `server/deps`, `server/_build` and both NIF
+      # `.build` directories, so every release compiled the two Swift NIFs and
+      # the whole Elixir dependency tree cold. Pointing the caches outside the
+      # workspace puts them out of the clean's reach.
+      #
+      # Keyed by runner name because a runner process runs one job at a time:
+      # two jobs landing on the same host (this one and the on-demand
+      # `xcresult-processor-image.yml`) can then never share a cache and
+      # cannot race on the release directory.
+      - name: Point build caches outside the workspace
+        run: |
+          set -euo pipefail
+          cache_root="${HOME}/.cache/tuist-ci/server-macos-release/${RUNNER_NAME// /_}"
+          mkdir -p "${cache_root}/nif"
+          {
+            echo "MIX_BUILD_ROOT=${cache_root}/mix-build"
+            echo "MIX_DEPS_PATH=${cache_root}/mix-deps"
+            echo "TUIST_NIF_BUILD_ROOT=${cache_root}/nif"
+          } >> "$GITHUB_ENV"
+
       - name: Build server release for macOS
         id: release
         working-directory: server
         run: |
           set -euo pipefail
+          RELEASE_DIR="${MIX_BUILD_ROOT}/prod/rel/tuist"
           MIX_ENV=prod mix deps.get --only prod
           ./native/xcresult_nif/build.sh
           ./native/xcactivitylog_nif/build.sh
           MIX_ENV=prod mix compile --force --warnings-as-errors
+          # `mix release --overwrite` writes over the release directory
+          # without emptying it first, so a file dropped since the previous
+          # release would survive in a persistent build root and get baked
+          # into the image.
+          rm -rf "$RELEASE_DIR"
           MIX_ENV=prod mix release tuist --overwrite
-          if [ -n "${TUIST_MIX_BUILD_ROOT:-}" ]; then
-            RELEASE_DIR="${TUIST_MIX_BUILD_ROOT}/server/prod/rel/tuist"
-          else
-            RELEASE_DIR="$(pwd)/_build/prod/rel/tuist"
-          fi
           echo "dir=${RELEASE_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Package release tarball
@@ -1078,11 +1100,19 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
+      # Overrides the action's default of 4. This job sits on the production
+      # cascade's critical path and the push is most of its wall clock, and
+      # unlike the runner-image matrix it uploads alone rather than as one leg
+      # of a five-way fan-out, so it has the whole rate-limit budget to
+      # itself. Push throughput measured close to linear in this value from 1
+      # to 4 with no GHCR throttling; if that stops holding, lower it back
+      # rather than reaching for a larger chunk size.
       - name: Push image to GHCR
         timeout-minutes: 90
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
+          concurrency: "8"
           remote-names: |
             ghcr.io/tuist/tuist-xcresult-processor:${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
             ghcr.io/tuist/tuist-xcresult-processor:latest

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -57,6 +57,27 @@ jobs:
           install_args: "erlang elixir"
           working_directory: server
 
+      # `actions/checkout` runs `git clean -ffdx` on this host's persistent
+      # workspace, which deletes `server/deps`, `server/_build` and both NIF
+      # `.build` directories, so every run compiled the two Swift NIFs and the
+      # whole Elixir dependency tree cold. Pointing the caches outside the
+      # workspace puts them out of the clean's reach.
+      #
+      # Keyed by runner name because a runner process runs one job at a time:
+      # two jobs landing on the same host (this one and the release job in
+      # `server-production-deployment.yml`) can then never share a cache and
+      # cannot race on the release directory.
+      - name: Point build caches outside the workspace
+        run: |
+          set -euo pipefail
+          cache_root="${HOME}/.cache/tuist-ci/server-macos-release/${RUNNER_NAME// /_}"
+          mkdir -p "${cache_root}/nif"
+          {
+            echo "MIX_BUILD_ROOT=${cache_root}/mix-build"
+            echo "MIX_DEPS_PATH=${cache_root}/mix-deps"
+            echo "TUIST_NIF_BUILD_ROOT=${cache_root}/nif"
+          } >> "$GITHUB_ENV"
+
       # 1. Build the macOS Erlang release. Includes both the xcresult NIF
       # (used by xcresult-processor mode) and the xcactivitylog NIF
       # (used by build-processor mode). Both are macOS-only and both
@@ -69,29 +90,25 @@ jobs:
         working-directory: server
         run: |
           set -euo pipefail
+          RELEASE_DIR="${MIX_BUILD_ROOT}/prod/rel/tuist"
           MIX_ENV=prod mix deps.get --only prod
           # `mix release` doesn't invoke the per-NIF build.sh scripts;
           # run them explicitly so the .so / .dylib land in priv/native
           # before the release tarball is assembled.
           ./native/xcresult_nif/build.sh
           ./native/xcactivitylog_nif/build.sh
-          # The bare-metal Mac mini reuses a single $TUIST_MIX_BUILD_ROOT
-          # across runs, which is mostly fine — except mix's mtime-based
-          # incremental compile occasionally keeps a stale .beam after a
-          # rebase. `--force` recompiles every .ex regardless; the BEAM
-          # build is fast enough (~30s) that the safety is worth more
-          # than the saved time.
+          # The build root persists across runs. That is mostly fine, except
+          # that mix's mtime-based incremental compile occasionally keeps a
+          # stale .beam after a rebase. `--force` recompiles every .ex
+          # regardless; the BEAM build is fast enough (~30s) that the safety
+          # is worth more than the saved time.
           MIX_ENV=prod mix compile --force --warnings-as-errors
+          # `mix release --overwrite` writes over the release directory
+          # without emptying it first, so a file dropped since the previous
+          # release would survive in a persistent build root and get baked
+          # into the image.
+          rm -rf "$RELEASE_DIR"
           MIX_ENV=prod mix release tuist --overwrite
-          # mix.exs honors $TUIST_MIX_BUILD_ROOT (set on the bare-metal
-          # runner to share the BEAM build cache across jobs). When it's
-          # set, the release lands at $TUIST_MIX_BUILD_ROOT/server/prod/
-          # rel/tuist; when unset, plain ./_build/prod/rel/tuist.
-          if [ -n "${TUIST_MIX_BUILD_ROOT:-}" ]; then
-            RELEASE_DIR="${TUIST_MIX_BUILD_ROOT}/server/prod/rel/tuist"
-          else
-            RELEASE_DIR="$(pwd)/_build/prod/rel/tuist"
-          fi
           echo "dir=${RELEASE_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Package release tarball

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -161,9 +161,16 @@ jobs:
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         # The production workflow owns semantic-version and latest tags.
         # This on-demand workflow publishes only its commit tag.
+        #
+        # `concurrency` matches the release job's override of the action's
+        # default of 4: this image pushes alone rather than as one leg of the
+        # runner-image matrix, so it has the whole rate-limit budget to
+        # itself. Keeping the two in step means a dispatch run measures what
+        # the release path will do.
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor
+          concurrency: "8"
           remote-names: ghcr.io/tuist/tuist-xcresult-processor:${{ steps.image-tag.outputs.value }}
 
       - name: Cleanup

--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -33,6 +33,12 @@ needs a live GUI session for Virtualization.framework, so hosted
 runners can't do this). Builder fleet operator runbook:
 [`../vm-image-builder.md`](../vm-image-builder.md).
 
+The macOS release build reuses caches that live outside the checkout, at
+`~/.cache/tuist-ci/server-macos-release/<runner-name>/` on each builder
+host: `mix-build` (`MIX_BUILD_ROOT`), `mix-deps` (`MIX_DEPS_PATH`), and
+`nif` (`TUIST_NIF_BUILD_ROOT`, the SwiftPM scratch path for both NIFs).
+Delete that directory on a host to force a cold build there.
+
 Registry publication uses the shared
 [`tart-push`](../../.github/actions/tart-push/action.yml)
 action. Its bounded concurrency, chunking, retry, and route diagnostics are

--- a/server/native/xcactivitylog_nif/build.sh
+++ b/server/native/xcactivitylog_nif/build.sh
@@ -6,10 +6,20 @@ PRIV_DIR="${SCRIPT_DIR}/../../priv/native"
 
 cd "$SCRIPT_DIR"
 
-echo "==> Building Swift NIF library..."
-swift build -c release --replace-scm-with-registry 2>&1
+# CI checks out onto a persistent workspace and `actions/checkout` runs
+# `git clean -ffdx`, which deletes an in-tree .build and forces a cold Swift
+# compile on every run. TUIST_NIF_BUILD_ROOT moves the scratch directory
+# outside the workspace so it survives the clean.
+if [ -n "${TUIST_NIF_BUILD_ROOT:-}" ]; then
+    SCRATCH_PATH="${TUIST_NIF_BUILD_ROOT}/xcactivitylog_nif"
+else
+    SCRATCH_PATH="${SCRIPT_DIR}/.build"
+fi
 
-SWIFT_BUILD_DIR=".build/release"
+echo "==> Building Swift NIF library..."
+swift build -c release --replace-scm-with-registry --scratch-path "$SCRATCH_PATH" 2>&1
+
+SWIFT_BUILD_DIR="${SCRATCH_PATH}/release"
 DYLIB_NAME="libXCActivityLogNIF.dylib"
 
 if [ ! -f "$SWIFT_BUILD_DIR/$DYLIB_NAME" ]; then

--- a/server/native/xcresult_nif/build.sh
+++ b/server/native/xcresult_nif/build.sh
@@ -15,10 +15,20 @@ cd "$SCRIPT_DIR"
 
 mkdir -p "$PRIV_DIR"
 
-echo "==> Building Swift NIF library..."
-swift build -c release --replace-scm-with-registry 2>&1
+# CI checks out onto a persistent workspace and `actions/checkout` runs
+# `git clean -ffdx`, which deletes an in-tree .build and forces a cold Swift
+# compile on every run. TUIST_NIF_BUILD_ROOT moves the scratch directory
+# outside the workspace so it survives the clean.
+if [ -n "${TUIST_NIF_BUILD_ROOT:-}" ]; then
+    SCRATCH_PATH="${TUIST_NIF_BUILD_ROOT}/xcresult_nif"
+else
+    SCRATCH_PATH="${SCRIPT_DIR}/.build"
+fi
 
-SWIFT_BUILD_DIR=".build/release"
+echo "==> Building Swift NIF library..."
+swift build -c release --replace-scm-with-registry --scratch-path "$SCRATCH_PATH" 2>&1
+
+SWIFT_BUILD_DIR="${SCRATCH_PATH}/release"
 DYLIB_NAME="libXCResultNIF.dylib"
 
 if [ ! -f "$SWIFT_BUILD_DIR/$DYLIB_NAME" ]; then


### PR DESCRIPTION
> Describe here the purpose of your PR.

The xcresult-processor image release sits on the production cascade's critical path. It gates `tag-infra-releases`, which gates `build`, which gates `canary`, so nothing else advances while it runs. It fires often: any non-`chore`/`ci` conventional commit touching `server/lib/tuist/**` cuts a version, which was 25 releases in the 14 days to 2026-08-26, four on some days. With `concurrency: release-workflow-<ref>` and `cancel-in-progress: false`, merges queue behind it.

Measured on [run 32946146646](https://github.com/tuist/tuist/actions/runs/32946146646), the job took 23.3 min out of the 35 min between `check-releases` finishing and canary starting. The split:

| Step | Time |
|---|---|
| Build server release for macOS | 7.8 min |
| Packer build | 1.0 min |
| Push image to GHCR | 13.9 min |

This PR attacks both halves.

### Root cause of the build half

`actions/checkout` runs `git clean -ffdx` on the builder host's persistent workspace. The run log shows it deleting `server/_build/`, `server/deps/`, and both NIF `.build/` directories on every run, so each release compiled the xcresult NIF (206s), the xcactivitylog NIF (55s), and the whole Elixir dependency tree (~2.5 min) from scratch.

A caching scheme for this was half-built and inert. `writeBuildCacheEnv` in `infra/macos-host-bootstrap/actions_runner.go` provisions `/opt/tuist-build-cache` owned by the runner user and appends `export TUIST_MIX_BUILD_ROOT=/opt/tuist-build-cache` to `/etc/zshenv` on every builder, and both workflows branched on that variable to locate the release. It never took effect, for two independent reasons:

1. `/etc/zshenv` is a zsh init file, and GitHub Actions `run:` steps execute under bash, so the export is never sourced. The comment on `writeBuildCacheEnv` reasons carefully about zsh login versus interactive files and concludes the runner's per-step shells are covered, but they are not zsh at all. Run 32946146646 proves it: the tar ran from `.../server/_build/prod/rel/tuist`, so `if [ -n "${TUIST_MIX_BUILD_ROOT:-}" ]` took the false branch.
2. Nothing ever wired the variable into Mix. There is no `build_path` or `deps_path` in `server/mix.exs`, so even with the variable visible, mix would still have written to the in-workspace `_build` while the workflow computed `RELEASE_DIR=/opt/tuist-build-cache/server/prod/rel/tuist` and the tar step failed on a missing directory.

The second reason matters for how this is fixed: repairing only the transport would have broken the build.

### What changed

**Build caches move outside the workspace.** Mix already supports this natively, so the fix uses `MIX_BUILD_ROOT` and `MIX_DEPS_PATH` rather than reviving the bespoke variable. The Swift side gets a new `TUIST_NIF_BUILD_ROOT` that the two NIF build scripts pass to `swift build --scratch-path`. Both scripts keep their in-tree `.build` default when the variable is unset, so `server/Dockerfile`'s Linux build (which calls `swift build` directly) and `mise run xcresult-processor:build-image` are unaffected.

**The push gets `concurrency: 8`.** Set as an input on this job only, leaving the shared `tart-push` default at 4 for the runner-image fan-out. Push throughput was measured close to linear in this value from 1 to 4 in #12543 with zero GHCR rate-limit warnings even at five jobs times four streams, and unlike the runner-image matrix this job uploads alone, so it has the whole rate-limit budget to itself. The action's retry loop already accumulates progress across attempts, so if GHCR does start throttling the cost is a backoff rather than a failure, and the fix is to lower this back rather than reach for a larger chunk size.

### Why not just rebuild less often

That was the obvious alternative and it is the wrong direction. `infra/xcresult-processor-image/AGENTS.md` documents that the trigger is already deliberately conservative, and that the conservatism took production down once: a server change landed under a skipped scope, the baked release kept querying a column a migration had just dropped. The image bakes a full server release, so "the server changed" is its correct trigger. Narrowing the include paths buys cascade minutes by reopening that exact failure class.

### Two details worth a reviewer's attention

**Cache directories are keyed by `RUNNER_NAME`.** A runner process runs one job at a time, so keying this way means the release job and the on-demand `xcresult-processor-image.yml` can never share a cache directory or race on the release directory, even when they land on the same host. The cost is a few GB per runner rather than per host.

**`mix release --overwrite` does not empty the release directory first.** I verified this: a file planted in `rel/<name>` survives the next release. That was harmless when `_build` was thrown away every run, but with a persistent build root a file dropped since the previous release would survive and get baked into the image. Hence the `rm -rf "$RELEASE_DIR"` before `mix release`.

### Validation

Both halves were exercised on the real builder fleet by dispatching `xcresult-processor-image.yml` against this branch. That workflow publishes only a `:<sha8>` tag, and the deploy resolver matches `^[0-9]+\.[0-9]+\.[0-9]+$` only, so a branch run cannot reach production. Both runs landed on the same builder (`tuist-tuist-builders-fleet-rg4h9-xmvdc`), so run 2 is the warm-cache case.

| Step | Baseline (prod [32946146646](https://github.com/tuist/tuist/actions/runs/32946146646)) | Run 1 ([32957993307](https://github.com/tuist/tuist/actions/runs/32957993307)), cold cache | Run 2 ([32959445788](https://github.com/tuist/tuist/actions/runs/32959445788)), warm cache |
|---|---|---|---|
| Build server release for macOS | 7.8 min | 7.7 min | **0.8 min** |
| Packer build | 1.0 min | 0.9 min | 0.9 min |
| Push image to GHCR | 13.9 min | **6.5 min** | 7.5 min |
| Job total | 23.3 min | 15.8 min | **9.8 min** |

Within the warm build step, the xcresult NIF went from 206s to 5.79s and the xcactivitylog NIF from 55s to 6.08s. The Elixir dependency tree came from cache and only the app itself recompiled, 908 files in 20s, which is `--force` doing its job. The release was written to `/Users/m1/.cache/tuist-ci/server-macos-release/<runner>/mix-build/prod/rel/tuist` and the tarball came out at 244M, byte-for-byte the same size as the baseline, so nothing is being dropped from the artifact.

The push ran at `Registry concurrency: 8` and reported `Pushed ... on attempt 1` both times, with no rate-limit warnings in either run. The only warning emitted was an unrelated Node 20 deprecation notice on `actions/checkout`.

One incidental confirmation: run 2 re-baked the same commit and still paid 7.5 min to push, because Tart's layer boundaries are fixed 512 MiB disk offsets and booting macOS scatters APFS writes across roughly 40 of them regardless of payload. That is the structural cost the follow-up below is aimed at.

### Impact

The job drops from 23.3 min to roughly 10 min once caches are warm. The first run on each builder after this merges is still cold, so it should not be read as a regression.

Note that this PR is scoped `perf(infra)`, which the processor image's cliff config does not scope-skip, and it touches both `infra/xcresult-processor-image/**` and `server/native/xcresult_nif/**`. Merging it therefore cuts a new processor image release.

### Follow-up not in this PR

`build` declares `needs: [check-releases, tag-infra-releases]` but never reads a tag-infra output. It is a pure sequencing gate, and the thing that actually needs the tags is the deploy, since `server-deployment.yml` resolves `xcresult-processor-image@` from git tags at deploy time. Moving that gate to `canary` and `production-hotfix` would let the Linux image build run concurrently with the Mac VM build instead of after it, worth another ~10 min on every cascade, and it would help every fleet-image release rather than just this one.

`writeBuildCacheEnv` and `builderMixBuildRoot` in `infra/macos-host-bootstrap/actions_runner.go` are now definitively dead: this PR removes their only readers. They are left in place because `infra/macos-host-bootstrap/**` sits in the `capi-scaleway` release component's include paths, so deleting them cuts a provider release, and the `/etc/zshenv` line only actually disappears from a host on re-bootstrap. Worth a separate cleanup.

### How to test locally

The NIF scratch-path plumbing is the part that runs on any Mac:

```bash
mkdir -p /tmp/nifcache
TUIST_NIF_BUILD_ROOT=/tmp/nifcache ./server/native/xcactivitylog_nif/build.sh
time TUIST_NIF_BUILD_ROOT=/tmp/nifcache ./server/native/xcactivitylog_nif/build.sh
```

77.07s cold against 3.2s warm locally, with the dylib at `/tmp/nifcache/xcactivitylog_nif/release/libXCActivityLogNIF.dylib`. Unsetting the variable must keep the in-tree `.build` behaviour that `server/Dockerfile` and `mise run xcresult-processor:build-image` depend on:

```bash
./server/native/xcactivitylog_nif/build.sh && ls server/native/xcactivitylog_nif/.build/release
```

The Mix side was checked against a throwaway project: `MIX_BUILD_ROOT` puts artifacts under `$MIX_BUILD_ROOT/prod/`, `MIX_DEPS_PATH` relocates `deps/`, `mix release` writes to `$MIX_BUILD_ROOT/prod/rel/<name>`, and a file planted in that directory survives the next `--force`-free `mix release --overwrite`, which is what the `rm -rf` guards against.

The full path is covered by the two fleet runs in the Validation section. To repeat it:

```bash
gh workflow run xcresult-processor-image.yml --ref claude/xcresult-processor-rebuild-702159 -f xcode_version=26.6
```
