### PR TITLE
fix(infra): preserve pentest deployer credential during teardown

### DIFF
--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -47,8 +47,6 @@ env:
   HELM_RELEASE_NAME: pentest
   NAMESPACE: tuist-pentest
   HOST: pentest.tuist.dev
-  CLUSTER_NAME: tuist-pentest
-  GITHUB_ENVIRONMENT: server-k8s-pentest
 
 jobs:
   resolve:
@@ -332,7 +330,7 @@ jobs:
           mkdir -p "$(dirname "$KUBECONFIG")"
           echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
-      - name: Remove release and namespace
+      - name: Remove release and persistent data
         run: |
           set -euo pipefail
 
@@ -340,64 +338,12 @@ jobs:
             helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
           fi
 
-          if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-            kubectl delete namespace "$NAMESPACE" --wait=true --timeout=5m
-          fi
-      - name: Recreate the deployment credential
-        # Deleting the namespace removes the github-actions-deployer
-        # ServiceAccount and its token secret, which the KUBECONFIG environment
-        # secret references. Without recreating them the cluster would no
-        # longer be deployable from CI until bootstrap is re-run. Reapply the
-        # bootstrap credential manifest (namespace, SA, token secret, cluster
-        # binding) and refresh KUBECONFIG with the new token.
-        run: |
-          set -euo pipefail
-
-          sed "s/__NAMESPACE__/${NAMESPACE}/g" infra/k8s/mgmt/ci-service-account.yaml \
-            | kubectl apply -f -
-
-          ci_server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')"
-          ci_certificate_authority="$(kubectl -n "$NAMESPACE" get secret github-actions-deployer-token \
-            -o jsonpath='{.data.ca\.crt}')"
-
-          ci_token=""
-          for _ in $(seq 1 30); do
-            ci_token="$(kubectl -n "$NAMESPACE" get secret github-actions-deployer-token \
-              -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
-            if [ -n "$ci_token" ]; then
-              break
-            fi
-            sleep 2
-          done
-
-          if [ -z "$ci_server" ] || [ -z "$ci_certificate_authority" ] || [ -z "$ci_token" ]; then
-            echo "::error::Could not mint the GitHub Actions deployment kubeconfig."
-            exit 1
-          fi
-
-          ci_kubeconfig="$(mktemp)"
-          printf '%s\n' \
-            'apiVersion: v1' \
-            'kind: Config' \
-            'clusters:' \
-            "  - name: ${CLUSTER_NAME}" \
-            '    cluster:' \
-            "      server: ${ci_server}" \
-            "      certificate-authority-data: ${ci_certificate_authority}" \
-            'contexts:' \
-            "  - name: ci" \
-            '    context:' \
-            "      cluster: ${CLUSTER_NAME}" \
-            "      namespace: ${NAMESPACE}" \
-            '      user: github-actions-deployer' \
-            'users:' \
-            "  - name: github-actions-deployer" \
-            '    user:' \
-            "      token: ${ci_token}" \
-            'current-context: ci' > "$ci_kubeconfig"
-
-          base64 < "$ci_kubeconfig" | gh secret set KUBECONFIG --env "$GITHUB_ENVIRONMENT" --repo "$GITHUB_REPOSITORY"
-          rm -f "$ci_kubeconfig"
+          # Clean up persistent volumes and non-Helm artifacts so no assessment data remains,
+          # while keeping the namespace, ServiceAccount, and deployer token intact for CI.
+          kubectl -n "$NAMESPACE" delete pvc --all --timeout=5m
+          kubectl -n "$NAMESPACE" delete secret pentest-seed-account --ignore-not-found
+          kubectl -n "$NAMESPACE" delete certificate pentest-tuist-dev-tls --ignore-not-found
+          kubectl annotate namespace "$NAMESPACE" "tuist.dev/expires-at-" --overwrite
 
   cleanup-expired:
     name: Remove expired pentest release
@@ -446,9 +392,12 @@ jobs:
             exit 0
           fi
 
-          echo "Pentest environment expired at $expires_at; removing the release."
+          echo "Pentest environment expired at $expires_at; removing the release and persistent data."
           if helm status "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" >/dev/null 2>&1; then
             helm uninstall "$HELM_RELEASE_NAME" --namespace "$NAMESPACE" --wait --timeout 5m
           fi
 
-          kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=true --timeout=5m
+          kubectl -n "$NAMESPACE" delete pvc --all --timeout=5m
+          kubectl -n "$NAMESPACE" delete secret pentest-seed-account --ignore-not-found
+          kubectl -n "$NAMESPACE" delete certificate pentest-tuist-dev-tls --ignore-not-found
+          kubectl annotate namespace "$NAMESPACE" "tuist.dev/expires-at-" --overwrite


### PR DESCRIPTION
## What changed

Updated the `delete` and `cleanup-expired` jobs in `.github/workflows/pentest-deployment.yml` to:
- Uninstall the `pentest` Helm release
- Delete all persistent volume claims in `tuist-pentest` (wiping PostgreSQL, ClickHouse, and cache storage)
- Delete assessment-specific secrets and certificates (`pentest-seed-account`, `pentest-tuist-dev-tls`)
- Clear the `tuist.dev/expires-at` namespace annotation
- Preserve the `tuist-pentest` namespace itself along with `github-actions-deployer` ServiceAccount and `github-actions-deployer-token` Secret

Removed the previous `Recreate the deployment credential` step and unused workflow environment variables.

## Why

When the pentest environment is deleted (via workflow dispatch `action: delete` or the nightly `cleanup-expired` schedule), deleting the `tuist-pentest` namespace permanently destroyed the `github-actions-deployer` ServiceAccount and its token Secret. Because the `KUBECONFIG` GitHub environment secret holds a kubeconfig minted from that token, any subsequent deployment failed immediately at `Verify cluster reachability` with `Unauthorized`.

An earlier attempt in #12666 tried recreating the ServiceAccount and using `gh secret set` from the workflow to push a newly minted token back to GitHub. However, `GITHUB_TOKEN` in GitHub Actions cannot write repository or environment secrets.

## Root cause

Deleting the namespace containing the deployment credential invalidated the token referenced by CI. Because permanent cluster retirement is handled separately by `pentest-cluster-retirement.yml`, the application teardown only needs to remove application workloads, secrets, and data.

## Approach

Keep the namespace and the deployer ServiceAccount/Secret persistent throughout the cluster's lifecycle, exactly like our other workload clusters (`tuist-staging`, `tuist-canary`, `tuist-preview`). Teardown cleanly removes all application resources, persistent volume claims, and temporary secrets, guaranteeing that data is deleted while keeping CI access unbroken.

## Validation

- Verified workflow YAML syntax.
- Validated that `helm uninstall` + `kubectl delete pvc --all` + secret cleanup removes all assessment data and workloads.
