### PR TITLE
fix(server): stop a missing diagnostic location crashing the build processor

### DIFF
--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -64,13 +64,6 @@ public func parseXCActivityLog(
     case let .success(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)
-            guard jsonData.count <= Int32.max else {
-                return writeMessage(
-                    "parsed output is \(jsonData.count) bytes, which exceeds the \(Int32.max)-byte NIF limit",
-                    outputPtr: outputPtr,
-                    outputLen: outputLen
-                )
-            }
             let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: jsonData.count)
             jsonData.withUnsafeBytes { rawBytes in
                 buffer.initialize(from: rawBytes.bindMemory(to: CChar.self).baseAddress!, count: jsonData.count)
@@ -86,8 +79,6 @@ public func parseXCActivityLog(
     }
 }
 
-private let maximumMessageBytes = 64 * 1024
-
 // Writes a plain UTF-8 error message into the output buffer. The C bridge
 // surfaces the bytes as an Erlang binary in `{:error, <<message>>}`, so a
 // raw string is enough — no JSON wrapping needed on this path.
@@ -96,7 +87,7 @@ private func writeMessage(
     outputPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     outputLen: UnsafeMutablePointer<Int32>
 ) -> Int32 {
-    let bytes = Array(message.utf8.prefix(maximumMessageBytes))
+    let bytes = Array(message.utf8)
     let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: max(bytes.count, 1))
     for (i, byte) in bytes.enumerated() {
         buffer[i] = CChar(bitPattern: byte)

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -64,6 +64,13 @@ public func parseXCActivityLog(
     case let .success(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)
+            guard jsonData.count <= Int32.max else {
+                return writeMessage(
+                    "parsed output is \(jsonData.count) bytes, which exceeds the \(Int32.max)-byte NIF limit",
+                    outputPtr: outputPtr,
+                    outputLen: outputLen
+                )
+            }
             let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: jsonData.count)
             jsonData.withUnsafeBytes { rawBytes in
                 buffer.initialize(from: rawBytes.bindMemory(to: CChar.self).baseAddress!, count: jsonData.count)
@@ -79,6 +86,8 @@ public func parseXCActivityLog(
     }
 }
 
+private let maximumMessageBytes = 64 * 1024
+
 // Writes a plain UTF-8 error message into the output buffer. The C bridge
 // surfaces the bytes as an Erlang binary in `{:error, <<message>>}`, so a
 // raw string is enough — no JSON wrapping needed on this path.
@@ -87,7 +96,7 @@ private func writeMessage(
     outputPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     outputLen: UnsafeMutablePointer<Int32>
 ) -> Int32 {
-    let bytes = Array(message.utf8)
+    let bytes = Array(message.utf8.prefix(maximumMessageBytes))
     let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: max(bytes.count, 1))
     for (i, byte) in bytes.enumerated() {
         buffer[i] = CChar(bitPattern: byte)

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SafeNumeric.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SafeNumeric.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum SafeNumeric {
+    /// XCLogParser reports `UInt64.max` for a diagnostic whose text-document
+    /// location carries no line or column, and `0` when there is no location
+    /// object at all. Both map to `0` here.
+    static func location(_ number: UInt64) -> Int {
+        number == UInt64.max ? 0 : Int(clamping: number)
+    }
+
+    static func milliseconds(_ seconds: Double, rounding rule: FloatingPointRoundingRule = .up) -> Int {
+        let millis = (seconds * 1000).rounded(rule)
+        guard millis.isFinite else { return 0 }
+        if millis >= Double(Int.max) { return Int.max }
+        if millis <= Double(Int.min) { return Int.min }
+        return Int(millis)
+    }
+}

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -37,8 +37,8 @@ public struct XCActivityLogParser: Sendable {
                 name: step.title.replacingOccurrences(of: "Build target ", with: ""),
                 project: extractProject(from: subSteps.first { extractProject(from: [$0]).first?.project != "" }
                     .map { [$0] } ?? []).first?.project ?? "",
-                build_duration: Int((step.duration * 1000).rounded(.up)),
-                compilation_duration: Int((step.compilationDuration * 1000).rounded(.up)),
+                build_duration: SafeNumeric.milliseconds(step.duration),
+                compilation_duration: SafeNumeric.milliseconds(step.compilationDuration),
                 status: hasErrors ? "failure" : "success"
             )
         }
@@ -60,8 +60,10 @@ public struct XCActivityLogParser: Sendable {
             casReader: casReader
         )
 
-        let duration = Int(activityLog.mainSection.timeStoppedRecording * 1000)
-            - Int(activityLog.mainSection.timeStartedRecording * 1000)
+        let duration = SafeNumeric.milliseconds(
+            activityLog.mainSection.timeStoppedRecording - activityLog.mainSection.timeStartedRecording,
+            rounding: .towardZero
+        )
 
         return BuildData(
             unique_identifier: activityLog.mainSection.uniqueIdentifier,
@@ -207,10 +209,10 @@ public struct XCActivityLogParser: Sendable {
                     step_type: stepTypeString(from: step.signature),
                     path: path,
                     message: notice.detail.flatMap(cleanIssueDetail),
-                    starting_line: Int(notice.startingLineNumber),
-                    ending_line: Int(notice.endingLineNumber),
-                    starting_column: Int(notice.startingColumnNumber),
-                    ending_column: Int(notice.endingColumnNumber)
+                    starting_line: SafeNumeric.location(notice.startingLineNumber),
+                    ending_line: SafeNumeric.location(notice.endingLineNumber),
+                    starting_column: SafeNumeric.location(notice.startingColumnNumber),
+                    ending_column: SafeNumeric.location(notice.endingColumnNumber)
                 ))
             }
         }
@@ -287,7 +289,7 @@ public struct XCActivityLogParser: Sendable {
                 target: extractTargetFromSignature(step.signature),
                 project: extractProjectFromSignature(step.signature),
                 path: doc,
-                compilation_duration: Int((step.compilationDuration * 1000).rounded(.up))
+                compilation_duration: SafeNumeric.milliseconds(step.compilationDuration)
             )
         }
     }

--- a/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/SafeNumericTests.swift
+++ b/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/SafeNumericTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import XCActivityLogParser
+
+@Suite
+struct SafeNumericTests {
+    @Test func location_mapsMissingLocationSentinelToZero() {
+        #expect(SafeNumeric.location(UInt64.max) == 0)
+    }
+
+    @Test func location_clampsValuesAboveIntMax() {
+        #expect(SafeNumeric.location(UInt64(Int.max) + 1) == Int.max)
+    }
+
+    @Test func location_passesThroughRealLineNumbers() {
+        #expect(SafeNumeric.location(0) == 0)
+        #expect(SafeNumeric.location(1) == 1)
+        #expect(SafeNumeric.location(48273) == 48273)
+    }
+
+    @Test func milliseconds_convertsFiniteSeconds() {
+        #expect(SafeNumeric.milliseconds(1.5) == 1500)
+        #expect(SafeNumeric.milliseconds(0) == 0)
+        #expect(SafeNumeric.milliseconds(0.0001) == 1)
+    }
+
+    @Test func milliseconds_roundsTowardZeroWhenAsked() {
+        #expect(SafeNumeric.milliseconds(1.9999, rounding: .towardZero) == 1999)
+    }
+
+    @Test func milliseconds_mapsNonFiniteToZero() {
+        #expect(SafeNumeric.milliseconds(.nan) == 0)
+        #expect(SafeNumeric.milliseconds(.infinity) == 0)
+        #expect(SafeNumeric.milliseconds(-.infinity) == 0)
+    }
+
+    @Test func milliseconds_mapsSecondsThatOverflowToInfinityToZero() {
+        #expect(SafeNumeric.milliseconds(.greatestFiniteMagnitude) == 0)
+        #expect(SafeNumeric.milliseconds(-.greatestFiniteMagnitude) == 0)
+    }
+
+    @Test func milliseconds_clampsFiniteMagnitudesBeyondIntRange() {
+        #expect(SafeNumeric.milliseconds(1e30) == Int.max)
+        #expect(SafeNumeric.milliseconds(-1e30) == Int.min)
+    }
+}


### PR DESCRIPTION
### What is happening

Processor pods in production crash-loop with exit code 132 and `reason: Error`, which fires the "Pod restarts (possible overload)" alert.

This is not the memory problem it resembles. The crashing pod peaked at 6.07 GiB against a 16Gi limit, the node reported `MemoryPressure: False`, and across seven days every processor termination was `reason="Error"`, never `OOMKilled`. Restarts are chronic and bursty rather than tied to a deploy: the 30 day history alternates quiet days with spikes of 11 to 14 per day.

132 is 128 + 4, i.e. SIGILL. Production nodes are amd64, where a Swift runtime trap compiles to `ud2` and raises SIGILL. A trap inside a NIF takes down the entire BEAM.

### Root cause

XCLogParser (pinned 0.2.49) returns `UInt64.max` from `Notice.realLocationNumber` when a diagnostic carries a `DVTTextDocumentLocation` with no line or column. Its own comment documents this:

> If there is no location, Xcode reports UIInt64.max ... returns the same number

The parser fed that value straight into `Issue.starting_line: Int`, and `Int(UInt64.max)` traps. A single diagnostic without a source location was therefore enough to kill the VM.

A check that could have falsified this held up: the sentinel never appears in ClickHouse `build_issues` (max `starting_line` was 48273 across 2M sampled rows), because the process dies before the row is written. The column is `UInt64`, so it would have stored the value fine.

### Why this looked like overload

Nothing raised, so Oban recorded no error. In-flight jobs were left in `executing` with zero recorded errors, then rescued and retried into the same log, so the pod restarted repeatedly until they hit `max_attempts`. That zero-error signature is the fingerprint distinguishing a VM kill from a job exception.

With `TUIST_PROCESS_BUILD_QUEUE_CONCURRENCY=5`, each crash also discarded up to five unrelated in-flight jobs plus their unflushed ClickHouse RowBinary buffers, which is silent analytics loss.

### What changed

A new `SafeNumeric` helper provides two trap-free conversions, and the nine raw conversion sites now route through it:

- `location(_:)` maps the `UInt64.max` sentinel to `0` and clamps anything else above `Int.max`. Mapping to `0` matches the convention XCLogParser already uses for its no-location-object branch, so the value stays consistent with the roughly 6% of rows that already carry `0`.
- `milliseconds(_:rounding:)` maps non-finite values to `0` and clamps finite magnitudes beyond `Int` range.

The `Int(Double)` audit was part of the same pass, since `Int(nan)` and `Int(inf)` trap identically. The total build duration is now converted once from the difference of the two timestamps rather than subtracting two independent conversions, which also removes an overflow-on-subtract path.

A helper was chosen over inline guards at nine call sites because the conversions are pure and shared, which keeps them directly testable without widening any visibility purely for tests.

### Reviewer notes

- Mapping the sentinel to `0` rather than `Int.max` is deliberate. A bogus `Int.max` line number or duration would poison analytics far worse than a `0`, and `0` already means "unknown location" on the sibling code path.
- Two `Int32` conversions in the NIF entry point were briefly guarded here and then removed. Nothing observed approaches the 2 GiB ceiling: the largest constructible xcactivitylog payload is roughly 170 MB, about 12x under it, and `xcresult_nif` carries the same pattern about 70x under. They are `Int32(Int)` rather than `Int(Double)`, so they sat outside this audit, and guarding an unreachable condition would dilute a fix that a real crash traces to. If a payload ever does approach 2 GiB, the answer is to handle the size, not to error out.
- Two adjacent issues were left alone as larger calls than this fix: `box.value!` in the NIF is a force-unwrap that would also kill the VM, though it is guarded by the timeout check; and more broadly, any NIF trap costing five unrelated jobs argues for parsing out of process.
- This does not retroactively rescue jobs already stranded in `executing`; they drain via `max_attempts`.
- The package is not covered by the repo swiftformat config (`mise/tasks/cli/lint.sh` scopes it to `cli/` and `app/`), and pre-existing files already fail it. Reformatting was deliberately skipped so the fix is not buried in unrelated churn. The new files pass the config as written.

### How to test locally

```bash
cd server/native/xcactivitylog_nif && swift test --replace-scm-with-registry
```

21 tests pass across 2 suites: the 13 pre-existing parser tests are unchanged, plus 8 new ones covering the sentinel, clamping, and non-finite cases.

Release build, which is what `build.sh` ships:

```bash
cd server/native/xcactivitylog_nif && swift build -c release --replace-scm-with-registry
```

The premise was also confirmed directly rather than by inspection. Forcing `Int(UInt64.max)` to a runtime value traps, exiting 133 on arm64 (`brk #1`, SIGTRAP) and 132 on the amd64 production target via `ud2`, matching the code observed in production:

```bash
printf 'import Foundation\nlet raw = ProcessInfo.processInfo.environment["V"] ?? "18446744073709551615"\nprint(Int(UInt64(raw)!))\n' > /tmp/trapcheck.swift && swift /tmp/trapcheck.swift; echo "exit: $?"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


