### PR TITLE
fix(cli): keep the binary cache within its byte budget and survive a full cache volume

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -960,6 +960,7 @@ import XcodeGraph
             cacheStorage: CacheStoring,
             scratchDirectory: AbsolutePath
         ) async throws -> [CacheStorableTarget] {
+            try await pruneLocalCache(makingRoomFor: artifacts.map(\.path))
             try await fileSystem.makeDirectory(at: scratchDirectory.appending(component: "Metadatas"))
             let storableTargets = Dictionary(
                 uniqueKeysWithValues: try await artifacts
@@ -981,6 +982,13 @@ import XcodeGraph
             )
 
             return try await cacheStorage.store(storableTargets, cacheCategory: .binaries)
+        }
+
+        private func pruneLocalCache(makingRoomFor paths: [AbsolutePath]) async throws {
+            guard let maxBytes = Environment.current.variables["TUIST_CACHE_MAX_BYTES"].flatMap({ Int($0) })
+            else { return }
+            try await CacheLocalStorage(cacheDirectoriesProvider: CacheDirectoriesProvider())
+                .clean(maxBytes: maxBytes, makingRoomFor: paths)
         }
 
         private func cacheableTargets(

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -960,7 +960,6 @@ import XcodeGraph
             cacheStorage: CacheStoring,
             scratchDirectory: AbsolutePath
         ) async throws -> [CacheStorableTarget] {
-            try await pruneLocalCache(makingRoomFor: artifacts.map(\.path))
             try await fileSystem.makeDirectory(at: scratchDirectory.appending(component: "Metadatas"))
             let storableTargets = Dictionary(
                 uniqueKeysWithValues: try await artifacts
@@ -982,13 +981,6 @@ import XcodeGraph
             )
 
             return try await cacheStorage.store(storableTargets, cacheCategory: .binaries)
-        }
-
-        private func pruneLocalCache(makingRoomFor paths: [AbsolutePath]) async throws {
-            guard let maxBytes = Environment.current.variables["TUIST_CACHE_MAX_BYTES"].flatMap({ Int($0) })
-            else { return }
-            try await CacheLocalStorage(cacheDirectoriesProvider: CacheDirectoriesProvider())
-                .clean(maxBytes: maxBytes, makingRoomFor: paths)
         }
 
         private func cacheableTargets(

--- a/cli/Sources/TuistServer/CacheStoring.swift
+++ b/cli/Sources/TuistServer/CacheStoring.swift
@@ -56,6 +56,13 @@
             _ items: Set<CacheStorableItem>,
             cacheCategory: RemoteCacheCategory
         ) async throws -> [CacheItem: AbsolutePath]
+        /// Entries for `resolvedHashes` have already been handed to the caller, so a storage that
+        /// evicts to make room for what it fetches must not reclaim them.
+        func fetch(
+            _ items: Set<CacheStorableItem>,
+            cacheCategory: RemoteCacheCategory,
+            preserving resolvedHashes: Set<String>
+        ) async throws -> [CacheItem: AbsolutePath]
         func store(
             _ items: [CacheStorableItem: [AbsolutePath]],
             cacheCategory: RemoteCacheCategory
@@ -63,6 +70,15 @@
     }
 
     extension CacheStoring {
+        /// A storage that never evicts has nothing to preserve.
+        public func fetch(
+            _ items: Set<CacheStorableItem>,
+            cacheCategory: RemoteCacheCategory,
+            preserving _: Set<String>
+        ) async throws -> [CacheItem: AbsolutePath] {
+            try await fetch(items, cacheCategory: cacheCategory)
+        }
+
         public func fetch(
             _ targets: Set<CacheStorableTarget>,
             cacheCategory: RemoteCacheCategory

--- a/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
@@ -152,6 +152,21 @@ struct BinaryCachePrunerTests {
         #expect(reclaimed > 0)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func pruneToBudget_neverRemovesAPreservedEntryEvenAsTheLeastRecentlyUsed() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "1500000"
+        let binariesDirectory = try await seedEntries(count: 3, in: temporaryDirectory)
+
+        // hash2 is the least recently used, so the byte prune reaches it first.
+        try await subject(binariesDirectory: binariesDirectory).pruneToBudget(preserving: ["hash2"])
+
+        // Then: the build is already holding hash2, so it survives while the rest of the tail goes.
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash2")))
+        #expect(!(try await fileSystem.exists(binariesDirectory.appending(component: "hash1"))))
+    }
+
     /// `count` ~1 MB entries, staggered so entry 0 is the most recently used.
     private func seedEntries(count: Int, in temporaryDirectory: AbsolutePath) async throws -> AbsolutePath {
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")

--- a/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
@@ -1,0 +1,114 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Mockable
+import Path
+import Testing
+import TuistCore
+import TuistEnvironment
+import TuistEnvironmentTesting
+
+@testable import TuistCacheEE
+@testable import TuistTesting
+
+struct BinaryCachePrunerTests {
+    private let fileSystem = FileSystem()
+
+    @Test(.inTemporaryDirectory)
+    func pruneToBudget_evictsEntriesToMakeRoomForIncomingArtifacts() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = try await seedEntries(count: 3, in: temporaryDirectory)
+
+        let incoming = temporaryDirectory.appending(component: "incoming")
+        try await fileSystem.makeDirectory(at: incoming)
+        FileManager.default.createFile(
+            atPath: incoming.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        // When: a budget that holds ~2 entries, one of which the incoming artifact claims.
+        try await subject(binariesDirectory: binariesDirectory)
+            .clean(maxBytes: 2_500_000 - 1_000_000, minimumEntries: 0)
+
+        // Then
+        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(remaining.count == 1)
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func pruneToBudget_evictsEveryEntryWhenTheIncomingArtifactsNeedTheWholeBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "2500000"
+        let binariesDirectory = try await seedEntries(count: 1, in: temporaryDirectory)
+
+        let incoming = temporaryDirectory.appending(component: "incoming")
+        try await fileSystem.makeDirectory(at: incoming)
+        FileManager.default.createFile(
+            atPath: incoming.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 2_000_000)
+        )
+
+        // When: the incoming artifact claims all but 0.5 MB of the budget, which the
+        // cached 1 MB entry does not fit into.
+        try await subject(binariesDirectory: binariesDirectory).pruneToBudget(makingRoomFor: [incoming])
+
+        // Then
+        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(remaining.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func pruneToBudget_keepsTheMostRecentlyUsedEntryWhenItAloneExceedsTheBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "100"
+        let binariesDirectory = try await seedEntries(count: 1, in: temporaryDirectory)
+
+        // When
+        try await subject(binariesDirectory: binariesDirectory).pruneToBudget()
+
+        // Then: dropping it would only force a full re-pull on the next generate.
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func pruneToBudget_isANoOpWithoutABudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = try await seedEntries(count: 3, in: temporaryDirectory)
+
+        // When
+        try await subject(binariesDirectory: binariesDirectory).pruneToBudget()
+
+        // Then
+        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(remaining.count == 3)
+    }
+
+    /// `count` ~1 MB entries, staggered so entry 0 is the most recently used.
+    private func seedEntries(count: Int, in temporaryDirectory: AbsolutePath) async throws -> AbsolutePath {
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+        for index in 0 ..< count {
+            let entry = binariesDirectory.appending(component: "hash\(index)")
+            let artifact = entry.appending(component: "framework.xcframework")
+            try await fileSystem.makeDirectory(at: artifact)
+            FileManager.default.createFile(
+                atPath: artifact.appending(component: "binary").pathString,
+                contents: Data(repeating: 0x41, count: 1_000_000)
+            )
+            let date = Calendar.current.date(byAdding: .hour, value: -index, to: Date())!
+            try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: entry.pathString)
+        }
+        return binariesDirectory
+    }
+
+    private func subject(binariesDirectory: AbsolutePath) -> BinaryCachePruner {
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+        return BinaryCachePruner(cacheDirectoriesProvider: cacheDirectoriesProvider, fileSystem: fileSystem)
+    }
+}

--- a/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
@@ -86,6 +86,58 @@ struct BinaryCachePrunerTests {
         #expect(remaining.count == 3)
     }
 
+    @Test(.inTemporaryDirectory)
+    func size_measuresARegularFileRatherThanItsEmptyGlob() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        // Macros are cached as `.macro` executables and every entry carries a metadata plist, so
+        // artifacts are not always directories.
+        let macro = temporaryDirectory.appending(component: "Target.macro")
+        FileManager.default.createFile(
+            atPath: macro.pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        let size = try await subject(binariesDirectory: temporaryDirectory).size(of: macro)
+
+        #expect(size == 1_000_000)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func headroom_isWhatTheBudgetHasLeftAfterTheEntriesTheCacheHolds() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "2500000"
+        let binariesDirectory = try await seedEntries(count: 2, in: temporaryDirectory)
+
+        let headroom = try #require(try await subject(binariesDirectory: binariesDirectory).headroom())
+
+        // The two entries hold ~2 MB, plus the inode size of the directories carrying them.
+        #expect(headroom > 490_000 && headroom <= 500_000)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func headroom_isUnboundedWithoutABudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = try await seedEntries(count: 1, in: temporaryDirectory)
+
+        #expect(try await subject(binariesDirectory: binariesDirectory).headroom() == nil)
+    }
+
+    @Test func admission_claimsAgainstTheRemainingBudget() async throws {
+        let admission = CacheBudgetAdmission(remaining: 1000)
+
+        #expect(await admission.admit(600))
+        #expect(await admission.admit(400))
+        #expect(await admission.admit(1) == false)
+    }
+
+    @Test func admission_admitsEverythingWhenUnbounded() async throws {
+        let admission = CacheBudgetAdmission(remaining: nil)
+
+        #expect(await admission.admit(Int.max))
+        #expect(await admission.admit(Int.max))
+    }
+
     /// `count` ~1 MB entries, staggered so entry 0 is the most recently used.
     private func seedEntries(count: Int, in temporaryDirectory: AbsolutePath) async throws -> AbsolutePath {
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")

--- a/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/BinaryCachePrunerTests.swift
@@ -138,6 +138,20 @@ struct BinaryCachePrunerTests {
         #expect(await admission.admit(Int.max))
     }
 
+    @Test(.inTemporaryDirectory)
+    func evictLeastRecentlyUsed_neverReclaimsAPreservedEntry() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = try await seedEntries(count: 2, in: temporaryDirectory)
+
+        // hash1 is the least recently used, so it would go first if it were a candidate.
+        let reclaimed = try await subject(binariesDirectory: binariesDirectory)
+            .evictLeastRecentlyUsed(atLeast: 5_000_000, notModifiedAfter: Date(), preserving: ["hash1"])
+
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash1")))
+        #expect(!(try await fileSystem.exists(binariesDirectory.appending(component: "hash0"))))
+        #expect(reclaimed > 0)
+    }
+
     /// `count` ~1 MB entries, staggered so entry 0 is the most recently used.
     private func seedEntries(count: Int, in temporaryDirectory: AbsolutePath) async throws -> AbsolutePath {
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")

--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -618,6 +618,74 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func clean_evictsEveryEntryWhenTheIncomingArtifactsNeedTheWholeBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        let entry = binariesDirectory.appending(component: "hash0")
+        try await fileSystem.makeDirectory(at: entry)
+        FileManager.default.createFile(
+            atPath: entry.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        let incoming = temporaryDirectory.appending(component: "incoming")
+        try await fileSystem.makeDirectory(at: incoming)
+        FileManager.default.createFile(
+            atPath: incoming.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 2_000_000)
+        )
+
+        // When: the incoming artifact claims all but 0.5 MB of the budget, which the
+        // cached 1 MB entry does not fit into.
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: MockArtifactSigning(),
+            fileSystem: fileSystem
+        )
+        try await subject.clean(maxBytes: 2_500_000, makingRoomFor: [incoming])
+
+        // Then
+        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(remaining.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func clean_keepsTheMostRecentlyUsedEntryWhenItAloneExceedsTheByteBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        let entry = binariesDirectory.appending(component: "hash0")
+        try await fileSystem.makeDirectory(at: entry)
+        FileManager.default.createFile(
+            atPath: entry.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: MockArtifactSigning(),
+            fileSystem: fileSystem
+        )
+        try await subject.clean(maxBytes: 100)
+
+        // Then: dropping it would only force a full re-pull on the next generate.
+        #expect(try await fileSystem.exists(entry))
+    }
+
+    @Test(.inTemporaryDirectory)
     func clean_keepsRecentEntries() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")

--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -407,6 +407,57 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func store_keepsTheRemoteUploadWhenTheLocalCacheIsFull() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        // A real 2 MB volume, so the copy fails with the ENOSPC the runner cache image raises.
+        let imagePath = temporaryDirectory.appending(component: "cache")
+        let mountPoint = temporaryDirectory.appending(component: "volume")
+        try hdiutil([
+            "create", "-size", "2m", "-fs", "APFS", "-volname", "TuistCache", "-type", "SPARSE",
+            "-quiet", imagePath.pathString,
+        ])
+        try await fileSystem.makeDirectory(at: mountPoint)
+        try hdiutil([
+            "attach", imagePath.pathString + ".sparseimage", "-nobrowse", "-noverify", "-quiet",
+            "-mountpoint", mountPoint.pathString,
+        ])
+        defer { try? hdiutil(["detach", mountPoint.pathString, "-force", "-quiet"]) }
+
+        let binariesDirectory = mountPoint.appending(component: "Binaries")
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        let artifact = temporaryDirectory.appending(components: "build", "Big.xcframework")
+        try await fileSystem.makeDirectory(at: artifact)
+        FileManager.default.createFile(
+            atPath: artifact.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 5_000_000)
+        )
+
+        let artifactSigner = MockArtifactSigning()
+        given(artifactSigner).sign(.any).willReturn()
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem
+        )
+
+        // When
+        let got = try await subject.store(
+            [.init(name: "Big", hash: "hash"): [artifact]],
+            cacheCategory: .binaries
+        )
+
+        // Then
+        #expect(got.isEmpty)
+        #expect(!(try await fileSystem.exists(binariesDirectory.appending(component: "hash"))))
+    }
+
+    @Test(.inTemporaryDirectory)
     func clean_removesOldEntries() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
@@ -645,4 +696,14 @@ struct CacheLocalStorageTests {
         let timeSinceModification = Date().timeIntervalSince(modificationDate)
         #expect(timeSinceModification < 5)
     }
+}
+
+@discardableResult
+private func hdiutil(_ arguments: [String]) throws -> Int32 {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+    process.arguments = arguments
+    try process.run()
+    process.waitUntilExit()
+    return process.terminationStatus
 }

--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -522,6 +522,51 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func clean_evictsEntriesToMakeRoomForIncomingArtifacts() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        // Three ~1 MB entries, staggered so entry 0 is most recently used.
+        for i in 0 ..< 3 {
+            let entry = binariesDirectory.appending(component: "hash\(i)")
+            let artifact = entry.appending(component: "framework.xcframework")
+            try await fileSystem.makeDirectory(at: artifact)
+            FileManager.default.createFile(
+                atPath: artifact.appending(component: "binary").pathString,
+                contents: Data(repeating: 0x41, count: 1_000_000)
+            )
+            let date = Calendar.current.date(byAdding: .hour, value: -i, to: Date())!
+            try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: entry.pathString)
+        }
+
+        let incoming = temporaryDirectory.appending(component: "incoming")
+        try await fileSystem.makeDirectory(at: incoming)
+        FileManager.default.createFile(
+            atPath: incoming.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        // When: a budget that holds ~2 entries, one of which the incoming artifact claims.
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: MockArtifactSigning(),
+            fileSystem: fileSystem
+        )
+        try await subject.clean(maxBytes: 2_500_000, makingRoomFor: [incoming])
+
+        // Then
+        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(remaining.count == 1)
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
+    }
+
+    @Test(.inTemporaryDirectory)
     func clean_keepsRecentEntries() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")

--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -7,6 +7,7 @@ import Testing
 import TuistCore
 import TuistEnvironment
 import TuistEnvironmentTesting
+import TuistServer
 
 @testable import TuistCacheEE
 @testable import TuistSupport
@@ -454,6 +455,49 @@ struct CacheLocalStorageTests {
         #expect(got.count == 1)
         #expect(!(try await fileSystem.exists(staleEntry)))
         #expect(try await fileSystem.exists(binariesDirectory.appending(components: "new", "New.xcframework")))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func store_admitsOnlyTheArtifactsThatFitTheByteBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "2500000"
+
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        // Macro artifacts are executables rather than bundles, so this also covers a batch whose
+        // size only counts if a regular file measures as itself.
+        var items: [CacheStorableItem: [AbsolutePath]] = [:]
+        for index in 0 ..< 3 {
+            let macro = temporaryDirectory.appending(component: "Target\(index).macro")
+            FileManager.default.createFile(
+                atPath: macro.pathString,
+                contents: Data(repeating: 0x41, count: 1_000_000)
+            )
+            items[.init(name: "Target\(index)", hash: "hash\(index)")] = [macro]
+        }
+
+        let artifactSigner = MockArtifactSigning()
+        given(artifactSigner).sign(.any).willReturn()
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem
+        )
+
+        // When: three 1 MB artifacts against a 2.5 MB budget.
+        let got = try await subject.store(items, cacheCategory: .binaries)
+
+        // Then: the batch is admitted a fitting subset at a time rather than written whole.
+        #expect(got.count == 2)
+        let entries = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
+        #expect(entries.count == 2)
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -5,6 +5,8 @@ import Mockable
 import Path
 import Testing
 import TuistCore
+import TuistEnvironment
+import TuistEnvironmentTesting
 
 @testable import TuistCacheEE
 @testable import TuistSupport
@@ -406,25 +408,62 @@ struct CacheLocalStorageTests {
         #expect(result.first?.hash == hash)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func store_evictsLeastRecentlyUsedEntriesToStayWithinTheByteBudget() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "1500000"
+
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+        let staleEntry = binariesDirectory.appending(component: "stale")
+        try await fileSystem.makeDirectory(at: staleEntry)
+        FileManager.default.createFile(
+            atPath: staleEntry.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        let artifact = temporaryDirectory.appending(components: "build", "New.xcframework")
+        try await fileSystem.makeDirectory(at: artifact)
+        FileManager.default.createFile(
+            atPath: artifact.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_000_000)
+        )
+
+        let artifactSigner = MockArtifactSigning()
+        given(artifactSigner).sign(.any).willReturn()
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem
+        )
+
+        // When: the incoming artifact leaves 0.5 MB of the budget, which the stale entry exceeds.
+        let got = try await subject.store(
+            [.init(name: "New", hash: "new"): [artifact]],
+            cacheCategory: .binaries
+        )
+
+        // Then
+        #expect(got.count == 1)
+        #expect(!(try await fileSystem.exists(staleEntry)))
+        #expect(try await fileSystem.exists(binariesDirectory.appending(components: "new", "New.xcframework")))
+    }
+
     @Test(.inTemporaryDirectory)
     func store_keepsTheRemoteUploadWhenTheLocalCacheIsFull() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 
-        // A real 2 MB volume, so the copy fails with the ENOSPC the runner cache image raises.
-        let imagePath = temporaryDirectory.appending(component: "cache")
-        let mountPoint = temporaryDirectory.appending(component: "volume")
-        try hdiutil([
-            "create", "-size", "2m", "-fs", "APFS", "-volname", "TuistCache", "-type", "SPARSE",
-            "-quiet", imagePath.pathString,
-        ])
-        try await fileSystem.makeDirectory(at: mountPoint)
-        try hdiutil([
-            "attach", imagePath.pathString + ".sparseimage", "-nobrowse", "-noverify", "-quiet",
-            "-mountpoint", mountPoint.pathString,
-        ])
-        defer { try? hdiutil(["detach", mountPoint.pathString, "-force", "-quiet"]) }
+        let volume = try TinyVolume.attached()
+        defer { volume.detach() }
 
-        let binariesDirectory = mountPoint.appending(component: "Binaries")
+        let binariesDirectory = volume.mountPoint.appending(component: "Binaries")
         let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
         given(cacheDirectoriesProvider)
             .cacheDirectory(for: .value(.binaries))
@@ -573,119 +612,6 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func clean_evictsEntriesToMakeRoomForIncomingArtifacts() async throws {
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
-        try await fileSystem.makeDirectory(at: binariesDirectory)
-
-        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
-        given(cacheDirectoriesProvider)
-            .cacheDirectory(for: .value(.binaries))
-            .willReturn(binariesDirectory)
-
-        // Three ~1 MB entries, staggered so entry 0 is most recently used.
-        for i in 0 ..< 3 {
-            let entry = binariesDirectory.appending(component: "hash\(i)")
-            let artifact = entry.appending(component: "framework.xcframework")
-            try await fileSystem.makeDirectory(at: artifact)
-            FileManager.default.createFile(
-                atPath: artifact.appending(component: "binary").pathString,
-                contents: Data(repeating: 0x41, count: 1_000_000)
-            )
-            let date = Calendar.current.date(byAdding: .hour, value: -i, to: Date())!
-            try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: entry.pathString)
-        }
-
-        let incoming = temporaryDirectory.appending(component: "incoming")
-        try await fileSystem.makeDirectory(at: incoming)
-        FileManager.default.createFile(
-            atPath: incoming.appending(component: "binary").pathString,
-            contents: Data(repeating: 0x41, count: 1_000_000)
-        )
-
-        // When: a budget that holds ~2 entries, one of which the incoming artifact claims.
-        let subject = CacheLocalStorage(
-            cacheDirectoriesProvider: cacheDirectoriesProvider,
-            artifactSigner: MockArtifactSigning(),
-            fileSystem: fileSystem
-        )
-        try await subject.clean(maxBytes: 2_500_000, makingRoomFor: [incoming])
-
-        // Then
-        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
-        #expect(remaining.count == 1)
-        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
-    }
-
-    @Test(.inTemporaryDirectory)
-    func clean_evictsEveryEntryWhenTheIncomingArtifactsNeedTheWholeBudget() async throws {
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
-        try await fileSystem.makeDirectory(at: binariesDirectory)
-
-        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
-        given(cacheDirectoriesProvider)
-            .cacheDirectory(for: .value(.binaries))
-            .willReturn(binariesDirectory)
-
-        let entry = binariesDirectory.appending(component: "hash0")
-        try await fileSystem.makeDirectory(at: entry)
-        FileManager.default.createFile(
-            atPath: entry.appending(component: "binary").pathString,
-            contents: Data(repeating: 0x41, count: 1_000_000)
-        )
-
-        let incoming = temporaryDirectory.appending(component: "incoming")
-        try await fileSystem.makeDirectory(at: incoming)
-        FileManager.default.createFile(
-            atPath: incoming.appending(component: "binary").pathString,
-            contents: Data(repeating: 0x41, count: 2_000_000)
-        )
-
-        // When: the incoming artifact claims all but 0.5 MB of the budget, which the
-        // cached 1 MB entry does not fit into.
-        let subject = CacheLocalStorage(
-            cacheDirectoriesProvider: cacheDirectoriesProvider,
-            artifactSigner: MockArtifactSigning(),
-            fileSystem: fileSystem
-        )
-        try await subject.clean(maxBytes: 2_500_000, makingRoomFor: [incoming])
-
-        // Then
-        let remaining = try await fileSystem.glob(directory: binariesDirectory, include: ["*"]).collect()
-        #expect(remaining.isEmpty)
-    }
-
-    @Test(.inTemporaryDirectory)
-    func clean_keepsTheMostRecentlyUsedEntryWhenItAloneExceedsTheByteBudget() async throws {
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
-        try await fileSystem.makeDirectory(at: binariesDirectory)
-
-        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
-        given(cacheDirectoriesProvider)
-            .cacheDirectory(for: .value(.binaries))
-            .willReturn(binariesDirectory)
-
-        let entry = binariesDirectory.appending(component: "hash0")
-        try await fileSystem.makeDirectory(at: entry)
-        FileManager.default.createFile(
-            atPath: entry.appending(component: "binary").pathString,
-            contents: Data(repeating: 0x41, count: 1_000_000)
-        )
-
-        let subject = CacheLocalStorage(
-            cacheDirectoriesProvider: cacheDirectoriesProvider,
-            artifactSigner: MockArtifactSigning(),
-            fileSystem: fileSystem
-        )
-        try await subject.clean(maxBytes: 100)
-
-        // Then: dropping it would only force a full re-pull on the next generate.
-        #expect(try await fileSystem.exists(entry))
-    }
-
-    @Test(.inTemporaryDirectory)
     func clean_keepsRecentEntries() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
@@ -764,14 +690,4 @@ struct CacheLocalStorageTests {
         let timeSinceModification = Date().timeIntervalSince(modificationDate)
         #expect(timeSinceModification < 5)
     }
-}
-
-@discardableResult
-private func hdiutil(_ arguments: [String]) throws -> Int32 {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
-    process.arguments = arguments
-    try process.run()
-    process.waitUntilExit()
-    return process.terminationStatus
 }

--- a/cli/Tests/TuistCacheEETests/Storage/CacheStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheStorageTests.swift
@@ -197,15 +197,34 @@ struct CacheStorageTests {
         ).willReturn([
             cacheItem: path,
         ])
-        given(remoteStorage).fetch(.value(Set([])), cacheCategory: .value(.binaries)).willReturn(
-            [:]
-        )
+        given(remoteStorage).fetch(.value(Set([])), cacheCategory: .value(.binaries), preserving: .any)
+            .willReturn([:])
 
         // When
         let result = try await subject.fetch([cacheStorableItem], cacheCategory: .binaries)
 
         // Then
         #expect(result[cacheItem] == "/Absolute/Path")
+    }
+
+    @Test(.inTemporaryDirectory)
+    func fetch_asks_the_remote_storage_to_preserve_the_entries_resolved_locally() async throws {
+        // Given
+        let localHit = CacheStorableItem(name: "Local", hash: "local-hash")
+        let remoteMiss = CacheStorableItem(name: "Remote", hash: "remote-hash")
+        given(localStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn(
+            [.test(name: "Local", hash: "local-hash"): "/Absolute/Path"]
+        )
+        given(remoteStorage).fetch(.any, cacheCategory: .value(.binaries), preserving: .any).willReturn([:])
+
+        // When
+        _ = try await subject.fetch([localHit, remoteMiss], cacheCategory: .binaries)
+
+        // Then: the caller is already building against the local hit, so it must survive any
+        // eviction the download path performs to make room.
+        verify(remoteStorage)
+            .fetch(.any, cacheCategory: .value(.binaries), preserving: .value(Set(["local-hash"])))
+            .called(1)
     }
 
     @Test(.inTemporaryDirectory)
@@ -226,7 +245,7 @@ struct CacheStorageTests {
                 Set([
                     cacheStorableItem,
                 ])
-            ), cacheCategory: .value(.binaries)
+            ), cacheCategory: .value(.binaries), preserving: .any
         ).willReturn([
             cacheItem: path,
         ])
@@ -255,7 +274,7 @@ struct CacheStorageTests {
                 Set([
                     cacheStorableItem,
                 ])
-            ), cacheCategory: .value(.binaries)
+            ), cacheCategory: .value(.binaries), preserving: .any
         ).willReturn([:])
 
         // When

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -256,6 +256,88 @@ struct ModuleCacheRemoteStorageTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController(), .withMockedEnvironment())
+    func fetch_when_the_budget_is_spent_evicts_least_recently_used_entries_to_make_room() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "1500000"
+
+        let binariesDirectory = temporaryDirectory.appending(component: "Binaries")
+        try await fileSystem.makeDirectory(at: binariesDirectory)
+        // An older entry that leaves no room for the download.
+        let staleEntry = binariesDirectory.appending(component: "stale")
+        try await fileSystem.makeDirectory(at: staleEntry)
+        FileManager.default.createFile(
+            atPath: staleEntry.appending(component: "binary").pathString,
+            contents: Data(repeating: 0x41, count: 1_400_000)
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Calendar.current.date(byAdding: .hour, value: -1, to: Date())!],
+            ofItemAtPath: staleEntry.pathString
+        )
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(binariesDirectory)
+
+        let appleArchiver = MockAppleArchiving()
+        let subject = ModuleCacheRemoteStorage(
+            fullHandle: fullHandle,
+            cacheURL: Constants.URLs.production,
+            serverURL: Constants.URLs.production,
+            serverAuthenticationController: serverAuthenticationController,
+            appleArchiver: appleArchiver,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            multipartUploadService: multipartUploadService,
+            downloadModuleCacheService: downloadModuleCacheService,
+            getCacheActionItemService: getCacheActionItemService,
+            uploadCacheActionItemService: uploadCacheActionItemService,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem,
+            retryProvider: retryProvider,
+            concurrencyLimit: 15,
+            cacheActionItemConcurrencyLimit: 15
+        )
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .any,
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(Data("payload".utf8))
+        given(appleArchiver)
+            .decompress(archive: .any, to: .any)
+            .willProduce { _, directory in
+                try FileManager.default.createDirectory(
+                    at: directory.appending(component: "target.xcframework").url,
+                    withIntermediateDirectories: true
+                )
+                FileManager.default.createFile(
+                    atPath: directory.appending(components: "target.xcframework", "binary").pathString,
+                    contents: Data(repeating: 0x41, count: 1_000_000)
+                )
+            }
+
+        // When
+        let got = try await subject.fetch(
+            Set([.init(name: "target", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        // Then: the artifact the build wants displaces the one it does not.
+        #expect(got.count == 1)
+        #expect(!(try await fileSystem.exists(staleEntry)))
+        #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash")))
+        #expect(AlertController.current.warnings().isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController(), .withMockedEnvironment())
     func fetch_when_the_download_does_not_fit_the_byte_budget_is_treated_as_a_cache_miss() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -11,6 +11,8 @@ import TuistAppleArchiver
 import TuistCache
 import TuistConstants
 import TuistCore
+import TuistEnvironment
+import TuistEnvironmentTesting
 import TuistLoggerTesting
 import TuistServer
 import TuistSupport
@@ -251,6 +253,71 @@ struct ModuleCacheRemoteStorageTests {
                 serverAuthenticationController: .any
             )
             .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController(), .withMockedEnvironment())
+    func fetch_when_the_download_does_not_fit_the_byte_budget_is_treated_as_a_cache_miss() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let environment = try #require(Environment.mocked)
+        environment.variables["TUIST_CACHE_MAX_BYTES"] = "1000000"
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(temporaryDirectory.appending(component: "Binaries"))
+
+        let appleArchiver = MockAppleArchiving()
+        let subject = ModuleCacheRemoteStorage(
+            fullHandle: fullHandle,
+            cacheURL: Constants.URLs.production,
+            serverURL: Constants.URLs.production,
+            serverAuthenticationController: serverAuthenticationController,
+            appleArchiver: appleArchiver,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            multipartUploadService: multipartUploadService,
+            downloadModuleCacheService: downloadModuleCacheService,
+            getCacheActionItemService: getCacheActionItemService,
+            uploadCacheActionItemService: uploadCacheActionItemService,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem,
+            retryProvider: retryProvider,
+            concurrencyLimit: 15,
+            cacheActionItemConcurrencyLimit: 15
+        )
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .any,
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(Data("payload".utf8))
+        // Decompresses to 5 MB against a 1 MB budget, so it never reaches the volume.
+        given(appleArchiver)
+            .decompress(archive: .any, to: .any)
+            .willProduce { _, directory in
+                FileManager.default.createFile(
+                    atPath: directory.appending(component: "target.xcframework").pathString,
+                    contents: Data(repeating: 0x41, count: 5_000_000)
+                )
+            }
+
+        // When
+        let got = try await subject.fetch(
+            Set([.init(name: "target", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        // Then
+        #expect(got.isEmpty == true)
+        #expect(AlertController.current.warnings().map(\.message).map { $0.plain() } ==
+            ["The local cache ran out of space, so these artifacts were rebuilt from source instead of being cached: target"]
+        )
     }
 
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -254,6 +254,70 @@ struct ModuleCacheRemoteStorageTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())
+    func fetch_when_the_local_cache_is_full_is_treated_as_a_cache_miss() async throws {
+        // Given
+        let volume = try TinyVolume.attached()
+        defer { volume.detach() }
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(volume.mountPoint.appending(component: "Binaries"))
+
+        let appleArchiver = MockAppleArchiving()
+        let subject = ModuleCacheRemoteStorage(
+            fullHandle: fullHandle,
+            cacheURL: Constants.URLs.production,
+            serverURL: Constants.URLs.production,
+            serverAuthenticationController: serverAuthenticationController,
+            appleArchiver: appleArchiver,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            multipartUploadService: multipartUploadService,
+            downloadModuleCacheService: downloadModuleCacheService,
+            getCacheActionItemService: getCacheActionItemService,
+            uploadCacheActionItemService: uploadCacheActionItemService,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem,
+            retryProvider: retryProvider,
+            concurrencyLimit: 15,
+            cacheActionItemConcurrencyLimit: 15
+        )
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .any,
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(Data("payload".utf8))
+        // The download succeeds and decompresses; only keeping it locally cannot.
+        given(appleArchiver)
+            .decompress(archive: .any, to: .any)
+            .willProduce { _, directory in
+                FileManager.default.createFile(
+                    atPath: directory.appending(component: "target.xcframework").pathString,
+                    contents: Data(repeating: 0x41, count: 5_000_000)
+                )
+            }
+
+        // When
+        let got = try await subject.fetch(
+            Set([.init(name: "target", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        // Then
+        #expect(got.isEmpty == true)
+        #expect(AlertController.current.warnings().map(\.message).map { $0.plain() } ==
+            ["The local cache ran out of space, so these artifacts were rebuilt from source instead of being cached: target"]
+        )
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())
     func fetch_when_one_artifact_is_corrupted_still_returns_the_valid_ones() async throws {
         // Given
         // Drive decompression through a mock archiver so the corrupt case is

--- a/cli/Tests/TuistCacheEETests/Utilities/TinyVolume.swift
+++ b/cli/Tests/TuistCacheEETests/Utilities/TinyVolume.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Path
+
+/// A real 2 MB APFS volume. Copies into it fail with the same ENOSPC the runner cache image
+/// raises, rather than a hand-made error that would only prove a matcher matches its own fixture.
+///
+/// It mounts outside the test's temporary directory: a full volume inside the tree the test host
+/// writes its own output into makes the host fail those writes.
+struct TinyVolume {
+    let mountPoint: AbsolutePath
+    private let baseDirectory: AbsolutePath
+
+    static func attached() throws -> TinyVolume {
+        let baseDirectory = try AbsolutePath(
+            validating: FileManager.default.temporaryDirectory
+                .appendingPathComponent("tuist-tiny-volume-\(UUID().uuidString)").path
+        )
+        let mountPoint = baseDirectory.appending(component: "mount")
+        try FileManager.default.createDirectory(atPath: mountPoint.pathString, withIntermediateDirectories: true)
+        let image = baseDirectory.appending(component: "tiny")
+        try hdiutil([
+            "create", "-size", "2m", "-fs", "APFS", "-volname", "TuistCache", "-type", "SPARSE",
+            "-quiet", image.pathString,
+        ])
+        try hdiutil([
+            "attach", image.pathString + ".sparseimage", "-nobrowse", "-noverify", "-quiet",
+            "-mountpoint", mountPoint.pathString,
+        ])
+        return TinyVolume(mountPoint: mountPoint, baseDirectory: baseDirectory)
+    }
+
+    func detach() {
+        try? Self.hdiutil(["detach", mountPoint.pathString, "-force", "-quiet"])
+        try? FileManager.default.removeItem(atPath: baseDirectory.pathString)
+    }
+
+    @discardableResult
+    private static func hdiutil(_ arguments: [String]) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+        process.arguments = arguments
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -10,8 +10,6 @@
     import TuistConfig
     import TuistConfigLoader
     import TuistCore
-    import TuistEnvironment
-    import TuistEnvironmentTesting
     import TuistHasher
     import TuistServer
     import TuistSupport
@@ -168,32 +166,6 @@
                     passthroughXcodeBuildArguments: .any
                 )
                 .called(1)
-        }
-
-        @Test(.inTemporaryDirectory, .withMockedEnvironment())
-        func run_evictsLeastRecentlyUsedBinariesPastTheCacheByteBudget() async throws {
-            let environment = try #require(Environment.mocked)
-            environment.variables["TUIST_CACHE_MAX_BYTES"] = "2500000"
-            let binariesDirectory = environment.cacheDirectory.appending(component: "Binaries")
-            try await fileSystem.makeDirectory(at: binariesDirectory)
-
-            // Three ~1 MB entries, staggered so entry 0 is most recently used.
-            for index in 0 ..< 3 {
-                let entry = binariesDirectory.appending(component: "hash\(index)")
-                try await fileSystem.makeDirectory(at: entry)
-                FileManager.default.createFile(
-                    atPath: entry.appending(component: "binary").pathString,
-                    contents: Data(repeating: 0x41, count: 1_000_000)
-                )
-                let date = Calendar.current.date(byAdding: .hour, value: -index, to: Date())!
-                try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: entry.pathString)
-            }
-
-            try await run(noUpload: false)
-
-            #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
-            #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash1")))
-            #expect(!(try await fileSystem.exists(binariesDirectory.appending(component: "hash2"))))
         }
 
         private func run(

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -10,6 +10,8 @@
     import TuistConfig
     import TuistConfigLoader
     import TuistCore
+    import TuistEnvironment
+    import TuistEnvironmentTesting
     import TuistHasher
     import TuistServer
     import TuistSupport
@@ -166,6 +168,32 @@
                     passthroughXcodeBuildArguments: .any
                 )
                 .called(1)
+        }
+
+        @Test(.inTemporaryDirectory, .withMockedEnvironment())
+        func run_evictsLeastRecentlyUsedBinariesPastTheCacheByteBudget() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["TUIST_CACHE_MAX_BYTES"] = "2500000"
+            let binariesDirectory = environment.cacheDirectory.appending(component: "Binaries")
+            try await fileSystem.makeDirectory(at: binariesDirectory)
+
+            // Three ~1 MB entries, staggered so entry 0 is most recently used.
+            for index in 0 ..< 3 {
+                let entry = binariesDirectory.appending(component: "hash\(index)")
+                try await fileSystem.makeDirectory(at: entry)
+                FileManager.default.createFile(
+                    atPath: entry.appending(component: "binary").pathString,
+                    contents: Data(repeating: 0x41, count: 1_000_000)
+                )
+                let date = Calendar.current.date(byAdding: .hour, value: -index, to: Date())!
+                try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: entry.pathString)
+            }
+
+            try await run(noUpload: false)
+
+            #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash0")))
+            #expect(try await fileSystem.exists(binariesDirectory.appending(component: "hash1")))
+            #expect(!(try await fileSystem.exists(binariesDirectory.appending(component: "hash2"))))
         }
 
         private func run(


### PR DESCRIPTION
Fixes the Cache job on main, which has failed on every run since 2026-08-26 with the runner cache volume out of space. The fix itself is [tuist/TuistCacheEE#77](https://github.com/tuist/TuistCacheEE/pull/77); this PR carries the tests and the submodule bump. Both that PR and [tuist/TuistCacheEE#78](https://github.com/tuist/TuistCacheEE/pull/78), which landed the branch this repository had been pinned into, are merged, so the submodule now points at TuistCacheEE `main`.

### What changed

The local binaries cache is now kept within the byte budget a runner stages for it, and a full cache volume no longer fails the command that filled it. Almost all of that lives in the storage layer; the one change here is a `CacheStoring.fetch` overload that carries the entries a caller has already resolved, so a storage that evicts to make room for its downloads cannot reclaim a path it has just handed out. Its default implementation forwards to the existing `fetch`, so storages that never evict are unaffected and no call site outside the composite changes.

### Why

Every Cache job on main since [run 33050513853](https://github.com/tuist/tuist/actions/runs/33050513853/job/98444591703) and the four before it died in the store phase:

```
Error Domain=NSCocoaErrorDomain Code=640 "TuistSDK couldn't be copied to TuistSDK.framework because there isn't enough space."
NSDestinationFilePath=/Users/runner/.tuist-cache-volume/tuist/Binaries/6652ddd6.../TuistSDK
NSUnderlyingError = NSPOSIXErrorDomain Code=28 "No space left on device"
```

Not the host disk: `tart_kubelet_cache_volume_root_free_bytes` read between 25 and 65 GiB free on every production runner host during the failures, so the branch image could still grow. The 20 GiB APFS volume inside it is what filled. Five consecutive failures landed on five different runner VMs, which ruled out a single bad host and pointed at the account's own cache.

### Root cause

Two things met.

The byte budget had no reader on the paths that write the most. `TUIST_CACHE_MAX_BYTES` is staged by the runner dispatch hook at roughly the volume's binary share, but its only reader was `GenerateService.run`. Neither `tuist cache` nor the remote download path pruned, so a warm that produces 248 xcframeworks across iOS device, iOS simulator and macOS slices wrote all of them unbounded, on top of every previous commit's hash directories, and remote cache hits added more. Nothing removed any of it.

The image also got smaller. [#12281](https://github.com/tuist/tuist/pull/12281) moved production `masterCapGib` from 28 to 20 and `casGib` from 16 to 11 on 2026-08-12, taking the binary budget from 10 GiB to 7 GiB and the image from 28 GiB to 20 GiB. Jobs ending above 99 percent fill (`tart_kubelet_cache_volume_fill_percent`) went from roughly 0 to 2 a day to 21, then 36, then 47 from that day, and have sat between 25 and 52 a day since. That change was correct for master admission; it left an unpruned cache with no headroom, and 2026-08-26 is simply when accumulation crossed the new ceiling.

Raising `masterCapGib` back was considered and rejected: resident masters per host scale as `gib/cap`, so a larger cap evicts the masters it is meant to hold. The arithmetic is in the comment above the value in `infra/helm/tuist/values-managed-production.yaml`.

Per-account volume sizing, which is what the largest accounts actually need, is deliberately out of scope here and tracked separately.

### Impact

On runners the Cache job stops failing, the cache stays at its budget instead of growing without bound, and a full volume no longer fails a warm or a fetch. On developer machines and customer CI the budget is unset, so the prune returns immediately and nothing about the local cache changes; the full-volume handling applies everywhere and only replaces a hard failure with a warning.

### How to test locally

```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistCacheEETests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

Every behavioural test here was confirmed red against the pre-fix tree.

`store_admitsOnlyTheArtifactsThatFitTheByteBudget` stores three 1 MB macro executables against a 2.5 MB budget; pre-fix all three land, because an oversized batch was copied whole and a regular file measured as zero bytes. `fetch_when_the_download_does_not_fit_the_byte_budget_is_treated_as_a_cache_miss` pre-fix caches a 5 MB download against a 1 MB budget.

`TinyVolume` mounts a real 2 MB APFS sparse image for the two ENOSPC backstop tests, so they fail with the `NSCocoaErrorDomain 640` production raises rather than a hand-made error that would only prove the matcher matches its own fixture. It mounts outside the test's temporary directory, because a full volume inside the tree the test host writes into makes the host fail its own writes. Filling a volume on purpose still makes the test host log three `writing to output file got error: No space left on device` lines; the run and the result bundle are unaffected, verified with an explicit `-resultBundlePath`.

`fetch_when_the_budget_is_spent_evicts_least_recently_used_entries_to_make_room` pre-fix declines the download, keeps the stale entry, and shows users a rebuilt-from-source warning.

`fetch_asks_the_remote_storage_to_preserve_the_entries_resolved_locally` pins the composite passing its local hits down, and `evictLeastRecentlyUsed_neverReclaimsAPreservedEntry` pins that they are skipped even when they are the least recently used candidate.

`BinaryCachePrunerTests` covers the eviction floor, artifact sizing for files and directories, headroom, and the admission actor.




