### PR TITLE
fix(infra): diagnose stalled pentest deployments

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -9,12 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: Deploy or delete the pentest environment
+        description: Deploy, diagnose, or delete the pentest environment
         required: true
         default: deploy
         type: choice
         options:
           - deploy
+          - diagnose
           - delete
       expires_at:
         description: Absolute UTC expiry timestamp in the form 2026-09-30T18:00:00Z. Required for deploy.
@@ -275,6 +276,37 @@ jobs:
             echo "- Image tag: \`$IMAGE_TAG\`"
             echo "- Excluded: Kura, package registry, runners, codebase search, Mac workloads, and package catalog synchronization"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  diagnose:
+    name: Diagnose pentest environment
+    needs: resolve
+    if: inputs.action == 'diagnose'
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-pentest
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "kubectl"
+          cache: "false"
+          env: "false"
+      - name: Load Kubernetes configuration
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Inspect workload readiness
+        run: |
+          set -euo pipefail
+
+          # This intentionally prints workload metadata and Kubernetes events
+          # only. It never reads Secret resources or container logs.
+          kubectl -n "$NAMESPACE" get deployments,statefulsets,jobs,pods,persistentvolumeclaims -o wide
+          kubectl -n "$NAMESPACE" get events --sort-by='.lastTimestamp'
 
   delete:
     name: Delete pentest environment


### PR DESCRIPTION
## What changed

Adds a `diagnose` action to the Pentest Deployment workflow. It loads the approved pentest Kubernetes configuration and reports only workload readiness metadata and recent Kubernetes events.

## Why

The first two pentest installation attempts both reached the Helm readiness timeout. The atomic rollback intentionally removes the workloads before operators can inspect their state.

## Approach

The diagnostic action is read-only. It does not read Secret resources or container logs, and it reuses the existing protected GitHub environment for cluster access.

## Impact

Operators can determine which deployment, StatefulSet, Job, Pod, or volume claim is blocking a pentest installation without weakening the production deployment path or exposing credentials.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pentest-deployment.yml")'`
- `git diff --check`
