### PR TITLE
feat(infra): raise the us-east OVH box's egress budget to 5 Gbit/s

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -764,9 +764,15 @@ ovhFleets:
       offer: advance-1
       datacenter: vin
       os: ubuntu_24.04
-      # Node egress budget (Mbps): Advance-1 ~3 Gbit/s, advertised as
-      # tuist.dev/egress-mbps so the scheduler bin-packs the 750-Mbps-floor pods.
-      egressBudgetMbps: 3000
+      # Node egress budget (Mbps), advertised as tuist.dev/egress-mbps so the
+      # scheduler bin-packs the 750-Mbps-floor pods. This describes the ONE box
+      # this fleet holds (replicas: 1), whose public uplink is 5 Gbit/s — not
+      # the advance-1 offer in general, which us-west still runs at 3 Gbit/s.
+      # A second, slower box added here would inherit this number and be
+      # over-committed; give it its own fleet key (with a displayName prefix
+      # that is not a prefix of this one — adoption is HasPrefix-matched) or
+      # move the budget per-box before growing the fleet.
+      egressBudgetMbps: 5000
     sshExternalSecret:
       enabled: true
       item: OVH_FLEET_SSH


### PR DESCRIPTION
## What changed

`ovhFleets.us-east.machine.egressBudgetMbps` in `values-managed-production.yaml` goes from `3000` to `5000`, with a comment recording that the number describes the single box the fleet holds rather than the `advance-1` offer in general.

## Why

The production us-east Kura box (`tuist-tuist-ovh-fleet-us-east-5764k-jjgbg`) runs a 5 Gbit/s public uplink, but the fleet template still declared the 3 Gbit/s the offer originally shipped with. Two things consume that number and were both working from the understated value:

- **The scheduler.** The OVH machine controller advertises the budget as the node's `tuist.dev/egress-mbps` extended resource (`controllers/shared/node_egress.go`), which is what bin-packs Kura cache pods by their guaranteed egress floor. At 3k, ~2 Gbit/s of real capacity was invisible to placement.
- **The egress-tree agent.** It reads the same node resource (`internal/agent/agent.go:373`) as the root cap of the shared per-node HTB tree, so the box was also being shaped to 3 Gbit/s.

Verified live before changing anything — production holds exactly three OVH nodes, each alone in its own fleet at `replicas: 1`:

| Fleet | Offer / DC | `spec.egressBudgetMbps` | Node capacity |
|---|---|---|---|
| `tuist-tuist-ovh-fleet-us-east` | advance-1 / vin | 3000 | 3k |
| `tuist-tuist-ovh-fleet-us-west` | advance-1 / hil | 3000 | 3k |
| `tuist-tuist-ovh-fleet-ap-southeast` | ADVANCE-2 EPYC / sgp | 1000 | 1k |

## Why a fleet-level value is acceptable here

`egressBudgetMbps` lives on the `OVHDedicatedMachineTemplate`, one per `ovhFleets.<key>`, so it cannot express per-box heterogeneity. That is fine today because `us-east` is its own fleet key at one replica: the change describes exactly one machine and leaves `us-west` (same `advance-1` offer, still 3 Gbit/s) alone.

It stops being fine the moment a second, slower box joins this fleet — it would inherit 5000 and be over-committed by ~2 Gbit/s, silently, since the symptom is shaped-traffic overrun rather than an error. Two options were considered for that future and deliberately deferred:

- **A sibling fleet key at `replicas: 0`** for future 3 Gbit boxes. Rejected for now as speculative config, and because it carries a live footgun: adoption matches datacenter by prefix, offer by case-insensitive substring, and displayName by `strings.HasPrefix` (`internal/ovh/client.go:198`). Two `us-east` fleets on the same offer and datacenter would be separated only by that prefix, so `…-us-east` would also match `…-us-east-3g-*` boxes and could adopt one. `claimedServiceNames` only prevents double-claiming an already-adopted box, not the wrong fleet claiming a free one first. If this is added later, neither prefix may contain the other.
- **Deriving the budget per box** from OVH's per-server network specification, with `spec.egressBudgetMbps` as the override. This is the shape that makes a mixed-bandwidth region work without naming games, and would have self-corrected this drift. Worth doing if mixed hardware in one region becomes a standing condition rather than a one-off.

The comment added next to the value states both the constraint and the exits, so the next person growing this fleet meets it.

## Deploying

Helm only renders the `OVHDedicatedMachineTemplate`; the MachineDeployment uses `strategy: OnDelete`, so CAPI will **not** propagate the template change into the existing `OVHDedicatedMachine`, and Helm does not backfill live CRs (`infra/cluster-api-provider-tuist/AGENTS.md`). Merging this alone changes nothing on the running node — it only sets what a recreated machine inherits.

To apply it to the live box, patch the machine CR:

```
kubectl --context tuist-k8s-production -n tuist \
  patch ovhdedicatedmachine tuist-tuist-ovh-fleet-us-east-5764k-jjgbg \
  --type=merge -p '{"spec":{"egressBudgetMbps":5000}}'
```

There is no validating webhook on the kind, so the spec is mutable, and the CR watch triggers a reconcile immediately. `ReconcileNodeEgressCapacity` then rewrites the node's status capacity (it re-applies on every reconcile, which is also why patching the Node directly does not work — it gets stomped back to the machine's value on the next loop).

Verify:

```
kubectl --context tuist-k8s-production get node tuist-tuist-ovh-fleet-us-east-5764k-jjgbg \
  -o jsonpath='{.status.capacity.tuist\.dev/egress-mbps}'
```

Expect `5k`. The egress-tree agent on that node should log `node egress budget changed` and republish `kura_egress_tree_node_budget_mbps` at 5000.

## Follow-up worth checking

`us-west` runs the same `advance-1` offer and still declares 3000. If OVH lifted the uplink for the offer rather than for this one box, that node is mis-advertised the same way and is leaving ~2 Gbit/s unused.

## Validation

- Confirmed the live fleet topology, machine specs and node capacities with `kubectl` against production (table above) — the premise that other OVH machines would be affected does not hold; each region is its own fleet at one replica.
- Traced both consumers of the value in the code (`node_egress.go`, `egress-tree-agent`) to confirm what the number actually drives.
- No deploy run from this PR; the node-side change is the patch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)