### PR TITLE
fix(app): create the menu bar extra once to avoid a duplicated status item

### DIFF
--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -23,20 +23,18 @@ import TuistServer
         }
 
         var body: some Scene {
-            appDelegate.menuBarExtra = FluidMenuBarExtra(title: "Tuist", image: "MenuBarIcon") {
-                if bootstrapper.isReady {
-                    ServerCredentialsStore.$current.withValue(
-                        ServerCredentialsStore(backend: .keychain)
-                    ) {
-                        CachedValueStore.$current.withValue(CachedValueStore(backend: .inSystemProcess)) {
-                            MenuBarView(
-                                appDelegate: appDelegate,
-                                updaterController: updaterController
-                            )
-                        }
-                    }
-                } else {
-                    ProgressView()
+            // `FluidMenuBarExtra` creates an `NSStatusItem` on initialization and expects to be
+            // initialized only once for the lifetime of the app. `body` is re-evaluated, for example
+            // when `bootstrapper.isReady` changes, so creating the extra unconditionally here leaves
+            // a stale duplicated icon in the menu bar. The readiness state is instead observed by
+            // `MenuBarRootView`, which swaps the spinner for the menu inside the same status item.
+            if appDelegate.menuBarExtra == nil {
+                appDelegate.menuBarExtra = FluidMenuBarExtra(title: "Tuist", image: "MenuBarIcon") {
+                    MenuBarRootView(
+                        bootstrapper: bootstrapper,
+                        appDelegate: appDelegate,
+                        updaterController: updaterController
+                    )
                 }
             }
 
@@ -49,6 +47,29 @@ import TuistServer
             }
             .commands {
                 CommandGroup(replacing: .appSettings) {}
+            }
+        }
+    }
+
+    private struct MenuBarRootView: View {
+        @ObservedObject var bootstrapper: AppBootstrapper
+        let appDelegate: AppDelegate
+        let updaterController: SPUStandardUpdaterController
+
+        var body: some View {
+            if bootstrapper.isReady {
+                ServerCredentialsStore.$current.withValue(
+                    ServerCredentialsStore(backend: .keychain)
+                ) {
+                    CachedValueStore.$current.withValue(CachedValueStore(backend: .inSystemProcess)) {
+                        MenuBarView(
+                            appDelegate: appDelegate,
+                            updaterController: updaterController
+                        )
+                    }
+                }
+            } else {
+                ProgressView()
             }
         }
     }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12680>

Launching the macOS menu bar app shows **two** Tuist status items: the left one works, the right one opens a panel with a spinner that never resolves. Both belong to the same process, and it reproduces on every launch.

Root cause: `TuistApp` creates the `FluidMenuBarExtra` inside `Scene.body`. `FluidMenuBarExtra` creates an `NSStatusItem` in its initializer and is documented to be initialized once per app lifetime, but `body` is re-evaluated when `AppBootstrapper` flips `isReady` shortly after launch — so a second extra (and second status item) is created, and the first one lingers in the menu bar. The stale one is also permanently stuck on the spinner because `FluidMenuBarExtraWindow` evaluates its content closure once at init, outside any observing `View.body`, so the `bootstrapper.isReady` branch it captured never re-renders.

The fix creates the extra only once, and moves the readiness branch into a `MenuBarRootView` that holds the bootstrapper as `@ObservedObject`, so the single status item's window transitions from the spinner to `MenuBarView` reactively.

### How to test locally

1. Build and launch the macOS app.
2. Before the fix: two Tuist icons appear in the menu bar right after launch; the right one only ever shows a spinner.
3. After the fix: a single icon appears; its panel shows the spinner only until bootstrap completes, then the regular menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnZDXXir6fpfaxFWkCTKc8
