### PR TITLE
feat(server): shrink a Kura claim after 30 idle days instead of 90

### DIFF
--- a/server/lib/tuist/kura/claim_sizing.ex
+++ b/server/lib/tuist/kura/claim_sizing.ex
@@ -33,7 +33,7 @@ defmodule Tuist.Kura.ClaimSizing do
       %{shed_age_under: {:floor_fraction, 1.0}, window_days: 14}
     ],
     grow_headroom_factor: 1.25,
-    shrink_window_days: 90,
+    shrink_window_days: 30,
     shrink_occupancy_percent: 40,
     shrink_target_occupancy_percent: 60,
     max_step_factor: 2.0

--- a/server/lib/tuist/kura/workers/claim_sizing_worker.ex
+++ b/server/lib/tuist/kura/workers/claim_sizing_worker.ex
@@ -17,6 +17,7 @@ defmodule Tuist.Kura.Workers.ClaimSizingWorker do
 
   alias Tuist.Kura
   alias Tuist.Kura.ClaimProposals
+  alias Tuist.Kura.ClaimSizing
   alias Tuist.Kura.StorageRollups
   alias Tuist.Kura.StorageTelemetry
 
@@ -31,8 +32,17 @@ defmodule Tuist.Kura.Workers.ClaimSizingWorker do
   @ingest_lookback_days 2
 
   # Past the longest policy window no rollup can change a verdict, so there is
-  # nothing to gain from recomputing one.
-  @refresh_horizon_days 90
+  # nothing to gain from recomputing one. Derived from the policy rather than
+  # restated here, so shortening a window cannot leave this scanning a range
+  # nothing reads, nor lengthening one leave it too narrow to feed a verdict.
+  defp refresh_horizon_days do
+    policy = ClaimSizing.default_policy()
+
+    policy.grow_windows
+    |> Enum.map(& &1.window_days)
+    |> Enum.max()
+    |> max(policy.shrink_window_days)
+  end
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
@@ -53,7 +63,7 @@ defmodule Tuist.Kura.Workers.ClaimSizingWorker do
 
     StorageTelemetry.dates_with_telemetry_ingested_since(
       since,
-      Date.add(today, -@refresh_horizon_days),
+      Date.add(today, -refresh_horizon_days()),
       today
     )
   end

--- a/server/test/tuist/kura/claim_sizing_test.exs
+++ b/server/test/tuist/kura/claim_sizing_test.exs
@@ -329,23 +329,23 @@ defmodule Tuist.Kura.ClaimSizingTest do
   describe "evaluate/2 shrinking" do
     test "proposes shrinking after a long window of low occupancy" do
       # 6Gi peak at the 60% occupancy target asks for 10Gi.
-      context = context(current_claim_size: "16Gi", rollups: idle_days(90, @today))
+      context = context(current_claim_size: "16Gi", rollups: idle_days(30, @today))
 
       assert {:shrink, "10Gi", evidence} = ClaimSizing.evaluate(context)
       assert evidence["region"] == "us-east"
-      assert evidence["window_days"] == 90
+      assert evidence["window_days"] == 30
       assert evidence["max_occupancy_percent"] == 25
     end
 
     test "one step never less than halves the claim" do
-      rollups = idle_days(90, @today, max_live_segment_bytes: 2 * @gibibyte)
+      rollups = idle_days(30, @today, max_live_segment_bytes: 2 * @gibibyte)
 
       assert {:shrink, "8Gi", _evidence} = ClaimSizing.evaluate(context(rollups: rollups))
     end
 
     test "never shrinks under the validated minimum claim" do
       rollups =
-        idle_days(90, @today,
+        idle_days(30, @today,
           max_live_segment_bytes: div(@gibibyte, 2),
           last_ring_budget_bytes: 6 * @gibibyte
         )
@@ -357,36 +357,36 @@ defmodule Tuist.Kura.ClaimSizingTest do
 
     test "a day without snapshots breaks the idle streak" do
       rollups =
-        90
+        30
         |> idle_days(@today)
-        |> List.replace_at(45, rollup(Date.add(@today, -44), eviction_count: 0))
+        |> List.replace_at(15, rollup(Date.add(@today, -14), eviction_count: 0))
 
       assert ClaimSizing.evaluate(context(rollups: rollups)) == :none
     end
 
     test "an eviction inside the window breaks the idle streak" do
       rollups =
-        90
+        30
         |> idle_days(@today)
         |> List.replace_at(
-          45,
-          rollup(Date.add(@today, -44), snapshot_count: 96, max_occupancy_percent: 25, eviction_count: 1)
+          15,
+          rollup(Date.add(@today, -14), snapshot_count: 96, max_occupancy_percent: 25, eviction_count: 1)
         )
 
       assert ClaimSizing.evaluate(context(rollups: rollups)) == :none
     end
 
-    test "a window shorter than 90 days withholds the proposal" do
-      assert ClaimSizing.evaluate(context(rollups: idle_days(89, @today))) == :none
+    test "a window shorter than the shrink window withholds the proposal" do
+      assert ClaimSizing.evaluate(context(rollups: idle_days(29, @today))) == :none
     end
 
     test "a shrink needs its whole window after the last resize" do
-      rollups = idle_days(90, @today)
+      rollups = idle_days(30, @today)
 
-      recent = context(rollups: rollups, last_resized_at: DateTime.new!(Date.add(@today, -30), ~T[12:00:00], "Etc/UTC"))
+      recent = context(rollups: rollups, last_resized_at: DateTime.new!(Date.add(@today, -10), ~T[12:00:00], "Etc/UTC"))
       assert ClaimSizing.evaluate(recent) == :none
 
-      settled = context(rollups: rollups, last_resized_at: DateTime.new!(Date.add(@today, -91), ~T[12:00:00], "Etc/UTC"))
+      settled = context(rollups: rollups, last_resized_at: DateTime.new!(Date.add(@today, -31), ~T[12:00:00], "Etc/UTC"))
       assert {:shrink, "10Gi", _evidence} = ClaimSizing.evaluate(settled)
     end
   end
@@ -394,7 +394,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
   describe "evaluate/2 across regions" do
     test "a growing region wins over a shrinking one" do
       rollups =
-        moderate_churn(14, @today) ++ Enum.map(idle_days(90, @today), &Map.put(&1, :region, "eu-central"))
+        moderate_churn(14, @today) ++ Enum.map(idle_days(30, @today), &Map.put(&1, :region, "eu-central"))
 
       assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["region"] == "us-east"
@@ -402,7 +402,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
 
     test "shrinking needs every region with data to agree" do
       rollups =
-        idle_days(90, @today) ++
+        idle_days(30, @today) ++
           Enum.map(churn_days(5, @today, median_shed_age_seconds: 5 * @day_seconds), &Map.put(&1, :region, "eu-central"))
 
       assert ClaimSizing.evaluate(context(rollups: rollups)) == :none


### PR DESCRIPTION
## What changed

`ClaimSizing.@default_policy`'s `shrink_window_days` goes from `90` to `30`.

## Why

Shrinking asked for a full quarter of corroborating evidence: 30 consecutive days below 40% occupancy, with snapshots present and no evictions on any of them. That was deliberately conservative for a first deploy — shrinking evicts a ring down to fit, so cache above the new size is lost.

The cost is that the first possible shrink sits a quarter out from the day telemetry starts, which means an over-provisioned account keeps holding disk it demonstrably does not use for months. A claim is an admission decision (each replica requests it as ephemeral-storage), so an oversized claim refuses neighbours rather than merely wasting space.

30 days is still a month of unbroken evidence, and the surrounding guards are unchanged and do most of the safety work:

- a single day with an eviction, or without snapshots, breaks the streak
- one step never more than halves the claim
- the result is floored at the validated minimum claim
- every region holding an instance must agree before the account shrinks
- the whole window must fall after the last resize

## Also in here

The worker's rollup refresh horizon is now derived from the policy instead of restating `90` beside it. That horizon exists because no rollup older than the longest policy window can change a verdict. Leaving a literal there meant this change would have left it scanning two months of days nothing reads — and lengthening a window later would have left it too narrow to feed the verdict it was sized for.

## Validation

- 564 tests pass across `test/tuist/kura`; `mix credo` clean.
- Confirmed the constant is load-bearing rather than the tests passing incidentally: with it reverted to `90`, the shrink cases fail because 30 days of idle rollups no longer qualify.
- Shrink test fixtures moved from 90-day to 30-day windows, including the streak-breaking cases (a day without snapshots, a day with an eviction) and the post-resize case.

## Blast radius

Nothing shrinks imminently. Production has **one** day of rollups — the tables were created by today's deploy (2026-08-27) — so the earliest any account can satisfy a 30-day window is late September, and only if it stays under 40% occupancy every day in between. Current fleet average occupancy is 35.4%, so real candidates are plausible; none are close to qualifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)