### PR TITLE
fix(server): give each project card background a unique svg id

### DIFF
--- a/server/lib/tuist_web/live/projects_live.ex
+++ b/server/lib/tuist_web/live/projects_live.ex
@@ -510,10 +510,17 @@ defmodule TuistWeb.ProjectsLive do
   defp build_system_badge(_), do: nil
 
   defp project_background(assigns) do
+    unique_id = UUIDv7.generate()
+
+    assigns =
+      assigns
+      |> assign(:mask_id, "mask0_#{unique_id}")
+      |> assign(:radial_gradient_id, "paint0_radial_#{unique_id}")
+
     ~H"""
     <svg viewBox="0 0 292 196" fill="none" xmlns="http://www.w3.org/2000/svg" data-part="background">
       <mask
-        id="mask0_1989_22018"
+        id={@mask_id}
         style="mask-type:alpha"
         maskUnits="userSpaceOnUse"
         x="0"
@@ -526,11 +533,11 @@ defmodule TuistWeb.ProjectsLive do
           y="-0.5"
           width="291"
           height="197"
-          fill="url(#paint0_radial_1989_22018)"
+          fill={"url(##{@radial_gradient_id})"}
           fill-opacity="0.2"
         />
       </mask>
-      <g mask="url(#mask0_1989_22018)">
+      <g mask={"url(##{@mask_id})"}>
         <path d="M11 149.75H281" />
         <path d="M11 98H281" />
         <path d="M11 46.25H281" />
@@ -546,7 +553,7 @@ defmodule TuistWeb.ProjectsLive do
       </g>
       <defs>
         <radialGradient
-          id="paint0_radial_1989_22018"
+          id={@radial_gradient_id}
           cx="0"
           cy="0"
           r="1"

--- a/server/test/tuist_web/live/projects_live_test.exs
+++ b/server/test/tuist_web/live/projects_live_test.exs
@@ -57,6 +57,21 @@ defmodule TuistWeb.ProjectsLiveTest do
     assert html =~ ~s(form="create-project-form")
   end
 
+  test "renders several project cards without duplicating dom ids", %{conn: conn, account: account} do
+    for name <- ["first-project", "second-project", "third-project"] do
+      ProjectsFixtures.project_fixture(account_id: account.id, name: name)
+    end
+
+    {:ok, _view, html} = live(conn, ~p"/#{account.name}/projects")
+
+    document = Floki.parse_fragment!(html)
+
+    assert document |> Floki.find(~s([data-part="project"])) |> length() == 3
+
+    ids = Floki.attribute(document, "[id]", "id")
+    assert ids == Enum.uniq(ids)
+  end
+
   test "ignores a stale pagination cursor on initial load", %{conn: conn, account: account} do
     for index <- 1..7 do
       ProjectsFixtures.project_fixture(account_id: account.id, name: "project-#{index}")


### PR DESCRIPTION
## What changed

`TuistWeb.ProjectsLive.project_background/1` now derives its SVG `mask` and `radialGradient` ids from a per-render `UUIDv7.generate()` instead of hardcoding the ids that came out of the design tool.

A regression test in `projects_live_test.exs` renders three project cards and asserts every `id` in the resulting document is unique.

## Why

The projects dashboard shipped duplicate DOM ids. `project_background/1` is rendered once per project card, and it embedded `mask0_1989_22018` and `paint0_radial_1989_22018` verbatim, so any account with more than one project emitted the same ids several times over.

This surfaced as a CI failure in `test/tuist_web/live/public_account_live_test.exs:123` ("members of a public account still see the account's private projects"), which creates two projects:

```
** (RuntimeError) Duplicate id found while testing LiveView: paint0_radial_1989_22018
```

Run: https://github.com/tuist/tuist/actions/runs/33082062821/job/98551656202

## Why it looked like a flake

The same commit passed 7681/7681 on the `Test` job and failed on `Test (oldest supported ClickHouse)`. That is not two different code paths — it is a race in how the failure is reported.

`Phoenix.LiveViewTest.ClientProxy` discovers the duplicate while parsing the connected render and reports it with `send(self(), {:test_error, type, msg})`, then raises in its own `handle_info/2` (`client_proxy.ex:565`). By that point the test process has usually already received its mount reply from `live/2` and moved on, so whether the resulting EXIT lands before the test finishes comes down to scheduling.

So the bug is real on every run; only the crash is intermittent. That also means a regression test that just calls `live/2` and waits to be killed reproduces it unreliably, which is why the new test asserts on the rendered document instead.

## Why a per-render UUID

This matches the existing convention for these design-tool SVGs: `TuistWeb.Components.EmptyStateBackground` and `TuistWeb.Components.EmptyTabStateBackground` already build their mask and gradient ids from `UUIDv7.generate()`.

The obvious alternative, deriving the ids from the project, is worse here. Once an account crosses the pagination threshold the same project renders in both the recent grid and the all-projects grid, so `project.id` alone still collides and every call site would need a section prefix. Two of the five call sites are empty states with no project at all.

The other hardcoded-id SVGs in the codebase (`previews_live`, `bundles_live`, `members_live`, `billing_live`, `public_project_cta_banner`) are each rendered at most once per page, or already suffix their ids with a caller-supplied `@id`, so they are not affected.

## Reviewer notes

`Floki.attribute/2` only reads the attributes of the tree's top-level nodes, so the test uses the 3-arity `Floki.attribute(document, "[id]", "id")`. With the 2-arity form the assertion passes even against the unfixed component.

## Validation

- The new test reproduces the exact CI error against the unfixed component (`git stash` on the component, test red), and passes with the fix.
- `public_account_live_test.exs` + `projects_live_test.exs`: 16 passed, repeated across six seeds.
- Full `test/tuist_web/live/`: 741/743 with `--warnings-as-errors`. The two failures are the known local baseline where the test env compiles only the `en` locale, so `/ko/customers` redirects to login; both are in files this change does not touch.
- `mix format` and `mix credo --strict` clean.

Unrelated observation, deliberately left out of this change: `mix deps.get` upgrades `phoenix_live_view` 1.2.10 to 1.2.11 despite the committed lock, which is why the CI stack trace above reports 1.2.11. I reverted that lock churn so it does not ride along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
