### PR TITLE
fix(infra): use numeric ports in pentest egress network policies

### DIFF
--- a/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
@@ -2,6 +2,14 @@
 # The pentest environment uses embedded data services. Keep each consumer's
 # path explicit so a compromise of one workload cannot probe arbitrary ports
 # on its neighbours.
+#
+# Egress rules use explicit numeric ports instead of named ports. Cilium
+# resolves named ports in egress rules against the destination pods' ports,
+# and a name such as `http` maps to different numeric ports across the
+# embedded services (cache 80, clickhouse 8123, server 8080). Cilium treats
+# that as "duplicate named ports" and silently skips the whole rule, so the
+# traffic it was meant to allow is dropped. Ingress rules resolve named ports
+# against the local pod's own ports, so they keep using named ports.
 {{- $dnsNamespace := .Values.server.networkPolicy.dnsNamespace }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -22,28 +30,28 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "postgresql") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: postgres
+          port: 5432
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: http
+          port: 8123
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "object-storage") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: api
+          port: 9000
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "cache") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: http
+          port: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -73,21 +81,21 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "postgresql") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: postgres
+          port: 5432
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: http
+          port: 8123
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "object-storage") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: api
+          port: 9000
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -117,21 +125,21 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "server") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: http
+          port: 8080
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "postgresql") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: postgres
+          port: 5432
     - to:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "object-storage") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: api
+          port: 9000
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -161,7 +169,7 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: native
+          port: 9000
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -191,7 +199,7 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: native
+          port: 9000
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -221,7 +229,7 @@ spec:
               {{- include "tuist.componentLabels" (dict "root" . "component" "object-storage") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: api
+          port: 9000
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## What changed

The pentest Helm chart's egress NetworkPolicies (`infra/helm/tuist/templates/pentest-data-networkpolicy.yaml`) now use explicit numeric ports instead of named ports for every egress rule. Ingress rules are unchanged.

## Why

The pentest deployment has been failing consistently: the `pentest-tuist-server-migrate-r1` Job never completes, and after 20 minutes Helm's `--atomic` rolls the release back, leaving an empty namespace.

The migrate Job's init container waits for ClickHouse readiness (`curl http://pentest-tuist-clickhouse:8123/ping`). On the cluster, Cilium was dropping those packets:

```
Skipping named port ... error="duplicate named ports" portName=http protocol=TCP trafficDirection=egress
```

Cilium resolves named ports in egress rules against the destination pods' ports. In the pentest stack the name `http` maps to different numeric ports across the embedded services:

- cache: 80
- clickhouse: 8123
- server: 8080

Cilium treats that as duplicate named ports and silently skips the whole egress rule, so the server and migration pods could never reach ClickHouse (or cache). The same applied to every egress rule that used the `http` name. Rules using `postgres`, `api`, and `native` resolved fine because those names are unambiguous.

## Root cause

Named ports in egress rules are ambiguous when the same name maps to different numeric ports on different destinations. Cilium skips the rule instead of failing loudly, so the traffic it was meant to allow is dropped.

## Approach

Switch the pentest egress rules to explicit numeric ports. Ingress rules keep named ports because they resolve against the local pod's own ports, which is unambiguous per pod.

## Validation

- `helm template` renders the corrected rules (server-internal-egress: 5432/8123/9000/80, server-migration-egress: 5432/8123/9000, cache-egress: 8080/5432/9000).
- Manually deployed the chart to the pentest cluster without `--atomic` and confirmed via Cilium monitor that egress to ClickHouse was denied with `match none` before the fix.