### PR TITLE
fix(infra): stop alloy-metrics OOM-killing the stable-egress nodes

### DIFF
--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -722,6 +722,41 @@ k8s-monitoring:
   #              is running stale config — last reload failed"
   #   - Runbook: kubectl logs <pod> -c alloy to find the parse error;
   #              fix the config in the values overlay, re-deploy, restart pod.
+  #
+  # The include list also carries a small collector self-diagnosis set,
+  # because until 2026-08-26 the two config-load metrics were the ONLY
+  # `alloy_*` series reaching Grafana Cloud and a collector that cannot
+  # report on itself cannot be debugged. That day one alloy-metrics replica
+  # grew from 0.74 GiB to 2.73 GiB over seven days with no restarts while
+  # nine peers doing identical work stayed under 443 MiB, and there was no
+  # way to see whether it held more series, owned more targets, leaked
+  # goroutines, or simply could not drain its queue. Diagnosis fell back to
+  # reading Alloy's own logs out of Loki. `pods/portforward` is a `create`
+  # verb the read-only access tier denies, so the Alloy UI on :12345 is not
+  # a fallback.
+  #
+  # Each name below answers one question about a replica that peers cannot:
+  #   - cluster_node_peers / cluster_node_gossip_health_score: does it see a
+  #     different ring than its peers? A partial membership view makes a
+  #     replica compute a different hash partition and over-claim targets.
+  #   - prometheus_remote_write_wal_storage_active_series: is it holding
+  #     more series, and is that number growing? The first thing to look at.
+  #   - prometheus_sd_discovered_targets: is discovery skewed, or only the
+  #     clustered assignment?
+  #   - prometheus_remote_storage_samples_pending / shards / shards_desired:
+  #     is the send queue backing up?
+  #   - highest_timestamp_in_seconds minus queue_highest_sent_timestamp_seconds:
+  #     remote-write lag. Chronic lag grows the WAL, which grows memory.
+  #   - samples_failed / retried / dropped: is data being lost, and when?
+  #   - go_goroutines, go_memstats_heap_inuse_bytes,
+  #     alloy_resources_process_resident_memory_bytes: goroutine leak vs Go
+  #     heap growth vs RSS growth. Heap flat while RSS climbs is off-heap.
+  #   - alloy_component_controller_running_components: component instances
+  #     accumulating rather than being torn down.
+  #
+  # Roughly 30 series per collector Pod. Kept identical across roles so the
+  # blocks stay comparable; the Prometheus WAL and remote-storage names are
+  # simply not emitted by the Loki-writing role, which costs nothing.
   integrations:
     collector: alloy-metrics
     alloy:
@@ -741,6 +776,24 @@ k8s-monitoring:
               includeMetrics:
                 - alloy_config_last_load_successful
                 - alloy_config_last_load_success_timestamp_seconds
+                # Collector self-diagnosis. See the block comment above.
+                - alloy_component_controller_running_components
+                - alloy_resources_process_resident_memory_bytes
+                - cluster_node_gossip_health_score
+                - cluster_node_peers
+                - go_goroutines
+                - go_memstats_heap_inuse_bytes
+                - prometheus_remote_storage_highest_timestamp_in_seconds
+                - prometheus_remote_storage_queue_highest_sent_timestamp_seconds
+                - prometheus_remote_storage_samples_dropped_total
+                - prometheus_remote_storage_samples_failed_total
+                - prometheus_remote_storage_samples_pending
+                - prometheus_remote_storage_samples_retried_total
+                - prometheus_remote_storage_shards
+                - prometheus_remote_storage_shards_desired
+                - prometheus_remote_write_wal_storage_active_series
+                - prometheus_sd_discovered_targets
+                - prometheus_wal_watcher_current_segment
               excludeMetrics:
                 - loki_write_request_duration_seconds_bucket
         - name: alloy-logs
@@ -752,6 +805,24 @@ k8s-monitoring:
               includeMetrics:
                 - alloy_config_last_load_successful
                 - alloy_config_last_load_success_timestamp_seconds
+                # Collector self-diagnosis. See the block comment above.
+                - alloy_component_controller_running_components
+                - alloy_resources_process_resident_memory_bytes
+                - cluster_node_gossip_health_score
+                - cluster_node_peers
+                - go_goroutines
+                - go_memstats_heap_inuse_bytes
+                - prometheus_remote_storage_highest_timestamp_in_seconds
+                - prometheus_remote_storage_queue_highest_sent_timestamp_seconds
+                - prometheus_remote_storage_samples_dropped_total
+                - prometheus_remote_storage_samples_failed_total
+                - prometheus_remote_storage_samples_pending
+                - prometheus_remote_storage_samples_retried_total
+                - prometheus_remote_storage_shards
+                - prometheus_remote_storage_shards_desired
+                - prometheus_remote_write_wal_storage_active_series
+                - prometheus_sd_discovered_targets
+                - prometheus_wal_watcher_current_segment
               excludeMetrics:
                 - loki_write_request_duration_seconds_bucket
         - name: alloy-singleton
@@ -763,6 +834,24 @@ k8s-monitoring:
               includeMetrics:
                 - alloy_config_last_load_successful
                 - alloy_config_last_load_success_timestamp_seconds
+                # Collector self-diagnosis. See the block comment above.
+                - alloy_component_controller_running_components
+                - alloy_resources_process_resident_memory_bytes
+                - cluster_node_gossip_health_score
+                - cluster_node_peers
+                - go_goroutines
+                - go_memstats_heap_inuse_bytes
+                - prometheus_remote_storage_highest_timestamp_in_seconds
+                - prometheus_remote_storage_queue_highest_sent_timestamp_seconds
+                - prometheus_remote_storage_samples_dropped_total
+                - prometheus_remote_storage_samples_failed_total
+                - prometheus_remote_storage_samples_pending
+                - prometheus_remote_storage_samples_retried_total
+                - prometheus_remote_storage_shards
+                - prometheus_remote_storage_shards_desired
+                - prometheus_remote_write_wal_storage_active_series
+                - prometheus_sd_discovered_targets
+                - prometheus_wal_watcher_current_segment
               excludeMetrics:
                 - loki_write_request_duration_seconds_bucket
         - name: alloy-receiver
@@ -774,6 +863,24 @@ k8s-monitoring:
               includeMetrics:
                 - alloy_config_last_load_successful
                 - alloy_config_last_load_success_timestamp_seconds
+                # Collector self-diagnosis. See the block comment above.
+                - alloy_component_controller_running_components
+                - alloy_resources_process_resident_memory_bytes
+                - cluster_node_gossip_health_score
+                - cluster_node_peers
+                - go_goroutines
+                - go_memstats_heap_inuse_bytes
+                - prometheus_remote_storage_highest_timestamp_in_seconds
+                - prometheus_remote_storage_queue_highest_sent_timestamp_seconds
+                - prometheus_remote_storage_samples_dropped_total
+                - prometheus_remote_storage_samples_failed_total
+                - prometheus_remote_storage_samples_pending
+                - prometheus_remote_storage_samples_retried_total
+                - prometheus_remote_storage_shards
+                - prometheus_remote_storage_shards_desired
+                - prometheus_remote_write_wal_storage_active_series
+                - prometheus_sd_discovered_targets
+                - prometheus_wal_watcher_current_segment
               excludeMetrics:
                 - loki_write_request_duration_seconds_bucket
         - name: grafana-cloud-traces-sampler
@@ -785,6 +892,24 @@ k8s-monitoring:
               includeMetrics:
                 - alloy_config_last_load_successful
                 - alloy_config_last_load_success_timestamp_seconds
+                # Collector self-diagnosis. See the block comment above.
+                - alloy_component_controller_running_components
+                - alloy_resources_process_resident_memory_bytes
+                - cluster_node_gossip_health_score
+                - cluster_node_peers
+                - go_goroutines
+                - go_memstats_heap_inuse_bytes
+                - prometheus_remote_storage_highest_timestamp_in_seconds
+                - prometheus_remote_storage_queue_highest_sent_timestamp_seconds
+                - prometheus_remote_storage_samples_dropped_total
+                - prometheus_remote_storage_samples_failed_total
+                - prometheus_remote_storage_samples_pending
+                - prometheus_remote_storage_samples_retried_total
+                - prometheus_remote_storage_shards
+                - prometheus_remote_storage_shards_desired
+                - prometheus_remote_write_wal_storage_active_series
+                - prometheus_sd_discovered_targets
+                - prometheus_wal_watcher_current_segment
               excludeMetrics:
                 - loki_write_request_duration_seconds_bucket
 

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -1044,26 +1044,36 @@ k8s-monitoring:
       # The floor that leaves is per-env, and nothing overrides these
       # resources per env: 15.1 GiB in production, whose general pool is
       # ccx23, against 7.47 GiB in staging, canary and pentest, whose pools
-      # are cpx32. So 3Gi is ~20% of a production general node but ~40% of a
+      # are cpx32. So 4Gi is ~26% of a production general node but ~53% of a
       # staging one. That is a ceiling, not a reservation. Only the 512Mi
       # request is reserved, and those envs scrape a fraction of production's
       # targets, so a replica there should never approach it; if one ever
       # does, the cgroup kill still contains it, which is the whole point.
       #
-      # 3Gi rather than something near the 443 MiB that most replicas use: a
+      # 4Gi rather than something near the 443 MiB that most replicas use: a
       # legitimately heavy shard is real, not a leak. The ap-southeast
-      # replica holds a steady 2.2 GiB working set, oscillating 1.6 to 2.75
-      # over 24h with no trend and no restarts. A limit under that would
-      # OOMKill it, hand its targets to a peer, and walk the same kill around
-      # the ring. No CPU limit: throttling a scraper turns into scrape
-      # timeouts and gaps.
+      # replica holds a steady working set, oscillating 1.6 to 2.75 GiB over
+      # 24h with no trend and no restarts. A limit under that would OOMKill
+      # it, hand its targets to a peer, and walk the same kill around the
+      # ring.
+      #
+      # The headroom above 2.75 GiB is not slack, it is the cost of the
+      # toleration removal above. Dropping two members from an 11-node ring
+      # grows every survivor's share by 11/9, so that replica projects to
+      # ~3.2 GiB mean and ~3.3 GiB peak once its targets redistribute. Sizing
+      # this against the pre-change distribution would have had the same
+      # commit that removes the members OOMKill the replica that absorbs
+      # them. Re-derive it if the ring loses members again.
+      #
+      # No CPU limit: throttling a scraper turns into scrape timeouts and
+      # gaps.
       alloy:
         resources:
           requests:
             cpu: 100m
             memory: 512Mi
           limits:
-            memory: 3Gi
+            memory: 4Gi
       # Custom scrape jobs for the macOS fleet's node_exporter (:9100)
       # and tart-kubelet controller-runtime metrics (:8080). Both bind
       # to the tailnet interface on each Mac mini — see

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -891,6 +891,32 @@ k8s-monitoring:
           - key: tuist.dev/stable-egress
             operator: Exists
             effect: NoSchedule
+      # The subchart ships this container with no requests and no limits, so
+      # the scheduler accounts nothing for it and nothing caps its growth.
+      # That is fatal on the two smallest node shapes this DaemonSet lands on:
+      # `md-egress` is 2 vCPU / 3.72 GiB, against 15 GiB and up everywhere
+      # else. On 2026-08-26 the replica on md-egress-r4rrm had grown to
+      # 2.73 GiB from 0.74 GiB a week earlier and produced 27 node-level OOM
+      # kills in 24h, the only node in production with any. Without a limit
+      # the kernel OOMs at node scope rather than the cgroup, so the blast
+      # radius was the whole node: kubelet and containerd stalled
+      # (ContainerGCFailed), the Node flapped NotReady five times in six
+      # hours, and hcloud-csi-node's 3s liveness probe timed out and
+      # restarted the CSI driver 20 times. The stable-egress controller
+      # carried the Floating IP to the healthy peer, which is the only reason
+      # this was not an egress outage.
+      #
+      # A limit turns that into a contained pod restart whose targets
+      # redistribute across the clustered peers. 1Gi is more than twice the
+      # 443 MiB high-water mark of the nine healthy replicas. No CPU limit:
+      # throttling a scraper turns into scrape timeouts and gaps.
+      alloy:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
       # Custom scrape jobs for the macOS fleet's node_exporter (:9100)
       # and tart-kubelet controller-runtime metrics (:8080). Both bind
       # to the tailnet interface on each Mac mini — see

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -881,42 +881,55 @@ k8s-monitoring:
       controller:
         # Tolerate the customer-facing cache-node taint so host metrics
         # keep flowing from the dedicated Dedibox/OVH cache boxes.
+        #
+        # Deliberately NOT tolerating tuist.dev/stable-egress. Scraping does
+        # not require locality: hostMetrics scrapes the node-exporter
+        # DaemonSet over the pod network and clusterMetrics scrapes the
+        # kubelet API, so a peer collects the egress nodes' targets just as
+        # well. What locality does require is node-exporter and alloy-logs,
+        # which read /proc and local container logs, and both keep their own
+        # stable-egress toleration. Running a clustered collector there is
+        # what caused the 2026-08-26 incident below.
         tolerations:
           - key: tuist.dev/kura-cache
             operator: Exists
             effect: NoSchedule
-          # Keep scraping host/pod metrics from the tainted stable-egress
-          # gateway nodes — otherwise the egress pool is a monitoring blind spot
-          # and the egress alerts can't see it.
-          - key: tuist.dev/stable-egress
-            operator: Exists
-            effect: NoSchedule
       # The subchart ships this container with no requests and no limits, so
       # the scheduler accounts nothing for it and nothing caps its growth.
-      # That is fatal on the two smallest node shapes this DaemonSet lands on:
-      # `md-egress` is 2 vCPU / 3.72 GiB, against 15 GiB and up everywhere
-      # else. On 2026-08-26 the replica on md-egress-r4rrm had grown to
-      # 2.73 GiB from 0.74 GiB a week earlier and produced 27 node-level OOM
-      # kills in 24h, the only node in production with any. Without a limit
-      # the kernel OOMs at node scope rather than the cgroup, so the blast
-      # radius was the whole node: kubelet and containerd stalled
+      #
+      # On 2026-08-26 the replica on md-egress-r4rrm reached 2.73 GiB on a
+      # node with 3.72 GiB allocatable and produced 27 node-level OOM kills
+      # in 24h, the only node in production with any. Without a limit the
+      # kernel OOMs at node scope rather than the cgroup, so the blast radius
+      # was the whole node: kubelet and containerd stalled
       # (ContainerGCFailed), the Node flapped NotReady five times in six
       # hours, and hcloud-csi-node's 3s liveness probe timed out and
       # restarted the CSI driver 20 times. The stable-egress controller
       # carried the Floating IP to the healthy peer, which is the only reason
       # this was not an egress outage.
       #
-      # A limit turns that into a contained pod restart whose targets
-      # redistribute across the clustered peers. 1Gi is more than twice the
-      # 443 MiB high-water mark of the nine healthy replicas. No CPU limit:
-      # throttling a scraper turns into scrape timeouts and gaps.
+      # Placement is the root of it. This is a DaemonSet, so it lands on
+      # every Linux node, but clustering hash-partitions targets across the
+      # ring, so what a replica must hold has nothing to do with which node
+      # it runs on. Across an 11-node fleet spanning 3.72 GiB to 125 GiB that
+      # mismatch is guaranteed to land a heavy shard on a node too small for
+      # it. Dropping the stable-egress toleration confines the DaemonSet to
+      # nodes of 15.1 GiB and up.
+      #
+      # 3Gi rather than something near the 443 MiB that most replicas use: a
+      # legitimately heavy shard is real, not a leak. The ap-southeast
+      # replica holds a steady 2.2 GiB working set, oscillating 1.6 to 2.75
+      # over 24h with no trend and no restarts. A limit under that would
+      # OOMKill it, hand its targets to a peer, and walk the same kill around
+      # the ring. No CPU limit: throttling a scraper turns into scrape
+      # timeouts and gaps.
       alloy:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
           limits:
-            memory: 1Gi
+            memory: 3Gi
       # Custom scrape jobs for the macOS fleet's node_exporter (:9100)
       # and tart-kubelet controller-runtime metrics (:8080). Both bind
       # to the tailnet interface on each Mac mini — see

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -1036,10 +1036,19 @@ k8s-monitoring:
       # Placement is the root of it. This is a DaemonSet, so it lands on
       # every Linux node, but clustering hash-partitions targets across the
       # ring, so what a replica must hold has nothing to do with which node
-      # it runs on. Across an 11-node fleet spanning 3.72 GiB to 125 GiB that
-      # mismatch is guaranteed to land a heavy shard on a node too small for
-      # it. Dropping the stable-egress toleration confines the DaemonSet to
-      # nodes of 15.1 GiB and up.
+      # it runs on. In production that fleet spans 3.72 GiB to 125 GiB, so
+      # the mismatch is guaranteed to land a heavy shard on a node too small
+      # for it. Dropping the stable-egress toleration removes the 3.72 GiB
+      # gateway nodes, which every env runs.
+      #
+      # The floor that leaves is per-env, and nothing overrides these
+      # resources per env: 15.1 GiB in production, whose general pool is
+      # ccx23, against 7.47 GiB in staging, canary and pentest, whose pools
+      # are cpx32. So 3Gi is ~20% of a production general node but ~40% of a
+      # staging one. That is a ceiling, not a reservation. Only the 512Mi
+      # request is reserved, and those envs scrape a fraction of production's
+      # targets, so a replica there should never approach it; if one ever
+      # does, the cgroup kill still contains it, which is the whole point.
       #
       # 3Gi rather than something near the 443 MiB that most replicas use: a
       # legitimately heavy shard is real, not a leak. The ap-southeast


### PR DESCRIPTION
## What changed

Three things to the `alloy-metrics` collector and the Alloy self-monitoring integration:

- Dropped the `tuist.dev/stable-egress` toleration, so the DaemonSet no longer schedules onto the 3.72 GiB egress gateway nodes.
- Gave the `alloy` container resource requests (100m CPU / 512Mi memory) and a 3Gi memory limit. It previously had `resources: {}`: no requests, no limits.
- Extended the alloy integration's `includeMetrics` so the collectors report enough about themselves to be debugged.

## Why

A `Pod CrashLoop / Frequent Restarts` alert fired on 2026-08-26 for `hcloud-csi-node-bqz89` in `kube-system` on `tuist-production`, container `hcloud-csi-driver`, 8 restarts in an hour (20 lifetime).

It is not a CSI problem. The node it runs on, `tuist-md-egress-5ql7b-6p9hl-r4rrm`, was being OOM killed:

- `increase(node_vmstat_oom_kill[24h])` = 27 on that node, and it is the only node in production with any.
- Kubelet events: four `SystemOOM ... victim process: alloy` in 30 minutes, plus `ContainerGCFailed: context deadline exceeded` and five `NodeNotReady` flaps in six hours.

The consumer is `k8s-monitoring-alloy-metrics-vc9jw` at 2.73 GiB working set on a node with 3.72 GiB allocatable.

There was no customer impact. The stable-egress controller moved the Floating IP `116.202.0.10` to the healthy peer `6wzlv` and has held it there, which is exactly the single-node SPOF this pool exists to remove.

## Root cause

The chart never bounded this container. With no request the scheduler treats the node as free, and with no limit the kernel OOM killer fires at node scope instead of the cgroup, so the blast radius is the whole node rather than one pod. The chain to the alert is: alloy OOM, then kubelet and containerd stall, then the Node flaps NotReady, then `hcloud-csi-driver`'s liveness probe (`timeout=3s, period=2s, failure=5`) times out and the kubelet restarts it.

Underneath that is a placement mismatch. `alloy-metrics` is a DaemonSet, so it lands on every Linux node, but `presets: [clustered]` hash-partitions scrape targets across the ring, so what a replica has to hold is unrelated to which node it runs on. Across a fleet spanning 3.72 GiB to 125 GiB, that eventually puts a heavy shard on a node that cannot hold it. Confining the DaemonSet to the nodes that can is the actual fix; the limit is the guardrail behind it.

## Why dropping the toleration does not create a blind spot

The toleration was added so the egress pool would not be a monitoring blind spot. That premise does not hold for a clustered collector, because scraping needs no locality:

- `hostMetrics` scrapes the node-exporter DaemonSet over the pod network.
- `clusterMetrics` scrapes the kubelet API.

Any peer replica collects the egress nodes' targets just as well. The collectors that genuinely do read local state keep their own `stable-egress` toleration, verified in the rendered output: `alloy-logs` (reads container logs and the journal) has it explicitly, and `node-exporter` (reads `/proc`) covers it with a blanket `operator: Exists` toleration. Host and pod metrics for the egress pool keep flowing.

## Why 4Gi and not something near the 443 MiB most replicas use

Because one replica is legitimately heavy, and telling the two apart matters:

| | `vc9jw` (egress) | `dlwhk` (OVH ap-southeast) |
|---|---|---|
| 7d memory | 0.74 to 2.73 GiB, monotonic | sawtooth 1.6 to 2.75, no trend |
| restarts | 15, all on 2026-08-26 | 0 |
| remote-write reshards (6h) | 14 | 0 |
| remote-write errors (6h) | 11 | 0 |

`dlwhk` holds a steady working set, 2.68 GiB mean and 2.75 GiB peak. A limit below that would OOMKill a healthy replica, hand its targets to a peer, and walk the same kill around the ring.

The headroom above that is not slack, it is the cost of the toleration removal. Dropping two members from an 11-node ring grows every survivor's share by 11/9, so `dlwhk` projects to roughly 3.2 GiB mean and 3.3 GiB peak once the removed members' targets redistribute (holding the lightest replica's 225 MiB as the non-shard baseline; the result is over 3Gi under every baseline assumption tried). An earlier revision of this branch set 3Gi, derived from the pre-change distribution, which would have meant the very commit that removes the two members OOMKills the replica absorbing them. 4Gi carries about 19% headroom over the projected peak. Re-derive it if the ring changes size again.

The floor this leaves is per-env and nothing overrides these resources per env: 15.1 GiB in production (ccx23 general pool) against 7.47 GiB in staging, canary and pentest (cpx32, measured on a live staging node). So 4Gi is ~26% of a production general node but ~53% of a staging one. That is a ceiling rather than a reservation: only the 512Mi request is reserved, and those envs scrape a fraction of production's targets.

There is no CPU limit on purpose. Throttling a scrape loop converts into scrape timeouts and metric gaps, which is the failure this collector exists to prevent.

## Why the self-metrics are in this PR and not a follow-up

`vc9jw`'s growth is still unexplained: seven days of near-linear climb with zero restarts while nine peers doing identical work stay under 443 MiB. Its remote-write noise is downstream of the OOM kills, not causal (every error is `context canceled` or `Failed to flush all samples on shutdown`, and the reshards from 1 to 50 are each a fresh process draining a backlog; seven distinct `remote_name` values in six hours is seven restarts, not seven upstream failures).

The first two changes make that harder to see, not easier. Today the growth is a seven-day uninterrupted curve on a node that fails loudly. Afterwards it becomes a cgroup OOMKill roughly every eight days that resets to baseline, on a node with headroom, alerting nobody. The symptom goes away and the bug does not.

That is only acceptable if the collector can be diagnosed while it happens, and today it cannot. The alloy integration already scrapes every collector's `/metrics` every 60s, but `useDefaultAllowList: false` with a two-entry include list discarded all of it, so the only `alloy_*` series reaching Grafana Cloud was `alloy_config_last_load_successful`. Diagnosis for this incident fell back to reading Alloy's own logs out of Loki, and `pods/portforward` is a `create` verb the read-only access tier denies, so the Alloy UI on :12345 is not a fallback either.

Each added name answers one question about a replica that its peers cannot:

- `cluster_node_peers`, `cluster_node_gossip_health_score`: does it see a different ring than its peers? A partial membership view makes a replica compute a different hash partition and over-claim targets. This is a live hypothesis for `vc9jw` that could not be tested during the incident.
- `prometheus_remote_write_wal_storage_active_series`: is it holding more series, and is that number growing? The first thing to look at.
- `prometheus_sd_discovered_targets`: is discovery skewed, or only the clustered assignment?
- `prometheus_remote_storage_samples_pending`, `shards`, `shards_desired`: is the send queue backing up?
- `highest_timestamp_in_seconds` minus `queue_highest_sent_timestamp_seconds`: remote-write lag. Chronic lag grows the WAL, which grows memory.
- `samples_failed_total`, `samples_retried_total`, `samples_dropped_total`: is data being lost, and when?
- `go_goroutines`, `go_memstats_heap_inuse_bytes`, `alloy_resources_process_resident_memory_bytes`: goroutine leak vs Go heap growth vs RSS growth. Heap flat while RSS climbs points off-heap.
- `alloy_component_controller_running_components`: component instances accumulating rather than being torn down.

Every name is taken from the subchart's own default allow-list for the Alloy integration, so they are known-real metric names rather than guesses. Cost is roughly 30 series per collector Pod and no new scrape, since the endpoint is already being polled. Applied to all five roles so the blocks stay comparable; the Prometheus WAL and remote-storage names are simply not emitted by the Loki-writing role, which costs nothing.

## What this still does not fix

The growth itself. This PR contains the blast radius and makes the next occurrence diagnosable; it does not explain the cause.

Adjacent and deliberately not touched: `alloy-logs` also has `resources: {}`. It is well behaved at 105 to 134 MiB across the fleet, so it is a latent version of this hole rather than an active one.

## Rollout note

Removing a toleration reduces the cluster from 11 alloy-metrics members to 9, which reshuffles the hash ring and redistributes every shard. Expect a brief scrape disturbance across the fleet as targets move, and roughly 22% more targets per surviving replica. The memory limit is sized for that post-reshuffle distribution, not the current one.

This does not touch the egress datapath. The change is confined to the k8s-monitoring release in the `observability` namespace; the stable-egress controller, the Cilium egress gateway policy, and the Floating IP are all outside this chart. Removing a metrics scraper from the gateway nodes reduces load on them, and `alloy-metrics` was verified to have no node-local target filtering (its three `__meta_kubernetes_pod_node_name` rules are `replace` into a label, not `keep`), so peers continue to scrape those nodes' targets.

## Validation

- `helm dependency build` then `helm template` against `values.yaml` + `values-production.yaml` renders clean.
- Confirmed in the rendered `Alloy` CRs that `alloy-metrics` now carries only the `tuist.dev/kura-cache` toleration and `spec.alloy.resources` of 100m/512Mi requests with a 4Gi limit.
- Confirmed `alloy-logs` retains all four of its tolerations including `tuist.dev/stable-egress`, and `node-exporter` retains its blanket `operator: Exists`.
- Confirmed all five rendered `keep_metrics` regexes carry the extended list.
- Confirmed the added metrics survive the destination write-relabel that drops `job=~"integrations/(process|self)"`: `alloy_config_last_load_successful` reaches Grafana Cloud today through this same path.
- Checked every remaining node the DaemonSet can land on: 15.1 GiB (md-0) through 57 GiB (ovh ap-southeast).
- Not applied to any cluster. Read-only access only; the rollout needs a human-driven elevation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

