### PR TITLE
fix(infra): latch the runner watchdog on the Listener's inbound job message

### DIFF
--- a/infra/linux-runner-image/run-job.sh
+++ b/infra/linux-runner-image/run-job.sh
@@ -102,6 +102,29 @@ export ACTIONS_RUNNER_HOOK_JOB_STARTED="${JOB_STARTED_HOOK}"
 
 idle_timeout="${TUIST_RUNNER_IDLE_TIMEOUT_SECONDS:-0}"
 
+# RUNNER_PERFLOG makes the Listener append a `MessageReceived_<type>` line to
+# `<dir>/Runner.perf` the instant a message arrives from GitHub, before it
+# acknowledges the assignment and before it fetches the job body. That is
+# seconds ahead of Runner.Worker, and it is the earliest local evidence that
+# this runner has been given work.
+#
+# The Listener's poll loop returns nothing on an idle timeout, so the file
+# stays empty until GitHub actually routes something here. Only the two
+# job-request message types count; a refresh or cancel message is not an
+# assignment.
+RUNNER_PERF_DIR=/home/runner/actions-runner/_perf
+RUNNER_PERF_FILE="${RUNNER_PERF_DIR}/Runner.perf"
+rm -rf "${RUNNER_PERF_DIR}"
+export RUNNER_PERFLOG="${RUNNER_PERF_DIR}"
+# 404/409/422 on the job fetch make the Listener skip the message and go back
+# to waiting, so a received message does not always become a Worker. Bound how
+# long the watchdog defers on one.
+WORKER_GRACE_SECONDS=60
+job_message_received() {
+  grep -q 'MessageReceived_PipelineAgentJobRequest\|MessageReceived_RunnerJobRequest' \
+    "${RUNNER_PERF_FILE}" 2>/dev/null
+}
+
 ./run.sh --jitconfig "${jit}" --disableupdate &
 runner_pid=$!
 
@@ -118,30 +141,27 @@ if [ "${idle_timeout}" -gt 0 ] 2>/dev/null; then
       sleep 1
       waited=$((waited + 1))
     done
-    # Neither latch can see a job GitHub has only just placed. The Listener
-    # acknowledges the assignment, forks Runner.Worker two to four seconds
-    # later, and the hook writes the marker a beat after that, so a single
-    # check at the deadline reads "idle" for a runner GitHub has already,
-    # irrevocably, given work to. An ephemeral runner killed
-    # post-acknowledgment marks that job failed rather than re-queuing it,
-    # and GitHub then spends ten minutes waiting out the job's lock before
-    # anyone learns it died.
+    # Both process-level latches trail the assignment. The Listener
+    # acknowledges the job, fetches its body over HTTP and only then forks
+    # Runner.Worker, with the job-started hook later still, so a check at the
+    # deadline reads "idle" for a runner GitHub has already, irrevocably,
+    # given work to. Killing it there marks that job failed rather than
+    # re-queuing it, and GitHub then spends ten minutes waiting out the job's
+    # lock before anyone learns it died.
     #
-    # Confirming the idle state across that gap closes it. Both latches are
-    # re-read every round and either one standing down ends the watchdog for
-    # good. The last read is immediately before the signal, so what stays
-    # exposed is the instant between them rather than the whole multi-second
-    # gap.
-    IDLE_CONFIRM_ROUNDS=4
-    IDLE_CONFIRM_SLEEP=2
-    confirmations=0
+    # Deferring on the Listener's own record of the inbound message covers
+    # that gap, because that record predates the acknowledgment rather than
+    # trailing it. What stays exposed is the interval between the last read
+    # and the signal below, not the fetch.
+    worker_wait=0
     while :; do
       [ -e "${JOB_STARTED_MARKER}" ] && exit 0
       pgrep -f "Runner.Worker" >/dev/null 2>&1 && exit 0
       kill -0 "${runner_pid}" 2>/dev/null || exit 0
-      [ "${confirmations}" -ge "${IDLE_CONFIRM_ROUNDS}" ] && break
-      sleep "${IDLE_CONFIRM_SLEEP}"
-      confirmations=$((confirmations + 1))
+      job_message_received || break
+      [ "${worker_wait}" -ge "${WORKER_GRACE_SECONDS}" ] && break
+      sleep 1
+      worker_wait=$((worker_wait + 1))
     done
     echo "$(date -u +%FT%TZ) run-job: no job assigned within ${idle_timeout}s; terminating idle runner"
     kill -TERM "${runner_pid}" 2>/dev/null || true

--- a/infra/linux-runner-image/run-job.sh
+++ b/infra/linux-runner-image/run-job.sh
@@ -118,20 +118,33 @@ if [ "${idle_timeout}" -gt 0 ] 2>/dev/null; then
       sleep 1
       waited=$((waited + 1))
     done
-    # The marker alone leaves a narrow race: the hook fires when the
-    # Worker STARTS the job, a second or more after the Listener has
-    # already acknowledged the assignment — so a job handed over in the
-    # last seconds of the budget could still be TERMed as idle after
-    # GitHub irrevocably placed it, and an ephemeral runner killed
-    # post-acknowledgment marks the job failed rather than re-queuing it.
-    # The Runner.Worker process exists from the moment the Listener
-    # dispatches, before the hook runs, so it is the authoritative
-    # "this runner has work" signal.
-    if [ ! -e "${JOB_STARTED_MARKER}" ] && ! pgrep -f "Runner.Worker" >/dev/null 2>&1 &&
-      kill -0 "${runner_pid}" 2>/dev/null; then
-      echo "$(date -u +%FT%TZ) run-job: no job assigned within ${idle_timeout}s; terminating idle runner"
-      kill -TERM "${runner_pid}" 2>/dev/null || true
-    fi
+    # Neither latch can see a job GitHub has only just placed. The Listener
+    # acknowledges the assignment, forks Runner.Worker two to four seconds
+    # later, and the hook writes the marker a beat after that, so a single
+    # check at the deadline reads "idle" for a runner GitHub has already,
+    # irrevocably, given work to. An ephemeral runner killed
+    # post-acknowledgment marks that job failed rather than re-queuing it,
+    # and GitHub then spends ten minutes waiting out the job's lock before
+    # anyone learns it died.
+    #
+    # Confirming the idle state across that gap closes it. Both latches are
+    # re-read every round and either one standing down ends the watchdog for
+    # good. The last read is immediately before the signal, so what stays
+    # exposed is the instant between them rather than the whole multi-second
+    # gap.
+    IDLE_CONFIRM_ROUNDS=4
+    IDLE_CONFIRM_SLEEP=2
+    confirmations=0
+    while :; do
+      [ -e "${JOB_STARTED_MARKER}" ] && exit 0
+      pgrep -f "Runner.Worker" >/dev/null 2>&1 && exit 0
+      kill -0 "${runner_pid}" 2>/dev/null || exit 0
+      [ "${confirmations}" -ge "${IDLE_CONFIRM_ROUNDS}" ] && break
+      sleep "${IDLE_CONFIRM_SLEEP}"
+      confirmations=$((confirmations + 1))
+    done
+    echo "$(date -u +%FT%TZ) run-job: no job assigned within ${idle_timeout}s; terminating idle runner"
+    kill -TERM "${runner_pid}" 2>/dev/null || true
   ) &
   watchdog_pid=$!
   printf '%s' "${watchdog_pid}" >"${WATCHDOG_PID_FILE}" 2>/dev/null || true

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -1219,6 +1219,29 @@ HOOK
       export ACTIONS_RUNNER_HOOK_JOB_STARTED="${JOB_STARTED_HOOK}"
       idle_timeout="${TUIST_RUNNER_IDLE_TIMEOUT_SECONDS:-0}"
 
+      # RUNNER_PERFLOG makes the Listener append a `MessageReceived_<type>`
+      # line to `<dir>/Runner.perf` the instant a message arrives from
+      # GitHub, before it acknowledges the assignment and before it fetches
+      # the job body. That is seconds ahead of Runner.Worker, and it is the
+      # earliest local evidence that this runner has been given work.
+      #
+      # The Listener's poll loop returns nothing on an idle timeout, so the
+      # file stays empty until GitHub actually routes something here. Only
+      # the two job-request message types count; a refresh or cancel message
+      # is not an assignment.
+      RUNNER_PERF_DIR=/Users/runner/actions-runner/_perf
+      RUNNER_PERF_FILE="${RUNNER_PERF_DIR}/Runner.perf"
+      rm -rf "${RUNNER_PERF_DIR}"
+      export RUNNER_PERFLOG="${RUNNER_PERF_DIR}"
+      # 404/409/422 on the job fetch make the Listener skip the message and
+      # go back to waiting, so a received message does not always become a
+      # Worker. Bound how long the watchdog defers on one.
+      WORKER_GRACE_SECONDS=60
+      job_message_received() {
+        grep -q 'MessageReceived_PipelineAgentJobRequest\|MessageReceived_RunnerJobRequest' \
+          "${RUNNER_PERF_FILE}" 2>/dev/null
+      }
+
       # `--jitconfig` implies ephemeral: the runner accepts one job
       # and exits. `--disableupdate` pins the runner to whatever
       # version is baked into the image; we bump that via Renovate
@@ -1247,30 +1270,27 @@ HOOK
             sleep 1
             waited=$((waited + 1))
           done
-          # Neither latch can see a job GitHub has only just placed. The
-          # Listener acknowledges the assignment, forks Runner.Worker two to
-          # four seconds later, and the hook writes the marker a beat after
-          # that, so a single check at the deadline reads "idle" for a runner
-          # GitHub has already, irrevocably, given work to. An ephemeral
-          # runner killed post-acknowledgment marks that job failed rather
-          # than re-queuing it, and GitHub then spends ten minutes waiting
-          # out the job's lock before anyone learns it died.
+          # Both process-level latches trail the assignment. The Listener
+          # acknowledges the job, fetches its body over HTTP and only then
+          # forks Runner.Worker, with the job-started hook later still, so a
+          # check at the deadline reads "idle" for a runner GitHub has
+          # already, irrevocably, given work to. Killing it there marks that
+          # job failed rather than re-queuing it, and GitHub then spends ten
+          # minutes waiting out the job's lock before anyone learns it died.
           #
-          # Confirming the idle state across that gap closes it. Both latches
-          # are re-read every round and either one standing down ends the
-          # watchdog for good. The last read is immediately before the
-          # signal, so what stays exposed is the instant between them rather
-          # than the whole multi-second gap.
-          IDLE_CONFIRM_ROUNDS=4
-          IDLE_CONFIRM_SLEEP=2
-          confirmations=0
+          # Deferring on the Listener's own record of the inbound message
+          # covers that gap, because that record predates the acknowledgment
+          # rather than trailing it. What stays exposed is the interval
+          # between the last read and the signal below, not the fetch.
+          worker_wait=0
           while :; do
             [ -e "${JOB_STARTED_MARKER}" ] && exit 0
             pgrep -f "Runner.Worker" >/dev/null 2>&1 && exit 0
             kill -0 "${runner_pid}" 2>/dev/null || exit 0
-            [ "${confirmations}" -ge "${IDLE_CONFIRM_ROUNDS}" ] && break
-            sleep "${IDLE_CONFIRM_SLEEP}"
-            confirmations=$((confirmations + 1))
+            job_message_received || break
+            [ "${worker_wait}" -ge "${WORKER_GRACE_SECONDS}" ] && break
+            sleep 1
+            worker_wait=$((worker_wait + 1))
           done
           echo "$(date -u +%FT%TZ) dispatch-poll: no job assigned within ${idle_timeout}s; terminating idle runner"
           kill -TERM "${runner_pid}" 2>/dev/null || true

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -1247,17 +1247,33 @@ HOOK
             sleep 1
             waited=$((waited + 1))
           done
-          # The marker alone leaves a narrow race: the hook fires when the
-          # Worker STARTS the job, a second or more after the Listener has
-          # acknowledged the assignment, and an ephemeral runner killed
-          # post-acknowledgment marks the job failed rather than re-queuing
-          # it. The Runner.Worker process exists from the moment the
-          # Listener dispatches, before the hook runs.
-          if [ ! -e "${JOB_STARTED_MARKER}" ] && ! pgrep -f "Runner.Worker" >/dev/null 2>&1 &&
-            kill -0 "${runner_pid}" 2>/dev/null; then
-            echo "$(date -u +%FT%TZ) dispatch-poll: no job assigned within ${idle_timeout}s; terminating idle runner"
-            kill -TERM "${runner_pid}" 2>/dev/null || true
-          fi
+          # Neither latch can see a job GitHub has only just placed. The
+          # Listener acknowledges the assignment, forks Runner.Worker two to
+          # four seconds later, and the hook writes the marker a beat after
+          # that, so a single check at the deadline reads "idle" for a runner
+          # GitHub has already, irrevocably, given work to. An ephemeral
+          # runner killed post-acknowledgment marks that job failed rather
+          # than re-queuing it, and GitHub then spends ten minutes waiting
+          # out the job's lock before anyone learns it died.
+          #
+          # Confirming the idle state across that gap closes it. Both latches
+          # are re-read every round and either one standing down ends the
+          # watchdog for good. The last read is immediately before the
+          # signal, so what stays exposed is the instant between them rather
+          # than the whole multi-second gap.
+          IDLE_CONFIRM_ROUNDS=4
+          IDLE_CONFIRM_SLEEP=2
+          confirmations=0
+          while :; do
+            [ -e "${JOB_STARTED_MARKER}" ] && exit 0
+            pgrep -f "Runner.Worker" >/dev/null 2>&1 && exit 0
+            kill -0 "${runner_pid}" 2>/dev/null || exit 0
+            [ "${confirmations}" -ge "${IDLE_CONFIRM_ROUNDS}" ] && break
+            sleep "${IDLE_CONFIRM_SLEEP}"
+            confirmations=$((confirmations + 1))
+          done
+          echo "$(date -u +%FT%TZ) dispatch-poll: no job assigned within ${idle_timeout}s; terminating idle runner"
+          kill -TERM "${runner_pid}" 2>/dev/null || true
         ) &
         watchdog_pid=$!
         printf '%s' "${watchdog_pid}" >"${WATCHDOG_PID_FILE}" 2>/dev/null || true


### PR DESCRIPTION
## What changed

Both runner images arm an idle watchdog around the GitHub Actions runner so a guest that never receives work releases its warm-pool slot. Its stand-down latches were the job-started marker and a live `Runner.Worker`, both of which appear seconds *after* GitHub has committed a job to the runner.

The watchdog now also reads the Listener's own record of the inbound job message, which lands *before* the commitment. `RUNNER_PERFLOG` is exported at runner start, and when the Listener has recorded a job-request message the watchdog waits for the Worker to materialise rather than terminating. That wait is bounded, because the Listener also skips messages whose job was acquired elsewhere.

Applied identically to `infra/runner-image/dispatch-poll.sh` (macOS) and `infra/linux-runner-image/run-job.sh` (Linux), which carry the same block.

## Why

### Root cause

On 2026-08-27 three jobs failed with `##[error]The runner has received a shutdown signal.` The runner was not evicted, garbage-collected or reclaimed. It killed itself.

Taking [job 98512461809](https://github.com/tuist/tuist/actions/runs/33070357699/job/98512461809) as the worked example, the server dispatched the runner at 12:08:23.498 and the guest published `exiting (rc=143); halting VM` at 12:13:47. Measured across 210 clean firings, runner start to watchdog fire is 309 s median and runner start to VM halt is 323 s median, which puts the guard's check at 12:13:33. GitHub's `created_at` for the job it killed is 12:13:33.

| Time | Event |
| --- | --- |
| 12:13:33 | guard runs: no marker, no `Runner.Worker`, `run.sh` alive, so SIGTERM |
| 12:13:35 | GitHub assigns the job |
| 12:13:37 | `Runner.Worker` forks, latch 2 would now hold |
| 12:13:39 | job-started hook writes the marker, latch 1 would now hold |

Killing an ephemeral runner after GitHub has placed a job marks that job failed rather than re-queuing it, and GitHub then waits out the job's lock: both macOS occurrences and the Linux one were marked failed exactly 10 minutes and 1 second after they started. That interval is GitHub-side and not tunable, so the only lever is not killing the runner.

### Why the first attempt did not work

The first commit on this branch confirmed the same two latches repeatedly for 8 seconds before terminating. Review caught that this moves the window rather than narrowing it, and the point is correct: the vulnerable interval is the visibility lag, so relocating the decision from T to T+8 leaves an identically wide gap at the new edge. Reproduced against that commit, with the job assigned at deadline +7 and the Worker appearing at +10, the runner is still terminated.

The first validation missed it because the harness created `Runner.Worker` at assignment time. It modelled "Worker visible at +7", not "assigned at +7", so the lag it was supposed to exercise was absent.

### Where the real signal is

From [Runner.cs](https://github.com/actions/runner/blob/v2.336.0/src/Runner.Listener/Runner.cs), at the version both images pin (2.336.0):

- line 607: `HostContext.WritePerfCounter($"MessageReceived_{message.MessageType}")`, the moment a message is returned by the poll loop
- line 697: `AcknowledgeMessageAsync(...)`, where the runner takes ownership
- line 762: `jobDispatcher.Run(jobRequestMessage, runOnce)`, which forks the Worker

Between 697 and 762 sits `GetJobMessageAsync`, a full HTTP fetch of the job body. That fetch is the 2 to 4 seconds, and it is why every process-level latch trails the assignment.

Line 607 runs before all of it. [HostContext.cs](https://github.com/actions/runner/blob/v2.336.0/src/Runner.Common/HostContext.cs) writes those counters to `$RUNNER_PERFLOG/Runner.perf` when that variable is set, one appended line per counter. `GetNextMessageAsync` loops internally and continues on an empty poll, so the file stays empty while the runner is genuinely idle: it is not a busy signal that needs filtering.

Only `MessageReceived_PipelineAgentJobRequest` and `MessageReceived_RunnerJobRequest` count. A refresh or cancel message is not an assignment, and `BrokerMigrationMessage` never reaches the counter because it is handled inside the poll loop.

### Scope

Not macOS-only. Both images carry the same block, and every RunnerPool ships `idleTimeoutSeconds: 300`, Linux included (the 120 asserted in the runners-controller tests is not what is deployed). The Linux occurrence, job 98427051039, recorded zero steps and stored no log at all: the runner died before the Worker wrote anything.

### Exposure

A 31-day census of every failed or cancelled run across all attempts, plus every run re-run into a success (11,549 distinct jobs), found 6 jobs failing at the 601 second mark. Three are ordinary ten-minute failures whose last step completed 3 seconds before the job did. Three are this bug, all on 2026-08-27.

They cluster because the watchdog barely fired before then. Firings per day were around 1 from 28 July to 25 August, then 376 on 26 August and 664 on 27 August. That step is the stuck-job loop #12673 addresses: four jobs left permanently `queued` by a GitHub incident on 26 August consumed 1,099 runner dispatches in 23 hours, and every one of those runners reaches the idle deadline having never been given work. #12673 removes the supply of doomed runners; this PR removes what happens to them at the deadline.

## Why this solution

The race cannot be closed completely from inside the guest, because some instant will always separate the last read from the signal. What is fixable is its width. It was the whole acknowledge-plus-fetch interval, seconds wide; it is now the few milliseconds between the final `job_message_received` call and `kill`.

If `RUNNER_PERFLOG` is ever not honoured, the check simply never returns true and the guard behaves exactly as it does today. The degraded mode is the current behaviour, not a runner that is never reaped.

Alternatives considered:

- **Confirm the existing latches for longer.** What the first commit did. Moves the window without narrowing it, per the review.
- **Grep the Listener's `_diag` trace instead.** Same timing, but couples to log prose rather than to a documented diagnostic file with a stable one-counter-per-line format.
- **Raise `TUIST_RUNNER_IDLE_TIMEOUT_SECONDS`.** Moves the deadline without narrowing the window. The race is per-firing, not per-second-of-budget.
- **Drop the watchdog.** It exists because GitHub assigns queued jobs to any label-eligible runner, so a runner minted for one job can wait forever for work that ran on a sibling. Removing it strands warm-pool slots indefinitely.
- **Ask GitHub whether the runner is busy before killing.** The guest holds no GitHub credential, and it would put a network round trip on the kill path for a signal already available locally and earlier.

## Impact

Removes a class of failure where a runner GitHub has just given work to is killed before it can start, failing a job that never ran and burning 10 minutes of wall clock before anyone learns it failed. In the 27 August instance the killed job was `Release Kura Binary (aarch64-apple-darwin)`, which skipped `Release Kura Docker Image` and cut no `kura@` tag, so a Mac flake blocked publishing the Linux amd64 image production runs.

A genuinely idle runner is still reaped at the deadline, with no added delay. A runner that received a job message which never becomes a Worker is reaped `WORKER_GRACE_SECONDS` later.

## Validation

Red before green, against the shipped text rather than a transcription. The harness slices the watchdog subshell body out of each real script between stable anchors, then drives it with a fake runner process, a fake `Runner.Worker`, a stand-in `Runner.perf`, and **assignment and local visibility as separate events**, which is what the first harness got wrong.

Reviewer's scenario, assigned at deadline +7 with the Worker visible at +10, against the first commit on this branch:

```
v1 confirmation-loop (the version reviewed): TERMED
```

Production shape, assigned 1 second before the deadline with the Worker visible 2 seconds after it:

```
v0 original          : TERMED
v1 confirmation-loop : SURVIVED
v2 perf-log latch    : SURVIVED
```

Full matrix on this commit, identical results for both scripts:

| Scenario | macOS | Linux | Correct? |
| --- | --- | --- | --- |
| assigned at deadline -1, Worker at +2 (production shape) | survives | survives | yes, this is the bug |
| assigned at deadline -1, Worker at +5 (slow fetch) | survives | survives | yes, the lag no longer matters |
| assigned at deadline -1, Worker never (skipped acquire) | reaped | reaped | yes, after the grace bound |
| never assigned | reaped | reaped | yes, warm-pool reap intact |

The middle two rows are the ones the first version could not satisfy: v1 survives a fixed lag and fails a longer one, because it was betting on the lag being shorter than its confirmation window.

`bash -n` clean on both files, which is what `linux-runner-image.yml` runs today. The upstream mechanism was read at tag v2.336.0, the version both images pin, rather than at `main`.

Not covered here: `RUNNER_PERFLOG` has not been exercised against a live runner in this change. The image build plus a staging run is what confirms the file appears where expected, and `linux-runner-image.yml` gates its build job on `github.event.pull_request.draft == false`, so that does not run while this PR is a draft.

## Follow-up not in this PR

- Extract the guard into a shared, unit-testable helper so it has a committed regression test rather than a local harness. The duplication across two images is where this bug lived twice.
- The `Release Kura Docker Image` dependency on the macOS matrix legs, and the `release-helm` guard that reads a failed upstream as `skipped`. Both are in `.github/workflows/server-production-deployment.yml` and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
