### PR TITLE
fix(server): report object storage failures on multipart uploads instead of raising

### DIFF
--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -119,8 +119,7 @@ defmodule Tuist.Shards do
   end
 
   def start_upload_for_plan_id(%Project{} = project, %Account{} = account, plan_id, artifact \\ nil) do
-    upload_id = Storage.multipart_start(artifact_object_key(account, project, plan_id, artifact), account)
-    {:ok, upload_id}
+    Storage.multipart_start(artifact_object_key(account, project, plan_id, artifact), account)
   end
 
   def get_shard(%Project{} = project, %Account{} = account, reference, shard_index, opts \\ []) do
@@ -160,8 +159,6 @@ defmodule Tuist.Shards do
       parts,
       account
     )
-
-    :ok
   end
 
   def generate_upload_url(%Project{} = project, %Account{} = account, reference, upload_id, part_number, artifact \\ nil) do

--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -104,7 +104,22 @@ defmodule Tuist.Storage do
       %{object_key: object_key, upload_id: upload_id}
     )
 
+    report_multipart_complete_failure(object_key, upload_id, result)
+
     result
+  end
+
+  defp report_multipart_complete_failure(_object_key, _upload_id, :ok), do: :ok
+
+  defp report_multipart_complete_failure(_object_key, _upload_id, {:error, :multipart_upload_not_found}), do: :ok
+
+  defp report_multipart_complete_failure(object_key, upload_id, {:error, reason}) do
+    Logger.error("Could not complete the multipart upload #{upload_id} for #{object_key}: #{inspect(reason)}")
+
+    Sentry.capture_message("Object storage rejected the completion of a multipart upload",
+      level: :error,
+      extra: %{object_key: object_key, upload_id: upload_id, reason: inspect(reason)}
+    )
   end
 
   defp multipart_complete_upload_error({:http_error, 404, %{body: body}} = reason) when is_binary(body) do
@@ -366,34 +381,54 @@ defmodule Tuist.Storage do
   end
 
   def multipart_start(object_key, actor) do
-    {time, upload_id} =
+    {time, result} =
       Performance.measure_time_in_milliseconds(fn ->
         case storage_provider(actor) do
           :azure_blob ->
-            AzureBlob.multipart_start(object_key)
+            {:ok, AzureBlob.multipart_start(object_key)}
 
           :s3 ->
-            {config, bucket_name} = s3_config_and_bucket(actor)
-            headers = region_headers(actor)
-
-            operation =
-              bucket_name
-              |> ExAws.S3.initiate_multipart_upload(object_key)
-              |> Map.put(:headers, Map.new(headers))
-
-            %{body: %{upload_id: upload_id}} = ExAws.request!(operation, Map.merge(config, fast_api_req_opts()))
-
-            upload_id
+            s3_multipart_start(object_key, actor)
         end
       end)
 
-    :telemetry.execute(
-      Tuist.Telemetry.event_name_storage_multipart_start_upload(),
-      %{duration: time},
-      %{object_key: object_key}
-    )
+    case result do
+      {:ok, _upload_id} ->
+        :telemetry.execute(
+          Tuist.Telemetry.event_name_storage_multipart_start_upload(),
+          %{duration: time},
+          %{object_key: object_key}
+        )
 
-    upload_id
+      {:error, reason} ->
+        report_multipart_start_failure(object_key, reason)
+    end
+
+    result
+  end
+
+  defp s3_multipart_start(object_key, actor) do
+    {config, bucket_name} = s3_config_and_bucket(actor)
+    headers = region_headers(actor)
+
+    operation =
+      bucket_name
+      |> ExAws.S3.initiate_multipart_upload(object_key)
+      |> Map.put(:headers, Map.new(headers))
+
+    case ExAws.request(operation, Map.merge(config, fast_api_req_opts())) do
+      {:ok, %{body: %{upload_id: upload_id}}} -> {:ok, upload_id}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp report_multipart_start_failure(object_key, reason) do
+    Logger.error("Could not start a multipart upload for #{object_key}: #{inspect(reason)}")
+
+    Sentry.capture_message("Object storage rejected the start of a multipart upload",
+      level: :error,
+      extra: %{object_key: object_key, reason: inspect(reason)}
+    )
   end
 
   def delete_all_objects(prefix, actor) do

--- a/server/lib/tuist_web/api/storage_error.ex
+++ b/server/lib/tuist_web/api/storage_error.ex
@@ -1,0 +1,19 @@
+defmodule TuistWeb.API.StorageError do
+  @moduledoc """
+  Shared response for API endpoints whose object-storage operation failed.
+
+  The reason the operation failed is logged and reported by `Tuist.Storage`, so
+  the response body only tells the caller where to look.
+  """
+
+  import Phoenix.Controller, only: [json: 2]
+  import Plug.Conn, only: [put_status: 2]
+
+  @message "The artifact could not be uploaded because the object storage rejected the request. Check the server's object storage configuration."
+
+  def render(conn) do
+    conn
+    |> put_status(:internal_server_error)
+    |> json(%{message: @message})
+  end
+end

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -16,6 +16,7 @@ defmodule TuistWeb.API.AnalyticsController do
   alias TuistWeb.API.Schemas.CommandEvent
   alias TuistWeb.API.Schemas.CommandEventArtifact
   alias TuistWeb.API.Schemas.Error
+  alias TuistWeb.API.StorageError
   alias TuistWeb.Authentication
   alias TuistWeb.Headers
   alias TuistWeb.Plugs.LoaderPlug
@@ -715,8 +716,13 @@ defmodule TuistWeb.API.AnalyticsController do
       ) do
     with {:ok, object_key} <-
            get_object_key(%{type: type, run_id: run_id, name: command_event_artifact.name}, conn) do
-      upload_id = Storage.multipart_start(object_key, selected_project.account)
-      json(conn, %{status: "success", data: %{upload_id: upload_id}})
+      case Storage.multipart_start(object_key, selected_project.account) do
+        {:ok, upload_id} ->
+          json(conn, %{status: "success", data: %{upload_id: upload_id}})
+
+        {:error, _reason} ->
+          StorageError.render(conn)
+      end
     end
   end
 
@@ -829,19 +835,22 @@ defmodule TuistWeb.API.AnalyticsController do
       ) do
     with {:ok, object_key} <-
            get_object_key(%{type: type, run_id: run_id, name: command_event_artifact.name}, conn) do
-      :ok =
-        Storage.multipart_complete_upload(
-          object_key,
-          upload_id,
-          Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
-            {part_number, etag}
-          end),
-          selected_project.account
-        )
+      case Storage.multipart_complete_upload(
+             object_key,
+             upload_id,
+             Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
+               {part_number, etag}
+             end),
+             selected_project.account
+           ) do
+        :ok ->
+          conn
+          |> put_status(:no_content)
+          |> json(%{})
 
-      conn
-      |> put_status(:no_content)
-      |> json(%{})
+        {:error, _reason} ->
+          StorageError.render(conn)
+      end
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -15,6 +15,7 @@ defmodule TuistWeb.API.BuildsController do
   alias TuistWeb.API.Schemas.Builds.Build
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
+  alias TuistWeb.API.StorageError
   alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
@@ -1040,9 +1041,13 @@ defmodule TuistWeb.API.BuildsController do
       ) do
     object_key = Builds.build_storage_key(selected_project.account.name, selected_project.name, build_id)
 
-    multipart_upload_id = Storage.multipart_start(object_key, selected_project.account)
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, multipart_upload_id} ->
+        json(conn, %{status: "success", data: %{upload_id: multipart_upload_id}})
 
-    json(conn, %{status: "success", data: %{upload_id: multipart_upload_id}})
+      {:error, _reason} ->
+        StorageError.render(conn)
+    end
   end
 
   operation(:multipart_generate_url,
@@ -1171,16 +1176,19 @@ defmodule TuistWeb.API.BuildsController do
       ) do
     object_key = Builds.build_storage_key(selected_project.account.name, selected_project.name, build_id)
 
-    :ok =
-      Storage.multipart_complete_upload(
-        object_key,
-        multipart_upload_id,
-        Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
-          {part_number, etag}
-        end),
-        selected_project.account
-      )
+    case Storage.multipart_complete_upload(
+           object_key,
+           multipart_upload_id,
+           Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
+             {part_number, etag}
+           end),
+           selected_project.account
+         ) do
+      :ok ->
+        json(conn, %{status: "success", data: %{}})
 
-    json(conn, %{status: "success", data: %{}})
+      {:error, _reason} ->
+        StorageError.render(conn)
+    end
   end
 end

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -17,6 +17,7 @@ defmodule TuistWeb.API.CacheController do
   alias TuistWeb.API.Schemas.CacheArtifactDownloadURL
   alias TuistWeb.API.Schemas.CacheCategory
   alias TuistWeb.API.Schemas.Error
+  alias TuistWeb.API.StorageError
   alias TuistWeb.Authentication
   alias TuistWeb.Headers
 
@@ -622,21 +623,21 @@ defmodule TuistWeb.API.CacheController do
         } = conn,
         _params
       ) do
-    json(conn, %{
-      status: "success",
-      data: %{
-        upload_id:
-          Storage.multipart_start(
-            get_object_key(%{
-              hash: hash,
-              name: name,
-              project_slug: project_slug,
-              cache_category: cache_category
-            }),
-            selected_project.account
-          )
-      }
-    })
+    object_key =
+      get_object_key(%{
+        hash: hash,
+        name: name,
+        project_slug: project_slug,
+        cache_category: cache_category
+      })
+
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, upload_id} ->
+        json(conn, %{status: "success", data: %{upload_id: upload_id}})
+
+      {:error, _reason} ->
+        StorageError.render(conn)
+    end
   end
 
   def multipart_start(conn, _params) do
@@ -847,6 +848,9 @@ defmodule TuistWeb.API.CacheController do
         conn
         |> put_status(:conflict)
         |> json(%{message: "The multipart upload is no longer active. Start a new upload and retry."})
+
+      {:error, _reason} ->
+        StorageError.render(conn)
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -17,6 +17,7 @@ defmodule TuistWeb.API.PreviewsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.PreviewSupportedPlatform
+  alias TuistWeb.API.StorageError
   alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.API.TransformQueryArrayParamsPlug, [:supported_platforms])
@@ -195,21 +196,7 @@ defmodule TuistWeb.API.PreviewsController do
            build_version: build_version
          }) do
       {:ok, app_build} ->
-        upload_id =
-          Storage.multipart_start(
-            AppBuilds.storage_key(%{
-              account_handle: account_handle,
-              project_handle: project_handle,
-              app_build: app_build
-            }),
-            selected_project.account
-          )
-
-        # We're returning app_build.id as preview_id, so we don't break CLI pre-4.54.0 version.
-        json(conn, %{
-          status: "success",
-          data: %{upload_id: upload_id, preview_id: app_build.id, app_build_id: app_build.id}
-        })
+        start_app_build_upload(conn, app_build, account_handle, project_handle, selected_project)
 
       {:error, %Ecto.Changeset{errors: errors}} ->
         if Keyword.has_key?(errors, :binary_id) do
@@ -375,32 +362,25 @@ defmodule TuistWeb.API.PreviewsController do
 
     case AppBuilds.app_build_by_id(app_build_id, preload: [:preview]) do
       {:ok, app_build} ->
-        :ok =
-          Storage.multipart_complete_upload(
-            AppBuilds.storage_key(%{
-              account_handle: account_handle,
-              project_handle: project_handle,
-              app_build: app_build
-            }),
-            upload_id,
-            Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
-              {part_number, etag}
-            end),
-            selected_project.account
-          )
+        object_key =
+          AppBuilds.storage_key(%{
+            account_handle: account_handle,
+            project_handle: project_handle,
+            app_build: app_build
+          })
 
-        AppBuilds.update_preview_with_app_build(app_build.preview.id, app_build)
+        parts_list =
+          Enum.map(parts, fn %{part_number: part_number, etag: etag} ->
+            {part_number, etag}
+          end)
 
-        Tuist.Analytics.preview_upload(Authentication.authenticated_subject(conn))
+        case Storage.multipart_complete_upload(object_key, upload_id, parts_list, selected_project.account) do
+          :ok ->
+            complete_app_build_upload(conn, app_build, account_handle, project_handle, selected_project)
 
-        {:ok, preview} =
-          AppBuilds.preview_by_id(app_build.preview.id,
-            preload: [:app_builds, :created_by_account]
-          )
-
-        conn
-        |> put_status(:ok)
-        |> json(map_preview(preview, account_handle, project_handle, selected_project.account))
+          {:error, _reason} ->
+            StorageError.render(conn)
+        end
 
       {:error, :not_found} ->
         conn
@@ -412,6 +392,40 @@ defmodule TuistWeb.API.PreviewsController do
         |> put_status(:bad_request)
         |> json(%{message: reason})
     end
+  end
+
+  defp start_app_build_upload(conn, app_build, account_handle, project_handle, selected_project) do
+    object_key =
+      AppBuilds.storage_key(%{
+        account_handle: account_handle,
+        project_handle: project_handle,
+        app_build: app_build
+      })
+
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, upload_id} ->
+        # We're returning app_build.id as preview_id, so we don't break CLI pre-4.54.0 version.
+        json(conn, %{
+          status: "success",
+          data: %{upload_id: upload_id, preview_id: app_build.id, app_build_id: app_build.id}
+        })
+
+      {:error, _reason} ->
+        StorageError.render(conn)
+    end
+  end
+
+  defp complete_app_build_upload(conn, app_build, account_handle, project_handle, selected_project) do
+    AppBuilds.update_preview_with_app_build(app_build.preview.id, app_build)
+
+    Tuist.Analytics.preview_upload(Authentication.authenticated_subject(conn))
+
+    {:ok, preview} =
+      AppBuilds.preview_by_id(app_build.preview.id, preload: [:app_builds, :created_by_account])
+
+    conn
+    |> put_status(:ok)
+    |> json(map_preview(preview, account_handle, project_handle, selected_project.account))
   end
 
   operation(:show,

--- a/server/lib/tuist_web/controllers/api/shards_controller.ex
+++ b/server/lib/tuist_web/controllers/api/shards_controller.ex
@@ -8,6 +8,7 @@ defmodule TuistWeb.API.ShardsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.Shards.Shard
   alias TuistWeb.API.Schemas.Shards.ShardPlan
+  alias TuistWeb.API.StorageError
   alias TuistWeb.Headers
 
   @suite_catch_all_minimum_cli_version Version.parse!("4.202.0-canary.21")
@@ -230,6 +231,9 @@ defmodule TuistWeb.API.ShardsController do
         conn
         |> put_status(:bad_request)
         |> json(%{message: "Either shard_plan_id or reference is required."})
+
+      {:error, _reason} ->
+        StorageError.render(conn)
     end
   end
 
@@ -560,6 +564,9 @@ defmodule TuistWeb.API.ShardsController do
         conn
         |> put_status(:bad_request)
         |> json(%{message: "Either shard_plan_id or reference is required."})
+
+      {:error, _reason} ->
+        StorageError.render(conn)
     end
   end
 

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -1990,7 +1990,7 @@ defmodule Tuist.ShardsTest do
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key =~ "shards/"
         assert key =~ "/bundle.zip"
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload(project, account, "upload-ref-1")
@@ -2008,7 +2008,7 @@ defmodule Tuist.ShardsTest do
 
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key == Shards.bundle_object_key(account, project, plan.id)
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload_for_plan(project, account, plan)
@@ -2021,7 +2021,7 @@ defmodule Tuist.ShardsTest do
 
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key == Shards.bundle_object_key(account, project, plan_id)
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload_for_plan_id(project, account, plan_id)

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -627,21 +627,57 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn ^operation, opts ->
+      expect(ExAws, :request, fn ^operation, opts ->
         # Verify fast_api_req_opts are included
         assert Map.get(opts, :receive_timeout) == 5_000
         assert Map.get(opts, :pool_timeout) == 1_000
         assert Map.get(opts, :test) == :config
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, :test) == upload_id
+      assert Storage.multipart_start(object_key, :test) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
 
       assert is_number(duration)
+    end
+
+    test "returns an error and reports it when the object storage rejects the request" do
+      # Given
+      event_name = Tuist.Telemetry.event_name_storage_multipart_start_upload()
+      event_ref = :telemetry_test.attach_event_handlers(self(), [event_name])
+
+      object_key = UUIDv7.generate()
+      bucket_name = UUIDv7.generate()
+      reason = {:http_error, 403, %{body: "<Code>InvalidAccessKeyId</Code>"}}
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> %{test: :config} end)
+
+      operation = %S3{headers: %{}}
+
+      expect(ExAws.S3, :initiate_multipart_upload, fn ^bucket_name, ^object_key ->
+        operation
+      end)
+
+      expect(ExAws, :request, fn ^operation, _opts -> {:error, reason} end)
+
+      expect(Sentry, :capture_message, fn message, opts ->
+        assert message == "Object storage rejected the start of a multipart upload"
+        assert Keyword.get(opts, :level) == :error
+        assert Keyword.get(opts, :extra)[:object_key] == object_key
+        assert Keyword.get(opts, :extra)[:reason] =~ "InvalidAccessKeyId"
+        :ok
+      end)
+
+      # When
+      got = Storage.multipart_start(object_key, :test)
+
+      # Then
+      assert got == {:error, reason}
+      refute_received {^event_name, ^event_ref, _measurements, _metadata}
     end
   end
 
@@ -1193,14 +1229,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         # Verify region header is added
         assert updated_operation.headers == %{"X-Tigris-Regions" => "eur"}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -1227,14 +1263,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         # Verify region header is added
         assert updated_operation.headers == %{"X-Tigris-Regions" => "usa"}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -1261,14 +1297,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn ^operation, _opts ->
+      expect(ExAws, :request, fn ^operation, _opts ->
         # Verify no region headers are added
         assert operation.headers == %{}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -1428,16 +1464,16 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         assert updated_operation.headers == %{}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
       result = Storage.multipart_start(object_key, account)
 
       # Then
-      assert result == upload_id
+      assert result == {:ok, upload_id}
     end
 
     test "object_exists? uses custom S3 config" do

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -1046,7 +1046,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -1077,7 +1077,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/some-id.json"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -1109,7 +1109,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/session.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -1491,7 +1491,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Authenticate with user instead of project token
@@ -1511,6 +1511,35 @@ defmodule TuistWeb.AnalyticsControllerTest do
       assert response_data["upload_id"] == upload_id
     end
 
+    test "returns a storage error when the object storage rejects the upload start",
+         %{conn: conn, user: user} do
+      # Given
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+      command_event = CommandEventsFixtures.command_event_fixture(project_id: project.id)
+
+      object_key =
+        "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
+
+      expect(Storage, :multipart_start, fn ^object_key, _account ->
+        {:error, {:http_error, 403, %{body: "<Code>InvalidAccessKeyId</Code>"}}}
+      end)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/api/projects/#{account.name}/#{project.name}/runs/#{command_event.id}/start",
+          type: "result_bundle"
+        )
+
+      # Then
+      assert json_response(conn, :internal_server_error)["message"] =~ "object storage"
+    end
+
     test "starts multipart upload for a result_bundle_object using project from URL",
          %{conn: conn, user: user} do
       # Given
@@ -1523,7 +1552,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/some-id.json"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Authenticate with user instead of project token
@@ -1556,7 +1585,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/session.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -1591,7 +1620,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       object_key = "#{account.name}/#{project.name}/runs/#{nonexistent_run_id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -1824,6 +1853,39 @@ defmodule TuistWeb.AnalyticsControllerTest do
       response = json_response(conn, :no_content)
       assert response == %{}
     end
+
+    test "returns a storage error when the object storage rejects the upload completion", %{
+      conn: conn,
+      user: user
+    } do
+      # Given
+      account = Accounts.get_account_from_user(user)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+      command_event = CommandEventsFixtures.command_event_fixture(project_id: project.id)
+      upload_id = "1234"
+
+      expect(Storage, :multipart_complete_upload, fn _object_key, ^upload_id, _parts, _account ->
+        {:error, {:http_error, 403, %{body: "<Code>InvalidAccessKeyId</Code>"}}}
+      end)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/api/projects/#{account.name}/#{project.name}/runs/#{command_event.id}/complete",
+          command_event_artifact: %{type: "result_bundle"},
+          multipart_upload_parts: %{
+            parts: [%{part_number: 1, etag: "etag1"}],
+            upload_id: upload_id
+          }
+        )
+
+      # Then
+      assert json_response(conn, :internal_server_error)["message"] =~ "object storage"
+    end
   end
 
   describe "PUT /api/projects/:account_handle/:project_handle/runs/:run_id/complete_artifacts_uploads" do
@@ -1889,7 +1951,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Using project authentication (old way)

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -603,7 +603,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
       build_id = Ecto.UUID.generate()
 
       stub(Storage, :multipart_start, fn _key, _account ->
-        "multipart-upload-id-123"
+        {:ok, "multipart-upload-id-123"}
       end)
 
       conn =
@@ -642,7 +642,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
 
       stub(Storage, :multipart_start, fn _key, account ->
         send(test_pid, {:multipart_start_account, account.id})
-        "multipart-upload-id-123"
+        {:ok, "multipart-upload-id-123"}
       end)
 
       conn

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -1089,7 +1089,7 @@ defmodule TuistWeb.API.CacheControllerTest do
       object_key = "#{project_id}/#{cache_category}/#{hash}/#{name}"
 
       expect(Storage, :multipart_start, fn ^object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -25,7 +25,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -82,7 +82,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -115,7 +115,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -145,7 +145,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -174,7 +174,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -219,7 +219,7 @@ defmodule TuistWeb.PreviewsControllerTest do
         )
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -256,7 +256,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       binary_id = "550E8400-E29B-41D4-A716-446655440000"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -290,7 +290,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       build_version = "123"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -372,7 +372,7 @@ defmodule TuistWeb.PreviewsControllerTest do
         )
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When


### PR DESCRIPTION
## What changed

Object-storage failures in the multipart upload endpoints are now reported and answered instead of raised.

- `Tuist.Storage.multipart_start/2` returns `{:ok, upload_id} | {:error, reason}` and uses the non-bang `ExAws.request`, matching `multipart_complete_upload/4` directly above it in the same module.
- Both functions log the reason and report it to Sentry with the object key. `:multipart_upload_not_found` is excluded, since that is an expected client condition the cache endpoint already answers with a 409.
- All call sites (analytics, builds, cache, previews, shards) answer a 500 whose body names object storage as the cause, via the new `TuistWeb.API.StorageError`.
- `Tuist.Shards.complete_upload_for_plan/6` discarded the storage result and returned a hardcoded `:ok`. It now propagates.

Telemetry for `multipart_start` still fires only on success, which is what happened before when the failure path raised. The `multipart_start_upload` counter keeps meaning "uploads started" and the duration histogram stays free of fast-failure samples.

## Why

A self-hosted user reported their CI filling up with:

```
Uploading run metadata...
Failed to upload run metadata: unknownError(500)
```

Their server logs held two lines that at first looked unrelated: `[warning] Bandit request raised an exception` and `The Access Key Id you provided does not exist in our records`.

They are the same event. Run metadata upload is two steps, and only the second was failing. The command event (`POST /api/analytics`) is Postgres and ClickHouse only, and was landing fine. The artifacts that follow, the `.xcresult` result bundle and the CLI session logs, go through `POST /api/projects/:account/:project/runs/:run_id/start`, which calls `Storage.multipart_start`. Because that used `ExAws.request!`, S3's `InvalidAccessKeyId` raised straight out of the controller, and the client saw `MultipartUploadStartAnalyticsServiceError.unknownError(500)` with no message at all. Every run uploads a session artifact, so it fired on every job.

The misconfiguration was theirs to fix, but identifying it took a round trip through support and a dig through server logs to correlate a Bandit stacktrace with an S3 error line. A storage misconfiguration should name itself.

## Root cause

`ExAws.request!` in `Storage.multipart_start/2`, with no rescue anywhere between it and Bandit. The completion leg had the same class of bug reached differently: `analytics`, `builds` and `previews` matched the result with `:ok = ...` (MatchError on any error), and `cache` handled only `:multipart_upload_not_found` (CaseClauseError on anything else).

## Why this shape

Returning a tagged tuple rather than rescuing at the controller keeps the module internally consistent, since `multipart_complete_upload/4` already had exactly this contract.

The reporting lives in `Tuist.Storage` rather than in each controller so that non-web callers such as `Tuist.Shards` are covered by the same path, and so the reason is recorded once. Sentry is called explicitly because `Sentry.LoggerHandler` is attached with its defaults, which do not capture plain `Logger.error` messages. Without the explicit call, turning the raise into a log would have quietly removed the Sentry event that exists today.

The response body is deliberately generic. The actual reason goes to the log and to Sentry, where the operator is, not to the API consumer.

## Scope note

The completion leg is included even though the reported failure never reached it: under this exact misconfiguration `start` fails first, so the CLI never gets that far. But it is the same request flow and the same bug class, and leaving it would mean a transient storage error at completion time still produced an opaque crash.

## User and developer impact

- Self-hosted operators get a log line and a Sentry event naming the object key and the storage reason, instead of a Bandit stacktrace they have to correlate by hand.
- Direct API consumers get a response body pointing at object storage configuration.
- Shard uploads no longer report success for a completion that failed.
- No behavior change on the success path, and no change to the OpenAPI spec, so the CLI client does not need regenerating. The CLI still renders a 500 as `unknownError(500)`; surfacing the server's message client-side would mean documenting a 500 response and regenerating, which is worth doing separately.

## Validation

- Full server suite: 7586/7590 passing. The 4 failures are the known locale baseline (`marketing_blog_iframe`, `layout_live`, `marketing_controller`, `marketing_customers_live`), which fail identically on a clean tree.
- `mix credo --strict` is at baseline: 3 refactoring opportunities, 59 readability, 81 design, unchanged from `main`. An earlier revision pushed `PreviewsController.multipart_start` to cyclomatic complexity 10; the upload body was extracted into `start_app_build_upload/5` to bring it back.
- `mix format` clean.
- New tests: `Storage.multipart_start/2` returning `{:error, reason}` and reporting to Sentry without emitting telemetry, plus analytics endpoint coverage for both `start` and `complete` answering 500 with a storage message.
- Existing tests updated for the new return contract across storage, shards, analytics, builds, cache and previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
