### PR TITLE
fix(infra): allow clickhouse egress to postgres in pentest network policies

### DIFF
--- a/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/pentest-data-networkpolicy.yaml
@@ -144,6 +144,36 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "clickhouse-egress") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse-egress
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.componentLabels" (dict "root" . "component" "postgresql") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: {{ include "tuist.componentName" (dict "root" . "component" "clickhouse-init-egress") }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
@@ -254,6 +284,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "cache") | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 14 }}
       ports:
         - protocol: TCP
           port: postgres


### PR DESCRIPTION
## What changed

Added a `clickhouse-egress` NetworkPolicy and updated `postgresql-ingress` in `infra/helm/tuist/templates/pentest-data-networkpolicy.yaml` to permit ClickHouse pods to resolve DNS and connect to PostgreSQL on port 5432.

## Why

After fixing the initial named-port egress issue in #12662, the pentest migration job progressed past ClickHouse connectivity and began running ClickHouse migrations. It then failed on:

```
** (RuntimeError) Failed to connect to PostgreSQL database. Error: %MatchError{term: {:error, %Mint.TransportError{reason: :timeout}}}
    lib/tuist-0.1.0/priv/ingest_repo/migrations/20250701125026_update_clickhouse_xcode_graph_command_event_id_to_string.exs:244: Tuist.ClickHouseRepo.Migrations.UpdateClickhouseXcodeGraphCommandEventIdToString.validate_clickhouse_migration_prerequisites!/1
```

The migration validates its prerequisites by executing:

```sql
SELECT count(*) FROM postgresql('pentest-tuist-postgresql:5432', 'tuist', 'command_events', ...)
```

Under the pentest environment's `defaultDenyAllPods: true`:
- The `clickhouse` component had no egress NetworkPolicy, blocking outbound TCP connections to PostgreSQL (and DNS).
- The `postgresql-ingress` NetworkPolicy did not admit the `clickhouse` component.

ClickHouse hung attempting to establish the TCP connection to Postgres, causing the Ecto driver to time out after 15 seconds and failing the release.

## Root cause

ClickHouse migrations query PostgreSQL directly via ClickHouse's `postgresql()` table function. The isolated pentest network policies did not anticipate ClickHouse acting as a client to PostgreSQL.

## Approach

1. Add a `clickhouse-egress` NetworkPolicy permitting DNS (UDP/TCP 53) and TCP 5432 to `app.kubernetes.io/component=postgresql`.
2. Add `app.kubernetes.io/component=clickhouse` to the `postgresql-ingress` NetworkPolicy's admitted sources.

## Validation

- `helm template` renders the new `pentest-tuist-clickhouse-egress` and updated `pentest-tuist-postgresql-ingress` policies.
- Migration failure verified directly on the live pentest cluster via migration pod logs.
