### PR TITLE
fix(cli): prevent duplicate static framework module maps

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -43,6 +43,19 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         let derivedDirectory = try await derivedDirectory(for: graph)
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
+        // Xcode processes every unconditionally direct xcframework into the build products directory. That copy is
+        // visible to the target graph, so adding the same vendor module map from a dynamic route would define the
+        // module twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route.
+        var unconditionallyDirectlyLinkedXCFrameworkPaths = Set<AbsolutePath>()
+        for (source, dependencies) in graph.dependencies {
+            guard case .target = source else { continue }
+            for dependency in dependencies {
+                guard graph.dependencyConditions[(source, dependency)] == nil,
+                      case let .xcframework(xcframework) = dependency
+                else { continue }
+                unconditionallyDirectlyLinkedXCFrameworkPaths.insert(xcframework.path)
+            }
+        }
 
         let graph = try await mapGraph(
             graph: graph
@@ -92,8 +105,11 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
 
             let staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies =
                 staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies
+                    .filter {
+                        $0.xcframework.containsLibrary()
+                            && !unconditionallyDirectlyLinkedXCFrameworkPaths.contains($0.xcframework.path)
+                    }
                     .map(\.xcframework)
-                    .filter { $0.containsLibrary() }
 
             sideEffects += try await generateModuleMapAndUmbrellaHeader(
                 for: staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies,

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -184,6 +184,191 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_when_static_xcframework_library_is_linked_directly_and_via_dynamic_xcframework() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let dynamicFramework: GraphDependency = .testXCFramework(
+            path: try temporaryPath()
+                .appending(component: "DynamicFramework.xcframework")
+        )
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App"
+                        ),
+                        .test(
+                            name: "Consumer"
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    .target(name: "Consumer", path: projectPath),
+                    googleMaps,
+                ],
+                .target(name: "Consumer", path: projectPath): [
+                    dynamicFramework,
+                ],
+                dynamicFramework: [
+                    googleMaps,
+                ],
+            ]
+        )
+
+        var expectedGraph = graph
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "App",
+                        settings: .test()
+                    ),
+                    .test(
+                        name: "Consumer",
+                        settings: .test()
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
+    func test_map_when_static_xcframework_library_is_linked_directly_for_other_platforms() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "macos-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let dynamicFramework: GraphDependency = .testXCFramework(
+            path: try temporaryPath()
+                .appending(component: "DynamicFramework.xcframework")
+        )
+        let appDependency = GraphDependency.target(name: "App", path: projectPath)
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App"
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                appDependency: [
+                    dynamicFramework,
+                    googleMaps,
+                ],
+                dynamicFramework: [
+                    googleMaps,
+                ],
+            ],
+            dependencyConditions: [
+                GraphEdge(from: appDependency, to: googleMaps): try XCTUnwrap(.when([.ios])),
+                GraphEdge(from: dynamicFramework, to: googleMaps): try XCTUnwrap(.when([.macos])),
+            ]
+        )
+
+        var expectedGraph = graph
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "App",
+                        settings: .test(
+                            base: [
+                                "HEADER_SEARCH_PATHS": [
+                                    "\"$(SRCROOT)/../GoogleMaps.xcframework/macos-arm64/Headers\"",
+                                ],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
     /// Some static Objective-C xcframeworks keep their module map and headers in a `Headers/<ModuleName>/`
     /// subdirectory and re-import each other with the `<ModuleName/...>` prefix. Such a "nested"
     /// layout gets only the `Headers` root (the parent of the module subdirectory) on the search
@@ -291,7 +476,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertBetterEqual([], gotSideEffects)
     }
 
-    func test_map_when_static_xcframework_framework_linked_via_dynamic_xcframework() async throws {
+    func test_map_when_static_xcframework_framework_is_linked_directly_and_via_dynamic_xcframework() async throws {
         // Given
         let projectPath = try temporaryPath()
             .appending(component: "Project")
@@ -328,6 +513,21 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                     .testXCFramework(
                         path: try temporaryPath()
                             .appending(component: "DynamicFramework.xcframework")
+                    ),
+                    .testXCFramework(
+                        path: googleMapsPath,
+                        infoPlist: .test(
+                            libraries: [
+                                .test(
+                                    identifier: "ios-arm64",
+                                    path: try RelativePath(validating: "GoogleMaps.framework/GoogleMaps")
+                                ),
+                            ]
+                        ),
+                        linking: .static,
+                        moduleMaps: [
+                            googleMapsHeadersPath.appending(component: "module.modulemap"),
+                        ]
                     ),
                 ],
                 .testXCFramework(


### PR DESCRIPTION
## What changed

- Detect static library framework bundles that are directly linked by a project target without a platform restriction.
- Do not add a second vendor module map for the same bundle when it is reached through a dynamic framework.
- Add regression coverage for cross-target propagation, platform-restricted links, and static framework bundles.

## Why

A direct framework link is already processed by Xcode. Re-exposing the same vendor module map through a dynamic dependency makes the compiler discover two definitions of the same module.

## Root cause

The static-framework mapper restored vendor header visibility for dependencies behind dynamic frameworks, but did not account for the same bundle already being processed through a direct link in the target graph.

## Approach

The mapper collects unconditionally direct framework paths once for the graph and suppresses only duplicate static-library module-map handling. Platform-restricted direct links and static framework bundles retain their existing search-path behavior.

## Impact

Projects that combine a direct static framework link with the same framework behind a dynamic dependency no longer receive two module-map definitions. No migration is required.

## Validation

- `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `mise run cli:lint --fix`
- `git diff --check`
