### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://join.slack.com/t/tuistapp/shared_invite/zt-1lqw355mp-zElRwLeoZ2EQsgGEkyaFgg"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=slack" alt="Slack Workspace"></a>
   <a href="https://t.me/tuist"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=telegram" alt="Slack Workspace"></a>
   <div>
-    <a href="https://cal.com/team/tuist/cloud?utm_source=banner&utm_campaign=oss" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" width="150"/></a>
   </div>
   <a href="https://translate.tuist.dev/engage/tuist/">
   <img src="https://translate.tuist.dev/widget/tuist/svg-badge.svg" alt="Translation status" />
@@ -476,7 +475,7 @@ Thanks goes to these wonderful people:
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/baekteun"><img src="https://avatars.githubusercontent.com/u/74440939?v=4" width="100px;" alt=""/><br /><sub><b>baegteun</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://vcoutasso.com"><img src="https://avatars.githubusercontent.com/u/44986513?v=4" width="100px;" alt=""/><br /><sub><b>Vinícius Couto Tasso</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://blog.jihoon.me"><img src="https://avatars.githubusercontent.com/u/68891494?v=4" width="100px;" alt=""/><br /><sub><b>안지훈</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://jihoon.me"><img src="https://avatars.githubusercontent.com/u/68891494?v=4" width="100px;" alt=""/><br /><sub><b>안지훈</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dxmvsh"><img src="https://avatars.githubusercontent.com/u/44325936?v=4" width="100px;" alt=""/><br /><sub><b>Dimash</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/danibachar"><img src="https://avatars.githubusercontent.com/u/6380777?v=4" width="100px;" alt=""/><br /><sub><b>danibachar</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dp221125"><img src="https://avatars.githubusercontent.com/u/10572119?v=4" width="100px;" alt=""/><br /><sub><b>한석호(MilKyo)</b></sub></a></td>


### PR DESCRIPTION
Link-checked the README and fixed what is confirmed dead. Every dead URL was re-verified with curl (browser UA; NXDOMAIN double-checked via 8.8.8.8), and every replacement URL returns HTTP 200.

- `http://blog.jihoon.me` → `https://jihoon.me`
  - blog.jihoon.me is NXDOMAIN (dig @8.8.8.8 empty). Same contributor (GitHub user jihoonahn, id 68891494 matching the avatar in this row) now lists blog=jihoon.me in their GitHub profile; https://jihoon.me returns 200 with title/canonical jihoon.me — same person's site on the parent domain.
- removed entry with `https://cal.com/team/tuist/cloud?utm_source=banner&utm_campaign=oss`
  - cal.com/team/tuist/cloud returns 404, and the whole team page is gone (cal.com/team/tuist, /cloud, /15min, /demo, /intro all 404). No cal.com booking link exists anywhere on tuist.dev or in tuist org repos (GitHub code search only finds this same dead URL), so the 'Book us with Cal.com' promo banner points at a defunct booking page and should be removed.

Happy to adjust or split this if you'd prefer a different fix for any item.