### PR TITLE
perf(infra): stop serialising the deploy image build behind the infra tags

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1955,15 +1955,6 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: Build deployment images
-    # Deliberately does NOT wait on `tag-infra-releases`. This job reads no
-    # tag-infra output and never touches a git tag: `image_tag` is
-    # `sha-<commit>`, and the checkout is a shallow `ref: github.sha` with no
-    # tags fetched. What actually needs the `<component>@<semver>` tags is the
-    # deploy, where `server-deployment.yml` resolves each fleet and runtime
-    # image version from them, so the gate lives on the three deploying jobs
-    # (`canary`, `production`, `production-hotfix`) instead. Keeping it here
-    # serialised the Linux image build behind the macOS Tart image bakes for
-    # no benefit.
     needs: [check-releases]
     if: >-
       always() &&

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1955,11 +1955,19 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: Build deployment images
-    needs: [check-releases, tag-infra-releases]
+    # Deliberately does NOT wait on `tag-infra-releases`. This job reads no
+    # tag-infra output and never touches a git tag: `image_tag` is
+    # `sha-<commit>`, and the checkout is a shallow `ref: github.sha` with no
+    # tags fetched. What actually needs the `<component>@<semver>` tags is the
+    # deploy, where `server-deployment.yml` resolves each fleet and runtime
+    # image version from them, so the gate lives on the three deploying jobs
+    # (`canary`, `production`, `production-hotfix`) instead. Keeping it here
+    # serialised the Linux image build behind the macOS Tart image bakes for
+    # no benefit.
+    needs: [check-releases]
     if: >-
       always() &&
       needs.check-releases.result == 'success' &&
-      needs.tag-infra-releases.result == 'success' &&
       (
         needs.check-releases.outputs.deployable-changed == 'true' ||
         needs.check-releases.outputs.runner-image-should-release == 'true' ||
@@ -2080,12 +2088,12 @@ jobs:
   # fast-path ships straight to production without waiting on the canary
   # cascade.
   canary:
-    needs: [check-releases, build]
+    needs: [check-releases, build, tag-infra-releases]
     # `build` runs under `if: always()` so it survives the many skipped sibling
     # release jobs. A plain-`if` dependent of an `always()`-guarded job gets
     # caught by skip-propagation and is itself skipped even when `build`
     # succeeded, so the whole deploy tail must re-assert success explicitly.
-    if: ${{ always() && needs.build.result == 'success' && needs.check-releases.outputs.is-hotfix != 'true' }}
+    if: ${{ always() && needs.build.result == 'success' && needs.tag-infra-releases.result == 'success' && needs.check-releases.outputs.is-hotfix != 'true' }}
     # server-deployment.yml's build-kura-runtime job requests id-token: write;
     # a reusable workflow's permissions are validated against the caller at
     # startup, so this leg must grant the callee's full permission union.
@@ -2330,10 +2338,12 @@ jobs:
         acceptance-tests,
         backward-compatibility-acceptance,
         kura-canary-rollout-gate,
+        tag-infra-releases,
       ]
     if: >-
       always() &&
       needs.build.result == 'success' &&
+      needs.tag-infra-releases.result == 'success' &&
       needs.canary.result == 'success' &&
       needs.acceptance-tests.result == 'success' &&
       needs.backward-compatibility-acceptance.result == 'success' &&
@@ -2360,9 +2370,16 @@ jobs:
   # hotfix so the fast-path is the only deploy in flight. The
   # `always() && needs.build.result == 'success'` guard mirrors `canary`
   # (see its comment) so this leg is not skip-propagated away.
+  #
+  # `tag-infra-releases` is not a new blocker on the urgent path: this leg
+  # inherited that wait through `build` until the gate moved onto the
+  # deploying jobs, so its timing is unchanged. It has to stay, because
+  # `server-deployment.yml` resolves fleet and runtime image versions from the
+  # `<component>@<semver>` tags and would otherwise silently pin the previous
+  # version of anything this run released.
   production-hotfix:
-    needs: [check-releases, build]
-    if: ${{ always() && needs.build.result == 'success' && needs.check-releases.outputs.is-hotfix == 'true' }}
+    needs: [check-releases, build, tag-infra-releases]
+    if: ${{ always() && needs.build.result == 'success' && needs.tag-infra-releases.result == 'success' && needs.check-releases.outputs.is-hotfix == 'true' }}
     # See `canary` above: grant the callee's full permission union.
     permissions:
       contents: read

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -2361,13 +2361,6 @@ jobs:
   # hotfix so the fast-path is the only deploy in flight. The
   # `always() && needs.build.result == 'success'` guard mirrors `canary`
   # (see its comment) so this leg is not skip-propagated away.
-  #
-  # `tag-infra-releases` is not a new blocker on the urgent path: this leg
-  # inherited that wait through `build` until the gate moved onto the
-  # deploying jobs, so its timing is unchanged. It has to stay, because
-  # `server-deployment.yml` resolves fleet and runtime image versions from the
-  # `<component>@<semver>` tags and would otherwise silently pin the previous
-  # version of anything this run released.
   production-hotfix:
     needs: [check-releases, build, tag-infra-releases]
     if: ${{ always() && needs.build.result == 'success' && needs.tag-infra-releases.result == 'success' && needs.check-releases.outputs.is-hotfix == 'true' }}


### PR DESCRIPTION
> Describe here the purpose of your PR.

`build` declared `needs: [check-releases, tag-infra-releases]`, so the Linux deployment image build could not start until every fleet and runtime image release job had finished and been tagged. That made the macOS Tart image bakes a strict prefix of the production cascade rather than a parallel branch of it.

On [run 32946146646](https://github.com/tuist/tuist/actions/runs/32946146646) that ordering cost 10.3 min of pure wall clock:

| | |
|---|---|
| `check-releases` ends | 08:24:30 |
| `release-xcresult-processor-image` | 08:24:33 to 08:47:53 (23.3 min) |
| `tag-infra-releases` | 08:48:04 to 08:49:22 |
| `build` | 08:49:27 to 08:59:45 (10.3 min) |
| `canary` starts | 08:59:46 |

`build` sat idle for 25 minutes waiting on a macOS VM image it has nothing to do with.

### Why the dependency was safe to move

It was pure sequencing. `build` reads no output from `tag-infra-releases`, and across the whole 127-line job there is no `git tag`, no `git describe`, and no tag fetch. `image_tag` is derived from the commit alone:

```yaml
- id: tag
  env:
    DEPLOY_SHA: ${{ github.sha }}
  run: echo "image_tag=sha-${DEPLOY_SHA:0:12}" >> "$GITHUB_OUTPUT"
```

and the checkout is a shallow `ref: ${{ github.sha }}` with no `fetch-depth: 0`, so the tags are not even present in that job's working copy. The only two references to `tag-infra-releases` in the entire job were the `needs` entry and the `if` gate this PR removes.

### Why the gate still has to exist somewhere

What genuinely needs the `<component>@<semver>` tags is the deploy. `server-deployment.yml`'s `resolve()` walks `git tag --list "<prefix>*" --merged "$DEPLOY_SHA"` newest-first to pin the xcresult-processor, Kura runtime, macOS and Linux runner image, CAPI provider, runners-controller and egress-tree-agent versions. If a deploy runs before `tag-infra-releases` has pushed this run's tags, `resolve()` does not fail: it silently falls back to the previous version of whatever this run just released. That is the failure this gate prevents, and it is a deploy-time concern, not a build-time one.

So the gate moves onto the three jobs that actually deploy: `canary`, `production` and `production-hotfix`.

`production` already listed `canary` explicitly rather than relying on the transitive path through the acceptance jobs, with a comment saying the invariant should be encoded in the deploying job's own gate. The tag gate follows that same convention rather than leaning on `canary` to carry it.

### The hotfix path is unchanged

`production-hotfix` gains `tag-infra-releases` in its `needs`, which looks like a new blocker on a path whose whole point is not waiting. It is not: the hotfix leg needs `build`, and `build` needed `tag-infra-releases`, so this leg already waited on exactly the same thing transitively. Its timing is identical before and after. It has to keep waiting for the reason above, since a hotfix that pins a stale fleet image is the same silent-rollback bug as any other deploy.

### Impact

The cascade's time to first deploy becomes `max(fleet image releases + tagging, build)` instead of their sum.

Using the same run as the example, time from `check-releases` finishing to `canary` starting goes from ~35 min to ~25 min. The saving is proportional to how long the slowest fleet image bake takes, so it is largest exactly when it matters most. The xcresult-processor image alone released 25 times in the 14 days to 2026-08-26.

On merges that release no fleet image at all, the release jobs skip, `tag-infra-releases` runs in ~1.3 min, and the saving is that 1.3 min.

This is a companion to #12622, which attacks the other side of the same problem by making the xcresult-processor image build itself faster. They are independent and can land in either order.

### How to test locally

> Document how to test your changes locally

This is a workflow-graph change with no runnable local component. It was verified by reading the resulting graph rather than by inspection of the diff alone:

```bash
for j in build canary production production-hotfix publish-releases; do
  echo "--- $j ---"
  yq ".jobs[\"$j\"].needs" .github/workflows/server-production-deployment.yml
done
```

which gives:

- `build` to `[check-releases]`
- `canary` to `[check-releases, build, tag-infra-releases]`
- `production` to `[check-releases, build, canary, acceptance-tests, backward-compatibility-acceptance, kura-canary-rollout-gate, tag-infra-releases]`
- `production-hotfix` to `[check-releases, build, tag-infra-releases]`
- `publish-releases` unchanged, and it never depended on `build`

Every consumer of `build` was checked to confirm the gate did not go missing on any of them:

```bash
grep -n "needs\.build\b" .github/workflows/server-production-deployment.yml
```

The only three consumers are `canary`, `production` and `production-hotfix`, and all three now carry `needs.tag-infra-releases.result == 'success'` in their `if`.

The real proof is the next merge to `main`: `build` should start alongside the release jobs rather than after `tag-infra-releases`, and the deploy legs should still wait for it.
