### PR TITLE
fix(server): match an interactive shell by pod when its claim has no job

### DIFF
--- a/server/lib/tuist/runners/interactive_sessions.ex
+++ b/server/lib/tuist/runners/interactive_sessions.ex
@@ -885,6 +885,14 @@ defmodule Tuist.Runners.InteractiveSessions do
     where(query, [session], session.pod_name == ^pod_name)
   end
 
+  # A claim is keyed by Pod and outlives the job it was minted for, so its
+  # `workflow_job_id` is NULL between a displaced job being detached and the
+  # next one binding. The Pod still holds the session, so it matches on
+  # `pod_name` alone. An `== nil` comparison raises instead.
+  defp where_session_belongs_to_pod_or_binding(query, pod_name, %{workflow_job_id: nil}) do
+    where(query, [session], session.pod_name == ^pod_name)
+  end
+
   defp where_session_belongs_to_pod_or_binding(query, pod_name, binding) do
     where(
       query,

--- a/server/test/tuist/runners/interactive_sessions_test.exs
+++ b/server/test/tuist/runners/interactive_sessions_test.exs
@@ -407,6 +407,36 @@ defmodule Tuist.Runners.InteractiveSessionsTest do
       assert same_session.id == session.id
     end
 
+    test "resolves the shell session by pod when the live claim has no job attached" do
+      account = account_fixture()
+      user = user_fixture()
+      pod_name = "live-shell-detached-claim-pod"
+
+      {:ok, session} =
+        InteractiveSessions.request_shell(
+          job(account, %{pod_name: pod_name, fleet_name: "linux-amd64"}),
+          account,
+          user
+        )
+
+      # A claim outlives the job it was minted for: a displaced job is detached
+      # from the claim so the Pod keeps its slot, leaving `workflow_job_id` NULL
+      # until GitHub binds the next one. The Pod still holds the session.
+      stub(Claims, :by_pod_name, fn ^pod_name ->
+        {:ok,
+         %{
+           workflow_job_id: nil,
+           account_id: account.id,
+           fleet_name: "linux-amd64",
+           pod_name: pod_name
+         }}
+      end)
+
+      assert InteractiveSessions.current_shell_for_pod(pod_name).id == session.id
+      assert {:ok, same_session} = InteractiveSessions.validate_shell_pod(session.id, pod_name)
+      assert same_session.id == session.id
+    end
+
     test "refreshes an existing shell session to the current job pod when no live binding exists" do
       account = account_fixture()
       user = user_fixture()


### PR DESCRIPTION
## What changed

`Tuist.Runners.InteractiveSessions.where_session_belongs_to_pod_or_binding/3` gains a clause for a binding whose `workflow_job_id` is `nil`: it matches the session on `pod_name` alone, the same as the existing no-binding clause.

## Why

Production raised `ArgumentError: comparing session.workflow_job_id with nil is forbidden as it is unsafe` on `GET /api/internal/runners/interactive/shell/sessions` ([TUIST-4JG](https://tuist.sentry.io/issues/143239195/)), 34 times in a 65 second window.

### Root cause

[#12640](https://github.com/tuist/tuist/pull/12640) re-keyed `runner_claims` by `pod_name` and made `workflow_job_id` nullable, so a claim now outlives the job it was minted for and carries no job at all between a displaced job being detached and the next one binding.

Shell discovery interpolates that value into an equality comparison:

```elixir
session.workflow_job_id == ^binding.workflow_job_id
```

Ecto refuses `== nil` at runtime, so the request 500s rather than falling back to the Pod the caller already named.

The same PR added a `not is_nil(c.workflow_job_id)` guard to `Claims.by_pod_name/1`, which is why the deployed code no longer produces this. The incident was the rolling-update window: replicas still on the previous image had no such guard, read the first NULL-job claim a new replica wrote, and raised until they drained.

Timeline, all UTC:

| Time | Event |
| --- | --- |
| 13:00:22 | migration `20260827113742` makes `workflow_job_id` nullable |
| 13:00:27 | ReplicaSet for the image carrying #12640 created |
| 13:01:21.7 | first claim row written with a NULL `workflow_job_id` |
| 13:01:25.1 | first `ArgumentError`, all on the previous ReplicaSet |
| 13:02:30 | last error, previous ReplicaSet drained |

The migration's rollout note does anticipate that old replicas cannot read a NULL `workflow_job_id`, and scopes the cost to a `count(workflow_job_id)` per fleet and one `PodReconciliationWorker` tick. This call site was not in that list, and unlike those two it does not degrade, it raises.

### Why this fix

The incident is already resolved by the rollout completing, so this is not what restores service. What it removes is the coupling that produced it: the query builder was safe only because a guard in a different module happened to filter NULLs out, an invariant that holds across two modules and, during a deploy, across two releases at once. Adding the clause makes the builder total against a column that is now legitimately nullable, so no future binding source has to know about this constraint.

The alternative, dropping the `not is_nil` filter from `Claims.by_pod_name/1` so the consumer sees the detached claim, was rejected: `binding_matches_session?/2` rejects a NULL-job binding anyway, so nothing downstream gains from it, and it would change behaviour #12640 deliberately chose.

Scope is deliberately narrow. Every other binding source was checked and none can currently yield a `nil` job: `Claims.by_workflow_job_id/1` takes an integer, `RunnerSessions.live_for_pod/1` and `live_for_workflow_job/2` read a column that is still `NOT NULL` (verified, zero live rows with NULL), and `binding_for_session/1` reads a `NOT NULL` column.

## Impact

Interactive shell discovery resolves the session by Pod instead of raising when a Pod's claim currently has no job attached. No schema change, no behaviour change on any path where the claim names a job.

## Validation

- Added a regression test that reproduces the production failure exactly, same `Ecto.Query.Builder.not_nil!/2` frame at `interactive_sessions.ex:889` from `current_shell_for_pod/1` at `:115`. Confirmed red before the fix and green after.
- `mix test test/tuist/runners/ test/tuist_web/controllers/runner_interactive_shell_agent_controller_test.exs --warnings-as-errors`: 736 passed.
- `mix format --check-formatted` and `mix credo --strict` on the changed module: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
