### PR TITLE
fix(infra): build registry image from repository root

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -125,7 +125,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
-          context: ./registry
+          context: .
           file: ./registry/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}


### PR DESCRIPTION
> Fix the package-registry image build for the Pentest Deployment workflow. Its Dockerfile copies both the `registry/` directory and shared repository files, while the workflow previously sent only `registry/` as the build context. That made `registry/priv` unavailable and stopped the deployment before any cluster changes. The workflow now uses the repository root as its context while retaining the package-registry Dockerfile.

### How to test locally

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/pentest-deployment.yml`
- `git diff --check`
- `docker buildx build --check --file registry/Dockerfile .`
