### PR TITLE
refactor(infra): remove Kura from pentest

### DIFF
--- a/.github/workflows/pentest-cluster-retirement.yml
+++ b/.github/workflows/pentest-cluster-retirement.yml
@@ -25,7 +25,6 @@ env:
   CLUSTER_NAMESPACE: org-tuist
   APPLICATION_NAMESPACE: tuist-pentest
   HELM_RELEASE_NAME: pentest
-  KURA_INSTANCE: pentest-kura
 
 jobs:
   validate:
@@ -114,13 +113,6 @@ jobs:
               --namespace "$APPLICATION_NAMESPACE" --wait --timeout 10m
           fi
 
-          if KUBECONFIG="$WORKLOAD_KUBECONFIG" kubectl -n kura get kurainstance "$KURA_INSTANCE" >/dev/null 2>&1; then
-            KUBECONFIG="$WORKLOAD_KUBECONFIG" kubectl -n kura delete kurainstance "$KURA_INSTANCE" \
-              --wait=true --timeout=10m
-          fi
-
-          KUBECONFIG="$WORKLOAD_KUBECONFIG" kubectl -n kura delete secret pentest-kura-introspection \
-            --ignore-not-found
           KUBECONFIG="$WORKLOAD_KUBECONFIG" kubectl delete namespace "$APPLICATION_NAMESPACE" \
             --ignore-not-found --wait=true --timeout=10m
       - name: Delete the Cluster resource

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -1,9 +1,9 @@
 name: Pentest Deployment
 
 # Deploys the dedicated Tuist environment used for authorized security
-# assessments. It targets the `tuist-pentest` workload cluster, whose Kura
-# controller, credentials, data volumes, and platform components are separate
-# from every other Tuist environment.
+# assessments. It targets the `tuist-pentest` workload cluster, whose
+# application, data volumes, and platform components are separate from every
+# other Tuist environment.
 
 on:
   workflow_dispatch:
@@ -43,15 +43,11 @@ env:
   REGISTRY: ghcr.io
   SERVER_IMAGE_NAME: tuist/tuist
   REGISTRY_IMAGE_NAME: tuist/registry
-  KURA_RUNTIME_IMAGE_NAME: tuist/kura
   HELM_CHART_PATH: infra/helm/tuist
   HELM_RELEASE_NAME: pentest
   NAMESPACE: tuist-pentest
   HOST: pentest.tuist.dev
   REGISTRY_HOST: registry-pentest.tuist.dev
-  KURA_INSTANCE: pentest-kura
-  KURA_HOST: kura-pentest.tuist.dev
-  KURA_ACCOUNT_HANDLE: pentest
 
 jobs:
   resolve:
@@ -132,31 +128,9 @@ jobs:
           build-args: |
             MIX_ENV=prod
 
-  build-kura-runtime:
-    name: Build Kura runtime image
-    needs: resolve
-    if: inputs.action == 'deploy'
-    runs-on: tuist-linux-large
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./kura
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.KURA_RUNTIME_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}
-
   deploy:
     name: Deploy pentest environment
-    needs: [resolve, build-server, build-registry, build-kura-runtime]
+    needs: [resolve, build-server, build-registry]
     if: inputs.action == 'deploy'
     runs-on: tuist-linux
     environment:
@@ -165,7 +139,6 @@ jobs:
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
-      KURA_RUNTIME_TAG: ${{ needs.resolve.outputs.image_tag }}
       PENTEST_USER_EMAIL: ${{ secrets.PENTEST_USER_EMAIL }}
       PENTEST_USER_PASSWORD: ${{ secrets.PENTEST_USER_PASSWORD }}
       ROTATE_ACCOUNT_PASSWORD: ${{ inputs.rotate_account_password }}
@@ -215,46 +188,10 @@ jobs:
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability
         run: kubectl --request-timeout=10s get --raw /version >/dev/null
-      - name: Verify Kura platform
+      - name: Remove excluded Kura resources
         run: |
           set -euo pipefail
-
-          controllers="$(
-            kubectl -n kura get deployment \
-              -l app.kubernetes.io/component=kura-controller -o name 2>/dev/null | wc -l | tr -d ' '
-          )"
-          if [ "$controllers" -lt 1 ]; then
-            echo "::error::No Kura controller is running in the pentest cluster. Run the Pentest Platform Reconcile workflow before deploying."
-            exit 1
-          fi
-
-          controller_images="$(
-            kubectl -n kura get deployment \
-              -l app.kubernetes.io/component=kura-controller \
-              -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{end}'
-          )"
-          while IFS= read -r controller_image; do
-            case "$controller_image" in
-              *:sha-* | *@sha256:*) ;;
-              *)
-                echo "::error::The Kura controller must use an immutable image reference. Reconcile the pentest platform before deploying."
-                exit 1
-                ;;
-            esac
-          done <<< "$controller_images"
-
-          kubectl -n kura rollout status deployment \
-            -l app.kubernetes.io/component=kura-controller --timeout=1m
-
-          if ! kubectl -n kura get deployment \
-            -l app.kubernetes.io/component=kura-controller \
-            -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{range .args[*]}{.}{"\n"}{end}{end}{end}' \
-            | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null; then
-            echo "::error::The Kura controller is not configured to issue TLS for kura-pentest.tuist.dev. Run the Pentest Platform Reconcile workflow."
-            exit 1
-          fi
-
-          kubectl -n kura get secret kura-shared-secrets >/dev/null
+          kubectl delete namespace kura --ignore-not-found --wait=true --timeout=10m
       - name: Prepare the isolated namespace, credentials, and expiry
         env:
           EXPIRES_AT: ${{ inputs.expires_at }}
@@ -265,28 +202,6 @@ jobs:
           kubectl label namespace "$NAMESPACE" tuist.dev/environment=pentest --overwrite
           kubectl annotate namespace "$NAMESPACE" "tuist.dev/expires-at=$EXPIRES_AT" --overwrite
 
-          KURA_CLIENT_SECRET_NAME=pentest-kura-introspection
-          kura_client_id="$(kubectl -n kura get secret "$KURA_CLIENT_SECRET_NAME" \
-            -o jsonpath='{.data.KURA_CONTROL_PLANE_CLIENT_ID}' 2>/dev/null | base64 -d 2>/dev/null || true)"
-          kura_client_secret="$(kubectl -n kura get secret "$KURA_CLIENT_SECRET_NAME" \
-            -o jsonpath='{.data.KURA_CONTROL_PLANE_CLIENT_SECRET}' 2>/dev/null | base64 -d 2>/dev/null || true)"
-
-          if [ -z "$kura_client_id" ]; then
-            kura_client_id="pentest-kura-$(openssl rand -hex 16)"
-          fi
-          if [ -z "$kura_client_secret" ]; then
-            kura_client_secret="$(openssl rand -hex 32)"
-          fi
-
-          echo "::add-mask::$kura_client_secret"
-          kubectl -n kura create secret generic "$KURA_CLIENT_SECRET_NAME" \
-            --from-literal="KURA_CONTROL_PLANE_CLIENT_ID=$kura_client_id" \
-            --from-literal="KURA_CONTROL_PLANE_CLIENT_SECRET=$kura_client_secret" \
-            --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n "$NAMESPACE" create secret generic "$KURA_CLIENT_SECRET_NAME" \
-            --from-literal="KURA_CONTROL_PLANE_CLIENT_ID=$kura_client_id" \
-            --from-literal="KURA_CONTROL_PLANE_CLIENT_SECRET=$kura_client_secret" \
-            --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n "$NAMESPACE" create secret generic pentest-seed-account \
             --from-literal="email=$PENTEST_USER_EMAIL" \
             --from-literal="password=$PENTEST_USER_PASSWORD" \
@@ -300,36 +215,20 @@ jobs:
             --namespace "$NAMESPACE" \
             -f "$HELM_CHART_PATH/values-pentest.yaml" \
             --set "server.image.tag=$IMAGE_TAG" \
-            --set "registry.image.tag=$IMAGE_TAG" \
-            --set "kuraRuntime.image.tag=$KURA_RUNTIME_TAG" \
-            --set "kuraRuntime.instance.name=$KURA_INSTANCE" \
-            --set "kuraRuntime.instance.publicHost=$KURA_HOST" \
-            --set "kuraRuntime.instance.accountHandle=$KURA_ACCOUNT_HANDLE" \
-            --set "kuraRuntime.instance.tenantID=$KURA_ACCOUNT_HANDLE" \
-            --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" > rendered.yaml
+            --set "registry.image.tag=$IMAGE_TAG" > rendered.yaml
 
           if grep -Eq '^kind: (RunnerPool|MachineDeployment|ScalewayAppleSiliconMachineTemplate)$' rendered.yaml; then
             echo "::error::The pentest render must not provision runner infrastructure."
             exit 1
           fi
 
-          if ! grep -q '^kind: KuraInstance$' rendered.yaml; then
-            echo "::error::The pentest render must contain the isolated Kura instance."
+          if grep -q '^kind: KuraInstance$' rendered.yaml; then
+            echo "::error::The pentest render must not contain a Kura instance."
             exit 1
           fi
 
-          if grep -q 'name: "kura-shared-secrets"' rendered.yaml; then
-            echo "::error::The pentest release must not consume the Kura controller shared credential."
-            exit 1
-          fi
-
-          if ! awk -v kura_host="$KURA_HOST" '
-            $0 == "kind: KuraInstance" { in_kura_instance = 1; next }
-            /^---$/ { in_kura_instance = 0 }
-            in_kura_instance && $0 == "  publicHost: " kura_host { found = 1 }
-            END { exit !found }
-          ' rendered.yaml; then
-            echo "::error::The pentest Kura instance must use $KURA_HOST."
+          if grep -q 'KURA_CONTROL_PLANE_CLIENT_' rendered.yaml; then
+            echo "::error::The pentest release must not consume Kura credentials."
             exit 1
           fi
       - name: Install or upgrade
@@ -340,12 +239,6 @@ jobs:
             -f "$HELM_CHART_PATH/values-pentest.yaml" \
             --set "server.image.tag=$IMAGE_TAG" \
             --set "registry.image.tag=$IMAGE_TAG" \
-            --set "kuraRuntime.image.tag=$KURA_RUNTIME_TAG" \
-            --set "kuraRuntime.instance.name=$KURA_INSTANCE" \
-            --set "kuraRuntime.instance.publicHost=$KURA_HOST" \
-            --set "kuraRuntime.instance.accountHandle=$KURA_ACCOUNT_HANDLE" \
-            --set "kuraRuntime.instance.tenantID=$KURA_ACCOUNT_HANDLE" \
-            --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
             --atomic --timeout 20m --wait --wait-for-jobs
       - name: Verify deployed services
         run: |
@@ -353,9 +246,8 @@ jobs:
 
           kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-server --timeout=10m
           kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-registry --timeout=10m
-          kubectl -n kura wait --for=jsonpath='{.status.phase}'=Ready "kurainstance/$KURA_INSTANCE" --timeout=10m
 
-          for endpoint in "https://$HOST/ready" "https://$REGISTRY_HOST/up" "https://$KURA_HOST/ready"; do
+          for endpoint in "https://$HOST/ready" "https://$REGISTRY_HOST/up"; do
             for attempt in $(seq 1 60); do
               if curl -fsSL --max-time 5 "$endpoint" >/dev/null; then
                 echo "OK: $endpoint returned 200"
@@ -370,17 +262,16 @@ jobs:
               sleep 10
             done
           done
-      - name: Provision the pentest Kura account
+      - name: Provision the pentest account
         run: |
           set -euo pipefail
 
-          PREVIEW_ACCOUNT_HANDLE="$KURA_ACCOUNT_HANDLE" \
+          PREVIEW_ACCOUNT_HANDLE=pentest \
           PREVIEW_USER_EMAIL="$PENTEST_USER_EMAIL" \
           PREVIEW_USER_PASSWORD="$PENTEST_USER_PASSWORD" \
           PREVIEW_ROTATE_USER_PASSWORD="$ROTATE_ACCOUNT_PASSWORD" \
           PREVIEW_SEED_CONTENT=0 \
           SEED_CREDENTIALS_DIRECTORY=/var/run/tuist/seed-account \
-          KURA_ENDPOINT_URL="https://$KURA_HOST" \
           RELEASE_NAME="$HELM_RELEASE_NAME" \
           mise -C infra run preview:seed-account --namespace "$NAMESPACE"
       - name: Remove bootstrap credentials from the server pod
@@ -406,12 +297,10 @@ jobs:
             echo "## Pentest environment deployed"
             echo "- Application: https://$HOST"
             echo "- Package registry: https://$REGISTRY_HOST"
-            echo "- Kura: https://$KURA_HOST"
-            echo "- Kura account handle: \`$KURA_ACCOUNT_HANDLE\`"
             echo "- Namespace: \`$NAMESPACE\`"
             echo "- Expires at: \`$EXPIRES_AT\`"
             echo "- Image tag: \`$IMAGE_TAG\`"
-            echo "- Excluded: runners, codebase search, Mac workloads, and package catalog synchronization"
+            echo "- Excluded: Kura, runners, codebase search, Mac workloads, and package catalog synchronization"
           } >> "$GITHUB_STEP_SUMMARY"
 
   delete:
@@ -443,12 +332,6 @@ jobs:
           if helm status "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" >/dev/null 2>&1; then
             helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
           fi
-
-          if kubectl -n kura get kurainstance "$KURA_INSTANCE" >/dev/null 2>&1; then
-            kubectl -n kura wait --for=delete "kurainstance/$KURA_INSTANCE" --timeout=10m
-          fi
-
-          kubectl -n kura delete secret pentest-kura-introspection --ignore-not-found
 
           if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
             kubectl delete namespace "$NAMESPACE" --wait=true --timeout=5m
@@ -506,9 +389,4 @@ jobs:
             helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
           fi
 
-          if kubectl -n kura get kurainstance "$KURA_INSTANCE" >/dev/null 2>&1; then
-            kubectl -n kura wait --for=delete "kurainstance/$KURA_INSTANCE" --timeout=10m
-          fi
-
-          kubectl -n kura delete secret pentest-kura-introspection --ignore-not-found
           kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=true --timeout=5m

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -42,12 +42,10 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   SERVER_IMAGE_NAME: tuist/tuist
-  REGISTRY_IMAGE_NAME: tuist/registry
   HELM_CHART_PATH: infra/helm/tuist
   HELM_RELEASE_NAME: pentest
   NAMESPACE: tuist-pentest
   HOST: pentest.tuist.dev
-  REGISTRY_HOST: registry-pentest.tuist.dev
 
 jobs:
   resolve:
@@ -102,35 +100,9 @@ jobs:
             MIX_ENV=prod
             APT_CACHE_BUST=${{ github.run_id }}
 
-  build-registry:
-    name: Build package registry image
-    needs: resolve
-    if: inputs.action == 'deploy'
-    runs-on: tuist-linux
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-          submodules: false
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./registry/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}
-          build-args: |
-            MIX_ENV=prod
-
   deploy:
     name: Deploy pentest environment
-    needs: [resolve, build-server, build-registry]
+    needs: [resolve, build-server]
     if: inputs.action == 'deploy'
     runs-on: tuist-linux
     environment:
@@ -214,8 +186,7 @@ jobs:
           helm template "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" \
             -f "$HELM_CHART_PATH/values-pentest.yaml" \
-            --set "server.image.tag=$IMAGE_TAG" \
-            --set "registry.image.tag=$IMAGE_TAG" > rendered.yaml
+            --set "server.image.tag=$IMAGE_TAG" > rendered.yaml
 
           if grep -Eq '^kind: (RunnerPool|MachineDeployment|ScalewayAppleSiliconMachineTemplate)$' rendered.yaml; then
             echo "::error::The pentest render must not provision runner infrastructure."
@@ -224,6 +195,11 @@ jobs:
 
           if grep -q '^kind: KuraInstance$' rendered.yaml; then
             echo "::error::The pentest render must not contain a Kura instance."
+            exit 1
+          fi
+
+          if grep -q 'app.kubernetes.io/component: registry' rendered.yaml; then
+            echo "::error::The pentest render must not contain a package registry."
             exit 1
           fi
 
@@ -238,16 +214,14 @@ jobs:
             --create-namespace \
             -f "$HELM_CHART_PATH/values-pentest.yaml" \
             --set "server.image.tag=$IMAGE_TAG" \
-            --set "registry.image.tag=$IMAGE_TAG" \
             --atomic --timeout 20m --wait --wait-for-jobs
       - name: Verify deployed services
         run: |
           set -euo pipefail
 
           kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-server --timeout=10m
-          kubectl -n "$NAMESPACE" rollout status deploy/pentest-tuist-registry --timeout=10m
 
-          for endpoint in "https://$HOST/ready" "https://$REGISTRY_HOST/up"; do
+          for endpoint in "https://$HOST/ready"; do
             for attempt in $(seq 1 60); do
               if curl -fsSL --max-time 5 "$endpoint" >/dev/null; then
                 echo "OK: $endpoint returned 200"
@@ -296,11 +270,10 @@ jobs:
           {
             echo "## Pentest environment deployed"
             echo "- Application: https://$HOST"
-            echo "- Package registry: https://$REGISTRY_HOST"
             echo "- Namespace: \`$NAMESPACE\`"
             echo "- Expires at: \`$EXPIRES_AT\`"
             echo "- Image tag: \`$IMAGE_TAG\`"
-            echo "- Excluded: Kura, runners, codebase search, Mac workloads, and package catalog synchronization"
+            echo "- Excluded: Kura, package registry, runners, codebase search, Mac workloads, and package catalog synchronization"
           } >> "$GITHUB_STEP_SUMMARY"
 
   delete:

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -1,27 +1,17 @@
 name: Pentest Platform Reconcile
 
 # Reconciles the cluster-scoped platform resources for the dedicated pentest
-# cluster. The Kura controller is installed independently from the application
-# release so application deployment cannot alter shared controller state.
+# cluster. Application deployment does not alter shared platform state.
 
 on:
   workflow_dispatch:
-    inputs:
-      kura_controller_image_tag:
-        description: Immutable Kura controller image tag published by the Kura Controller Image workflow.
-        required: true
-        type: string
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: pentest-platform-reconcile
   cancel-in-progress: false
-
-env:
-  KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
 
 jobs:
   reconcile:
@@ -32,7 +22,6 @@ jobs:
     timeout-minutes: 30
     env:
       KUBECONFIG: /tmp/tuist-pentest-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
-      KURA_CONTROLLER_IMAGE_TAG: ${{ inputs.kura_controller_image_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,16 +31,6 @@ jobs:
           install_args: "helm kubectl"
           cache: "false"
           env: "false"
-      - name: Validate the immutable controller reference
-        run: |
-          set -euo pipefail
-          case "$KURA_CONTROLLER_IMAGE_TAG" in
-            sha-* | *@sha256:*) ;;
-            *)
-              echo "::error::Use a sha-* tag or digest published by the Kura Controller Image workflow."
-              exit 1
-              ;;
-          esac
       - name: Load Kubernetes configuration
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
@@ -66,21 +45,9 @@ jobs:
           fi
       - name: Reconcile platform chart
         run: mise -C infra run k8s:install-platform "$KUBECONFIG" tuist-pentest
-      - name: Reconcile Kura platform
-        run: mise -C infra run k8s:install-kura-platform "$KUBECONFIG" pentest
-      - name: Verify the Kura controller
-        run: |
-          set -euo pipefail
-          kubectl -n kura rollout status deployment \
-            -l app.kubernetes.io/component=kura-controller --timeout=5m
-          kubectl -n kura get deployment \
-            -l app.kubernetes.io/component=kura-controller \
-            -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{range .args[*]}{.}{"\n"}{end}{end}{end}' \
-            | grep -Fx -- '--grpc-cluster-issuer=letsencrypt-cloudflare' >/dev/null
       - name: Summary
         run: |
           {
             echo "## Pentest platform reconciled"
-            echo "- Kura controller: \`$KURA_CONTROLLER_IMAGE_TAG\`"
             echo "- Cluster: \`tuist-pentest\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -47,10 +47,9 @@ Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph sta
   KuraInstance). The Kura controller itself runs once cluster-wide in the
   `kura` namespace; each preview's `KuraInstance` is created there.
 - `clusters/cluster-pentest.yaml` is the isolated security-assessment cluster.
-  Its Kura controller, credentials, data volumes, and application namespace
-  are not shared with preview or any managed environment. It has no runner or
-  Mac worker pools; `values-pentest.yaml` keeps its embedded data services
-  persistent and places Kura on the dedicated `kura` worker pool.
+  Its data volumes and application namespace are not shared with preview or
+  any managed environment. It has no runner, Mac, or Kura worker pools;
+  `values-pentest.yaml` keeps its embedded data services persistent.
 - `clusters/README.md` — ClusterClass authoring + caph-upstream porting notes.
 - `mgmt/cluster-autoscaler.yaml`, `mgmt/etcd-snapshot.yaml`, `mgmt/tailscale.yaml` — mgmt-cluster workloads (Cluster API node autoscaling for managed Kura/app clusters, hourly etcd snapshot to Tigris, tailnet-only operator access).
 - `mgmt/bootstrap/` — Helm values for the per-workload bootstrap (Cilium, HCCM, hcloud-csi, ESO `ClusterSecretStore`).

--- a/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
@@ -307,9 +307,11 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "cache") | nindent 14 }}
+        {{- if .Values.registry.enabled }}
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "registry") | nindent 14 }}
+        {{- end }}
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "object-storage-init") | nindent 14 }}

--- a/infra/helm/tuist/templates/server-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/server-networkpolicy.yaml
@@ -22,6 +22,7 @@ spec:
       ports:
         - protocol: TCP
           port: http
+    {{- if .Values.server.networkPolicy.kuraEnabled }}
     - from:
         - namespaceSelector:
             matchLabels:
@@ -32,6 +33,7 @@ spec:
       ports:
         - protocol: TCP
           port: http
+    {{- end }}
     {{- with .Values.server.networkPolicy.observabilityNamespace }}
     - from:
         - namespaceSelector:
@@ -51,6 +53,7 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    {{- if .Values.server.networkPolicy.kuraEnabled }}
     - to:
         - namespaceSelector:
             matchLabels:
@@ -58,6 +61,7 @@ spec:
       ports:
         - protocol: TCP
           port: 4000
+    {{- end }}
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/infra/helm/tuist/values-pentest.yaml
+++ b/infra/helm/tuist/values-pentest.yaml
@@ -38,10 +38,6 @@ server:
       item: TUIST_LICENSE_KEY
       field: password
   appUrl: https://pentest.tuist.dev
-  kuraIntrospection:
-    # The deployment creates this dedicated credential in the application
-    # namespace. It is distinct from the Kura controller's shared Secret.
-    secretName: pentest-kura-introspection
   serviceAccount:
     create: true
   automountServiceAccountToken: false
@@ -57,10 +53,7 @@ server:
   networkPolicy:
     enabled: true
     defaultDenyAllPods: true
-    kuraNamespace: kura
-    kuraPodLabels:
-      app.kubernetes.io/name: kura
-      app.kubernetes.io/instance: pentest-kura
+    kuraEnabled: false
     # The public HTTP(S) egress rule excludes the complete private and
     # link-local address ranges. In particular, this blocks the Hetzner
     # metadata endpoint at 169.254.169.254 from an application compromise.
@@ -202,34 +195,3 @@ registryCache:
 
 observability:
   enabled: false
-
-kuraRuntime:
-  image:
-    repository: ghcr.io/tuist/kura
-  instance:
-    enabled: true
-    name: pentest-kura
-    namespace: kura
-    # Keep this tenant fixed. Changing it in place could attach a different
-    # account to the existing Kura persistent volume.
-    accountHandle: pentest
-    tenantID: pentest
-    region: pentest
-    replicas: 1
-    publicHost: kura-pentest.tuist.dev
-    ingressClassName: nginx
-    storageSize: 10Gi
-    nodeSelector:
-      node.cluster.x-k8s.io/pool: kura
-    tolerations:
-      - key: tuist.dev/kura-cache
-        operator: Equal
-        value: "true"
-        effect: NoSchedule
-    networkPolicy:
-      enabled: true
-    controlPlaneCredentials:
-      # This Secret is created in the Kura namespace by the deployment
-      # workflow. Its values override the controller's shared credentials
-      # for this one pentest runtime.
-      secretName: pentest-kura-introspection

--- a/infra/helm/tuist/values-pentest.yaml
+++ b/infra/helm/tuist/values-pentest.yaml
@@ -71,10 +71,6 @@ server:
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: preview
-    - name: TUIST_REGISTRY_URL
-      value: https://registry-pentest.tuist.dev/swift
-    - name: SWIFT_REGISTRY_SYNC_ENABLED
-      value: "false"
     - name: TUIST_GITHUB_AUTH_ENABLED
       value: "false"
     - name: TUIST_GOOGLE_AUTH_ENABLED
@@ -133,41 +129,6 @@ objectStorage:
     persistence:
       create: true
       size: 100Gi
-
-registry:
-  enabled: true
-  managedSecrets: false
-  deployEnv: preview
-  sentryEnv: preview
-  poolSize: "2"
-  automountServiceAccountToken: false
-  metrics:
-    enabled: false
-  ingress:
-    enabled: true
-    className: nginx
-    host: registry-pentest.tuist.dev
-    tlsSecretName: registry-pentest-tuist-dev-tls
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-cloudflare
-  networkPolicy:
-    enabled: true
-    # Keep the registry's public egress away from the cluster network and
-    # the Hetzner metadata endpoint as well.
-    clusterCIDRs:
-      - 10.0.0.0/8
-      - 172.16.0.0/12
-      - 192.168.0.0/16
-      - 169.254.0.0/16
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      memory: 512Mi
-
-swiftRegistrySync:
-  enabled: false
 
 processor:
   enabled: false

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -711,6 +711,7 @@ server:
       app.kubernetes.io/component: controller
     dnsNamespace: kube-system
     observabilityNamespace: observability
+    kuraEnabled: true
     kuraNamespace: kura
     # Additional labels for Kura runtime pods allowed to call the server.
     # Empty preserves the existing namespace-wide behavior.

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -36,14 +36,13 @@ clusters/
 | `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
 | `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
-| `tuist-pentest` | 3× cpx22 | md-0: 2× cpx32 (`pool=general`); kura: 1× cpx32 (`pool=kura`, tainted) |
+| `tuist-pentest` | 3× cpx22 | md-0: 2× cpx32 (`pool=general`) |
 
 `tuist-pentest` is a dedicated, fixed-duration security-assessment cluster.
-It intentionally has no runner, Mac, processor, or stable-egress pools. Kura
-runs on its own tainted worker pool, while its controller and credentials are
-confined to this cluster. When the engagement ends, remove its manifest in a
-reviewed change, then run the **Pentest Cluster Retirement** workflow to delete
-the Cluster resource and its managed infrastructure.
+It intentionally has no Kura, runner, Mac, processor, or stable-egress pools.
+When the engagement ends, remove its manifest in a reviewed change, then run
+the **Pentest Cluster Retirement** workflow to delete the Cluster resource and
+its managed infrastructure.
 
 The `md-egress` pool is the HA (≥2 node) stable-egress gateway: the
 production Phoenix server's public egress is SNAT'd through the active

--- a/infra/k8s/clusters/cluster-pentest.yaml
+++ b/infra/k8s/clusters/cluster-pentest.yaml
@@ -2,8 +2,8 @@
 #
 # This is deliberately a separate cluster, rather than a namespace on
 # tuist-preview: the assessment receives its own Kubernetes control plane,
-# Kura controller credentials, persistent volumes, and platform resources.
-# There are no runner or macOS worker pools in this topology.
+# persistent volumes, and platform resources. There are no runner, macOS, or
+# Kura worker pools in this topology.
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
@@ -56,23 +56,3 @@ spec:
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: general
-        # Kura is placed on a separate tainted node pool. This keeps its cache
-        # data and resource pressure apart from the application stack while
-        # retaining the dedicated cluster boundary for the whole engagement.
-        - class: hcloud-worker
-          name: kura
-          replicas: 1
-          failureDomain: fsn1
-          rollout:
-            strategy:
-              type: RollingUpdate
-              rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 0
-          metadata:
-            labels:
-              node.cluster.x-k8s.io/pool: kura
-          variables:
-            overrides:
-              - name: workerNodeTaints
-                value: tuist.dev/kura-cache=true:NoSchedule

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -415,10 +415,9 @@ The hourly `preview-sweep.yml` workflow gets the first cleanup chance and is the
 
 `tuist-pentest` is a separate workload cluster for an authorized security
 assessment. It uses the existing `tuist-workloads` Hetzner project, not a new
-Hetzner project, but does not share Kubernetes resources or Kura credentials
-with any other environment. Its topology is three control-plane nodes, two
-general workers, and one tainted Kura worker. It deliberately contains no
-runner or Mac worker pools.
+Hetzner project, but does not share Kubernetes resources with any other
+environment. Its topology is three control-plane nodes and two general workers.
+It deliberately contains no Kura, runner, or Mac worker pools.
 
 Before applying `cluster-pentest.yaml`, create a `tuist-k8s-pentest`
 1Password vault with the pentest-only `TUIST_LICENSE_KEY` and a service-account
@@ -435,17 +434,12 @@ set to `tuist-pentest`, then put the generated kubeconfig in the `server-k8s-pen
 Environment. That Environment also needs `PENTEST_USER_EMAIL` and
 `PENTEST_USER_PASSWORD`; these are used once to create the assessment account.
 
-After bootstrap, run the **Pentest Platform Reconcile** workflow with an
-immutable Kura controller image tag. It installs the cluster platform and the
-cluster-local Kura controller with the certificate issuer required for
-`kura-pentest.tuist.dev`. The controller's source credentials stay in the
-pentest cluster; the application deployment copies only the two introspection
-keys into `tuist-pentest`.
+After bootstrap, run the **Pentest Platform Reconcile** workflow. It installs
+the cluster platform required by the application and package registry.
 
 Deploy through **Pentest Deployment** with an `expires_at` timestamp. The
-scheduled cleanup removes the application namespace and its Kura instance
-after that time. Extending an engagement means re-deploying with a later
-timestamp.
+scheduled cleanup removes the application namespace after that time. Extending
+an engagement means re-deploying with a later timestamp.
 
 When the engagement ends, first remove
 `infra/k8s/clusters/cluster-pentest.yaml` in a reviewed change and merge it.

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -435,7 +435,7 @@ Environment. That Environment also needs `PENTEST_USER_EMAIL` and
 `PENTEST_USER_PASSWORD`; these are used once to create the assessment account.
 
 After bootstrap, run the **Pentest Platform Reconcile** workflow. It installs
-the cluster platform required by the application and package registry.
+the cluster platform required by the application.
 
 Deploy through **Pentest Deployment** with an `expires_at` timestamp. The
 scheduled cleanup removes the application namespace after that time. Extending

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -563,7 +563,7 @@ to point at $LB_IP.
   canary    -> canary.tuist.dev
   production -> tuist.dev (and any apex aliases)
   preview   -> ExternalDNS reconciles *.preview.tuist.dev from the ingress Service
-  pentest   -> pentest.tuist.dev (plus registry-pentest.tuist.dev and kura-pentest.tuist.dev)
+  pentest   -> pentest.tuist.dev (plus registry-pentest.tuist.dev)
 
 Verify the certificate and ingress on the new cluster (domain cut not needed for this):
   curl -k --resolve "staging.tuist.dev:443:$LB_IP" https://staging.tuist.dev/health

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -563,7 +563,7 @@ to point at $LB_IP.
   canary    -> canary.tuist.dev
   production -> tuist.dev (and any apex aliases)
   preview   -> ExternalDNS reconciles *.preview.tuist.dev from the ingress Service
-  pentest   -> pentest.tuist.dev (plus registry-pentest.tuist.dev)
+  pentest   -> pentest.tuist.dev
 
 Verify the certificate and ingress on the new cluster (domain cut not needed for this):
   curl -k --resolve "staging.tuist.dev:443:$LB_IP" https://staging.tuist.dev/health

--- a/infra/mise/tasks/k8s/install-kura-platform.sh
+++ b/infra/mise/tasks/k8s/install-kura-platform.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Install or upgrade the cluster-wide Kura controller in the `kura` namespace. Requires KURA_CONTROLLER_IMAGE_TAG."
 #USAGE arg "<kubeconfig>" help="Path to the workload cluster kubeconfig"
-#USAGE arg "[profile]" help="Controller placement and TLS profile (preview | pentest)" default="preview"
 
 # Installs ONLY the kuraController resources from the tuist Helm chart into
 # the `kura` namespace, using `helm template --show-only` so we don't have
@@ -19,7 +18,6 @@
 set -euo pipefail
 
 WL_KUBECONFIG="$1"
-PROFILE="${2:-preview}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CHART_PATH="$REPO_ROOT/infra/helm/tuist"
 KURA_NAMESPACE="kura"
@@ -36,14 +34,6 @@ if [ ! -r "$WL_KUBECONFIG" ]; then
   echo "ERROR: kubeconfig not readable: $WL_KUBECONFIG" >&2
   exit 1
 fi
-
-case "$PROFILE" in
-  preview|pentest) ;;
-  *)
-    echo "ERROR: profile must be preview or pentest." >&2
-    exit 64
-    ;;
-esac
 
 export KUBECONFIG="$WL_KUBECONFIG"
 
@@ -63,7 +53,7 @@ if [ -z "$CLIENT_SECRET" ]; then
 fi
 echo "::add-mask::$CLIENT_SECRET"
 
-log "Rendering Kura controller manifests for namespace=$KURA_NAMESPACE tag=$KURA_CONTROLLER_IMAGE_TAG profile=$PROFILE"
+log "Rendering Kura controller manifests for namespace=$KURA_NAMESPACE tag=$KURA_CONTROLLER_IMAGE_TAG"
 HELM_ARGS=(
   helm template kura-platform "$CHART_PATH"
   --namespace "$KURA_NAMESPACE" \
@@ -78,19 +68,13 @@ HELM_ARGS=(
   --set-string "kuraController.sharedSecrets.kuraIntrospection.clientSecret=$CLIENT_SECRET"
 )
 
-if [ "$PROFILE" = "preview" ]; then
-  # Every non-control-plane preview worker carries this taint.
-  HELM_ARGS+=(
-    --set "kuraController.tolerations[0].key=role"
-    --set "kuraController.tolerations[0].operator=Equal"
-    --set "kuraController.tolerations[0].value=preview"
-    --set "kuraController.tolerations[0].effect=NoSchedule"
-  )
-else
-  # The pentest controller must issue a certificate for its dedicated Kura
-  # hostname. The issuer is installed by the cluster's platform chart.
-  HELM_ARGS+=(--set kuraController.tlsClusterIssuer=letsencrypt-cloudflare)
-fi
+# Every non-control-plane preview worker carries this taint.
+HELM_ARGS+=(
+  --set "kuraController.tolerations[0].key=role"
+  --set "kuraController.tolerations[0].operator=Equal"
+  --set "kuraController.tolerations[0].value=preview"
+  --set "kuraController.tolerations[0].effect=NoSchedule"
+)
 
 "${HELM_ARGS[@]}" | kubectl apply -f -
 

--- a/infra/mise/tasks/preview/seed-account.sh
+++ b/infra/mise/tasks/preview/seed-account.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Seed an account and wire it to a KuraInstance. Called by preview and pentest deployment workflows. Idempotent."
+#MISE description="Seed an account and optionally wire it to a KuraInstance. Called by preview and pentest deployment workflows. Idempotent."
 #USAGE flag "--namespace <ns>" help="Kubernetes namespace where the preview server runs" default="default"
 
 # Environment-driven inputs (so the same script works for both kind and the
@@ -8,9 +8,9 @@
 #   PREVIEW_ACCOUNT_HANDLE  Account handle to create (matches the
 #                           KuraInstance's tenantID so the Lua hook's
 #                           strict tenant check passes). Default: preview.
-#   KURA_ENDPOINT_URL       Internal URL clients use to reach the preview's
-#                           Kura runtime. Stored on the account's
-#                           kura_servers row.
+#   KURA_ENDPOINT_URL       Optional internal URL clients use to reach the
+#                           preview's Kura runtime. When supplied, it is
+#                           stored on the account's cache-endpoint row.
 #   RELEASE_NAME            Helm release name; used to find the server pod.
 #   PREVIEW_USER_PASSWORD   Password for a newly seeded user, or the value
 #                           used by an explicit rotation. Default:
@@ -49,7 +49,7 @@ SEED_MODULES_PER_TEST="${SEED_MODULES_PER_TEST:-2}"
 SEED_SUITES_PER_MODULE="${SEED_SUITES_PER_MODULE:-2}"
 SEED_CASES_PER_SUITE="${SEED_CASES_PER_SUITE:-4}"
 SEED_CH_BATCH_SIZE="${SEED_CH_BATCH_SIZE:-5000}"
-KURA_ENDPOINT_URL="${KURA_ENDPOINT_URL:?KURA_ENDPOINT_URL must be set}"
+KURA_ENDPOINT_URL="${KURA_ENDPOINT_URL:-}"
 RELEASE_NAME="${RELEASE_NAME:?RELEASE_NAME must be set}"
 SEED_CREDENTIALS_DIRECTORY="${SEED_CREDENTIALS_DIRECTORY:-}"
 
@@ -114,7 +114,11 @@ handle = System.get_env("PREVIEW_ACCOUNT_HANDLE")
 email = System.get_env("PREVIEW_USER_EMAIL")
 password = System.get_env("PREVIEW_USER_PASSWORD")
 rotate_password? = Environment.truthy?(System.get_env("PREVIEW_ROTATE_USER_PASSWORD", "0"))
-endpoint_url = System.get_env("PREVIEW_KURA_URL")
+endpoint_url =
+  case System.get_env("PREVIEW_KURA_URL") do
+    "" -> nil
+    value -> value
+  end
 
 existing_account = Accounts.get_account_by_handle(handle)
 
@@ -176,11 +180,15 @@ if rotate_password? do
   Logger.info("preview-seed: rotated password for " <> email)
 end
 
-Logger.info("preview-seed: wiring Kura endpoint for account handle " <> account.name)
+if endpoint_url do
+  Logger.info("preview-seed: wiring Kura endpoint for account handle " <> account.name)
 
-case Accounts.create_account_cache_endpoint(account, %{url: endpoint_url, technology: :kura}) do
-  {:ok, _} -> Logger.info("preview-seed: created kura cache endpoint " <> endpoint_url)
-  {:error, _} -> Logger.info("preview-seed: kura cache endpoint already present")
+  case Accounts.create_account_cache_endpoint(account, %{url: endpoint_url, technology: :kura}) do
+    {:ok, _} -> Logger.info("preview-seed: created kura cache endpoint " <> endpoint_url)
+    {:error, _} -> Logger.info("preview-seed: kura cache endpoint already present")
+  end
+else
+  Logger.info("preview-seed: no Kura endpoint requested")
 end
 
 System.halt(0)
@@ -226,4 +234,4 @@ else
          "PREVIEW_KURA_URL=$KURA_ENDPOINT_URL" \
          /app/bin/tuist eval "$SEED_SCRIPT"
 fi
-echo "    Seeded account=${PREVIEW_ACCOUNT_HANDLE} endpoint=${KURA_ENDPOINT_URL}"
+echo "    Seeded account=${PREVIEW_ACCOUNT_HANDLE}"


### PR DESCRIPTION
> The pentest environment only needs the Tuist application and its embedded data services. It currently provisions Kura and the package registry, including their images, endpoints, credentials, worker capacity, and network access. Kura is also the source of the current restart alert. Removing both unused features is safer and simpler than maintaining them in the assessment environment.

> The deployment now removes the legacy `kura` namespace before installing the application. It removes the Kura controller reconciliation, runtime image, runtime resource, endpoint, credentials, worker pool, and network-policy peer. It also removes the package-registry image build, public hostname, Helm component, health check, and its object-storage network-policy peer. The shared account seeder now supports an account without a Kura endpoint, while preview behavior remains unchanged when an endpoint is supplied.

### How to test locally

- Parsed the three pentest workflows and the changed YAML files.
- Ran shell syntax and ShellCheck validation for the changed scripts.
- Ran `helm lint` with pentest values.
- Rendered the pentest chart and asserted it contains no Kura resource, Kura credential, Kura network-policy peer, or package-registry component.
- Ran `git diff --check`.
