### PR TITLE
fix(server): retry confirmation email delivery

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -21,6 +21,7 @@ defmodule Tuist.Accounts do
   alias Tuist.Accounts.UserNotifier
   alias Tuist.Accounts.UserRole
   alias Tuist.Accounts.UserToken
+  alias Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker
   alias Tuist.Base64
   alias Tuist.Billing
   alias Tuist.CacheEndpoints
@@ -2002,12 +2003,12 @@ defmodule Tuist.Accounts do
   ## Confirmation
 
   @doc ~S"""
-  Delivers the confirmation email instructions to the given user.
+  Queues the confirmation email instructions for the given user.
 
   ## Examples
 
       iex> deliver_user_confirmation_instructions(user, &url(~p"/users/confirm/#{&1}"))
-      {:ok, %{to: ..., body: ...}}
+      :ok
 
       iex> deliver_user_confirmation_instructions(confirmed_user, &url(~p"/users/confirm/#{&1}"))
       {:error, :already_confirmed}
@@ -2023,15 +2024,25 @@ defmodule Tuist.Accounts do
         :ok
 
       true ->
-        Repo.delete_all(UserToken.by_user_and_contexts_query(user, ["confirm"]))
+        fn ->
+          Repo.delete_all(UserToken.by_user_and_contexts_query(user, ["confirm"]))
 
-        {encoded_token, user_token} = UserToken.build_email_token(user, "confirm")
-        Repo.insert!(user_token)
+          {encoded_token, user_token} = UserToken.build_email_token(user, "confirm")
+          Repo.insert!(user_token)
 
-        UserNotifier.deliver_confirmation_instructions(%{
-          user: user,
-          confirmation_url: confirmation_url.(encoded_token)
-        })
+          user.id
+          |> DeliverConfirmationInstructionsWorker.new_confirmation_instructions(confirmation_url.(encoded_token))
+          |> Oban.insert()
+          |> case do
+            {:ok, _job} -> :ok
+            {:error, reason} -> Repo.rollback(reason)
+          end
+        end
+        |> Repo.transaction()
+        |> case do
+          {:ok, :ok} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
     end
   end
 

--- a/server/lib/tuist/accounts/user_notifier.ex
+++ b/server/lib/tuist/accounts/user_notifier.ex
@@ -104,8 +104,8 @@ defmodule Tuist.Accounts.UserNotifier do
   Deliver instructions to confirm account.
   """
   def deliver_confirmation_instructions(%{user: user, confirmation_url: confirmation_url}) do
-    deliver(
-      user.email,
+    user.email
+    |> build_email(
       dgettext("dashboard_account", "Confirmation instructions"),
       html_email(
         """
@@ -127,6 +127,7 @@ defmodule Tuist.Accounts.UserNotifier do
         Environment.email_icon_url()
       )
     )
+    |> Mailer.deliver_now()
   end
 
   @doc """

--- a/server/lib/tuist/accounts/workers/deliver_confirmation_instructions_worker.ex
+++ b/server/lib/tuist/accounts/workers/deliver_confirmation_instructions_worker.ex
@@ -1,0 +1,46 @@
+defmodule Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker do
+  @moduledoc """
+  Delivers a user confirmation email outside the registration request.
+
+  The confirmation URL is encrypted before it is persisted in the job arguments,
+  so the token remains protected while Oban retries a transient delivery failure.
+  """
+  use Oban.Worker, queue: :default, max_attempts: 5
+
+  alias Tuist.Accounts.User
+  alias Tuist.Accounts.UserNotifier
+  alias Tuist.Repo
+
+  @confirmation_url_salt "confirmation-instructions-url"
+  @confirmation_url_max_age_seconds 7 * 24 * 60 * 60
+
+  def new_confirmation_instructions(user_id, confirmation_url) do
+    new(%{user_id: user_id, encrypted_confirmation_url: encrypt_confirmation_url(confirmation_url)})
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "encrypted_confirmation_url" => encrypted_confirmation_url}}) do
+    with %User{} = user <- Repo.get(User, user_id),
+         {:ok, confirmation_url} <- decrypt_confirmation_url(encrypted_confirmation_url),
+         {:ok, _email} <-
+           UserNotifier.deliver_confirmation_instructions(%{
+             user: user,
+             confirmation_url: confirmation_url
+           }) do
+      :ok
+    else
+      nil -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp encrypt_confirmation_url(confirmation_url) do
+    Phoenix.Token.encrypt(TuistWeb.Endpoint, @confirmation_url_salt, confirmation_url)
+  end
+
+  defp decrypt_confirmation_url(encrypted_confirmation_url) do
+    Phoenix.Token.decrypt(TuistWeb.Endpoint, @confirmation_url_salt, encrypted_confirmation_url,
+      max_age: @confirmation_url_max_age_seconds
+    )
+  end
+end

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -32,7 +32,7 @@ msgstr ""
 msgid "%{month}/%{year}"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:208
+#: lib/tuist/accounts/user_notifier.ex:209
 #: lib/tuist_web/live/accept_invitation_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Accept invitation"
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Deleting your account will also delete all the projects that belong to it"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:142
+#: lib/tuist/accounts/user_notifier.ex:143
 #, elixir-autogen, elixir-format
 msgid "Did you request to reset your password?"
 msgstr ""
@@ -420,18 +420,18 @@ msgstr ""
 msgid "Get started with no credit card required—try with no commitment."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:205
+#: lib/tuist/accounts/user_notifier.ex:206
 #, elixir-autogen, elixir-format
 msgid "Hola %{invitee_email}, you can join the organization by clicking the button below:"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:144
+#: lib/tuist/accounts/user_notifier.ex:145
 #, elixir-autogen, elixir-format
 msgid "Hola %{name}, you can reset your password by clicking the button below:"
 msgstr ""
 
 #: lib/tuist/accounts/user_notifier.ex:123
-#: lib/tuist/accounts/user_notifier.ex:152
+#: lib/tuist/accounts/user_notifier.ex:153
 #, elixir-autogen, elixir-format
 msgid "If you didn't make this request, feel free to ignore this email."
 msgstr ""
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Invitation not found"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:199
+#: lib/tuist/accounts/user_notifier.ex:200
 #, elixir-autogen, elixir-format
 msgid "Invitation to %{organization_name}"
 msgstr ""
@@ -682,12 +682,12 @@ msgstr ""
 msgid "Renaming your organization can have unintended side effects."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:138
+#: lib/tuist/accounts/user_notifier.ex:139
 #, elixir-autogen, elixir-format
 msgid "Reset password instructions"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:147
+#: lib/tuist/accounts/user_notifier.ex:148
 #, elixir-autogen, elixir-format
 msgid "Reset your password"
 msgstr ""
@@ -947,12 +947,12 @@ msgstr ""
 msgid "You received this email because you recently signed up for a Tuist account."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:150
+#: lib/tuist/accounts/user_notifier.ex:151
 #, elixir-autogen, elixir-format
 msgid "You received this email because you requested a password reset for your Tuist account."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:203
+#: lib/tuist/accounts/user_notifier.ex:204
 #, elixir-autogen, elixir-format
 msgid "You were invited to join the %{organization_name} Tuist organization by %{inviter_email}"
 msgstr ""
@@ -1874,28 +1874,28 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:244
+#: lib/tuist/accounts/user_notifier.ex:245
 #, elixir-autogen, elixir-format
 msgid "Hi %{user_email}, your account was added to %{organization_name} by your identity provider's automated user provisioning (SCIM)."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:253
+#: lib/tuist/accounts/user_notifier.ex:254
 #, elixir-autogen, elixir-format
 msgid "If this is unexpected, contact your identity provider administrator (the team that manages your single sign-on) to remove this provisioning. An organization admin in Tuist can also remove you from %{organization_name}."
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:247
+#: lib/tuist/accounts/user_notifier.ex:248
 #, elixir-autogen, elixir-format
 msgid "If you expected this, no action is needed. You can open the organization here:"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:250
+#: lib/tuist/accounts/user_notifier.ex:251
 #, elixir-autogen, elixir-format
 msgid "Open %{organization_name}"
 msgstr ""
 
-#: lib/tuist/accounts/user_notifier.ex:234
-#: lib/tuist/accounts/user_notifier.ex:242
+#: lib/tuist/accounts/user_notifier.ex:235
+#: lib/tuist/accounts/user_notifier.ex:243
 #, elixir-autogen, elixir-format
 msgid "You were added to the %{organization_name} Tuist organization"
 msgstr ""

--- a/server/test/tuist/accounts/workers/deliver_confirmation_instructions_worker_test.exs
+++ b/server/test/tuist/accounts/workers/deliver_confirmation_instructions_worker_test.exs
@@ -1,0 +1,76 @@
+defmodule Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorkerTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Tuist.Accounts.User
+  alias Tuist.Accounts.UserNotifier
+  alias Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker
+  alias Tuist.Repo
+
+  describe "perform/1" do
+    test "delivers the confirmation email" do
+      user = %User{id: 1, email: "user@example.com"}
+      confirmation_url = "https://tuist.dev/users/confirm/token"
+
+      expect(Repo, :get, fn User, 1 -> user end)
+
+      expect(UserNotifier, :deliver_confirmation_instructions, fn delivery ->
+        assert delivery.user.id == user.id
+        assert delivery.confirmation_url == confirmation_url
+        {:ok, :stub_email}
+      end)
+
+      job = DeliverConfirmationInstructionsWorker.new_confirmation_instructions(user.id, confirmation_url)
+
+      assert :ok = DeliverConfirmationInstructionsWorker.perform(oban_job(job))
+    end
+
+    test "retries when email delivery fails" do
+      user = %User{id: 1, email: "user@example.com"}
+
+      expect(Repo, :get, fn User, 1 -> user end)
+
+      expect(UserNotifier, :deliver_confirmation_instructions, fn _ ->
+        {:error, :mailgun_internal_server_error}
+      end)
+
+      job =
+        DeliverConfirmationInstructionsWorker.new_confirmation_instructions(
+          user.id,
+          "https://tuist.dev/users/confirm/token"
+        )
+
+      assert {:error, :mailgun_internal_server_error} =
+               DeliverConfirmationInstructionsWorker.perform(oban_job(job))
+    end
+
+    test "does not persist the confirmation URL in plaintext" do
+      confirmation_url = "https://tuist.dev/users/confirm/token"
+
+      job =
+        DeliverConfirmationInstructionsWorker.new_confirmation_instructions(1, confirmation_url)
+
+      args = oban_job(job).args
+
+      refute Map.has_key?(args, "confirmation_url")
+      refute args["encrypted_confirmation_url"] == confirmation_url
+    end
+
+    test "does not retry when the user has been deleted" do
+      expect(Repo, :get, fn User, -1 -> nil end)
+
+      job =
+        DeliverConfirmationInstructionsWorker.new_confirmation_instructions(
+          -1,
+          "https://tuist.dev/users/confirm/token"
+        )
+
+      assert :ok = DeliverConfirmationInstructionsWorker.perform(oban_job(job))
+    end
+  end
+
+  defp oban_job(changeset) do
+    args = Map.new(changeset.changes.args, fn {key, value} -> {to_string(key), value} end)
+    %Oban.Job{args: args}
+  end
+end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -2625,7 +2625,7 @@ defmodule Tuist.AccountsTest do
             })
 
           assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
-          assert :ok = perform_job(job)
+          assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
@@ -2640,7 +2640,7 @@ defmodule Tuist.AccountsTest do
         :ok = Accounts.deliver_user_confirmation_instructions(%{user: user, confirmation_url: confirmation_url})
 
         assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
-        assert :ok = perform_job(job)
+        assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
       end)
 
       assert Accounts.deliver_user_confirmation_instructions(%{
@@ -2680,7 +2680,7 @@ defmodule Tuist.AccountsTest do
             })
 
           assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
-          assert :ok = perform_job(job)
+          assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
         end)
 
       %{user: user, token: token}

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -18,6 +18,7 @@ defmodule Tuist.AccountsTest do
   alias Tuist.Accounts.User
   alias Tuist.Accounts.UserRole
   alias Tuist.Accounts.UserToken
+  alias Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker
   alias Tuist.Authentication
   alias Tuist.Base64
   alias Tuist.Billing
@@ -2617,10 +2618,14 @@ defmodule Tuist.AccountsTest do
     test "sends token through notification", %{user: user} do
       token =
         extract_user_token(fn confirmation_url ->
-          Accounts.deliver_user_confirmation_instructions(%{
-            user: user,
-            confirmation_url: confirmation_url
-          })
+          :ok =
+            Accounts.deliver_user_confirmation_instructions(%{
+              user: user,
+              confirmation_url: confirmation_url
+            })
+
+          assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
+          assert :ok = perform_job(job)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
@@ -2632,7 +2637,10 @@ defmodule Tuist.AccountsTest do
 
     test "returns :ok without issuing a new token within the cooldown window", %{user: user} do
       extract_user_token(fn confirmation_url ->
-        Accounts.deliver_user_confirmation_instructions(%{user: user, confirmation_url: confirmation_url})
+        :ok = Accounts.deliver_user_confirmation_instructions(%{user: user, confirmation_url: confirmation_url})
+
+        assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
+        assert :ok = perform_job(job)
       end)
 
       assert Accounts.deliver_user_confirmation_instructions(%{
@@ -2665,10 +2673,14 @@ defmodule Tuist.AccountsTest do
 
       token =
         extract_user_token(fn confirmation_url ->
-          Accounts.deliver_user_confirmation_instructions(%{
-            user: user,
-            confirmation_url: confirmation_url
-          })
+          :ok =
+            Accounts.deliver_user_confirmation_instructions(%{
+              user: user,
+              confirmation_url: confirmation_url
+            })
+
+          assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
+          assert :ok = perform_job(job)
         end)
 
       %{user: user, token: token}

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -2626,6 +2626,9 @@ defmodule Tuist.AccountsTest do
 
           assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
           assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
+          assert_receive {:delivered_email, email}
+
+          email
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
@@ -2641,6 +2644,9 @@ defmodule Tuist.AccountsTest do
 
         assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
         assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
+        assert_receive {:delivered_email, email}
+
+        email
       end)
 
       assert Accounts.deliver_user_confirmation_instructions(%{
@@ -2681,6 +2687,9 @@ defmodule Tuist.AccountsTest do
 
           assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
           assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
+          assert_receive {:delivered_email, email}
+
+          email
         end)
 
       %{user: user, token: token}

--- a/server/test/tuist_web/live/user_confirmation_live_test.exs
+++ b/server/test/tuist_web/live/user_confirmation_live_test.exs
@@ -18,6 +18,9 @@ defmodule TuistWeb.UserConfirmationLiveTest do
 
     assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
     assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
+    assert_receive {:delivered_email, email}
+
+    email
   end
 
   setup do

--- a/server/test/tuist_web/live/user_confirmation_live_test.exs
+++ b/server/test/tuist_web/live/user_confirmation_live_test.exs
@@ -7,6 +7,18 @@ defmodule TuistWeb.UserConfirmationLiveTest do
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker
+
+  defp deliver_confirmation_instructions(user, confirmation_url) do
+    :ok =
+      Accounts.deliver_user_confirmation_instructions(%{
+        user: user,
+        confirmation_url: confirmation_url
+      })
+
+    assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
+    assert :ok = perform_job(job)
+  end
 
   setup do
     %{user: user_fixture(confirmed_at: nil)}
@@ -16,10 +28,7 @@ defmodule TuistWeb.UserConfirmationLiveTest do
     test "confirms the given token", %{conn: conn, user: user} do
       token =
         extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(%{
-            user: user,
-            confirmation_url: url
-          })
+          deliver_confirmation_instructions(user, url)
         end)
 
       {:ok, lv, _html} = live(conn, ~p"/users/confirm/#{token}")
@@ -40,10 +49,7 @@ defmodule TuistWeb.UserConfirmationLiveTest do
     } do
       token =
         extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(%{
-            user: user,
-            confirmation_url: url
-          })
+          deliver_confirmation_instructions(user, url)
         end)
 
       {:ok, lv, _html} = live(conn, ~p"/users/confirm/#{token}")
@@ -66,10 +72,7 @@ defmodule TuistWeb.UserConfirmationLiveTest do
 
       token =
         extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(%{
-            user: user,
-            confirmation_url: url
-          })
+          deliver_confirmation_instructions(user, url)
         end)
 
       {:ok, lv, _html} = live(conn, ~p"/users/confirm/#{token}")

--- a/server/test/tuist_web/live/user_confirmation_live_test.exs
+++ b/server/test/tuist_web/live/user_confirmation_live_test.exs
@@ -17,7 +17,7 @@ defmodule TuistWeb.UserConfirmationLiveTest do
       })
 
     assert [job] = all_enqueued(worker: DeliverConfirmationInstructionsWorker)
-    assert :ok = perform_job(job)
+    assert :ok = perform_job(DeliverConfirmationInstructionsWorker, job.args)
   end
 
   setup do

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -6,6 +6,8 @@ defmodule TuistWeb.UserRegistrationLiveTest do
   import Phoenix.LiveViewTest
   import TuistTestSupport.Fixtures.AccountsFixtures
 
+  alias Tuist.Accounts.Workers.DeliverConfirmationInstructionsWorker
+
   describe "Registration page" do
     test "renders registration page", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/users/register")
@@ -60,6 +62,35 @@ defmodule TuistWeb.UserRegistrationLiveTest do
   end
 
   describe "Registration with email confirmation" do
+    test "completes registration when confirmation email delivery fails", %{conn: conn} do
+      stub(Tuist.Environment, :skip_email_confirmation?, fn -> false end)
+      stub(Tuist.Environment, :skip_email_confirmation?, fn _ -> false end)
+
+      stub(Tuist.Accounts.UserNotifier, :deliver_confirmation_instructions, fn _ ->
+        raise "Mailgun is temporarily unavailable"
+      end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      lv
+      |> form("#login_form",
+        user: %{
+          email: "mail-provider-outage@example.com",
+          password: "StrongP@ssword!2028",
+          username: "mail-provider-outage"
+        }
+      )
+      |> render_submit()
+
+      assert has_element?(lv, "#registration-success")
+      assert {:ok, user} = Tuist.Accounts.get_user_by_email("mail-provider-outage@example.com")
+
+      assert_enqueued(
+        worker: DeliverConfirmationInstructionsWorker,
+        args: %{user_id: user.id}
+      )
+    end
+
     test "trims whitespace from email and username before registration", %{conn: conn} do
       stub(Tuist.Environment, :skip_email_confirmation?, fn -> true end)
       stub(Tuist.Environment, :skip_email_confirmation?, fn _ -> true end)

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -77,12 +77,12 @@ defmodule TuistWeb.UserRegistrationLiveTest do
         user: %{
           email: "mail-provider-outage@example.com",
           password: "StrongP@ssword!2028",
-          username: "mail-provider-outage"
+          username: "mailprovideroutage"
         }
       )
       |> render_submit()
 
-      assert has_element?(lv, "#registration-success")
+      assert has_element?(lv, "#signup-success")
       assert {:ok, user} = Tuist.Accounts.get_user_by_email("mail-provider-outage@example.com")
 
       assert_enqueued(


### PR DESCRIPTION
## What changed

- Queue confirmation-email delivery in a background job instead of sending it during account registration.
- Retry transient delivery failures up to five times and encrypt the confirmation link stored with the job.
- Update confirmation and registration tests for queued delivery, including a regression test for a provider failure.

## Why

Creating an account should not fail because the email provider has a temporary outage.

## Root cause

The registration LiveView sent the confirmation email synchronously with a raising mailer call. A Mailgun internal-server-error response raised from that call and terminated the registration process after the account had been created.

## Approach

The confirmation token and the background job are created in one database transaction. The worker uses the non-raising mailer result and returns delivery failures to Oban so it schedules a retry. The encrypted confirmation link remains valid for the same seven-day period as the confirmation token.

## Impact

Registrations complete successfully during temporary email-provider failures. The confirmation email is delivered once the provider recovers, without exposing the confirmation link in plaintext job arguments.

### How to test locally

- `mix test test/tuist/accounts/workers/deliver_confirmation_instructions_worker_test.exs` passed with 4 tests.
- The local server compiled and started successfully.
- The registration and account integration tests could not run because the local ClickHouse instance rejects the transaction sandbox before test assertions run.
