### PR TITLE
fix(infra): configure cert-manager with recursive nameservers for DNS-01

### DIFF
--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -48,6 +48,9 @@ cert-manager:
     enabled: false
   prometheus:
     enabled: true
+  extraArgs:
+    - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
+    - --dns01-recursive-nameservers-only
 
 ingress-nginx:
   enabled: true


### PR DESCRIPTION
## What changed

Added `--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53` and `--dns01-recursive-nameservers-only` to cert-manager controller `extraArgs` in `infra/helm/platform/values.yaml`.

## Why

ACME DNS-01 certificate issuance (via Let's Encrypt + Cloudflare) requires cert-manager to verify that the `_acme-challenge` TXT record has propagated before presenting the challenge to Let's Encrypt.

By default, cert-manager attempts to discover the authoritative nameservers of the target domain (e.g. `pentest.tuist.dev`) by walking up the DNS hierarchy via `/etc/resolv.conf` (CoreDNS / Hetzner upstream resolver). For subdomains that are not directly delegated, the upstream resolver returns an empty answer, causing cert-manager to log:

```
propagation check failed err="DNS record for \"pentest.tuist.dev\" not yet propagated"
```

even though the TXT record is already live and resolvable on Cloudflare's public DNS (1.1.1.1). This hangs TLS certificate issuance indefinitely, causing deployment verification steps to time out.

## Root cause

Cert-manager's default authoritative NS discovery fails through Hetzner's upstream resolver for subdomains without explicit delegation.

## Approach

Configure cert-manager to query public recursive nameservers (`1.1.1.1:53, 8.8.8.8:53`) directly for ACME DNS-01 propagation checks.

## Validation

- `helm template` on the platform chart renders the controller args:
  ```yaml
  - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
  - --dns01-recursive-nameservers-only
  ```
- Public TXT record verified live on 1.1.1.1 via `dig TXT _acme-challenge.pentest.tuist.dev @1.1.1.1`.
