### PR TITLE
feat(infra): shape every annotated kura pod, not just kura-tuist-*

### DIFF
--- a/infra/egress-tree-agent/AGENTS.md
+++ b/infra/egress-tree-agent/AGENTS.md
@@ -233,15 +233,16 @@ growth is the signal.
 
 ## Rollout state
 
-Ships disabled (`egressTreeAgent.enabled: false`). Intended sequence:
-observe mode on ca-east (generous ceilings, floors informational), validate
-per-tenant counters, then real ceilings/floors per region.
-`egressTreeAgent.betaPodPrefix` (`BETA_POD_PREFIX`) narrows attachment to
-pods whose name starts with the prefix — the per-account beta gate for the
-first enforcement step. Excluded pods stay unshaped and count in
-`kura_egress_tree_beta_excluded_pods` (deliberately not in `skipped_pods`,
-which alerts). Sibling allowlists are computed over all annotated pods, so a
-matched pod keeps its bypass even when its co-located sibling is excluded;
-prefix changes converge within one reconcile cycle in both directions. The per-replica
-floor double-count in scheduler bin-packing must be fixed before floors go
-live (known issue, separate change).
+Ships disabled (`egressTreeAgent.enabled: false`). Enabled on canary and
+production, where it now attaches to **every** annotated pod on the listed
+pools: the `BETA_POD_PREFIX` gate that held the first enforcement step to
+`kura-tuist-*` pods is gone, and with it the
+`kura_egress_tree_beta_excluded_pods` gauge. The annotation is the only
+opt-in left, so an account reaches the tree the moment kura-controller
+renders `tuist.dev/egress-class` onto its pods. Newly matched pods attach
+within one reconcile cycle; nothing detaches, so removing the gate only ever
+widens enforcement.
+
+Remaining sequencing: ceilings are live, floors stay informational until the
+per-replica floor double-count in scheduler bin-packing is fixed (known
+issue, separate change).

--- a/infra/egress-tree-agent/AGENTS.md
+++ b/infra/egress-tree-agent/AGENTS.md
@@ -233,13 +233,14 @@ growth is the signal.
 
 ## Rollout state
 
-Ships disabled (`egressTreeAgent.enabled: false`). Enabled on canary and
-production, where it now attaches to **every** annotated pod on the listed
-pools: the `BETA_POD_PREFIX` gate that held the first enforcement step to
-`kura-tuist-*` pods is gone, and with it the
-`kura_egress_tree_beta_excluded_pods` gauge. The annotation is the only
-opt-in left, so an account reaches the tree the moment kura-controller
-renders `tuist.dev/egress-class` onto its pods. Newly matched pods attach
+Ships disabled (`egressTreeAgent.enabled: false`). Enabled on staging,
+canary, and production, where it attaches to **every** annotated pod on the
+listed pools. Staging has run ungated since the agent landed (#12525);
+canary and production now match it, because the `BETA_POD_PREFIX` gate that
+held their first enforcement step to `kura-tuist-*` pods (#12564) is gone,
+and with it the `kura_egress_tree_beta_excluded_pods` gauge. The annotation
+is the only opt-in left, so an account reaches the tree the moment
+kura-controller renders `tuist.dev/egress-class` onto its pods. Newly matched pods attach
 within one reconcile cycle; nothing detaches, so removing the gate only ever
 widens enforcement.
 

--- a/infra/egress-tree-agent/cmd/agent/main.go
+++ b/infra/egress-tree-agent/cmd/agent/main.go
@@ -167,7 +167,6 @@ func main() {
 	a := &agent.Agent{
 		NodeName:          nodeName,
 		DefaultNodeMbps:   defaultNodeMbps,
-		BetaPodPrefix:     os.Getenv("BETA_POD_PREFIX"),
 		ReturnDetachAfter: returnDetachAfter,
 		Pods:              podInformer.Lister(),
 		Nodes:             nodeInformer.Lister(),

--- a/infra/egress-tree-agent/internal/agent/agent.go
+++ b/infra/egress-tree-agent/internal/agent/agent.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"net"
 	"slices"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,17 +25,6 @@ type Agent struct {
 	// that do not advertise tuist.dev/egress-mbps capacity. Zero means: no
 	// budget, no tree, pods stay unshaped.
 	DefaultNodeMbps int64
-	// BetaPodPrefix, when non-empty, restricts attachment to pods whose
-	// name starts with the prefix (a beta-rollout gate: shape one account's
-	// pods before the fleet). Excluded pods stay on the unshaped
-	// Cilium-only path and are counted separately from skipped pods so the
-	// exclusion never alerts. The desired tree and the sibling allowlists
-	// are still computed over every annotated pod, so a matched pod keeps
-	// its co-located sibling in the bypass even when that sibling is not
-	// itself attached. Clearing or changing the prefix converges through
-	// the normal reconcile: newly matched pods attach, no-longer-matched
-	// pods detach via stale-pin cleanup within one cycle.
-	BetaPodPrefix string
 	// ReturnDetachAfter is the number of consecutive return-program attach
 	// failures after which every pod program is detached. Attached pod
 	// programs redirect into the trampoline, and without a return program
@@ -109,7 +97,6 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 		// skipped-pod gauge carries the signal.
 		a.Metrics.NodeBudgetMbps.Set(0)
 		a.Metrics.AttachedPods.Set(0)
-		a.Metrics.BetaExcludedPods.Set(0)
 		a.Metrics.SkippedPods.Set(float64(len(pods) + skipped))
 		if len(pods) > 0 {
 			a.Log.Warn("node advertises no egress budget; pods stay unshaped",
@@ -154,7 +141,6 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 	}
 
 	attached := 0
-	betaExcluded := 0
 	active := map[string]bool{}
 	deviceOf := map[string]string{}
 	// Pods still desired but unconverged this cycle: their last known-good
@@ -164,10 +150,6 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 	retained := map[string]bool{}
 	for _, attachment := range attachments {
 		key := attachment.Namespace + "/" + attachment.Name
-		if a.BetaPodPrefix != "" && !strings.HasPrefix(attachment.Name, a.BetaPodPrefix) {
-			betaExcluded++
-			continue
-		}
 		device, ok := interfaces[key]
 		if !ok {
 			skipped++
@@ -205,7 +187,6 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 	}
 	a.Metrics.AttachedPods.Set(float64(attached))
 	a.Metrics.SkippedPods.Set(float64(skipped))
-	a.Metrics.BetaExcludedPods.Set(float64(betaExcluded))
 
 	if err := a.Attacher.CleanupStale(active); err != nil {
 		a.Log.Error("cleaning stale pins failed", "error", err)

--- a/infra/egress-tree-agent/internal/agent/metrics.go
+++ b/infra/egress-tree-agent/internal/agent/metrics.go
@@ -14,7 +14,6 @@ type Metrics struct {
 	AttachedPods         prometheus.Gauge
 	ReturnAttachFailures prometheus.Counter
 	SkippedPods          prometheus.Gauge
-	BetaExcludedPods     prometheus.Gauge
 	LinkReattaches       prometheus.Counter
 	SiblingOverflow      prometheus.Counter
 	NodeBudgetMbps       prometheus.Gauge
@@ -50,10 +49,6 @@ func NewMetrics(registry prometheus.Registerer) *Metrics {
 		SkippedPods: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "kura_egress_tree_skipped_pods",
 			Help: "Annotated pods not attached this cycle (unresolvable device or malformed annotation).",
-		}),
-		BetaExcludedPods: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "kura_egress_tree_beta_excluded_pods",
-			Help: "Annotated pods excluded from attachment by the BETA_POD_PREFIX gate.",
 		}),
 		LinkReattaches: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "kura_egress_tree_link_reattach_total",
@@ -106,7 +101,7 @@ func NewMetrics(registry prometheus.Registerer) *Metrics {
 	}
 	registry.MustRegister(
 		m.ReconcileTotal, m.ReconcileErrors, m.AttachedPods, m.ReturnAttachFailures,
-		m.SkippedPods, m.BetaExcludedPods,
+		m.SkippedPods,
 		m.LinkReattaches, m.SiblingOverflow, m.NodeBudgetMbps, m.ClassSentBytes, m.ClassDrops,
 		m.ClassBacklogBytes, m.DirectPackets, m.PodRedirected, m.PodGuardPass,
 		m.PodSiblingBypass, m.Returned, m.ReturnDropped,

--- a/infra/helm/tuist/templates/egress-tree-agent.yaml
+++ b/infra/helm/tuist/templates/egress-tree-agent.yaml
@@ -119,10 +119,6 @@ spec:
               value: ":{{ .Values.egressTreeAgent.metricsPort }}"
             - name: DEFAULT_NODE_EGRESS_MBPS
               value: {{ .Values.egressTreeAgent.defaultNodeEgressMbps | quote }}
-            {{- with .Values.egressTreeAgent.betaPodPrefix }}
-            - name: BETA_POD_PREFIX
-              value: {{ . | quote }}
-            {{- end }}
           securityContext:
             # Privileged like every datapath agent on these nodes: it creates
             # host veth devices, installs qdiscs, writes net sysctls, and

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -272,11 +272,9 @@ kuraController:
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
 # and its traffic is node-local runner reads that must not be shaped.
-# betaPodPrefix keeps the first enforcement step on kura-tuist-* pods.
 egressTreeAgent:
   enabled: true
   nodePools: [kura-dedibox, kura-ca-east]
-  betaPodPrefix: "kura-tuist-"
 
 # CloudNativePG cluster — canary shape. 2 instances (primary + 1 sync
 # replica), 10Gi per instance. Matches the cluster's general-purpose

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -312,11 +312,9 @@ kuraController:
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
 # and its traffic is node-local runner reads that must not be shaped.
-# betaPodPrefix keeps the first enforcement step on kura-tuist-* pods.
 egressTreeAgent:
   enabled: true
   nodePools: [kura-dedibox, kura-us-east, kura-us-west, kura-ap-southeast]
-  betaPodPrefix: "kura-tuist-"
 
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
 # sync replicas), 100Gi per instance. Each instance is a streaming

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -306,11 +306,6 @@ egressTreeAgent:
   # detaches every pod program (shaped packets drop at the trampoline peer
   # without a return program; unshaped beats blackholed).
   returnAttachMaxFailures: 3
-  # Beta-rollout gate: when set, the agent attaches its BPF programs only to
-  # pods whose name starts with this prefix (e.g. "kura-<account>-"); every
-  # other annotated pod stays on the unshaped Cilium-only path and is counted
-  # in kura_egress_tree_beta_excluded_pods. Empty = shape all annotated pods.
-  betaPodPrefix: ""
   # Observe-mode fallback for the tree's root ceiling on nodes that do not
   # advertise tuist.dev/egress-mbps capacity. 0 = no fallback: such nodes get
   # no tree and their pods stay unshaped on the node-local leg.


### PR DESCRIPTION
## What changed

The `egress-tree-agent` no longer restricts itself to `kura-tuist-*` pods. It now attaches its tcx shaper program to **every** pod carrying the `tuist.dev/egress-class` annotation on the pools it runs on, so the shared per-node HTB tree enforces ceilings (and, once floors go live, floors) for all tenants on canary and production rather than one account.

The beta gate is deleted rather than blanked:

- `internal/agent/agent.go` — `BetaPodPrefix` field and the `strings.HasPrefix` skip in the attachment loop (plus the now-unused `strings` import).
- `internal/agent/metrics.go` — the `kura_egress_tree_beta_excluded_pods` gauge, which can only ever report 0 now.
- `cmd/agent/main.go` — the `BETA_POD_PREFIX` env read.
- `infra/helm/tuist/` — the `egressTreeAgent.betaPodPrefix` value, the env block that rendered it, and the `betaPodPrefix: "kura-tuist-"` overrides in the canary and production values files.
- `AGENTS.md` — rollout section rewritten to describe the current state.

## Why

The prefix existed to hold the first enforcement step to a single account while the datapath was validated in production. That step is done, and the gate is what is now keeping the other accounts' egress unbounded on the node-local leg — exactly the traffic this agent was built to arbitrate. Leaving it in place also leaves the fleet in a state where one tenant is shaped and its neighbours are not, which is the worst version of the tree: the shaped account bears the ceiling while unshaped neighbours can still starve it.

## Why deleted rather than set to `""`

`betaPodPrefix: ""` was already the chart default and would have produced the same runtime behaviour. Removing the mechanism instead keeps a one-shot rollout lever from reading as a supported per-account control that someone could reach for later — there is no per-account knob it could correctly implement, since class ids and rates are allocated per account by the controller and the annotation is the contract. The `kura_egress_tree_beta_excluded_pods` gauge goes with it for the same reason; a permanently-zero metric is a false affordance in dashboards.

## Verification that no second gate stands behind this one

`instanceNeedsEgressClass` in `infra/kura-controller/controllers/kurainstance_controller.go` decides which instances get a class from the region's `kubernetes.io/egress-bandwidth` annotation or a non-zero `spec.egressGuaranteedMbps` — region configuration, never an account allowlist. So annotated pods for every account on the shaped pools already exist; the agent was simply declining to attach to them. Repo-wide grep confirms no remaining reference to `betaPodPrefix`, `BETA_POD_PREFIX`, or the removed metric in dashboards, alert rules, or values.

## Impact

Widening only — newly matched pods attach within one reconcile cycle, and nothing detaches. Accounts other than `tuist` on the canary and production kura pools go from unshaped to shaped at their region's ceiling once the agent releases and the DaemonSet rolls. The fail-safe invariants are untouched: return-program-before-pod-program ordering, the detach-after-N-failures escape hatch, and fail-open on a missing node budget all behave as before.

Worth watching on the first rolled node: `kura_egress_tree_direct_packets` (a stamp with no class), `kura_egress_tree_class_drops`, `kura_egress_tree_skipped_pods`, and `rate(node_softnet_dropped_total)` now that more pods take the trampoline's two extra backlog trips.

Floors remain informational: the per-replica floor double-count in scheduler bin-packing is still open and is tracked separately — this PR does not change that sequencing.

## Validation

- `go build ./...`, `go vet ./...`, and test compilation pass under `GOOS=linux`; `gofmt` reports no diffs.
- A full local build needs a stub for the bpf2go bindings (deliberately not committed — generated by the Dockerfile and CI on Linux), and the test binary cannot execute on darwin. Both are pre-existing constraints documented in `infra/egress-tree-agent/AGENTS.md`, not introduced here; CI exercises the real generate + build + test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)