### PR TITLE
feat(swifterpm): stabilize persistent dependency installs

### DIFF
--- a/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
+++ b/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
@@ -4,11 +4,20 @@ extension Config {
         /// Arguments passed to the Swift Package Manager's `swift package` command when running `swift package resolve`.
         public var passthroughSwiftPackageManagerArguments: [String]
 
+        /// Names of process environment variables that Tuist excludes from dependency-manifest evaluation and cache keys.
+        ///
+        /// Each entry is either a literal name (for example, `CI_JOB_ID`) or a name ending in `*` for prefix matching
+        /// (for example, `GITHUB_RUN_*`). Excluding a variable makes it unavailable to every `Package.swift` evaluated
+        /// during `tuist install`, so only exclude variables that do not affect dependency declarations.
+        public var manifestEnvironmentExcluded: [String]
+
         public static func options(
-            passthroughSwiftPackageManagerArguments: [String] = []
+            passthroughSwiftPackageManagerArguments: [String] = [],
+            manifestEnvironmentExcluded: [String] = []
         ) -> Self {
             self.init(
-                passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments
+                passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
+                manifestEnvironmentExcluded: manifestEnvironmentExcluded
             )
         }
     }

--- a/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
+++ b/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
@@ -4,21 +4,60 @@ extension Config {
         /// Arguments passed to the Swift Package Manager's `swift package` command when running `swift package resolve`.
         public var passthroughSwiftPackageManagerArguments: [String]
 
-        /// Names of process environment variables that Tuist excludes from dependency-manifest evaluation and cache keys.
-        ///
-        /// Each entry is either a literal name (for example, `CI_JOB_ID`) or a name ending in `*` for prefix matching
-        /// (for example, `GITHUB_RUN_*`). Excluding a variable makes it unavailable to every `Package.swift` evaluated
-        /// during `tuist install`, so only exclude variables that do not affect dependency declarations.
-        public var manifestEnvironmentExcluded: [String]
+        /// Controls which process environment variables dependency manifests can observe during installation.
+        public var manifestEnvironment: ManifestEnvironment
 
         public static func options(
             passthroughSwiftPackageManagerArguments: [String] = [],
-            manifestEnvironmentExcluded: [String] = []
+            manifestEnvironment: ManifestEnvironment = .automatic
         ) -> Self {
             self.init(
                 passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
-                manifestEnvironmentExcluded: manifestEnvironmentExcluded
+                manifestEnvironment: manifestEnvironment
             )
+        }
+
+        /// Controls which environment variables are visible to dependency manifests and participate in their cache keys.
+        public struct ManifestEnvironment: Codable, Equatable, Sendable {
+            /// Whether to exclude volatile values that Tuist recognizes from supported continuous-integration providers.
+            public let usesAutomaticProviderDefaults: Bool
+
+            /// Patterns for variables that remain visible, even when an automatic provider default would exclude them.
+            public let includedVariablePatterns: [String]
+
+            /// Patterns for additional variables to hide from dependency manifests and their cache keys.
+            public let excludedVariablePatterns: [String]
+
+            private init(
+                usesAutomaticProviderDefaults: Bool,
+                includedVariablePatterns: [String] = [],
+                excludedVariablePatterns: [String] = []
+            ) {
+                self.usesAutomaticProviderDefaults = usesAutomaticProviderDefaults
+                self.includedVariablePatterns = includedVariablePatterns
+                self.excludedVariablePatterns = excludedVariablePatterns
+            }
+
+            /// Uses provider-specific defaults to hide volatile continuous-integration values.
+            public static let automatic = Self(usesAutomaticProviderDefaults: true)
+
+            /// Preserves the complete process environment.
+            public static let all = Self(usesAutomaticProviderDefaults: false)
+
+            /// Uses provider-specific defaults, optionally restoring or excluding additional variables.
+            ///
+            /// Entries can be literal names (for example, `CI_JOB_ID`) or names ending in `*` for prefix matching
+            /// (for example, `GITHUB_RUN_*`). Included entries take precedence over automatic and custom exclusions.
+            public static func automatic(
+                including includedVariablePatterns: [String] = [],
+                excluding excludedVariablePatterns: [String] = []
+            ) -> Self {
+                Self(
+                    usesAutomaticProviderDefaults: true,
+                    includedVariablePatterns: includedVariablePatterns,
+                    excludedVariablePatterns: excludedVariablePatterns
+                )
+            }
         }
     }
 }

--- a/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
+++ b/cli/Sources/ProjectDescription/ConfigInstallOptions.swift
@@ -5,15 +5,15 @@ extension Config {
         public var passthroughSwiftPackageManagerArguments: [String]
 
         /// Controls which process environment variables dependency manifests can observe during installation.
-        public var manifestEnvironment: ManifestEnvironment
+        public var packageManifestEnvironment: ManifestEnvironment
 
         public static func options(
             passthroughSwiftPackageManagerArguments: [String] = [],
-            manifestEnvironment: ManifestEnvironment = .automatic
+            packageManifestEnvironment: ManifestEnvironment = .automatic
         ) -> Self {
             self.init(
                 passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
-                manifestEnvironment: manifestEnvironment
+                packageManifestEnvironment: packageManifestEnvironment
             )
         }
 

--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -201,24 +201,40 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
 
     public struct InstallOptions: Codable, Equatable, Sendable, Hashable {
         public var passthroughSwiftPackageManagerArguments: [String]
-        public var manifestEnvironmentExcluded: [String]
+        public var manifestEnvironment: ManifestEnvironment
 
         public init(
             passthroughSwiftPackageManagerArguments: [String] = [],
-            manifestEnvironmentExcluded: [String] = []
+            manifestEnvironment: ManifestEnvironment = .init()
         ) {
             self.passthroughSwiftPackageManagerArguments = passthroughSwiftPackageManagerArguments
-            self.manifestEnvironmentExcluded = manifestEnvironmentExcluded
+            self.manifestEnvironment = manifestEnvironment
+        }
+
+        public struct ManifestEnvironment: Codable, Equatable, Sendable, Hashable {
+            public let usesAutomaticProviderDefaults: Bool
+            public let includedVariablePatterns: [String]
+            public let excludedVariablePatterns: [String]
+
+            public init(
+                usesAutomaticProviderDefaults: Bool = true,
+                includedVariablePatterns: [String] = [],
+                excludedVariablePatterns: [String] = []
+            ) {
+                self.usesAutomaticProviderDefaults = usesAutomaticProviderDefaults
+                self.includedVariablePatterns = includedVariablePatterns
+                self.excludedVariablePatterns = excludedVariablePatterns
+            }
         }
 
         #if DEBUG
             public static func test(
                 passthroughSwiftPackageManagerArguments: [String] = [],
-                manifestEnvironmentExcluded: [String] = []
+                manifestEnvironment: ManifestEnvironment = .init()
             ) -> Self {
                 .init(
                     passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
-                    manifestEnvironmentExcluded: manifestEnvironmentExcluded
+                    manifestEnvironment: manifestEnvironment
                 )
             }
         #endif

--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -212,15 +212,15 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
         }
 
         #if DEBUG
-        public static func test(
-            passthroughSwiftPackageManagerArguments: [String] = [],
-            manifestEnvironmentExcluded: [String] = []
-        ) -> Self {
-            .init(
-                passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
-                manifestEnvironmentExcluded: manifestEnvironmentExcluded
-            )
-        }
+            public static func test(
+                passthroughSwiftPackageManagerArguments: [String] = [],
+                manifestEnvironmentExcluded: [String] = []
+            ) -> Self {
+                .init(
+                    passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
+                    manifestEnvironmentExcluded: manifestEnvironmentExcluded
+                )
+            }
         #endif
     }
 

--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -201,21 +201,26 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
 
     public struct InstallOptions: Codable, Equatable, Sendable, Hashable {
         public var passthroughSwiftPackageManagerArguments: [String]
+        public var manifestEnvironmentExcluded: [String]
 
         public init(
-            passthroughSwiftPackageManagerArguments: [String] = []
+            passthroughSwiftPackageManagerArguments: [String] = [],
+            manifestEnvironmentExcluded: [String] = []
         ) {
             self.passthroughSwiftPackageManagerArguments = passthroughSwiftPackageManagerArguments
+            self.manifestEnvironmentExcluded = manifestEnvironmentExcluded
         }
 
         #if DEBUG
-            public static func test(
-                passthroughSwiftPackageManagerArguments: [String] = []
-            ) -> Self {
-                .init(
-                    passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments
-                )
-            }
+        public static func test(
+            passthroughSwiftPackageManagerArguments: [String] = [],
+            manifestEnvironmentExcluded: [String] = []
+        ) -> Self {
+            .init(
+                passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
+                manifestEnvironmentExcluded: manifestEnvironmentExcluded
+            )
+        }
         #endif
     }
 

--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -201,14 +201,14 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
 
     public struct InstallOptions: Codable, Equatable, Sendable, Hashable {
         public var passthroughSwiftPackageManagerArguments: [String]
-        public var manifestEnvironment: ManifestEnvironment
+        public var packageManifestEnvironment: ManifestEnvironment
 
         public init(
             passthroughSwiftPackageManagerArguments: [String] = [],
-            manifestEnvironment: ManifestEnvironment = .init()
+            packageManifestEnvironment: ManifestEnvironment = .init()
         ) {
             self.passthroughSwiftPackageManagerArguments = passthroughSwiftPackageManagerArguments
-            self.manifestEnvironment = manifestEnvironment
+            self.packageManifestEnvironment = packageManifestEnvironment
         }
 
         public struct ManifestEnvironment: Codable, Equatable, Sendable, Hashable {
@@ -230,11 +230,11 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
         #if DEBUG
             public static func test(
                 passthroughSwiftPackageManagerArguments: [String] = [],
-                manifestEnvironment: ManifestEnvironment = .init()
+                packageManifestEnvironment: ManifestEnvironment = .init()
             ) -> Self {
                 .init(
                     passthroughSwiftPackageManagerArguments: passthroughSwiftPackageManagerArguments,
-                    manifestEnvironment: manifestEnvironment
+                    packageManifestEnvironment: packageManifestEnvironment
                 )
             }
         #endif

--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -89,10 +89,15 @@ struct InstallService: InstallServicing {
             packagePath: packageManifestPath.parentDirectory,
             arguments: mergedArguments
         )
-        let manifestEnvironmentExcluded = config.project.generatedProject?
-            .installOptions.manifestEnvironmentExcluded ?? []
+        let manifestEnvironment = config.project.generatedProject?.installOptions.manifestEnvironment ?? .init()
 
-        try await PackageManifestEnvironment.withExcludedVariables(manifestEnvironmentExcluded) {
+        try await PackageManifestEnvironment.withConfiguration(
+            .init(
+                usesAutomaticProviderDefaults: manifestEnvironment.usesAutomaticProviderDefaults,
+                includedVariablePatterns: manifestEnvironment.includedVariablePatterns,
+                excludedVariablePatterns: manifestEnvironment.excludedVariablePatterns
+            )
+        ) {
             if update {
                 Logger.current.notice("Updating dependencies.", metadata: .section)
 

--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -89,13 +89,13 @@ struct InstallService: InstallServicing {
             packagePath: packageManifestPath.parentDirectory,
             arguments: mergedArguments
         )
-        let manifestEnvironment = config.project.generatedProject?.installOptions.manifestEnvironment ?? .init()
+        let packageManifestEnvironment = config.project.generatedProject?.installOptions.packageManifestEnvironment ?? .init()
 
         try await PackageManifestEnvironment.withConfiguration(
             .init(
-                usesAutomaticProviderDefaults: manifestEnvironment.usesAutomaticProviderDefaults,
-                includedVariablePatterns: manifestEnvironment.includedVariablePatterns,
-                excludedVariablePatterns: manifestEnvironment.excludedVariablePatterns
+                usesAutomaticProviderDefaults: packageManifestEnvironment.usesAutomaticProviderDefaults,
+                includedVariablePatterns: packageManifestEnvironment.includedVariablePatterns,
+                excludedVariablePatterns: packageManifestEnvironment.excludedVariablePatterns
             )
         ) {
             if update {

--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -89,23 +89,27 @@ struct InstallService: InstallServicing {
             packagePath: packageManifestPath.parentDirectory,
             arguments: mergedArguments
         )
+        let manifestEnvironmentExcluded = config.project.generatedProject?
+            .installOptions.manifestEnvironmentExcluded ?? []
 
-        if update {
-            Logger.current.notice("Updating dependencies.", metadata: .section)
+        try await PackageManifestEnvironment.withExcludedVariables(manifestEnvironmentExcluded) {
+            if update {
+                Logger.current.notice("Updating dependencies.", metadata: .section)
 
-            try await swiftPackageManagerController.update(
-                at: packageManifestPath.parentDirectory,
-                arguments: mergedArguments,
-                printOutput: true
-            )
-        } else {
-            Logger.current.notice("Resolving and fetching dependencies.", metadata: .section)
+                try await swiftPackageManagerController.update(
+                    at: packageManifestPath.parentDirectory,
+                    arguments: mergedArguments,
+                    printOutput: true
+                )
+            } else {
+                Logger.current.notice("Resolving and fetching dependencies.", metadata: .section)
 
-            try await swiftPackageManagerController.resolve(
-                at: packageManifestPath.parentDirectory,
-                arguments: mergedArguments,
-                printOutput: true
-            )
+                try await swiftPackageManagerController.resolve(
+                    at: packageManifestPath.parentDirectory,
+                    arguments: mergedArguments,
+                    printOutput: true
+                )
+            }
         }
 
         try await savePackageResolved(

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -54,7 +54,11 @@ extension TuistConfig.TuistGeneratedProjectOptions.InstallOptions {
     ) -> Self {
         return .init(
             passthroughSwiftPackageManagerArguments: manifest.passthroughSwiftPackageManagerArguments,
-            manifestEnvironmentExcluded: manifest.manifestEnvironmentExcluded
+            manifestEnvironment: .init(
+                usesAutomaticProviderDefaults: manifest.manifestEnvironment.usesAutomaticProviderDefaults,
+                includedVariablePatterns: manifest.manifestEnvironment.includedVariablePatterns,
+                excludedVariablePatterns: manifest.manifestEnvironment.excludedVariablePatterns
+            )
         )
     }
 }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -54,10 +54,10 @@ extension TuistConfig.TuistGeneratedProjectOptions.InstallOptions {
     ) -> Self {
         return .init(
             passthroughSwiftPackageManagerArguments: manifest.passthroughSwiftPackageManagerArguments,
-            manifestEnvironment: .init(
-                usesAutomaticProviderDefaults: manifest.manifestEnvironment.usesAutomaticProviderDefaults,
-                includedVariablePatterns: manifest.manifestEnvironment.includedVariablePatterns,
-                excludedVariablePatterns: manifest.manifestEnvironment.excludedVariablePatterns
+            packageManifestEnvironment: .init(
+                usesAutomaticProviderDefaults: manifest.packageManifestEnvironment.usesAutomaticProviderDefaults,
+                includedVariablePatterns: manifest.packageManifestEnvironment.includedVariablePatterns,
+                excludedVariablePatterns: manifest.packageManifestEnvironment.excludedVariablePatterns
             )
         )
     }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -53,7 +53,8 @@ extension TuistConfig.TuistGeneratedProjectOptions.InstallOptions {
         manifest: ProjectDescription.Config.InstallOptions
     ) -> Self {
         return .init(
-            passthroughSwiftPackageManagerArguments: manifest.passthroughSwiftPackageManagerArguments
+            passthroughSwiftPackageManagerArguments: manifest.passthroughSwiftPackageManagerArguments,
+            manifestEnvironmentExcluded: manifest.manifestEnvironmentExcluded
         )
     }
 }

--- a/cli/Sources/TuistSupport/SwiftPackageManager/PackageManifestEnvironment.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/PackageManifestEnvironment.swift
@@ -1,23 +1,110 @@
 import Foundation
 
 public enum PackageManifestEnvironment {
-    @TaskLocal public static var excludedVariablePatterns: [String] = []
+    public struct Configuration: Sendable {
+        let usesAutomaticProviderDefaults: Bool
+        let includedVariablePatterns: [String]
+        let excludedVariablePatterns: [String]
 
-    public static func withExcludedVariables<T>(
-        _ patterns: [String],
+        public init(
+            usesAutomaticProviderDefaults: Bool = true,
+            includedVariablePatterns: [String] = [],
+            excludedVariablePatterns: [String] = []
+        ) {
+            self.usesAutomaticProviderDefaults = usesAutomaticProviderDefaults
+            self.includedVariablePatterns = includedVariablePatterns
+            self.excludedVariablePatterns = excludedVariablePatterns
+        }
+    }
+
+    @TaskLocal public static var configuration = Configuration()
+
+    public static func withConfiguration<T>(
+        _ configuration: Configuration,
         operation: () async throws -> T
     ) async rethrows -> T {
-        try await $excludedVariablePatterns.withValue(patterns) {
+        try await $configuration.withValue(configuration) {
             try await operation()
         }
     }
 
     static func filtered(_ variables: [String: String]) -> [String: String]? {
-        let patterns = excludedVariablePatterns
-        guard !patterns.isEmpty else { return nil }
+        let configuration = configuration
+        let automaticPatterns = configuration
+            .usesAutomaticProviderDefaults ? automaticExcludedVariablePatterns(in: variables) : []
+        let excludedVariablePatterns = automaticPatterns + configuration.excludedVariablePatterns
+        guard !excludedVariablePatterns.isEmpty else { return nil }
+
         return variables.filter { key, _ in
-            !matches(key: key, patterns: patterns)
+            !matches(key: key, patterns: excludedVariablePatterns) ||
+                matches(key: key, patterns: configuration.includedVariablePatterns)
         }
+    }
+
+    private static func automaticExcludedVariablePatterns(in variables: [String: String]) -> [String] {
+        var patterns: [String] = []
+
+        if variables["GITLAB_CI"] == "true" {
+            patterns += [
+                "CI_CONCURRENT_ID",
+                "CI_CONCURRENT_PROJECT_ID",
+                "CI_JOB_ID",
+                "CI_JOB_RETRY_COUNT",
+                "CI_JOB_STARTED_AT",
+                "CI_JOB_STARTED_AT_SLUG",
+                "CI_JOB_STATUS",
+                "CI_JOB_URL",
+                "CI_PIPELINE_CREATED_AT",
+                "CI_PIPELINE_ID",
+                "CI_PIPELINE_IID",
+                "CI_PIPELINE_URL",
+                "CI_TRACEPARENT",
+                "CI_TRACESTATE",
+                "CI_UPSTREAM_JOB_ID",
+                "CI_UPSTREAM_PIPELINE_ID",
+            ]
+        }
+
+        if variables["GITHUB_ACTIONS"] == "true" {
+            patterns += [
+                "GITHUB_ACTION",
+                "GITHUB_ARTIFACTS",
+                "GITHUB_ARTIFACTS_LIST",
+                "GITHUB_ENV",
+                "GITHUB_OUTPUT",
+                "GITHUB_PATH",
+                "GITHUB_RUN_ATTEMPT",
+                "GITHUB_RUN_ID",
+                "GITHUB_RUN_NUMBER",
+                "GITHUB_STEP_SUMMARY",
+            ]
+        }
+
+        if variables["BITRISE_IO"] == "true" {
+            patterns += [
+                "BITRISE_BUILD_NUMBER",
+                "BITRISE_BUILD_SLUG",
+                "BITRISE_BUILD_TRIGGER_TIMESTAMP",
+                "BITRISE_BUILD_URL",
+                "BITRISE_DEPLOY_DIR",
+                "BITRISE_TEST_DEPLOY_DIR",
+                "BITRISE_TEST_RESULT_DIR",
+                "BITRISEIO_PIPELINE_BUILD_URL",
+                "BITRISEIO_PIPELINE_ID",
+            ]
+        }
+
+        if variables["CM_BUILD_ID"] != nil {
+            patterns += [
+                "CM_ARTIFACT_LINKS",
+                "CM_BUILD_ID",
+                "CM_BUILD_OUTPUT_DIR",
+                "CM_ENV",
+                "CM_EXPORT_DIR",
+            ]
+        }
+
+        return patterns
     }
 
     private static func matches(key: String, patterns: [String]) -> Bool {

--- a/cli/Sources/TuistSupport/SwiftPackageManager/PackageManifestEnvironment.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/PackageManifestEnvironment.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum PackageManifestEnvironment {
+    @TaskLocal public static var excludedVariablePatterns: [String] = []
+
+    public static func withExcludedVariables<T>(
+        _ patterns: [String],
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await $excludedVariablePatterns.withValue(patterns) {
+            try await operation()
+        }
+    }
+
+    static func filtered(_ variables: [String: String]) -> [String: String]? {
+        let patterns = excludedVariablePatterns
+        guard !patterns.isEmpty else { return nil }
+        return variables.filter { key, _ in
+            !matches(key: key, patterns: patterns)
+        }
+    }
+
+    private static func matches(key: String, patterns: [String]) -> Bool {
+        patterns.contains { pattern in
+            if pattern.hasSuffix("*") {
+                let prefix = pattern.dropLast()
+                return !prefix.isEmpty && key.hasPrefix(prefix)
+            }
+            return key == pattern
+        }
+    }
+}

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -139,9 +139,10 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
             extraArguments: arguments + ["resolve"]
         )
 
+        let environment = manifestEnvironment ?? environmentVariables()
         printOutput ?
-            try await commandRunner().runAndPrint(arguments: command) :
-            try await commandRunner().runAndWait(arguments: command)
+            try await commandRunner().runAndPrint(arguments: command, environment: environment) :
+            try await commandRunner().runAndWait(arguments: command, environment: environment)
     }
 
     public func update(at path: AbsolutePath, arguments: [String], printOutput: Bool) async throws {
@@ -161,9 +162,10 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
             extraArguments: arguments + ["update"]
         )
 
+        let environment = manifestEnvironment ?? environmentVariables()
         printOutput ?
-            try await commandRunner().runAndPrint(arguments: command) :
-            try await commandRunner().runAndWait(arguments: command)
+            try await commandRunner().runAndPrint(arguments: command, environment: environment) :
+            try await commandRunner().runAndWait(arguments: command, environment: environment)
     }
 
     public func setToolsVersion(at path: AbsolutePath, to version: Version) async throws {
@@ -300,7 +302,12 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
         }
 
         request.quiet = request.quiet || !printOutput
+        request.manifestEnvironment = manifestEnvironment
         return request
+    }
+
+    private var manifestEnvironment: [String: String]? {
+        PackageManifestEnvironment.filtered(environmentVariables())
     }
 
     private func swifterPMArguments(command: String, packagePath: AbsolutePath, arguments: [String]) -> [String] {

--- a/cli/Sources/TuistTesting/Utils/MockCommandRunner.swift
+++ b/cli/Sources/TuistTesting/Utils/MockCommandRunner.swift
@@ -64,12 +64,13 @@ public final class MockCommandRunner: CommandRunning, @unchecked Sendable {
 
     public func run(
         arguments: [String],
-        environment _: [String: String],
+        environment: [String: String],
         workingDirectory: Path.AbsolutePath?
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream { continuation in
             let command = arguments.joined(separator: " ")
             lock.lock()
+            env = environment
             _calls.append(command)
             _workingDirectories.append(workingDirectory)
             let stub = _captureStubs[command] ?? _defaultCaptureStubs

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -268,7 +268,7 @@ final class DumpServiceTests: TuistTestCase {
                     }
                   },
                   "installOptions": {
-                    "manifestEnvironment": {
+                    "packageManifestEnvironment": {
                       "excludedVariablePatterns": [
 
                       ],

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -268,9 +268,15 @@ final class DumpServiceTests: TuistTestCase {
                     }
                   },
                   "installOptions": {
-                    "manifestEnvironmentExcluded": [
+                    "manifestEnvironment": {
+                      "excludedVariablePatterns": [
 
-                    ],
+                      ],
+                      "includedVariablePatterns": [
+
+                      ],
+                      "usesAutomaticProviderDefaults": true
+                    },
                     "passthroughSwiftPackageManagerArguments": [
                       "--replace-scm-with-registry"
                     ]

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -268,6 +268,9 @@ final class DumpServiceTests: TuistTestCase {
                     }
                   },
                   "installOptions": {
+                    "manifestEnvironmentExcluded": [
+
+                    ],
                     "passthroughSwiftPackageManagerArguments": [
                       "--replace-scm-with-registry"
                     ]

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
@@ -14,7 +14,7 @@ struct TuistGeneratedProjectManifestMapperTests {
         let got = TuistConfig.TuistGeneratedProjectOptions.InstallOptions.from(
             manifest: .options(
                 passthroughSwiftPackageManagerArguments: ["--force-resolved-versions"],
-                manifestEnvironment: .automatic(
+                packageManifestEnvironment: .automatic(
                     including: ["CI_JOB_ID"],
                     excluding: ["GITHUB_RUN_*"]
                 )
@@ -22,9 +22,9 @@ struct TuistGeneratedProjectManifestMapperTests {
         )
 
         #expect(got.passthroughSwiftPackageManagerArguments == ["--force-resolved-versions"])
-        #expect(got.manifestEnvironment.usesAutomaticProviderDefaults == true)
-        #expect(got.manifestEnvironment.includedVariablePatterns == ["CI_JOB_ID"])
-        #expect(got.manifestEnvironment.excludedVariablePatterns == ["GITHUB_RUN_*"])
+        #expect(got.packageManifestEnvironment.usesAutomaticProviderDefaults == true)
+        #expect(got.packageManifestEnvironment.includedVariablePatterns == ["CI_JOB_ID"])
+        #expect(got.packageManifestEnvironment.excludedVariablePatterns == ["GITHUB_RUN_*"])
     }
 
     @Test func buildInsightsDisabled_when_fullHandle_is_nil() async throws {

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
@@ -10,16 +10,21 @@ import TuistCore
 struct TuistGeneratedProjectManifestMapperTests {
     private let fileSystem = FileSystem()
 
-    @Test func installOptions_mapsManifestEnvironmentExcluded() {
+    @Test func installOptions_mapsManifestEnvironment() {
         let got = TuistConfig.TuistGeneratedProjectOptions.InstallOptions.from(
             manifest: .options(
                 passthroughSwiftPackageManagerArguments: ["--force-resolved-versions"],
-                manifestEnvironmentExcluded: ["CI_JOB_ID", "GITHUB_RUN_*"]
+                manifestEnvironment: .automatic(
+                    including: ["CI_JOB_ID"],
+                    excluding: ["GITHUB_RUN_*"]
+                )
             )
         )
 
         #expect(got.passthroughSwiftPackageManagerArguments == ["--force-resolved-versions"])
-        #expect(got.manifestEnvironmentExcluded == ["CI_JOB_ID", "GITHUB_RUN_*"])
+        #expect(got.manifestEnvironment.usesAutomaticProviderDefaults == true)
+        #expect(got.manifestEnvironment.includedVariablePatterns == ["CI_JOB_ID"])
+        #expect(got.manifestEnvironment.excludedVariablePatterns == ["GITHUB_RUN_*"])
     }
 
     @Test func buildInsightsDisabled_when_fullHandle_is_nil() async throws {

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
@@ -10,6 +10,18 @@ import TuistCore
 struct TuistGeneratedProjectManifestMapperTests {
     private let fileSystem = FileSystem()
 
+    @Test func installOptions_mapsManifestEnvironmentExcluded() {
+        let got = TuistConfig.TuistGeneratedProjectOptions.InstallOptions.from(
+            manifest: .options(
+                passthroughSwiftPackageManagerArguments: ["--force-resolved-versions"],
+                manifestEnvironmentExcluded: ["CI_JOB_ID", "GITHUB_RUN_*"]
+            )
+        )
+
+        #expect(got.passthroughSwiftPackageManagerArguments == ["--force-resolved-versions"])
+        #expect(got.manifestEnvironmentExcluded == ["CI_JOB_ID", "GITHUB_RUN_*"])
+    }
+
     @Test func buildInsightsDisabled_when_fullHandle_is_nil() async throws {
         try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
             // When

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/PackageManifestEnvironmentTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/PackageManifestEnvironmentTests.swift
@@ -1,0 +1,78 @@
+import Testing
+
+@testable import TuistSupport
+
+struct PackageManifestEnvironmentTests {
+    @Test func automatic_defaults_exclude_volatile_gitlab_variables() async throws {
+        let variables = [
+            "CI_JOB_ID": "job-1",
+            "CI_JOB_TOKEN": "token",
+            "CI_PIPELINE_ID": "pipeline-1",
+            "CI_COMMIT_REF_NAME": "main",
+            "GITLAB_CI": "true",
+        ]
+
+        let filtered = try await PackageManifestEnvironment.withConfiguration(.init()) {
+            PackageManifestEnvironment.filtered(variables)
+        }
+
+        #expect(
+            filtered == [
+                "CI_COMMIT_REF_NAME": "main",
+                "CI_JOB_TOKEN": "token",
+                "GITLAB_CI": "true",
+            ]
+        )
+    }
+
+    @Test func automatic_defaults_can_restore_a_provider_variable() async throws {
+        let variables = [
+            "CI_JOB_ID": "job-1",
+            "CI_PIPELINE_ID": "pipeline-1",
+            "GITLAB_CI": "true",
+        ]
+
+        let filtered = try await PackageManifestEnvironment.withConfiguration(
+            .init(includedVariablePatterns: ["CI_JOB_ID"])
+        ) {
+            PackageManifestEnvironment.filtered(variables)
+        }
+
+        #expect(filtered == ["CI_JOB_ID": "job-1", "GITLAB_CI": "true"])
+    }
+
+    @Test func all_environment_returns_no_filtered_environment() async throws {
+        let filtered = try await PackageManifestEnvironment.withConfiguration(
+            .init(usesAutomaticProviderDefaults: false)
+        ) {
+            PackageManifestEnvironment.filtered(["CI_JOB_ID": "job-1", "GITLAB_CI": "true"])
+        }
+
+        #expect(filtered == nil)
+    }
+
+    @Test func automatic_defaults_exclude_volatile_variables_for_each_supported_provider() async throws {
+        let providers = [
+            (
+                ["GITHUB_ACTIONS": "true", "GITHUB_RUN_ID": "run", "GITHUB_REF": "refs/heads/main"],
+                ["GITHUB_ACTIONS": "true", "GITHUB_REF": "refs/heads/main"]
+            ),
+            (
+                ["BITRISE_IO": "true", "BITRISE_BUILD_SLUG": "build", "BITRISE_GIT_BRANCH": "main"],
+                ["BITRISE_IO": "true", "BITRISE_GIT_BRANCH": "main"]
+            ),
+            (
+                ["CM_BUILD_ID": "build", "BUILD_NUMBER": "1", "CM_BRANCH": "main"],
+                ["BUILD_NUMBER": "1", "CM_BRANCH": "main"]
+            ),
+        ]
+
+        for (variables, expected) in providers {
+            let filtered = try await PackageManifestEnvironment.withConfiguration(.init()) {
+                PackageManifestEnvironment.filtered(variables)
+            }
+
+            #expect(filtered == expected)
+        }
+    }
+}

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -187,7 +187,9 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         ])
 
         // When
-        try await PackageManifestEnvironment.withExcludedVariables(["CI_*"]) {
+        try await PackageManifestEnvironment.withConfiguration(
+            .init(usesAutomaticProviderDefaults: false, excludedVariablePatterns: ["CI_*"])
+        ) {
             try await subject.resolve(at: path, arguments: [], printOutput: false)
         }
 
@@ -216,7 +218,9 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         )
 
         // When
-        try await PackageManifestEnvironment.withExcludedVariables(["CI_JOB_ID"]) {
+        try await PackageManifestEnvironment.withConfiguration(
+            .init(usesAutomaticProviderDefaults: false, excludedVariablePatterns: ["CI_JOB_ID"])
+        ) {
             try await subject.resolve(at: path, arguments: [], printOutput: false)
         }
 

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -163,6 +163,68 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertTrue(swifterPM.resolveRequests.isEmpty)
     }
 
+    func test_resolve_excludes_configured_manifest_environment_variables() async throws {
+        // Given
+        let path = try temporaryPath()
+        let environment = [
+            "TUIST_USE_SWIFTERPM": "0",
+            "CI_JOB_ID": "first-job",
+            "CI_PIPELINE_ID": "pipeline",
+            "RETAINED": "value",
+        ]
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { environment }
+        )
+        mockCommandRunner.succeedCommand([
+            "swift",
+            "package",
+            "--package-path",
+            path.pathString,
+            "resolve",
+        ])
+
+        // When
+        try await PackageManifestEnvironment.withExcludedVariables(["CI_*"]) {
+            try await subject.resolve(at: path, arguments: [], printOutput: false)
+        }
+
+        // Then
+        XCTAssertEqual(
+            mockCommandRunner.env,
+            [
+                "TUIST_USE_SWIFTERPM": "0",
+                "RETAINED": "value",
+            ]
+        )
+    }
+
+    func test_resolve_passes_excluded_manifest_environment_to_swifterpm() async throws {
+        // Given
+        let path = try temporaryPath()
+        let environment = [
+            "CI_JOB_ID": "first-job",
+            "RETAINED": "value",
+        ]
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { environment }
+        )
+
+        // When
+        try await PackageManifestEnvironment.withExcludedVariables(["CI_JOB_ID"]) {
+            try await subject.resolve(at: path, arguments: [], printOutput: false)
+        }
+
+        // Then
+        let request = try XCTUnwrap(swifterPM.resolveRequests.first)
+        XCTAssertEqual(request.manifestEnvironment, ["RETAINED": "value"])
+    }
+
     func test_resolve_when_swifterpm_is_enabled_and_packagePathArgument_is_passed_usesIt() async throws {
         // Given
         let path = try temporaryPath()

--- a/server/priv/docs/en/guides/features/projects/best-practices.md
+++ b/server/priv/docs/en/guides/features/projects/best-practices.md
@@ -98,7 +98,7 @@ import ProjectDescription
 let tuist = Tuist(
     project: .tuist(
         installOptions: .options(
-            manifestEnvironment: .automatic(
+            packageManifestEnvironment: .automatic(
                 including: ["CI_JOB_ID"]
             )
         )
@@ -106,7 +106,7 @@ let tuist = Tuist(
 )
 ```
 
-Use `manifestEnvironment: .all` to preserve the complete process environment. You can also exclude organization-specific volatile values with `manifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions.
+Use `packageManifestEnvironment: .all` to preserve the complete process environment. You can also exclude organization-specific volatile values with `packageManifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Tuist supplies the resulting environment to the package resolver as well as `Package.swift`, so never exclude credentials or another value needed to fetch a dependency. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions.
 
 ### Agentic coding and worktrees {#agentic-coding-and-worktrees}
 

--- a/server/priv/docs/en/guides/features/projects/best-practices.md
+++ b/server/priv/docs/en/guides/features/projects/best-practices.md
@@ -76,19 +76,13 @@ tuist install --force-resolved-versions
 
 This flag ensures that dependencies are resolved using the exact versions pinned in `Package.resolved`, eliminating issues caused by non-determinism in dependency resolution. This is particularly important on CI where reproducible builds are critical.
 
-#### Warm dependency installation on persistent continuous-integration runners
+#### Dependency installation on continuous-integration runners
 
-Tuist uses [SwifterPM](https://github.com/tuist/swifterpm) for `tuist install`. SwifterPM stores downloaded package sources in a shared cache and restores projects from that cache, making repeated installations faster. On a persistent continuous-integration runner, keep its source cache between jobs at `~/.cache/swifterpm`, or at `$XDG_CACHE_HOME/swifterpm` when `XDG_CACHE_HOME` is set. A runner with no persistent source cache takes the native Swift Package Manager path for the cold installation.
+Tuist uses [SwifterPM](https://github.com/tuist/swifterpm) for `tuist install`. SwifterPM maintains a local source cache and restores package checkouts from it when possible. On an ephemeral continuous-integration runner, every job starts without that cache, so installation follows the native [Swift Package Manager](https://www.swift.org/package-manager/) path. No additional configuration is needed.
 
-Continuous-integration installations copy cached package directories by default. On a persistent runner, pass `--cached-directory-materialization=symlink` to `tuist install` so that a warm installation links each worktree back to the cache instead of copying every checkout into `.build`:
+Package manifests can read process environment variables while declaring dependencies. The package-manifest cache therefore accounts for those variables. Job-specific values can change on every run without changing the declared dependencies, which would otherwise prevent a cache hit.
 
-```bash
-tuist install --cached-directory-materialization=symlink
-```
-
-Package manifests can read process environment variables while declaring dependencies. The package-manager cache therefore accounts for the whole environment when caching a manifest. A new job identifier can make that cache cold even when it does not change the declared dependencies.
-
-Tuist handles this automatically for [GitLab](https://docs.gitlab.com/ci/variables/predefined_variables/), [GitHub Actions](https://docs.github.com/actions/reference/workflows-and-actions/variables), [Bitrise](https://docs.bitrise.io/en/bitrise-ci/references/available-environment-variables/), and [Codemagic](https://docs.codemagic.io/yaml-basic-configuration/environment-variables/). When it recognizes one of those environments, it hides only volatile run metadata, such as job or run identifiers, retry counts, and per-step temporary paths, before evaluating `Package.swift` and calculating manifest cache keys. Branch, reference, commit, workflow, and other configuration values remain visible.
+Tuist handles this automatically for [GitLab](https://docs.gitlab.com/ci/variables/predefined_variables/), [GitHub Actions](https://docs.github.com/actions/reference/workflows-and-actions/variables), [Bitrise](https://docs.bitrise.io/en/bitrise-ci/references/available-environment-variables/), and [Codemagic](https://docs.codemagic.io/yaml-basic-configuration/environment-variables/). When it recognizes one of those environments, it hides only volatile run metadata, such as GitHub Actions run identifiers, retry counts, and per-step temporary paths, before evaluating `Package.swift` and calculating package-manifest cache keys. Branch, reference, commit, workflow, and other configuration values remain visible. These defaults apply on both ephemeral and persistent runners.
 
 If a package manifest intentionally uses one of the automatic exclusions to declare dependencies, restore that variable explicitly in `Tuist.swift`:
 
@@ -107,6 +101,14 @@ let tuist = Tuist(
 ```
 
 Use `packageManifestEnvironment: .all` to preserve the complete process environment. You can also exclude organization-specific volatile values with `packageManifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Tuist supplies the resulting environment to the package resolver as well as `Package.swift`, so never exclude credentials or another value needed to fetch a dependency. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions.
+
+#### Faster warm installations on persistent runners
+
+This is an optional optimization for a runner whose local cache survives between jobs. Keep SwifterPM's source cache at `~/.cache/swifterpm`, or at `$XDG_CACHE_HOME/swifterpm` when `XDG_CACHE_HOME` is set. With a warm source cache, pass `--cached-directory-materialization=symlink` to link each worktree to the cached checkouts instead of copying them into `.build`:
+
+```bash
+tuist install --cached-directory-materialization=symlink
+```
 
 ### Agentic coding and worktrees {#agentic-coding-and-worktrees}
 

--- a/server/priv/docs/en/guides/features/projects/best-practices.md
+++ b/server/priv/docs/en/guides/features/projects/best-practices.md
@@ -78,9 +78,15 @@ This flag ensures that dependencies are resolved using the exact versions pinned
 
 #### Warm dependency installation on persistent continuous-integration runners
 
-Tuist uses SwifterPM for `tuist install`. On a persistent continuous-integration runner, keep SwifterPM's source cache between jobs at `~/.cache/swifterpm`, or at `$XDG_CACHE_HOME/swifterpm` when `XDG_CACHE_HOME` is set. A runner with no persistent source cache takes the native Swift Package Manager path for the cold installation.
+Tuist uses [SwifterPM](https://github.com/tuist/swifterpm) for `tuist install`. SwifterPM stores downloaded package sources in a shared cache and restores projects from that cache, making repeated installations faster. On a persistent continuous-integration runner, keep its source cache between jobs at `~/.cache/swifterpm`, or at `$XDG_CACHE_HOME/swifterpm` when `XDG_CACHE_HOME` is set. A runner with no persistent source cache takes the native Swift Package Manager path for the cold installation.
 
-Continuous-integration installs copy cached package directories by default. On a persistent runner, use symlink materialization instead so that a warm installation links each worktree back to the cache instead of copying every checkout into `.build`:
+Continuous-integration installations copy cached package directories by default. On a persistent runner, pass `--cached-directory-materialization=symlink` to `tuist install` so that a warm installation links each worktree back to the cache instead of copying every checkout into `.build`:
+
+```bash
+tuist install --cached-directory-materialization=symlink
+```
+
+Package manifests can read process environment variables while declaring dependencies. The package-manager cache therefore accounts for the whole environment when caching a manifest. A new job identifier can make that cache cold even when it does not change the declared dependencies. Use `manifestEnvironmentExcluded` in `Tuist.swift` to remove such variables before Tuist evaluates `Package.swift` and calculates manifest cache keys:
 
 ```swift
 import ProjectDescription
@@ -88,10 +94,6 @@ import ProjectDescription
 let tuist = Tuist(
     project: .tuist(
         installOptions: .options(
-            passthroughSwiftPackageManagerArguments: [
-                "--force-resolved-versions",
-                "--cached-directory-materialization=symlink",
-            ],
             manifestEnvironmentExcluded: [
                 "CI_JOB_ID",
                 "CI_PIPELINE_ID",
@@ -101,7 +103,7 @@ let tuist = Tuist(
 )
 ```
 
-`manifestEnvironmentExcluded` prevents job-specific values from changing dependency-manifest cache keys. It also hides the values from every evaluated `Package.swift`, so only exclude variables that do not affect dependency declarations. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`.
+`manifestEnvironmentExcluded` hides the listed values from every evaluated `Package.swift`, so only exclude variables that do not affect dependency declarations. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`.
 
 ### Agentic coding and worktrees {#agentic-coding-and-worktrees}
 

--- a/server/priv/docs/en/guides/features/projects/best-practices.md
+++ b/server/priv/docs/en/guides/features/projects/best-practices.md
@@ -76,6 +76,33 @@ tuist install --force-resolved-versions
 
 This flag ensures that dependencies are resolved using the exact versions pinned in `Package.resolved`, eliminating issues caused by non-determinism in dependency resolution. This is particularly important on CI where reproducible builds are critical.
 
+#### Warm dependency installation on persistent continuous-integration runners
+
+Tuist uses SwifterPM for `tuist install`. On a persistent continuous-integration runner, keep SwifterPM's source cache between jobs at `~/.cache/swifterpm`, or at `$XDG_CACHE_HOME/swifterpm` when `XDG_CACHE_HOME` is set. A runner with no persistent source cache takes the native Swift Package Manager path for the cold installation.
+
+Continuous-integration installs copy cached package directories by default. On a persistent runner, use symlink materialization instead so that a warm installation links each worktree back to the cache instead of copying every checkout into `.build`:
+
+```swift
+import ProjectDescription
+
+let tuist = Tuist(
+    project: .tuist(
+        installOptions: .options(
+            passthroughSwiftPackageManagerArguments: [
+                "--force-resolved-versions",
+                "--cached-directory-materialization=symlink",
+            ],
+            manifestEnvironmentExcluded: [
+                "CI_JOB_ID",
+                "CI_PIPELINE_ID",
+            ]
+        )
+    )
+)
+```
+
+`manifestEnvironmentExcluded` prevents job-specific values from changing dependency-manifest cache keys. It also hides the values from every evaluated `Package.swift`, so only exclude variables that do not affect dependency declarations. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`.
+
 ### Agentic coding and worktrees {#agentic-coding-and-worktrees}
 
 Coding agents and human contributors increasingly work in parallel: a developer keeps a worktree open for the feature they are reviewing while one or more agents iterate on their own branches in sibling worktrees. A few project choices make this much smoother.

--- a/server/priv/docs/en/guides/features/projects/best-practices.md
+++ b/server/priv/docs/en/guides/features/projects/best-practices.md
@@ -86,7 +86,11 @@ Continuous-integration installations copy cached package directories by default.
 tuist install --cached-directory-materialization=symlink
 ```
 
-Package manifests can read process environment variables while declaring dependencies. The package-manager cache therefore accounts for the whole environment when caching a manifest. A new job identifier can make that cache cold even when it does not change the declared dependencies. Use `manifestEnvironmentExcluded` in `Tuist.swift` to remove such variables before Tuist evaluates `Package.swift` and calculates manifest cache keys:
+Package manifests can read process environment variables while declaring dependencies. The package-manager cache therefore accounts for the whole environment when caching a manifest. A new job identifier can make that cache cold even when it does not change the declared dependencies.
+
+Tuist handles this automatically for [GitLab](https://docs.gitlab.com/ci/variables/predefined_variables/), [GitHub Actions](https://docs.github.com/actions/reference/workflows-and-actions/variables), [Bitrise](https://docs.bitrise.io/en/bitrise-ci/references/available-environment-variables/), and [Codemagic](https://docs.codemagic.io/yaml-basic-configuration/environment-variables/). When it recognizes one of those environments, it hides only volatile run metadata, such as job or run identifiers, retry counts, and per-step temporary paths, before evaluating `Package.swift` and calculating manifest cache keys. Branch, reference, commit, workflow, and other configuration values remain visible.
+
+If a package manifest intentionally uses one of the automatic exclusions to declare dependencies, restore that variable explicitly in `Tuist.swift`:
 
 ```swift
 import ProjectDescription
@@ -94,16 +98,15 @@ import ProjectDescription
 let tuist = Tuist(
     project: .tuist(
         installOptions: .options(
-            manifestEnvironmentExcluded: [
-                "CI_JOB_ID",
-                "CI_PIPELINE_ID",
-            ]
+            manifestEnvironment: .automatic(
+                including: ["CI_JOB_ID"]
+            )
         )
     )
 )
 ```
 
-`manifestEnvironmentExcluded` hides the listed values from every evaluated `Package.swift`, so only exclude variables that do not affect dependency declarations. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`.
+Use `manifestEnvironment: .all` to preserve the complete process environment. You can also exclude organization-specific volatile values with `manifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Entries can be exact names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions.
 
 ### Agentic coding and worktrees {#agentic-coding-and-worktrees}
 

--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -58,7 +58,7 @@ Useful SwiftPM-shaped flags are supported, including `--package-path`, `--cache-
 
 Credentials for registries and binary artifact downloads are read from `~/.netrc`, from the `SWIFTPM_NETRC_DATA` environment variable, or from the file given by `--netrc-file`. Pass `--disable-netrc` to skip all of them. A `--netrc-file` that does not exist is an error rather than a silent fallback to unauthenticated requests.
 
-By default, `swifterpm` copies cached directories into the project scratch directory on CI and symlinks them elsewhere. Pass `--cached-directory-materialization symlink` to preserve global-cache symlinks on CI. The accepted values are `automatic`, `copy`, and `symlink`.
+By default, `swifterpm` copies cached directories into the project scratch directory during [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) and symlinks them elsewhere. Pass `--cached-directory-materialization=symlink` to preserve global-cache symlinks during continuous integration. The accepted values are `automatic`, `copy`, and `symlink`.
 
 > [!NOTE]
 > `swifterpm resolve` writes `Package.resolved` with an `originHash` derived from `Package.swift`, while SwiftPM derives its hash from the dependency graph. Running `swift package resolve` after `swifterpm resolve` in the same checkout may treat the lockfile as stale and resolve again.
@@ -66,11 +66,11 @@ By default, `swifterpm` copies cached directories into the project scratch direc
 ## Continuous integration
 
 > [!IMPORTANT]
-> Cache `~/.cache/swifterpm` (or `$XDG_CACHE_HOME/swifterpm`). Without it, every CI run is a cold run.
+> Cache `~/.cache/swifterpm` (or `$XDG_CACHE_HOME/swifterpm`). Without it, every continuous-integration run is a cold run.
 
-The order-of-magnitude numbers in [Benchmarks](#benchmarks-) all come from the warm global cache, not from resolution itself, which is still delegated to SwiftPM. Warm runs range from 8.96x to 201x faster than SwiftPM; cold runs range from 9.15x faster to 0.78x *slower*, depending on the graph. A pipeline that caches SwiftPM's directories but not this one therefore gives up the large wins and lands back in that cold range.
+The order-of-magnitude numbers in [Benchmarks](#benchmarks-) all come from the warm global cache, not from resolution itself, which is still delegated to SwiftPM. Warm runs range from 8.96x to 201x faster than SwiftPM. When any pin for the current package is missing from SwifterPM's source cache, SwifterPM delegates the installation directly to SwiftPM rather than doing a second restoration pass first. That keeps a cold package on SwiftPM's path while preserving SwifterPM's cache benefit once every pin is available.
 
-The scratch directory (`.build`) is cold on every CI run regardless, since it lives in the freshly checked out workspace. The global cache is the only part that can carry over, and it is a new path that no pre-existing configuration knows about, so this bites hardest when switching an existing pipeline over:
+The scratch directory (`.build`) is cold on every continuous-integration run regardless, since it lives in the freshly checked out workspace. The global cache is the only part that can carry over, and it is a new path that no pre-existing configuration knows about, so this bites hardest when switching an existing pipeline over:
 
 ```yaml
 - uses: actions/cache@v4
@@ -81,6 +81,25 @@ The scratch directory (`.build`) is cold on every CI run regardless, since it li
 ```
 
 The cache is content-addressed by package identity, version, and revision, so a stale restore is safe: entries that no longer match are simply unused, and `restore-keys` lets a run start from the closest previous cache instead of from nothing.
+
+For a persistent runner that keeps the SwifterPM cache on disk between jobs, configure symlink materialization. It avoids copying every cached checkout into a new scratch directory, leaving the warm path as inexpensive links back to the persistent cache.
+
+When the runner also changes job-specific environment variables between installs, configure Tuist to exclude values that do not affect dependency declarations. Tuist removes these values before evaluating `Package.swift` and before calculating manifest cache keys in both resolver modes:
+
+```swift
+let config = Config(
+    project: .tuist(
+        installOptions: .options(
+            passthroughSwiftPackageManagerArguments: [
+                "--cached-directory-materialization=symlink"
+            ],
+            manifestEnvironmentExcluded: ["CI_JOB_ID", "CI_PIPELINE_ID"]
+        )
+    )
+)
+```
+
+The materialization option is for persistent runner caches. Entries in `manifestEnvironmentExcluded` can be literal names or trailing-wildcard prefixes such as `GITHUB_RUN_*`. Never exclude a value that a package manifest uses to choose dependencies.
 
 ## Bazel Swift package resolver
 

--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -84,22 +84,21 @@ The cache is content-addressed by package identity, version, and revision, so a 
 
 For a persistent runner that keeps the SwifterPM cache on disk between jobs, configure symlink materialization. It avoids copying every cached checkout into a new scratch directory, leaving the warm path as inexpensive links back to the persistent cache.
 
-When the runner also changes job-specific environment variables between installs, configure Tuist to exclude values that do not affect dependency declarations. Tuist removes these values before evaluating `Package.swift` and before calculating manifest cache keys in both resolver modes:
+Package manifests can read process environment variables while declaring dependencies, so the package-manager cache keys include the environment they observe. Tuist automatically hides volatile run metadata when it recognizes [GitLab](https://docs.gitlab.com/ci/variables/predefined_variables/), [GitHub Actions](https://docs.github.com/actions/reference/workflows-and-actions/variables), [Bitrise](https://docs.bitrise.io/en/bitrise-ci/references/available-environment-variables/), or [Codemagic](https://docs.codemagic.io/yaml-basic-configuration/environment-variables/). This keeps job or run identifiers, retry counts, and per-step temporary paths from needlessly making a warm manifest cache cold. Branch, reference, commit, workflow, and other configuration values remain visible.
+
+Restore an automatically excluded variable only when a package manifest intentionally uses it to declare dependencies:
 
 ```swift
 let config = Config(
     project: .tuist(
         installOptions: .options(
-            passthroughSwiftPackageManagerArguments: [
-                "--cached-directory-materialization=symlink"
-            ],
-            manifestEnvironmentExcluded: ["CI_JOB_ID", "CI_PIPELINE_ID"]
+            manifestEnvironment: .automatic(including: ["CI_JOB_ID"])
         )
     )
 )
 ```
 
-The materialization option is for persistent runner caches. Entries in `manifestEnvironmentExcluded` can be literal names or trailing-wildcard prefixes such as `GITHUB_RUN_*`. Never exclude a value that a package manifest uses to choose dependencies.
+Use `manifestEnvironment: .all` to preserve the complete process environment, or add organization-specific volatile values with `manifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Entries can be literal names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions. Never exclude a value that a package manifest uses to choose dependencies.
 
 ## Bazel Swift package resolver
 

--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -92,13 +92,13 @@ Restore an automatically excluded variable only when a package manifest intentio
 let config = Config(
     project: .tuist(
         installOptions: .options(
-            manifestEnvironment: .automatic(including: ["CI_JOB_ID"])
+            packageManifestEnvironment: .automatic(including: ["CI_JOB_ID"])
         )
     )
 )
 ```
 
-Use `manifestEnvironment: .all` to preserve the complete process environment, or add organization-specific volatile values with `manifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Entries can be literal names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions. Never exclude a value that a package manifest uses to choose dependencies.
+Use `packageManifestEnvironment: .all` to preserve the complete process environment, or add organization-specific volatile values with `packageManifestEnvironment: .automatic(excluding: ["BUILD_RUN_*"])`. Tuist supplies the resulting environment to the package resolver as well as `Package.swift`, so never exclude credentials or another value needed to fetch a dependency. Entries can be literal names or trailing-wildcard prefixes such as `GITHUB_RUN_*`; included entries take precedence over automatic and custom exclusions.
 
 ## Bazel Swift package resolver
 

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -618,8 +618,7 @@ enum CLIRunner {
         if try await PackageResolver.shouldUseNativeColdPath(
             packageDir: package,
             cacheRoot: cacheRoot
-        )
-        {
+        ) {
             let resolved = try await PackageResolver.resolveWithSwiftPackageManagerProcess(
                 packageDir: package,
                 scratchDir: scratch,
@@ -632,6 +631,12 @@ enum CLIRunner {
                 writeResolvedFile: shouldWrite(write: write, printOnly: printOnly),
                 forceResolvedVersions: readOnly,
                 forwardOutput: !cli.quiet
+            )
+            let cache = try await Cache(root: cacheRoot)
+            try await WorkspaceRestorer.cacheNativeSourceCheckouts(
+                scratchDir: scratch,
+                cache: cache,
+                resolved: resolved
             )
             if !cli.quiet {
                 ResolvedFile.print(resolved)

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -602,17 +602,46 @@ enum CLIRunner {
         restore: Bool,
         printOnly: Bool
     ) async throws {
-        let cache = try await Cache(
-            root: cliCacheDir(cli: cli, paths: paths, commandCacheDir: cacheDir))
+        let cacheRoot = try Cache.resolvedRoot(
+            cliCacheDir(cli: cli, paths: paths, commandCacheDir: cacheDir))
         let package = canonicalPackageDir(
             commandPackageDir(cli: cli, paths: paths, commandPackageDir: packageDir))
         let scratch = commandScratchDir(
             cli: cli, paths: paths, packageDir: package, commandScratchDir: nil)
-        let registryConfig = try await cliRegistryConfig(
-            cli: cli, paths: paths, package: package)
         let readOnly =
             cli.forceResolvedVersions || cli.disableAutomaticResolution
             || cli.onlyUseVersionsFromResolvedFile
+
+        // Use the same native cold path as the embeddable API. The direct
+        // invocation is only safe for lockfiles SwiftPM itself understands;
+        // preserve SwifterPM's compatibility path for older custom pin kinds.
+        if try await PackageResolver.shouldUseNativeColdPath(
+            packageDir: package,
+            cacheRoot: cacheRoot
+        )
+        {
+            let resolved = try await PackageResolver.resolveWithSwiftPackageManagerProcess(
+                packageDir: package,
+                scratchDir: scratch,
+                cacheDir: cacheRoot,
+                registryConfigurationPath: paths.resolve(cli.configPath),
+                defaultRegistryURL: cli.defaultRegistryURL,
+                disableSandbox: cli.disableSandbox,
+                scmToRegistryTransformation: try scmToRegistryTransformation(cli),
+                useExistingResolvedFile: preferResolvedFile,
+                writeResolvedFile: shouldWrite(write: write, printOnly: printOnly),
+                forceResolvedVersions: readOnly,
+                forwardOutput: !cli.quiet
+            )
+            if !cli.quiet {
+                ResolvedFile.print(resolved)
+            }
+            return
+        }
+
+        let cache = try await Cache(root: cacheRoot)
+        let registryConfig = try await cliRegistryConfig(
+            cli: cli, paths: paths, package: package)
 
         let resolved = try await PackageResolver.resolveOrLoad(
             packageDir: package,

--- a/swifterpm/Sources/swifterpm/Cache.swift
+++ b/swifterpm/Sources/swifterpm/Cache.swift
@@ -4,11 +4,7 @@ struct Cache: Sendable {
     let root: URL
 
     init(root: URL?) async throws {
-        if let root {
-            self.root = root
-        } else {
-            self.root = try Cache.defaultRoot()
-        }
+        self.root = try Cache.resolvedRoot(root)
         let cacheRoot = self.root
         let topLevelPaths = [
             "sources",
@@ -37,6 +33,10 @@ struct Cache: Sendable {
     }
 
     func sourcePath(pin: ResolvedPin) throws -> URL {
+        try Cache.sourcePath(root: root, pin: pin)
+    }
+
+    static func sourcePath(root: URL, pin: ResolvedPin) throws -> URL {
         if pin.kind == "registry" {
             throw ToolError.message("registry source paths require registry URL and checksum")
         }
@@ -119,6 +119,22 @@ struct Cache: Sendable {
             at: root.appendingPathComponent("locks").appendingPathComponent(namespace)
                 .appendingPathComponent("\(Hashing.stable(key)).lock")
         )
+    }
+
+    func hasCachedSources() async throws -> Bool {
+        try await Cache.hasCachedSources(at: root)
+    }
+
+    static func resolvedRoot(_ root: URL?) throws -> URL {
+        try root ?? defaultRoot()
+    }
+
+    static func hasCachedSources(at root: URL) async throws -> Bool {
+        let sources = root.appendingPathComponent("sources")
+        guard try await fileSystem.exists(sources.absolutePath) else {
+            return false
+        }
+        return try await !fileSystem.contentsOfDirectory(at: sources).isEmpty
     }
 
     private static func defaultRoot() throws -> URL {

--- a/swifterpm/Sources/swifterpm/Environment.swift
+++ b/swifterpm/Sources/swifterpm/Environment.swift
@@ -5,6 +5,9 @@ enum Environment {
     static var values: [String: String]?
 
     @TaskLocal
+    static var manifestValues: [String: String]?
+
+    @TaskLocal
     static var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
 
     /// The netrc every download authenticates against. Entry points install it once
@@ -21,6 +24,18 @@ enum Environment {
         operation: () async throws -> T
     ) async throws -> T {
         try await Environment.$netrc.withValue(netrc) {
+            try await operation()
+        }
+    }
+
+    static func withManifestEnvironment<T>(
+        _ environment: [String: String]?,
+        operation: () async throws -> T
+    ) async throws -> T {
+        guard let environment else {
+            return try await operation()
+        }
+        return try await Environment.$manifestValues.withValue(environment) {
             try await operation()
         }
     }
@@ -50,6 +65,10 @@ enum Environment {
     /// dump was produced under.
     static var current: [String: String] {
         values ?? ProcessInfo.processInfo.environment
+    }
+
+    static var manifest: [String: String] {
+        manifestValues ?? current
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Manifest.swift
+++ b/swifterpm/Sources/swifterpm/Manifest.swift
@@ -114,7 +114,10 @@ enum ManifestLoader {
         }
         args.append("dump-package")
         let result = try await SystemProcess.run(
-            "/usr/bin/swift", args, workingDirectory: packageDir
+            "/usr/bin/swift",
+            args,
+            workingDirectory: packageDir,
+            customEnvironment: Environment.manifestValues
         )
         let cache = cacheFilePath(packageDir: packageDir)
         try? await fileSystem.atomicWrite(result.stdout, to: cache)

--- a/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
+++ b/swifterpm/Sources/swifterpm/ManifestEnvironmentFingerprint.swift
@@ -33,7 +33,7 @@ enum ManifestEnvironmentFingerprint {
 
     /// The fingerprint for the environment swifterpm currently runs in.
     static func current() -> String {
-        digest(for: Environment.current)
+        digest(for: Environment.manifest)
     }
 
     /// A deterministic fingerprint for `environment`, encoded as sorted JSON so a value

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -83,7 +83,7 @@ enum PackageResolver {
         let data: Data?
     }
 
-    private static func resolveWithSwiftPackageManagerProcess(
+    static func resolveWithSwiftPackageManagerProcess(
         packageDir: URL,
         scratchDir: URL?,
         cacheDir: URL,
@@ -93,6 +93,7 @@ enum PackageResolver {
         scmToRegistryTransformation: SCMToRegistryTransformation,
         useExistingResolvedFile: Bool,
         writeResolvedFile: Bool,
+        forceResolvedVersions: Bool = false,
         forwardOutput: Bool
     ) async throws -> ResolvedPins {
         let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
@@ -113,12 +114,17 @@ enum PackageResolver {
                     registryConfigurationPath: registryConfigurationPath,
                     defaultRegistryURL: defaultRegistryURL,
                     disableSandbox: disableSandbox,
-                    scmToRegistryTransformation: scmToRegistryTransformation
+                    scmToRegistryTransformation: scmToRegistryTransformation,
+                    forceResolvedVersions: forceResolvedVersions
                 ),
                 workingDirectory: packageDir,
+                customEnvironment: Environment.manifestValues,
                 forwardOutput: forwardOutput
             )
-            let resolved = try await ResolvedFile.read(packageDir: packageDir)
+            let resolvedPathExists = try await fileSystem.exists(resolvedPath.absolutePath)
+            let resolved = resolvedPathExists
+                ? try await ResolvedFile.read(packageDir: packageDir)
+                : ResolvedPins(originHash: nil, pins: [], version: 3)
             if !writeResolvedFile, let snapshot {
                 try await restoreResolvedFile(snapshot, at: resolvedPath)
             }
@@ -131,6 +137,40 @@ enum PackageResolver {
         }
     }
 
+    /// Returns true when SwifterPM cannot restore every pinned dependency from
+    /// its own source cache. In that case native SwiftPM is the shortest
+    /// correct path: it is already responsible for fetching each missing pin.
+    static func shouldUseNativeColdPath(packageDir: URL, cacheRoot: URL) async throws -> Bool {
+        let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
+        guard try await fileSystem.exists(resolvedPath.absolutePath) else {
+            return true
+        }
+
+        let pins = try await ResolvedFile.read(packageDir: packageDir).pins
+        guard pins.allSatisfy({
+            PinKind.isSourceControl($0.kind)
+                || PinKind.isRegistry($0.kind)
+                || $0.kind == "fileSystem"
+        })
+        else {
+            return false
+        }
+
+        for pin in pins {
+            // A registry source path includes the archive checksum, which is
+            // only available after a registry request. Do not make that extra
+            // request just to probe the cache on a cold installation.
+            guard PinKind.isSourceControl(pin.kind) else {
+                return true
+            }
+            let source = try Cache.sourcePath(root: cacheRoot, pin: pin)
+            guard try await fileSystem.exists(source.appendingPathComponent("Package.swift").absolutePath) else {
+                return true
+            }
+        }
+        return false
+    }
+
     private static func swiftPackageResolveArguments(
         packageDir: URL,
         scratchDir: URL?,
@@ -138,7 +178,8 @@ enum PackageResolver {
         registryConfigurationPath: URL?,
         defaultRegistryURL: String?,
         disableSandbox: Bool,
-        scmToRegistryTransformation: SCMToRegistryTransformation
+        scmToRegistryTransformation: SCMToRegistryTransformation,
+        forceResolvedVersions: Bool = false
     ) -> [String] {
         var arguments = [
             "package",
@@ -171,6 +212,9 @@ enum PackageResolver {
             arguments.append("--use-registry-identity-for-scm")
         case .replaceSCMWithRegistry:
             arguments.append("--replace-scm-with-registry")
+        }
+        if forceResolvedVersions {
+            arguments.append("--force-resolved-versions")
         }
         arguments.append("resolve")
         return arguments
@@ -308,7 +352,12 @@ enum PackageResolver {
             disableSandbox: disableSandbox,
             scmToRegistryTransformation: scmToRegistryTransformation
         ) + ["--force-resolved-versions"]
-        try await SystemProcess.run("swift", arguments, workingDirectory: packageDir)
+        try await SystemProcess.run(
+            "swift",
+            arguments,
+            workingDirectory: packageDir,
+            customEnvironment: Environment.manifestValues
+        )
     }
 
     private static func normalizeLoadedResolvedFile(

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -627,6 +627,48 @@ enum WorkspaceRestorer {
         return results.sorted { $0.0 < $1.0 }
     }
 
+    /// Makes source-control checkouts created by native SwiftPM available to future SwifterPM
+    /// installations. On the usual same-volume cache layout this is a rename, not a copy.
+    static func cacheNativeSourceCheckouts(
+        scratchDir: URL,
+        cache: Cache,
+        resolved: ResolvedPins
+    ) async throws {
+        let checkouts = scratchDir.appendingPathComponent("checkouts")
+        try await ConcurrentTasks.forEach(resolved.pins.filter { PinKind.isSourceControl($0.kind) }) { pin in
+            let checkout = checkouts.appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+            guard fileSystem.isDirectoryAndNotSymlink(checkout),
+                  try await cachedSourceIsUsable(checkout)
+            else { return }
+
+            let destination = try cache.sourcePath(pin: pin)
+            if try await cachedSourceIsUsable(destination) {
+                return
+            }
+
+            let lock = try await cache.lock(namespace: "sources", key: destination.path)
+            _ = lock
+            if try await cachedSourceIsUsable(destination) {
+                return
+            }
+
+            if try await fileSystem.exists(destination.absolutePath) {
+                try await fileSystem.remove(destination.absolutePath)
+            }
+
+            try await fileSystem.move(from: checkout.absolutePath, to: destination.absolutePath)
+            do {
+                try await fileSystem.createSymbolicLink(
+                    from: checkout.absolutePath,
+                    to: destination.absolutePath
+                )
+            } catch {
+                try? await fileSystem.move(from: destination.absolutePath, to: checkout.absolutePath)
+                throw error
+            }
+        }
+    }
+
     private static func sourceRestoreError(pin: ResolvedPin, error: any Error) -> ToolError {
         let revision = (try? pin.revision()).map { " at \($0)" } ?? ""
         return ToolError.message(

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -83,6 +83,7 @@ enum SystemProcess {
         _ arguments: [String],
         workingDirectory: URL? = nil,
         environment: [String: String] = [:],
+        customEnvironment: [String: String]? = nil,
         forwardOutput: Bool = false,
         outputLimit: Int = 64 * 1024 * 1024
     ) async throws -> Result {
@@ -90,7 +91,7 @@ enum SystemProcess {
             let result = try await Subprocess.run(
                 subprocessExecutable(executable),
                 arguments: Arguments(arguments),
-                environment: subprocessEnvironment(environment),
+                environment: subprocessEnvironment(environment, customEnvironment: customEnvironment),
                 workingDirectory: workingDirectory.map { FilePath($0.path) },
                 output: .standardOutput,
                 error: .standardError
@@ -106,7 +107,7 @@ enum SystemProcess {
         let result = try await Subprocess.run(
             subprocessExecutable(executable),
             arguments: Arguments(arguments),
-            environment: subprocessEnvironment(environment),
+            environment: subprocessEnvironment(environment, customEnvironment: customEnvironment),
             workingDirectory: workingDirectory.map { FilePath($0.path) },
             output: .bytes(limit: outputLimit),
             error: .bytes(limit: outputLimit)
@@ -144,9 +145,27 @@ enum SystemProcess {
         executable.contains("/") ? .path(FilePath(executable)) : .name(executable)
     }
 
-    private static func subprocessEnvironment(_ environment: [String: String])
+    private static func subprocessEnvironment(
+        _ environment: [String: String],
+        customEnvironment: [String: String]?
+    )
         -> Subprocess.Environment
     {
+        if let customEnvironment {
+            var values: [Subprocess.Environment.Key: String] = [:]
+            var overrides: [Subprocess.Environment.Key: String?] = [:]
+            for (key, value) in customEnvironment {
+                if let subprocessKey = Subprocess.Environment.Key(rawValue: key) {
+                    values[subprocessKey] = value
+                }
+            }
+            for (key, value) in environment {
+                if let subprocessKey = Subprocess.Environment.Key(rawValue: key) {
+                    overrides[subprocessKey] = value
+                }
+            }
+            return .custom(values).updating(overrides)
+        }
         guard !environment.isEmpty else { return .inherit }
         var overrides: [Subprocess.Environment.Key: String?] = [:]
         for (key, value) in environment {

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -47,6 +47,7 @@ public struct SwifterPMResolutionRequest: Sendable {
     public var packageInfoCacheDirectory: URL?
     public var scmToRegistryTransformation: SCMToRegistryTransformation
     public var cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization?
+    public var manifestEnvironment: [String: String]?
     public var quiet: Bool
 
     public init(
@@ -65,6 +66,7 @@ public struct SwifterPMResolutionRequest: Sendable {
         packageInfoCacheDirectory: URL? = nil,
         scmToRegistryTransformation: SCMToRegistryTransformation = .disabled,
         cachedDirectoryMaterialization: SwifterPMCachedDirectoryMaterialization? = nil,
+        manifestEnvironment: [String: String]? = nil,
         quiet: Bool = false
     ) {
         self.packageDirectory = packageDirectory
@@ -82,6 +84,7 @@ public struct SwifterPMResolutionRequest: Sendable {
         self.packageInfoCacheDirectory = packageInfoCacheDirectory
         self.scmToRegistryTransformation = scmToRegistryTransformation
         self.cachedDirectoryMaterialization = cachedDirectoryMaterialization
+        self.manifestEnvironment = manifestEnvironment
         self.quiet = quiet
     }
 }
@@ -133,10 +136,12 @@ public struct SwifterPM: Sendable {
         -> SwifterPMResolutionResult
     {
         try await Environment.withNetrc(try await loadNetrc(request.netrc)) {
-            try await Environment.withCachedDirectoryMaterialization(
-                request.cachedDirectoryMaterialization
-            ) {
-                try await runResolution(request: request, preferResolvedFile: true)
+            try await Environment.withManifestEnvironment(request.manifestEnvironment) {
+                try await Environment.withCachedDirectoryMaterialization(
+                    request.cachedDirectoryMaterialization
+                ) {
+                    try await runResolution(request: request, preferResolvedFile: true)
+                }
             }
         }
     }
@@ -145,10 +150,12 @@ public struct SwifterPM: Sendable {
         -> SwifterPMResolutionResult
     {
         try await Environment.withNetrc(try await loadNetrc(request.netrc)) {
-            try await Environment.withCachedDirectoryMaterialization(
-                request.cachedDirectoryMaterialization
-            ) {
-                try await runResolution(request: request, preferResolvedFile: false)
+            try await Environment.withManifestEnvironment(request.manifestEnvironment) {
+                try await Environment.withCachedDirectoryMaterialization(
+                    request.cachedDirectoryMaterialization
+                ) {
+                    try await runResolution(request: request, preferResolvedFile: false)
+                }
             }
         }
     }
@@ -209,7 +216,36 @@ public struct SwifterPM: Sendable {
     ) async throws -> SwifterPMResolutionResult {
         let package = request.packageDirectory.standardizedFileURL
         let scratch = request.scratchDirectory ?? package.appendingPathComponent(".build")
-        let cache = try await Cache(root: request.cacheDirectory)
+        let cacheRoot = try Cache.resolvedRoot(request.cacheDirectory)
+
+        // A cache only helps when it has every pin for this package. Going
+        // straight to the native resolver for any missing pin avoids manifest
+        // precomputation and restoration work before SwiftPM fetches it.
+        if try await PackageResolver.shouldUseNativeColdPath(
+            packageDir: package,
+            cacheRoot: cacheRoot
+        )
+        {
+            let resolved = try await PackageResolver.resolveWithSwiftPackageManagerProcess(
+                packageDir: package,
+                scratchDir: scratch,
+                cacheDir: cacheRoot,
+                registryConfigurationPath: request.registryConfigurationPath,
+                defaultRegistryURL: request.defaultRegistryURL,
+                disableSandbox: request.disableSandbox,
+                scmToRegistryTransformation: request.scmToRegistryTransformation,
+                useExistingResolvedFile: preferResolvedFile,
+                writeResolvedFile: request.writeResolvedFile,
+                forceResolvedVersions: request.forceResolvedVersions,
+                forwardOutput: !request.quiet
+            )
+            if !request.quiet {
+                ResolvedFile.print(resolved)
+            }
+            return SwifterPMResolutionResult(resolved)
+        }
+
+        let cache = try await Cache(root: cacheRoot)
         let registryConfig = try await RegistryConfig.load(
             packageDir: package,
             configPath: request.registryConfigurationPath,

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -224,8 +224,7 @@ public struct SwifterPM: Sendable {
         if try await PackageResolver.shouldUseNativeColdPath(
             packageDir: package,
             cacheRoot: cacheRoot
-        )
-        {
+        ) {
             let resolved = try await PackageResolver.resolveWithSwiftPackageManagerProcess(
                 packageDir: package,
                 scratchDir: scratch,
@@ -238,6 +237,12 @@ public struct SwifterPM: Sendable {
                 writeResolvedFile: request.writeResolvedFile,
                 forceResolvedVersions: request.forceResolvedVersions,
                 forwardOutput: !request.quiet
+            )
+            let cache = try await Cache(root: cacheRoot)
+            try await WorkspaceRestorer.cacheNativeSourceCheckouts(
+                scratchDir: scratch,
+                cache: cache,
+                resolved: resolved
             )
             if !request.quiet {
                 ResolvedFile.print(resolved)

--- a/swifterpm/Tests/swifterpmTests/CLIRunnerTests.swift
+++ b/swifterpm/Tests/swifterpmTests/CLIRunnerTests.swift
@@ -63,7 +63,6 @@ struct CLIRunnerTests {
                 ))
 
             #expect(try await fileSystem.currentWorkingDirectory().pathString == currentDirectory)
-            #expect(try await fileSystem.exists(root.appendingPathComponent("cache/sources").absolutePath))
         }
     }
 

--- a/swifterpm/Tests/swifterpmTests/CacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/CacheTests.swift
@@ -39,7 +39,7 @@ struct CacheTests {
     @Test
     func initializesExpectedCacheDirectories() async throws {
         try await withTemporaryDirectory { root in
-            _ = try await Cache(root: root)
+            let cache = try await Cache(root: root)
 
             for path in [
                 "sources",
@@ -52,6 +52,13 @@ struct CacheTests {
             ] {
                 #expect(try await fileSystem.exists(root.appendingPathComponent(path).absolutePath))
             }
+            #expect(try await !cache.hasCachedSources())
+
+            try await fileSystem.makeDirectory(
+                at: root.appendingPathComponent("sources/example").absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            #expect(try await cache.hasCachedSources())
         }
     }
 

--- a/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ManifestEnvironmentFingerprintTests.swift
@@ -21,6 +21,21 @@ struct ManifestEnvironmentFingerprintTests {
     }
 
     @Test
+    func currentUsesScopedManifestEnvironment() async throws {
+        try await Environment.$values.withValue([
+            "BENCH_NONCE": "first",
+            "RETAINED": "value",
+        ]) {
+            try await Environment.withManifestEnvironment(["RETAINED": "value"]) {
+                #expect(
+                    ManifestEnvironmentFingerprint.current()
+                        == ManifestEnvironmentFingerprint.digest(for: ["RETAINED": "value"])
+                )
+            }
+        }
+    }
+
+    @Test
     func digestDistinguishesEmbeddedNewlinesFromSeparateEntries() {
         // A value containing the delimiter must not collide with two distinct entries.
         let withNewline = ManifestEnvironmentFingerprint.digest(for: ["A": "x\nB=y"])

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -155,7 +155,7 @@ struct ResolveTests {
     }
 
     @Test
-    func coldResolutionUsesSwiftPMWithoutPopulatingTheSwifterPMSourceCache() async throws {
+    func coldResolutionSeedsTheSwifterPMSourceCache() async throws {
         try await withTemporaryDirectory { root in
             let dependency = root.appendingPathComponent("Dependency")
             try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
@@ -176,7 +176,43 @@ struct ResolveTests {
                 ))
 
             #expect(result.pins.map(\.identity) == ["dependency"])
-            #expect(try await !cache.hasCachedSources())
+            #expect(try await cache.hasCachedSources())
+            #expect(
+                try await !PackageResolver.shouldUseNativeColdPath(
+                    packageDir: package,
+                    cacheRoot: cache.root
+                )
+            )
+
+            let pin = try #require(
+                try await ResolvedFile.read(packageDir: package).pins.first
+            )
+            let cachedSource = try cache.sourcePath(pin: pin)
+            try await fileSystem.atomicWrite(
+                "cached\n",
+                to: cachedSource.appendingPathComponent(".swifterpm-cache-marker")
+            )
+
+            let freshScratch = root.appendingPathComponent("fresh-scratch")
+            let warmResult = try await SwifterPM().resolve(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: freshScratch,
+                    disableSandbox: true,
+                    quiet: true
+                ))
+
+            #expect(warmResult.pins.map(\.identity) == ["dependency"])
+            #expect(
+                try await fileSystem.exists(
+                    freshScratch
+                        .appendingPathComponent("checkouts")
+                        .appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+                        .appendingPathComponent(".swifterpm-cache-marker")
+                        .absolutePath
+                )
+            )
         }
     }
 

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -154,6 +154,70 @@ struct ResolveTests {
         }
     }
 
+    @Test
+    func coldResolutionUsesSwiftPMWithoutPopulatingTheSwifterPMSourceCache() async throws {
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tags: ["1.0.0"])
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(at: package, dependencyURL: dependency.path)
+            let cacheDirectory = root.appendingPathComponent("cache")
+            let cache = try await Cache(root: cacheDirectory)
+
+            let result = try await SwifterPM().resolve(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: root.appendingPathComponent("scratch"),
+                    disableSandbox: true,
+                    quiet: true
+                ))
+
+            #expect(result.pins.map(\.identity) == ["dependency"])
+            #expect(try await !cache.hasCachedSources())
+        }
+    }
+
+    @Test
+    func nativeColdPathIsUsedWhenTheSharedCacheOnlyContainsOtherPackages() async throws {
+        try await withTemporaryDirectory { root in
+            let package = root.appendingPathComponent("App")
+            try await writeMinimalPackageManifest(at: package, name: "App")
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let cachedPin = ResolvedPin(
+                identity: "cached",
+                kind: "remoteSourceControl",
+                location: "https://example.com/cached.git",
+                state: .init(branch: nil, revision: "aaaaaaaa", version: "1.0.0")
+            )
+            let missingPin = ResolvedPin(
+                identity: "missing",
+                kind: "remoteSourceControl",
+                location: "https://example.com/missing.git",
+                state: .init(branch: nil, revision: "bbbbbbbb", version: "1.0.0")
+            )
+            let cachedSource = try cache.sourcePath(pin: cachedPin)
+            try await fileSystem.makeDirectory(
+                at: cachedSource.absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            try await writeMinimalPackageManifest(at: cachedSource, name: "Cached")
+            try await ResolvedFile.write(
+                packageDir: package,
+                resolved: .init(originHash: "origin", pins: [missingPin], version: 3)
+            )
+
+            #expect(
+                try await PackageResolver.shouldUseNativeColdPath(
+                    packageDir: package,
+                    cacheRoot: cache.root
+                )
+            )
+        }
+    }
+
     private func initGitDependency(at dependency: URL, tags: [String]) async throws {
         try await SystemProcess.run("git", ["init"], workingDirectory: dependency)
         try await SystemProcess.run(

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -4,6 +4,18 @@ import Testing
 
 struct SupportTests {
     @Test
+    func customProcessEnvironmentDoesNotInheritExcludedVariables() async throws {
+        let result = try await SystemProcess.run(
+            "/usr/bin/env",
+            [],
+            customEnvironment: ["SWIFTERPM_TEST_RETAINED": "value"]
+        )
+
+        #expect(result.stdoutString.contains("SWIFTERPM_TEST_RETAINED=value"))
+        #expect(!result.stdoutString.contains("HOME="))
+    }
+
+    @Test
     func hashingAndRevisionHelpersAreStable() {
         let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         #expect(Hashing.sha256Hex(Data("abc".utf8)) == expected)


### PR DESCRIPTION
## What changed

- Added `manifestEnvironmentExcluded` to `Config.InstallOptions`.
- Evaluated dependency manifests with the filtered environment in both SwifterPM and the native [Swift Package Manager (SwiftPM)](https://www.swift.org/package-manager/) path.
- Delegated a cold dependency installation to native Swift Package Manager whenever the current lockfile has a dependency missing from SwifterPM cache.
- Documented persistent-runner configuration in the Tuist documentation and the SwifterPM README.

## Why

Persistent [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) runners retain dependency caches while job identifiers change on every run. Those unrelated values can invalidate dependency-manifest cache entries, and a cold restoration could take longer than native Swift Package Manager resolution.

## Root cause

Swift Package Manager includes the process environment in its manifest-cache identity, and SwifterPM independently fingerprints that environment. A cached source for an unrelated package was also enough to select the restoration path when the current dependency graph was cold.

## Approach

`manifestEnvironmentExcluded` removes explicitly named variables from child manifest processes. Since those values are unavailable to the manifests, excluding them from cache keys is safe only when they do not affect dependency declarations.

Before restoring a graph, SwifterPM checks the current lockfile against its source cache. When any source-control pin is missing, or when a registry pin would require a network request merely to probe the cache, it delegates straight to native Swift Package Manager.

## Impact

Persistent runners can keep fast warm installations by retaining the SwifterPM cache and using symlink materialization. Teams can exclude non-semantic job identifiers such as `CI_JOB_ID` and `CI_PIPELINE_ID` without changing dependency-manifest cache entries.

### How to test locally

- `mise x bazel@8.7.0 -- bazel test //:swifterpm_tests --test_output=errors --nocache_test_results`
- `git diff --check origin/main...HEAD`
- Attempted `tuist generate tuist TuistSupport TuistSupportTests TuistKit TuistKitTests ProjectDescription --no-open`; the existing `BasicContainers is not a valid configured external dependency` generation failure prevented this check.
