### PR TITLE
fix(cli): validate and explain generate targets when source targets are kept

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -273,6 +273,13 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                 preserveGraphBeforeFocus: shouldPreserveHashingGraph
             )
 
+            // Emptying `includedTargets` above also drops the focus mapper, and with it the only
+            // check that the requested targets exist. Validate them separately so a misspelled
+            // target fails instead of silently generating the whole workspace.
+            if includedTargets.isEmpty, !cacheSources.isEmpty {
+                mappers.append(ValidateIncludedTargetsGraphMapper(includedTargets: cacheSources))
+            }
+
             if cacheProfile != .none {
                 if !shouldPreserveHashingGraph {
                     mappers.append(

--- a/cli/Sources/TuistKit/Mappers/ValidateIncludedTargetsGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/ValidateIncludedTargetsGraphMapper.swift
@@ -1,0 +1,44 @@
+import Foundation
+import TuistConfig
+import TuistCore
+import XcodeGraph
+
+/// Validates the targets a command was asked to focus on without touching the graph.
+///
+/// `FocusTargetsGraphMappers` is what normally rejects a target that is not in the graph, but
+/// `cacheOptions.keepSourceTargets` deliberately keeps every target in the generated project and so
+/// runs no focus mapper. This restores the same validation for that path, so a misspelled target
+/// fails the command instead of silently generating the whole workspace.
+struct ValidateIncludedTargetsGraphMapper: GraphMapping {
+    let includedTargets: Set<TargetQuery>
+
+    func map(graph: Graph, environment: MapperEnvironment) throws -> (
+        Graph, [SideEffectDescriptor], MapperEnvironment
+    ) {
+        guard !includedTargets.isEmpty else { return (graph, [], environment) }
+
+        let graphTraverser = GraphTraverser(graph: graph)
+        let matchedTargets = graphTraverser.filterIncludedTargets(
+            basedOn: graphTraverser.allTargets(),
+            testPlan: nil,
+            includedTargets: includedTargets,
+            excludedTargets: []
+        )
+
+        let includedTargetNames: [String] = includedTargets.compactMap {
+            guard case let .named(name) = $0 else { return nil }
+            return name
+        }
+        let unavailableIncludedTargets = Set(includedTargetNames)
+            .subtracting(matchedTargets.map(\.target.name))
+        if !unavailableIncludedTargets.isEmpty {
+            throw FocusTargetsGraphMappersError.targetsNotFound(Array(unavailableIncludedTargets))
+        }
+
+        if matchedTargets.isEmpty {
+            throw FocusTargetsGraphMappersError.noTargetsFound
+        }
+
+        return (graph, [], environment)
+    }
+}

--- a/cli/Sources/TuistKit/Services/GenerateService.swift
+++ b/cli/Sources/TuistKit/Services/GenerateService.swift
@@ -145,6 +145,15 @@ public struct GenerateService {
             cacheStorage = try await cacheStorageFactory.cacheLocalStorage()
         }
 
+        if !includedTargets.isEmpty,
+           config.project.generatedProject?.cacheOptions.keepSourceTargets == true
+        {
+            AlertController.current.warning(.alert(
+                "The targets you passed don't scope the generated project.",
+                takeaway: "keepSourceTargets keeps every target in the project and looks up every replaceable target in the cache. Disable it to generate a focused project."
+            ))
+        }
+
         let resolvedCacheProfile = try config.resolveCacheProfile(
             ignoreBinaryCache: ignoreBinaryCache,
             includedTargets: includedTargets,

--- a/cli/Tests/TuistKitTests/Mappers/Factories/CacheGraphMapperFactoryValidationTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Factories/CacheGraphMapperFactoryValidationTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import TuistConfig
+import TuistServer
+import XcodeGraph
+@testable import TuistCore
+@testable import TuistKit
+@testable import TuistTesting
+
+#if canImport(TuistCacheEE)
+    import TuistCacheEE
+
+    struct CacheGraphMapperFactoryValidationTests {
+        private let cacheStorage = MockCacheStoring()
+        private let subject = CacheGraphMapperFactory(contentHasher: ContentHasher())
+
+        @Test func generation_validates_the_requested_targets_when_source_targets_are_kept() {
+            // Given
+            let config = Tuist.test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: true))))
+            let cacheSources: Set<TargetQuery> = [.named("MyTarget")]
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: cacheSources,
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            let mapper = got.compactMap { $0 as? ValidateIncludedTargetsGraphMapper }.first
+            #expect(mapper?.includedTargets == cacheSources)
+        }
+
+        @Test func generation_validates_the_requested_targets_when_the_binary_cache_is_disabled() {
+            // Given
+            let config = Tuist.test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: true))))
+            let cacheSources: Set<TargetQuery> = [.named("MyTarget")]
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .none,
+                cacheSources: cacheSources,
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            let mapper = got.compactMap { $0 as? ValidateIncludedTargetsGraphMapper }.first
+            #expect(mapper?.includedTargets == cacheSources)
+        }
+
+        @Test func generation_leaves_the_validation_to_the_focus_mapper_when_the_graph_is_focused() {
+            // Given
+            let config = Tuist.test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: false))))
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: [.named("MyTarget")],
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            #expect(got.contains { $0 is FocusTargetsGraphMappers })
+            #expect(!got.contains { $0 is ValidateIncludedTargetsGraphMapper })
+        }
+
+        @Test func generation_does_not_validate_when_no_targets_were_requested() {
+            // Given
+            let config = Tuist.test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: true))))
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: [],
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            #expect(!got.contains { $0 is ValidateIncludedTargetsGraphMapper })
+        }
+    }
+#endif

--- a/cli/Tests/TuistKitTests/Mappers/ValidateIncludedTargetsGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/ValidateIncludedTargetsGraphMapperTests.swift
@@ -1,0 +1,63 @@
+import Path
+import Testing
+import TuistCore
+import XcodeGraph
+@testable import TuistKit
+@testable import TuistTesting
+
+struct ValidateIncludedTargetsGraphMapperTests {
+    @Test func map_throws_when_an_included_target_is_not_in_the_graph() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/Project")
+        let project = Project.test(path: path, targets: [Target.test(name: "App")])
+        let graph = Graph.test(projects: [path: project])
+        let subject = ValidateIncludedTargetsGraphMapper(includedTargets: [.named("Typo")])
+
+        // When / Then
+        await #expect(throws: FocusTargetsGraphMappersError.targetsNotFound(["Typo"])) {
+            try await subject.map(graph: graph, environment: MapperEnvironment())
+        }
+    }
+
+    @Test func map_throws_when_no_target_matches_the_included_queries() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/Project")
+        let project = Project.test(path: path, targets: [Target.test(name: "App")])
+        let graph = Graph.test(projects: [path: project])
+        let subject = ValidateIncludedTargetsGraphMapper(includedTargets: [.tagged("unused-tag")])
+
+        // When / Then
+        await #expect(throws: FocusTargetsGraphMappersError.noTargetsFound) {
+            try await subject.map(graph: graph, environment: MapperEnvironment())
+        }
+    }
+
+    @Test func map_returns_the_graph_untouched_when_every_included_target_matches() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/Project")
+        let project = Project.test(path: path, targets: [Target.test(name: "App"), Target.test(name: "Framework")])
+        let graph = Graph.test(name: "input", projects: [path: project])
+        let subject = ValidateIncludedTargetsGraphMapper(includedTargets: [.named("App")])
+
+        // When
+        let (got, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        #expect(got == graph)
+        #expect(sideEffects.isEmpty)
+    }
+
+    @Test func map_returns_the_graph_untouched_when_no_targets_are_included() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/Project")
+        let project = Project.test(path: path, targets: [Target.test(name: "App")])
+        let graph = Graph.test(name: "input", projects: [path: project])
+        let subject = ValidateIncludedTargetsGraphMapper(includedTargets: [])
+
+        // When
+        let (got, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        #expect(got == graph)
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -416,6 +416,58 @@ struct GenerateServiceTests {
         }
     }
 
+    @Test func warnsThatRequestedTargetsDoNotScopeTheProjectWhenSourceTargetsAreKept() async throws {
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: true))))
+        )
+        let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willReturn((workspacePath, .test(), MapperEnvironment()))
+        let alertController = AlertController()
+
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(
+                path: nil,
+                includedTargets: [.named("MyTarget")],
+                noOpen: true,
+                configuration: nil,
+                ignoreBinaryCache: false,
+                cacheProfile: nil
+            )
+        }
+
+        #expect(
+            alertController.warnings().map(\.message).map { $0.plain() } == [
+                "The targets you passed don't scope the generated project.",
+            ]
+        )
+    }
+
+    @Test func doesNotWarnAboutRequestedTargetsWhenSourceTargetsAreNotKept() async throws {
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .generated(.test(cacheOptions: .test(keepSourceTargets: false))))
+        )
+        let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willReturn((workspacePath, .test(), MapperEnvironment()))
+        let alertController = AlertController()
+
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(
+                path: nil,
+                includedTargets: [.named("MyTarget")],
+                noOpen: true,
+                configuration: nil,
+                ignoreBinaryCache: false,
+                cacheProfile: nil
+            )
+        }
+
+        #expect(alertController.warnings().isEmpty)
+    }
+
     @Test func usesLocalCacheStorageWhenRemoteCacheHasTransientServerFailure() async throws {
         given(configLoader).loadConfig(path: .any).willReturn(
             .test(project: .testGeneratedProject())


### PR DESCRIPTION
> No issue; came out of a customer report in Slack about cache dashboard numbers.

## What changed

Two things, both about `cacheOptions.keepSourceTargets`:

1. `ValidateIncludedTargetsGraphMapper` validates the targets passed to `tuist generate` when focusing was skipped, reusing `FocusTargetsGraphMappersError` so the failure is identical to the focused path.
2. `tuist generate` warns that those targets do not scope the generated project when `keepSourceTargets` is on.

## Why

`keepSourceTargets` disables focusing by emptying `includedTargets` in the generation mapper chain, so the generated project keeps every target rather than being narrowed to the requested one. That is deliberate. The side effect was not.

`targetsNotFound` and `noTargetsFound` are raised in exactly one place:

```
grep -rn "targetsNotFound\|noTargetsFound" cli/Sources --include="*.swift"
# cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift only
```

Dropping the focus mapper therefore dropped all validation of the targets the user typed. On `main` today, with `keepSourceTargets` enabled, `tuist generate SomeTypo` generates the whole workspace and exits successfully, having silently ignored the argument. `--no-binary-cache` has the same hole, since the blanking happens regardless of the cache profile.

The warning addresses the confusion that surfaced this. A team warmed one app's dependency closure with `tuist cache <app> --configuration <config>`, then ran `tuist generate <app> --configuration <config>` and saw a low cache hit rate. Nothing was broken: with `keepSourceTargets` the generation still looks up every replaceable target in the workspace, because the project it produces contains the whole workspace. The reported rate answers "how much of this project is binary-backed", which is not the question the target argument makes it look like it is answering.

## Why this approach

An earlier attempt (#12642, closed) narrowed the binary replacement to the requested target's dependency closure so the two commands would agree. That was wrong: under `keepSourceTargets` the project keeps dependents that focus would prune, so every replaceable target in it is a legitimate candidate, and narrowing would stop an unfiltered `tuist cache` from benefiting a later focused `tuist generate`.

Restoring focus under `keepSourceTargets` is also not an option, since not pruning the graph is the whole point of the option, and an earlier attempt at teaching tree-shaking to honour the flag had to be corrected in #8227.

That leaves the honest fix: make the argument fail when it is wrong, and say what it actually does when it is right.

A separate mapper rather than a flag on `FocusTargetsGraphMappers` keeps each mapper doing one thing, and keeps validation out of a mapper whose job is to mutate the graph. It reuses the existing error type so users see one message for one problem.

## Impact

- With `keepSourceTargets` on, a target that does not exist now fails the command instead of being ignored. This is a behaviour change for anyone relying on the silent no-op, which seems very unlikely to be deliberate.
- With `keepSourceTargets` on and targets passed, one warning is emitted per run.
- Nothing changes when `keepSourceTargets` is off: focus already validates, and the factory does not add the mapper there.
- No change to hashing, cache lookups, cache keys, or the generated project's contents.

## Validation

Written test-first. The two validation tests failed against a pass-through mapper before the logic landed, and the wiring and warning tests passed at that point, which is what pinned the behaviour to the right layer.

New tests, all Swift Testing:

- `ValidateIncludedTargetsGraphMapperTests`: throws `targetsNotFound` for a misspelled target, throws `noTargetsFound` when a query matches nothing, passes the graph through untouched when every target matches and when no targets were requested.
- `CacheGraphMapperFactoryValidationTests`: the mapper is wired in when source targets are kept, including with the binary cache disabled; it is absent when the graph is focused, where `FocusTargetsGraphMappers` already validates; it is absent when no targets were requested.
- `GenerateServiceTests`: the warning is emitted with `keepSourceTargets` on and targets passed, and not emitted with it off.

Runs:

- New suites plus `GraphMapperFactoryTests`, `CacheGraphMapperFactoryTests`: `** TEST SUCCEEDED **`, 88 cases, 0 failures.
- `FocusTargetsGraphMappersTests` and `TuistCacheProfileResolverTests` as a regression check: green.
- `mise run lint`: no warnings on the changed files.

### How to test locally

```
mise exec -- tuist generate tuist ProjectDescription TuistKitTests --no-open
```

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests \
  -only-testing TuistKitTests/ValidateIncludedTargetsGraphMapperTests \
  -only-testing TuistKitTests/CacheGraphMapperFactoryValidationTests \
  CODE_SIGNING_ALLOWED=NO
```

To see the bug this fixes, set `keepSourceTargets: true` in a fixture's `Tuist.swift` and run `tuist generate DoesNotExist`. On `main` it succeeds and generates everything; with this change it fails with "The following targets were not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
