### PR TITLE
perf(server): translate only the catalog entries that changed

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -19,9 +19,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Runs queue instead of cancelling: a cancelled run has already paid for the
+# model calls it made, and cancelling it threw that spend away.
 concurrency:
   group: l10n-translations
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   MISE_VERSION: "2026.5.15"
@@ -31,7 +33,7 @@ jobs:
   translate:
     name: Translate
     runs-on: tuist-linux
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v4.0.1
@@ -62,6 +64,10 @@ jobs:
           title: "chore(server): update translations"
           body: |
             Automated translation update triggered by changes to `.pot` files or `L10N.md` context.
+
+            Merge this promptly. The `.l10n/*.lock` files only advance when this
+            lands, and every run made against stale locks re-translates entries
+            that are already done.
           add-paths: |
             .l10n/**
             server/priv/gettext/**/*.po

--- a/translate.exs
+++ b/translate.exs
@@ -391,6 +391,161 @@ defmodule L10n.Lock do
   end
 end
 
+defmodule L10n.Catalog do
+  @moduledoc """
+  Diffs and merges Gettext catalogs so a run only translates what is missing.
+
+  A `.pot` msgid *is* the English source string, so a reworded string arrives as
+  a new key rather than a mutation of an existing one. That makes "what still
+  needs translating" a plain set difference against the `.po` already on disk,
+  and lets a run send a handful of entries instead of regenerating a catalog.
+
+  Every function here is pure, so the incremental behaviour is testable without
+  reaching a model.
+  """
+
+  @nplurals %{
+    "es" => 2,
+    "ja" => 1,
+    "ka" => 2,
+    "ko" => 1,
+    "ru" => 3,
+    "yue_Hant" => 1,
+    "zh_Hans" => 1,
+    "zh_Hant" => 1
+  }
+
+  @doc "Parses `.po`/`.pot` content."
+  def parse(content), do: Expo.PO.parse_string(content)
+
+  @doc "Number of plural forms for `locale`."
+  def nplurals(locale), do: Map.get(@nplurals, locale, 2)
+
+  @doc """
+  Identity of a message inside a catalog: its optional context, its source
+  string, and its plural source string.
+  """
+  def key(message) do
+    {
+      flatten(Map.get(message, :msgctxt)),
+      flatten(Map.get(message, :msgid)),
+      flatten(Map.get(message, :msgid_plural))
+    }
+  end
+
+  @doc "Indexes messages by `key/1`."
+  def index(messages), do: Map.new(messages, &{key(&1), &1})
+
+  @doc "True when every plural form of the message carries a translation."
+  def translated?(%{msgstr: msgstr}) when is_map(msgstr) do
+    msgstr != %{} and Enum.all?(msgstr, fn {_index, value} -> present?(value) end)
+  end
+
+  def translated?(%{msgstr: msgstr}), do: present?(msgstr)
+  def translated?(_message), do: false
+
+  @doc """
+  The messages in `pot_messages` that `existing` does not already translate.
+  """
+  def untranslated(pot_messages, existing) do
+    Enum.reject(pot_messages, fn message ->
+      case Map.fetch(existing, key(message)) do
+        {:ok, current} -> translated?(current)
+        :error -> false
+      end
+    end)
+  end
+
+  @doc """
+  Serializes `messages` as a standalone `.pot` fragment to send to the model.
+  """
+  def fragment(messages) do
+    %Expo.Messages{headers: [], messages: Enum.map(messages, &blank(&1, 2))}
+    |> Expo.PO.compose()
+    |> IO.iodata_to_binary()
+  end
+
+  @doc """
+  Rebuilds the full catalog for `locale` from `pot`, taking each translation
+  from `fresh` when the model just produced one and from `existing` otherwise.
+
+  Structure, references, flags and comments always come from `pot`, so a merge
+  also refreshes metadata that drifted since the last run.
+  """
+  def merge(%Expo.Messages{} = pot, existing, fresh, locale, plural_forms) do
+    messages =
+      Enum.map(pot.messages, fn message ->
+        translation = Map.get(fresh, key(message)) || Map.get(existing, key(message))
+        apply_translation(message, translation, locale)
+      end)
+
+    %Expo.Messages{
+      pot
+      | headers: headers(locale, plural_forms),
+        messages: messages,
+        top_comments: []
+    }
+  end
+
+  @doc "The `.po` header block for `locale`."
+  def headers(locale, plural_forms) do
+    [
+      "",
+      "Language: #{locale}\n",
+      "MIME-Version: 1.0\n",
+      "Content-Type: text/plain; charset=UTF-8\n",
+      "Content-Transfer-Encoding: 8bit\n",
+      "Plural-Forms: #{plural_forms}\n"
+    ]
+  end
+
+  defp apply_translation(message, nil, locale), do: blank(message, nplurals(locale))
+
+  defp apply_translation(message, translation, locale) do
+    source = Map.get(translation, :msgstr)
+
+    cond do
+      is_map(Map.get(message, :msgstr)) ->
+        %{message | msgstr: plural_msgstr(source, nplurals(locale))}
+
+      is_list(source) and present?(source) ->
+        %{message | msgstr: source}
+
+      true ->
+        blank(message, nplurals(locale))
+    end
+  end
+
+  defp plural_msgstr(source, count) when is_map(source) do
+    Map.new(0..(count - 1), fn index -> {index, Map.get(source, index, [""])} end)
+  end
+
+  defp plural_msgstr(source, count) when is_list(source) do
+    Map.new(0..(count - 1), fn
+      0 -> {0, source}
+      index -> {index, source}
+    end)
+  end
+
+  defp plural_msgstr(_source, count), do: Map.new(0..(count - 1), &{&1, [""]})
+
+  defp blank(message, count) do
+    if is_map(Map.get(message, :msgstr)) do
+      %{message | msgstr: Map.new(0..(count - 1), &{&1, [""]})}
+    else
+      %{message | msgstr: [""]}
+    end
+  end
+
+  defp flatten(nil), do: nil
+  defp flatten(value) when is_binary(value), do: value
+  defp flatten(value) when is_list(value), do: IO.iodata_to_binary(value)
+
+  defp present?(value) when is_list(value), do: value |> IO.iodata_to_binary() |> present?()
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_value), do: false
+end
+
 defmodule L10n.Translator do
   @moduledoc """
   Translates .pot files to target locales using an LLM via req_llm.
@@ -405,6 +560,7 @@ defmodule L10n.Translator do
   @base_retry_delay_ms 1_000
   @retryable_statuses [429, 500, 502, 503, 504]
   @retryable_transport_reasons [:closed, :timeout, :econnrefused, :econnreset]
+  @batch_size 40
 
   @plural_forms %{
     "es" => "nplurals=2; plural=n != 1;",
@@ -455,34 +611,32 @@ defmodule L10n.Translator do
   end
 
   @doc """
-  Translates a single .pot file content to the given locale.
+  Translates one batch of still-untranslated messages for a locale.
 
-  Constructs a system prompt with translation rules and L10N.md context,
-  sends the full .pot content as the user message, and returns the
-  translated .po file content as a string.
+  The batch is serialized as a `.pot` fragment, so the model only ever sees the
+  entries that need work: a commit that adds three strings sends three entries
+  instead of regenerating the catalog. The reply is parsed back into an index
+  keyed by `L10n.Catalog.key/1`, and any entry the model drops simply stays
+  untranslated and is picked up by the next run.
   """
-  def translate(pot_content, locale, language, context_body, locale_override, model, timeout) do
+  def translate_batch(messages, locale, language, context_body, locale_override, model, timeout) do
     plural_forms = Map.get(@plural_forms, locale, "nplurals=2; plural=n != 1;")
 
     system_prompt = """
     You are a professional translator specializing in software localization.
-    You translate Gettext PO template files from English to #{language} (#{locale}).
+    You translate Gettext PO entries from English to #{language} (#{locale}).
 
-    Output ONLY a valid Gettext .po file. No markdown fences, no explanation, no preamble.
+    Output ONLY valid Gettext PO entries. No markdown fences, no explanation, no
+    preamble, and no PO header entry.
 
     Rules:
-    1. The first entry must be the PO header with this exact metadata:
-       - Language: #{locale}
-       - MIME-Version: 1.0
-       - Content-Type: text/plain; charset=UTF-8
-       - Content-Transfer-Encoding: 8bit
-       - Plural-Forms: #{plural_forms}
+    1. Return exactly one entry for every entry you are given, in the same order.
     2. Preserve all msgid values exactly as they appear in the source.
     3. Translate each msgid into the corresponding msgstr for #{language}.
     4. Preserve all Elixir interpolation variables like %{name} exactly as-is in the translation.
     5. Preserve all HTML tags exactly as-is in the translation.
     6. Preserve all comment lines (lines starting with #) from the source.
-    7. For plural forms (msgid_plural), provide the correct number of msgstr[N] entries for #{language}.
+    7. For plural forms (msgid_plural), provide exactly #{L10n.Catalog.nplurals(locale)} msgstr[N] entries for #{language} (#{plural_forms}).
     8. Do not translate proper nouns, brand names, or technical terms unless the context instructs otherwise.
     9. Do not add the fuzzy flag to any translations.
     10. Do not wrap long lines - keep each msgstr on a single line or use the same multi-line format as the source.
@@ -493,40 +647,32 @@ defmodule L10n.Translator do
     """
 
     user_prompt = """
-    Translate the following .pot file to #{language} (#{locale}):
+    Translate the following #{length(messages)} PO entries to #{language} (#{locale}):
 
-    #{pot_content}
+    #{L10n.Catalog.fragment(messages)}
     """
 
     import ReqLLM.Context
 
-    messages = [
-      system(system_prompt),
-      user(user_prompt)
-    ]
-
-    resolved_model = resolve_model(model)
-
-    case generate_text_with_retries(
-           resolved_model,
-           messages,
-           timeout,
-           locale,
-           String.starts_with?(model, "hive:")
-         ) do
-      {:ok, response} ->
-        text =
-          response
-          |> ReqLLM.Response.text()
-          |> String.trim()
-          |> String.replace(~r/^```[a-z]*\n/, "")
-          |> String.replace(~r/\n```$/, "")
-          |> String.trim()
-
-        {:ok, text}
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, response} <-
+           generate_text_with_retries(
+             resolve_model(model),
+             [system(system_prompt), user(user_prompt)],
+             timeout,
+             locale,
+             String.starts_with?(model, "hive:")
+           ) do
+      response
+      |> ReqLLM.Response.text()
+      |> String.trim()
+      |> String.replace(~r/^```[a-z]*\n/, "")
+      |> String.replace(~r/\n```$/, "")
+      |> String.trim()
+      |> L10n.Catalog.parse()
+      |> case do
+        {:ok, parsed} -> {:ok, L10n.Catalog.index(parsed.messages)}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -684,35 +830,39 @@ defmodule L10n.Translator do
         if not force and not L10n.Lock.stale?(lock_path, hash) do
           {:skipped, locale}
         else
+          po_filename = Path.basename(pot_relative_path, ".pot") <> ".po"
+          output_path = Path.join([l10n_dir, target["path"], po_filename])
+
           try do
-            with {:ok, po_content} <-
-                   translate(
-                     pot_content,
-                     locale,
-                     language,
-                     context_body,
-                     locale_override,
-                     model,
-                     request_timeout
-                   ),
-                 :ok <- L10n.Validator.validate(po_content) do
-              po_filename = Path.basename(pot_relative_path, ".pot") <> ".po"
-              output_path = Path.join([l10n_dir, target["path"], po_filename])
-              output_path |> Path.dirname() |> File.mkdir_p!()
-              File.write!(output_path, po_content <> "\n")
+            case translate_catalog(
+                   pot_content,
+                   output_path,
+                   locale,
+                   language,
+                   context_body,
+                   locale_override,
+                   model,
+                   request_timeout,
+                   force,
+                   Keyword.get(opts, :batch_fn, &translate_batch/7)
+                 ) do
+              {:ok, :complete} ->
+                L10n.Lock.write!(lock_path, %{
+                  hash: hash,
+                  model: model,
+                  source_file: pot_relative_path,
+                  source_hash: source_hash,
+                  context_files: context_files,
+                  locale_override_files: locale_override_files
+                })
 
-              L10n.Lock.write!(lock_path, %{
-                hash: hash,
-                model: model,
-                source_file: pot_relative_path,
-                source_hash: source_hash,
-                context_files: context_files,
-                locale_override_files: locale_override_files
-              })
+                {:translated, locale}
 
-              {:translated, locale}
-            else
-              {:error, reason} -> {:error, locale, reason}
+              {:ok, {:partial, reason}} ->
+                {:error, locale, reason}
+
+              {:error, reason} ->
+                {:error, locale, reason}
             end
           rescue
             e -> {:error, locale, Exception.message(e)}
@@ -735,6 +885,92 @@ defmodule L10n.Translator do
         {:error, target["locale"], inspect(reason)}
     end)
   end
+
+  # Translates only the entries `output_path` is still missing, then rewrites it.
+  #
+  # The merged catalog is written even when some batches fail, so a run that is
+  # cancelled or rate-limited part-way still banks its progress and the next run
+  # only picks up what is left. The lock is advanced solely when every entry is
+  # translated, so partial progress never reads as up to date.
+  #
+  # Editing the L10N.md context therefore no longer retranslates a whole catalog:
+  # it re-locks against the new context and translates whatever is missing. Use
+  # `--force` to re-apply changed context rules to entries already translated.
+  defp translate_catalog(
+         pot_content,
+         output_path,
+         locale,
+         language,
+         context_body,
+         locale_override,
+         model,
+         timeout,
+         force,
+         batch_fn
+       ) do
+    plural_forms = Map.get(@plural_forms, locale, "nplurals=2; plural=n != 1;")
+
+    with {:ok, pot} <- L10n.Catalog.parse(pot_content) do
+      existing = read_catalog(output_path)
+      baseline = if force, do: %{}, else: existing
+      pending = L10n.Catalog.untranslated(pot.messages, baseline)
+
+      {fresh, errors} =
+        translate_batches(
+          pending,
+          locale,
+          language,
+          context_body,
+          locale_override,
+          model,
+          timeout,
+          batch_fn
+        )
+
+      merged = L10n.Catalog.merge(pot, existing, fresh, locale, plural_forms)
+      content = merged |> Expo.PO.compose() |> IO.iodata_to_binary()
+
+      with :ok <- L10n.Validator.validate(content) do
+        output_path |> Path.dirname() |> File.mkdir_p!()
+        File.write!(output_path, content)
+
+        missing = Enum.count(merged.messages, &(not L10n.Catalog.translated?(&1)))
+
+        cond do
+          errors != [] -> {:ok, {:partial, Enum.join(errors, "; ")}}
+          missing > 0 -> {:ok, {:partial, "#{missing} entries left untranslated"}}
+          true -> {:ok, :complete}
+        end
+      end
+    end
+  end
+
+  defp translate_batches([], _locale, _language, _context, _override, _model, _timeout, _fun) do
+    {%{}, []}
+  end
+
+  defp translate_batches(pending, locale, language, context, override, model, timeout, fun) do
+    pending
+    |> Enum.chunk_every(@batch_size)
+    |> Enum.reduce({%{}, []}, fn batch, {translated, errors} ->
+      case fun.(batch, locale, language, context, override, model, timeout) do
+        {:ok, index} -> {Map.merge(translated, index), errors}
+        {:error, reason} -> {translated, errors ++ [describe(reason)]}
+      end
+    end)
+  end
+
+  defp read_catalog(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, catalog} <- L10n.Catalog.parse(content) do
+      L10n.Catalog.index(catalog.messages)
+    else
+      _error -> %{}
+    end
+  end
+
+  defp describe(reason) when is_binary(reason), do: reason
+  defp describe(reason), do: inspect(reason)
 end
 
 defmodule L10n.Validator do
@@ -1714,4 +1950,8 @@ defmodule L10n.CLI do
   end
 end
 
-L10n.CLI.run(System.argv())
+# Loading this file defines the modules; the pipeline only runs when the file is
+# executed directly, so `translate_test.exs` can require it without translating.
+if System.get_env("L10N_SKIP_CLI") != "1" do
+  L10n.CLI.run(System.argv())
+end

--- a/translate_test.exs
+++ b/translate_test.exs
@@ -1,0 +1,417 @@
+# Unit tests for the pure parts of translate.exs.
+#
+#     elixir translate_test.exs
+#
+# Nothing here reaches a model: the incremental translation logic is a set
+# difference over catalog keys plus a merge, so it can be proven on fixtures.
+
+System.put_env("L10N_SKIP_CLI", "1")
+Code.require_file("translate.exs", __DIR__)
+
+ExUnit.start()
+
+defmodule L10n.CatalogTest do
+  use ExUnit.Case, async: true
+
+  alias L10n.Catalog
+
+  @pot """
+  msgid ""
+  msgstr ""
+
+  #: lib/app.ex:1
+  msgid "Hello"
+  msgstr ""
+
+  #: lib/app.ex:2
+  msgid "Goodbye"
+  msgstr ""
+
+  #: lib/app.ex:3
+  msgid "One item"
+  msgid_plural "%{count} items"
+  msgstr[0] ""
+  msgstr[1] ""
+  """
+
+  defp pot, do: parse(@pot)
+
+  defp parse(content) do
+    {:ok, messages} = Catalog.parse(content)
+    messages
+  end
+
+  defp msgids(messages), do: Enum.map(messages, &IO.iodata_to_binary(&1.msgid))
+
+  describe "untranslated/2" do
+    test "returns every message when nothing is translated yet" do
+      assert pot().messages |> Catalog.untranslated(%{}) |> msgids() ==
+               ["Hello", "Goodbye", "One item"]
+    end
+
+    test "returns only the messages missing from an existing catalog" do
+      existing =
+        parse("""
+        msgid ""
+        msgstr ""
+
+        msgid "Hello"
+        msgstr "Hola"
+        """)
+
+      pending = Catalog.untranslated(pot().messages, Catalog.index(existing.messages))
+
+      assert msgids(pending) == ["Goodbye", "One item"]
+    end
+
+    test "treats an empty msgstr as untranslated" do
+      existing =
+        parse("""
+        msgid ""
+        msgstr ""
+
+        msgid "Hello"
+        msgstr ""
+        """)
+
+      pending = Catalog.untranslated(pot().messages, Catalog.index(existing.messages))
+
+      assert "Hello" in msgids(pending)
+    end
+
+    test "treats a partially translated plural as untranslated" do
+      existing =
+        parse("""
+        msgid ""
+        msgstr ""
+
+        msgid "One item"
+        msgid_plural "%{count} items"
+        msgstr[0] "Un elemento"
+        msgstr[1] ""
+        """)
+
+      pending = Catalog.untranslated(pot().messages, Catalog.index(existing.messages))
+
+      assert "One item" in msgids(pending)
+    end
+
+    test "a reworded source string surfaces as a new message" do
+      existing =
+        parse("""
+        msgid ""
+        msgstr ""
+
+        msgid "Hi"
+        msgstr "Hola"
+        """)
+
+      pending = Catalog.untranslated(pot().messages, Catalog.index(existing.messages))
+
+      assert "Hello" in msgids(pending)
+    end
+
+    test "distinguishes messages that differ only by context" do
+      with_context =
+        parse("""
+        msgid ""
+        msgstr ""
+
+        msgctxt "menu"
+        msgid "Hello"
+        msgstr "Hola"
+        """)
+
+      pending = Catalog.untranslated(pot().messages, Catalog.index(with_context.messages))
+
+      assert "Hello" in msgids(pending)
+    end
+  end
+
+  describe "fragment/1" do
+    test "round-trips through the parser and carries only the given messages" do
+      fragment = pot().messages |> Enum.take(1) |> Catalog.fragment()
+
+      assert msgids(parse(fragment).messages) == ["Hello"]
+    end
+  end
+
+  describe "merge/5" do
+    test "keeps existing translations and applies fresh ones" do
+      existing =
+        Catalog.index(
+          parse("""
+          msgid ""
+          msgstr ""
+
+          msgid "Hello"
+          msgstr "Hola"
+          """).messages
+        )
+
+      fresh =
+        Catalog.index(
+          parse("""
+          msgid ""
+          msgstr ""
+
+          msgid "Goodbye"
+          msgstr "Adios"
+          """).messages
+        )
+
+      merged = Catalog.merge(pot(), existing, fresh, "es", "nplurals=2; plural=n != 1;")
+      by_id = Map.new(merged.messages, &{IO.iodata_to_binary(&1.msgid), &1})
+
+      assert IO.iodata_to_binary(by_id["Hello"].msgstr) == "Hola"
+      assert IO.iodata_to_binary(by_id["Goodbye"].msgstr) == "Adios"
+    end
+
+    test "prefers a fresh translation over the existing one" do
+      existing =
+        Catalog.index(parse(~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "viejo"\n|).messages)
+
+      fresh =
+        Catalog.index(parse(~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "nuevo"\n|).messages)
+
+      merged = Catalog.merge(pot(), existing, fresh, "es", "nplurals=2; plural=n != 1;")
+      by_id = Map.new(merged.messages, &{IO.iodata_to_binary(&1.msgid), &1})
+
+      assert IO.iodata_to_binary(by_id["Hello"].msgstr) == "nuevo"
+    end
+
+    test "leaves untranslated messages blank rather than dropping them" do
+      merged = Catalog.merge(pot(), %{}, %{}, "es", "nplurals=2; plural=n != 1;")
+
+      assert msgids(merged.messages) == ["Hello", "Goodbye", "One item"]
+      refute Enum.any?(merged.messages, &Catalog.translated?/1)
+    end
+
+    test "sizes plural forms to the locale" do
+      for {locale, count} <- [{"ru", 3}, {"ja", 1}, {"es", 2}] do
+        merged = Catalog.merge(pot(), %{}, %{}, locale, "nplurals=#{count};")
+        plural = Enum.find(merged.messages, &is_map(&1.msgstr))
+
+        assert map_size(plural.msgstr) == count, "#{locale} expected #{count} plural forms"
+      end
+    end
+
+    test "writes the locale header" do
+      merged = Catalog.merge(pot(), %{}, %{}, "ko", "nplurals=1; plural=0;")
+
+      assert "Language: ko\n" in merged.headers
+      assert "Plural-Forms: nplurals=1; plural=0;\n" in merged.headers
+    end
+
+    test "refreshes references from the template" do
+      existing =
+        Catalog.index(
+          parse("""
+          msgid ""
+          msgstr ""
+
+          #: lib/old_location.ex:99
+          msgid "Hello"
+          msgstr "Hola"
+          """).messages
+        )
+
+      merged = Catalog.merge(pot(), existing, %{}, "es", "nplurals=2; plural=n != 1;")
+      hello = Enum.find(merged.messages, &(IO.iodata_to_binary(&1.msgid) == "Hello"))
+
+      assert hello.references == [[{"lib/app.ex", 1}]]
+    end
+
+    test "produces output the validator accepts" do
+      existing =
+        Catalog.index(parse(~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n|).messages)
+
+      content =
+        pot()
+        |> Catalog.merge(existing, %{}, "es", "nplurals=2; plural=n != 1;")
+        |> Expo.PO.compose()
+        |> IO.iodata_to_binary()
+
+      assert :ok == L10n.Validator.validate(content)
+    end
+
+    test "a full merge leaves nothing pending on the next run" do
+      fresh =
+        Catalog.index(
+          parse("""
+          msgid ""
+          msgstr ""
+
+          msgid "Hello"
+          msgstr "Hola"
+
+          msgid "Goodbye"
+          msgstr "Adios"
+
+          msgid "One item"
+          msgid_plural "%{count} items"
+          msgstr[0] "Un elemento"
+          msgstr[1] "%{count} elementos"
+          """).messages
+        )
+
+      merged = Catalog.merge(pot(), %{}, fresh, "es", "nplurals=2; plural=n != 1;")
+
+      assert Catalog.untranslated(pot().messages, Catalog.index(merged.messages)) == []
+    end
+  end
+end
+
+defmodule L10n.IncrementalTranslationTest do
+  use ExUnit.Case, async: true
+
+  alias L10n.Catalog
+
+  @pot """
+  msgid ""
+  msgstr ""
+
+  #: lib/app.ex:1
+  msgid "Hello"
+  msgstr ""
+
+  #: lib/app.ex:2
+  msgid "Goodbye"
+  msgstr ""
+  """
+
+  @targets [%{"locale" => "es", "language" => "Spanish", "path" => "es/LC_MESSAGES"}]
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "l10n-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  defp po_path(root), do: Path.join([root, "es/LC_MESSAGES/default.po"])
+  defp lock_path(root), do: L10n.Lock.lock_path(root, "priv/gettext/default.pot", "es")
+
+  defp write_po!(root, content) do
+    path = po_path(root)
+    path |> Path.dirname() |> File.mkdir_p!()
+    File.write!(path, content)
+  end
+
+  # Records every batch it is handed, then translates each entry as "<msgid>!".
+  defp recorder(test_pid) do
+    fn batch, _locale, _language, _context, _override, _model, _timeout ->
+      send(test_pid, {:batch, Enum.map(batch, &IO.iodata_to_binary(&1.msgid))})
+
+      body =
+        Enum.map_join(batch, "\n", fn message ->
+          id = IO.iodata_to_binary(message.msgid)
+          ~s|msgid "#{id}"\nmsgstr "#{id}!"\n|
+        end)
+
+      {:ok, parsed} = Catalog.parse(body)
+      {:ok, Catalog.index(parsed.messages)}
+    end
+  end
+
+  defp run(root, opts) do
+    L10n.Translator.translate_all(
+      @pot,
+      @targets,
+      "context",
+      "test:model",
+      root,
+      root,
+      "priv/gettext/default.pot",
+      [],
+      Keyword.merge([locale_override_fn: fn _ -> {"", []} end], opts)
+    )
+  end
+
+  test "an already-complete catalog costs no model calls and still advances the lock", %{
+    root: root
+  } do
+    write_po!(
+      root,
+      ~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n\nmsgid "Goodbye"\nmsgstr "Adios"\n|
+    )
+
+    assert [{:translated, "es"}] = run(root, batch_fn: recorder(self()))
+
+    refute_received {:batch, _}
+    assert File.exists?(lock_path(root))
+  end
+
+  test "only the missing entries reach the model", %{root: root} do
+    write_po!(root, ~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n|)
+
+    assert [{:translated, "es"}] = run(root, batch_fn: recorder(self()))
+
+    assert_received {:batch, ["Goodbye"]}
+    refute_received {:batch, _}
+
+    {:ok, written} = Catalog.parse(File.read!(po_path(root)))
+
+    by_id =
+      Map.new(written.messages, &{IO.iodata_to_binary(&1.msgid), IO.iodata_to_binary(&1.msgstr)})
+
+    assert by_id == %{"Hello" => "Hola", "Goodbye" => "Goodbye!"}
+  end
+
+  test "a failed batch banks progress but does not advance the lock", %{root: root} do
+    write_po!(root, ~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n|)
+
+    failing = fn _batch, _l, _lang, _c, _o, _m, _t -> {:error, "provider exploded"} end
+
+    assert [{:error, "es", reason}] = run(root, batch_fn: failing)
+    assert reason =~ "provider exploded"
+
+    refute File.exists?(lock_path(root))
+
+    # The existing translation survives, so the next run only retries "Goodbye".
+    {:ok, written} = Catalog.parse(File.read!(po_path(root)))
+
+    by_id =
+      Map.new(written.messages, &{IO.iodata_to_binary(&1.msgid), IO.iodata_to_binary(&1.msgstr)})
+
+    assert by_id["Hello"] == "Hola"
+    assert by_id["Goodbye"] == ""
+  end
+
+  test "a partially answered batch leaves the rest for the next run", %{root: root} do
+    partial = fn _batch, _l, _lang, _c, _o, _m, _t ->
+      {:ok, parsed} = Catalog.parse(~s|msgid "Hello"\nmsgstr "Hola"\n|)
+      {:ok, Catalog.index(parsed.messages)}
+    end
+
+    assert [{:error, "es", reason}] = run(root, batch_fn: partial)
+    assert reason =~ "1 entries left untranslated"
+    refute File.exists?(lock_path(root))
+
+    assert [{:translated, "es"}] = run(root, batch_fn: recorder(self()))
+    assert_received {:batch, ["Goodbye"]}
+  end
+
+  test "force re-sends entries that are already translated", %{root: root} do
+    write_po!(
+      root,
+      ~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n\nmsgid "Goodbye"\nmsgstr "Adios"\n|
+    )
+
+    assert [{:translated, "es"}] = run(root, batch_fn: recorder(self()), force: true)
+
+    assert_received {:batch, ["Hello", "Goodbye"]}
+  end
+
+  test "a fresh lock skips the catalog entirely", %{root: root} do
+    write_po!(
+      root,
+      ~s|msgid ""\nmsgstr ""\n\nmsgid "Hello"\nmsgstr "Hola"\n\nmsgid "Goodbye"\nmsgstr "Adios"\n|
+    )
+
+    assert [{:translated, "es"}] = run(root, batch_fn: recorder(self()))
+    assert [{:skipped, "es"}] = run(root, batch_fn: recorder(self()))
+
+    refute_received {:batch, _}
+  end
+end


### PR DESCRIPTION
## Why

Hive's inference gateway was burning roughly $13/day on the `tuist/tuist translation` token, and I went looking for where it was going. Two bursts a day, each around 200 requests generating about 19,000 output tokens apiece. That is a full retranslation of every catalog into every locale, twice a day.

The trigger is ordinary: `.github/workflows/l10n.yml` fires on any push to `main` that touches a `.pot` file, and gettext extraction rewrites `.pot` files whenever a UI string moves. So normal server PRs kept kicking off full-corpus retranslations.

Two things were compounding.

**The output was never landing.** The last commit touching `.l10n/` or any `.po` on `main` is `bde548ef69` from 2026-05-19, and there is no `l10n/update-translations` branch on the remote right now. So the locks describe the world as of May, every run finds nearly everything stale, and the next push starts from the same May baseline and redoes it.

**Every run regenerated whole files.** `translate/7` sent the entire `.pot` and asked for the entire `.po` back, so one changed string cost a full catalog across eight locales.

Worth saying clearly: the lockfiles themselves are fine. I recomputed all 134 lock hashes against current content with the real code. 42 are fresh and correctly skipped, 78 are stale because the source genuinely changed, and 14 are stale because `server/L10N/ko.md` and `server/L10N/ru.md` were added in June after those locks were written. Zero are stale without cause. The reference comment normalization works too, which I checked against `61f22ecb74` where all 190 changed lines in `marketing.pot` were `#:` line number churn that correctly did not move the hash. The lock layer was reporting an old baseline honestly, not misbehaving.

## What changed

**Incremental translation.** New `L10n.Catalog` module diffs the `.pot` against the `.po` already on disk and returns only the entries that lack a translation. A `.pot` msgid is itself the English source string, so a reworded string shows up as a new key rather than a mutated one, which makes "what still needs work" a plain set difference over catalog keys. Entries go to the model in batches of 40 as a small `.pot` fragment, and the reply is merged back over the existing translations.

The `.po` header is now built deterministically from the locale rather than asked for in the prompt, so there is one less thing for the model to get wrong.

**Progress is banked.** The merged `.po` is written even when a batch fails, and the lock advances only when every entry is translated. A run that is cancelled or rate limited part way through keeps what it earned, and the next run picks up only the remainder. Previously a failure anywhere threw away the whole catalog.

**Runs queue instead of cancelling.** `cancel-in-progress` is now `false`. The Aug 25 burst had triggering pushes at 13:43, 14:06 and 14:54 UTC and the Aug 26 burst at 08:02, 09:00 and 10:07. Each new push killed a run that had already paid for its model calls, and the cancelled run never reached the "Create PR" step, so the spend produced nothing at all.

## Tradeoffs

Editing `L10N.md` no longer retranslates everything. The composite lock hash still includes the context, so a context edit is still detected and the lock is rewritten, but only missing entries are translated. Re-applying changed context rules to entries that are already translated is now an explicit `--force`. I think that is the right default given a one line context tweak previously cost a full corpus run, but it is a behavior change and worth a second opinion.

Batching at 40 entries means a cold start makes more requests than before, each much smaller. Total tokens are roughly the same for a genuine cold start, but no single request is enormous, and because progress is banked a slow first run is no longer all or nothing. I raised the job timeout to 90 minutes for headroom.

I considered pushing translations straight to `main` instead of opening a PR, since the PR not landing is the root problem. That is a repo policy call rather than a script change, so I left the PR flow alone and added a note in the generated PR body. **This still needs a human decision: if the generated PR keeps not getting merged, the locks stay stale and a good chunk of this win does not materialize.**

## Verification

`translate_test.exs` is new and runs with `elixir translate_test.exs`. 21 tests, no model access needed, since the diff and merge logic is pure and the batch call is injectable through `batch_fn` following the `locale_override_fn` idiom already in the script.

Coverage includes empty and partial msgstrs, plural forms sized per locale (ru 3, ja 1, es 2), messages that differ only by msgctxt, reference refreshing from the template, validator round trip, and the end to end cases: an already complete catalog costing zero model calls, only missing entries reaching the model, a failed batch banking progress without advancing the lock, a partially answered batch leaving the rest for the next run, and `--force` re-sending everything.

Measured against the catalogs on `main` today:

| | |
|---|---|
| catalog x locale pairs | 136 |
| entries if regenerating whole files | 21,648 |
| entries actually missing | 3,424 |
| pairs needing zero model calls | 64 of 136 |

So about 16% of the previous output volume, and that is the worst case measured against three month old `.po` files. Once a run lands, steady state is only genuinely new strings.
