### PR TITLE
fix(server): freeze the clock in the runner allowance projection test

### DIFF
--- a/server/test/tuist/runners/allowance_test.exs
+++ b/server/test/tuist/runners/allowance_test.exs
@@ -257,10 +257,15 @@ defmodule Tuist.Runners.AllowanceTest do
     end
 
     test "reports the period, its projection, what is included and the period before", %{account: account} do
-      # 60 minutes on the 1st of this month, so the projection scales a
-      # known figure across a known number of days.
-      now = DateTime.utc_now()
-      started = %{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+      # 60 minutes on the 1st of the period, so the projection scales a
+      # known figure across a known stretch of it. The clock is frozen
+      # because the projection divides by elapsed seconds: against the
+      # real clock the same usage projects to a different figure
+      # depending on the hour of the day and the length of the month the
+      # test happens to run in.
+      now = ~U[2024-01-17 00:00:00.000000Z]
+      stub(DateTime, :utc_now, fn -> now end)
+      started = %{now | day: 1}
 
       Repo.insert!(%RunnerSession{
         account_id: account.id,
@@ -290,11 +295,10 @@ defmodule Tuist.Runners.AllowanceTest do
       # Inside the allowance, so nothing of it is billable yet.
       assert row.billed == Money.new(0, :USD)
 
-      # Straight-line to the end of the window. Measured in seconds
-      # rather than whole days, so allow a minute either side of the
-      # day-granular estimate rather than restating the arithmetic.
-      days_in_month = Date.days_in_month(DateTime.to_date(now))
-      assert_in_delta row.projected_minutes, div(60 * days_in_month, now.day), 2
+      # Straight-line to the end of the window: 60 minutes over the 16
+      # elapsed days of a 31-day month, which is 116 minutes and a
+      # quarter by the end of it.
+      assert row.projected_minutes == 116
       assert row.projected_minutes >= row.minutes
     end
 


### PR DESCRIPTION
The `period_breakdown/1 platform rows` projection test in `server/test/tuist/runners/allowance_test.exs` fails depending on what time of day CI happens to run.

### What changed

The test now freezes the clock at `2024-01-17T00:00:00Z` with `stub(DateTime, :utc_now, ...)` and asserts the projection exactly:

```elixir
assert row.projected_minutes == 116
```

instead of comparing against a whole-day approximation with a delta of 2.

### Why

`Allowance.project/4` extrapolates from elapsed seconds since the start of the period:

```elixir
elapsed = max(DateTime.diff(now, period_start, :second), 1)
total = max(DateTime.diff(period_end, period_start, :second), elapsed)
ms * total / elapsed / 60_000
```

The test approximated that with whole days via `now.day`. But `period_start` is the first of the month at 00:00:00, so on day N at hour H only `N - 1 + H/24` days have actually elapsed, not `N`. The two estimates diverge most early in the UTC day and late in a long month, and the divergence exceeds the delta of 2.

Observed on 2026-08-27, a 31-day month on day 27: CI at 03:31 UTC produced `projected_minutes = 71` against an expected 68 and failed; the same test passed locally at 04:45 UTC, where the implementation yields 70 and the delta is exactly 2. The crossover sits around 04:20 UTC. Nothing about the change under test was involved: it fires on any PR whose CI lands in that window.

### Why freezing rather than recomputing the expectation

Recomputing the expected value on the same elapsed-seconds basis would keep the assertion tied to the wall clock, so it would still be a different number on every run, and it would come close to restating `project/4` inline. Freezing removes both the hour-of-day and the day-of-month dependence in one move, and `stub(DateTime, :utc_now, ...)` is the pattern already used in `bundles_test.exs` and `command_events_test.exs`.

The frozen date was picked so the assertion stays meaningful:

- The session still runs 60 minutes on the 1st of the period, with exactly 16 days elapsed in a 31-day month, so the projection is `60 * 31 / 16 = 116.25`, truncated to 116.
- 16 of 31 days is 51% elapsed, comfortably past `@projection_minimum_elapsed_percent` (10%), so a projection is still returned rather than gated to `nil`.
- Mid-month and mid-ratio, so neither the one-microsecond-short `end_of_month` nor the integer division moves the result across a boundary.

### Impact

Test-only. No production behaviour changes.

### How to test locally

```
cd server && mix test test/tuist/runners/allowance_test.exs
```

22 passed. The single test also passes with `--seed 0`, and its result no longer depends on the wall clock.

### Not addressed here

Several other tests in the same file build sessions relative to the real clock and then assert against the calendar-month window: `allowance_test.exs:180` (`days_ago` up to 3), `:310` (-4h), `:340` (-1h), `:487` (-4h). `compute_milliseconds_by_machine` clips a session to the window rather than dropping it, so in the first hours or days of a month those runs land partly or wholly in the previous period and the minute assertions shift. Same class of defect, different trigger; left out of this PR to keep it to the reported failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
