### PR TITLE
feat(server): restore the production M2-L runner fleet to 9 hosts

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -944,16 +944,17 @@ macosFleet:
     name: tuist-runner-cache
     cidr: 172.16.0.0/22
 
-# Customer-runner Mac mini fleet. 7 M2-L hosts at one guest each plus
-# 2 M4-XL hosts at two = 11 concurrent customer runs.
+# Customer-runner Mac mini fleet. 9 M2-L hosts at one guest each plus
+# 2 M4-XL hosts at two = 13 concurrent customer runs.
 #
 # Sized against measured demand, not host count. macOS job concurrency
 # over the 7 days to 2026-08-25 ran p50 3 / p95 5 / p99 6 with a peak of
-# 8, so 11 keeps a margin above the observed peak while the M4s absorb
-# what the retired M2-Ls used to hold. The M2-L count came down from 9
-# when the second M4 landed: 2 M4 hosts add 4 slots, so keeping all 9
-# M2-Ls would have meant 13 slots against a workload that has never
-# asked for 9.
+# 8, so 13 keeps burst headroom above the observed peak. Trimming the
+# M2-L group to match the peak more tightly saves nothing: a host
+# released from this fleet is parked back in `tuist-pool-` and keeps
+# billing under Apple's 24h floor either way, so the only thing a
+# smaller hostCount buys is queueing, and a queued macOS job pays a
+# full cold boot.
 #
 # Apple's SLA permits two guests per host and Tart enforces it; whether
 # a host runs two is purely a function of how much CPU/RAM tart-kubelet
@@ -966,8 +967,6 @@ macosFleet:
 # releases can safely bump all enabled managed environments.
 runnersFleet:
   enabled: true
-  # 7, down from 9, offset by the 4 slots the two M4-XL hosts add.
-  #
   # Scaling this DOWN does not stop the bill. On Machine deletion the
   # controller renames the host back into the `tuist-pool-` pool and
   # reinstalls it — the mini stays alive and keeps billing, deliberately,
@@ -979,7 +978,7 @@ runnersFleet:
   # no nodeDrainTimeout, so an evicted Pod is not waited on: retire while
   # the target hosts hold no owned (job-running) runner Pod, or a
   # customer job dies with the node.
-  hostCount: 7
+  hostCount: 9
   # Pre-ordered pool. Operator orders M2-L hosts in the Scaleway
   # console with names starting with `tuist-pool-` ahead of
   # bringing this block live (Mac mini lead times can stretch
@@ -1155,8 +1154,8 @@ runnersFleet:
   # for BOTH shapes (M4: 1 of these or 2 of those; M2-L: 0 or 1), which
   # is the invariant `macosFleetAllocatableMemory` divides against. A 56
   # GB variant would force `hostMemoryMB` to 57344, and the 6 vCPU pools,
-  # which carry all of today's traffic, would then be handed a 15-slot
-  # budget against 11 placeable ones.
+  # which carry all of today's traffic, would then be handed a 17-slot
+  # budget against 13 placeable ones.
   #
   # It is also exactly 2x the baseline shape in both dimensions, so
   # `Catalog.billing_multiplier/3` meters it at precisely 2.0000 compute
@@ -1195,13 +1194,13 @@ runnersFleet:
       # min(cpu, memory) quotient for a shape and caps every pool sharing
       # it at that sum (2 today, both on M4-XL). It has to be derived
       # there rather than written here because the byte budget cannot see
-      # it: 157696 / 28672 reads as 5, pooling memory from M2-L hosts
+      # it: 186368 / 28672 reads as 6, pooling memory from M2-L hosts
       # that cannot seat one of these Pods at all.
       #
       # Set it to the M4-XL host count regardless, as the per-pool bound
       # it is: no single Xcode version should be able to take the whole
       # shape. It moves with `machineGroups[m4].hostCount`, not with the
-      # 11-slot totals the `xcodeOverrides` below use.
+      # 13-slot totals the `xcodeOverrides` below use.
       #
       # Cold: no warm floor. A 12 vCPU Pod parks a whole M4-XL, and idle
       # it would halve the fleet's dual-guest capacity to keep one
@@ -1218,19 +1217,19 @@ runnersFleet:
   # fleet allocator, which apportions the fleet's GUEST-slot budget
   # across all macOS pools using the three-tier (floor / load /
   # headroom) policy. `minWarmPoolFloor` is the always-on warm
-  # guarantee; `maxReplicas: 11` lets either pool absorb the whole
+  # guarantee; `maxReplicas: 13` lets either pool absorb the whole
   # fleet under skewed demand and the allocator caps the joint sum
   # so the pools don't double-book.
   #
   # The budget is slots, not minis: the allocator divides the fleet's
-  # advertised memory by this shape's 14336 MB, so the 7 M2-L hosts are
-  # 7 slots and the 2 M4-XL hosts are 2 each, for 11. These ceilings must
+  # advertised memory by this shape's 14336 MB, so the 9 M2-L hosts are
+  # 9 slots and the 2 M4-XL hosts are 2 each, for 13. These ceilings must
   # move with that number — the allocator never exceeds a pool's
   # maxReplicas, so leaving them behind would let an M4 boot but keep
   # every pool clamped below the capacity it adds, and its second guest
   # would sit idle.
   #
-  # Floors sum to 1 of the 11-slot budget; the remaining 10 slots are
+  # Floors sum to 1 of the 13-slot budget; the remaining 12 slots are
   # dynamically apportioned by queue depth across the pools. Older
   # Xcodes sit cold (floor 0) so an unused runner doesn't tie up a host.
   #
@@ -1247,27 +1246,27 @@ runnersFleet:
       autoscaling:
         enabled: true
         minWarmPoolFloor: 1
-        maxReplicas: 11
+        maxReplicas: 13
     "26.5":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 11
+        maxReplicas: 13
     "26.4.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 11
+        maxReplicas: 13
     "26.3":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 11
+        maxReplicas: 13
     "26.0.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 11
+        maxReplicas: 13
   # Resolved at deploy time from the latest `runner-image@` git tag.
   runnerImageSemver: ""
   pools: []

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -935,15 +935,15 @@ func macosNodeWithResources(name, fleetSelector string, cpu int64, memoryMB int6
 	return node
 }
 
-// The production topology: 7 M2-L (8 CPU / 14336 MB) + 2 M4-XL
-// (12 CPU / 28672 MB). The 6 vCPU shape seats 11, the 12 vCPU shape
+// The production topology: 9 M2-L (8 CPU / 14336 MB) + 2 M4-XL
+// (12 CPU / 28672 MB). The 6 vCPU shape seats 13, the 12 vCPU shape
 // seats 2 — and the second number is the one no fleet-wide division can
-// produce, since 157696 MB / 28672 reads as 5.
+// produce, since 186368 MB / 28672 reads as 6.
 func TestAutoscaler_ShapePlacementCapsCountSeatsPerNode(t *testing.T) {
 	const fleet = "runners-macos"
 
 	objects := []client.Object{}
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 9; i++ {
 		objects = append(objects, macosNodeWithResources(fmt.Sprintf("m2-%d", i), fleet, 8, 14336))
 	}
 	for i := 0; i < 2; i++ {
@@ -967,8 +967,8 @@ func TestAutoscaler_ShapePlacementCapsCountSeatsPerNode(t *testing.T) {
 		t.Fatalf("shapePlacementCaps: %v", err)
 	}
 
-	if got := caps[small.key()]; got != 11 {
-		t.Fatalf("6 vCPU seats = %d, want 11 (7 M2-L at one + 2 M4-XL at two)", got)
+	if got := caps[small.key()]; got != 13 {
+		t.Fatalf("6 vCPU seats = %d, want 13 (9 M2-L at one + 2 M4-XL at two)", got)
 	}
 	if got := caps[large.key()]; got != 2 {
 		t.Fatalf("12 vCPU seats = %d, want 2 (M4-XL only, one guest each)", got)

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -84,8 +84,8 @@ const (
 	// maxFleetReservations is how many hosts may be held across the whole
 	// fleet at once. Every reservation is capacity withdrawn from the
 	// small shapes while it converges, so this stays at one: a second
-	// concurrent drain would take a quarter of an 11-slot fleet offline
-	// to serve two large jobs.
+	// concurrent drain would hold two hosts at once, up to 4 of the
+	// 13-slot production fleet, to serve two large jobs.
 	maxFleetReservations = 1
 )
 


### PR DESCRIPTION
Brings the production customer-runner Mac mini fleet back to 9 M2-L hosts, up from the 7 it was trimmed to in #12605.

### What changed

`runnersFleet.hostCount` goes 7 -> 9 in `infra/helm/tuist/values-managed-production.yaml`. With the two M4-XL hosts at two guests each, macOS customer-run concurrency goes from 11 slots to 13.

Everything derived from that slot count moves with it:

- All five `xcodeOverrides[*].maxReplicas` go 11 -> 13. These are not cosmetic. The fleet allocator never exceeds a pool's `maxReplicas`, so leaving them behind would let the two extra minis boot and then clamp every pool below the capacity they add, leaving the new slots idle. The values file already carries that warning inline.
- The 12 vCPU shape's `maxReplicas` deliberately stays at 2. It is a per-pool bound tied to `machineGroups[m4].hostCount`, not to the fleet total, and no single Xcode version should be able to take the whole M4-XL group.
- Comments that stated the old topology are updated with it, including the byte-budget illustration: the fleet now advertises 186368 MB, which the fleet-wide division reads as 6 nominal 28 GiB slots against the 2 that are real. That gap is the reason the per-shape placement cap exists, so the number wants to stay accurate.

Two places outside the values file asserted the old numbers as fact rather than as a fixture, so they moved too:

- `controllers/autoscaler_controller_test.go` labels its fixture "the production topology" and hard-codes 7 M2-L / 11 seats. Now 9 M2-L / 13 seats. The invariant under test is unchanged: the fleet-wide division still over-counts the large shape (6 vs 2).
- `controllers/reservation.go` sized `maxFleetReservations` against "an 11-slot fleet". Reworded against the 13-slot fleet.

`internal/scaling/allocate_test.go` also uses 157696 MB, but as a self-contained fixture with no claim about production, and its assertion holds regardless, so it is left alone.

### Why

Reversing the trim from #12605. That change sized the fleet tightly against measured demand (macOS job concurrency over the 7 days to 2026-08-25 ran p50 3 / p95 5 / p99 6, peak 8), which 11 slots covers on paper. The argument for going back to 9 is that trimming was not actually buying anything: a host removed from this fleet is renamed back into the `tuist-pool-` pool and reinstalled rather than released, so it keeps billing under Apple's 24h floor either way. Releasing the hardware is a separate operator step in the Scaleway console. What the smaller `hostCount` did buy was queueing, and a queued macOS job pays a full cold boot. The header comment in the values file now says this instead of narrating the 9 -> 7 -> 9 history.

### Reviewer notes

Adoption is SKU-exact and there is no auto-order fallback, so the two extra M2-L minis must already be parked in the Scaleway console under `tuist-pool-` names before this rolls out. The previous trim deliberately left the retired hosts parked rather than released, so they are most likely still there, but it is worth confirming before merge.

If they are not there, this does not wedge the deploy. `helm --wait` tracks built-in workload kinds, not MachineDeployment, and this fleet renders no Helm-managed workload pinned to its nodes (runner Pods come from the runners-controller). The Machines simply sit on `NoAvailableHost` and the slots never appear. That is specific to `runnersFleet`; `macosFleet` pins the xcresult-processor Deployment to its nodes and really would wedge `helm --wait`.

Scaling this direction is also the safe one. The nodeDrainTimeout caveat in the values file applies to scaling DOWN, where CAPI deletes the most-recently-created Machines without waiting on evicted Pods.

### How to test locally

Render the production chart and check the three numbers that matter:

```
cd infra/helm/tuist
helm template tuist . -f values-managed-common.yaml -f values-managed-production.yaml \
  --set-string image.tag=test \
  --set-string runnersFleet.runnerImageSemver=1.2.3 \
  --set-string runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/runner:test \
  --set-string registry.image.tag=test --set-string cache.image.tag=test \
  --set-string kura.image.tag=test --set-string kuraController.image.tag=test \
  --set-string egressTreeAgent.image.tag=test --set-string codebaseSearch.image.tag=test
```

The `tuist-tuist-runners-fleet` MachineDeployment renders `replicas: 9`, `tuist-tuist-runners-fleet-m4` stays at `replicas: 2`, the five 6 vCPU macOS pools render `maxReplicas: 13`, and the five 12 vCPU pools stay at `maxReplicas: 2`.

Then the controller suite:

```
cd infra/runners-controller && go test ./... -count=1
```

### Validation run

- `helm template` against the production values, asserting all four numbers above.
- Parsed the rendered values to confirm the derived arithmetic every comment now claims: 9 + 2x2 = 13 slots, 186368 MB advertised, 186368 / 14336 = 13.0, 186368 / 28672 = 6.5.
- Full `go test ./... -count=1` in `infra/runners-controller`: all packages pass, including the updated `TestAutoscaler_ShapePlacementCapsCountSeatsPerNode`.
- `gofmt -l` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
