### PR TITLE
fix(server): guard every gettext domain in CI and regenerate stale templates

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -149,54 +149,43 @@ jobs:
             fi
           }
 
-          # Extract only (without --merge) to check if marketing.pot changes
-          # DO NOT use --merge here as it would modify .po translation files
-          cp priv/gettext/marketing.pot priv/gettext/marketing.pot.backup
+          # Extract only (without --merge) to check whether any .pot template
+          # is out of date. DO NOT use --merge here as it would modify the .po
+          # translation files. Every domain under priv/gettext is discovered by
+          # a glob so a newly added domain is guarded without editing this job.
+          POT_LIST=/tmp/gettext-pot-files.txt
+          printf '%s\n' priv/gettext/*.pot | sort > "$POT_LIST"
 
-          # Dashboard domains to check
-          DASHBOARD_DOMAINS="dashboard dashboard_account dashboard_auth dashboard_builds dashboard_cache dashboard_integrations dashboard_previews dashboard_projects dashboard_tests"
-
-          # Backup all dashboard .pot files
-          for domain in $DASHBOARD_DOMAINS; do
-            if [ -f "priv/gettext/${domain}.pot" ]; then
-              cp "priv/gettext/${domain}.pot" "priv/gettext/${domain}.pot.backup"
-            fi
-          done
+          while read -r pot; do
+            cp "$pot" "${pot}.backup"
+          done < "$POT_LIST"
 
           run_gettext_extract /tmp/gettext-extract.log
 
-          exit_code=0
-
-          if ! diff -q priv/gettext/marketing.pot.backup priv/gettext/marketing.pot > /dev/null; then
-            echo "::error title=Marketing gettext template out of sync::The marketing.pot file is not up-to-date. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
-            exit_code=1
-          else
-            echo "✅ Marketing gettext template is up-to-date"
-          fi
-          rm priv/gettext/marketing.pot.backup
-
-          # Check each dashboard domain for changes
           CHANGED_DOMAINS=""
-          for domain in $DASHBOARD_DOMAINS; do
-            if [ -f "priv/gettext/${domain}.pot.backup" ]; then
-              if ! diff -q "priv/gettext/${domain}.pot.backup" "priv/gettext/${domain}.pot" > /dev/null 2>&1; then
-                CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
-              fi
-              rm "priv/gettext/${domain}.pot.backup"
-            elif [ -f "priv/gettext/${domain}.pot" ]; then
-              # New domain file was created
-              CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
+
+          while read -r pot; do
+            if ! diff -q "${pot}.backup" "$pot" > /dev/null 2>&1; then
+              CHANGED_DOMAINS="$CHANGED_DOMAINS $(basename "$pot" .pot)"
+            fi
+            rm -f "${pot}.backup"
+          done < "$POT_LIST"
+
+          # A domain created by the extraction has no backup to diff against.
+          for pot in priv/gettext/*.pot; do
+            if ! grep -qxF "$pot" "$POT_LIST"; then
+              CHANGED_DOMAINS="$CHANGED_DOMAINS $(basename "$pot" .pot)"
             fi
           done
 
+          rm -f "$POT_LIST"
+
           if [ -n "$CHANGED_DOMAINS" ]; then
-            echo "::error title=Dashboard gettext templates out of sync::The following .pot files are not up-to-date:$CHANGED_DOMAINS. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
-            exit_code=1
-          else
-            echo "✅ All dashboard gettext templates are up-to-date"
+            echo "::error title=Gettext templates out of sync::The following .pot files are not up-to-date:$CHANGED_DOMAINS. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
+            exit 1
           fi
 
-          exit "$exit_code"
+          echo "✅ All gettext templates are up-to-date"
       - name: Check marketing translations exist
         run: |
           # Check if marketing.pot exists

--- a/server/priv/gettext/dashboard_usage.pot
+++ b/server/priv/gettext/dashboard_usage.pot
@@ -27,7 +27,7 @@ msgstr ""
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:42
+#: lib/tuist_web/live/usage_live.ex:47
 #: lib/tuist_web/live/usage_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Usage"
@@ -45,10 +45,10 @@ msgstr ""
 msgid "Ingress"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:342
-#: lib/tuist_web/live/usage_live.ex:343
-#: lib/tuist_web/live/usage_live.ex:465
-#: lib/tuist_web/live/usage_live.ex:466
+#: lib/tuist_web/live/usage_live.ex:359
+#: lib/tuist_web/live/usage_live.ex:360
+#: lib/tuist_web/live/usage_live.ex:488
+#: lib/tuist_web/live/usage_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Cache traffic"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:473
+#: lib/tuist_web/live/usage_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "No cache traffic in this window yet"
 msgstr ""
@@ -123,12 +123,12 @@ msgstr ""
 msgid "Usage value"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:445
+#: lib/tuist_web/live/usage_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Linux"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:444
+#: lib/tuist_web/live/usage_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "macOS"
 msgstr ""
@@ -178,37 +178,37 @@ msgstr ""
 msgid "Billing period:"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:420
+#: lib/tuist_web/live/usage_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count} minutes."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:440
+#: lib/tuist_web/live/usage_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count}."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:432
+#: lib/tuist_web/live/usage_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Nothing ran last period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:426
+#: lib/tuist_web/live/usage_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "On track for about %{count} minutes this period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:77
+#: lib/tuist_web/live/usage_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "since the previous period"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:335
+#: lib/tuist_web/live/usage_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Projected"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:453
+#: lib/tuist_web/live/usage_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "Current period %{from} – %{to}"
 msgstr ""


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What changed

The Gettext CI job's coverage is no longer a hardcoded list. `Check gettext templates are up-to-date` now globs `priv/gettext/*.pot`, so all 17 domains are checked instead of 10, and a new domain is guarded the moment its template lands.

`server/priv/gettext/dashboard_usage.pot` is regenerated in the same commit.

## Why

The job iterated a hardcoded `DASHBOARD_DOMAINS` list plus a separately handled `marketing` domain. Seven domains were checked by nothing: `dashboard_gradle`, `dashboard_runners`, `dashboard_slack`, `dashboard_usage`, `default`, `docs`, `errors`. Adding a domain required remembering to edit the workflow, and forgetting was silent.

That gap was already costing us. `dashboard_usage.pot` was stale on `main`: commit 9f4e29c2b6 touched both `usage_live.ex` and the template, so the template was regenerated before that commit's final edits and the source references drifted (`:42` to `:47`, `:342` to `:359`, `:465` to `:488`, and others). Nothing failed, because `dashboard_usage` was not in the list.

## Notes for reviewers

Two things I folded in while rewriting the step, both worth a look:

**Marketing is no longer special-cased.** The glob already matches `marketing.pot`, so keeping its separate `cp`/`diff`/error branch would have double-reported it. One loop, one error message naming every changed domain.

**The pre-extract file list is snapshotted rather than re-globbed after extraction.** This preserves the old "new domain file was created" branch. As a side effect a deleted `.pot` is now caught for every domain, since extraction recreates it and it shows up as having no backup.

The obvious alternative was to keep the list and append the missing seven. That fixes today's gap without fixing the mechanism that created it, so the glob won.

I left the separate `Check dashboard translations templates exist` step's hardcoded list alone. A glob there would be a tautology (`for f in *.pot; do [ -f "$f" ]`) — its "these domains must exist" intent inherently needs a list. The deletion case it guards is now covered by the up-to-date check anyway, so that step is largely redundant and worth a follow-up decision rather than an unasked change here.

The `dashboard_usage.pot` diff is source references only. No msgids were added or removed, and no `.po` files are touched, per the Weblate/tuistit rule.

## How to test locally

Run the extract from `server/`, without `--merge`:

```
mix gettext.extract
```

It should report nothing extracted and leave `git status` clean, since the templates are now in sync.

To exercise the CI step itself, pull its script straight out of the workflow and run it:

```
yq -r '.jobs.gettext.steps[] | select(.name == "Check gettext templates are up-to-date") | .run' .github/workflows/server.yml > /tmp/gettext-step.sh
cd server && MIX_ENV=test bash /tmp/gettext-step.sh
```

## Validation

I ran the step's script verbatim against the working tree:

- Passes on the regenerated template (exit 0), leaving no `.backup` files behind.
- Reverting `dashboard_usage.pot` to its `HEAD` version makes it fail with `The following .pot files are not up-to-date: dashboard_usage` — the exact regression the old job could not see.
- A second `mix gettext.extract` is a no-op, so the templates are genuinely in sync.
- Spot-checked eight of the new line numbers against `usage_live.ex`; each lands exactly on its `dgettext` call.
- A sandbox dry-run confirmed modified, new, deleted and unchanged domains are each classified correctly.
- `shellcheck -s bash` clean. `actionlint` reports only pre-existing self-hosted-runner-label warnings across the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
