### PR TITLE
fix(kura): gate the release on changed paths, not the commit scope

### DIFF
--- a/kura/cliff.toml
+++ b/kura/cliff.toml
@@ -52,17 +52,22 @@ commit_preprocessors = [
     # calls per release (each would paginate the whole repo's commits+PRs).
     { pattern = '\(#([0-9]+)\)', replace = "([#${1}](https://github.com/tuist/tuist/pull/${1}))" },
 ]
+# Matched by type only. `--include-path kura/**/*` is what decides whether a
+# commit belongs to this component; requiring the scope to say `kura` as well
+# meant a commit that changed these files under another scope passed the path
+# filter and was then dropped, so no version bump and no release. That silently
+# left the shed-age and ring-occupancy telemetry unreleased when #12606 landed
+# it under `feat(server)`.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bkura\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bkura\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bkura\\b[^)]*\\)", skip = true },
-    { message = "^[a-z]+\\([^)]+\\)", skip = true },
+    { message = "^feat[(:!]", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix[(:!]", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?[(:!]", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf[(:!]", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor[(:!]", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style[(:!]", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test[(:!]", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore[(:!]", skip = true },
+    { message = "^ci[(:!]", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = true


### PR DESCRIPTION
## What changed

`kura/cliff.toml` now matches commits by type only (`^feat[(:!]`, `^fix[(:!]`, …) instead of requiring the conventional scope to contain `kura`, and the `^[a-z]+\([^)]+\)` catch-all with `skip = true` is gone.

## Why

The component release check runs:

```
git cliff --include-path "kura/**/*" --config kura/cliff.toml --bumped-version
```

`--include-path` correctly restricts git-cliff to commits touching `kura/`, but the parsers then required the *scope* to say `kura` too, and `filter_commits = true` dropped everything else. So a commit that changed `kura/` under any other scope passed the path filter and was silently discarded — no version bump, no release. The path filter was doing nothing; the scope was the real gate, and it was the wrong one.

## Root cause of the miss it caused

[#12606](https://github.com/tuist/tuist/pull/12606) was squash-merged as `feat(server): size Kura disk claims from shedding and occupancy telemetry`. It carries the Rust changes that make nodes report segment shed age and ring occupancy. Being `server`-scoped, it cut no Kura release, so `kura@0.28.0` remains the latest tag and the fleet runs an image with none of that telemetry in it.

The server half deployed and is healthy — the ClickHouse tables exist and the sizing worker has been running clean every ten minutes — but both tables stay empty, so no rollup and no proposal can ever form. Disk sizing is inert until this releases.

Squash merging is the aggravator: it collapses a PR into one message with one scope, so a PR touching several components can only ever satisfy one of their gates.

## Why this fix

This is the same change [#11059](https://github.com/tuist/tuist/pull/11059) made to `linux-runner-image`, where the identical bug shipped that image without the docker CLI and left Docker jobs failing with `docker: not found`.

## Validation

Reproduced the real history on a fixture — a `kura@0.28.0` tag plus the exact squash-merge message touching `kura/` — and compared both configs against it:

| config | `--bumped-version` |
| --- | --- |
| before (scope-gated) | `There is nothing to bump` → `kura@0.28.0` |
| after (type-only) | `kura@0.29.0` |

Also confirmed `--include-path` still constrains membership: a `feat` touching only `server/` produces no Kura bump, while a foreign-scoped commit touching `kura/` is picked up and grouped correctly in the changelog.

Merging this cuts `kura@0.29.0`, which builds from the current tree and therefore ships the telemetry that #12606 already landed.

## Scope

Deliberately limited to `kura`. Eleven other components share the same catch-all, and converting them together is **not** safe — measured blast radius of a type-only conversion, counting commits that would newly qualify since each component's latest tag:

| component | newly qualifying |
| --- | --- |
| gradle | 1548 |
| app | 10 |
| helm | 2 |
| cache | 2 |
| kura | 1 |
| skills | 1 |

`gradle` has an **empty `include_paths`**, so `--include-path` restricts nothing and its scope gate is load-bearing; type-only matching would make every feat/fix in the repo cut a gradle release. `app`'s paths reach into `cli/Sources/**`, so it needs a judgement call too. Those are worth fixing, but deliberately and separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)