### PR TITLE
chore(infra): trim the macOS build cache comments

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1017,16 +1017,9 @@ jobs:
 
           git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../../" --tag "${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}" -o CHANGELOG.md 2>/dev/null
 
-      # `actions/checkout` runs `git clean -ffdx` on this host's persistent
-      # workspace, which deletes `server/deps`, `server/_build` and both NIF
-      # `.build` directories, so every release compiled the two Swift NIFs and
-      # the whole Elixir dependency tree cold. Pointing the caches outside the
-      # workspace puts them out of the clean's reach.
-      #
-      # Keyed by runner name because a runner process runs one job at a time:
-      # two jobs landing on the same host (this one and the on-demand
-      # `xcresult-processor-image.yml`) can then never share a cache and
-      # cannot race on the release directory.
+      # `git clean -ffdx` in actions/checkout reaches anything inside the
+      # workspace, so the caches live outside it, keyed by runner name so
+      # concurrent jobs on one host never share them.
       - name: Point build caches outside the workspace
         run: |
           set -euo pipefail
@@ -1048,10 +1041,8 @@ jobs:
           ./native/xcresult_nif/build.sh
           ./native/xcactivitylog_nif/build.sh
           MIX_ENV=prod mix compile --force --warnings-as-errors
-          # `mix release --overwrite` writes over the release directory
-          # without emptying it first, so a file dropped since the previous
-          # release would survive in a persistent build root and get baked
-          # into the image.
+          # `mix release --overwrite` does not empty the directory first, so a
+          # persistent build root would carry stale files into the image.
           rm -rf "$RELEASE_DIR"
           MIX_ENV=prod mix release tuist --overwrite
           echo "dir=${RELEASE_DIR}" >> "$GITHUB_OUTPUT"
@@ -1100,13 +1091,8 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
-      # Overrides the action's default of 4. This job sits on the production
-      # cascade's critical path and the push is most of its wall clock, and
-      # unlike the runner-image matrix it uploads alone rather than as one leg
-      # of a five-way fan-out, so it has the whole rate-limit budget to
-      # itself. Push throughput measured close to linear in this value from 1
-      # to 4 with no GHCR throttling; if that stops holding, lower it back
-      # rather than reaching for a larger chunk size.
+      # 8 rather than the action's default of 4: this image pushes alone, not
+      # as one leg of the runner-image matrix.
       - name: Push image to GHCR
         timeout-minutes: 90
         uses: ./.github/actions/tart-push

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -57,16 +57,9 @@ jobs:
           install_args: "erlang elixir"
           working_directory: server
 
-      # `actions/checkout` runs `git clean -ffdx` on this host's persistent
-      # workspace, which deletes `server/deps`, `server/_build` and both NIF
-      # `.build` directories, so every run compiled the two Swift NIFs and the
-      # whole Elixir dependency tree cold. Pointing the caches outside the
-      # workspace puts them out of the clean's reach.
-      #
-      # Keyed by runner name because a runner process runs one job at a time:
-      # two jobs landing on the same host (this one and the release job in
-      # `server-production-deployment.yml`) can then never share a cache and
-      # cannot race on the release directory.
+      # `git clean -ffdx` in actions/checkout reaches anything inside the
+      # workspace, so the caches live outside it, keyed by runner name so
+      # concurrent jobs on one host never share them.
       - name: Point build caches outside the workspace
         run: |
           set -euo pipefail
@@ -97,16 +90,13 @@ jobs:
           # before the release tarball is assembled.
           ./native/xcresult_nif/build.sh
           ./native/xcactivitylog_nif/build.sh
-          # The build root persists across runs. That is mostly fine, except
-          # that mix's mtime-based incremental compile occasionally keeps a
-          # stale .beam after a rebase. `--force` recompiles every .ex
-          # regardless; the BEAM build is fast enough (~30s) that the safety
-          # is worth more than the saved time.
+          # The build root persists across runs, so mix's mtime-based
+          # incremental compile can keep a stale .beam after a rebase.
+          # `--force` recompiles every .ex regardless; the BEAM build is fast
+          # enough (~30s) that the safety is worth more than the saved time.
           MIX_ENV=prod mix compile --force --warnings-as-errors
-          # `mix release --overwrite` writes over the release directory
-          # without emptying it first, so a file dropped since the previous
-          # release would survive in a persistent build root and get baked
-          # into the image.
+          # `mix release --overwrite` does not empty the directory first, so a
+          # persistent build root would carry stale files into the image.
           rm -rf "$RELEASE_DIR"
           MIX_ENV=prod mix release tuist --overwrite
           echo "dir=${RELEASE_DIR}" >> "$GITHUB_OUTPUT"
@@ -162,11 +152,8 @@ jobs:
         # The production workflow owns semantic-version and latest tags.
         # This on-demand workflow publishes only its commit tag.
         #
-        # `concurrency` matches the release job's override of the action's
-        # default of 4: this image pushes alone rather than as one leg of the
-        # runner-image matrix, so it has the whole rate-limit budget to
-        # itself. Keeping the two in step means a dispatch run measures what
-        # the release path will do.
+        # 8 rather than the action's default of 4, matching the release job:
+        # this image pushes alone, not as one leg of the runner-image matrix.
         uses: ./.github/actions/tart-push
         with:
           local-name: tuist-xcresult-processor

--- a/server/native/xcactivitylog_nif/build.sh
+++ b/server/native/xcactivitylog_nif/build.sh
@@ -6,10 +6,8 @@ PRIV_DIR="${SCRIPT_DIR}/../../priv/native"
 
 cd "$SCRIPT_DIR"
 
-# CI checks out onto a persistent workspace and `actions/checkout` runs
-# `git clean -ffdx`, which deletes an in-tree .build and forces a cold Swift
-# compile on every run. TUIST_NIF_BUILD_ROOT moves the scratch directory
-# outside the workspace so it survives the clean.
+# CI sets this to a path outside the workspace, which `git clean -ffdx`
+# would otherwise wipe between runs.
 if [ -n "${TUIST_NIF_BUILD_ROOT:-}" ]; then
     SCRATCH_PATH="${TUIST_NIF_BUILD_ROOT}/xcactivitylog_nif"
 else

--- a/server/native/xcresult_nif/build.sh
+++ b/server/native/xcresult_nif/build.sh
@@ -15,10 +15,8 @@ cd "$SCRIPT_DIR"
 
 mkdir -p "$PRIV_DIR"
 
-# CI checks out onto a persistent workspace and `actions/checkout` runs
-# `git clean -ffdx`, which deletes an in-tree .build and forces a cold Swift
-# compile on every run. TUIST_NIF_BUILD_ROOT moves the scratch directory
-# outside the workspace so it survives the clean.
+# CI sets this to a path outside the workspace, which `git clean -ffdx`
+# would otherwise wipe between runs.
 if [ -n "${TUIST_NIF_BUILD_ROOT:-}" ]; then
     SCRATCH_PATH="${TUIST_NIF_BUILD_ROOT}/xcresult_nif"
 else


### PR DESCRIPTION
> Describe here the purpose of your PR.

Follow-up to #12622. The comments that landed with the macOS build caches explained the bug that motivated the change and the measurements behind the push concurrency, instead of stating what the configuration does. A reader of the workflow does not need the history, so this cuts each one to the constraint that would otherwise be invisible.

Comment-only: 53 lines removed, 22 added, no behaviour change.

| Location | Kept as |
|---|---|
| Cache step, both workflows | `git clean -ffdx` reaches inside the workspace, so the caches sit outside it and are keyed by runner name |
| `rm -rf "$RELEASE_DIR"` | `mix release --overwrite` does not empty the directory first |
| `tart-push` concurrency, both workflows | 8 rather than the default 4, because this image pushes alone rather than as one leg of the runner-image matrix |
| `TUIST_NIF_BUILD_ROOT` in both `build.sh` | CI points this outside the workspace, which `git clean -ffdx` would otherwise wipe |

The `--force` comment in `xcresult-processor-image.yml` predates #12622 and was reworded there to drop its reference to the old `TUIST_MIX_BUILD_ROOT`. It is tightened here in the same pass; its substance is unchanged.

Scoped `chore` on purpose. `server/native/xcresult_nif/**` is in the xcresult-processor-image release component's include paths, and that component's cliff config skips `chore`, so a comment-only change does not cut a version and spend ~23 min rebaking a Tart image. This is the skipped-scope behaviour that `infra/xcresult-processor-image/AGENTS.md` warns about for schema- or runtime-affecting changes, which this is not.

### How to test locally

> Document how to test your changes locally

Nothing to run. The diff touches only comment lines, which can be confirmed with:

```bash
git diff origin/main | grep -E "^[+-]" | grep -vE "^[+-]\s*#" | grep -vE "^(---|\+\+\+)"
```

That prints nothing, so every changed line is a comment.
