### PR TITLE
fix(server): keep the test case history column within the analytics beside it

### DIFF
--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -23,7 +23,7 @@ defmodule TuistWeb.TestCaseLive do
 
   # The overview's history sits in its own column beside the widgets and the
   # chart, and runs as deep as they do. Anything past that is a tab away.
-  @overview_history_page_size 8
+  @overview_history_page_size 6
 
   def mount(
         %{"test_case_id" => test_case_id} = _params,

--- a/server/test/tuist_web/live/test_case_live_test.exs
+++ b/server/test/tuist_web/live/test_case_live_test.exs
@@ -744,7 +744,7 @@ defmodule TuistWeb.TestCaseLiveTest do
         |> Floki.parse_document!()
         |> Floki.find("[data-part='analytics-history'] [data-part='timeline-item']")
 
-      assert length(items) == 8
+      assert length(items) == 6
       assert has_element?(lv, "[data-part='analytics-history'] a", "View more")
     end
 


### PR DESCRIPTION
The test case overview lays the history timeline out in its own column beside the widgets and the duration chart. With enough events, that column grew taller than everything next to it and stretched the whole analytics card, leaving the chart floating in empty space.

### What changed

`@overview_history_page_size` drops from 8 to 6, and the test that seeds 12 events and asserts the truncation now expects 6.

### Why 6

Both columns are fixed-height in CSS, so this is arithmetic rather than a guess.

Left column: two widget rows (20 padding + 16 header + 12 gap + 38 value + 20 padding = 106px each, 8px grid gap) + 16px gap + the 200px chart = **436px**.

History column with N events and the "View more" button: 20 (title) + 12 + (56N - 16) (timeline, last item drops its 16px bottom padding) + 12 + 24 (small button) = **56N + 52**.

That puts 8 events at 504px, the ~70px overhang that prompted this. 7 lands at 444px, still 8px over. 6 lands at 388px and fits with headroom. When the widgets render trend rows the left column grows to roughly 500px, so 6 is inside the box in both cases; the trendless layout is the tighter constraint and the one this solves for.

The alternative was capping the timeline with a `max-height` tied to the left column. That is robust to any event count but trades the clean cut for an inner scroll area, which reads worse in a summary column whose whole point is the "View more" link into the full history tab.

### Known limitation

The height math assumes single-line entries. A test case whose events carry long subtitles can still wrap and push past the chart. Fixing that generally means the `max-height` approach above.

### How to test locally

```
cd server && mix test test/tuist_web/live/test_case_live_test.exs
```

35 tests pass with `--warnings-as-errors`, and `mix format --check-formatted` is clean on both files.

Visually: open a test case with more than six history events and confirm the timeline ends above the chart legend rather than below it.