### PR TITLE
fix(infra): recreate pentest deployer credential after delete

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -47,6 +47,8 @@ env:
   HELM_RELEASE_NAME: pentest
   NAMESPACE: tuist-pentest
   HOST: pentest.tuist.dev
+  CLUSTER_NAME: tuist-pentest
+  GITHUB_ENVIRONMENT: server-k8s-pentest
 
 jobs:
   resolve:
@@ -315,6 +317,9 @@ jobs:
     runs-on: tuist-linux
     environment:
       name: server-k8s-pentest
+    permissions:
+      contents: read
+      secrets: write
     timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
@@ -341,6 +346,61 @@ jobs:
           if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
             kubectl delete namespace "$NAMESPACE" --wait=true --timeout=5m
           fi
+      - name: Recreate the deployment credential
+        # Deleting the namespace removes the github-actions-deployer
+        # ServiceAccount and its token secret, which the KUBECONFIG environment
+        # secret references. Without recreating them the cluster would no
+        # longer be deployable from CI until bootstrap is re-run. Reapply the
+        # bootstrap credential manifest (namespace, SA, token secret, cluster
+        # binding) and refresh KUBECONFIG with the new token.
+        run: |
+          set -euo pipefail
+
+          sed "s/__NAMESPACE__/${NAMESPACE}/g" infra/k8s/mgmt/ci-service-account.yaml \
+            | kubectl apply -f -
+
+          ci_server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')"
+          ci_certificate_authority="$(kubectl -n "$NAMESPACE" get secret github-actions-deployer-token \
+            -o jsonpath='{.data.ca\.crt}')"
+
+          ci_token=""
+          for _ in $(seq 1 30); do
+            ci_token="$(kubectl -n "$NAMESPACE" get secret github-actions-deployer-token \
+              -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+            if [ -n "$ci_token" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "$ci_server" ] || [ -z "$ci_certificate_authority" ] || [ -z "$ci_token" ]; then
+            echo "::error::Could not mint the GitHub Actions deployment kubeconfig."
+            exit 1
+          fi
+
+          ci_kubeconfig="$(mktemp)"
+          printf '%s\n' \
+            'apiVersion: v1' \
+            'kind: Config' \
+            'clusters:' \
+            "  - name: ${CLUSTER_NAME}" \
+            '    cluster:' \
+            "      server: ${ci_server}" \
+            "      certificate-authority-data: ${ci_certificate_authority}" \
+            'contexts:' \
+            "  - name: ci" \
+            '    context:' \
+            "      cluster: ${CLUSTER_NAME}" \
+            "      namespace: ${NAMESPACE}" \
+            '      user: github-actions-deployer' \
+            'users:' \
+            "  - name: github-actions-deployer" \
+            '    user:' \
+            "      token: ${ci_token}" \
+            'current-context: ci' > "$ci_kubeconfig"
+
+          base64 < "$ci_kubeconfig" | gh secret set KUBECONFIG --env "$GITHUB_ENVIRONMENT" --repo "$GITHUB_REPOSITORY"
+          rm -f "$ci_kubeconfig"
 
   cleanup-expired:
     name: Remove expired pentest release


### PR DESCRIPTION
## What changed

The `delete` action in `.github/workflows/pentest-deployment.yml` now recreates the `github-actions-deployer` ServiceAccount and its token secret after removing the pentest namespace, and refreshes the `KUBECONFIG` GitHub environment secret with the new token.

## Why

The `delete` action tears down the `tuist-pentest` namespace, which is where the `github-actions-deployer` ServiceAccount and its long-lived token secret live. The `KUBECONFIG` environment secret is minted from that token, so after a `delete` the cluster can no longer be deployed from CI until bootstrap is re-run (which requires the management cluster talosconfig and an interactive operator).

I hit this while validating the pentest deployment: after the two earlier network-policy fixes, I used the `delete` action to reset the environment, and the next `deploy` failed immediately with `Unauthorized` at "Verify cluster reachability".

## Root cause

Deleting a namespace destroys every object it contains. The CI credential is namespace-scoped (it must be, since `ci-service-account.yaml` scopes the ServiceAccount and token to `__NAMESPACE__`), so tearing down the namespace invalidates the `KUBECONFIG` secret.

## Approach

After the uninstall and namespace deletion, the delete job reapplies the same `infra/k8s/mgmt/ci-service-account.yaml` manifest bootstrap uses (namespace, ServiceAccount, token secret, cluster binding), waits for the token to be minted, rebuilds the CI kubeconfig exactly as bootstrap does, and pushes it back to the `KUBECONFIG` environment secret via `gh secret set`.

The delete job gains job-scoped `permissions: secrets: write` so the token can refresh the environment secret; the rest of the workflow keeps its existing permissions.

## Validation

- Workflow YAML parses.
- The credential recreation logic mirrors bootstrap's `bootstrap-pentest.sh` (same manifest, same kubeconfig shape, same secret name).
- Validated the underlying flow live on the pentest cluster with the admin kubeconfig: recreating the namespace + SA + token and rebuilding the kubeconfig restores CI access (verified with the admin credential; the deploy then progressed).

## Impact

Delete cycles no longer leave the pentest cluster in a state where only an operator with management-cluster access can restore deployability. A follow-up `deploy` after `delete` works out of the box.