### PR TITLE
fix(infra): reassert the chart's RunnerPool scaling ceiling on every deploy

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1154,6 +1154,78 @@ jobs:
             registry_image_tag="registry-disabled"
           fi
 
+
+          # Helm patches custom resources with a two-way JSON merge between the
+          # previously released manifest and the new one. A field whose rendered
+          # value has not changed is therefore absent from the patch, so a manual
+          # `kubectl patch` to it survives every later deploy: the RunnerPool
+          # `linux-4vcpu-16gb` sat at `maxReplicas: 8` from 2026-08-14 while the
+          # chart said 120, capping the pool at a fifteenth of its siblings.
+          # Reassert the ceiling keys so the chart is the source of truth again.
+          #
+          # Scoped to the two keys nothing else writes. `minWarmPoolFloor` is
+          # excluded because live values are owned by other field managers, and
+          # `spec.replicas` because the chart only seeds it and the
+          # runners-controller owns it from then on. Reasserting either would
+          # have this step fight the controller on every deploy.
+          echo "::group::Reassert chart-owned RunnerPool scaling ceiling"
+          runner_pools_render="$(mktemp)"
+          if helm template "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+               "${helm_values_args[@]}" \
+               --set server.image.tag="$IMAGE_TAG" \
+               --set codebaseSearch.image.tag="$CODEBASE_SEARCH_IMAGE_TAG" \
+               --set registry.image.tag="$registry_probe_tag" \
+               --set kuraController.image.tag="$KURA_CONTROLLER_IMAGE_TAG" \
+               "${image_sets[@]}" \
+               --show-only templates/runner-pool.yaml \
+               > "$runner_pools_render" 2>/dev/null; then
+            mapfile -t rendered_pools < <(
+              kubectl create --dry-run=client -o json -f "$runner_pools_render" |
+                jq -c -s '[.[] | if .kind == "List" then .items[] else . end
+                            | select(.kind == "RunnerPool" and .spec.autoscaling != null)
+                            | {name: .metadata.name, namespace: .metadata.namespace,
+                               autoscaling: (.spec.autoscaling
+                                 | with_entries(select(.key | . == "maxReplicas"
+                                                         or . == "scaleDownCooldownSeconds")))}
+                            | select(.autoscaling != {})]
+                          | .[]'
+            )
+            for rendered_pool in "${rendered_pools[@]}"; do
+              pool_name="$(jq -r '.name' <<< "$rendered_pool")"
+              # RunnerPools render into the runners namespace, which is not the
+              # release namespace the rest of this step operates in.
+              pool_namespace="$(jq -r '.namespace' <<< "$rendered_pool")"
+              want="$(jq -Sc '.autoscaling' <<< "$rendered_pool")"
+
+              live="$(
+                kubectl -n "$pool_namespace" get runnerpool "$pool_name" \
+                  -o jsonpath='{.spec.autoscaling}' 2>/dev/null || true
+              )"
+              if [ -z "$live" ]; then
+                # Not created yet; the upgrade below renders it from scratch.
+                continue
+              fi
+
+              have="$(jq -Sc '.' <<< "$live")"
+              # Merging the chart's keys over the live object is a no-op exactly
+              # when every reasserted key already matches, which leaves every
+              # other key alone rather than reporting it as drift.
+              if [ "$(jq -n --argjson h "$have" --argjson w "$want" '($h + $w) == $h')" = "true" ]; then
+                continue
+              fi
+
+              echo "RunnerPool $pool_namespace/$pool_name: scaling ceiling drifted from the chart; reasserting."
+              echo "  live:  $have"
+              echo "  chart: $want"
+              kubectl -n "$pool_namespace" patch runnerpool "$pool_name" --type=merge \
+                -p "$(jq -nc --argjson w "$want" '{spec: {autoscaling: $w}}')"
+            done
+          else
+            echo "Chart renders no RunnerPools for this environment; nothing to reassert."
+          fi
+          rm -f "$runner_pools_render"
+          echo "::endgroup::"
+
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" --create-namespace \
             "${helm_values_args[@]}" \

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1179,7 +1179,11 @@ jobs:
                "${image_sets[@]}" \
                --show-only templates/runner-pool.yaml \
                > "$runner_pools_render" 2>/dev/null; then
-            mapfile -t rendered_pools < <(
+            # `mapfile` does not report failures from a process substitution, so
+            # the pipeline is captured first: a `kubectl` or `jq` error would
+            # otherwise read as "no pools to reconcile" and let the upgrade
+            # proceed unreconciled.
+            rendered_pools_json="$(
               kubectl create --dry-run=client -o json -f "$runner_pools_render" |
                 jq -c -s '[.[] | if .kind == "List" then .items[] else . end
                             | select(.kind == "RunnerPool" and .spec.autoscaling != null)
@@ -1189,7 +1193,11 @@ jobs:
                                                          or . == "scaleDownCooldownSeconds")))}
                             | select(.autoscaling != {})]
                           | .[]'
-            )
+            )"
+            rendered_pools=()
+            if [ -n "$rendered_pools_json" ]; then
+              mapfile -t rendered_pools <<< "$rendered_pools_json"
+            fi
             for rendered_pool in "${rendered_pools[@]}"; do
               pool_name="$(jq -r '.name' <<< "$rendered_pool")"
               # RunnerPools render into the runners namespace, which is not the
@@ -1197,16 +1205,23 @@ jobs:
               pool_namespace="$(jq -r '.namespace' <<< "$rendered_pool")"
               want="$(jq -Sc '.autoscaling' <<< "$rendered_pool")"
 
-              live="$(
+              # `--ignore-not-found` separates the three states this read can be
+              # in: a missing pool prints nothing and exits 0, an existing one
+              # prints its JSON, and a genuine API error exits non-zero and stops
+              # the step instead of being swallowed into "nothing to do".
+              pool_json="$(
                 kubectl -n "$pool_namespace" get runnerpool "$pool_name" \
-                  -o jsonpath='{.spec.autoscaling}' 2>/dev/null || true
+                  --ignore-not-found -o json
               )"
-              if [ -z "$live" ]; then
+              if [ -z "$pool_json" ]; then
                 # Not created yet; the upgrade below renders it from scratch.
                 continue
               fi
 
-              have="$(jq -Sc '.' <<< "$live")"
+              # A pool whose autoscaling object was removed outright reads as
+              # `{}` and is drift the upgrade cannot repair either: an unset
+              # `maxReplicas` opts the pool out of autoscaling altogether.
+              have="$(jq -Sc '.spec.autoscaling // {}' <<< "$pool_json")"
               # Merging the chart's keys over the live object is a no-op exactly
               # when every reasserted key already matches, which leaves every
               # other key alone rather than reporting it as drift.


### PR DESCRIPTION
## What changed

The deploy workflow now reasserts the chart's `spec.autoscaling.maxReplicas` and
`spec.autoscaling.scaleDownCooldownSeconds` on every `RunnerPool` immediately before
`helm upgrade`, patching only the pools whose live values disagree with the rendered chart.

## Why

Helm cannot correct these fields on its own. For custom resources there is no strategic-merge
metadata, so Helm falls back to a **two-way** JSON merge between the previously released
manifest and the new one. A field whose rendered value has not changed between two revisions is
simply absent from the patch, and live drift on it is invisible to the upgrade. A one-off
`kubectl patch` to such a field is therefore permanent: it survives every subsequent deploy, and
`kubectl get` will not show you why, because `managedFields` are hidden unless you pass
`--show-managed-fields`.

## Root cause this fixes

`tuist-tuist-runner-pool-linux-4vcpu-16gb` has been capped at `maxReplicas: 8` since
2026-08-14T14:17:33Z, while the chart has said `120` for every Linux shape since #10794 (May):

```
kubectl-patch | Update | 2026-08-14T14:17:33Z
    autoscaling subfields: f:maxReplicas, f:scaleDownCooldownSeconds
helm          | Update | 2026-08-18T21:20:36Z
    autoscaling subfields: f:enabled, f:minWarmPoolFloor
```

It is the only one of the eight Linux pools patched. The other seven run at 120/300. The patch
looks like an emergency mitigation taken during #12306 ("stop unschedulable Pods from starving
sibling Linux runner pools"); the chart-side fix from that incident landed, but the manual patch
was never reverted and no deploy could undo it.

That stale ceiling is what turned a normal afternoon demand surge on 2026-08-25 into the
`linux-4vcpu-16gb` runner-stranding spike. With capacity pinned at 8, utilisation went to
roughly 3.3x at 17:00Z, and the share of jobs waiting five minutes or more for a runner went
from 1.1% (08-24) to 14.4% (08-25), peaking at a 98-minute wait. The sibling pool serving
`tuist-linux` stayed at 0.0% across the same window.

## Why it is scoped to two keys

`minWarmPoolFloor` and `spec.replicas` both have other legitimate field-manager owners on live
objects, so reasserting them would put this step in a write loop against the runners-controller
on every deploy. Only the two keys the manual patch actually captured are reasserted.

The comparison is a merge no-op test rather than an equality test, so any key the chart does not
render is left alone instead of being reported as drift.

## Validation

Rendered the production chart locally (18 RunnerPools) and ran the exact extraction, comparison
and patch-body logic against live production state read-only. It resolves to a single patch,
against the intended pool:

```
WOULD PATCH tuist-runners/tuist-tuist-runner-pool-linux-4vcpu-16gb
   live:  {"enabled":true,"maxReplicas":8,"minWarmPoolFloor":0,"scaleDownCooldownSeconds":15}
   want:  {"maxReplicas":120,"scaleDownCooldownSeconds":300}
   body:  {"spec":{"autoscaling":{"maxReplicas":120,"scaleDownCooldownSeconds":300}}}
--- unchanged=17 would-patch=1
```

`minWarmPoolFloor: 0` is preserved on the patched pool, and the other 17 pools are untouched.

An earlier revision of this step keyed off `$NAMESPACE`; the dry run caught that RunnerPools
render into the runners namespace rather than the release namespace, so it now uses each
rendered object's own `metadata.namespace`.

Also checked: the workflow YAML parses, and the step's shell body passes `bash -n`. The
`helm template` invocation reuses the same values and `--set` flags as the existing registry
render probe in the same step, so it needs no new inputs.

## Impact

The next production deploy restores the pool to the fleet-wide ceiling, and any future manual
patch to a scaling ceiling is corrected on the following deploy instead of silently persisting.

Note that raising this ceiling alone does not add fleet capacity: both Linux bare-metal nodes
currently sit at 88-89% memory requests, and the Linux runner fleet is a fixed pair of Hetzner
Robot machines with no MachineDeployment behind it. That capacity question is worth taking
separately.


## Review follow-up

Two failure modes were found in the first revision, both of which resolved to "quietly do
nothing" and let the upgrade proceed unreconciled. Fixed in c5c22b4494.

**The live read collapsed three states into an empty string** and skipped all of them: a missing
pool, a pool whose `spec.autoscaling` had been removed outright, and a genuine API error that
`|| true` swallowed. The middle case is drift the upgrade cannot repair either, and it is the
most damaging one, because an unset `maxReplicas` opts the pool out of autoscaling altogether
(see the `MaxReplicas <= 0` branch in `infra/runners-controller/internal/scaling/desired.go`).
The read now uses `--ignore-not-found -o json` and normalizes with `.spec.autoscaling // {}`.
Verified against production:

```
NotFound                        -> empty output, exit 0  (skipped, helm creates it)
unknown resource (API error)    -> exit 1                (step stops)
existing pool, autoscaling gone -> have={}, merge-noop=false (patched)
```

**`mapfile` does not report failures from a process substitution**, so a `kubectl` or `jq` error
in the extraction pipeline left the array empty and the step successful. The pipeline is now
captured into a variable first, where `set -euo pipefail` applies. Reproduced both shapes:

```
old: mapfile -t arr < <(false | jq ...)   -> exit 0, 0 pools, reconciliation silently skipped
new: json="$(false | jq ...)"             -> exit 1, step aborts
new: json="$(echo '[]' | jq '.[]')"       -> exit 0, 0 pools, clean no-op
```

The empty-string guard around `mapfile` matters on its own: `mapfile <<< ""` would otherwise
produce a single empty element for an environment that legitimately renders no pools.

Re-ran the end-to-end dry run against live production after both fixes, with the same result as
before: `unchanged=17 would-patch=1 absent=0`, the one patch being `linux-4vcpu-16gb`. Also
confirmed the chart renders and fully considers 13/13/18 RunnerPools for
staging/canary/production, so no environment silently takes the "no RunnerPools" branch.
