### PR TITLE
fix(infra): point release references at the workflow that actually runs them

### DIFF
--- a/.github/actions/reclaim-tart-disk/action.yml
+++ b/.github/actions/reclaim-tart-disk/action.yml
@@ -9,9 +9,9 @@ description: |
   and friends, ~80 GB each on the 512 GB M2-L) survive across
   runs whenever there's headroom. `tart prune --older-than` is
   access-time based, so sibling matrix legs (e.g. xcode 26.5
-  next to 26.4.1 in `release.yml`'s `runner-image-build`) and
-  back-to-back releases hit a warm cache and skip a ~10 min
-  pull per Xcode.
+  next to 26.4.1 in `server-production-deployment.yml`'s
+  `runner-image-build` matrix) and back-to-back releases hit a
+  warm cache and skip a ~10 min pull per Xcode.
 
 inputs:
   free-floor-gb:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2065,8 +2065,10 @@ runnersFleet:
   # `<runnerImageRepository>:macos-<xcode-dashes>-<runnerImageSemver>`.
   # Customers route via account-scoped Runner Profiles; the server
   # resolves (account, requested-label) → profile → pool. Keep this
-  # list in sync with the `runner-image-build.strategy.matrix.xcode`
-  # matrix in `.github/workflows/release.yml`.
+  # list in sync with `infra/runner-image/profiles.json` — the list
+  # `server-production-deployment.yml`'s `runner-image-build` matrix
+  # expands. A catalog entry with no runner image published for it
+  # renders a pool that can never pull.
   xcodeVersions:
     - xcodeVersion: "26.6"
       default: true

--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -129,12 +129,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: manager
-          # SHA-tagged build from the hetzner-robot-controller-image
-          # workflow during pre-release iteration. Once
-          # release.yml's release-hetzner-robot-controller has run
-          # for the first time, the bump-chart-image-pins step
-          # rewrites this line to a semver tag (`0.1.0`, `0.2.0`,
-          # …) and from there it's owned by the release pipeline.
+          # Semver tag published by
+          # `hetzner-robot-controller-release.yml`, which builds and
+          # pushes `:<semver>` + `:latest` and cuts the
+          # `hetzner-robot-controller@<semver>` tag. Nothing rewrites
+          # this line, so bump it by hand to the released version.
+          # `hetzner-robot-controller-image.yml` only builds
+          # `:sha-*`/`:latest` for pre-release iteration.
           image: ghcr.io/tuist/tuist-hetzner-robot-controller:0.1.0
           imagePullPolicy: IfNotPresent
           args:

--- a/infra/macos-host-bootstrap/actions_runner.go
+++ b/infra/macos-host-bootstrap/actions_runner.go
@@ -57,10 +57,16 @@ type GHActionsRunnerConfig struct {
 }
 
 // builderMixBuildRoot is the host-side path the bare-metal builder
-// exports as TUIST_MIX_BUILD_ROOT in /etc/zshenv. The
-// xcresult-processor build workflow (and the matching leg in
-// release.yml) read this env var so consecutive `mix release` runs
-// share their BEAM build cache across jobs on the same host.
+// exports as TUIST_MIX_BUILD_ROOT in /etc/zshenv, so consecutive
+// `mix release` runs can share their BEAM build cache across jobs on
+// the same host.
+//
+// Nothing reads the variable today: both macOS server-release paths
+// (`xcresult-processor-image.yml` and the matching leg in
+// `server-production-deployment.yml`) set their own MIX_BUILD_ROOT
+// under ~/.cache/tuist-ci/server-macos-release/<runner-name>, keyed
+// by runner name so two jobs landing on one host cannot race on the
+// release directory.
 //
 // Hardcoded (rather than CR-configurable) because the value is an
 // implementation detail of one specific workflow's caching scheme.
@@ -72,9 +78,9 @@ const builderMixBuildRoot = "/opt/tuist-build-cache"
 // installBuilderTooling lays down the host-level dependencies the
 // image-bake workflows expect to find on PATH: Homebrew, Packer
 // from `hashicorp/tap`, `crane` (for GHCR auth via
-// `crane auth login` before `tart push`, and to resolve a pushed
-// tag to its immutable digest in `release.yml`'s runner-image leg),
-// and `oras` (for `macos-xcode-image.yml`'s pull of the pre-mirrored
+// `crane auth login`, which writes the credentials Tart reads to
+// clone a private base image and to `tart push` the result), and
+// `oras` (for `macos-xcode-image.yml`'s pull of the pre-mirrored
 // Xcode .xip from `ghcr.io/tuist/xcode-xips`).
 //
 // `hashicorp/tap` instead of Homebrew core because HashiCorp pulled

--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -298,7 +298,7 @@ packer build runner.pkr.hcl
 CI:
 - **Steady state.** `feat(runner-image)` / `fix(runner-image)`
   conventional commits on `main` trigger a two-job chain in
-  `release.yml`:
+  `server-production-deployment.yml`:
   1. `runner-image-build` is a matrix job; its `matrix.xcode` is
      read from `infra/runner-image/profiles.json` (the single source
      of truth) by `check-releases` and expanded via `fromJSON`. One
@@ -309,13 +309,14 @@ CI:
      (`:macos-<dashes>`) tags. `fail-fast: true` — if any profile
      fails, sibling builds abort so the chart pin doesn't move to a
      partially-published set.
-  2. `release-runner-image` (ubuntu) pins `runnersFleet.runnerImage`
-     to the default profile's immutable per-release tag
-     (`:macos-<profile>-<semver>` — constructed from the version, no
-     registry lookup), rewrites the managed-env values files that
-     already carry a pin, generates release notes / `CHANGELOG.md`,
-     uploads artifacts. Downstream tag + GitHub-Release jobs key off
-     this job's `result == 'success'`.
+  2. `release-runner-image` (ubuntu) renders the published image
+     list for the GitHub Release body from `profiles.json`, generates
+     release notes / `CHANGELOG.md`, and uploads artifacts. It
+     rewrites no values file: the `runner-image@<semver>` tag that
+     `tag-infra-releases` creates is what the chart's
+     `runnersFleet.runnerImageSemver` resolves to at deploy time.
+     Downstream tag + GitHub-Release jobs key off this job's
+     `result == 'success'`.
 
   Concurrency scales with builder count: 2 hosts publish 2 profiles
   in parallel, more hosts cut the wall-clock proportionally. No
@@ -366,23 +367,25 @@ Active profiles are the single source of truth in
 file lives under `infra/runner-image/**` — the component's only
 include path in `mise/tasks/release/components.json` — editing the
 list both reshapes the build matrix and triggers a runner-image
-release, with no `release.yml` edit. Unrelated `release.yml` churn no
-longer rebuilds the images.
+release, with no `server-production-deployment.yml` edit. Unrelated
+churn in that workflow no longer rebuilds the images.
 
 - **Active.** Rebuilt on every `release-runner-image` run (every
   `feat(runner-image)` / `fix(runner-image)` commit landing on
   `main`). Each adds ~30 min on a single builder; matrix-fanned across
   the fleet so adding a third builder lets you carry a third profile
   at the same wall-clock cost.
-- **Default profile.** The first matrix entry. The chart's
-  `runnersFleet.runnerImage` pin tracks its immutable
-  `:macos-<dashes>-<semver>` tag, so a new fleet rollout = put the
-  desired profile first.
+- **Default profile.** The first entry, by convention. Which
+  version `runs-on: tuist-macos` actually resolves to is the
+  catalog entry marked `default: true` in
+  `runnersFleet.xcodeVersions`, so moving the default means editing
+  both this list and that catalog.
 - **Out-of-rotation profiles.** Any other `:macos-<dashes>` tag
   that's been published in the past and still exists in GHCR. They
-  don't refresh on `release.yml` runs — customers can keep pinning
-  to them, but new runner-agent / dispatch-loop / launchd changes
-  only land in them when the operator explicitly refreshes via
+  don't refresh on `server-production-deployment.yml` runs —
+  customers can keep pinning to them, but new runner-agent /
+  dispatch-loop / launchd changes only land in them when the
+  operator explicitly refreshes via
 
       gh workflow run runner-image.yml -f xcode_version=26.X.Y
 
@@ -404,8 +407,9 @@ Bumping the Xcode customers see on their runners:
    additional entry (most common — gives customers it alongside the
    existing default), or put it first to make it the newest / default
    profile. **If you move the first entry, also bump
-   `release.yml`'s xcresult-processor `XCODE_VERSION` to match** —
-   that image must be at least as new as the newest runner profile.
+   `server-production-deployment.yml`'s xcresult-processor
+   `XCODE_VERSION` to match** — that image must be at least as new
+   as the newest runner profile.
    Also add the matching `runnersFleet.xcodeVersions` entry in
    `values-managed-common.yaml` so the fleet renders a pool for it.
    Commit with a `feat(runner-image): ...` message so check-releases

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -37,12 +37,15 @@ packer {
 # ~30 min.
 #
 # Active Xcode versions baked per release are listed in
+# `infra/runner-image/profiles.json`. `check-releases` reads that list
+# into `server-production-deployment.yml`'s `runner-image-build`
+# matrix, which fans out one build per profile, publishing one
+# `ghcr.io/tuist/tuist-runner:macos-<xcode-dashes>-<semver>` tag each
+# that the managed envs' charts reference via
+# `runnersFleet.runnerImageSemver`. Keep the list aligned with
 # `runnersFleet.xcodeVersions` in
-# `infra/helm/tuist/values-managed-common.yaml`. `release.yml`'s
-# `runner-image-build` job fans out across those versions, publishing
-# one `ghcr.io/tuist/tuist-runner:macos-<xcode-dashes>-<semver>` tag
-# per profile that each managed env's chart references via
-# `runnersFleet.runnerImageSemver`.
+# `infra/helm/tuist/values-managed-common.yaml` — every Xcode that
+# ships a pool needs an image published for it.
 #
 # Image layout (mirrors GitHub-hosted macOS paths so on-disk
 # artifacts that bake absolute paths — SwiftPM `.build/checkouts/`,

--- a/infra/stable-egress-controller/AGENTS.md
+++ b/infra/stable-egress-controller/AGENTS.md
@@ -95,7 +95,7 @@ controller-runtime's fake client + a fake Floating IP manager.
 ## Releasing
 
 Wired into the standard component release flow (`mise/tasks/release/components.json`
-+ `release.yml`), like the other infra controllers: a conventional commit scoped
++ `server-production-deployment.yml`), like the other infra controllers: a conventional commit scoped
 `…(stable-egress-controller)` touching `infra/stable-egress-controller/**`
 triggers a `stable-egress-controller@<semver>` tag + a
 `ghcr.io/tuist/tuist-stable-egress-controller:<semver>` image. The deployed tag

--- a/infra/vm-image-builder.md
+++ b/infra/vm-image-builder.md
@@ -60,7 +60,7 @@ if not:
 |---|---|---|
 | `tart`              | `/usr/local/bin/tart`             | Operator-image-baked `tart.app` tarball (`installTart` in `macos-host-bootstrap`). Same install path the macosFleet and runnersFleet hosts use; Tart's version is pinned by what the operator image ships. |
 | `packer`            | `/opt/homebrew/bin/packer`        | Homebrew (`hashicorp/tap/packer`) installed by the builder tail (`installBuilderTooling`) and `brew pin`'d. A follow-up will bake Packer into the operator image too, dropping Homebrew from the bootstrap entirely. |
-| `crane`             | `/opt/homebrew/bin/crane`         | Homebrew core, installed by `installBuilderTooling`. Used by the image-build workflows to write GHCR credentials into `~/.docker/config.json` for `tart push` (`crane auth login`), and by `release.yml`'s runner-image leg to resolve a pushed tag to its immutable digest (`crane digest`). |
+| `crane`             | `/opt/homebrew/bin/crane`         | Homebrew core, installed by `installBuilderTooling`. Used by the image-build workflows to write GHCR credentials into `~/.docker/config.json` (`crane auth login`), which Tart reads via the Docker credential-helper protocol for both the clone of a private base image and the `tart push` at the end. |
 | `oras`              | `/opt/homebrew/bin/oras`          | Homebrew core, installed by `installBuilderTooling`. Used by `macos-xcode-image.yml` to pull the pre-mirrored Xcode `.xip` artifacts from `ghcr.io/tuist/xcode-xips`. |
 | Actions runner      | `/opt/actions-runner/`            | Downloaded directly from `actions/runner`'s GitHub releases by `installActionsRunner` and registered as a launchd LaunchAgent under `m1`. |
 

--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -73,20 +73,23 @@ produced by every customer runner profile. xcresulttool's JSON
 schema changes across Xcode majors, so the processor should run on
 at least as new an Xcode as any active runner-image profile.
 
-The Xcode version is declared inline in `.github/workflows/release.yml`'s
+The Xcode version is declared inline in
+`.github/workflows/server-production-deployment.yml`'s
 `release-xcresult-processor-image.Build image` step (current value is
 the `XCODE_VERSION` env var on that step). Bump it alongside the
-runner-image matrix when promoting a new Xcode to the fleet:
+runner-image profile list when promoting a new Xcode to the fleet:
 
 1. Publish a Layer 1 image with the new Xcode — first run
    `mise run xcode-mirror:upload 26.X.Y` on a maintainer Mac to put
    the .xip into `ghcr.io/tuist/xcode-xips:26.X.Y`, then
    `gh workflow run macos-xcode-image.yml -f xcode_version=26.X.Y`.
    See `infra/macos-xcode-image/AGENTS.md` for the runbook.
-2. Update the runner-image active matrix and this image's
-   `XCODE_VERSION` env var in `release.yml` in the same commit so
-   the processor never lags an active runner profile. Merge with
-   a `feat(xcresult-processor-image): bump to Xcode 26.X.Y` message;
+2. Add the version to `infra/runner-image/profiles.json` (the list
+   the runner-image build matrix expands) and bump this image's
+   `XCODE_VERSION` env var in `server-production-deployment.yml` in
+   the same commit so the processor never lags an active runner
+   profile. Merge with a
+   `feat(xcresult-processor-image): bump to Xcode 26.X.Y` message;
    check-releases picks it up from `infra/xcresult-processor-image/**`.
 
 To rebuild against a different Xcode without bumping the inline

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "GitHub Actions runner version baked into the Tart runner image. Bumps land as `fix(runner-image): …` commits which release.yml's release-runner-image flow picks up to rebuild the image and push a new `runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
+      "description": "GitHub Actions runner version baked into the Tart runner image. Bumps land as `fix(runner-image): …` commits which server-production-deployment.yml's release-runner-image flow picks up to rebuild the image and push a new `runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
       "fileMatch": ["^infra/runner-image/runner\\.pkr\\.hcl$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
@@ -18,7 +18,7 @@
     },
     {
       "customType": "regex",
-      "description": "ARG-based version pins in the Linux runner image (actions/runner, kubectl, helm, gh). Bumps land as `fix(linux-runner-image): …` commits which release.yml's release-linux-runner-image flow picks up to rebuild the image and push a new `linux-runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
+      "description": "ARG-based version pins in the Linux runner image (actions/runner, kubectl, helm, gh). Bumps land as `fix(linux-runner-image): …` commits which server-production-deployment.yml's release-linux-runner-image flow picks up to rebuild the image and push a new `linux-runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
       "fileMatch": ["^infra/linux-runner-image/Dockerfile$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG\\s+[A-Z_]+=(?<currentValue>[^\\s]+)"

--- a/server/priv/docs/en/contributors/releases.md
+++ b/server/priv/docs/en/contributors/releases.md
@@ -151,9 +151,9 @@ Users need to clear their cache after updating.
 
 ## Release workflows
 
-The server, app, cache, Gradle plugin, skills, Noora, and infrastructure components release through `.github/workflows/release.yml`. It runs on pushes to main, uses git cliff for change detection, and handles the full process including artifacts and GitHub releases.
+The server, Kura, the Helm chart, and the infrastructure images release through `.github/workflows/server-production-deployment.yml`. It runs on pushes to main and cascades canary → acceptance tests → production. The app, cache, Gradle plugin, skills, Noora, and the standalone infra controllers each have a dedicated `*-release.yml` workflow. All of them share change detection: `mise/tasks/release/components.json` declares each component's tag prefix and include paths, and git cliff turns the matching commits into release notes.
 
-The CLI has its own set of workflows (it is excluded from `release.yml`):
+The CLI has its own set of workflows:
 
 - `cli-release.yml` - publishes a canary on every CLI-touching push to main
 - `cli-rc.yml` - manually cuts or iterates a release candidate


### PR DESCRIPTION
`.github/workflows/release.yml` no longer exists, but a dozen infra docs and code comments still pointed at it. The legs it used to describe (runner-image, linux-runner-image, xcresult-processor-image, the infra controllers) now live in `.github/workflows/server-production-deployment.yml`.

Several of these had drifted well past a rename: they described steps that were restructured or removed outright. Each reference was verified against the current workflow rather than renamed in place, so this fixes the mechanism descriptions too, not just the filename.

### What changed

**The runner-image build matrix is data-driven now.** `runner.pkr.hcl` and the chart's `runnersFleet.xcodeVersions` comment both named `values-managed-common.yaml` as the source of truth for what gets built. It isn't: `check-releases` reads `infra/runner-image/profiles.json` into the `runner-image-matrix` output and the matrix expands it via `fromJSON`. The chart catalog is the thing kept *in sync with* profiles.json, so the direction of that instruction is inverted, and the "a catalog entry with no runner image published for it renders a pool that can never pull" warning is carried over from the reference runbook.

**`release-runner-image` rewrites no values file.** `infra/runner-image/AGENTS.md` described it pinning `runnersFleet.runnerImage` to the default profile's immutable tag and rewriting the managed-env values files. That job only renders the Release body image list, generates release notes and CHANGELOG, and uploads artifacts. The `runner-image@<semver>` tag cut by `tag-infra-releases` is what `runnersFleet.runnerImageSemver` resolves to at deploy time. There is also no longer a "Resolve default profile + digest" step, and no `runnersFleet.runnerImage` digest pin for it to write. Relatedly, "default profile = the first matrix entry" was wrong about the mechanism: `runner-pool.yaml` resolves the default from the catalog entry marked `default: true`, so moving the default means editing both lists.

**Nothing calls `crane digest` any more.** Both `infra/vm-image-builder.md` and `installBuilderTooling`'s doc comment claimed crane was on the builder hosts partly to resolve a pushed tag to its immutable digest. `crane digest` appears nowhere in the repo. Crane is there purely for `crane auth login`, which writes the credentials Tart reads to clone a private base image and to push the result.

**`hetzner-robot-controller` moved to its own workflow.** `infra/k8s/mgmt/hetzner-robot-controller.yaml` claimed a `bump-chart-image-pins` step would rewrite its image line once the release leg had run. No such step exists anywhere in the repo, and the component releases from `hetzner-robot-controller-release.yml`, which publishes `:<semver>` + `:latest` and cuts the tag but touches no manifest. That pin is hand-maintained, and the comment now says so.

**The contributor releases doc** listed the app, cache, Gradle plugin, skills and Noora as releasing through the same workflow as the server. Each has had a dedicated `*-release.yml` for a while; what they actually share is change detection via `mise/tasks/release/components.json` + git cliff.

Also renamed in `infra/stable-egress-controller/AGENTS.md`, `infra/xcresult-processor-image/AGENTS.md`, `.github/actions/reclaim-tart-disk/action.yml`, and the two Renovate rule descriptions for the runner images.

### Two things worth a follow-up

Both are stated accurately in the touched comments rather than left as false claims, but neither is fixed here because both are behaviour changes rather than documentation:

- **`TUIST_MIX_BUILD_ROOT` looks dead.** `writeBuildCacheEnv` still exports it to `/etc/zshenv`, and `builderMixBuildRoot` still hardcodes `/opt/tuist-build-cache`, but nothing reads the variable. Both macOS server-release paths (`xcresult-processor-image.yml` and the matching leg in `server-production-deployment.yml`) set their own `MIX_BUILD_ROOT` under `~/.cache/tuist-ci/server-macos-release/<runner-name>`, keyed by runner name so two jobs on one host cannot race on the release directory.
- **The hetzner-robot-controller image pin is manual.** Worth deciding whether the release workflow should bump it, or whether the platform chart should resolve it at deploy time the way the other infra controllers do.

### Scope note

`infra/macos-xcode-image/AGENTS.md` is deliberately untouched. It still carries the same stale references at lines 155 and 211 on `main`, but it was already corrected in a6a96d7ecb on `claude/xcode-27-beta-vm-9b85ba`, and editing it here would conflict with that branch. Its "Promoting a new Xcode to customer runners" section is the reference the runner-image and xcresult-processor runbooks in this PR were aligned to.

### How to test locally

Docs and comments only, no behaviour change. To confirm nothing stale is left and nothing was broken:

```bash
grep -rn "release\.yml" --include="*.md" --include="*.go" --include="*.hcl" --include="*.yaml" --include="*.yml" --include="*.json" . | grep -v node_modules | grep -v "\.github/workflows/" | grep -vE "app-release|cache-release|cli-release|gradle-release|noora-release|skills-release|grafana-datasource-release|hetzner-robot-controller-release|server-production-deployment"
```

That should return only the two `infra/macos-xcode-image/AGENTS.md` hits explained above.

Validation run on this branch: `gofmt -l infra/macos-host-bootstrap/actions_runner.go` (clean), `go build ./...` in `infra/macos-host-bootstrap` (ok), `packer fmt -check runner.pkr.hcl` in `infra/runner-image` (clean), a JSON parse of `renovate.json`, and a YAML parse of `infra/helm/tuist/values.yaml`, `.github/actions/reclaim-tart-disk/action.yml` and `infra/k8s/mgmt/hetzner-robot-controller.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
