### PR TITLE
fix(server): settle an xcresult whose test-results output is empty

### DIFF
--- a/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -208,6 +208,21 @@
             )
         }
 
+        /// The server parses the uploaded bundle with `xcresulttool`, and a bundle
+        /// it cannot read produces a run with no test results. Reporting the tool's
+        /// own reason here puts it in front of whoever ran the tests, on the machine
+        /// that produced the bundle. The upload still runs, so the run reaches the
+        /// server and settles there rather than going missing.
+        private func warnIfResultBundleIsNotReadable(_ resultBundle: AbsolutePath) async {
+            do {
+                try await xcresultToolController.verifyReadable(resultBundle)
+            } catch {
+                Logger.current.warning(
+                    "The result bundle at \(resultBundle.pathString) can't be read, so this run's test results won't be available: \(error)"
+                )
+            }
+        }
+
         public func uploadResultBundle(
             _ resultBundle: AbsolutePath,
             fullHandle: String,
@@ -262,6 +277,7 @@
             let archiveStart = Date()
             switch artifact.type {
             case .resultBundle:
+                await warnIfResultBundleIsNotReadable(passedArtifactPath)
                 #if canImport(TuistAppleArchiver)
                     // AppleArchive (LZFSE) is substantially faster than deflate for xcresult
                     // bundles and skips the pre-copy the zip path needs. The server-side

--- a/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
+++ b/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
@@ -9,6 +9,7 @@ public protocol XCResultToolControlling {
     func resultBundleObject(_ path: AbsolutePath) async throws -> String
     func resultBundleObject(_ path: AbsolutePath, id: String) async throws -> String
     func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws
+    func verifyReadable(_ resultBundlePath: AbsolutePath) async throws
 }
 
 public struct XCResultToolController: XCResultToolControlling {
@@ -54,6 +55,19 @@ public struct XCResultToolController: XCResultToolControlling {
                 ]
             )
         }
+    }
+
+    /// Reads the bundle's test-results summary, which fails when the bundle has
+    /// no `Info.plist` or its manifest references objects the bundle does not
+    /// contain. It walks the same object graph the server reads but returns
+    /// only the summary, and a bundle that ran no tests still reads cleanly.
+    public func verifyReadable(_ resultBundlePath: AbsolutePath) async throws {
+        _ = try await commandRunner.capture(
+            arguments: [
+                "/usr/bin/xcrun", "xcresulttool", "get", "test-results", "summary",
+                "--path", resultBundlePath.pathString,
+            ]
+        )
     }
 
     public func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws {

--- a/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
@@ -91,6 +91,10 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         let serverURL: URL = .test()
         let commandEventID = UUID().uuidString
 
+        given(xcresultToolController)
+            .verifyReadable(.any)
+            .willReturn(())
+
         #if canImport(TuistAppleArchiver)
             // On macOS the result_bundle path goes through AppleArchive, not the zip
             // `FileArchiver`. Stub compress to write an .aar file so the downstream
@@ -253,6 +257,97 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
             .init(number: 1, contentLength: 20)
         )
         XCTAssertEqual(gotUploadPartURL, uploadPartURL)
+    }
+
+    func test_uploadResultBundle_warns_when_the_bundle_is_not_readable() async throws {
+        try await withMockedDependencies {
+            // Given
+            let temporaryDirectory = try temporaryPath()
+            let resultBundle = temporaryDirectory.appending(component: "artifact.xcresult")
+            try await FileSystem().makeDirectory(at: resultBundle)
+            let serverURL: URL = .test()
+            let commandEventID = UUID().uuidString
+
+            given(xcresultToolController)
+                .verifyReadable(.value(resultBundle))
+                .willThrow(TestError("item missing for id 0~abc"))
+
+            #if canImport(TuistAppleArchiver)
+                given(appleArchiver)
+                    .compress(
+                        directory: .value(resultBundle),
+                        to: .any,
+                        excludePatterns: .value([]),
+                        preservesBaseDirectory: .value(true)
+                    )
+                    .willProduce { _, archivePath, _, _ in
+                        try Data("fake-aar".utf8).write(to: archivePath.url)
+                    }
+            #else
+                let fileArchiver = MockFileArchiving()
+                given(fileArchiverFactory)
+                    .makeFileArchiver(for: .value([resultBundle]))
+                    .willReturn(fileArchiver)
+                let artifactArchivePath = temporaryDirectory.appending(component: "artifact.zip")
+                try await FileSystem().touch(artifactArchivePath)
+                given(fileArchiver)
+                    .zip(name: .value("artifact"))
+                    .willReturn(artifactArchivePath)
+            #endif
+
+            given(multipartUploadStartAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .value(.init(type: .resultBundle)),
+                    accountHandle: .any,
+                    projectHandle: .any,
+                    commandEventId: .any,
+                    serverURL: .any
+                )
+                .willReturn("upload-id")
+
+            given(multipartUploadArtifactService)
+                .multipartUploadArtifact(
+                    artifactPath: .any,
+                    generateUploadURL: .any,
+                    updateProgress: .any
+                )
+                .willReturn([(etag: "etag", partNumber: 1)])
+
+            given(multipartUploadCompleteAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .any,
+                    accountHandle: .any,
+                    projectHandle: .any,
+                    commandEventId: .any,
+                    uploadId: .any,
+                    parts: .any,
+                    serverURL: .any
+                )
+                .willReturn(())
+
+            // When
+            try await subject.uploadResultBundle(
+                resultBundle,
+                fullHandle: "account/project",
+                commandEventId: commandEventID,
+                serverURL: serverURL
+            )
+
+            // Then: the reason the results will be missing is reported locally, and the
+            // upload still happens so the run is not silently dropped.
+            XCTAssertPrinterContains("item missing for id 0~abc", at: .warning, >=)
+            verify(multipartUploadCompleteAnalyticsService)
+                .uploadAnalyticsArtifact(
+                    .any,
+                    accountHandle: .any,
+                    projectHandle: .any,
+                    commandEventId: .any,
+                    uploadId: .any,
+                    parts: .any,
+                    serverURL: .any
+                )
+                .called(1)
+        }
     }
 
     func test_upload_session() async throws {

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -176,8 +176,28 @@ defmodule Tuist.Processor.XCResultProcessor do
   defp normalize_parse_error({:error, reason}, xcresult_path) do
     message = parse_error_message(reason)
     Logger.error("xcresult parse failed at #{xcresult_path}: #{message}")
-    {:error, stable_parse_error(message, xcresult_path)}
+    reason = stable_parse_error(message, xcresult_path)
+    report_unprocessable_parse_failure(reason, message, xcresult_path)
+    {:error, reason}
   end
+
+  # `:empty_test_results` cancels the job on its first attempt, so Oban never
+  # reports it, and the xcresult-processor Deployment sets no `TUIST_LOKI_URL`,
+  # so the log line above stays on the host. Capture the failure directly to
+  # keep its rate and the xcresulttool diagnostic visible. The static message
+  # and fingerprint hold the grouping; the volatile bundle path is stripped out
+  # of the detail the same way it is for a reported parse failure.
+  defp report_unprocessable_parse_failure(:empty_test_results, message, xcresult_path) do
+    Sentry.capture_message("xcresult test-results output was empty",
+      extra: %{detail: String.replace(message, xcresult_path, "<xcresult>")},
+      fingerprint: ["xcresult-empty-test-results"],
+      level: :warning
+    )
+
+    :ok
+  end
+
+  defp report_unprocessable_parse_failure(_reason, _message, _xcresult_path), do: :ok
 
   defp parse_error_message(reason) when is_binary(reason) do
     case JSON.decode(reason) do

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -188,15 +188,21 @@ defmodule Tuist.Processor.XCResultProcessor do
 
   defp parse_error_message(reason), do: inspect(reason)
 
-  # A dedicated atom rather than a sanitized string: the timeout is the one
-  # failure mode with its own alert, and an atom is what a queue-consumer
-  # rule and a `grep` can both key on unambiguously. The elapsed seconds it
-  # replaces are a compile-time constant in the NIF, not information.
+  # Dedicated atoms rather than sanitized strings: these are the failure modes
+  # callers act on, and an atom is what a queue-consumer rule and a `grep` can
+  # both key on unambiguously. The timeout's elapsed seconds are a compile-time
+  # constant in the NIF, not information, and absent test-results output says
+  # nothing beyond its own absence.
   defp stable_parse_error(message, xcresult_path) do
-    if String.starts_with?(message, "xcresult parsing timed out") do
-      :parse_timeout
-    else
-      {:parse_failed, String.replace(message, xcresult_path, "<xcresult>")}
+    cond do
+      String.starts_with?(message, "xcresult parsing timed out") ->
+        :parse_timeout
+
+      String.starts_with?(message, "xcresulttool produced no test-results output") ->
+        :empty_test_results
+
+      true ->
+        {:parse_failed, String.replace(message, xcresult_path, "<xcresult>")}
     end
   end
 

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -46,10 +46,11 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   # Failures whose root cause is the uploaded archive itself, not anything
   # transient. Retrying is pointless and surfacing them as Oban errors lights
   # up Sentry every five attempts for what is fundamentally a CLI-side
-  # mistake (xcodebuild never populated the bundle, or the upload was a
-  # bare `quarantined_tests.json` skeleton). We mark the run as
-  # `failed_processing` once and cancel the job.
-  @unprocessable_input_reasons [:bundle_invalid, :xcresult_not_found]
+  # mistake (xcodebuild never populated the bundle, the upload was a bare
+  # `quarantined_tests.json` skeleton, or `xcresulttool` reads the bundle and
+  # returns no test results at all). We mark the run as `failed_processing`
+  # once and cancel the job.
+  @unprocessable_input_reasons [:bundle_invalid, :xcresult_not_found, :empty_test_results]
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"test_run_id" => test_run_id}} = job) do

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -7,7 +7,7 @@ public enum XCResultParserError: LocalizedError, Equatable {
     case failedToParseOutput(AbsolutePath)
     case timedOut(AbsolutePath, seconds: Int)
     case decodingFailed(step: String, path: AbsolutePath, detail: String)
-    case emptyOutput(step: String, path: AbsolutePath)
+    case emptyOutput(step: String, path: AbsolutePath, stderr: String)
 
     public var errorDescription: String? {
         switch self {
@@ -17,8 +17,13 @@ public enum XCResultParserError: LocalizedError, Equatable {
             return "xcresult parsing timed out after \(seconds)s at \(path.pathString)"
         case let .decodingFailed(step, path, detail):
             return "Failed to decode xcresult \(step) at \(path.pathString): \(detail)"
-        case let .emptyOutput(step, path):
-            return "xcresulttool produced no \(step) output at \(path.pathString)"
+        case let .emptyOutput(step, path, stderr):
+            let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let detail =
+                trimmed.isEmpty
+                    ? "<no stderr>"
+                    : String(trimmed.prefix(200)).replacingOccurrences(of: "\n", with: " ")
+            return "xcresulttool produced no \(step) output at \(path.pathString): \(detail)"
         }
     }
 }
@@ -117,7 +122,9 @@ public struct XCResultParser: Sendable {
             .runInTemporaryDirectory(prefix: "xcresult-test-results") { temporaryDirectory in
                 let tempFile = temporaryDirectory.appending(component: "test-results.json")
 
-                _ = try await commandRunner.run(
+                // stdout is redirected into `tempFile`, so what the command
+                // stream carries back is xcresulttool's stderr.
+                let toolStderr = try await commandRunner.run(
                     arguments: [
                         "/bin/sh", "-c",
                         // `exec` replaces the shell with the tool so cancellation, which signals
@@ -134,7 +141,9 @@ public struct XCResultParser: Sendable {
                 // the run instead of retrying a bundle that yields the same
                 // nothing on every attempt.
                 guard !jsonString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                    throw XCResultParserError.emptyOutput(step: "test-results", path: path)
+                    throw XCResultParserError.emptyOutput(
+                        step: "test-results", path: path, stderr: toolStderr
+                    )
                 }
                 guard let jsonData = jsonString.data(using: .utf8) else {
                     throw XCResultParserError.failedToParseOutput(path)

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -7,6 +7,7 @@ public enum XCResultParserError: LocalizedError, Equatable {
     case failedToParseOutput(AbsolutePath)
     case timedOut(AbsolutePath, seconds: Int)
     case decodingFailed(step: String, path: AbsolutePath, detail: String)
+    case emptyOutput(step: String, path: AbsolutePath)
 
     public var errorDescription: String? {
         switch self {
@@ -16,6 +17,8 @@ public enum XCResultParserError: LocalizedError, Equatable {
             return "xcresult parsing timed out after \(seconds)s at \(path.pathString)"
         case let .decodingFailed(step, path, detail):
             return "Failed to decode xcresult \(step) at \(path.pathString): \(detail)"
+        case let .emptyOutput(step, path):
+            return "xcresulttool produced no \(step) output at \(path.pathString)"
         }
     }
 }
@@ -125,6 +128,14 @@ public struct XCResultParser: Sendable {
 
                 let outputString = try await fileSystem.readTextFile(at: tempFile)
                 let jsonString = extractJSON(from: outputString)
+                // `xcresulttool get test-results tests` exits cleanly having
+                // written nothing for some bundles. Absent output is its own
+                // failure rather than a decode failure, so callers can settle
+                // the run instead of retrying a bundle that yields the same
+                // nothing on every attempt.
+                guard !jsonString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw XCResultParserError.emptyOutput(step: "test-results", path: path)
+                }
                 guard let jsonData = jsonString.data(using: .utf8) else {
                     throw XCResultParserError.failedToParseOutput(path)
                 }

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -12,6 +12,9 @@ import Testing
 /// run unchanged through the public parsing API.
 private struct XCResultToolStub: CommandRunning {
     let testResultsJSON: String
+    /// Yielded on the standard-error pipeline. The real invocation redirects
+    /// stdout into the temp file, so the stream carries only stderr.
+    var stderr: String = ""
 
     func run(
         arguments: [String],
@@ -25,6 +28,9 @@ private struct XCResultToolStub: CommandRunning {
                 if let close = tail.firstIndex(of: "'") {
                     try? testResultsJSON.write(toFile: String(tail[..<close]), atomically: true, encoding: .utf8)
                 }
+            }
+            if !stderr.isEmpty {
+                continuation.yield(.standardError(Array(stderr.utf8)))
             }
             continuation.finish()
         }
@@ -149,8 +155,30 @@ struct XCResultParserTests {
         let parser = XCResultParser(commandRunner: XCResultToolStub(testResultsJSON: ""))
         let path = try AbsolutePath(validating: "/tmp/empty.xcresult")
 
-        await #expect(throws: XCResultParserError.emptyOutput(step: "test-results", path: path)) {
+        await #expect(throws: XCResultParserError.emptyOutput(step: "test-results", path: path, stderr: "")) {
             try await parser.parse(path: path, rootDirectory: nil)
+        }
+    }
+
+    @Test
+    func parse_carriesXcresulttoolStderrOnAnEmptyTestResultsOutput() async throws {
+        // The invocation redirects stdout into a temp file, so the command
+        // stream carries xcresulttool's stderr and nothing else. That
+        // diagnostic is the only account of why the tool went silent, and it
+        // has to reach the error the server reports.
+        let parser = XCResultParser(
+            commandRunner: XCResultToolStub(
+                testResultsJSON: "",
+                stderr: "Error: item missing for id 0~abc\n"
+            )
+        )
+        let path = try AbsolutePath(validating: "/tmp/empty.xcresult")
+
+        await #expect {
+            try await parser.parse(path: path, rootDirectory: nil)
+        } throws: { error in
+            (error as? XCResultParserError)?.errorDescription?
+                .contains("Error: item missing for id 0~abc") == true
         }
     }
 

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -140,6 +140,21 @@ struct XCResultParserTests {
     }
 
     @Test
+    func parse_reportsAnEmptyTestResultsOutputAsItsOwnFailure() async throws {
+        // `xcresulttool get test-results tests` exits cleanly having written
+        // nothing for some bundles. Zero bytes decode as "dataCorrupted [...]
+        // The given data was not valid JSON", which reads as a malformed
+        // payload; absent output is its own failure, distinct from output we
+        // cannot decode.
+        let parser = XCResultParser(commandRunner: XCResultToolStub(testResultsJSON: ""))
+        let path = try AbsolutePath(validating: "/tmp/empty.xcresult")
+
+        await #expect(throws: XCResultParserError.emptyOutput(step: "test-results", path: path)) {
+            try await parser.parse(path: path, rootDirectory: nil)
+        }
+    }
+
+    @Test
     func parse_treatsAnAbsentActionLogAsEmptyInsteadOfFailing() async throws {
         // An aborted or test-less run uploads an xcresult with zero test nodes
         // and no action log: `xcresulttool get log --type action` prints "No

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -94,6 +94,17 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert {:error, :parse_timeout} = XCResultProcessor.process_local(fixture_zip)
     end
 
+    test "collapses an empty test-results output to a stable reason" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error, JSON.encode!(%{"error" => "xcresulttool produced no test-results output at #{xcresult_path}"})}
+      end)
+
+      assert {:error, :empty_test_results} = XCResultProcessor.process_local(fixture_zip)
+    end
+
     test "strips the bundle path out of a non-timeout parse failure" do
       {fixture_dir, fixture_zip} = create_xcresult_zip()
       on_exit(fn -> File.rm_rf(fixture_dir) end)

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -99,10 +99,48 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       on_exit(fn -> File.rm_rf(fixture_dir) end)
 
       expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
-        {:error, JSON.encode!(%{"error" => "xcresulttool produced no test-results output at #{xcresult_path}"})}
+        {:error,
+         JSON.encode!(%{
+           "error" => "xcresulttool produced no test-results output at #{xcresult_path}: Error: item missing for id 0~abc"
+         })}
+      end)
+
+      stub(Sentry, :capture_message, fn _message, _opts -> {:ok, "event-id"} end)
+
+      assert {:error, :empty_test_results} = XCResultProcessor.process_local(fixture_zip)
+    end
+
+    test "reports an empty test-results output to Sentry with the bundle path stripped" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error,
+         JSON.encode!(%{
+           "error" => "xcresulttool produced no test-results output at #{xcresult_path}: Error: item missing for id 0~abc"
+         })}
+      end)
+
+      expect(Sentry, :capture_message, fn message, opts ->
+        assert message == "xcresult test-results output was empty"
+        assert opts[:extra][:detail] =~ "Error: item missing for id 0~abc"
+        assert opts[:extra][:detail] =~ "<xcresult>"
+        refute opts[:extra][:detail] =~ "xcresult_test_fixture_"
+        {:ok, "event-id"}
       end)
 
       assert {:error, :empty_test_results} = XCResultProcessor.process_local(fixture_zip)
+    end
+
+    test "does not report an ordinary parse failure to Sentry itself" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :parse, fn _xcresult_path, _root_dir -> {:error, "parse failed"} end)
+
+      reject(&Sentry.capture_message/2)
+
+      assert {:error, {:parse_failed, "parse failed"}} = XCResultProcessor.process_local(fixture_zip)
     end
 
     test "strips the bundle path out of a non-timeout parse failure" do

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -532,7 +532,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
                ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 3))
     end
 
-    for reason <- [:bundle_invalid, :xcresult_not_found] do
+    for reason <- [:bundle_invalid, :xcresult_not_found, :empty_test_results] do
       test "discards the job and marks failed_processing on the first attempt for #{inspect(reason)}", %{
         account: account,
         project: project


### PR DESCRIPTION
Fixes [TUIST-4JC](https://tuist.sentry.io/issues/143040724/)

`ProcessXcresultWorker` was failing with:

```
{:parse_failed, "Failed to decode xcresult test-results at <xcresult>: dataCorrupted at []: The given data was not valid JSON. (0 bytes: <empty>)"}
```

### Root cause

`xcresulttool get test-results tests` exited cleanly having written **nothing**. Those zero bytes went straight to `JSONDecoder`, which reported them as a corrupt payload — a malformed-payload verdict for output that never arrived. `XCResultProcessor` then classified it as an ordinary `{:parse_failed, message}`, which the worker retries: five full download → extract → parse cycles per bundle, each returning an Oban error that reached Sentry.

The exit code has to have been 0. `tuist.Command`'s `CommandRunner` throws `CommandError.terminated` on any non-zero exit, so a `decodingFailed` message proves the tool terminated successfully. I measured xcresulttool's failure modes on Xcode 26.5 running the parser's exact shell form to confirm none of them can produce this message:

| Case | Exit | stdout |
| --- | --- | --- |
| Garbage / missing `Info.plist`, `unrecognized version N`, `item missing for id ...` | 64 | 0 bytes (message on stderr) |
| `get log --type action` with no action log | 1 | 0 bytes |
| `get test-results tests` on a build-only result bundle | 0 | valid JSON, `"testNodes": []` |
| Redirect target on a full volume | 1 | file never created |

So a test-less bundle does *not* produce empty output, and disk pressure fails earlier in the shell. The trigger inside xcresulttool remains unidentified, but it is settled by the archive rather than the machine: the bundle behind this issue failed identically on 4 attempts across 2 different processor pods (`...-7mb7q` and `...-59wzn`).

### What changed

Built test-first — each test was run red before the corresponding change.

- **`XCResultParser.swift`** — new `XCResultParserError.emptyOutput(step:path:)` (`"xcresulttool produced no <step> output at <path>"`). `loadTestOutput` guards on the trimmed output before decoding, so absent output is its own failure rather than a decode failure.
- **`XCResultProcessor.stable_parse_error/2`** — collapses that message prefix to the stable `:empty_test_results` atom, the same shape already used for `:parse_timeout`.
- **`ProcessXcresultWorker.@unprocessable_input_reasons`** — gains `:empty_test_results`, so the run is marked `failed_processing` once and the job is cancelled on the first attempt, alongside `:bundle_invalid` and `:xcresult_not_found`.

### Why not synthesize an empty run

Returning an empty `TestSummary` instead of an error was the obvious alternative, and it is wrong here: `run_status(_parsed_data, [])` maps an empty module list to `"success"`, so a bundle we could not read would surface as a green CI run. Failing loudly once and marking `failed_processing` is the honest outcome.

### Impact

- One `{:cancel, :empty_test_results}` instead of five Oban errors and five Sentry events per affected bundle, and four fewer download + extract + parse cycles.
- The run shows as `failed_processing` on attempt 1 rather than after roughly 18 minutes of backoff.
- `server/native/xcresult_nif` is a path dependency of the CLI (`Package.swift:1908`), so `tuist test` and `tuist inspect result-bundle` report the missing output directly too. Nothing else switches over `XCResultParserError`, so the added case breaks no callers.

### How to test locally

```bash
cd server/native/xcresult_nif && swift test --replace-scm-with-registry
```

```bash
cd server && mix test test/tuist/processor/xcresult_processor_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs
```

Validation run on this branch: 16 Swift tests pass (`parse_reportsAnEmptyTestResultsOutputAsItsOwnFailure` failed to compile before the enum case existed), 51 Elixir tests pass (both new assertions failed for the right reason first). `mix format`, `mix credo --strict` and `swiftformat` are clean; `swift test` re-resolves `Package.resolved`, which has been reverted.
