### PR TITLE
feat(server): replace Plain support chat with Atlas

### DIFF
--- a/infra/helm/tuist/templates/server-config-external-secrets.yaml
+++ b/infra/helm/tuist/templates/server-config-external-secrets.yaml
@@ -94,7 +94,6 @@ spec:
         {{- end }}
         TUIST_LOOPS_API_KEY: "{{ `{{ .TUIST_LOOPS_API_KEY | trim }}` }}"
         TUIST_CLICKHOUSE_URL: "{{ `{{ .TUIST_CLICKHOUSE_URL | trim }}` }}"
-        TUIST_PLAIN_AUTHENTICATION_SECRET: "{{ `{{ .TUIST_PLAIN_AUTHENTICATION_SECRET | trim }}` }}"
         TUIST_CACHE_API_KEY: "{{ `{{ .TUIST_CACHE_API_KEY | trim }}` }}"
         TUIST_SECRET_KEY_BASE: "{{ `{{ .TUIST_SECRET_KEY_BASE | trim }}` }}"
         TUIST_SECRET_KEY_PASSWORD: "{{ `{{ .TUIST_SECRET_KEY_PASSWORD | trim }}` }}"
@@ -150,8 +149,6 @@ spec:
       remoteRef: { key: "LOOPS/api_key" }
     - secretKey: TUIST_CLICKHOUSE_URL
       remoteRef: { key: "CLICKHOUSE/url" }
-    - secretKey: TUIST_PLAIN_AUTHENTICATION_SECRET
-      remoteRef: { key: "PLAIN/authentication_secret" }
     - secretKey: TUIST_CACHE_API_KEY
       remoteRef: { key: "CACHE_API_KEY/password" }
     # secret_key.base is read from the blob (not the chart) in managed envs

--- a/server/fnox.toml
+++ b/server/fnox.toml
@@ -34,7 +34,6 @@ TUIST_STRIPE_SECRET_KEY = { provider = "onepass", value = "STRIPE/secret_key" }
 TUIST_STRIPE_PUBLISHABLE_KEY = { provider = "onepass", value = "STRIPE/publishable_key" }
 TUIST_STRIPE_ENDPOINT_SECRET = { provider = "onepass", value = "STRIPE/endpoint_secret" }
 TUIST_MAILGUN_API_KEY = { provider = "onepass", value = "MAILGUN/api_key" }
-TUIST_PLAIN_AUTHENTICATION_SECRET = { provider = "onepass", value = "PLAIN/authentication_secret" }
 TUIST_LOOPS_API_KEY = { provider = "onepass", value = "LOOPS/api_key" }
 TUIST_CACHE_API_KEY = { provider = "onepass", value = "CACHE_API_KEY/password" }
 # Tuist OIDC provider (CLI/agent login). Only the three fields the code reads

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -10,7 +10,6 @@ defmodule Tuist.Environment do
   @dev_all_locales Application.compile_env(:tuist, :dev_all_locales, false)
 
   @runtime_envs ~w(prod can stag preview)
-  @default_atlas_support_chat_url "https://atlas.tuist.dev"
   @default_database_schema "public"
   @postgres_identifier_regex ~r/^[a-zA-Z_][a-zA-Z0-9_]*$/
   @agent_auth_default_trusted_providers [
@@ -1522,17 +1521,6 @@ defmodule Tuist.Environment do
       URI.to_string(%{URI.parse(get_url(:production)) | path: path})
     else
       URI.to_string(%{URI.parse(app_base_url(secrets)) | path: path})
-    end
-  end
-
-  def atlas_support_chat_url(url \\ System.get_env("TUIST_ATLAS_SUPPORT_CHAT_URL")) do
-    case URI.parse(url || @default_atlas_support_chat_url) do
-      %URI{scheme: scheme, host: host} = uri when scheme in ["http", "https"] and is_binary(host) ->
-        URI.to_string(%URI{scheme: scheme, host: host, port: uri.port})
-
-      _ ->
-        raise ArgumentError,
-              "TUIST_ATLAS_SUPPORT_CHAT_URL must be an HTTP or HTTPS origin"
     end
   end
 

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -10,6 +10,7 @@ defmodule Tuist.Environment do
   @dev_all_locales Application.compile_env(:tuist, :dev_all_locales, false)
 
   @runtime_envs ~w(prod can stag preview)
+  @default_atlas_support_chat_url "https://atlas.tuist.dev"
   @default_database_schema "public"
   @postgres_identifier_regex ~r/^[a-zA-Z_][a-zA-Z0-9_]*$/
   @agent_auth_default_trusted_providers [
@@ -618,10 +619,6 @@ defmodule Tuist.Environment do
       _ ->
         nil
     end
-  end
-
-  def plain_authentication_secret(secrets \\ secrets()) do
-    get([:plain, :authentication_secret], secrets)
   end
 
   def database_pool_size(secrets \\ secrets()) do
@@ -1525,6 +1522,17 @@ defmodule Tuist.Environment do
       URI.to_string(%{URI.parse(get_url(:production)) | path: path})
     else
       URI.to_string(%{URI.parse(app_base_url(secrets)) | path: path})
+    end
+  end
+
+  def atlas_support_chat_url(url \\ System.get_env("TUIST_ATLAS_SUPPORT_CHAT_URL")) do
+    case URI.parse(url || @default_atlas_support_chat_url) do
+      %URI{scheme: scheme, host: host} = uri when scheme in ["http", "https"] and is_binary(host) ->
+        URI.to_string(%URI{scheme: scheme, host: host, port: uri.port})
+
+      _ ->
+        raise ArgumentError,
+              "TUIST_ATLAS_SUPPORT_CHAT_URL must be an HTTP or HTTPS origin"
     end
   end
 

--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -20,7 +20,11 @@ defmodule TuistWeb.LayoutComponents do
       :if={!Map.get(assigns, :support_chat_disabled?, false)}
       defer
       nonce={get_csp_nonce()}
-      src={Tuist.Environment.atlas_support_chat_url() <> "/support/chat.js"}
+      src={
+        URI.parse("https://atlas.tuist.dev")
+        |> URI.append_path("/support/chat.js")
+        |> URI.to_string()
+      }
     >
     </script>
     """

--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -14,46 +14,14 @@ defmodule TuistWeb.LayoutComponents do
     """
   end
 
-  attr(:current_user, :map, default: nil)
-
-  def head_plain_script(assigns) do
-    current_user = Map.get(assigns, :current_user)
-    plain_authentication_secret = Tuist.Environment.plain_authentication_secret()
-
-    plain_opts =
-      Map.merge(
-        %{appId: "liveChatApp_01JSH0MMH3KHE7PX1781CV2HZG"},
-        if(is_nil(current_user) or is_nil(plain_authentication_secret),
-          do: %{},
-          else: %{
-            customerDetails: %{
-              email: current_user.email,
-              emailHash:
-                :hmac
-                |> :crypto.mac(:sha256, plain_authentication_secret, current_user.email)
-                |> Base.encode16(case: :lower),
-              chatAvatarUrl: Tuist.Accounts.User.gravatar_url(current_user)
-            }
-          }
-        )
-      )
-
-    assigns = assign(assigns, :plain_opts, plain_opts)
-
+  def head_support_chat_script(assigns) do
     ~H"""
     <script
-      :if={Tuist.Environment.analytics_enabled?() and not Map.get(assigns, :plain_disabled?, false)}
+      :if={!Map.get(assigns, :support_chat_disabled?, false)}
+      defer
       nonce={get_csp_nonce()}
+      src={Tuist.Environment.atlas_support_chat_url() <> "/support/chat.js"}
     >
-      (function(d, script) {
-        script = d.createElement('script');
-        script.async = false;
-        script.onload = function(){
-          Plain.init(<%= raw JSON.encode!(@plain_opts) %>);
-        };
-        script.src = 'https://chat.cdn-plain.com/index.js';
-        d.getElementsByTagName('head')[0].appendChild(script);
-      }(document));
     </script>
     """
   end

--- a/server/lib/tuist_web/docs/layouts/root.html.heex
+++ b/server/lib/tuist_web/docs/layouts/root.html.heex
@@ -64,7 +64,7 @@
     />
     <!-- Analytics -->
     <TuistWeb.LayoutComponents.head_analytics_scripts page_section="docs" {assigns} />
-    <TuistWeb.LayoutComponents.head_plain_script current_user={assigns[:current_user]} {assigns} />
+    <TuistWeb.LayoutComponents.head_support_chat_script {assigns} />
     <link rel="canonical" href={Tuist.Environment.app_url(path: @current_path)} />
     <meta property="og:locale" content={@locale} />
     <link

--- a/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
@@ -19,7 +19,7 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeController do
             |> put_resp_content_type("text/html")
             |> put_layout(false)
             |> put_view(MarketingHTML)
-            |> assign(:plain_disabled?, true)
+            |> assign(:support_chat_disabled?, true)
             |> assign(:analytics_disabled?, true)
             |> render(template)
 

--- a/server/lib/tuist_web/marketing/layouts/root.html.heex
+++ b/server/lib/tuist_web/marketing/layouts/root.html.heex
@@ -125,7 +125,7 @@
     <!-- hCaptcha -->
     <script nonce={get_csp_nonce()} src="https://js.hcaptcha.com/1/api.js" async defer>
     </script>
-    <TuistWeb.LayoutComponents.head_plain_script current_user={@current_user} {assigns} />
+    <TuistWeb.LayoutComponents.head_support_chat_script {assigns} />
     <link rel="canonical" href={Tuist.Environment.app_url(path: @current_path)} />
   </head>
   <body data-scrollable="true">

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -40,25 +40,23 @@ defmodule TuistWeb.Router do
 
   def csp_opts(_conn) do
     s3_endpoint = Tuist.Environment.s3_endpoint()
+    support_chat_url = Tuist.Environment.atlas_support_chat_url()
 
     [
       frame_ancestors: "'self'",
       img_src:
         "'self' data: https://github.com https://*.githubusercontent.com https://*.gravatar.com https://*.s3.amazonaws.com https://videos.tuist.dev https://developer.apple.com https://tuist.dev https://*.tuist.dev #{s3_endpoint}",
       media_src: "'self' https://*.mastodon.social https://hachyderm.io https://fosstodon.org #{s3_endpoint}",
-      style_src:
-        "'self' 'unsafe-inline' https://fonts.googleapis.com https://chat.cdn-plain.com https://cdn.jsdelivr.net https://rsms.me",
+      style_src: "'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://rsms.me",
       style_src_attr: "'unsafe-inline'",
       style_src_elem:
-        "'self' 'unsafe-inline' https://fonts.googleapis.com https://chat.cdn-plain.com https://cdn.jsdelivr.net https://rsms.me https://marketing.tuist.dev",
+        "'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://rsms.me https://marketing.tuist.dev",
       script_src: "'self' 'nonce' 'wasm-unsafe-eval'",
       script_src_elem:
-        "'self' 'nonce' https://d3js.org https://cdn.jsdelivr.net https://esm.sh https://chat.cdn-plain.com https://*.posthog.com https://marketing.tuist.dev",
-      font_src:
-        "'self' https://fonts.gstatic.com https://chat.cdn-plain.com data: https://fonts.scalar.com https://rsms.me",
-      frame_src: "'self' https://chat.cdn-plain.com https://*.tuist.dev https://newassets.hcaptcha.com",
-      connect_src:
-        "'self' https://chat.cdn-plain.com https://chat.uk.plain.com https://*.posthog.com https://search.tuist.dev #{s3_endpoint}"
+        "'self' 'nonce' https://d3js.org https://cdn.jsdelivr.net https://esm.sh #{support_chat_url} https://*.posthog.com https://marketing.tuist.dev",
+      font_src: "'self' https://fonts.gstatic.com data: https://fonts.scalar.com https://rsms.me",
+      frame_src: "'self' #{support_chat_url} https://*.tuist.dev https://newassets.hcaptcha.com",
+      connect_src: "'self' https://*.posthog.com https://search.tuist.dev #{s3_endpoint}"
     ]
   end
 

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -40,7 +40,6 @@ defmodule TuistWeb.Router do
 
   def csp_opts(_conn) do
     s3_endpoint = Tuist.Environment.s3_endpoint()
-    support_chat_url = Tuist.Environment.atlas_support_chat_url()
 
     [
       frame_ancestors: "'self'",
@@ -53,9 +52,9 @@ defmodule TuistWeb.Router do
         "'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://rsms.me https://marketing.tuist.dev",
       script_src: "'self' 'nonce' 'wasm-unsafe-eval'",
       script_src_elem:
-        "'self' 'nonce' https://d3js.org https://cdn.jsdelivr.net https://esm.sh #{support_chat_url} https://*.posthog.com https://marketing.tuist.dev",
+        "'self' 'nonce' https://d3js.org https://cdn.jsdelivr.net https://esm.sh https://atlas.tuist.dev https://*.posthog.com https://marketing.tuist.dev",
       font_src: "'self' https://fonts.gstatic.com data: https://fonts.scalar.com https://rsms.me",
-      frame_src: "'self' #{support_chat_url} https://*.tuist.dev https://newassets.hcaptcha.com",
+      frame_src: "'self' https://atlas.tuist.dev https://*.tuist.dev https://newassets.hcaptcha.com",
       connect_src: "'self' https://*.posthog.com https://search.tuist.dev #{s3_endpoint}"
     ]
   end

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Tuist Icon"
 msgstr ""
 
-#: lib/tuist_web/components/layout_components.ex:64
+#: lib/tuist_web/components/layout_components.ex:36
 #, elixir-autogen, elixir-format
 msgid "Tuist extends Apple's tools, helping you ship apps that stand out."
 msgstr ""

--- a/server/test/tuist_web/components/layout_components_test.exs
+++ b/server/test/tuist_web/components/layout_components_test.exs
@@ -6,10 +6,6 @@ defmodule TuistWeb.Components.LayoutComponentsTest do
   alias TuistWeb.LayoutComponents
   alias TuistWeb.Router
 
-  test "normalizes the configured Atlas support chat URL" do
-    assert Tuist.Environment.atlas_support_chat_url("http://localhost:3274/") == "http://localhost:3274"
-  end
-
   test "loads the Atlas support chat and permits it in the content security policy" do
     html = render_component(&LayoutComponents.head_support_chat_script/1, %{})
     content_security_policy = Router.csp_opts(%{})

--- a/server/test/tuist_web/components/layout_components_test.exs
+++ b/server/test/tuist_web/components/layout_components_test.exs
@@ -1,0 +1,30 @@
+defmodule TuistWeb.Components.LayoutComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias TuistWeb.LayoutComponents
+  alias TuistWeb.Router
+
+  test "normalizes the configured Atlas support chat URL" do
+    assert Tuist.Environment.atlas_support_chat_url("http://localhost:3274/") == "http://localhost:3274"
+  end
+
+  test "loads the Atlas support chat and permits it in the content security policy" do
+    html = render_component(&LayoutComponents.head_support_chat_script/1, %{})
+    content_security_policy = Router.csp_opts(%{})
+
+    assert html =~ ~s(src="https://atlas.tuist.dev/support/chat.js")
+    refute html =~ "plain"
+
+    assert Keyword.fetch!(content_security_policy, :script_src_elem) =~ "https://atlas.tuist.dev"
+    assert Keyword.fetch!(content_security_policy, :frame_src) =~ "https://atlas.tuist.dev"
+    refute Keyword.fetch!(content_security_policy, :script_src_elem) =~ "plain"
+  end
+
+  test "omits the Atlas support chat from embedded blog visualizations" do
+    html = render_component(&LayoutComponents.head_support_chat_script/1, %{support_chat_disabled?: true})
+
+    refute html =~ "atlas.tuist.dev"
+  end
+end


### PR DESCRIPTION
## What changed

- Replaced the Plain support widget with Atlas’s embedded support chat on marketing and documentation pages.
- Added a configurable Atlas chat origin, and permitted that origin in the browser’s script and frame policies.
- Removed the unused Plain credential from local and managed deployment configuration.
- Kept the chat out of embedded blog visualizations.

## Why

Atlas now owns the support conversation interface. Loading its widget directly gives visitors the current Atlas experience and lets us retire the Plain integration and its credential.

## Approach

The chat script URL is built from the fixed Atlas origin and endpoint path with URI helpers. The browser policy lists the same fixed origin.

## Impact

Visitors receive the Atlas support chat on the public site. Embedded blog previews remain free of the widget. Managed environments no longer request the Plain secret.

## Validation

- mise exec -- mix test test/tuist_web/components/layout_components_test.exs
- helm template tuist infra/helm/tuist -f infra/helm/tuist/values-self-hosted-ci.yaml
- Rendered the support-chat component and verified the fixed script URL and browser policy entries.

A browser screenshot could not be captured because browser automation is disabled in this workspace.
