### PR TITLE
fix(infra): remove invalid secrets permission from pentest deployment workflow

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -317,9 +317,6 @@ jobs:
     runs-on: tuist-linux
     environment:
       name: server-k8s-pentest
-    permissions:
-      contents: read
-      secrets: write
     timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config


### PR DESCRIPTION
## What changed

Removed the invalid `permissions: secrets: write` block from the `delete` job in `.github/workflows/pentest-deployment.yml`.

## Why

GitHub Actions does not recognize `secrets` as a valid permission scope in the `permissions` map (only `contents`, `packages`, `actions`, `pull-requests`, etc. are valid). Having `secrets: write` causes GitHub to fail workflow dispatch with HTTP 422:

```
failed to parse workflow: (Line: 322, Col: 7): Unexpected value 'secrets'
```

## Validation

Workflow YAML parsed and validated.
