### PR TITLE
fix(infra): make pentest bootstrap recoverable

### DIFF
--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -27,13 +27,9 @@ kubectl create namespace platform
 kubectl -n platform create secret generic cloudflare-api-token \
   --from-literal=api-token="$CLOUDFLARE_API_TOKEN"
 
-# 3. Fetch chart dependencies.
-helm dependency update infra/helm/platform
-
-# 4. Install the platform with the right provider overlay.
-helm upgrade --install platform infra/helm/platform \
-  -n platform \
-  -f infra/helm/platform/values-hetzner.yaml
+# 3. Install the platform through the managed-cluster task. It reconciles the
+# cert-manager custom resource definitions before Helm renders the ClusterIssuer.
+mise -C infra run k8s:install-platform "$KUBECONFIG" tuist-<environment>
 ```
 
 Other clouds can plug in by adding a `values-<provider>.yaml` overlay that
@@ -192,4 +188,4 @@ kubectl -n tuist exec deploy/tuist-tuist-server -- curl -fsS https://api.ipify.o
 - The main ingress-nginx LoadBalancer is annotated for Hetzner Cloud (Nuremberg region) by default. Managed Tuist cluster overlays pin it explicitly to `fsn1`, matching the general worker pools; regional Kura LoadBalancers are pinned separately.
 - Production Kura ingress controllers are shared per region. Their LoadBalancers are placed in `fsn1`, `ash`, and `hil` and their pods are pinned to the matching Kura node pools.
 - external-dns is scoped by `txtOwnerId: tuist-platform` — one cluster, one TXT prefix. Run it with `policy: sync` only if you're happy with it deleting DNS records that aren't tracked by any Ingress.
-- cert-manager CRDs are installed by the subchart (`installCRDs: true`). If another tool manages them, turn that off.
+- cert-manager custom resource definitions are reconciled by `k8s:install-platform` before the Helm release. A direct Helm install is supported only after another tool has applied those definitions.

--- a/infra/helm/platform/crds/externaldns.k8s.io_dnsendpoints.yaml
+++ b/infra/helm/platform/crds/externaldns.k8s.io_dnsendpoints.yaml
@@ -6,6 +6,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    # externaldns.k8s.io is a Kubernetes community-owned API group. The
+    # upstream ExternalDNS API approval is required by Kubernetes 1.34+.
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
   name: dnsendpoints.externaldns.k8s.io
 spec:
   group: externaldns.k8s.io

--- a/infra/helm/platform/values-hetzner.yaml
+++ b/infra/helm/platform/values-hetzner.yaml
@@ -1,8 +1,6 @@
 # Hetzner-specific overlay for the platform chart.
-# Layer on top of the base values:
-#   helm upgrade --install platform infra/helm/platform \
-#     -n platform --create-namespace \
-#     -f infra/helm/platform/values-hetzner.yaml
+# Loaded by k8s:install-platform after the base platform values. The task
+# reconciles cert-manager custom resource definitions before Helm runs.
 
 ingress-nginx:
   controller:

--- a/infra/helm/platform/values-tuist-pentest.yaml
+++ b/infra/helm/platform/values-tuist-pentest.yaml
@@ -7,3 +7,14 @@ ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
         load-balancer.hetzner.cloud/node-selector: topology.kubernetes.io/region=fsn1
+
+# The security-assessment stack uses its embedded PostgreSQL deployment. It
+# never renders a CloudNativePG Cluster, so do not install the cluster-wide
+# operator or its Barman backup plugin. Besides avoiding unused controllers,
+# this keeps the first platform install independent from certificates that the
+# new cert-manager deployment has not issued yet.
+cloudnative-pg:
+  enabled: false
+
+plugin-barman-cloud:
+  enabled: false

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -40,7 +40,12 @@ ingressCertificate:
 
 cert-manager:
   enabled: true
-  installCRDs: true
+  # CRDs are reconciled by k8s:install-platform before Helm runs. Keeping
+  # them outside the release prevents Helm from trying to adopt CRDs created
+  # during a recovery bootstrap.
+  installCRDs: false
+  crds:
+    enabled: false
   prometheus:
     enabled: true
 

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -1,12 +1,12 @@
 # Platform-level values for the Tuist-managed Kubernetes cluster.
 # This chart is installed once per cluster (staging / production), not per app release.
 #
-# Install:
-#   helm dependency update infra/helm/platform
-#   helm upgrade --install platform infra/helm/platform \
-#     -n platform --create-namespace \
-#     --set cloudflare.apiTokenSecret.create=false \
-#     --set cloudflare.email=ops@tuist.dev
+# Managed-cluster install:
+#   mise -C infra run k8s:install-platform <workload-kubeconfig> <cluster-name>
+#
+# The task reconciles cert-manager custom resource definitions before Helm
+# renders this chart. Do not use a direct Helm install to bootstrap a fresh
+# managed cluster.
 #
 # The Cloudflare API token is expected in a pre-existing Secret in the platform
 # namespace (see infra/k8s/onboarding.md for the bootstrap commands).

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -16,8 +16,9 @@
 #      wait for caph's `hcloud` Secret. HCCM + CSI read `hcloud`.
 #   4. Install hcloud-cloud-controller-manager (sets providerID,
 #      enables LoadBalancer Services).
-#   5. Install hcloud-csi-driver (for parity; no PVCs use it today).
-#   6. Wait for nodes to go Ready (CNI- and CCM-dependent).
+#   5. Wait for CAPI machines and workload nodes to go Ready (CNI- and
+#      CCM-dependent).
+#   6. Install hcloud-csi-driver (for parity; no PVCs use it today).
 #   7. Install the platform chart (cert-manager, ESO, external-dns,
 #      metrics-server, and ingress-nginx only for app-serving clusters).
 #   8. Install Cluster API core for the Mac mini fleet substrate.
@@ -210,15 +211,7 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hccm hcloud/hcloud-cloud-cont
   --wait --timeout 3m
 
 # ---------------------------------------------------------------------------
-log "Step 5/13: install hcloud-csi-driver"
-
-KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hcloud-csi hcloud/hcloud-csi \
-  --namespace kube-system \
-  -f "$BOOTSTRAP_DIR/hcloud-csi-values.yaml" \
-  --wait --timeout 3m
-
-# ---------------------------------------------------------------------------
-log "Step 6/13: wait for CAPI machines and workload nodes to go Ready"
+log "Step 5/13: wait for CAPI machines and workload nodes to go Ready"
 
 echo -n "Waiting for $EXPECTED_MACHINE_COUNT CAPI Machines to exist"
 MACHINE_COUNT=0
@@ -248,7 +241,78 @@ if ! KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" wait --for=condition=
   exit 1
 fi
 
-KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready nodes --all --timeout=5m
+# A CAPI Machine's nodeRef is the authoritative relationship between a live
+# Machine and a workload Node. Previous failed provisioning attempts can leave
+# non-ready Node objects behind even after CAPI removed their Machines. They
+# must not make the bootstrap wait for every Node in the cluster forever, nor
+# remain as targets for the hcloud-csi-node DaemonSet below.
+ACTIVE_NODE_NAMES=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get machines.cluster.x-k8s.io \
+  -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" \
+  -o jsonpath='{range .items[*]}{.status.nodeRef.name}{"\n"}{end}' | awk 'NF')
+ACTIVE_NODE_COUNT=$(printf '%s\n' "$ACTIVE_NODE_NAMES" | awk 'NF { count += 1 } END { print count + 0 }')
+
+if [ "$ACTIVE_NODE_COUNT" -ne "$EXPECTED_MACHINE_COUNT" ]; then
+  err "Only $ACTIVE_NODE_COUNT/$EXPECTED_MACHINE_COUNT ready CAPI Machines have a workload Node reference."
+  exit 1
+fi
+
+# Do not remove an unreferenced workload Node while the management cluster
+# still has a corresponding Hetzner infrastructure object. A mismatch means
+# deletion is still reconciling and needs an operator's investigation rather
+# than a bootstrap shortcut.
+HCLOUD_MACHINE_COUNT=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get hcloudmachines.infrastructure.cluster.x-k8s.io \
+  -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+if [ "$HCLOUD_MACHINE_COUNT" -ne "$EXPECTED_MACHINE_COUNT" ]; then
+  err "Management cluster has $HCLOUD_MACHINE_COUNT/$EXPECTED_MACHINE_COUNT Hetzner infrastructure Machines for $CLUSTER_NAME."
+  err "Refusing to prune workload Nodes while infrastructure deletion is still reconciling."
+  exit 1
+fi
+
+ORPHANED_NODE_NAMES=""
+while IFS= read -r workload_node_name; do
+  [ -z "$workload_node_name" ] && continue
+  node_is_active=false
+  while IFS= read -r active_node_name; do
+    if [ "$workload_node_name" = "$active_node_name" ]; then
+      node_is_active=true
+      break
+    fi
+  done <<< "$ACTIVE_NODE_NAMES"
+
+  if [ "$node_is_active" = false ]; then
+    ORPHANED_NODE_NAMES="${ORPHANED_NODE_NAMES}${workload_node_name}"$'\n'
+  fi
+done < <(KUBECONFIG="$WL_KUBECONFIG" kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+if [ -n "$ORPHANED_NODE_NAMES" ]; then
+  err "Found workload Node objects without a live CAPI Machine reference:"
+  printf '%s' "$ORPHANED_NODE_NAMES" >&2
+
+  if [ "${PRUNE_ORPHANED_NODES:-}" != "1" ]; then
+    err "After verifying these are stale, rerun with PRUNE_ORPHANED_NODES=1 to remove them."
+    exit 1
+  fi
+
+  while IFS= read -r orphaned_node_name; do
+    [ -z "$orphaned_node_name" ] && continue
+    KUBECONFIG="$WL_KUBECONFIG" kubectl delete node "$orphaned_node_name" --wait=false
+  done <<< "$ORPHANED_NODE_NAMES"
+fi
+
+while IFS= read -r active_node_name; do
+  KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready "node/$active_node_name" --timeout=5m
+done <<< "$ACTIVE_NODE_NAMES"
+
+# ---------------------------------------------------------------------------
+log "Step 6/13: install hcloud-csi-driver"
+
+# hcloud-csi-node is a DaemonSet. Helm's --wait therefore includes every
+# matching node in the readiness target. Waiting for CAPI first prevents a
+# fresh cluster from timing out while worker nodes are still joining.
+KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hcloud-csi hcloud/hcloud-csi \
+  --namespace kube-system \
+  -f "$BOOTSTRAP_DIR/hcloud-csi-values.yaml" \
+  --wait --timeout 3m
 
 # ---------------------------------------------------------------------------
 log "Step 7/13: install shared platform chart"

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -94,32 +94,34 @@ fi
 # roll out.
 HELM_TIMEOUT="15m"
 
-# Helm installs chart CRDs only on `install`, not on `upgrade`. Some
-# older workload clusters can predate the platform chart's cert-manager wiring, so
-# an upgrade can see `clusterissuers.cert-manager.io` missing forever.
-# Apply the cert-manager chart CRDs explicitly before templating our
-# ClusterIssuer.
-if ! KUBECONFIG="$WL_KUBECONFIG" kubectl get crd clusterissuers.cert-manager.io >/dev/null 2>&1; then
-  log "ClusterIssuer CRD missing; applying cert-manager CRDs"
+# Helm installs chart CRDs only on `install`, not on `upgrade`. It also refuses
+# to install when a recovery bootstrap has already created the CRDs without
+# Helm ownership annotations. Reconcile cert-manager CRDs independently before
+# templating our ClusterIssuer, and keep them outside the Helm release.
+cert_manager_chart="$(
+  find "$CHART_PATH/charts" -maxdepth 1 -name 'cert-manager-*.tgz' |
+    sort |
+    tail -n 1
+)"
 
-  cert_manager_chart="$(
-    find "$CHART_PATH/charts" -maxdepth 1 -name 'cert-manager-*.tgz' |
-      sort |
-      tail -n 1
-  )"
-
-  if [ -z "$cert_manager_chart" ]; then
-    echo "ERROR: cert-manager chart dependency not found under $CHART_PATH/charts" >&2
-    exit 1
-  fi
-
-  helm template platform "$cert_manager_chart" \
-    --namespace platform \
-    --set crds.enabled=true \
-    --show-only templates/crds.yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
-  KUBECONFIG="$WL_KUBECONFIG" kubectl wait \
-    --for=condition=Established crd/clusterissuers.cert-manager.io --timeout=2m
+if [ -z "$cert_manager_chart" ]; then
+  echo "ERROR: cert-manager chart dependency not found under $CHART_PATH/charts" >&2
+  exit 1
 fi
+
+if KUBECONFIG="$WL_KUBECONFIG" kubectl get crd clusterissuers.cert-manager.io >/dev/null 2>&1; then
+  log "Reconciling cert-manager CRDs"
+else
+  log "ClusterIssuer CRD missing; applying cert-manager CRDs"
+fi
+
+helm template platform "$cert_manager_chart" \
+  --namespace platform \
+  --set installCRDs=false \
+  --set crds.enabled=true \
+  --show-only templates/crds.yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
+KUBECONFIG="$WL_KUBECONFIG" kubectl wait \
+  --for=condition=Established crd/clusterissuers.cert-manager.io --timeout=2m
 
 # The ingress-nginx admission cert jobs are Helm hooks. Re-running them on
 # every server deploy makes the deploy path depend on a short-lived certgen


### PR DESCRIPTION
## What changed

- Made workload bootstrap wait for the live Cluster API Machine node references before installing the Hetzner storage driver. It can remove only confirmed orphaned Node objects when explicitly requested.
- Reconciled cert-manager custom resource definitions outside the Helm release and added the required Kubernetes approval annotation to the ExternalDNS definition.
- Disabled the unused CloudNativePG operator and Barman backup plugin for the pentest platform, which uses embedded PostgreSQL.
- Corrected the platform-chart documentation so managed clusters use `k8s:install-platform`, the task that prepares cert-manager definitions before Helm renders the ClusterIssuer.

## Why

The first pentest-cluster bootstrap exposed three independent cold-start failures: stale Node objects made the storage driver wait for removed machines, Helm could not adopt externally applied cert-manager definitions, and an unused Barman plugin waited for Transport Layer Security certificates before the new certificate manager was ready.

The adversarial review also found that the documented direct Helm command would render a `ClusterIssuer` without its custom resource definition on a fresh cluster. The installation task is already the production entry point, so the documentation now makes that requirement explicit.

## Approach

The bootstrap uses Cluster API Machine-to-Node references as the source of truth, with an explicit safety check before any orphan cleanup. Certificate-manager definitions are reconciled independently because Helm does not adopt pre-existing cluster-scoped definitions safely. The pentest overlay removes components that the embedded-database deployment cannot use, avoiding an unnecessary certificate dependency rather than introducing a second installation phase.

## Impact

The existing cluster-onboarding process can be rerun after merging this change. The subsequent pentest platform reconciliation keeps the same reduced platform shape, so it will not reintroduce the backup plugin. Direct Helm installation is no longer presented as a fresh managed-cluster bootstrap path.

## Validation

- `helm lint infra/helm/platform -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-pentest.yaml`
- Rendered the pentest platform chart and verified it omits CloudNativePG, Barman, and cert-manager definitions while retaining the ExternalDNS approval annotation.
- Rendered the previously documented direct Helm install path and confirmed it emits a `ClusterIssuer` but no cert-manager `ClusterIssuer` definition.
- `bash -n infra/mise/tasks/k8s/bootstrap-workload.sh`
- `bash -n infra/mise/tasks/k8s/install-platform.sh`
- `git diff --check`
