### PR TITLE
fix(server): resolve account handles by equality instead of ilike

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -136,7 +136,7 @@ defmodule Tuist.Accounts do
   end
 
   def get_account_by_handle(handle) do
-    Repo.one(from(a in Account, where: ilike(a.name, ^handle)))
+    Repo.one(from(a in Account, where: a.name == ^handle))
   end
 
   @doc """

--- a/server/lib/tuist_web/operator_grant.ex
+++ b/server/lib/tuist_web/operator_grant.ex
@@ -60,8 +60,7 @@ defmodule TuistWeb.OperatorGrant do
   # Tolerance for clock drift between the ops signer and this server.
   @clock_skew_seconds 60
   # Account handles are alphanumeric + dashes (mirrors the server's name
-  # validation). Reject anything else so a `%`/`_` in the grant can't be
-  # resolved as a SQL LIKE wildcard by `get_account_by_handle/1`.
+  # validation). Anything else is rejected before the handle is resolved.
   @account_handle_regex ~r/^[a-zA-Z0-9-]+$/
   @grant_header "x-tuist-operator-grant"
 

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -2052,6 +2052,29 @@ defmodule Tuist.AccountsTest do
       # Then
       assert got
     end
+
+    test "returns nil when the handle is a percent wildcard" do
+      # Given
+      AccountsFixtures.user_fixture(preload: [:account])
+      AccountsFixtures.user_fixture(preload: [:account])
+
+      # When
+      got = Accounts.get_account_by_handle("%")
+
+      # Then
+      assert is_nil(got)
+    end
+
+    test "returns nil when the handle is made of underscore wildcards" do
+      # Given
+      %{account: %{name: handle}} = AccountsFixtures.user_fixture(preload: [:account])
+
+      # When
+      got = Accounts.get_account_by_handle(String.duplicate("_", String.length(handle)))
+
+      # Then
+      assert is_nil(got)
+    end
   end
 
   describe "create_user/1" do

--- a/server/test/tuist_web/authentication_test.exs
+++ b/server/test/tuist_web/authentication_test.exs
@@ -540,6 +540,24 @@ defmodule TuistWeb.AuthenticationTest do
       assert conn.halted
       assert redirected_to(conn) == ~p"/users/log_in"
     end
+
+    test "redirects if the account handle is a wildcard matching many accounts", %{conn: conn} do
+      # Given
+      AccountsFixtures.organization_fixture()
+      AccountsFixtures.organization_fixture()
+      conn = %{conn | path_params: %{"account_handle" => "%"}}
+
+      # When
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> fetch_flash()
+        |> Authentication.require_authenticated_user_for_private_accounts([])
+
+      # Then
+      assert conn.halted
+      assert redirected_to(conn) == ~p"/users/log_in"
+    end
   end
 
   describe "require_authenticated_user_for_previews/2" do


### PR DESCRIPTION
Resolves [TUIST-4JB](https://tuist.sentry.io/issues/143038307/)

A request to `http://tuist.dev/_/` crashed in production with `Ecto.MultipleResultsError: expected at most one result but got 15`.

### Root cause

`Accounts.get_account_by_handle/1` resolved the handle with `ilike(a.name, ^handle)`. `ilike` treats `_` and `%` as SQL wildcards, so the path segment was interpreted as a pattern rather than a literal handle, and `_` matched every single-character account name. The caller in the request path, `TuistWeb.Authentication.require_authenticated_user_for_private_accounts/2`, resolves the account through `Repo.one`, which raises when the query returns more than one row.

### What changed

`get_account_by_handle/1` now matches with `a.name == ^handle`.

`accounts.name` is a `citext` column with a unique index (`index_accounts_on_name`, made citext in `20240521153130_make_organization_and_project_name_citext`), so `ilike` was never needed for case-insensitivity in the first place. Plain equality is already case-insensitive, treats `_` and `%` as literal characters, can return at most one row by construction, and uses the unique index instead of a sequential scan. This also matches how the neighbouring lookups already work: `get_account_ids_by_handles/1` and `Projects.get_project_by_account_and_project_handles/3` both compare with equality.

Escaping the wildcards before passing them to `ilike` would also have stopped the crash, but it would have kept a pattern match and a scan where an indexed equality is correct.

The comment on `@account_handle_regex` in `TuistWeb.OperatorGrant` justified the handle-format check by this `LIKE` behaviour, which is no longer accurate. The check itself stays, since it is legitimate validation of a grant claim; only the comment is updated.

### Impact

`get_account_by_handle/1` also backs cache-endpoint resolution (`hosted_kura_resolution/1`, `hosted_cache_endpoints_for_handle/2`) and the handle-taking API controllers, so those paths were crashable on the same input and are fixed by the same change. Handles that do not exist now consistently fall through to the existing not-found behaviour: for private account pages, a redirect to the log-in page.

Account handles are validated as `^[a-zA-Z0-9-]+$`, so no real handle contained a wildcard and no existing lookup changes its result.

### How to test locally

The change was developed test-first. To see the failure before the fix, revert the one-line change in `lib/tuist/accounts.ex` and run either of the new tests:

```
mix test test/tuist/accounts_test.exs -n 'get_account_by_handle'
```

```
mix test test/tuist_web/authentication_test.exs -n 'wildcard matching many accounts'
```

Before the fix, the first reproduces the reported error verbatim, and the second reproduces the reported stacktrace through `authentication.ex:478` into `Ecto.Repo.Queryable.one/3`. After the fix, both pass.

### Validation

- New context tests cover a `%` handle and an all-underscore handle; both return `nil`.
- A new plug test drives `require_authenticated_user_for_private_accounts/2` with a wildcard handle and asserts the redirect to log-in.
- The pre-existing "does case-insensitive searches" test still passes, confirming citext equality preserves that behaviour.
- Full server suite: 7505/7509 passing. The 4 failures are locale tests that fail identically on an unmodified tree in this environment, where only the `en` locale is compiled.
- `mix format --check-formatted` and `mix credo --strict` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
