### PR TITLE
fix(cli): scope binary cache replacement to the focused targets during generation

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -285,6 +285,11 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                     )
                 }
 
+                // Keeping the source targets empties `includedTargets` so the graph is never focused
+                // and the generated project holds every target. Binary replacement still has to
+                // follow the requested focus, otherwise `tuist cache <target>` warms the target's
+                // closure while `tuist generate <target>` hashes and looks up every replaceable
+                // target in the workspace.
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
                     decider: CacheProfileTargetReplacementDecider(
@@ -292,7 +297,8 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                         exceptions: cacheSources
                     ),
                     configuration: configuration,
-                    cacheStorage: cacheStorage
+                    cacheStorage: cacheStorage,
+                    replacementScope: includedTargets.isEmpty ? cacheSources : []
                 )
                 mappers.append(focusTargetsGraphMapper)
                 mappers.append(TreeShakePrunedTargetsGraphMapper())

--- a/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
@@ -765,4 +765,158 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             XCTAssertEqual(storedSubhashes[bHash], bSubhashes)
         }
     }
+
+    func test_map_scopes_cache_items_to_the_replacement_scope_when_the_graph_is_not_focused() async throws {
+        let path = try temporaryPath()
+        let runMetadataStorage = RunMetadataStorage()
+
+        try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
+            // Given
+            let focusedApp = Target.test(name: "FocusedApp", platform: .iOS, product: .app)
+            let focusedFramework = Target.test(name: "FocusedFramework", platform: .iOS, product: .framework)
+            let otherApp = Target.test(name: "OtherApp", platform: .iOS, product: .app)
+            let otherFramework = Target.test(name: "OtherFramework", platform: .iOS, product: .framework)
+            let project = Project.test(
+                path: path,
+                targets: [focusedApp, focusedFramework, otherApp, otherFramework]
+            )
+            let focusedFrameworkGraphTarget = GraphTarget(path: path, target: focusedFramework, project: project)
+            let otherFrameworkGraphTarget = GraphTarget(path: path, target: otherFramework, project: project)
+
+            let inputGraph = Graph.test(
+                name: "input",
+                projects: [path: project],
+                dependencies: [
+                    .target(name: focusedApp.name, path: path): [
+                        .target(name: focusedFramework.name, path: path),
+                    ],
+                    .target(name: otherApp.name, path: path): [
+                        .target(name: otherFramework.name, path: path),
+                    ],
+                ]
+            )
+            let outputGraph = Graph.test(
+                name: "output",
+                projects: inputGraph.projects,
+                dependencies: inputGraph.dependencies
+            )
+
+            subject = TargetsToCacheBinariesGraphMapper(
+                config: config,
+                cacheGraphContentHasher: cacheGraphContentHasher,
+                decider: CacheProfileTargetReplacementDecider(
+                    profile: .allPossible,
+                    exceptions: [.named("FocusedApp")]
+                ),
+                configuration: "Debug",
+                cacheGraphMutator: cacheGraphMutator,
+                cacheStorage: cacheStorage,
+                replacementScope: [.named("FocusedApp")]
+            )
+
+            given(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .any,
+                    configuration: .any,
+                    defaultConfiguration: .any,
+                    excludedTargets: .any,
+                    destination: .any
+                )
+                .willReturn([
+                    focusedFrameworkGraphTarget: .test(hash: "focused-framework-hash"),
+                    otherFrameworkGraphTarget: .test(hash: "other-framework-hash"),
+                ])
+            given(cacheStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn([:])
+            given(cacheGraphMutator)
+                .map(
+                    graph: .any,
+                    precompiledArtifacts: .any,
+                    sources: .any,
+                    keepSourceTargets: .any
+                )
+                .willReturn(outputGraph)
+
+            // When
+            _ = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
+
+            // Then
+            let binaryCacheItems = await runMetadataStorage.binaryCacheItems
+            XCTAssertEqual(Set(binaryCacheItems[path, default: [:]].keys), ["FocusedFramework"])
+            verify(cacheStorage)
+                .fetch(
+                    .value([CacheStorableItem(name: "FocusedFramework", hash: "focused-framework-hash")]),
+                    cacheCategory: .value(.binaries)
+                )
+                .called(1)
+        }
+    }
+
+    func test_map_keeps_every_target_in_scope_when_no_replacement_scope_is_given() async throws {
+        let path = try temporaryPath()
+        let runMetadataStorage = RunMetadataStorage()
+
+        try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
+            // Given
+            let focusedApp = Target.test(name: "FocusedApp", platform: .iOS, product: .app)
+            let focusedFramework = Target.test(name: "FocusedFramework", platform: .iOS, product: .framework)
+            let otherApp = Target.test(name: "OtherApp", platform: .iOS, product: .app)
+            let otherFramework = Target.test(name: "OtherFramework", platform: .iOS, product: .framework)
+            let project = Project.test(
+                path: path,
+                targets: [focusedApp, focusedFramework, otherApp, otherFramework]
+            )
+            let focusedFrameworkGraphTarget = GraphTarget(path: path, target: focusedFramework, project: project)
+            let otherFrameworkGraphTarget = GraphTarget(path: path, target: otherFramework, project: project)
+
+            let inputGraph = Graph.test(
+                name: "input",
+                projects: [path: project],
+                dependencies: [
+                    .target(name: focusedApp.name, path: path): [
+                        .target(name: focusedFramework.name, path: path),
+                    ],
+                    .target(name: otherApp.name, path: path): [
+                        .target(name: otherFramework.name, path: path),
+                    ],
+                ]
+            )
+            let outputGraph = Graph.test(
+                name: "output",
+                projects: inputGraph.projects,
+                dependencies: inputGraph.dependencies
+            )
+
+            given(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .any,
+                    configuration: .any,
+                    defaultConfiguration: .any,
+                    excludedTargets: .any,
+                    destination: .any
+                )
+                .willReturn([
+                    focusedFrameworkGraphTarget: .test(hash: "focused-framework-hash"),
+                    otherFrameworkGraphTarget: .test(hash: "other-framework-hash"),
+                ])
+            given(cacheStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn([:])
+            given(cacheGraphMutator)
+                .map(
+                    graph: .any,
+                    precompiledArtifacts: .any,
+                    sources: .any,
+                    keepSourceTargets: .any
+                )
+                .willReturn(outputGraph)
+
+            // When
+            _ = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
+
+            // Then
+            let binaryCacheItems = await runMetadataStorage.binaryCacheItems
+            XCTAssertEqual(
+                Set(binaryCacheItems[path, default: [:]].keys),
+                ["FocusedFramework", "OtherFramework"]
+            )
+        }
+    }
 }

--- a/cli/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
@@ -287,6 +287,50 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             XCTAssertContainsElementOfType(got, FocusTargetsGraphMappers.self, after: CacheHashingGraphMapper.self)
         }
 
+        func test_generation_scopes_binary_replacement_to_the_cache_sources_when_source_targets_are_kept() {
+            // Given
+            let config = Tuist.test(
+                project: .generated(.test(cacheOptions: .test(keepSourceTargets: true)))
+            )
+            let cacheSources: Set<TargetQuery> = Set([.named("MyTarget")])
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: cacheSources,
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            XCTAssertDoesntContainElementOfType(got, FocusTargetsGraphMappers.self)
+            let mapper = XCTAssertContainsElementOfType(got, TargetsToCacheBinariesGraphMapper.self)
+            XCTAssertEqual(mapper?.replacementScope, cacheSources)
+        }
+
+        func test_generation_does_not_scope_binary_replacement_when_the_graph_is_focused() {
+            // Given
+            let config = Tuist.test(
+                project: .generated(.test(cacheOptions: .test(keepSourceTargets: false)))
+            )
+            let cacheSources: Set<TargetQuery> = Set([.named("MyTarget")])
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: cacheSources,
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            XCTAssertContainsElementOfType(got, FocusTargetsGraphMappers.self)
+            let mapper = XCTAssertContainsElementOfType(got, TargetsToCacheBinariesGraphMapper.self)
+            XCTAssertEqual(mapper?.replacementScope, [])
+        }
+
         func test_generation_does_not_preserve_cache_hashing_graph_when_cache_is_disabled() {
             // Given
             let config = Tuist.test()


### PR DESCRIPTION
> No issue; reported by a customer in Slack.

## What changed

`CacheGraphMapperFactory.generation` now passes the requested targets to `TargetsToCacheBinariesGraphMapper` as a `replacementScope` whenever the graph was not focused, so binary replacement follows the requested focus even though the project keeps every source target.

The mapper side lives in the `cli/TuistCacheEE` submodule: https://github.com/tuist/TuistCacheEE/pull/76

## Why

A project using `cacheOptions.keepSourceTargets` reported that the cache dashboard disagreed with itself between two consecutive commands. `tuist cache <app> --configuration <config>` reported the focused app's dependency closure as cacheable. `tuist generate <app> --configuration <config>` run immediately afterwards reported the entire workspace as cacheable, so a run in which every warmed target hit still showed a low hit rate, because the denominator was roughly six times larger than the set that had been warmed.

### Root cause

The dashboard is reporting faithfully. `cacheable_targets` is derived server-side from which targets in the uploaded graph carry a `binary_cache_metadata.hash`, and the hit rate is `(local + remote) / cacheable`. The widened scope came from the CLI.

`keepSourceTargets` blanks `includedTargets` here so `FocusTargetsGraphMappers` never enters the chain (behaviour introduced in #8180, so the generated project keeps every source target). `TargetsToCacheBinariesGraphMapper` then derived its candidates from the unpruned graph via `graphTraverser.allTargets()`, so every replaceable target in the workspace was hashed, looked up in the cache, and reported.

`tuist cache <target>` has no such gate: `binaryCacheWarmingPreload` always focuses, and `CacheWarmTargetGraphSelector` narrows again to the requested targets' closure. So warm-then-generate could never reach a full hit rate, and the extra misses were targets the user never asked for.

The distinguishing signal in the reported data is that the generation's cacheable count was invariant to the focused set: `--cache-profile all-possible` with no targets, with one app, and with three apps all produced the same count. Projects without the option scale normally with the focused set, and projects on the same CLI version behave correctly, so this is config-dependent rather than a version regression.

## Why this approach

Restoring focus under `keepSourceTargets` was rejected: not pruning the graph is precisely what the option exists for, and an earlier attempt at making tree-shaking honour the flag had to be corrected afterwards (#8227) for producing invalid generated projects.

Excluding the out-of-scope targets from the content hasher was also rejected. Hashing deliberately runs over the unfocused `initialGraphWithSources` for hash stability, and the hasher's exclusion list is keyed by target name, which collides across projects. Narrowing the candidate set after hashing leaves cache keys byte-identical and bounds only what is looked up and reported.

The scope is computed with the same traversal `FocusTargetsGraphMappers` uses, so the focused and the scoped-but-unfocused paths resolve to the same target set by construction rather than by coincidence.

## Impact

Only generations in projects with `keepSourceTargets` enabled change behaviour. For those, `tuist generate <target>` attempts binary replacement for the focused target's closure, matching what `tuist cache <target>` warms, and the reported cache hit rate becomes meaningful. Targets outside the closure remain source targets, which they already were. Cache keys are unchanged, so no re-warming is required. Every other workflow (`cache`, `build`, `test`, and generation without `keepSourceTargets`) passes an empty scope and is unaffected.

## Validation

Written test-first; the behaviour test failed before the fix with exactly the reported symptom:

```
test_map_scopes_cache_items_to_the_replacement_scope_when_the_graph_is_not_focused  FAILED
  XCTAssertEqual failed: ("["OtherFramework", "FocusedFramework"]") is not equal to ("["FocusedFramework"]")
  failed - Expected exactly 1 invocation(s) of fetch, but was 0
```

Four tests added:

- `TargetsToCacheBinariesGraphMapperTests.test_map_scopes_cache_items_to_the_replacement_scope_when_the_graph_is_not_focused` asserts an unrelated app's framework no longer reaches `RunMetadataStorage.binaryCacheItems`, which is what becomes `cacheable_targets` on the server.
- `TargetsToCacheBinariesGraphMapperTests.test_map_keeps_every_target_in_scope_when_no_replacement_scope_is_given` pins the unscoped behaviour so the fix cannot over-narrow.
- `CacheGraphMapperFactoryTests.test_generation_scopes_binary_replacement_to_the_cache_sources_when_source_targets_are_kept` asserts the chain has no focus mapper and the cache mapper carries the scope.
- `CacheGraphMapperFactoryTests.test_generation_does_not_scope_binary_replacement_when_the_graph_is_focused` asserts the scope stays empty when focus already pruned the graph.

Runs after the fix:

- `TuistCacheEEUnitTests` full target: `** TEST SUCCEEDED **`, 67 cases.
- `TuistKitTests/CacheGraphMapperFactoryTests` and `TuistKitTests/GraphMapperFactoryTests`: `** TEST SUCCEEDED **`, 41 cases.
- `mise run lint`: no warnings on the changed files.

### How to test locally

```
mise exec -- tuist generate tuist ProjectDescription TuistCacheEETests TuistKitTests --no-open
```

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEUnitTests \
  -only-testing TuistCacheEETests/TargetsToCacheBinariesGraphMapperTests \
  CODE_SIGNING_ALLOWED=NO
```

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests \
  -only-testing TuistKitTests/CacheGraphMapperFactoryTests \
  CODE_SIGNING_ALLOWED=NO
```

Reverting the mapper change in `cli/TuistCacheEE` reproduces the failure above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
