### PR TITLE
fix(infra): harden pentest workflow verification

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -177,6 +177,7 @@ jobs:
         with:
           install_args: "helm jq kubectl"
           cache: "false"
+          env: "false"
       - name: Verify pentest account credentials
         env:
           EXPIRES_AT: ${{ inputs.expires_at }}
@@ -429,6 +430,7 @@ jobs:
         with:
           install_args: "helm kubectl"
           cache: "false"
+          env: "false"
       - name: Load Kubernetes configuration
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
@@ -468,6 +470,7 @@ jobs:
         with:
           install_args: "helm kubectl"
           cache: "false"
+          env: "false"
       - name: Load Kubernetes configuration
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -247,7 +247,7 @@ jobs:
 
           if ! kubectl -n kura get deployment \
             -l app.kubernetes.io/component=kura-controller \
-            -o jsonpath='{range .items[*].spec.template.spec.containers[*].args[*]}{.}{"\n"}{end}{end}' \
+            -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{range .args[*]}{.}{"\n"}{end}{end}{end}' \
             | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null; then
             echo "::error::The Kura controller is not configured to issue TLS for kura-pentest.tuist.dev. Run the Pentest Platform Reconcile workflow."
             exit 1

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -74,7 +74,7 @@ jobs:
             -l app.kubernetes.io/component=kura-controller --timeout=5m
           kubectl -n kura get deployment \
             -l app.kubernetes.io/component=kura-controller \
-            -o jsonpath='{range .items[*].spec.template.spec.containers[*].args[*]}{.}{"\n"}{end}{end}' \
+            -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{range .args[*]}{.}{"\n"}{end}{end}{end}' \
             | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null
       - name: Summary
         run: |

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           install_args: "helm kubectl"
           cache: "false"
+          env: "false"
       - name: Validate the immutable controller reference
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #12624.

> The Pentest Platform Reconcile workflow successfully installed and rolled out
> the Kura controller, but then failed while inspecting its arguments. The
> Kubernetes JSONPath expression opened one range and closed it twice, so the
> workflow failed even though the required certificate-issuer argument was
> present.
>
> Both pentest workflows now use explicit nested ranges for deployments,
> containers, and arguments. This makes the platform verification accurate and
> prevents the application deployment from failing on the same expression.
>
> The workflows also disable Mise's automatic environment export. The jobs
> still install the required tools and explicitly load the deployment
> credentials, while repository-local development variables no longer become
> visible in every GitHub Actions step.

### How to test locally

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/pentest-platform-reconcile.yml .github/workflows/pentest-deployment.yml`
- `git diff --check`
