### PR TITLE
feat(server): add dashboard read endpoint parity

### DIFF
--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -59,4 +59,16 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: server
-      run: mix deps.get
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
+      run: |
+        if [ -z "${GITHUB_TOKEN:-}" ]; then
+          mix deps.get
+          exit 0
+        fi
+
+        auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+        GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0='http.https://github.com/.extraheader' \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header" \
+          mix deps.get

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -9,6 +9,7 @@ on:
       - tuist_common/**
       - noora/**
       - .github/workflows/server.yml
+      - .github/actions/setup-server-mix/action.yml
       - server/pnpm-lock.yaml
       - .trivyignore
   pull_request:
@@ -18,6 +19,7 @@ on:
       - tuist_common/**
       - noora/**
       - .github/workflows/server.yml
+      - .github/actions/setup-server-mix/action.yml
       - server/pnpm-lock.yaml
       - noora/aube-lock.yaml
       - .trivyignore

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -632,6 +632,150 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Get a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)`.
+    public func getRunnerJob(_ input: Operations.getRunnerJob.Input) async throws -> Operations.getRunnerJob.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getRunnerJob.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/jobs/{}",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.workflow_job_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getRunnerJob.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.getRunnerJob.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getRunnerJob.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getRunnerJob.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.getRunnerJob.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getRunnerJob.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Downloads an artifact from the cache.
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
@@ -818,6 +962,150 @@ public struct Client: APIProtocol {
                     )
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.downloadCacheArtifact.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// List machine metrics for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)`.
+    public func listRunnerJobMetrics(_ input: Operations.listRunnerJobMetrics.Input) async throws -> Operations.listRunnerJobMetrics.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerJobMetrics.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/jobs/{}/metrics",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.workflow_job_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobMetrics.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobMetrics.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobMetrics.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerJobMetrics.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobMetrics.Output.TooManyRequests.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
@@ -1865,6 +2153,149 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// List runner profiles for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/profiles`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)`.
+    public func listRunnerProfiles(_ input: Operations.listRunnerProfiles.Input) async throws -> Operations.listRunnerProfiles.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerProfiles.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/profiles",
+                    parameters: [
+                        input.path.account_handle
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerProfiles.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerProfiles.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerProfiles.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerProfiles.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerProfiles.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// List test runs for a project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests`.
@@ -2383,6 +2814,151 @@ public struct Client: APIProtocol {
                     )
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.getBuild.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// Get a webhook delivery attempt.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)`.
+    public func getWebhookDeliveryAttempt(_ input: Operations.getWebhookDeliveryAttempt.Input) async throws -> Operations.getWebhookDeliveryAttempt.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getWebhookDeliveryAttempt.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/webhooks/{}/delivery-attempts/{}",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.webhook_endpoint_id,
+                        input.path.delivery_attempt_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookDeliveryAttempt.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.getWebhookDeliveryAttempt.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookDeliveryAttempt.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookDeliveryAttempt.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
@@ -3397,6 +3973,13 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
+                    name: "git_branch",
+                    value: input.query.git_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -3406,13 +3989,6 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "page_size",
                     value: input.query.page_size
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,
@@ -5839,6 +6415,205 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// List runner workflows for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/workflows`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)`.
+    public func listRunnerWorkflows(_ input: Operations.listRunnerWorkflows.Input) async throws -> Operations.listRunnerWorkflows.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerWorkflows.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/workflows",
+                    parameters: [
+                        input.path.account_handle
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page",
+                    value: input.query.page
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page_size",
+                    value: input.query.page_size
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "repository",
+                    value: input.query.repository
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "workflow_name",
+                    value: input.query.workflow_name
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "head_branch",
+                    value: input.query.head_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "platform",
+                    value: input.query.platform
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "sort_by",
+                    value: input.query.sort_by
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "sort_order",
+                    value: input.query.sort_order
+                )
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerWorkflows.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerWorkflows.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerWorkflows.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerWorkflows.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerWorkflows.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// It checks if an artifact exists in the cache.
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
@@ -6989,6 +7764,233 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// List runner jobs for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)`.
+    public func listRunnerJobs(_ input: Operations.listRunnerJobs.Input) async throws -> Operations.listRunnerJobs.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerJobs.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/jobs",
+                    parameters: [
+                        input.path.account_handle
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page",
+                    value: input.query.page
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page_size",
+                    value: input.query.page_size
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "status",
+                    value: input.query.status
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "conclusion",
+                    value: input.query.conclusion
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "repository",
+                    value: input.query.repository
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "workflow_name",
+                    value: input.query.workflow_name
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "job_name",
+                    value: input.query.job_name
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "head_branch",
+                    value: input.query.head_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "platform",
+                    value: input.query.platform
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "search",
+                    value: input.query.search
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "sort_by",
+                    value: input.query.sort_by
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "sort_order",
+                    value: input.query.sort_order
+                )
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobs.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerJobs.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobs.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobs.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerJobs.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobs.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// List cache runs associated with a given project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache-runs`.
@@ -7141,6 +8143,150 @@ public struct Client: APIProtocol {
                     )
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.listCacheRuns.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// List the steps for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)`.
+    public func listRunnerJobSteps(_ input: Operations.listRunnerJobSteps.Input) async throws -> Operations.listRunnerJobSteps.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerJobSteps.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/jobs/{}/steps",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.workflow_job_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobSteps.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobSteps.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobSteps.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerJobSteps.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobSteps.Output.TooManyRequests.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
@@ -11371,6 +12517,228 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// List delivery attempts for a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)`.
+    public func listWebhookDeliveryAttempts(_ input: Operations.listWebhookDeliveryAttempts.Input) async throws -> Operations.listWebhookDeliveryAttempts.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listWebhookDeliveryAttempts.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/webhooks/{}/delivery-attempts",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.webhook_endpoint_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page_size",
+                    value: input.query.page_size
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "after",
+                    value: input.query.after
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "before",
+                    value: input.query.before
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "start_datetime",
+                    value: input.query.start_datetime
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "end_datetime",
+                    value: input.query.end_datetime
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "status",
+                    value: input.query.status
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "event_type",
+                    value: input.query.event_type
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "event_id_search",
+                    value: input.query.event_id_search
+                )
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookDeliveryAttempts.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookDeliveryAttempts.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookDeliveryAttempts.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookDeliveryAttempts.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Shows the usage of an organization
     ///
     /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
@@ -12284,6 +13652,166 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// List captured log lines for a runner job.
+    ///
+    /// Returns log lines in display order. Page size defaults to 200 and is capped at 500.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)`.
+    public func listRunnerJobLogs(_ input: Operations.listRunnerJobLogs.Input) async throws -> Operations.listRunnerJobLogs.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listRunnerJobLogs.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/runners/jobs/{}/logs",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.workflow_job_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "offset",
+                    value: input.query.offset
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "limit",
+                    value: input.query.limit
+                )
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobLogs.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobLogs.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobLogs.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listRunnerJobLogs.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listRunnerJobLogs.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Get a specific device code.
     ///
     /// This endpoint returns a token for a given device code if the device code is authenticated.
@@ -12694,6 +14222,249 @@ public struct Client: APIProtocol {
                     )
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.listTestCaseEvents.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// List webhook endpoints for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)`.
+    public func listWebhookEndpoints(_ input: Operations.listWebhookEndpoints.Input) async throws -> Operations.listWebhookEndpoints.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listWebhookEndpoints.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/webhooks",
+                    parameters: [
+                        input.path.account_handle
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookEndpoints.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookEndpoints.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 429:
+                    let headers: Operations.listWebhookEndpoints.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listWebhookEndpoints.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// List a project's notification alert rules.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/notification-alerts`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)`.
+    public func listProjectNotificationAlerts(_ input: Operations.listProjectNotificationAlerts.Input) async throws -> Operations.listProjectNotificationAlerts.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listProjectNotificationAlerts.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/notification-alerts",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listProjectNotificationAlerts.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listProjectNotificationAlerts.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 429:
+                    let headers: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
@@ -15757,6 +17528,135 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Get an account token.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/tokens/{token_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)`.
+    public func getAccountToken(_ input: Operations.getAccountToken.Input) async throws -> Operations.getAccountToken.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getAccountToken.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/tokens/{}",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.token_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getAccountToken.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.getAccountToken.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getAccountToken.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getAccountToken.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getAccountToken.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Lists the organizations
     ///
     /// Returns all the organizations the authenticated subject is part of.
@@ -17218,6 +19118,150 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Get a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)`.
+    public func getWebhookEndpoint(_ input: Operations.getWebhookEndpoint.Input) async throws -> Operations.getWebhookEndpoint.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getWebhookEndpoint.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/accounts/{}/webhooks/{}",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.webhook_endpoint_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookEndpoint.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.getWebhookEndpoint.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookEndpoint.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookEndpoint.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.getWebhookEndpoint.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.getWebhookEndpoint.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Complete a multipart upload for a build archive.
     ///
     /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload of the build archive and enqueues it for server-side processing.
@@ -17529,6 +19573,165 @@ public struct Client: APIProtocol {
                     )
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.listTestModuleRuns.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// List an automation alert's revision history.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)`.
+    public func listAutomationAlertRevisions(_ input: Operations.listAutomationAlertRevisions.Input) async throws -> Operations.listAutomationAlertRevisions.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.listAutomationAlertRevisions.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/automations/alerts/{}/revisions",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.alert_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .get
+                )
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "before",
+                    value: input.query.before
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page_size",
+                    value: input.query.page_size
+                )
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                return (request, nil)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listAutomationAlertRevisions.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listAutomationAlertRevisions.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listAutomationAlertRevisions.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 429:
+                    let headers: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Headers = .init(
+                        retry_hyphen_after: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "retry-after",
+                            as: Swift.String.self
+                        ),
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "x-tuist-throttle-reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -34,6 +34,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/cache/endpoints`.
     /// - Remark: Generated from `#/paths//api/cache/endpoints/get(getCacheEndpoints)`.
     func getCacheEndpoints(_ input: Operations.getCacheEndpoints.Input) async throws -> Operations.getCacheEndpoints.Output
+    /// Get a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)`.
+    func getRunnerJob(_ input: Operations.getRunnerJob.Input) async throws -> Operations.getRunnerJob.Output
     /// Downloads an artifact from the cache.
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
@@ -46,6 +51,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/cache`.
     /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)`.
     func downloadCacheArtifact(_ input: Operations.downloadCacheArtifact.Input) async throws -> Operations.downloadCacheArtifact.Output
+    /// List machine metrics for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)`.
+    func listRunnerJobMetrics(_ input: Operations.listRunnerJobMetrics.Input) async throws -> Operations.listRunnerJobMetrics.Output
     /// It completes a multi-part upload.
     ///
     /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
@@ -85,6 +95,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/artifacts`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/artifacts/get(getBundleArtifactTree)`.
     func getBundleArtifactTree(_ input: Operations.getBundleArtifactTree.Input) async throws -> Operations.getBundleArtifactTree.Output
+    /// List runner profiles for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/profiles`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)`.
+    func listRunnerProfiles(_ input: Operations.listRunnerProfiles.Input) async throws -> Operations.listRunnerProfiles.Output
     /// List test runs for a project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests`.
@@ -100,6 +115,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/builds/{build_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/builds/{build_id}/get(getBuild)`.
     func getBuild(_ input: Operations.getBuild.Input) async throws -> Operations.getBuild.Output
+    /// Get a webhook delivery attempt.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)`.
+    func getWebhookDeliveryAttempt(_ input: Operations.getWebhookDeliveryAttempt.Input) async throws -> Operations.getWebhookDeliveryAttempt.Output
     /// Revokes a project token.
     ///
     /// - Remark: HTTP `DELETE /api/projects/{account_handle}/{project_handle}/tokens/{id}`.
@@ -240,6 +260,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/post(createRun)`.
     @available(*, deprecated)
     func createRun(_ input: Operations.createRun.Input) async throws -> Operations.createRun.Output
+    /// List runner workflows for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/workflows`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)`.
+    func listRunnerWorkflows(_ input: Operations.listRunnerWorkflows.Input) async throws -> Operations.listRunnerWorkflows.Output
     /// It checks if an artifact exists in the cache.
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
@@ -284,11 +309,21 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/cache/clean`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/clean/put(cleanCache)`.
     func cleanCache(_ input: Operations.cleanCache.Input) async throws -> Operations.cleanCache.Output
+    /// List runner jobs for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)`.
+    func listRunnerJobs(_ input: Operations.listRunnerJobs.Input) async throws -> Operations.listRunnerJobs.Output
     /// List cache runs associated with a given project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache-runs`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache-runs/get(listCacheRuns)`.
     func listCacheRuns(_ input: Operations.listCacheRuns.Input) async throws -> Operations.listCacheRuns.Output
+    /// List the steps for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)`.
+    func listRunnerJobSteps(_ input: Operations.listRunnerJobSteps.Input) async throws -> Operations.listRunnerJobSteps.Output
     /// Deletes a project with a given id.
     ///
     /// - Remark: HTTP `DELETE /api/projects/{id}`.
@@ -436,6 +471,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/builds/upload/generate-url`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/builds/upload/generate-url/post(generateBuildsMultipartUploadURL)`.
     func generateBuildsMultipartUploadURL(_ input: Operations.generateBuildsMultipartUploadURL.Input) async throws -> Operations.generateBuildsMultipartUploadURL.Output
+    /// List delivery attempts for a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)`.
+    func listWebhookDeliveryAttempts(_ input: Operations.listWebhookDeliveryAttempts.Input) async throws -> Operations.listWebhookDeliveryAttempts.Output
     /// Shows the usage of an organization
     ///
     /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
@@ -472,6 +512,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/get(getBundle)`.
     func getBundle(_ input: Operations.getBundle.Input) async throws -> Operations.getBundle.Output
+    /// List captured log lines for a runner job.
+    ///
+    /// Returns log lines in display order. Page size defaults to 200 and is capped at 500.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)`.
+    func listRunnerJobLogs(_ input: Operations.listRunnerJobLogs.Input) async throws -> Operations.listRunnerJobLogs.Output
     /// Get a specific device code.
     ///
     /// This endpoint returns a token for a given device code if the device code is authenticated.
@@ -489,6 +536,16 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/events`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/events/get(listTestCaseEvents)`.
     func listTestCaseEvents(_ input: Operations.listTestCaseEvents.Input) async throws -> Operations.listTestCaseEvents.Output
+    /// List webhook endpoints for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)`.
+    func listWebhookEndpoints(_ input: Operations.listWebhookEndpoints.Input) async throws -> Operations.listWebhookEndpoints.Output
+    /// List a project's notification alert rules.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/notification-alerts`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)`.
+    func listProjectNotificationAlerts(_ input: Operations.listProjectNotificationAlerts.Input) async throws -> Operations.listProjectNotificationAlerts.Output
     /// It initiates a multipart upload in the cache.
     ///
     /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
@@ -594,6 +651,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/xcode/builds/{build_id}/issues`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/xcode/builds/{build_id}/issues/get(listBuildIssues)`.
     func listBuildIssues(_ input: Operations.listBuildIssues.Input) async throws -> Operations.listBuildIssues.Output
+    /// Get an account token.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/tokens/{token_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)`.
+    func getAccountToken(_ input: Operations.getAccountToken.Input) async throws -> Operations.getAccountToken.Output
     /// Lists the organizations
     ///
     /// Returns all the organizations the authenticated subject is part of.
@@ -656,6 +718,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/gradle/builds/{build_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/gradle/builds/{build_id}/get(getGradleBuild)`.
     func getGradleBuild(_ input: Operations.getGradleBuild.Input) async throws -> Operations.getGradleBuild.Output
+    /// Get a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)`.
+    func getWebhookEndpoint(_ input: Operations.getWebhookEndpoint.Input) async throws -> Operations.getWebhookEndpoint.Output
     /// Complete a multipart upload for a build archive.
     ///
     /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload of the build archive and enqueues it for server-side processing.
@@ -668,6 +735,11 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests/{test_run_id}/modules`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/{test_run_id}/modules/get(listTestModuleRuns)`.
     func listTestModuleRuns(_ input: Operations.listTestModuleRuns.Input) async throws -> Operations.listTestModuleRuns.Output
+    /// List an automation alert's revision history.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)`.
+    func listAutomationAlertRevisions(_ input: Operations.listAutomationAlertRevisions.Input) async throws -> Operations.listAutomationAlertRevisions.Output
     /// List all project tokens.
     ///
     /// This endpoint returns all tokens for a given project.
@@ -806,6 +878,19 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// Get a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)`.
+    public func getRunnerJob(
+        path: Operations.getRunnerJob.Input.Path,
+        headers: Operations.getRunnerJob.Input.Headers = .init()
+    ) async throws -> Operations.getRunnerJob.Output {
+        try await getRunnerJob(Operations.getRunnerJob.Input(
+            path: path,
+            headers: headers
+        ))
+    }
     /// Downloads an artifact from the cache.
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
@@ -823,6 +908,19 @@ extension APIProtocol {
     ) async throws -> Operations.downloadCacheArtifact.Output {
         try await downloadCacheArtifact(Operations.downloadCacheArtifact.Input(
             query: query,
+            headers: headers
+        ))
+    }
+    /// List machine metrics for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)`.
+    public func listRunnerJobMetrics(
+        path: Operations.listRunnerJobMetrics.Input.Path,
+        headers: Operations.listRunnerJobMetrics.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerJobMetrics.Output {
+        try await listRunnerJobMetrics(Operations.listRunnerJobMetrics.Input(
+            path: path,
             headers: headers
         ))
     }
@@ -917,6 +1015,19 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// List runner profiles for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/profiles`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)`.
+    public func listRunnerProfiles(
+        path: Operations.listRunnerProfiles.Input.Path,
+        headers: Operations.listRunnerProfiles.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerProfiles.Output {
+        try await listRunnerProfiles(Operations.listRunnerProfiles.Input(
+            path: path,
+            headers: headers
+        ))
+    }
     /// List test runs for a project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests`.
@@ -956,6 +1067,19 @@ extension APIProtocol {
         headers: Operations.getBuild.Input.Headers = .init()
     ) async throws -> Operations.getBuild.Output {
         try await getBuild(Operations.getBuild.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// Get a webhook delivery attempt.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)`.
+    public func getWebhookDeliveryAttempt(
+        path: Operations.getWebhookDeliveryAttempt.Input.Path,
+        headers: Operations.getWebhookDeliveryAttempt.Input.Headers = .init()
+    ) async throws -> Operations.getWebhookDeliveryAttempt.Output {
+        try await getWebhookDeliveryAttempt(Operations.getWebhookDeliveryAttempt.Input(
             path: path,
             headers: headers
         ))
@@ -1304,6 +1428,21 @@ extension APIProtocol {
             body: body
         ))
     }
+    /// List runner workflows for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/workflows`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)`.
+    public func listRunnerWorkflows(
+        path: Operations.listRunnerWorkflows.Input.Path,
+        query: Operations.listRunnerWorkflows.Input.Query = .init(),
+        headers: Operations.listRunnerWorkflows.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerWorkflows.Output {
+        try await listRunnerWorkflows(Operations.listRunnerWorkflows.Input(
+            path: path,
+            query: query,
+            headers: headers
+        ))
+    }
     /// It checks if an artifact exists in the cache.
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
@@ -1410,6 +1549,21 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// List runner jobs for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)`.
+    public func listRunnerJobs(
+        path: Operations.listRunnerJobs.Input.Path,
+        query: Operations.listRunnerJobs.Input.Query = .init(),
+        headers: Operations.listRunnerJobs.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerJobs.Output {
+        try await listRunnerJobs(Operations.listRunnerJobs.Input(
+            path: path,
+            query: query,
+            headers: headers
+        ))
+    }
     /// List cache runs associated with a given project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache-runs`.
@@ -1422,6 +1576,19 @@ extension APIProtocol {
         try await listCacheRuns(Operations.listCacheRuns.Input(
             path: path,
             query: query,
+            headers: headers
+        ))
+    }
+    /// List the steps for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)`.
+    public func listRunnerJobSteps(
+        path: Operations.listRunnerJobSteps.Input.Path,
+        headers: Operations.listRunnerJobSteps.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerJobSteps.Output {
+        try await listRunnerJobSteps(Operations.listRunnerJobSteps.Input(
+            path: path,
             headers: headers
         ))
     }
@@ -1802,6 +1969,21 @@ extension APIProtocol {
             body: body
         ))
     }
+    /// List delivery attempts for a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)`.
+    public func listWebhookDeliveryAttempts(
+        path: Operations.listWebhookDeliveryAttempts.Input.Path,
+        query: Operations.listWebhookDeliveryAttempts.Input.Query = .init(),
+        headers: Operations.listWebhookDeliveryAttempts.Input.Headers = .init()
+    ) async throws -> Operations.listWebhookDeliveryAttempts.Output {
+        try await listWebhookDeliveryAttempts(Operations.listWebhookDeliveryAttempts.Input(
+            path: path,
+            query: query,
+            headers: headers
+        ))
+    }
     /// Shows the usage of an organization
     ///
     /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
@@ -1884,6 +2066,23 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// List captured log lines for a runner job.
+    ///
+    /// Returns log lines in display order. Page size defaults to 200 and is capped at 500.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)`.
+    public func listRunnerJobLogs(
+        path: Operations.listRunnerJobLogs.Input.Path,
+        query: Operations.listRunnerJobLogs.Input.Query = .init(),
+        headers: Operations.listRunnerJobLogs.Input.Headers = .init()
+    ) async throws -> Operations.listRunnerJobLogs.Output {
+        try await listRunnerJobLogs(Operations.listRunnerJobLogs.Input(
+            path: path,
+            query: query,
+            headers: headers
+        ))
+    }
     /// Get a specific device code.
     ///
     /// This endpoint returns a token for a given device code if the device code is authenticated.
@@ -1926,6 +2125,32 @@ extension APIProtocol {
         try await listTestCaseEvents(Operations.listTestCaseEvents.Input(
             path: path,
             query: query,
+            headers: headers
+        ))
+    }
+    /// List webhook endpoints for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)`.
+    public func listWebhookEndpoints(
+        path: Operations.listWebhookEndpoints.Input.Path,
+        headers: Operations.listWebhookEndpoints.Input.Headers = .init()
+    ) async throws -> Operations.listWebhookEndpoints.Output {
+        try await listWebhookEndpoints(Operations.listWebhookEndpoints.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// List a project's notification alert rules.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/notification-alerts`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)`.
+    public func listProjectNotificationAlerts(
+        path: Operations.listProjectNotificationAlerts.Input.Path,
+        headers: Operations.listProjectNotificationAlerts.Input.Headers = .init()
+    ) async throws -> Operations.listProjectNotificationAlerts.Output {
+        try await listProjectNotificationAlerts(Operations.listProjectNotificationAlerts.Input(
+            path: path,
             headers: headers
         ))
     }
@@ -2194,6 +2419,19 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// Get an account token.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/tokens/{token_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)`.
+    public func getAccountToken(
+        path: Operations.getAccountToken.Input.Path,
+        headers: Operations.getAccountToken.Input.Headers = .init()
+    ) async throws -> Operations.getAccountToken.Output {
+        try await getAccountToken(Operations.getAccountToken.Input(
+            path: path,
+            headers: headers
+        ))
+    }
     /// Lists the organizations
     ///
     /// Returns all the organizations the authenticated subject is part of.
@@ -2338,6 +2576,19 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// Get a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)`.
+    public func getWebhookEndpoint(
+        path: Operations.getWebhookEndpoint.Input.Path,
+        headers: Operations.getWebhookEndpoint.Input.Headers = .init()
+    ) async throws -> Operations.getWebhookEndpoint.Output {
+        try await getWebhookEndpoint(Operations.getWebhookEndpoint.Input(
+            path: path,
+            headers: headers
+        ))
+    }
     /// Complete a multipart upload for a build archive.
     ///
     /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload of the build archive and enqueues it for server-side processing.
@@ -2365,6 +2616,21 @@ extension APIProtocol {
         headers: Operations.listTestModuleRuns.Input.Headers = .init()
     ) async throws -> Operations.listTestModuleRuns.Output {
         try await listTestModuleRuns(Operations.listTestModuleRuns.Input(
+            path: path,
+            query: query,
+            headers: headers
+        ))
+    }
+    /// List an automation alert's revision history.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)`.
+    public func listAutomationAlertRevisions(
+        path: Operations.listAutomationAlertRevisions.Input.Path,
+        query: Operations.listAutomationAlertRevisions.Input.Query = .init(),
+        headers: Operations.listAutomationAlertRevisions.Input.Headers = .init()
+    ) async throws -> Operations.listAutomationAlertRevisions.Output {
+        try await listAutomationAlertRevisions(Operations.listAutomationAlertRevisions.Input(
             path: path,
             query: query,
             headers: headers
@@ -3532,6 +3798,137 @@ public enum Components {
                 case suite_name
             }
         }
+        /// - Remark: Generated from `#/components/schemas/RunnerJob`.
+        public struct RunnerJob: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/claimed_at`.
+            public var claimed_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/completed_at`.
+            public var completed_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/conclusion`.
+            public var conclusion: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/enqueued_at`.
+            public var enqueued_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/head_branch`.
+            public var head_branch: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/head_sha`.
+            public var head_sha: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/job_name`.
+            public var job_name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/log_archived_at`.
+            public var log_archived_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/memory_gb`.
+            public var memory_gb: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/platform`.
+            public var platform: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/repository`.
+            public var repository: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/requested_dispatch_label`.
+            public var requested_dispatch_label: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/run_attempt`.
+            public var run_attempt: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/started_at`.
+            public var started_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/status`.
+            public var status: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/updated_at`.
+            public var updated_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/vcpus`.
+            public var vcpus: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/workflow_job_id`.
+            public var workflow_job_id: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/workflow_name`.
+            public var workflow_name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJob/workflow_run_id`.
+            public var workflow_run_id: Swift.Int
+            /// Creates a new `RunnerJob`.
+            ///
+            /// - Parameters:
+            ///   - claimed_at:
+            ///   - completed_at:
+            ///   - conclusion:
+            ///   - enqueued_at:
+            ///   - head_branch:
+            ///   - head_sha:
+            ///   - job_name:
+            ///   - log_archived_at:
+            ///   - memory_gb:
+            ///   - platform:
+            ///   - repository:
+            ///   - requested_dispatch_label:
+            ///   - run_attempt:
+            ///   - started_at:
+            ///   - status:
+            ///   - updated_at:
+            ///   - vcpus:
+            ///   - workflow_job_id:
+            ///   - workflow_name:
+            ///   - workflow_run_id:
+            public init(
+                claimed_at: Foundation.Date? = nil,
+                completed_at: Foundation.Date? = nil,
+                conclusion: Swift.String,
+                enqueued_at: Foundation.Date,
+                head_branch: Swift.String,
+                head_sha: Swift.String,
+                job_name: Swift.String,
+                log_archived_at: Foundation.Date? = nil,
+                memory_gb: Swift.Int,
+                platform: Swift.String,
+                repository: Swift.String,
+                requested_dispatch_label: Swift.String,
+                run_attempt: Swift.Int,
+                started_at: Foundation.Date? = nil,
+                status: Swift.String,
+                updated_at: Foundation.Date,
+                vcpus: Swift.Int,
+                workflow_job_id: Swift.Int,
+                workflow_name: Swift.String,
+                workflow_run_id: Swift.Int
+            ) {
+                self.claimed_at = claimed_at
+                self.completed_at = completed_at
+                self.conclusion = conclusion
+                self.enqueued_at = enqueued_at
+                self.head_branch = head_branch
+                self.head_sha = head_sha
+                self.job_name = job_name
+                self.log_archived_at = log_archived_at
+                self.memory_gb = memory_gb
+                self.platform = platform
+                self.repository = repository
+                self.requested_dispatch_label = requested_dispatch_label
+                self.run_attempt = run_attempt
+                self.started_at = started_at
+                self.status = status
+                self.updated_at = updated_at
+                self.vcpus = vcpus
+                self.workflow_job_id = workflow_job_id
+                self.workflow_name = workflow_name
+                self.workflow_run_id = workflow_run_id
+            }
+            public enum CodingKeys: String, CodingKey {
+                case claimed_at
+                case completed_at
+                case conclusion
+                case enqueued_at
+                case head_branch
+                case head_sha
+                case job_name
+                case log_archived_at
+                case memory_gb
+                case platform
+                case repository
+                case requested_dispatch_label
+                case run_attempt
+                case started_at
+                case status
+                case updated_at
+                case vcpus
+                case workflow_job_id
+                case workflow_name
+                case workflow_run_id
+            }
+        }
         /// A newly created account token.
         ///
         /// - Remark: Generated from `#/components/schemas/AccountTokenCreated`.
@@ -3657,6 +4054,107 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/CacheRunsIndexPage`.
         public typealias CacheRunsIndexPage = Swift.Int
+        /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert`.
+        public struct ProjectNotificationAlert: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/bundle_name`.
+            public var bundle_name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/category`.
+            public var category: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/deviation_percentage`.
+            public var deviation_percentage: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/environment`.
+            public var environment: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/git_branch`.
+            public var git_branch: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/id`.
+            public var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/metric`.
+            public var metric: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/name`.
+            public var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/rolling_window_size`.
+            public var rolling_window_size: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/scheme`.
+            public var scheme: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/slack_channel_id`.
+            public var slack_channel_id: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/slack_channel_name`.
+            public var slack_channel_name: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/updated_at`.
+            public var updated_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/ProjectNotificationAlert/webhook_configured`.
+            public var webhook_configured: Swift.Bool
+            /// Creates a new `ProjectNotificationAlert`.
+            ///
+            /// - Parameters:
+            ///   - bundle_name:
+            ///   - category:
+            ///   - deviation_percentage:
+            ///   - environment:
+            ///   - git_branch:
+            ///   - id:
+            ///   - inserted_at:
+            ///   - metric:
+            ///   - name:
+            ///   - rolling_window_size:
+            ///   - scheme:
+            ///   - slack_channel_id:
+            ///   - slack_channel_name:
+            ///   - updated_at:
+            ///   - webhook_configured:
+            public init(
+                bundle_name: Swift.String,
+                category: Swift.String,
+                deviation_percentage: Swift.Double,
+                environment: Swift.String,
+                git_branch: Swift.String? = nil,
+                id: Swift.String,
+                inserted_at: Foundation.Date,
+                metric: Swift.String,
+                name: Swift.String,
+                rolling_window_size: Swift.Int? = nil,
+                scheme: Swift.String,
+                slack_channel_id: Swift.String? = nil,
+                slack_channel_name: Swift.String? = nil,
+                updated_at: Foundation.Date,
+                webhook_configured: Swift.Bool
+            ) {
+                self.bundle_name = bundle_name
+                self.category = category
+                self.deviation_percentage = deviation_percentage
+                self.environment = environment
+                self.git_branch = git_branch
+                self.id = id
+                self.inserted_at = inserted_at
+                self.metric = metric
+                self.name = name
+                self.rolling_window_size = rolling_window_size
+                self.scheme = scheme
+                self.slack_channel_id = slack_channel_id
+                self.slack_channel_name = slack_channel_name
+                self.updated_at = updated_at
+                self.webhook_configured = webhook_configured
+            }
+            public enum CodingKeys: String, CodingKey {
+                case bundle_name
+                case category
+                case deviation_percentage
+                case environment
+                case git_branch
+                case id
+                case inserted_at
+                case metric
+                case name
+                case rolling_window_size
+                case scheme
+                case slack_channel_id
+                case slack_channel_name
+                case updated_at
+                case webhook_configured
+            }
+        }
         /// The maximum number of builds to return in a single page.
         ///
         /// - Remark: Generated from `#/components/schemas/BuildsIndexPageSize`.
@@ -3926,6 +4424,93 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/TestTargetsPage`.
         public typealias TestTargetsPage = Swift.Int
+        /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision`.
+        public struct AutomationAlertRevision: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/actor`.
+            public struct actorPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/actor/email`.
+                public var email: Swift.String
+                /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/actor/id`.
+                public var id: Swift.Int
+                /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/actor/name`.
+                public var name: Swift.String
+                /// Creates a new `actorPayload`.
+                ///
+                /// - Parameters:
+                ///   - email:
+                ///   - id:
+                ///   - name:
+                public init(
+                    email: Swift.String,
+                    id: Swift.Int,
+                    name: Swift.String
+                ) {
+                    self.email = email
+                    self.id = id
+                    self.name = name
+                }
+                public enum CodingKeys: String, CodingKey {
+                    case email
+                    case id
+                    case name
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/actor`.
+            public var actor: Components.Schemas.AutomationAlertRevision.actorPayload?
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/changes`.
+            public var changes: OpenAPIRuntime.OpenAPIObjectContainer
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/event`.
+            @frozen public enum eventPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case created = "created"
+                case updated = "updated"
+            }
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/event`.
+            public var event: Components.Schemas.AutomationAlertRevision.eventPayload
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/id`.
+            public var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/snapshot`.
+            public var snapshot: OpenAPIRuntime.OpenAPIObjectContainer
+            /// - Remark: Generated from `#/components/schemas/AutomationAlertRevision/source`.
+            public var source: Swift.String
+            /// Creates a new `AutomationAlertRevision`.
+            ///
+            /// - Parameters:
+            ///   - actor:
+            ///   - changes:
+            ///   - event:
+            ///   - id:
+            ///   - inserted_at:
+            ///   - snapshot:
+            ///   - source:
+            public init(
+                actor: Components.Schemas.AutomationAlertRevision.actorPayload? = nil,
+                changes: OpenAPIRuntime.OpenAPIObjectContainer,
+                event: Components.Schemas.AutomationAlertRevision.eventPayload,
+                id: Swift.String,
+                inserted_at: Foundation.Date,
+                snapshot: OpenAPIRuntime.OpenAPIObjectContainer,
+                source: Swift.String
+            ) {
+                self.actor = actor
+                self.changes = changes
+                self.event = event
+                self.id = id
+                self.inserted_at = inserted_at
+                self.snapshot = snapshot
+                self.source = source
+            }
+            public enum CodingKeys: String, CodingKey {
+                case actor
+                case changes
+                case event
+                case id
+                case inserted_at
+                case snapshot
+                case source
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/TestCaseRunAttachmentParams`.
         public struct TestCaseRunAttachmentParams: Codable, Hashable, Sendable {
             /// The file name of the attachment.
@@ -5411,6 +5996,59 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/RunsIndexPageSize`.
         public typealias RunsIndexPageSize = Swift.Int
+        /// - Remark: Generated from `#/components/schemas/WebhookEndpoint`.
+        public struct WebhookEndpoint: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/event_types`.
+            public var event_types: [Swift.String]
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/id`.
+            public var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/name`.
+            public var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/signing_secret_last_four`.
+            public var signing_secret_last_four: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/updated_at`.
+            public var updated_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/WebhookEndpoint/url`.
+            public var url: Swift.String
+            /// Creates a new `WebhookEndpoint`.
+            ///
+            /// - Parameters:
+            ///   - event_types:
+            ///   - id:
+            ///   - inserted_at:
+            ///   - name:
+            ///   - signing_secret_last_four:
+            ///   - updated_at:
+            ///   - url:
+            public init(
+                event_types: [Swift.String],
+                id: Swift.String,
+                inserted_at: Foundation.Date,
+                name: Swift.String,
+                signing_secret_last_four: Swift.String? = nil,
+                updated_at: Foundation.Date,
+                url: Swift.String
+            ) {
+                self.event_types = event_types
+                self.id = id
+                self.inserted_at = inserted_at
+                self.name = name
+                self.signing_secret_last_four = signing_secret_last_four
+                self.updated_at = updated_at
+                self.url = url
+            }
+            public enum CodingKeys: String, CodingKey {
+                case event_types
+                case id
+                case inserted_at
+                case name
+                case signing_secret_last_four
+                case updated_at
+                case url
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/CacheStatus`.
         @frozen public enum CacheStatus: String, Codable, Hashable, Sendable, CaseIterable {
             case miss = "miss"
@@ -6116,6 +6754,77 @@ public enum Components {
                 case visibility
             }
         }
+        /// - Remark: Generated from `#/components/schemas/RunnerWorkflow`.
+        public struct RunnerWorkflow: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/avg_duration_ms`.
+            public var avg_duration_ms: Swift.Double?
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/cancelled_count`.
+            public var cancelled_count: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/failure_count`.
+            public var failure_count: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/in_progress_count`.
+            public var in_progress_count: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/last_run_at`.
+            public var last_run_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/repository`.
+            public var repository: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/skipped_count`.
+            public var skipped_count: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/success_count`.
+            public var success_count: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/total_jobs`.
+            public var total_jobs: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerWorkflow/workflow_name`.
+            public var workflow_name: Swift.String
+            /// Creates a new `RunnerWorkflow`.
+            ///
+            /// - Parameters:
+            ///   - avg_duration_ms:
+            ///   - cancelled_count:
+            ///   - failure_count:
+            ///   - in_progress_count:
+            ///   - last_run_at:
+            ///   - repository:
+            ///   - skipped_count:
+            ///   - success_count:
+            ///   - total_jobs:
+            ///   - workflow_name:
+            public init(
+                avg_duration_ms: Swift.Double? = nil,
+                cancelled_count: Swift.Int,
+                failure_count: Swift.Int,
+                in_progress_count: Swift.Int,
+                last_run_at: Foundation.Date,
+                repository: Swift.String,
+                skipped_count: Swift.Int,
+                success_count: Swift.Int,
+                total_jobs: Swift.Int,
+                workflow_name: Swift.String
+            ) {
+                self.avg_duration_ms = avg_duration_ms
+                self.cancelled_count = cancelled_count
+                self.failure_count = failure_count
+                self.in_progress_count = in_progress_count
+                self.last_run_at = last_run_at
+                self.repository = repository
+                self.skipped_count = skipped_count
+                self.success_count = success_count
+                self.total_jobs = total_jobs
+                self.workflow_name = workflow_name
+            }
+            public enum CodingKeys: String, CodingKey {
+                case avg_duration_ms
+                case cancelled_count
+                case failure_count
+                case in_progress_count
+                case last_run_at
+                case repository
+                case skipped_count
+                case success_count
+                case total_jobs
+                case workflow_name
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/TestRun`.
         public struct TestRun: Codable, Hashable, Sendable {
             /// The UUID of an associated build run.
@@ -6782,6 +7491,35 @@ public enum Components {
                 case expires_in
             }
         }
+        /// - Remark: Generated from `#/components/schemas/RunnerJobLogLine`.
+        public struct RunnerJobLogLine: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerJobLogLine/line_number`.
+            public var line_number: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobLogLine/message`.
+            public var message: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJobLogLine/ts`.
+            public var ts: Foundation.Date?
+            /// Creates a new `RunnerJobLogLine`.
+            ///
+            /// - Parameters:
+            ///   - line_number:
+            ///   - message:
+            ///   - ts:
+            public init(
+                line_number: Swift.Int,
+                message: Swift.String,
+                ts: Foundation.Date? = nil
+            ) {
+                self.line_number = line_number
+                self.message = message
+                self.ts = ts
+            }
+            public enum CodingKeys: String, CodingKey {
+                case line_number
+                case message
+                case ts
+            }
+        }
         /// A token to authenticate API requests as a project.
         ///
         /// - Remark: Generated from `#/components/schemas/ProjectToken`.
@@ -7201,6 +7939,104 @@ public enum Components {
                 case project_id
                 case test_run_url
                 case url
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/AccountToken`.
+        public struct AccountToken: Codable, Hashable, Sendable {
+            /// Whether token has access to all projects.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/all_projects`.
+            public var all_projects: Swift.Bool
+            /// When the token expires.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/expires_at`.
+            public var expires_at: Foundation.Date?
+            /// Token unique identifier.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/id`.
+            public var id: Swift.String
+            /// When the token was created.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// Friendly name for the token.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/name`.
+            public var name: Swift.String?
+            /// List of project handles the token can access when all_projects is false.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/project_handles`.
+            public var project_handles: [Swift.String]?
+            /// - Remark: Generated from `#/components/schemas/AccountToken/scopesPayload`.
+            @frozen public enum scopesPayloadPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case ci = "ci"
+                case mcp = "mcp"
+                case account_colon_scim_colon_write = "account:scim:write"
+                case account_colon_cache_colon_read = "account:cache:read"
+                case account_colon_cache_colon_write = "account:cache:write"
+                case account_colon_members_colon_read = "account:members:read"
+                case account_colon_members_colon_write = "account:members:write"
+                case account_colon_registry_colon_read = "account:registry:read"
+                case account_colon_registry_colon_write = "account:registry:write"
+                case account_colon_runners_colon_read = "account:runners:read"
+                case project_colon_previews_colon_read = "project:previews:read"
+                case project_colon_previews_colon_write = "project:previews:write"
+                case project_colon_admin_colon_read = "project:admin:read"
+                case project_colon_admin_colon_write = "project:admin:write"
+                case project_colon_cache_colon_read = "project:cache:read"
+                case project_colon_cache_colon_write = "project:cache:write"
+                case project_colon_bundles_colon_read = "project:bundles:read"
+                case project_colon_bundles_colon_write = "project:bundles:write"
+                case project_colon_tests_colon_read = "project:tests:read"
+                case project_colon_tests_colon_write = "project:tests:write"
+                case project_colon_builds_colon_read = "project:builds:read"
+                case project_colon_builds_colon_write = "project:builds:write"
+                case project_colon_runs_colon_read = "project:runs:read"
+                case project_colon_runs_colon_write = "project:runs:write"
+            }
+            /// Token scopes.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/scopes`.
+            public typealias scopesPayload = [Components.Schemas.AccountToken.scopesPayloadPayload]
+            /// Token scopes.
+            ///
+            /// - Remark: Generated from `#/components/schemas/AccountToken/scopes`.
+            public var scopes: Components.Schemas.AccountToken.scopesPayload
+            /// Creates a new `AccountToken`.
+            ///
+            /// - Parameters:
+            ///   - all_projects: Whether token has access to all projects.
+            ///   - expires_at: When the token expires.
+            ///   - id: Token unique identifier.
+            ///   - inserted_at: When the token was created.
+            ///   - name: Friendly name for the token.
+            ///   - project_handles: List of project handles the token can access when all_projects is false.
+            ///   - scopes: Token scopes.
+            public init(
+                all_projects: Swift.Bool,
+                expires_at: Foundation.Date? = nil,
+                id: Swift.String,
+                inserted_at: Foundation.Date,
+                name: Swift.String? = nil,
+                project_handles: [Swift.String]? = nil,
+                scopes: Components.Schemas.AccountToken.scopesPayload
+            ) {
+                self.all_projects = all_projects
+                self.expires_at = expires_at
+                self.id = id
+                self.inserted_at = inserted_at
+                self.name = name
+                self.project_handles = project_handles
+                self.scopes = scopes
+            }
+            public enum CodingKeys: String, CodingKey {
+                case all_projects
+                case expires_at
+                case id
+                case inserted_at
+                case name
+                case project_handles
+                case scopes
             }
         }
         /// An action run when an automation alert triggers or recovers.
@@ -9559,7 +10395,7 @@ public enum Components {
                 ///
                 /// - Remark: Generated from `#/components/schemas/AccountTokens/tokensPayload/name`.
                 public var name: Swift.String?
-                /// List of project handles the token can access (when all_projects is false).
+                /// List of project handles the token can access when all_projects is false.
                 ///
                 /// - Remark: Generated from `#/components/schemas/AccountTokens/tokensPayload/project_handles`.
                 public var project_handles: [Swift.String]?
@@ -9574,6 +10410,7 @@ public enum Components {
                     case account_colon_members_colon_write = "account:members:write"
                     case account_colon_registry_colon_read = "account:registry:read"
                     case account_colon_registry_colon_write = "account:registry:write"
+                    case account_colon_runners_colon_read = "account:runners:read"
                     case project_colon_previews_colon_read = "project:previews:read"
                     case project_colon_previews_colon_write = "project:previews:write"
                     case project_colon_admin_colon_read = "project:admin:read"
@@ -9605,7 +10442,7 @@ public enum Components {
                 ///   - id: Token unique identifier.
                 ///   - inserted_at: When the token was created.
                 ///   - name: Friendly name for the token.
-                ///   - project_handles: List of project handles the token can access (when all_projects is false).
+                ///   - project_handles: List of project handles the token can access when all_projects is false.
                 ///   - scopes: Token scopes.
                 public init(
                     all_projects: Swift.Bool,
@@ -9731,6 +10568,71 @@ public enum Components {
                 case multipart_upload_parts
             }
         }
+        /// - Remark: Generated from `#/components/schemas/RunnerJobMetric`.
+        public struct RunnerJobMetric: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/cpu_iowait_percent`.
+            public var cpu_iowait_percent: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/cpu_usage_percent`.
+            public var cpu_usage_percent: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/disk_total_bytes`.
+            public var disk_total_bytes: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/disk_used_bytes`.
+            public var disk_used_bytes: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/memory_total_bytes`.
+            public var memory_total_bytes: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/memory_used_bytes`.
+            public var memory_used_bytes: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/network_bytes_in`.
+            public var network_bytes_in: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/network_bytes_out`.
+            public var network_bytes_out: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/timestamp`.
+            public var timestamp: Swift.Double
+            /// Creates a new `RunnerJobMetric`.
+            ///
+            /// - Parameters:
+            ///   - cpu_iowait_percent:
+            ///   - cpu_usage_percent:
+            ///   - disk_total_bytes:
+            ///   - disk_used_bytes:
+            ///   - memory_total_bytes:
+            ///   - memory_used_bytes:
+            ///   - network_bytes_in:
+            ///   - network_bytes_out:
+            ///   - timestamp:
+            public init(
+                cpu_iowait_percent: Swift.Double,
+                cpu_usage_percent: Swift.Double,
+                disk_total_bytes: Swift.Int,
+                disk_used_bytes: Swift.Int,
+                memory_total_bytes: Swift.Int,
+                memory_used_bytes: Swift.Int,
+                network_bytes_in: Swift.Int,
+                network_bytes_out: Swift.Int,
+                timestamp: Swift.Double
+            ) {
+                self.cpu_iowait_percent = cpu_iowait_percent
+                self.cpu_usage_percent = cpu_usage_percent
+                self.disk_total_bytes = disk_total_bytes
+                self.disk_used_bytes = disk_used_bytes
+                self.memory_total_bytes = memory_total_bytes
+                self.memory_used_bytes = memory_used_bytes
+                self.network_bytes_in = network_bytes_in
+                self.network_bytes_out = network_bytes_out
+                self.timestamp = timestamp
+            }
+            public enum CodingKeys: String, CodingKey {
+                case cpu_iowait_percent
+                case cpu_usage_percent
+                case disk_total_bytes
+                case disk_used_bytes
+                case memory_total_bytes
+                case memory_used_bytes
+                case network_bytes_in
+                case network_bytes_out
+                case timestamp
+            }
+        }
         /// Parameters to start a multipart upload for a build archive.
         ///
         /// - Remark: Generated from `#/components/schemas/BuildMultipartUploadStartParams`.
@@ -9755,6 +10657,76 @@ public enum Components {
             case enabled = "enabled"
             case muted = "muted"
             case skipped = "skipped"
+        }
+        /// - Remark: Generated from `#/components/schemas/RunnerProfile`.
+        public struct RunnerProfile: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/id`.
+            public var id: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/memory_gb`.
+            public var memory_gb: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/name`.
+            public var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/platform`.
+            @frozen public enum platformPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case linux = "linux"
+                case macos = "macos"
+            }
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/platform`.
+            public var platform: Components.Schemas.RunnerProfile.platformPayload
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/protected`.
+            public var protected: Swift.Bool
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/updated_at`.
+            public var updated_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/vcpus`.
+            public var vcpus: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerProfile/xcode_version`.
+            public var xcode_version: Swift.String?
+            /// Creates a new `RunnerProfile`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - inserted_at:
+            ///   - memory_gb:
+            ///   - name:
+            ///   - platform:
+            ///   - protected:
+            ///   - updated_at:
+            ///   - vcpus:
+            ///   - xcode_version:
+            public init(
+                id: Swift.Int,
+                inserted_at: Foundation.Date,
+                memory_gb: Swift.Int,
+                name: Swift.String,
+                platform: Components.Schemas.RunnerProfile.platformPayload,
+                protected: Swift.Bool,
+                updated_at: Foundation.Date,
+                vcpus: Swift.Int,
+                xcode_version: Swift.String? = nil
+            ) {
+                self.id = id
+                self.inserted_at = inserted_at
+                self.memory_gb = memory_gb
+                self.name = name
+                self.platform = platform
+                self.protected = protected
+                self.updated_at = updated_at
+                self.vcpus = vcpus
+                self.xcode_version = xcode_version
+            }
+            public enum CodingKeys: String, CodingKey {
+                case id
+                case inserted_at
+                case memory_gb
+                case name
+                case platform
+                case protected
+                case updated_at
+                case vcpus
+                case xcode_version
+            }
         }
         /// - Remark: Generated from `#/components/schemas/AbsentCacheArtifact`.
         public struct AbsentCacheArtifact: Codable, Hashable, Sendable {
@@ -9804,6 +10776,53 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/ModuleCacheTargetsPageSize`.
         public typealias ModuleCacheTargetsPageSize = Swift.Int
+        /// - Remark: Generated from `#/components/schemas/RunnerJobStep`.
+        public struct RunnerJobStep: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/completed_at`.
+            public var completed_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/conclusion`.
+            public var conclusion: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/name`.
+            public var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/number`.
+            public var number: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/started_at`.
+            public var started_at: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/RunnerJobStep/status`.
+            public var status: Swift.String
+            /// Creates a new `RunnerJobStep`.
+            ///
+            /// - Parameters:
+            ///   - completed_at:
+            ///   - conclusion:
+            ///   - name:
+            ///   - number:
+            ///   - started_at:
+            ///   - status:
+            public init(
+                completed_at: Foundation.Date? = nil,
+                conclusion: Swift.String,
+                name: Swift.String,
+                number: Swift.Int,
+                started_at: Foundation.Date? = nil,
+                status: Swift.String
+            ) {
+                self.completed_at = completed_at
+                self.conclusion = conclusion
+                self.name = name
+                self.number = number
+                self.started_at = started_at
+                self.status = status
+            }
+            public enum CodingKeys: String, CodingKey {
+                case completed_at
+                case conclusion
+                case name
+                case number
+                case started_at
+                case status
+            }
+        }
         /// The page number to return.
         ///
         /// - Remark: Generated from `#/components/schemas/BuildCacheTasksIndexPage`.
@@ -9900,6 +10919,7 @@ public enum Components {
                 case account_colon_members_colon_write = "account:members:write"
                 case account_colon_registry_colon_read = "account:registry:read"
                 case account_colon_registry_colon_write = "account:registry:write"
+                case account_colon_runners_colon_read = "account:runners:read"
                 case project_colon_previews_colon_read = "project:previews:read"
                 case project_colon_previews_colon_write = "project:previews:write"
                 case project_colon_admin_colon_read = "project:admin:read"
@@ -11490,6 +12510,106 @@ public enum Components {
                 }
             }
         }
+        /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt`.
+        public struct WebhookDeliveryAttempt: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/attempt`.
+            public var attempt: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/duration_ms`.
+            public var duration_ms: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/error`.
+            public var error: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/event_id`.
+            public var event_id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/event_type`.
+            public var event_type: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/id`.
+            public var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/inserted_at`.
+            public var inserted_at: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/request_body`.
+            public var request_body: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/request_headers`.
+            public var request_headers: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/response_body`.
+            public var response_body: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/response_headers`.
+            public var response_headers: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/response_status`.
+            public var response_status: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/status`.
+            @frozen public enum statusPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case delivered = "delivered"
+                case failed = "failed"
+            }
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/status`.
+            public var status: Components.Schemas.WebhookDeliveryAttempt.statusPayload
+            /// - Remark: Generated from `#/components/schemas/WebhookDeliveryAttempt/webhook_endpoint_id`.
+            public var webhook_endpoint_id: Swift.String
+            /// Creates a new `WebhookDeliveryAttempt`.
+            ///
+            /// - Parameters:
+            ///   - attempt:
+            ///   - duration_ms:
+            ///   - error:
+            ///   - event_id:
+            ///   - event_type:
+            ///   - id:
+            ///   - inserted_at:
+            ///   - request_body:
+            ///   - request_headers:
+            ///   - response_body:
+            ///   - response_headers:
+            ///   - response_status:
+            ///   - status:
+            ///   - webhook_endpoint_id:
+            public init(
+                attempt: Swift.Int,
+                duration_ms: Swift.Int,
+                error: Swift.String,
+                event_id: Swift.String,
+                event_type: Swift.String,
+                id: Swift.String,
+                inserted_at: Foundation.Date,
+                request_body: Swift.String,
+                request_headers: Swift.String,
+                response_body: Swift.String,
+                response_headers: Swift.String,
+                response_status: Swift.Int,
+                status: Components.Schemas.WebhookDeliveryAttempt.statusPayload,
+                webhook_endpoint_id: Swift.String
+            ) {
+                self.attempt = attempt
+                self.duration_ms = duration_ms
+                self.error = error
+                self.event_id = event_id
+                self.event_type = event_type
+                self.id = id
+                self.inserted_at = inserted_at
+                self.request_body = request_body
+                self.request_headers = request_headers
+                self.response_body = response_body
+                self.response_headers = response_headers
+                self.response_status = response_status
+                self.status = status
+                self.webhook_endpoint_id = webhook_endpoint_id
+            }
+            public enum CodingKeys: String, CodingKey {
+                case attempt
+                case duration_ms
+                case error
+                case event_id
+                case event_type
+                case id
+                case inserted_at
+                case request_body
+                case request_headers
+                case response_body
+                case response_headers
+                case response_status
+                case status
+                case webhook_endpoint_id
+            }
+        }
         /// A new project token.
         ///
         /// - Remark: Generated from `#/components/schemas/ProjectFullToken`.
@@ -13048,6 +14168,459 @@ public enum Operations {
             }
         }
     }
+    /// Get a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)`.
+    public enum getRunnerJob {
+        public static let id: Swift.String = "getRunnerJob"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The workflow job identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/path/workflow_job_id`.
+                public var workflow_job_id: Swift.Int
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - workflow_job_id: The workflow job identifier.
+                public init(
+                    account_handle: Swift.String,
+                    workflow_job_id: Swift.Int
+                ) {
+                    self.account_handle = account_handle
+                    self.workflow_job_id = workflow_job_id
+                }
+            }
+            public var path: Operations.getRunnerJob.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getRunnerJob.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getRunnerJob.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.getRunnerJob.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.getRunnerJob.Input.Path,
+                headers: Operations.getRunnerJob.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/claimed_at`.
+                        public var claimed_at: Foundation.Date?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/completed_at`.
+                        public var completed_at: Foundation.Date?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/conclusion`.
+                        public var conclusion: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/enqueued_at`.
+                        public var enqueued_at: Foundation.Date
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/head_branch`.
+                        public var head_branch: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/head_sha`.
+                        public var head_sha: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/job_name`.
+                        public var job_name: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/log_archived_at`.
+                        public var log_archived_at: Foundation.Date?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/memory_gb`.
+                        public var memory_gb: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/platform`.
+                        public var platform: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/repository`.
+                        public var repository: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/requested_dispatch_label`.
+                        public var requested_dispatch_label: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/run_attempt`.
+                        public var run_attempt: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/started_at`.
+                        public var started_at: Foundation.Date?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/status`.
+                        public var status: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/updated_at`.
+                        public var updated_at: Foundation.Date
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/vcpus`.
+                        public var vcpus: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/workflow_job_id`.
+                        public var workflow_job_id: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/workflow_name`.
+                        public var workflow_name: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/json/workflow_run_id`.
+                        public var workflow_run_id: Swift.Int
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - claimed_at:
+                        ///   - completed_at:
+                        ///   - conclusion:
+                        ///   - enqueued_at:
+                        ///   - head_branch:
+                        ///   - head_sha:
+                        ///   - job_name:
+                        ///   - log_archived_at:
+                        ///   - memory_gb:
+                        ///   - platform:
+                        ///   - repository:
+                        ///   - requested_dispatch_label:
+                        ///   - run_attempt:
+                        ///   - started_at:
+                        ///   - status:
+                        ///   - updated_at:
+                        ///   - vcpus:
+                        ///   - workflow_job_id:
+                        ///   - workflow_name:
+                        ///   - workflow_run_id:
+                        public init(
+                            claimed_at: Foundation.Date? = nil,
+                            completed_at: Foundation.Date? = nil,
+                            conclusion: Swift.String,
+                            enqueued_at: Foundation.Date,
+                            head_branch: Swift.String,
+                            head_sha: Swift.String,
+                            job_name: Swift.String,
+                            log_archived_at: Foundation.Date? = nil,
+                            memory_gb: Swift.Int,
+                            platform: Swift.String,
+                            repository: Swift.String,
+                            requested_dispatch_label: Swift.String,
+                            run_attempt: Swift.Int,
+                            started_at: Foundation.Date? = nil,
+                            status: Swift.String,
+                            updated_at: Foundation.Date,
+                            vcpus: Swift.Int,
+                            workflow_job_id: Swift.Int,
+                            workflow_name: Swift.String,
+                            workflow_run_id: Swift.Int
+                        ) {
+                            self.claimed_at = claimed_at
+                            self.completed_at = completed_at
+                            self.conclusion = conclusion
+                            self.enqueued_at = enqueued_at
+                            self.head_branch = head_branch
+                            self.head_sha = head_sha
+                            self.job_name = job_name
+                            self.log_archived_at = log_archived_at
+                            self.memory_gb = memory_gb
+                            self.platform = platform
+                            self.repository = repository
+                            self.requested_dispatch_label = requested_dispatch_label
+                            self.run_attempt = run_attempt
+                            self.started_at = started_at
+                            self.status = status
+                            self.updated_at = updated_at
+                            self.vcpus = vcpus
+                            self.workflow_job_id = workflow_job_id
+                            self.workflow_name = workflow_name
+                            self.workflow_run_id = workflow_run_id
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case claimed_at
+                            case completed_at
+                            case conclusion
+                            case enqueued_at
+                            case head_branch
+                            case head_sha
+                            case job_name
+                            case log_archived_at
+                            case memory_gb
+                            case platform
+                            case repository
+                            case requested_dispatch_label
+                            case run_attempt
+                            case started_at
+                            case status
+                            case updated_at
+                            case vcpus
+                            case workflow_job_id
+                            case workflow_name
+                            case workflow_run_id
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/200/content/application\/json`.
+                    case json(Operations.getRunnerJob.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.getRunnerJob.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getRunnerJob.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getRunnerJob.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getRunnerJob.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.getRunnerJob.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getRunnerJob.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getRunnerJob.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.getRunnerJob.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.getRunnerJob.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getRunnerJob.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getRunnerJob.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getRunnerJob.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.getRunnerJob.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getRunnerJob.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getRunnerJob.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getRunnerJob.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.getRunnerJob.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/get(getRunnerJob)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.getRunnerJob.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.getRunnerJob.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// Downloads an artifact from the cache.
     ///
     /// This endpoint returns a signed URL that can be used to download an artifact from the cache.
@@ -13450,6 +15023,410 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.downloadCacheArtifact.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List machine metrics for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)`.
+    public enum listRunnerJobMetrics {
+        public static let id: Swift.String = "listRunnerJobMetrics"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The workflow job identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/path/workflow_job_id`.
+                public var workflow_job_id: Swift.Int
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - workflow_job_id: The workflow job identifier.
+                public init(
+                    account_handle: Swift.String,
+                    workflow_job_id: Swift.Int
+                ) {
+                    self.account_handle = account_handle
+                    self.workflow_job_id = workflow_job_id
+                }
+            }
+            public var path: Operations.listRunnerJobMetrics.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobMetrics.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobMetrics.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerJobMetrics.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerJobMetrics.Input.Path,
+                headers: Operations.listRunnerJobMetrics.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload`.
+                        public struct metricsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/cpu_iowait_percent`.
+                            public var cpu_iowait_percent: Swift.Double
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/cpu_usage_percent`.
+                            public var cpu_usage_percent: Swift.Double
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/disk_total_bytes`.
+                            public var disk_total_bytes: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/disk_used_bytes`.
+                            public var disk_used_bytes: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/memory_total_bytes`.
+                            public var memory_total_bytes: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/memory_used_bytes`.
+                            public var memory_used_bytes: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/network_bytes_in`.
+                            public var network_bytes_in: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/network_bytes_out`.
+                            public var network_bytes_out: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/timestamp`.
+                            public var timestamp: Swift.Double
+                            /// Creates a new `metricsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - cpu_iowait_percent:
+                            ///   - cpu_usage_percent:
+                            ///   - disk_total_bytes:
+                            ///   - disk_used_bytes:
+                            ///   - memory_total_bytes:
+                            ///   - memory_used_bytes:
+                            ///   - network_bytes_in:
+                            ///   - network_bytes_out:
+                            ///   - timestamp:
+                            public init(
+                                cpu_iowait_percent: Swift.Double,
+                                cpu_usage_percent: Swift.Double,
+                                disk_total_bytes: Swift.Int,
+                                disk_used_bytes: Swift.Int,
+                                memory_total_bytes: Swift.Int,
+                                memory_used_bytes: Swift.Int,
+                                network_bytes_in: Swift.Int,
+                                network_bytes_out: Swift.Int,
+                                timestamp: Swift.Double
+                            ) {
+                                self.cpu_iowait_percent = cpu_iowait_percent
+                                self.cpu_usage_percent = cpu_usage_percent
+                                self.disk_total_bytes = disk_total_bytes
+                                self.disk_used_bytes = disk_used_bytes
+                                self.memory_total_bytes = memory_total_bytes
+                                self.memory_used_bytes = memory_used_bytes
+                                self.network_bytes_in = network_bytes_in
+                                self.network_bytes_out = network_bytes_out
+                                self.timestamp = timestamp
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case cpu_iowait_percent
+                                case cpu_usage_percent
+                                case disk_total_bytes
+                                case disk_used_bytes
+                                case memory_total_bytes
+                                case memory_used_bytes
+                                case network_bytes_in
+                                case network_bytes_out
+                                case timestamp
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metrics`.
+                        public typealias metricsPayload = [Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload.metricsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metrics`.
+                        public var metrics: Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload.metricsPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - metrics:
+                        public init(metrics: Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload.metricsPayload) {
+                            self.metrics = metrics
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case metrics
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerJobMetrics.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobMetrics.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobMetrics.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job metrics
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerJobMetrics.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerJobMetrics.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobMetrics.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobMetrics.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerJobMetrics.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerJobMetrics.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobMetrics.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobMetrics.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerJobMetrics.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerJobMetrics.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerJobMetrics.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobMetrics.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerJobMetrics.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerJobMetrics.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/get(listRunnerJobMetrics)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerJobMetrics.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerJobMetrics.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):
@@ -16238,6 +18215,406 @@ public enum Operations {
             }
         }
     }
+    /// List runner profiles for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/profiles`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)`.
+    public enum listRunnerProfiles {
+        public static let id: Swift.String = "listRunnerProfiles"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                public init(account_handle: Swift.String) {
+                    self.account_handle = account_handle
+                }
+            }
+            public var path: Operations.listRunnerProfiles.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerProfiles.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerProfiles.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerProfiles.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerProfiles.Input.Path,
+                headers: Operations.listRunnerProfiles.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload`.
+                        public struct profilesPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/id`.
+                            public var id: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/inserted_at`.
+                            public var inserted_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/memory_gb`.
+                            public var memory_gb: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/name`.
+                            public var name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/platform`.
+                            @frozen public enum platformPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                                case linux = "linux"
+                                case macos = "macos"
+                            }
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/platform`.
+                            public var platform: Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.profilesPayloadPayload.platformPayload
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/protected`.
+                            public var protected: Swift.Bool
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/updated_at`.
+                            public var updated_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/vcpus`.
+                            public var vcpus: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profilesPayload/xcode_version`.
+                            public var xcode_version: Swift.String?
+                            /// Creates a new `profilesPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - id:
+                            ///   - inserted_at:
+                            ///   - memory_gb:
+                            ///   - name:
+                            ///   - platform:
+                            ///   - protected:
+                            ///   - updated_at:
+                            ///   - vcpus:
+                            ///   - xcode_version:
+                            public init(
+                                id: Swift.Int,
+                                inserted_at: Foundation.Date,
+                                memory_gb: Swift.Int,
+                                name: Swift.String,
+                                platform: Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.profilesPayloadPayload.platformPayload,
+                                protected: Swift.Bool,
+                                updated_at: Foundation.Date,
+                                vcpus: Swift.Int,
+                                xcode_version: Swift.String? = nil
+                            ) {
+                                self.id = id
+                                self.inserted_at = inserted_at
+                                self.memory_gb = memory_gb
+                                self.name = name
+                                self.platform = platform
+                                self.protected = protected
+                                self.updated_at = updated_at
+                                self.vcpus = vcpus
+                                self.xcode_version = xcode_version
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case id
+                                case inserted_at
+                                case memory_gb
+                                case name
+                                case platform
+                                case protected
+                                case updated_at
+                                case vcpus
+                                case xcode_version
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profiles`.
+                        public typealias profilesPayload = [Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.profilesPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/json/profiles`.
+                        public var profiles: Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.profilesPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - profiles:
+                        public init(profiles: Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload.profilesPayload) {
+                            self.profiles = profiles
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case profiles
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerProfiles.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerProfiles.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerProfiles.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner profiles
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerProfiles.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerProfiles.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerProfiles.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerProfiles.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerProfiles.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerProfiles.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerProfiles.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerProfiles.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runners are not enabled
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerProfiles.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerProfiles.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerProfiles.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/profiles/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerProfiles.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerProfiles.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerProfiles.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/profiles/get(listRunnerProfiles)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerProfiles.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerProfiles.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// List test runs for a project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests`.
@@ -18464,6 +20841,435 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.getBuild.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Get a webhook delivery attempt.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)`.
+    public enum getWebhookDeliveryAttempt {
+        public static let id: Swift.String = "getWebhookDeliveryAttempt"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The webhook endpoint identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/path/webhook_endpoint_id`.
+                public var webhook_endpoint_id: Swift.String
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/path/delivery_attempt_id`.
+                public var delivery_attempt_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - webhook_endpoint_id: The webhook endpoint identifier.
+                ///   - delivery_attempt_id:
+                public init(
+                    account_handle: Swift.String,
+                    webhook_endpoint_id: Swift.String,
+                    delivery_attempt_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.webhook_endpoint_id = webhook_endpoint_id
+                    self.delivery_attempt_id = delivery_attempt_id
+                }
+            }
+            public var path: Operations.getWebhookDeliveryAttempt.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getWebhookDeliveryAttempt.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getWebhookDeliveryAttempt.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.getWebhookDeliveryAttempt.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.getWebhookDeliveryAttempt.Input.Path,
+                headers: Operations.getWebhookDeliveryAttempt.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/attempt`.
+                        public var attempt: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/duration_ms`.
+                        public var duration_ms: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/error`.
+                        public var error: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/event_id`.
+                        public var event_id: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/event_type`.
+                        public var event_type: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/id`.
+                        public var id: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/inserted_at`.
+                        public var inserted_at: Foundation.Date
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/request_body`.
+                        public var request_body: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/request_headers`.
+                        public var request_headers: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/response_body`.
+                        public var response_body: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/response_headers`.
+                        public var response_headers: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/response_status`.
+                        public var response_status: Swift.Int
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/status`.
+                        @frozen public enum statusPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                            case delivered = "delivered"
+                            case failed = "failed"
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/status`.
+                        public var status: Operations.getWebhookDeliveryAttempt.Output.Ok.Body.jsonPayload.statusPayload
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/json/webhook_endpoint_id`.
+                        public var webhook_endpoint_id: Swift.String
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - attempt:
+                        ///   - duration_ms:
+                        ///   - error:
+                        ///   - event_id:
+                        ///   - event_type:
+                        ///   - id:
+                        ///   - inserted_at:
+                        ///   - request_body:
+                        ///   - request_headers:
+                        ///   - response_body:
+                        ///   - response_headers:
+                        ///   - response_status:
+                        ///   - status:
+                        ///   - webhook_endpoint_id:
+                        public init(
+                            attempt: Swift.Int,
+                            duration_ms: Swift.Int,
+                            error: Swift.String,
+                            event_id: Swift.String,
+                            event_type: Swift.String,
+                            id: Swift.String,
+                            inserted_at: Foundation.Date,
+                            request_body: Swift.String,
+                            request_headers: Swift.String,
+                            response_body: Swift.String,
+                            response_headers: Swift.String,
+                            response_status: Swift.Int,
+                            status: Operations.getWebhookDeliveryAttempt.Output.Ok.Body.jsonPayload.statusPayload,
+                            webhook_endpoint_id: Swift.String
+                        ) {
+                            self.attempt = attempt
+                            self.duration_ms = duration_ms
+                            self.error = error
+                            self.event_id = event_id
+                            self.event_type = event_type
+                            self.id = id
+                            self.inserted_at = inserted_at
+                            self.request_body = request_body
+                            self.request_headers = request_headers
+                            self.response_body = response_body
+                            self.response_headers = response_headers
+                            self.response_status = response_status
+                            self.status = status
+                            self.webhook_endpoint_id = webhook_endpoint_id
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case attempt
+                            case duration_ms
+                            case error
+                            case event_id
+                            case event_type
+                            case id
+                            case inserted_at
+                            case request_body
+                            case request_headers
+                            case response_body
+                            case response_headers
+                            case response_status
+                            case status
+                            case webhook_endpoint_id
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/200/content/application\/json`.
+                    case json(Operations.getWebhookDeliveryAttempt.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.getWebhookDeliveryAttempt.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookDeliveryAttempt.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookDeliveryAttempt.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook delivery attempt
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getWebhookDeliveryAttempt.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.getWebhookDeliveryAttempt.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookDeliveryAttempt.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookDeliveryAttempt.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.getWebhookDeliveryAttempt.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.getWebhookDeliveryAttempt.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookDeliveryAttempt.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookDeliveryAttempt.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook delivery attempt not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getWebhookDeliveryAttempt.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.getWebhookDeliveryAttempt.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}/get(getWebhookDeliveryAttempt)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.getWebhookDeliveryAttempt.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.getWebhookDeliveryAttempt.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):
@@ -20787,6 +23593,10 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -20795,24 +23605,20 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
+                ///   - git_branch: Filter bundles by git branch.
                 ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
-                ///   - git_branch: Filter bundles by git branch.
                 public init(
+                    git_branch: Swift.String? = nil,
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    page_size: Swift.Int? = nil
                 ) {
+                    self.git_branch = git_branch
                     self.page = page
                     self.page_size = page_size
-                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -28685,6 +31491,501 @@ public enum Operations {
             }
         }
     }
+    /// List runner workflows for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/workflows`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)`.
+    public enum listRunnerWorkflows {
+        public static let id: Swift.String = "listRunnerWorkflows"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                public init(account_handle: Swift.String) {
+                    self.account_handle = account_handle
+                }
+            }
+            public var path: Operations.listRunnerWorkflows.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query`.
+            public struct Query: Sendable, Hashable {
+                /// Page number (default: 1).
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/page`.
+                public var page: Swift.Int?
+                /// Results per page (default: 20, maximum: 100).
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/page_size`.
+                public var page_size: Swift.Int?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/repository`.
+                public var repository: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/workflow_name`.
+                public var workflow_name: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/head_branch`.
+                public var head_branch: Swift.String?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/platform`.
+                @frozen public enum platformPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case linux = "linux"
+                    case macos = "macos"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/platform`.
+                public var platform: Operations.listRunnerWorkflows.Input.Query.platformPayload?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/sort_by`.
+                @frozen public enum sort_byPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case workflow = "workflow"
+                    case success_rate = "success_rate"
+                    case jobs = "jobs"
+                    case avg_duration = "avg_duration"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/sort_by`.
+                public var sort_by: Operations.listRunnerWorkflows.Input.Query.sort_byPayload?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/sort_order`.
+                @frozen public enum sort_orderPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case asc = "asc"
+                    case desc = "desc"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/query/sort_order`.
+                public var sort_order: Operations.listRunnerWorkflows.Input.Query.sort_orderPayload?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - page: Page number (default: 1).
+                ///   - page_size: Results per page (default: 20, maximum: 100).
+                ///   - repository:
+                ///   - workflow_name:
+                ///   - head_branch:
+                ///   - platform:
+                ///   - sort_by:
+                ///   - sort_order:
+                public init(
+                    page: Swift.Int? = nil,
+                    page_size: Swift.Int? = nil,
+                    repository: Swift.String? = nil,
+                    workflow_name: Swift.String? = nil,
+                    head_branch: Swift.String? = nil,
+                    platform: Operations.listRunnerWorkflows.Input.Query.platformPayload? = nil,
+                    sort_by: Operations.listRunnerWorkflows.Input.Query.sort_byPayload? = nil,
+                    sort_order: Operations.listRunnerWorkflows.Input.Query.sort_orderPayload? = nil
+                ) {
+                    self.page = page
+                    self.page_size = page_size
+                    self.repository = repository
+                    self.workflow_name = workflow_name
+                    self.head_branch = head_branch
+                    self.platform = platform
+                    self.sort_by = sort_by
+                    self.sort_order = sort_order
+                }
+            }
+            public var query: Operations.listRunnerWorkflows.Input.Query
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerWorkflows.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerWorkflows.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerWorkflows.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerWorkflows.Input.Path,
+                query: Operations.listRunnerWorkflows.Input.Query = .init(),
+                headers: Operations.listRunnerWorkflows.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/pagination_metadata`.
+                        public var pagination_metadata: Components.Schemas.PaginationMetadata
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload`.
+                        public struct workflowsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/avg_duration_ms`.
+                            public var avg_duration_ms: Swift.Double?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/cancelled_count`.
+                            public var cancelled_count: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/failure_count`.
+                            public var failure_count: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/in_progress_count`.
+                            public var in_progress_count: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/last_run_at`.
+                            public var last_run_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/repository`.
+                            public var repository: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/skipped_count`.
+                            public var skipped_count: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/success_count`.
+                            public var success_count: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/total_jobs`.
+                            public var total_jobs: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflowsPayload/workflow_name`.
+                            public var workflow_name: Swift.String
+                            /// Creates a new `workflowsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - avg_duration_ms:
+                            ///   - cancelled_count:
+                            ///   - failure_count:
+                            ///   - in_progress_count:
+                            ///   - last_run_at:
+                            ///   - repository:
+                            ///   - skipped_count:
+                            ///   - success_count:
+                            ///   - total_jobs:
+                            ///   - workflow_name:
+                            public init(
+                                avg_duration_ms: Swift.Double? = nil,
+                                cancelled_count: Swift.Int,
+                                failure_count: Swift.Int,
+                                in_progress_count: Swift.Int,
+                                last_run_at: Foundation.Date,
+                                repository: Swift.String,
+                                skipped_count: Swift.Int,
+                                success_count: Swift.Int,
+                                total_jobs: Swift.Int,
+                                workflow_name: Swift.String
+                            ) {
+                                self.avg_duration_ms = avg_duration_ms
+                                self.cancelled_count = cancelled_count
+                                self.failure_count = failure_count
+                                self.in_progress_count = in_progress_count
+                                self.last_run_at = last_run_at
+                                self.repository = repository
+                                self.skipped_count = skipped_count
+                                self.success_count = success_count
+                                self.total_jobs = total_jobs
+                                self.workflow_name = workflow_name
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case avg_duration_ms
+                                case cancelled_count
+                                case failure_count
+                                case in_progress_count
+                                case last_run_at
+                                case repository
+                                case skipped_count
+                                case success_count
+                                case total_jobs
+                                case workflow_name
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflows`.
+                        public typealias workflowsPayload = [Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload.workflowsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/json/workflows`.
+                        public var workflows: Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload.workflowsPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - pagination_metadata:
+                        ///   - workflows:
+                        public init(
+                            pagination_metadata: Components.Schemas.PaginationMetadata,
+                            workflows: Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload.workflowsPayload
+                        ) {
+                            self.pagination_metadata = pagination_metadata
+                            self.workflows = workflows
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case pagination_metadata
+                            case workflows
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerWorkflows.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerWorkflows.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerWorkflows.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner workflows
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerWorkflows.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerWorkflows.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerWorkflows.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerWorkflows.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerWorkflows.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerWorkflows.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerWorkflows.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerWorkflows.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runners are not enabled
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerWorkflows.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerWorkflows.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerWorkflows.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/workflows/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerWorkflows.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerWorkflows.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerWorkflows.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/workflows/get(listRunnerWorkflows)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerWorkflows.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerWorkflows.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// It checks if an artifact exists in the cache.
     ///
     /// This endpoint checks if an artifact exists in the cache. It returns a 404 status code if the artifact does not exist.
@@ -31863,6 +35164,603 @@ public enum Operations {
             }
         }
     }
+    /// List runner jobs for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)`.
+    public enum listRunnerJobs {
+        public static let id: Swift.String = "listRunnerJobs"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                public init(account_handle: Swift.String) {
+                    self.account_handle = account_handle
+                }
+            }
+            public var path: Operations.listRunnerJobs.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query`.
+            public struct Query: Sendable, Hashable {
+                /// Page number (default: 1).
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/page`.
+                public var page: Swift.Int?
+                /// Results per page (default: 20, maximum: 100).
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/page_size`.
+                public var page_size: Swift.Int?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/status`.
+                @frozen public enum statusPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case queued = "queued"
+                    case claimed = "claimed"
+                    case running = "running"
+                    case completed = "completed"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/status`.
+                public var status: Operations.listRunnerJobs.Input.Query.statusPayload?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/conclusion`.
+                @frozen public enum conclusionPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case success = "success"
+                    case failure = "failure"
+                    case cancelled = "cancelled"
+                    case skipped = "skipped"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/conclusion`.
+                public var conclusion: Operations.listRunnerJobs.Input.Query.conclusionPayload?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/repository`.
+                public var repository: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/workflow_name`.
+                public var workflow_name: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/job_name`.
+                public var job_name: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/head_branch`.
+                public var head_branch: Swift.String?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/platform`.
+                @frozen public enum platformPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case linux = "linux"
+                    case macos = "macos"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/platform`.
+                public var platform: Operations.listRunnerJobs.Input.Query.platformPayload?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/search`.
+                public var search: Swift.String?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/sort_by`.
+                @frozen public enum sort_byPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case enqueued = "enqueued"
+                    case job = "job"
+                    case workflow = "workflow"
+                    case duration = "duration"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/sort_by`.
+                public var sort_by: Operations.listRunnerJobs.Input.Query.sort_byPayload?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/sort_order`.
+                @frozen public enum sort_orderPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case asc = "asc"
+                    case desc = "desc"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/query/sort_order`.
+                public var sort_order: Operations.listRunnerJobs.Input.Query.sort_orderPayload?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - page: Page number (default: 1).
+                ///   - page_size: Results per page (default: 20, maximum: 100).
+                ///   - status:
+                ///   - conclusion:
+                ///   - repository:
+                ///   - workflow_name:
+                ///   - job_name:
+                ///   - head_branch:
+                ///   - platform:
+                ///   - search:
+                ///   - sort_by:
+                ///   - sort_order:
+                public init(
+                    page: Swift.Int? = nil,
+                    page_size: Swift.Int? = nil,
+                    status: Operations.listRunnerJobs.Input.Query.statusPayload? = nil,
+                    conclusion: Operations.listRunnerJobs.Input.Query.conclusionPayload? = nil,
+                    repository: Swift.String? = nil,
+                    workflow_name: Swift.String? = nil,
+                    job_name: Swift.String? = nil,
+                    head_branch: Swift.String? = nil,
+                    platform: Operations.listRunnerJobs.Input.Query.platformPayload? = nil,
+                    search: Swift.String? = nil,
+                    sort_by: Operations.listRunnerJobs.Input.Query.sort_byPayload? = nil,
+                    sort_order: Operations.listRunnerJobs.Input.Query.sort_orderPayload? = nil
+                ) {
+                    self.page = page
+                    self.page_size = page_size
+                    self.status = status
+                    self.conclusion = conclusion
+                    self.repository = repository
+                    self.workflow_name = workflow_name
+                    self.job_name = job_name
+                    self.head_branch = head_branch
+                    self.platform = platform
+                    self.search = search
+                    self.sort_by = sort_by
+                    self.sort_order = sort_order
+                }
+            }
+            public var query: Operations.listRunnerJobs.Input.Query
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobs.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobs.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerJobs.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerJobs.Input.Path,
+                query: Operations.listRunnerJobs.Input.Query = .init(),
+                headers: Operations.listRunnerJobs.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload`.
+                        public struct jobsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/claimed_at`.
+                            public var claimed_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/completed_at`.
+                            public var completed_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/conclusion`.
+                            public var conclusion: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/enqueued_at`.
+                            public var enqueued_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/head_branch`.
+                            public var head_branch: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/head_sha`.
+                            public var head_sha: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/job_name`.
+                            public var job_name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/log_archived_at`.
+                            public var log_archived_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/memory_gb`.
+                            public var memory_gb: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/platform`.
+                            public var platform: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/repository`.
+                            public var repository: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/requested_dispatch_label`.
+                            public var requested_dispatch_label: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/run_attempt`.
+                            public var run_attempt: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/started_at`.
+                            public var started_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/status`.
+                            public var status: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/updated_at`.
+                            public var updated_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/vcpus`.
+                            public var vcpus: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/workflow_job_id`.
+                            public var workflow_job_id: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/workflow_name`.
+                            public var workflow_name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobsPayload/workflow_run_id`.
+                            public var workflow_run_id: Swift.Int
+                            /// Creates a new `jobsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - claimed_at:
+                            ///   - completed_at:
+                            ///   - conclusion:
+                            ///   - enqueued_at:
+                            ///   - head_branch:
+                            ///   - head_sha:
+                            ///   - job_name:
+                            ///   - log_archived_at:
+                            ///   - memory_gb:
+                            ///   - platform:
+                            ///   - repository:
+                            ///   - requested_dispatch_label:
+                            ///   - run_attempt:
+                            ///   - started_at:
+                            ///   - status:
+                            ///   - updated_at:
+                            ///   - vcpus:
+                            ///   - workflow_job_id:
+                            ///   - workflow_name:
+                            ///   - workflow_run_id:
+                            public init(
+                                claimed_at: Foundation.Date? = nil,
+                                completed_at: Foundation.Date? = nil,
+                                conclusion: Swift.String,
+                                enqueued_at: Foundation.Date,
+                                head_branch: Swift.String,
+                                head_sha: Swift.String,
+                                job_name: Swift.String,
+                                log_archived_at: Foundation.Date? = nil,
+                                memory_gb: Swift.Int,
+                                platform: Swift.String,
+                                repository: Swift.String,
+                                requested_dispatch_label: Swift.String,
+                                run_attempt: Swift.Int,
+                                started_at: Foundation.Date? = nil,
+                                status: Swift.String,
+                                updated_at: Foundation.Date,
+                                vcpus: Swift.Int,
+                                workflow_job_id: Swift.Int,
+                                workflow_name: Swift.String,
+                                workflow_run_id: Swift.Int
+                            ) {
+                                self.claimed_at = claimed_at
+                                self.completed_at = completed_at
+                                self.conclusion = conclusion
+                                self.enqueued_at = enqueued_at
+                                self.head_branch = head_branch
+                                self.head_sha = head_sha
+                                self.job_name = job_name
+                                self.log_archived_at = log_archived_at
+                                self.memory_gb = memory_gb
+                                self.platform = platform
+                                self.repository = repository
+                                self.requested_dispatch_label = requested_dispatch_label
+                                self.run_attempt = run_attempt
+                                self.started_at = started_at
+                                self.status = status
+                                self.updated_at = updated_at
+                                self.vcpus = vcpus
+                                self.workflow_job_id = workflow_job_id
+                                self.workflow_name = workflow_name
+                                self.workflow_run_id = workflow_run_id
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case claimed_at
+                                case completed_at
+                                case conclusion
+                                case enqueued_at
+                                case head_branch
+                                case head_sha
+                                case job_name
+                                case log_archived_at
+                                case memory_gb
+                                case platform
+                                case repository
+                                case requested_dispatch_label
+                                case run_attempt
+                                case started_at
+                                case status
+                                case updated_at
+                                case vcpus
+                                case workflow_job_id
+                                case workflow_name
+                                case workflow_run_id
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobs`.
+                        public typealias jobsPayload = [Operations.listRunnerJobs.Output.Ok.Body.jsonPayload.jobsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/jobs`.
+                        public var jobs: Operations.listRunnerJobs.Output.Ok.Body.jsonPayload.jobsPayload
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/json/pagination_metadata`.
+                        public var pagination_metadata: Components.Schemas.PaginationMetadata
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - jobs:
+                        ///   - pagination_metadata:
+                        public init(
+                            jobs: Operations.listRunnerJobs.Output.Ok.Body.jsonPayload.jobsPayload,
+                            pagination_metadata: Components.Schemas.PaginationMetadata
+                        ) {
+                            self.jobs = jobs
+                            self.pagination_metadata = pagination_metadata
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case jobs
+                            case pagination_metadata
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerJobs.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerJobs.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobs.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobs.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner jobs
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerJobs.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerJobs.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobs.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobs.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerJobs.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerJobs.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobs.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobs.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runners are not enabled
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerJobs.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerJobs.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerJobs.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobs.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerJobs.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerJobs.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/get(listRunnerJobs)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerJobs.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerJobs.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// List cache runs associated with a given project.
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache-runs`.
@@ -32455,6 +36353,392 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.listCacheRuns.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List the steps for a runner job.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)`.
+    public enum listRunnerJobSteps {
+        public static let id: Swift.String = "listRunnerJobSteps"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The workflow job identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/path/workflow_job_id`.
+                public var workflow_job_id: Swift.Int
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - workflow_job_id: The workflow job identifier.
+                public init(
+                    account_handle: Swift.String,
+                    workflow_job_id: Swift.Int
+                ) {
+                    self.account_handle = account_handle
+                    self.workflow_job_id = workflow_job_id
+                }
+            }
+            public var path: Operations.listRunnerJobSteps.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobSteps.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobSteps.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerJobSteps.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerJobSteps.Input.Path,
+                headers: Operations.listRunnerJobSteps.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload`.
+                        public struct stepsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/completed_at`.
+                            public var completed_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/conclusion`.
+                            public var conclusion: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/name`.
+                            public var name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/number`.
+                            public var number: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/started_at`.
+                            public var started_at: Foundation.Date?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/stepsPayload/status`.
+                            public var status: Swift.String
+                            /// Creates a new `stepsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - completed_at:
+                            ///   - conclusion:
+                            ///   - name:
+                            ///   - number:
+                            ///   - started_at:
+                            ///   - status:
+                            public init(
+                                completed_at: Foundation.Date? = nil,
+                                conclusion: Swift.String,
+                                name: Swift.String,
+                                number: Swift.Int,
+                                started_at: Foundation.Date? = nil,
+                                status: Swift.String
+                            ) {
+                                self.completed_at = completed_at
+                                self.conclusion = conclusion
+                                self.name = name
+                                self.number = number
+                                self.started_at = started_at
+                                self.status = status
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case completed_at
+                                case conclusion
+                                case name
+                                case number
+                                case started_at
+                                case status
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/steps`.
+                        public typealias stepsPayload = [Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload.stepsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/json/steps`.
+                        public var steps: Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload.stepsPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - steps:
+                        public init(steps: Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload.stepsPayload) {
+                            self.steps = steps
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case steps
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerJobSteps.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobSteps.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobSteps.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job steps
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerJobSteps.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerJobSteps.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobSteps.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobSteps.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerJobSteps.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerJobSteps.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobSteps.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobSteps.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerJobSteps.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerJobSteps.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerJobSteps.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobSteps.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerJobSteps.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerJobSteps.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps/get(listRunnerJobSteps)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerJobSteps.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerJobSteps.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):
@@ -35016,7 +39300,7 @@ public enum Operations {
                             ///
                             /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/GET/responses/200/content/json/tokensPayload/name`.
                             public var name: Swift.String?
-                            /// List of project handles the token can access (when all_projects is false).
+                            /// List of project handles the token can access when all_projects is false.
                             ///
                             /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/GET/responses/200/content/json/tokensPayload/project_handles`.
                             public var project_handles: [Swift.String]?
@@ -35031,6 +39315,7 @@ public enum Operations {
                                 case account_colon_members_colon_write = "account:members:write"
                                 case account_colon_registry_colon_read = "account:registry:read"
                                 case account_colon_registry_colon_write = "account:registry:write"
+                                case account_colon_runners_colon_read = "account:runners:read"
                                 case project_colon_previews_colon_read = "project:previews:read"
                                 case project_colon_previews_colon_write = "project:previews:write"
                                 case project_colon_admin_colon_read = "project:admin:read"
@@ -35062,7 +39347,7 @@ public enum Operations {
                             ///   - id: Token unique identifier.
                             ///   - inserted_at: When the token was created.
                             ///   - name: Friendly name for the token.
-                            ///   - project_handles: List of project handles the token can access (when all_projects is false).
+                            ///   - project_handles: List of project handles the token can access when all_projects is false.
                             ///   - scopes: Token scopes.
                             public init(
                                 all_projects: Swift.Bool,
@@ -35411,6 +39696,7 @@ public enum Operations {
                         case account_colon_members_colon_write = "account:members:write"
                         case account_colon_registry_colon_read = "account:registry:read"
                         case account_colon_registry_colon_write = "account:registry:write"
+                        case account_colon_runners_colon_read = "account:runners:read"
                         case project_colon_previews_colon_read = "project:previews:read"
                         case project_colon_previews_colon_write = "project:previews:write"
                         case project_colon_admin_colon_read = "project:admin:read"
@@ -43682,6 +47968,578 @@ public enum Operations {
             }
         }
     }
+    /// List delivery attempts for a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)`.
+    public enum listWebhookDeliveryAttempts {
+        public static let id: Swift.String = "listWebhookDeliveryAttempts"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The webhook endpoint identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/path/webhook_endpoint_id`.
+                public var webhook_endpoint_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - webhook_endpoint_id: The webhook endpoint identifier.
+                public init(
+                    account_handle: Swift.String,
+                    webhook_endpoint_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.webhook_endpoint_id = webhook_endpoint_id
+                }
+            }
+            public var path: Operations.listWebhookDeliveryAttempts.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query`.
+            public struct Query: Sendable, Hashable {
+                /// Results per page (default: 20, maximum: 100).
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/page_size`.
+                public var page_size: Swift.Int?
+                /// Cursor for the next page.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/after`.
+                public var after: Swift.String?
+                /// Cursor for the previous page.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/before`.
+                public var before: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/start_datetime`.
+                public var start_datetime: Foundation.Date?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/end_datetime`.
+                public var end_datetime: Foundation.Date?
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/status`.
+                @frozen public enum statusPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case delivered = "delivered"
+                    case failed = "failed"
+                }
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/status`.
+                public var status: Operations.listWebhookDeliveryAttempts.Input.Query.statusPayload?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/event_type`.
+                public var event_type: Swift.String?
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/query/event_id_search`.
+                public var event_id_search: Swift.String?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - page_size: Results per page (default: 20, maximum: 100).
+                ///   - after: Cursor for the next page.
+                ///   - before: Cursor for the previous page.
+                ///   - start_datetime:
+                ///   - end_datetime:
+                ///   - status:
+                ///   - event_type:
+                ///   - event_id_search:
+                public init(
+                    page_size: Swift.Int? = nil,
+                    after: Swift.String? = nil,
+                    before: Swift.String? = nil,
+                    start_datetime: Foundation.Date? = nil,
+                    end_datetime: Foundation.Date? = nil,
+                    status: Operations.listWebhookDeliveryAttempts.Input.Query.statusPayload? = nil,
+                    event_type: Swift.String? = nil,
+                    event_id_search: Swift.String? = nil
+                ) {
+                    self.page_size = page_size
+                    self.after = after
+                    self.before = before
+                    self.start_datetime = start_datetime
+                    self.end_datetime = end_datetime
+                    self.status = status
+                    self.event_type = event_type
+                    self.event_id_search = event_id_search
+                }
+            }
+            public var query: Operations.listWebhookDeliveryAttempts.Input.Query
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listWebhookDeliveryAttempts.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listWebhookDeliveryAttempts.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listWebhookDeliveryAttempts.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            public init(
+                path: Operations.listWebhookDeliveryAttempts.Input.Path,
+                query: Operations.listWebhookDeliveryAttempts.Input.Query = .init(),
+                headers: Operations.listWebhookDeliveryAttempts.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload`.
+                        public struct delivery_attemptsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/attempt`.
+                            public var attempt: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/duration_ms`.
+                            public var duration_ms: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/error`.
+                            public var error: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/event_id`.
+                            public var event_id: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/event_type`.
+                            public var event_type: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/id`.
+                            public var id: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/inserted_at`.
+                            public var inserted_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/request_body`.
+                            public var request_body: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/request_headers`.
+                            public var request_headers: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/response_body`.
+                            public var response_body: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/response_headers`.
+                            public var response_headers: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/response_status`.
+                            public var response_status: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/status`.
+                            @frozen public enum statusPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                                case delivered = "delivered"
+                                case failed = "failed"
+                            }
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/status`.
+                            public var status: Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.delivery_attemptsPayloadPayload.statusPayload
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attemptsPayload/webhook_endpoint_id`.
+                            public var webhook_endpoint_id: Swift.String
+                            /// Creates a new `delivery_attemptsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - attempt:
+                            ///   - duration_ms:
+                            ///   - error:
+                            ///   - event_id:
+                            ///   - event_type:
+                            ///   - id:
+                            ///   - inserted_at:
+                            ///   - request_body:
+                            ///   - request_headers:
+                            ///   - response_body:
+                            ///   - response_headers:
+                            ///   - response_status:
+                            ///   - status:
+                            ///   - webhook_endpoint_id:
+                            public init(
+                                attempt: Swift.Int,
+                                duration_ms: Swift.Int,
+                                error: Swift.String,
+                                event_id: Swift.String,
+                                event_type: Swift.String,
+                                id: Swift.String,
+                                inserted_at: Foundation.Date,
+                                request_body: Swift.String,
+                                request_headers: Swift.String,
+                                response_body: Swift.String,
+                                response_headers: Swift.String,
+                                response_status: Swift.Int,
+                                status: Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.delivery_attemptsPayloadPayload.statusPayload,
+                                webhook_endpoint_id: Swift.String
+                            ) {
+                                self.attempt = attempt
+                                self.duration_ms = duration_ms
+                                self.error = error
+                                self.event_id = event_id
+                                self.event_type = event_type
+                                self.id = id
+                                self.inserted_at = inserted_at
+                                self.request_body = request_body
+                                self.request_headers = request_headers
+                                self.response_body = response_body
+                                self.response_headers = response_headers
+                                self.response_status = response_status
+                                self.status = status
+                                self.webhook_endpoint_id = webhook_endpoint_id
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case attempt
+                                case duration_ms
+                                case error
+                                case event_id
+                                case event_type
+                                case id
+                                case inserted_at
+                                case request_body
+                                case request_headers
+                                case response_body
+                                case response_headers
+                                case response_status
+                                case status
+                                case webhook_endpoint_id
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attempts`.
+                        public typealias delivery_attemptsPayload = [Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.delivery_attemptsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/delivery_attempts`.
+                        public var delivery_attempts: Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.delivery_attemptsPayload
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/json/pagination_metadata`.
+                        public var pagination_metadata: Components.Schemas.PaginationMetadata
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - delivery_attempts:
+                        ///   - pagination_metadata:
+                        public init(
+                            delivery_attempts: Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload.delivery_attemptsPayload,
+                            pagination_metadata: Components.Schemas.PaginationMetadata
+                        ) {
+                            self.delivery_attempts = delivery_attempts
+                            self.pagination_metadata = pagination_metadata
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case delivery_attempts
+                            case pagination_metadata
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/200/content/application\/json`.
+                    case json(Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listWebhookDeliveryAttempts.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookDeliveryAttempts.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookDeliveryAttempts.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook delivery attempts
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listWebhookDeliveryAttempts.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listWebhookDeliveryAttempts.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/400/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/400/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookDeliveryAttempts.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookDeliveryAttempts.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// Invalid cursor parameters
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.listWebhookDeliveryAttempts.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.listWebhookDeliveryAttempts.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookDeliveryAttempts.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookDeliveryAttempts.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listWebhookDeliveryAttempts.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listWebhookDeliveryAttempts.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookDeliveryAttempts.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookDeliveryAttempts.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook endpoint not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listWebhookDeliveryAttempts.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listWebhookDeliveryAttempts.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/get(listWebhookDeliveryAttempts)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listWebhookDeliveryAttempts.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listWebhookDeliveryAttempts.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// Shows the usage of an organization
     ///
     /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
@@ -45565,10 +50423,6 @@ public enum Operations {
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/GET/path`.
             public struct Path: Sendable, Hashable {
-                /// The ID of the bundle.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/GET/path/bundle_id`.
-                public var bundle_id: Swift.String
                 /// The handle of the account.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/GET/path/account_handle`.
@@ -45577,20 +50431,24 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/GET/path/project_handle`.
                 public var project_handle: Swift.String
+                /// The ID of the bundle.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/{bundle_id}/GET/path/bundle_id`.
+                public var bundle_id: Swift.String
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
-                ///   - bundle_id: The ID of the bundle.
                 ///   - account_handle: The handle of the account.
                 ///   - project_handle: The handle of the project.
+                ///   - bundle_id: The ID of the bundle.
                 public init(
-                    bundle_id: Swift.String,
                     account_handle: Swift.String,
-                    project_handle: Swift.String
+                    project_handle: Swift.String,
+                    bundle_id: Swift.String
                 ) {
-                    self.bundle_id = bundle_id
                     self.account_handle = account_handle
                     self.project_handle = project_handle
+                    self.bundle_id = bundle_id
                 }
             }
             public var path: Operations.getBundle.Input.Path
@@ -45944,6 +50802,403 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.getBundle.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List captured log lines for a runner job.
+    ///
+    /// Returns log lines in display order. Page size defaults to 200 and is capped at 500.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)`.
+    public enum listRunnerJobLogs {
+        public static let id: Swift.String = "listRunnerJobLogs"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The workflow job identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/path/workflow_job_id`.
+                public var workflow_job_id: Swift.Int
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - workflow_job_id: The workflow job identifier.
+                public init(
+                    account_handle: Swift.String,
+                    workflow_job_id: Swift.Int
+                ) {
+                    self.account_handle = account_handle
+                    self.workflow_job_id = workflow_job_id
+                }
+            }
+            public var path: Operations.listRunnerJobLogs.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/query`.
+            public struct Query: Sendable, Hashable {
+                /// Zero-based log-line offset.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/query/offset`.
+                public var offset: Swift.Int?
+                /// Maximum number of lines, up to 500.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/query/limit`.
+                public var limit: Swift.Int?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - offset: Zero-based log-line offset.
+                ///   - limit: Maximum number of lines, up to 500.
+                public init(
+                    offset: Swift.Int? = nil,
+                    limit: Swift.Int? = nil
+                ) {
+                    self.offset = offset
+                    self.limit = limit
+                }
+            }
+            public var query: Operations.listRunnerJobLogs.Input.Query
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobLogs.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listRunnerJobLogs.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listRunnerJobLogs.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            public init(
+                path: Operations.listRunnerJobLogs.Input.Path,
+                query: Operations.listRunnerJobLogs.Input.Query = .init(),
+                headers: Operations.listRunnerJobLogs.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/linesPayload`.
+                        public struct linesPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/linesPayload/line_number`.
+                            public var line_number: Swift.Int
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/linesPayload/message`.
+                            public var message: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/linesPayload/ts`.
+                            public var ts: Foundation.Date?
+                            /// Creates a new `linesPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - line_number:
+                            ///   - message:
+                            ///   - ts:
+                            public init(
+                                line_number: Swift.Int,
+                                message: Swift.String,
+                                ts: Foundation.Date? = nil
+                            ) {
+                                self.line_number = line_number
+                                self.message = message
+                                self.ts = ts
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case line_number
+                                case message
+                                case ts
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/lines`.
+                        public typealias linesPayload = [Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload.linesPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/json/lines`.
+                        public var lines: Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload.linesPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - lines:
+                        public init(lines: Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload.linesPayload) {
+                            self.lines = lines
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case lines
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/200/content/application\/json`.
+                    case json(Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listRunnerJobLogs.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobLogs.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobLogs.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job log lines
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listRunnerJobLogs.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listRunnerJobLogs.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobLogs.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobLogs.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listRunnerJobLogs.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listRunnerJobLogs.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobLogs.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listRunnerJobLogs.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Runner job was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listRunnerJobLogs.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listRunnerJobLogs.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listRunnerJobLogs.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listRunnerJobLogs.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listRunnerJobLogs.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listRunnerJobLogs.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs/get(listRunnerJobLogs)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listRunnerJobLogs.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listRunnerJobLogs.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):
@@ -47138,6 +52393,727 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.listTestCaseEvents.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List webhook endpoints for an account.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)`.
+    public enum listWebhookEndpoints {
+        public static let id: Swift.String = "listWebhookEndpoints"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                public init(account_handle: Swift.String) {
+                    self.account_handle = account_handle
+                }
+            }
+            public var path: Operations.listWebhookEndpoints.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listWebhookEndpoints.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listWebhookEndpoints.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listWebhookEndpoints.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.listWebhookEndpoints.Input.Path,
+                headers: Operations.listWebhookEndpoints.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload`.
+                        public struct endpointsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/event_types`.
+                            public var event_types: [Swift.String]
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/id`.
+                            public var id: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/inserted_at`.
+                            public var inserted_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/name`.
+                            public var name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/signing_secret_last_four`.
+                            public var signing_secret_last_four: Swift.String?
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/updated_at`.
+                            public var updated_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpointsPayload/url`.
+                            public var url: Swift.String
+                            /// Creates a new `endpointsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - event_types:
+                            ///   - id:
+                            ///   - inserted_at:
+                            ///   - name:
+                            ///   - signing_secret_last_four:
+                            ///   - updated_at:
+                            ///   - url:
+                            public init(
+                                event_types: [Swift.String],
+                                id: Swift.String,
+                                inserted_at: Foundation.Date,
+                                name: Swift.String,
+                                signing_secret_last_four: Swift.String? = nil,
+                                updated_at: Foundation.Date,
+                                url: Swift.String
+                            ) {
+                                self.event_types = event_types
+                                self.id = id
+                                self.inserted_at = inserted_at
+                                self.name = name
+                                self.signing_secret_last_four = signing_secret_last_four
+                                self.updated_at = updated_at
+                                self.url = url
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case event_types
+                                case id
+                                case inserted_at
+                                case name
+                                case signing_secret_last_four
+                                case updated_at
+                                case url
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpoints`.
+                        public typealias endpointsPayload = [Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload.endpointsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/json/endpoints`.
+                        public var endpoints: Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload.endpointsPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - endpoints:
+                        public init(endpoints: Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload.endpointsPayload) {
+                            self.endpoints = endpoints
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case endpoints
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/200/content/application\/json`.
+                    case json(Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listWebhookEndpoints.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookEndpoints.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookEndpoints.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook endpoints
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listWebhookEndpoints.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listWebhookEndpoints.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookEndpoints.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listWebhookEndpoints.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listWebhookEndpoints.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listWebhookEndpoints.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listWebhookEndpoints.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listWebhookEndpoints.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listWebhookEndpoints.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listWebhookEndpoints.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/get(listWebhookEndpoints)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listWebhookEndpoints.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listWebhookEndpoints.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List a project's notification alert rules.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/notification-alerts`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)`.
+    public enum listProjectNotificationAlerts {
+        public static let id: Swift.String = "listProjectNotificationAlerts"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/path/project_handle`.
+                public var project_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                }
+            }
+            public var path: Operations.listProjectNotificationAlerts.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listProjectNotificationAlerts.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listProjectNotificationAlerts.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listProjectNotificationAlerts.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.listProjectNotificationAlerts.Input.Path,
+                headers: Operations.listProjectNotificationAlerts.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload`.
+                        public struct alert_rulesPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/bundle_name`.
+                            public var bundle_name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/category`.
+                            public var category: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/deviation_percentage`.
+                            public var deviation_percentage: Swift.Double
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/environment`.
+                            public var environment: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/git_branch`.
+                            public var git_branch: Swift.String?
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/id`.
+                            public var id: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/inserted_at`.
+                            public var inserted_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/metric`.
+                            public var metric: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/name`.
+                            public var name: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/rolling_window_size`.
+                            public var rolling_window_size: Swift.Int?
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/scheme`.
+                            public var scheme: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/slack_channel_id`.
+                            public var slack_channel_id: Swift.String?
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/slack_channel_name`.
+                            public var slack_channel_name: Swift.String?
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/updated_at`.
+                            public var updated_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rulesPayload/webhook_configured`.
+                            public var webhook_configured: Swift.Bool
+                            /// Creates a new `alert_rulesPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - bundle_name:
+                            ///   - category:
+                            ///   - deviation_percentage:
+                            ///   - environment:
+                            ///   - git_branch:
+                            ///   - id:
+                            ///   - inserted_at:
+                            ///   - metric:
+                            ///   - name:
+                            ///   - rolling_window_size:
+                            ///   - scheme:
+                            ///   - slack_channel_id:
+                            ///   - slack_channel_name:
+                            ///   - updated_at:
+                            ///   - webhook_configured:
+                            public init(
+                                bundle_name: Swift.String,
+                                category: Swift.String,
+                                deviation_percentage: Swift.Double,
+                                environment: Swift.String,
+                                git_branch: Swift.String? = nil,
+                                id: Swift.String,
+                                inserted_at: Foundation.Date,
+                                metric: Swift.String,
+                                name: Swift.String,
+                                rolling_window_size: Swift.Int? = nil,
+                                scheme: Swift.String,
+                                slack_channel_id: Swift.String? = nil,
+                                slack_channel_name: Swift.String? = nil,
+                                updated_at: Foundation.Date,
+                                webhook_configured: Swift.Bool
+                            ) {
+                                self.bundle_name = bundle_name
+                                self.category = category
+                                self.deviation_percentage = deviation_percentage
+                                self.environment = environment
+                                self.git_branch = git_branch
+                                self.id = id
+                                self.inserted_at = inserted_at
+                                self.metric = metric
+                                self.name = name
+                                self.rolling_window_size = rolling_window_size
+                                self.scheme = scheme
+                                self.slack_channel_id = slack_channel_id
+                                self.slack_channel_name = slack_channel_name
+                                self.updated_at = updated_at
+                                self.webhook_configured = webhook_configured
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case bundle_name
+                                case category
+                                case deviation_percentage
+                                case environment
+                                case git_branch
+                                case id
+                                case inserted_at
+                                case metric
+                                case name
+                                case rolling_window_size
+                                case scheme
+                                case slack_channel_id
+                                case slack_channel_name
+                                case updated_at
+                                case webhook_configured
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rules`.
+                        public typealias alert_rulesPayload = [Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload.alert_rulesPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/json/alert_rules`.
+                        public var alert_rules: Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload.alert_rulesPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - alert_rules:
+                        public init(alert_rules: Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload.alert_rulesPayload) {
+                            self.alert_rules = alert_rules
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case alert_rules
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/200/content/application\/json`.
+                    case json(Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listProjectNotificationAlerts.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listProjectNotificationAlerts.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listProjectNotificationAlerts.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Project notification alert rules
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listProjectNotificationAlerts.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listProjectNotificationAlerts.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listProjectNotificationAlerts.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listProjectNotificationAlerts.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listProjectNotificationAlerts.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listProjectNotificationAlerts.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/notification-alerts/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listProjectNotificationAlerts.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/notification-alerts/get(listProjectNotificationAlerts)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listProjectNotificationAlerts.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listProjectNotificationAlerts.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):
@@ -55647,6 +61623,396 @@ public enum Operations {
             }
         }
     }
+    /// Get an account token.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/tokens/{token_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)`.
+    public enum getAccountToken {
+        public static let id: Swift.String = "getAccountToken"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The token identifier.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/path/token_id`.
+                public var token_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - token_id: The token identifier.
+                public init(
+                    account_handle: Swift.String,
+                    token_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.token_id = token_id
+                }
+            }
+            public var path: Operations.getAccountToken.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getAccountToken.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getAccountToken.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.getAccountToken.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.getAccountToken.Input.Path,
+                headers: Operations.getAccountToken.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// Whether token has access to all projects.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/all_projects`.
+                        public var all_projects: Swift.Bool
+                        /// When the token expires.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/expires_at`.
+                        public var expires_at: Foundation.Date?
+                        /// Token unique identifier.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/id`.
+                        public var id: Swift.String
+                        /// When the token was created.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/inserted_at`.
+                        public var inserted_at: Foundation.Date
+                        /// Friendly name for the token.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/name`.
+                        public var name: Swift.String?
+                        /// List of project handles the token can access when all_projects is false.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/project_handles`.
+                        public var project_handles: [Swift.String]?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/scopesPayload`.
+                        @frozen public enum scopesPayloadPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                            case ci = "ci"
+                            case mcp = "mcp"
+                            case account_colon_scim_colon_write = "account:scim:write"
+                            case account_colon_cache_colon_read = "account:cache:read"
+                            case account_colon_cache_colon_write = "account:cache:write"
+                            case account_colon_members_colon_read = "account:members:read"
+                            case account_colon_members_colon_write = "account:members:write"
+                            case account_colon_registry_colon_read = "account:registry:read"
+                            case account_colon_registry_colon_write = "account:registry:write"
+                            case account_colon_runners_colon_read = "account:runners:read"
+                            case project_colon_previews_colon_read = "project:previews:read"
+                            case project_colon_previews_colon_write = "project:previews:write"
+                            case project_colon_admin_colon_read = "project:admin:read"
+                            case project_colon_admin_colon_write = "project:admin:write"
+                            case project_colon_cache_colon_read = "project:cache:read"
+                            case project_colon_cache_colon_write = "project:cache:write"
+                            case project_colon_bundles_colon_read = "project:bundles:read"
+                            case project_colon_bundles_colon_write = "project:bundles:write"
+                            case project_colon_tests_colon_read = "project:tests:read"
+                            case project_colon_tests_colon_write = "project:tests:write"
+                            case project_colon_builds_colon_read = "project:builds:read"
+                            case project_colon_builds_colon_write = "project:builds:write"
+                            case project_colon_runs_colon_read = "project:runs:read"
+                            case project_colon_runs_colon_write = "project:runs:write"
+                        }
+                        /// Token scopes.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/scopes`.
+                        public typealias scopesPayload = [Operations.getAccountToken.Output.Ok.Body.jsonPayload.scopesPayloadPayload]
+                        /// Token scopes.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/json/scopes`.
+                        public var scopes: Operations.getAccountToken.Output.Ok.Body.jsonPayload.scopesPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - all_projects: Whether token has access to all projects.
+                        ///   - expires_at: When the token expires.
+                        ///   - id: Token unique identifier.
+                        ///   - inserted_at: When the token was created.
+                        ///   - name: Friendly name for the token.
+                        ///   - project_handles: List of project handles the token can access when all_projects is false.
+                        ///   - scopes: Token scopes.
+                        public init(
+                            all_projects: Swift.Bool,
+                            expires_at: Foundation.Date? = nil,
+                            id: Swift.String,
+                            inserted_at: Foundation.Date,
+                            name: Swift.String? = nil,
+                            project_handles: [Swift.String]? = nil,
+                            scopes: Operations.getAccountToken.Output.Ok.Body.jsonPayload.scopesPayload
+                        ) {
+                            self.all_projects = all_projects
+                            self.expires_at = expires_at
+                            self.id = id
+                            self.inserted_at = inserted_at
+                            self.name = name
+                            self.project_handles = project_handles
+                            self.scopes = scopes
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case all_projects
+                            case expires_at
+                            case id
+                            case inserted_at
+                            case name
+                            case project_handles
+                            case scopes
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/200/content/application\/json`.
+                    case json(Operations.getAccountToken.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.getAccountToken.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getAccountToken.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getAccountToken.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// An account token.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getAccountToken.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.getAccountToken.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/401/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getAccountToken.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getAccountToken.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to get the token
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.getAccountToken.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.getAccountToken.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getAccountToken.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getAccountToken.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authorized to get the token
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.getAccountToken.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.getAccountToken.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/tokens/{token_id}/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getAccountToken.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getAccountToken.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// The account token was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/tokens/{token_id}/get(getAccountToken)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getAccountToken.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.getAccountToken.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// Lists the organizations
     ///
     /// Returns all the organizations the authenticated subject is part of.
@@ -59438,6 +65804,381 @@ public enum Operations {
             }
         }
     }
+    /// Get a webhook endpoint.
+    ///
+    /// - Remark: HTTP `GET /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}`.
+    /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)`.
+    public enum getWebhookEndpoint {
+        public static let id: Swift.String = "getWebhookEndpoint"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The account handle.
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/path/webhook_endpoint_id`.
+                public var webhook_endpoint_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The account handle.
+                ///   - webhook_endpoint_id:
+                public init(
+                    account_handle: Swift.String,
+                    webhook_endpoint_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.webhook_endpoint_id = webhook_endpoint_id
+                }
+            }
+            public var path: Operations.getWebhookEndpoint.Input.Path
+            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getWebhookEndpoint.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getWebhookEndpoint.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.getWebhookEndpoint.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            public init(
+                path: Operations.getWebhookEndpoint.Input.Path,
+                headers: Operations.getWebhookEndpoint.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/event_types`.
+                        public var event_types: [Swift.String]
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/id`.
+                        public var id: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/inserted_at`.
+                        public var inserted_at: Foundation.Date
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/name`.
+                        public var name: Swift.String
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/signing_secret_last_four`.
+                        public var signing_secret_last_four: Swift.String?
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/updated_at`.
+                        public var updated_at: Foundation.Date
+                        /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/json/url`.
+                        public var url: Swift.String
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - event_types:
+                        ///   - id:
+                        ///   - inserted_at:
+                        ///   - name:
+                        ///   - signing_secret_last_four:
+                        ///   - updated_at:
+                        ///   - url:
+                        public init(
+                            event_types: [Swift.String],
+                            id: Swift.String,
+                            inserted_at: Foundation.Date,
+                            name: Swift.String,
+                            signing_secret_last_four: Swift.String? = nil,
+                            updated_at: Foundation.Date,
+                            url: Swift.String
+                        ) {
+                            self.event_types = event_types
+                            self.id = id
+                            self.inserted_at = inserted_at
+                            self.name = name
+                            self.signing_secret_last_four = signing_secret_last_four
+                            self.updated_at = updated_at
+                            self.url = url
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case event_types
+                            case id
+                            case inserted_at
+                            case name
+                            case signing_secret_last_four
+                            case updated_at
+                            case url
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/200/content/application\/json`.
+                    case json(Operations.getWebhookEndpoint.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.getWebhookEndpoint.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookEndpoint.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookEndpoint.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook endpoint
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getWebhookEndpoint.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.getWebhookEndpoint.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookEndpoint.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookEndpoint.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.getWebhookEndpoint.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.getWebhookEndpoint.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookEndpoint.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.getWebhookEndpoint.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Webhook endpoint not found
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getWebhookEndpoint.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.getWebhookEndpoint.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getWebhookEndpoint.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.getWebhookEndpoint.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getWebhookEndpoint.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.getWebhookEndpoint.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/get(getWebhookEndpoint)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.getWebhookEndpoint.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.getWebhookEndpoint.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// Complete a multipart upload for a build archive.
     ///
     /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload of the build archive and enqueues it for server-side processing.
@@ -60273,6 +67014,474 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.listTestModuleRuns.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// List an automation alert's revision history.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)`.
+    public enum listAutomationAlertRevisions {
+        public static let id: Swift.String = "listAutomationAlertRevisions"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/path/project_handle`.
+                public var project_handle: Swift.String
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/path/alert_id`.
+                public var alert_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - alert_id:
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    alert_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.alert_id = alert_id
+                }
+            }
+            public var path: Operations.listAutomationAlertRevisions.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/query`.
+            public struct Query: Sendable, Hashable {
+                ///
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/query/before`.
+                public var before: Swift.String?
+                /// Results per page, up to 100.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/query/page_size`.
+                public var page_size: Swift.Int?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - before:
+                ///   - page_size: Results per page, up to 100.
+                public init(
+                    before: Swift.String? = nil,
+                    page_size: Swift.Int? = nil
+                ) {
+                    self.before = before
+                    self.page_size = page_size
+                }
+            }
+            public var query: Operations.listAutomationAlertRevisions.Input.Query
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listAutomationAlertRevisions.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.listAutomationAlertRevisions.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.listAutomationAlertRevisions.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            public init(
+                path: Operations.listAutomationAlertRevisions.Input.Path,
+                query: Operations.listAutomationAlertRevisions.Input.Query = .init(),
+                headers: Operations.listAutomationAlertRevisions.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/next_before`.
+                        public var next_before: Swift.String?
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload`.
+                        public struct revisionsPayloadPayload: Codable, Hashable, Sendable {
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/actor`.
+                            public struct actorPayload: Codable, Hashable, Sendable {
+                                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/actor/email`.
+                                public var email: Swift.String
+                                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/actor/id`.
+                                public var id: Swift.Int
+                                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/actor/name`.
+                                public var name: Swift.String
+                                /// Creates a new `actorPayload`.
+                                ///
+                                /// - Parameters:
+                                ///   - email:
+                                ///   - id:
+                                ///   - name:
+                                public init(
+                                    email: Swift.String,
+                                    id: Swift.Int,
+                                    name: Swift.String
+                                ) {
+                                    self.email = email
+                                    self.id = id
+                                    self.name = name
+                                }
+                                public enum CodingKeys: String, CodingKey {
+                                    case email
+                                    case id
+                                    case name
+                                }
+                            }
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/actor`.
+                            public var actor: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayloadPayload.actorPayload?
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/changes`.
+                            public var changes: OpenAPIRuntime.OpenAPIObjectContainer
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/event`.
+                            @frozen public enum eventPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                                case created = "created"
+                                case updated = "updated"
+                            }
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/event`.
+                            public var event: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayloadPayload.eventPayload
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/id`.
+                            public var id: Swift.String
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/inserted_at`.
+                            public var inserted_at: Foundation.Date
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/snapshot`.
+                            public var snapshot: OpenAPIRuntime.OpenAPIObjectContainer
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisionsPayload/source`.
+                            public var source: Swift.String
+                            /// Creates a new `revisionsPayloadPayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - actor:
+                            ///   - changes:
+                            ///   - event:
+                            ///   - id:
+                            ///   - inserted_at:
+                            ///   - snapshot:
+                            ///   - source:
+                            public init(
+                                actor: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayloadPayload.actorPayload? = nil,
+                                changes: OpenAPIRuntime.OpenAPIObjectContainer,
+                                event: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayloadPayload.eventPayload,
+                                id: Swift.String,
+                                inserted_at: Foundation.Date,
+                                snapshot: OpenAPIRuntime.OpenAPIObjectContainer,
+                                source: Swift.String
+                            ) {
+                                self.actor = actor
+                                self.changes = changes
+                                self.event = event
+                                self.id = id
+                                self.inserted_at = inserted_at
+                                self.snapshot = snapshot
+                                self.source = source
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case actor
+                                case changes
+                                case event
+                                case id
+                                case inserted_at
+                                case snapshot
+                                case source
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisions`.
+                        public typealias revisionsPayload = [Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayloadPayload]
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/json/revisions`.
+                        public var revisions: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayload
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - next_before:
+                        ///   - revisions:
+                        public init(
+                            next_before: Swift.String? = nil,
+                            revisions: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload.revisionsPayload
+                        ) {
+                            self.next_before = next_before
+                            self.revisions = revisions
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case next_before
+                            case revisions
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/200/content/application\/json`.
+                    case json(Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.listAutomationAlertRevisions.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listAutomationAlertRevisions.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listAutomationAlertRevisions.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Automation alert revisions
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.listAutomationAlertRevisions.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.listAutomationAlertRevisions.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listAutomationAlertRevisions.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listAutomationAlertRevisions.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.listAutomationAlertRevisions.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.listAutomationAlertRevisions.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listAutomationAlertRevisions.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listAutomationAlertRevisions.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Not found
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.listAutomationAlertRevisions.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.listAutomationAlertRevisions.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Whole seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/429/headers/retry-after`.
+                    public var retry_hyphen_after: Swift.String?
+                    /// Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/429/headers/x-tuist-throttle-reason`.
+                    public var x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - retry_hyphen_after: Whole seconds to wait before retrying.
+                    ///   - x_hyphen_tuist_hyphen_throttle_hyphen_reason: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+                    public init(
+                        retry_hyphen_after: Swift.String? = nil,
+                        x_hyphen_tuist_hyphen_throttle_hyphen_reason: Swift.String? = nil
+                    ) {
+                        self.retry_hyphen_after = retry_hyphen_after
+                        self.x_hyphen_tuist_hyphen_throttle_hyphen_reason = x_hyphen_tuist_hyphen_throttle_hyphen_reason
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/GET/responses/429/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.listAutomationAlertRevisions.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You've made too many unauthorized requests.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions/get(listAutomationAlertRevisions)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.listAutomationAlertRevisions.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.listAutomationAlertRevisions.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -635,6 +635,119 @@ components:
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Tests.TestCaseRun
       x-validate:
+    RunnerJob:
+      properties:
+        claimed_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        completed_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        conclusion:
+          type: string
+          x-struct:
+          x-validate:
+        enqueued_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        head_branch:
+          type: string
+          x-struct:
+          x-validate:
+        head_sha:
+          type: string
+          x-struct:
+          x-validate:
+        job_name:
+          type: string
+          x-struct:
+          x-validate:
+        log_archived_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        memory_gb:
+          type: integer
+          x-struct:
+          x-validate:
+        platform:
+          type: string
+          x-struct:
+          x-validate:
+        repository:
+          type: string
+          x-struct:
+          x-validate:
+        requested_dispatch_label:
+          type: string
+          x-struct:
+          x-validate:
+        run_attempt:
+          type: integer
+          x-struct:
+          x-validate:
+        started_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        status:
+          type: string
+          x-struct:
+          x-validate:
+        updated_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        vcpus:
+          type: integer
+          x-struct:
+          x-validate:
+        workflow_job_id:
+          type: integer
+          x-struct:
+          x-validate:
+        workflow_name:
+          type: string
+          x-struct:
+          x-validate:
+        workflow_run_id:
+          type: integer
+          x-struct:
+          x-validate:
+      required:
+        - workflow_job_id
+        - repository
+        - workflow_run_id
+        - workflow_name
+        - run_attempt
+        - job_name
+        - head_branch
+        - head_sha
+        - status
+        - conclusion
+        - platform
+        - vcpus
+        - memory_gb
+        - requested_dispatch_label
+        - enqueued_at
+        - updated_at
+      title: RunnerJob
+      type: object
+      x-struct:
+      x-validate:
     AccountTokenCreated:
       description: A newly created account token.
       properties:
@@ -721,6 +834,95 @@ components:
       minimum: 1
       title: CacheRunsIndexPage
       type: integer
+      x-struct:
+      x-validate:
+    ProjectNotificationAlert:
+      properties:
+        bundle_name:
+          type: string
+          x-struct:
+          x-validate:
+        category:
+          type: string
+          x-struct:
+          x-validate:
+        deviation_percentage:
+          type: number
+          x-struct:
+          x-validate:
+        environment:
+          type: string
+          x-struct:
+          x-validate:
+        git_branch:
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        id:
+          format: uuid
+          type: string
+          x-struct:
+          x-validate:
+        inserted_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        metric:
+          type: string
+          x-struct:
+          x-validate:
+        name:
+          type: string
+          x-struct:
+          x-validate:
+        rolling_window_size:
+          nullable: true
+          type: integer
+          x-struct:
+          x-validate:
+        scheme:
+          type: string
+          x-struct:
+          x-validate:
+        slack_channel_id:
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        slack_channel_name:
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        updated_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        webhook_configured:
+          type: boolean
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - name
+        - category
+        - metric
+        - deviation_percentage
+        - rolling_window_size
+        - git_branch
+        - scheme
+        - bundle_name
+        - environment
+        - slack_channel_id
+        - slack_channel_name
+        - webhook_configured
+        - inserted_at
+        - updated_at
+      title: ProjectNotificationAlert
+      type: object
       x-struct:
       x-validate:
     BuildsIndexPageSize:
@@ -921,6 +1123,71 @@ components:
       minimum: 1
       title: TestTargetsPage
       type: integer
+      x-struct:
+      x-validate:
+    AutomationAlertRevision:
+      properties:
+        actor:
+          nullable: true
+          properties:
+            email:
+              type: string
+              x-struct:
+              x-validate:
+            id:
+              type: integer
+              x-struct:
+              x-validate:
+            name:
+              type: string
+              x-struct:
+              x-validate:
+          required:
+            - id
+            - name
+            - email
+          type: object
+          x-struct:
+          x-validate:
+        changes:
+          type: object
+          x-struct:
+          x-validate:
+        event:
+          enum:
+            - created
+            - updated
+          type: string
+          x-struct:
+          x-validate:
+        id:
+          format: uuid
+          type: string
+          x-struct:
+          x-validate:
+        inserted_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        snapshot:
+          type: object
+          x-struct:
+          x-validate:
+        source:
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - event
+        - source
+        - actor
+        - changes
+        - snapshot
+        - inserted_at
+      title: AutomationAlertRevision
+      type: object
       x-struct:
       x-validate:
     TestCaseRunAttachmentParams:
@@ -1995,6 +2262,56 @@ components:
       type: integer
       x-struct:
       x-validate:
+    WebhookEndpoint:
+      properties:
+        event_types:
+          items:
+            type: string
+            x-struct:
+            x-validate:
+          type: array
+          x-struct:
+          x-validate:
+        id:
+          format: uuid
+          type: string
+          x-struct:
+          x-validate:
+        inserted_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        name:
+          type: string
+          x-struct:
+          x-validate:
+        signing_secret_last_four:
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        updated_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        url:
+          format: uri
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - name
+        - url
+        - event_types
+        - inserted_at
+        - updated_at
+      title: WebhookEndpoint
+      type: object
+      x-struct:
+      x-validate:
     CacheStatus:
       enum:
         - miss
@@ -2454,6 +2771,64 @@ components:
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Project
       x-validate:
+    RunnerWorkflow:
+      properties:
+        avg_duration_ms:
+          nullable: true
+          type: number
+          x-struct:
+          x-validate:
+        cancelled_count:
+          type: integer
+          x-struct:
+          x-validate:
+        failure_count:
+          type: integer
+          x-struct:
+          x-validate:
+        in_progress_count:
+          type: integer
+          x-struct:
+          x-validate:
+        last_run_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        repository:
+          type: string
+          x-struct:
+          x-validate:
+        skipped_count:
+          type: integer
+          x-struct:
+          x-validate:
+        success_count:
+          type: integer
+          x-struct:
+          x-validate:
+        total_jobs:
+          type: integer
+          x-struct:
+          x-validate:
+        workflow_name:
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - workflow_name
+        - repository
+        - total_jobs
+        - success_count
+        - failure_count
+        - cancelled_count
+        - skipped_count
+        - in_progress_count
+        - last_run_at
+      title: RunnerWorkflow
+      type: object
+      x-struct:
+      x-validate:
     TestRun:
       properties:
         build_run_id:
@@ -2891,6 +3266,30 @@ components:
       type: object
       x-struct:
       x-validate:
+    RunnerJobLogLine:
+      properties:
+        line_number:
+          type: integer
+          x-struct:
+          x-validate:
+        message:
+          type: string
+          x-struct:
+          x-validate:
+        ts:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - line_number
+        - ts
+        - message
+      title: RunnerJobLogLine
+      type: object
+      x-struct:
+      x-validate:
     ProjectToken:
       description: A token to authenticate API requests as a project.
       properties:
@@ -3202,6 +3601,89 @@ components:
       title: CommandEvent
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.CommandEvent
+      x-validate:
+    AccountToken:
+      properties:
+        all_projects:
+          description: Whether token has access to all projects.
+          type: boolean
+          x-struct:
+          x-validate:
+        expires_at:
+          description: When the token expires.
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        id:
+          description: Token unique identifier.
+          type: string
+          x-struct:
+          x-validate:
+        inserted_at:
+          description: When the token was created.
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        name:
+          description: Friendly name for the token.
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        project_handles:
+          description: List of project handles the token can access when all_projects is false.
+          items:
+            type: string
+            x-struct:
+            x-validate:
+          type: array
+          x-struct:
+          x-validate:
+        scopes:
+          description: Token scopes.
+          items:
+            enum:
+              - ci
+              - mcp
+              - account:scim:write
+              - account:cache:read
+              - account:cache:write
+              - account:members:read
+              - account:members:write
+              - account:registry:read
+              - account:registry:write
+              - account:runners:read
+              - project:previews:read
+              - project:previews:write
+              - project:admin:read
+              - project:admin:write
+              - project:cache:read
+              - project:cache:write
+              - project:bundles:read
+              - project:bundles:write
+              - project:tests:read
+              - project:tests:write
+              - project:builds:read
+              - project:builds:write
+              - project:runs:read
+              - project:runs:write
+            type: string
+            x-struct:
+            x-validate:
+          type: array
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - scopes
+        - all_projects
+        - inserted_at
+      title: AccountToken
+      type: object
+      x-struct:
       x-validate:
     AutomationAlertAction:
       description: An action run when an automation alert triggers or recovers.
@@ -5033,7 +5515,7 @@ components:
                 x-struct:
                 x-validate:
               project_handles:
-                description: List of project handles the token can access (when all_projects is false).
+                description: List of project handles the token can access when all_projects is false.
                 items:
                   type: string
                   x-struct:
@@ -5054,6 +5536,7 @@ components:
                     - account:members:write
                     - account:registry:read
                     - account:registry:write
+                    - account:runners:read
                     - project:previews:read
                     - project:previews:write
                     - project:admin:read
@@ -5079,6 +5562,7 @@ components:
               - scopes
               - all_projects
               - inserted_at
+            title: AccountToken
             type: object
             x-struct:
             x-validate:
@@ -5153,6 +5637,58 @@ components:
       type: object
       x-struct:
       x-validate:
+    RunnerJobMetric:
+      properties:
+        cpu_iowait_percent:
+          type: number
+          x-struct:
+          x-validate:
+        cpu_usage_percent:
+          type: number
+          x-struct:
+          x-validate:
+        disk_total_bytes:
+          type: integer
+          x-struct:
+          x-validate:
+        disk_used_bytes:
+          type: integer
+          x-struct:
+          x-validate:
+        memory_total_bytes:
+          type: integer
+          x-struct:
+          x-validate:
+        memory_used_bytes:
+          type: integer
+          x-struct:
+          x-validate:
+        network_bytes_in:
+          type: integer
+          x-struct:
+          x-validate:
+        network_bytes_out:
+          type: integer
+          x-struct:
+          x-validate:
+        timestamp:
+          type: number
+          x-struct:
+          x-validate:
+      required:
+        - timestamp
+        - cpu_usage_percent
+        - cpu_iowait_percent
+        - memory_used_bytes
+        - memory_total_bytes
+        - network_bytes_in
+        - network_bytes_out
+        - disk_used_bytes
+        - disk_total_bytes
+      title: RunnerJobMetric
+      type: object
+      x-struct:
+      x-validate:
     BuildMultipartUploadStartParams:
       description: Parameters to start a multipart upload for a build archive.
       properties:
@@ -5175,6 +5711,63 @@ components:
         - skipped
       title: TestCasesIndexState
       type: string
+      x-struct:
+      x-validate:
+    RunnerProfile:
+      properties:
+        id:
+          type: integer
+          x-struct:
+          x-validate:
+        inserted_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        memory_gb:
+          type: integer
+          x-struct:
+          x-validate:
+        name:
+          type: string
+          x-struct:
+          x-validate:
+        platform:
+          enum:
+            - linux
+            - macos
+          type: string
+          x-struct:
+          x-validate:
+        protected:
+          type: boolean
+          x-struct:
+          x-validate:
+        updated_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        vcpus:
+          type: integer
+          x-struct:
+          x-validate:
+        xcode_version:
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - name
+        - platform
+        - vcpus
+        - memory_gb
+        - protected
+        - inserted_at
+        - updated_at
+      title: RunnerProfile
+      type: object
       x-struct:
       x-validate:
     AbsentCacheArtifact:
@@ -5217,6 +5810,47 @@ components:
       minimum: 1
       title: ModuleCacheTargetsPageSize
       type: integer
+      x-struct:
+      x-validate:
+    RunnerJobStep:
+      properties:
+        completed_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        conclusion:
+          type: string
+          x-struct:
+          x-validate:
+        name:
+          type: string
+          x-struct:
+          x-validate:
+        number:
+          type: integer
+          x-struct:
+          x-validate:
+        started_at:
+          format: date-time
+          nullable: true
+          type: string
+          x-struct:
+          x-validate:
+        status:
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - number
+        - name
+        - status
+        - conclusion
+        - started_at
+        - completed_at
+      title: RunnerJobStep
+      type: object
       x-struct:
       x-validate:
     BuildCacheTasksIndexPage:
@@ -5334,6 +5968,7 @@ components:
               - account:members:write
               - account:registry:read
               - account:registry:write
+              - account:runners:read
               - project:previews:read
               - project:previews:write
               - project:admin:read
@@ -6352,6 +6987,89 @@ components:
       title: RunParams
       x-struct:
       x-validate:
+    WebhookDeliveryAttempt:
+      properties:
+        attempt:
+          type: integer
+          x-struct:
+          x-validate:
+        duration_ms:
+          type: integer
+          x-struct:
+          x-validate:
+        error:
+          type: string
+          x-struct:
+          x-validate:
+        event_id:
+          type: string
+          x-struct:
+          x-validate:
+        event_type:
+          type: string
+          x-struct:
+          x-validate:
+        id:
+          format: uuid
+          type: string
+          x-struct:
+          x-validate:
+        inserted_at:
+          format: date-time
+          type: string
+          x-struct:
+          x-validate:
+        request_body:
+          type: string
+          x-struct:
+          x-validate:
+        request_headers:
+          type: string
+          x-struct:
+          x-validate:
+        response_body:
+          type: string
+          x-struct:
+          x-validate:
+        response_headers:
+          type: string
+          x-struct:
+          x-validate:
+        response_status:
+          type: integer
+          x-struct:
+          x-validate:
+        status:
+          enum:
+            - delivered
+            - failed
+          type: string
+          x-struct:
+          x-validate:
+        webhook_endpoint_id:
+          format: uuid
+          type: string
+          x-struct:
+          x-validate:
+      required:
+        - id
+        - webhook_endpoint_id
+        - event_id
+        - event_type
+        - attempt
+        - status
+        - request_body
+        - request_headers
+        - response_status
+        - response_headers
+        - response_body
+        - error
+        - duration_ms
+        - inserted_at
+      title: WebhookDeliveryAttempt
+      type: object
+      x-struct:
+      x-validate:
     ProjectFullToken:
       description: A new project token.
       properties:
@@ -6875,6 +7593,181 @@ paths:
       summary: Get cache endpoints.
       tags:
         - Cache
+  /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}:
+    get:
+      callbacks: {}
+      operationId: getRunnerJob
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The workflow job identifier.
+          in: path
+          name: workflow_job_id
+          required: true
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  claimed_at:
+                    format: date-time
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  completed_at:
+                    format: date-time
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  conclusion:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  enqueued_at:
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  head_branch:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  head_sha:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  job_name:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  log_archived_at:
+                    format: date-time
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  memory_gb:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  platform:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  repository:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  requested_dispatch_label:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  run_attempt:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  started_at:
+                    format: date-time
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  status:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  updated_at:
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  vcpus:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  workflow_job_id:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  workflow_name:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  workflow_run_id:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                required:
+                  - workflow_job_id
+                  - repository
+                  - workflow_run_id
+                  - workflow_name
+                  - run_attempt
+                  - job_name
+                  - head_branch
+                  - head_sha
+                  - status
+                  - conclusion
+                  - platform
+                  - vcpus
+                  - memory_gb
+                  - requested_dispatch_label
+                  - enqueued_at
+                  - updated_at
+                title: RunnerJob
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner job
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runner job was not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: Get a runner job.
+      tags:
+        - Runners
   /api/cache:
     get:
       callbacks: {}
@@ -6971,6 +7864,131 @@ paths:
       summary: Downloads an artifact from the cache.
       tags:
         - Cache
+  /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics:
+    get:
+      callbacks: {}
+      operationId: listRunnerJobMetrics
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The workflow job identifier.
+          in: path
+          name: workflow_job_id
+          required: true
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  metrics:
+                    items:
+                      properties:
+                        cpu_iowait_percent:
+                          type: number
+                          x-struct:
+                          x-validate:
+                        cpu_usage_percent:
+                          type: number
+                          x-struct:
+                          x-validate:
+                        disk_total_bytes:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        disk_used_bytes:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        memory_total_bytes:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        memory_used_bytes:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        network_bytes_in:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        network_bytes_out:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        timestamp:
+                          type: number
+                          x-struct:
+                          x-validate:
+                      required:
+                        - timestamp
+                        - cpu_usage_percent
+                        - cpu_iowait_percent
+                        - memory_used_bytes
+                        - memory_total_bytes
+                        - network_bytes_in
+                        - network_bytes_out
+                        - disk_used_bytes
+                        - disk_total_bytes
+                      title: RunnerJobMetric
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - metrics
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner job metrics
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runner job was not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List machine metrics for a runner job.
+      tags:
+        - Runners
   /api/runs/{run_id}/complete:
     post:
       callbacks: {}
@@ -7716,6 +8734,128 @@ paths:
       summary: Get the artifact tree for a bundle.
       tags:
         - Bundles
+  /api/accounts/{account_handle}/runners/profiles:
+    get:
+      callbacks: {}
+      operationId: listRunnerProfiles
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  profiles:
+                    items:
+                      properties:
+                        id:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        inserted_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        memory_gb:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        platform:
+                          enum:
+                            - linux
+                            - macos
+                          type: string
+                          x-struct:
+                          x-validate:
+                        protected:
+                          type: boolean
+                          x-struct:
+                          x-validate:
+                        updated_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        vcpus:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        xcode_version:
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - id
+                        - name
+                        - platform
+                        - vcpus
+                        - memory_gb
+                        - protected
+                        - inserted_at
+                        - updated_at
+                      title: RunnerProfile
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - profiles
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner profiles
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runners are not enabled
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List runner profiles for an account.
+      tags:
+        - Runners
   /api/projects/{account_handle}/{project_handle}/tests:
     get:
       callbacks: {}
@@ -8677,6 +9817,161 @@ paths:
       summary: Get a build by ID.
       tags:
         - Builds
+  /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts/{delivery_attempt_id}:
+    get:
+      callbacks: {}
+      operationId: getWebhookDeliveryAttempt
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The webhook endpoint identifier.
+          in: path
+          name: webhook_endpoint_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: path
+          name: delivery_attempt_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  attempt:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  duration_ms:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  error:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  event_id:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  event_type:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  id:
+                    format: uuid
+                    type: string
+                    x-struct:
+                    x-validate:
+                  inserted_at:
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  request_body:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  request_headers:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  response_body:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  response_headers:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  response_status:
+                    type: integer
+                    x-struct:
+                    x-validate:
+                  status:
+                    enum:
+                      - delivered
+                      - failed
+                    type: string
+                    x-struct:
+                    x-validate:
+                  webhook_endpoint_id:
+                    format: uuid
+                    type: string
+                    x-struct:
+                    x-validate:
+                required:
+                  - id
+                  - webhook_endpoint_id
+                  - event_id
+                  - event_type
+                  - attempt
+                  - status
+                  - request_body
+                  - request_headers
+                  - response_status
+                  - response_headers
+                  - response_body
+                  - error
+                  - duration_ms
+                  - inserted_at
+                title: WebhookDeliveryAttempt
+                type: object
+                x-struct:
+                x-validate:
+          description: Webhook delivery attempt
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Webhook delivery attempt not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: Get a webhook delivery attempt.
+      tags:
+        - Webhooks
   /api/projects/{account_handle}/{project_handle}/tokens/{id}:
     delete:
       callbacks: {}
@@ -9244,22 +10539,6 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: Page number for pagination.
-          in: query
-          name: page
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
-        - description: Number of items per page.
-          in: query
-          name: page_size
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
         - description: Filter bundles by git branch.
           in: query
           name: git_branch
@@ -9268,12 +10547,28 @@ paths:
             type: string
             x-struct:
             x-validate:
+        - description: Page number for pagination.
+          in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
         - description: The handle of the account.
           in: path
           name: account_handle
           required: true
           schema:
             type: string
+            x-struct:
+            x-validate:
+        - description: Number of items per page.
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
             x-struct:
             x-validate:
         - description: The handle of the project.
@@ -11869,6 +13164,207 @@ paths:
       summary: 'Create a new run. DEPRECATED: Use POST /builds or POST /tests instead.'
       tags:
         - Runs
+  /api/accounts/{account_handle}/runners/workflows:
+    get:
+      callbacks: {}
+      operationId: listRunnerWorkflows
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: 'Page number (default: 1).'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: 'Results per page (default: 20, maximum: 100).'
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: repository
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: workflow_name
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: head_branch
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: platform
+          required: false
+          schema:
+            enum:
+              - linux
+              - macos
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: sort_by
+          required: false
+          schema:
+            enum:
+              - workflow
+              - success_rate
+              - jobs
+              - avg_duration
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: sort_order
+          required: false
+          schema:
+            enum:
+              - asc
+              - desc
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  pagination_metadata:
+                    $ref: '#/components/schemas/PaginationMetadata'
+                  workflows:
+                    items:
+                      properties:
+                        avg_duration_ms:
+                          nullable: true
+                          type: number
+                          x-struct:
+                          x-validate:
+                        cancelled_count:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        failure_count:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        in_progress_count:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        last_run_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        repository:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        skipped_count:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        success_count:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        total_jobs:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        workflow_name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - workflow_name
+                        - repository
+                        - total_jobs
+                        - success_count
+                        - failure_count
+                        - cancelled_count
+                        - skipped_count
+                        - in_progress_count
+                        - last_run_at
+                      title: RunnerWorkflow
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - workflows
+                  - pagination_metadata
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner workflows
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runners are not enabled
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List runner workflows for an account.
+      tags:
+        - Runners
   /api/cache/exists:
     get:
       callbacks: {}
@@ -12893,6 +14389,304 @@ paths:
       summary: Cleans cache for a given project
       tags:
         - Cache
+  /api/accounts/{account_handle}/runners/jobs:
+    get:
+      callbacks: {}
+      operationId: listRunnerJobs
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: 'Page number (default: 1).'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: 'Results per page (default: 20, maximum: 100).'
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: status
+          required: false
+          schema:
+            enum:
+              - queued
+              - claimed
+              - running
+              - completed
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: conclusion
+          required: false
+          schema:
+            enum:
+              - success
+              - failure
+              - cancelled
+              - skipped
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: repository
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: workflow_name
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: job_name
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: head_branch
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: platform
+          required: false
+          schema:
+            enum:
+              - linux
+              - macos
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: search
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: sort_by
+          required: false
+          schema:
+            enum:
+              - enqueued
+              - job
+              - workflow
+              - duration
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: sort_order
+          required: false
+          schema:
+            enum:
+              - asc
+              - desc
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  jobs:
+                    items:
+                      properties:
+                        claimed_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        completed_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        conclusion:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        enqueued_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        head_branch:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        head_sha:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        job_name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        log_archived_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        memory_gb:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        platform:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        repository:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        requested_dispatch_label:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        run_attempt:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        started_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        status:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        updated_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        vcpus:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        workflow_job_id:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        workflow_name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        workflow_run_id:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                      required:
+                        - workflow_job_id
+                        - repository
+                        - workflow_run_id
+                        - workflow_name
+                        - run_attempt
+                        - job_name
+                        - head_branch
+                        - head_sha
+                        - status
+                        - conclusion
+                        - platform
+                        - vcpus
+                        - memory_gb
+                        - requested_dispatch_label
+                        - enqueued_at
+                        - updated_at
+                      title: RunnerJob
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                  pagination_metadata:
+                    $ref: '#/components/schemas/PaginationMetadata'
+                required:
+                  - jobs
+                  - pagination_metadata
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner jobs
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runners are not enabled
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List runner jobs for an account.
+      tags:
+        - Runners
   /api/projects/{account_handle}/{project_handle}/cache-runs:
     get:
       callbacks: {}
@@ -13177,6 +14971,120 @@ paths:
       summary: List cache runs associated with a given project.
       tags:
         - Cache Runs
+  /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/steps:
+    get:
+      callbacks: {}
+      operationId: listRunnerJobSteps
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The workflow job identifier.
+          in: path
+          name: workflow_job_id
+          required: true
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  steps:
+                    items:
+                      properties:
+                        completed_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        conclusion:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        number:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        started_at:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        status:
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - number
+                        - name
+                        - status
+                        - conclusion
+                        - started_at
+                        - completed_at
+                      title: RunnerJobStep
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - steps
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner job steps
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runner job was not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List the steps for a runner job.
+      tags:
+        - Runners
   /api/projects/{id}:
     delete:
       callbacks: {}
@@ -13886,7 +15794,7 @@ paths:
                           x-struct:
                           x-validate:
                         project_handles:
-                          description: List of project handles the token can access (when all_projects is false).
+                          description: List of project handles the token can access when all_projects is false.
                           items:
                             type: string
                             x-struct:
@@ -13907,6 +15815,7 @@ paths:
                               - account:members:write
                               - account:registry:read
                               - account:registry:write
+                              - account:runners:read
                               - project:previews:read
                               - project:previews:write
                               - project:admin:read
@@ -13932,6 +15841,7 @@ paths:
                         - scopes
                         - all_projects
                         - inserted_at
+                      title: AccountToken
                       type: object
                       x-struct:
                       x-validate:
@@ -14023,6 +15933,7 @@ paths:
                       - account:members:write
                       - account:registry:read
                       - account:registry:write
+                      - account:runners:read
                       - project:previews:read
                       - project:previews:write
                       - project:admin:read
@@ -16658,6 +18569,241 @@ paths:
       summary: Generate a signed URL for uploading a build archive part.
       tags:
         - Builds
+  /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}/delivery-attempts:
+    get:
+      callbacks: {}
+      operationId: listWebhookDeliveryAttempts
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The webhook endpoint identifier.
+          in: path
+          name: webhook_endpoint_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+        - description: 'Results per page (default: 20, maximum: 100).'
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: Cursor for the next page.
+          in: query
+          name: after
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: Cursor for the previous page.
+          in: query
+          name: before
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: start_datetime
+          required: false
+          schema:
+            format: date-time
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: end_datetime
+          required: false
+          schema:
+            format: date-time
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: status
+          required: false
+          schema:
+            enum:
+              - delivered
+              - failed
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: event_type
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: event_id_search
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  delivery_attempts:
+                    items:
+                      properties:
+                        attempt:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        duration_ms:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        error:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        event_id:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        event_type:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        id:
+                          format: uuid
+                          type: string
+                          x-struct:
+                          x-validate:
+                        inserted_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        request_body:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        request_headers:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        response_body:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        response_headers:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        response_status:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        status:
+                          enum:
+                            - delivered
+                            - failed
+                          type: string
+                          x-struct:
+                          x-validate:
+                        webhook_endpoint_id:
+                          format: uuid
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - id
+                        - webhook_endpoint_id
+                        - event_id
+                        - event_type
+                        - attempt
+                        - status
+                        - request_body
+                        - request_headers
+                        - response_status
+                        - response_headers
+                        - response_body
+                        - error
+                        - duration_ms
+                        - inserted_at
+                      title: WebhookDeliveryAttempt
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                  pagination_metadata:
+                    $ref: '#/components/schemas/PaginationMetadata'
+                required:
+                  - delivery_attempts
+                  - pagination_metadata
+                type: object
+                x-struct:
+                x-validate:
+          description: Webhook delivery attempts
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid cursor parameters
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Webhook endpoint not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List delivery attempts for a webhook endpoint.
+      tags:
+        - Webhooks
   /api/organizations/{organization_name}/usage:
     get:
       callbacks: {}
@@ -17208,15 +19354,6 @@ paths:
       callbacks: {}
       operationId: getBundle
       parameters:
-        - description: The ID of the bundle.
-          in: path
-          name: bundle_id
-          required: true
-          schema:
-            format: uuid
-            type: string
-            x-struct:
-            x-validate:
         - description: The handle of the account.
           in: path
           name: account_handle
@@ -17230,6 +19367,15 @@ paths:
           name: project_handle
           required: true
           schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The ID of the bundle.
+          in: path
+          name: bundle_id
+          required: true
+          schema:
+            format: uuid
             type: string
             x-struct:
             x-validate:
@@ -17288,6 +19434,120 @@ paths:
       summary: Get a single bundle by ID
       tags:
         - Bundles
+  /api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/logs:
+    get:
+      callbacks: {}
+      description: Returns log lines in display order. Page size defaults to 200 and is capped at 500.
+      operationId: listRunnerJobLogs
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The workflow job identifier.
+          in: path
+          name: workflow_job_id
+          required: true
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: Zero-based log-line offset.
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+        - description: Maximum number of lines, up to 500.
+          in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  lines:
+                    items:
+                      properties:
+                        line_number:
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        message:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        ts:
+                          format: date-time
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - line_number
+                        - ts
+                        - message
+                      title: RunnerJobLogLine
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - lines
+                type: object
+                x-struct:
+                x-validate:
+          description: Runner job log lines
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Runner job was not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List captured log lines for a runner job.
+      tags:
+        - Runners
   /api/auth/device_code/{device_code}:
     get:
       callbacks: {}
@@ -17627,6 +19887,271 @@ paths:
       summary: List events for a test case.
       tags:
         - Test Cases
+  /api/accounts/{account_handle}/webhooks:
+    get:
+      callbacks: {}
+      operationId: listWebhookEndpoints
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  endpoints:
+                    items:
+                      properties:
+                        event_types:
+                          items:
+                            type: string
+                            x-struct:
+                            x-validate:
+                          type: array
+                          x-struct:
+                          x-validate:
+                        id:
+                          format: uuid
+                          type: string
+                          x-struct:
+                          x-validate:
+                        inserted_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        signing_secret_last_four:
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        updated_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        url:
+                          format: uri
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - id
+                        - name
+                        - url
+                        - event_types
+                        - inserted_at
+                        - updated_at
+                      title: WebhookEndpoint
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - endpoints
+                type: object
+                x-struct:
+                x-validate:
+          description: Webhook endpoints
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List webhook endpoints for an account.
+      tags:
+        - Webhooks
+  /api/projects/{account_handle}/{project_handle}/notification-alerts:
+    get:
+      callbacks: {}
+      operationId: listProjectNotificationAlerts
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  alert_rules:
+                    items:
+                      properties:
+                        bundle_name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        category:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        deviation_percentage:
+                          type: number
+                          x-struct:
+                          x-validate:
+                        environment:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        git_branch:
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        id:
+                          format: uuid
+                          type: string
+                          x-struct:
+                          x-validate:
+                        inserted_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        metric:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        name:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        rolling_window_size:
+                          nullable: true
+                          type: integer
+                          x-struct:
+                          x-validate:
+                        scheme:
+                          type: string
+                          x-struct:
+                          x-validate:
+                        slack_channel_id:
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        slack_channel_name:
+                          nullable: true
+                          type: string
+                          x-struct:
+                          x-validate:
+                        updated_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        webhook_configured:
+                          type: boolean
+                          x-struct:
+                          x-validate:
+                      required:
+                        - id
+                        - name
+                        - category
+                        - metric
+                        - deviation_percentage
+                        - rolling_window_size
+                        - git_branch
+                        - scheme
+                        - bundle_name
+                        - environment
+                        - slack_channel_id
+                        - slack_channel_name
+                        - webhook_configured
+                        - inserted_at
+                        - updated_at
+                      title: ProjectNotificationAlert
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - alert_rules
+                type: object
+                x-struct:
+                x-validate:
+          description: Project notification alert rules
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List a project's notification alert rules.
+      tags:
+        - Project Notification Alerts
   /api/cache/multipart/start:
     post:
       callbacks: {}
@@ -20410,6 +22935,136 @@ paths:
       summary: List build issues for a given build.
       tags:
         - Builds
+  /api/accounts/{account_handle}/tokens/{token_id}:
+    get:
+      callbacks: {}
+      operationId: getAccountToken
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The token identifier.
+          in: path
+          name: token_id
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  all_projects:
+                    description: Whether token has access to all projects.
+                    type: boolean
+                    x-struct:
+                    x-validate:
+                  expires_at:
+                    description: When the token expires.
+                    format: date-time
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  id:
+                    description: Token unique identifier.
+                    type: string
+                    x-struct:
+                    x-validate:
+                  inserted_at:
+                    description: When the token was created.
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  name:
+                    description: Friendly name for the token.
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  project_handles:
+                    description: List of project handles the token can access when all_projects is false.
+                    items:
+                      type: string
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                  scopes:
+                    description: Token scopes.
+                    items:
+                      enum:
+                        - ci
+                        - mcp
+                        - account:scim:write
+                        - account:cache:read
+                        - account:cache:write
+                        - account:members:read
+                        - account:members:write
+                        - account:registry:read
+                        - account:registry:write
+                        - account:runners:read
+                        - project:previews:read
+                        - project:previews:write
+                        - project:admin:read
+                        - project:admin:write
+                        - project:cache:read
+                        - project:cache:write
+                        - project:bundles:read
+                        - project:bundles:write
+                        - project:tests:read
+                        - project:tests:write
+                        - project:builds:read
+                        - project:builds:write
+                        - project:runs:read
+                        - project:runs:write
+                      type: string
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - id
+                  - scopes
+                  - all_projects
+                  - inserted_at
+                title: AccountToken
+                type: object
+                x-struct:
+                x-validate:
+          description: An account token.
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to get the token
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authorized to get the token
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The account token was not found
+      summary: Get an account token.
+      tags:
+        - Account tokens
   /api/organizations:
     get:
       callbacks: {}
@@ -21566,6 +24221,119 @@ paths:
       summary: Get a Gradle build by ID.
       tags:
         - Gradle
+  /api/accounts/{account_handle}/webhooks/{webhook_endpoint_id}:
+    get:
+      callbacks: {}
+      operationId: getWebhookEndpoint
+      parameters:
+        - description: The account handle.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: path
+          name: webhook_endpoint_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  event_types:
+                    items:
+                      type: string
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                  id:
+                    format: uuid
+                    type: string
+                    x-struct:
+                    x-validate:
+                  inserted_at:
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  name:
+                    type: string
+                    x-struct:
+                    x-validate:
+                  signing_secret_last_four:
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  updated_at:
+                    format: date-time
+                    type: string
+                    x-struct:
+                    x-validate:
+                  url:
+                    format: uri
+                    type: string
+                    x-struct:
+                    x-validate:
+                required:
+                  - id
+                  - name
+                  - url
+                  - event_types
+                  - inserted_at
+                  - updated_at
+                title: WebhookEndpoint
+                type: object
+                x-struct:
+                x-validate:
+          description: Webhook endpoint
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Webhook endpoint not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: Get a webhook endpoint.
+      tags:
+        - Webhooks
   /api/projects/{account_handle}/{project_handle}/builds/upload/complete:
     post:
       callbacks: {}
@@ -21829,6 +24597,177 @@ paths:
       summary: List test module runs for a test run.
       tags:
         - Tests
+  /api/projects/{account_handle}/{project_handle}/automations/alerts/{alert_id}/revisions:
+    get:
+      callbacks: {}
+      operationId: listAutomationAlertRevisions
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: path
+          name: alert_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+        - description: ''
+          in: query
+          name: before
+          required: false
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+        - description: Results per page, up to 100.
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
+            x-struct:
+            x-validate:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  next_before:
+                    format: uuid
+                    nullable: true
+                    type: string
+                    x-struct:
+                    x-validate:
+                  revisions:
+                    items:
+                      properties:
+                        actor:
+                          nullable: true
+                          properties:
+                            email:
+                              type: string
+                              x-struct:
+                              x-validate:
+                            id:
+                              type: integer
+                              x-struct:
+                              x-validate:
+                            name:
+                              type: string
+                              x-struct:
+                              x-validate:
+                          required:
+                            - id
+                            - name
+                            - email
+                          type: object
+                          x-struct:
+                          x-validate:
+                        changes:
+                          type: object
+                          x-struct:
+                          x-validate:
+                        event:
+                          enum:
+                            - created
+                            - updated
+                          type: string
+                          x-struct:
+                          x-validate:
+                        id:
+                          format: uuid
+                          type: string
+                          x-struct:
+                          x-validate:
+                        inserted_at:
+                          format: date-time
+                          type: string
+                          x-struct:
+                          x-validate:
+                        snapshot:
+                          type: object
+                          x-struct:
+                          x-validate:
+                        source:
+                          type: string
+                          x-struct:
+                          x-validate:
+                      required:
+                        - id
+                        - event
+                        - source
+                        - actor
+                        - changes
+                        - snapshot
+                        - inserted_at
+                      title: AutomationAlertRevision
+                      type: object
+                      x-struct:
+                      x-validate:
+                    type: array
+                    x-struct:
+                    x-validate:
+                required:
+                  - revisions
+                  - next_before
+                type: object
+                x-struct:
+                x-validate:
+          description: Automation alert revisions
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Not found
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You've made too many unauthorized requests.
+          headers:
+            retry-after:
+              description: Whole seconds to wait before retrying.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+            x-tuist-throttle-reason:
+              description: Set to `authorization` when the throttling is a response to the volume of unauthorized requests. Waiting out `retry-after` reaches the same denial.
+              schema:
+                type: string
+                x-struct:
+                x-validate:
+              style: simple
+      summary: List an automation alert's revision history.
+      tags:
+        - Automation Alerts
   /api/projects/{account_handle}/{project_handle}/tokens:
     get:
       callbacks: {}

--- a/cli/Sources/TuistServer/Services/GetBundleService.swift
+++ b/cli/Sources/TuistServer/Services/GetBundleService.swift
@@ -55,9 +55,9 @@ public struct GetBundleService: GetBundleServicing {
         let response = try await client.getBundle(
             .init(
                 path: .init(
-                    bundle_id: bundleId,
                     account_handle: handles.accountHandle,
-                    project_handle: handles.projectHandle
+                    project_handle: handles.projectHandle,
+                    bundle_id: bundleId
                 )
             )
         )

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,9 +63,9 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
+                    git_branch: gitBranch,
                     page: page,
-                    page_size: pageSize,
-                    git_branch: gitBranch
+                    page_size: pageSize
                 )
             )
         )

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -101,9 +101,16 @@ COPY noora /noora
 # errors on packages that clearly exist in mix.lock. Exit non-zero if every
 # attempt fails (the naive `|| sleep && break` form was masking failures).
 # Cache mounts for hex/rebar stores speed up redownloads when mix.lock changes.
-RUN --mount=type=cache,id=mix-hex,target=/root/.hex \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    --mount=type=cache,id=mix-hex,target=/root/.hex \
     --mount=type=cache,id=mix-rebar3,target=/root/.cache/rebar3 \
     set -e; \
+    if [ -n "${GITHUB_TOKEN:-}" ]; then \
+      auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"; \
+      export GIT_CONFIG_COUNT=1; \
+      export GIT_CONFIG_KEY_0='http.https://github.com/.extraheader'; \
+      export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"; \
+    fi; \
     attempts=0; \
     until mix deps.get --only $MIX_ENV; do \
       attempts=$((attempts + 1)); \

--- a/server/lib/tuist/accounts/account_token.ex
+++ b/server/lib/tuist/accounts/account_token.ex
@@ -41,6 +41,7 @@ defmodule Tuist.Accounts.AccountToken do
       "project:runs:write"
     ],
     @mcp_scope => [
+      "account:runners:read",
       "project:admin:read",
       "project:cache:read",
       "project:previews:read",
@@ -59,6 +60,7 @@ defmodule Tuist.Accounts.AccountToken do
     "account:members:write",
     "account:registry:read",
     "account:registry:write",
+    "account:runners:read",
     "project:previews:read",
     "project:previews:write",
     "project:admin:read",

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -455,6 +455,9 @@ defmodule Tuist.Authorization do
 
   object :runners do
     action :read do
+      desc("Allows anyone to read runner state for a public account.")
+      allow(:public_account)
+
       desc("Allows users of an account to read runner jobs, workflows, and live runner state.")
       allow([:authenticated_as_user, user_role: :user])
 

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -467,6 +467,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows users with ops access to read runner jobs, workflows, and live runner state.")
       allow([:authenticated_as_user, :ops_access])
+
+      desc("Allows an account token with account:runners:read scope to read runner state.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:runners:read"])
     end
 
     # Attaching a shell or a VNC session to a running VM executes commands on

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -77,6 +77,56 @@ defmodule Tuist.Automations do
     |> Repo.all()
   end
 
+  def get_alert_revision(alert_id, revision_id) do
+    case Repo.get_by(Revision, id: revision_id, automation_alert_id: alert_id) do
+      nil -> {:error, :not_found}
+      revision -> {:ok, revision}
+    end
+  end
+
+  def redact_revision(%Revision{} = revision) do
+    %{
+      id: revision.id,
+      event: revision.event,
+      source: revision.source,
+      actor: revision_actor(revision),
+      changes: redact_revision_changes(revision.changes),
+      snapshot: redact_revision_snapshot(revision.snapshot),
+      inserted_at: revision.inserted_at
+    }
+  end
+
+  defp revision_actor(%{actor: nil}), do: nil
+
+  defp revision_actor(%{actor: actor}) do
+    %{id: actor.id, name: actor.account.name, email: actor.email}
+  end
+
+  defp redact_revision_changes(changes) when is_map(changes) do
+    redact_revision_actions(changes, fn action_change ->
+      action_change
+      |> Map.update("from", [], &redact_actions/1)
+      |> Map.update("to", [], &redact_actions/1)
+    end)
+  end
+
+  defp redact_revision_changes(_changes), do: %{}
+
+  defp redact_revision_snapshot(snapshot) when is_map(snapshot) do
+    redact_revision_actions(snapshot, &redact_actions/1)
+  end
+
+  defp redact_revision_snapshot(_snapshot), do: %{}
+
+  defp redact_revision_actions(content, redactor) do
+    Enum.reduce(["trigger_actions", "recovery_actions"], content, fn field, acc ->
+      Map.update(acc, field, [], redactor)
+    end)
+  end
+
+  defp redact_actions(actions) when is_list(actions), do: Enum.map(actions, &redact_action/1)
+  defp redact_actions(_actions), do: []
+
   defp before_alert_revision(query, nil), do: query
 
   defp before_alert_revision(query, %Revision{inserted_at: inserted_at, id: id}) do
@@ -222,6 +272,8 @@ defmodule Tuist.Automations do
   end
 
   defp revision_value(_field, value), do: value
+
+  def redact_action(action) when is_map(action), do: Map.delete(action, "webhook_url_encrypted")
 
   defp redact_webhook_url(action) do
     case Map.pop(action, "webhook_url_encrypted") do

--- a/server/lib/tuist/docs_loader.ex
+++ b/server/lib/tuist/docs_loader.ex
@@ -364,14 +364,12 @@ defmodule Tuist.Docs.Loader do
 
   defp compile_heex_template(html, path) do
     {:ok,
-     EEx.compile_string(
+     Phoenix.LiveView.TagEngine.compile(
        html,
-       engine: Phoenix.LiveView.TagEngine,
        file: path,
        line: 1,
        caller: __ENV__,
        indentation: 0,
-       source: html,
        tag_handler: Phoenix.LiveView.HTMLEngine
      )}
   rescue

--- a/server/lib/tuist/mcp/components/tools/account_token_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/account_token_tools.ex
@@ -1,0 +1,214 @@
+defmodule Tuist.MCP.Components.Tools.AccountTokenTools do
+  @moduledoc false
+
+  alias Tuist.MCP.Formatter
+
+  def token_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => ["string", "null"]},
+        "scopes" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "all_projects" => %{"type" => "boolean"},
+        "expires_at" => %{"type" => ["string", "null"]},
+        "inserted_at" => %{"type" => "string"},
+        "project_handles" => %{"type" => "array", "items" => %{"type" => "string"}}
+      },
+      "required" => ["id", "name", "scopes", "all_projects", "expires_at", "inserted_at", "project_handles"],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize(token) do
+    %{
+      id: token.id,
+      name: token.name,
+      scopes: token.scopes,
+      all_projects: token.all_projects,
+      expires_at: Formatter.iso8601(token.expires_at),
+      inserted_at: Formatter.iso8601(token.inserted_at),
+      project_handles: Enum.map(token.projects || [], & &1.name)
+    }
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListAccountTokens do
+  @moduledoc """
+  List account tokens.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_account_tokens",
+    title: "List Account Tokens",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "page" => %{"type" => "integer", "description" => "Page number (default: 1)."},
+        "page_size" => %{"type" => "integer", "description" => "Results per page (default: 20, max: 100)."}
+      },
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "tokens" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.AccountTokenTools.token_schema()},
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["tokens", "pagination_metadata"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Accounts
+  alias Tuist.MCP.Components.Tools.AccountTokenTools
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description, do: "List account tokens without exposing their secret values."
+
+  @impl EMCP.Tool
+  def call(conn, args) do
+    case MCPTool.resolve_and_authorize_account(args, conn.assigns, :read, :account_token) do
+      {:ok, account} ->
+        {tokens, meta} =
+          Accounts.list_account_tokens(account, %{
+            order_by: [:inserted_at],
+            order_directions: [:desc],
+            page: MCPTool.page(args),
+            page_size: MCPTool.page_size(args)
+          })
+
+        MCPTool.json_response(
+          %{
+            tokens: Enum.map(tokens, &AccountTokenTools.serialize/1),
+            pagination_metadata: MCPTool.pagination_metadata(meta)
+          },
+          __MODULE__
+        )
+
+      {:error, message} ->
+        EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetAccountToken do
+  @moduledoc """
+  Get an account token's non-secret metadata.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_account_token",
+    title: "Get Account Token",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "token_id" => %{
+          "type" => "string",
+          "description" => "The token identifier, or a Tuist dashboard URL."
+        }
+      },
+      "required" => ["account_handle", "token_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.AccountTokenTools.token_schema()
+
+  alias Tuist.Accounts
+  alias Tuist.MCP.Components.Tools.AccountTokenTools
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description, do: "Get an account token's non-secret metadata."
+
+  @impl EMCP.Tool
+  def call(conn, %{"token_id" => token_id} = args) do
+    token_id = MCPTool.resource_id(token_id)
+
+    with {:ok, account} <- MCPTool.resolve_and_authorize_account(args, conn.assigns, :read, :account_token),
+         {:ok, token} <- Accounts.get_account_token(account, token_id) do
+      MCPTool.json_response(AccountTokenTools.serialize(token), __MODULE__)
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Account token not found: #{token_id}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListProjectTokens do
+  @moduledoc """
+  List project tokens.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_project_tokens",
+    title: "List Project Tokens",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "project_handle" => %{"type" => "string", "description" => "The project handle."}
+      },
+      "required" => ["account_handle", "project_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "tokens" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "inserted_at" => %{"type" => "string"}
+            },
+            "required" => ["id", "inserted_at"],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["tokens"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Formatter
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Projects
+
+  @impl EMCP.Tool
+  def description, do: "List project token metadata without exposing their secret values."
+
+  @impl EMCP.Tool
+  def call(conn, %{"account_handle" => account_handle, "project_handle" => project_handle}) do
+    with project when not is_nil(project) <-
+           Projects.get_project_by_account_and_project_handles(account_handle, project_handle),
+         {:ok, _account} <- MCPTool.authorize_account(conn.assigns, project.account, :read, :account_token) do
+      tokens =
+        project
+        |> Projects.get_project_tokens()
+        |> Enum.map(fn token -> %{id: token.id, inserted_at: Formatter.iso8601(token.inserted_at)} end)
+
+      MCPTool.json_response(%{tokens: tokens}, __MODULE__)
+    else
+      nil -> EMCP.Tool.error("Project not found: #{account_handle}/#{project_handle}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _args), do: EMCP.Tool.error("Provide account_handle and project_handle.")
+end

--- a/server/lib/tuist/mcp/components/tools/automation_alert_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/automation_alert_tools.ex
@@ -1,0 +1,263 @@
+defmodule Tuist.MCP.Components.Tools.AutomationAlertTools do
+  @moduledoc false
+
+  alias Tuist.Automations
+  alias Tuist.MCP.Formatter
+
+  def alert_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "enabled" => %{"type" => "boolean"},
+        "monitor_type" => %{"type" => "string"},
+        "trigger_config" => %{"type" => "object"},
+        "cadence" => %{"type" => "string"},
+        "trigger_actions" => %{"type" => "array", "items" => %{"type" => "object"}},
+        "recovery_enabled" => %{"type" => "boolean"},
+        "recovery_config" => %{"type" => "object"},
+        "recovery_actions" => %{"type" => "array", "items" => %{"type" => "object"}}
+      },
+      "required" => [
+        "id",
+        "name",
+        "enabled",
+        "monitor_type",
+        "trigger_config",
+        "cadence",
+        "trigger_actions",
+        "recovery_enabled",
+        "recovery_config",
+        "recovery_actions"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize(alert) do
+    %{
+      id: alert.id,
+      name: alert.name,
+      enabled: alert.enabled,
+      monitor_type: alert.monitor_type,
+      trigger_config: alert.trigger_config,
+      cadence: alert.cadence,
+      trigger_actions: Enum.map(alert.trigger_actions, &Automations.redact_action/1),
+      recovery_enabled: alert.recovery_enabled,
+      recovery_config: alert.recovery_config,
+      recovery_actions: Enum.map(alert.recovery_actions, &Automations.redact_action/1)
+    }
+  end
+
+  def revision_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "event" => %{"type" => "string", "enum" => ["created", "updated"]},
+        "source" => %{"type" => "string"},
+        "actor" => %{
+          "type" => ["object", "null"],
+          "properties" => %{
+            "id" => %{"type" => "integer"},
+            "name" => %{"type" => "string"},
+            "email" => %{"type" => "string"}
+          },
+          "required" => ["id", "name", "email"],
+          "additionalProperties" => false
+        },
+        "changes" => %{"type" => "object"},
+        "snapshot" => %{"type" => "object"},
+        "inserted_at" => %{"type" => "string"}
+      },
+      "required" => ["id", "event", "source", "actor", "changes", "snapshot", "inserted_at"],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize_revision(revision) do
+    revision
+    |> Automations.redact_revision()
+    |> Map.update!(:inserted_at, &Formatter.iso8601/1)
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListAutomationAlerts do
+  @moduledoc """
+  List automation alerts for a project.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_automation_alerts",
+    title: "List Automation Alerts",
+    read_only_hint: true,
+    authorize: [action: :read, category: :automation_alert],
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle."
+        }
+      },
+      "required" => ["account_handle", "project_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "alerts" => %{
+          "type" => "array",
+          "items" => Tuist.MCP.Components.Tools.AutomationAlertTools.alert_schema()
+        }
+      },
+      "required" => ["alerts"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Automations
+  alias Tuist.MCP.Components.Tools.AutomationAlertTools
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "List automation alerts for a project. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+
+  def execute(_conn, _args, project) do
+    {:ok,
+     %{
+       alerts:
+         project.id
+         |> Automations.list_alerts()
+         |> Enum.map(&AutomationAlertTools.serialize/1)
+     }}
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetAutomationAlert do
+  @moduledoc """
+  Get an automation alert.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_automation_alert",
+    title: "Get Automation Alert",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "alert_id" => %{
+          "type" => "string",
+          "description" => "The alert ID, or a Tuist dashboard URL."
+        }
+      },
+      "required" => ["alert_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.AutomationAlertTools.alert_schema()
+
+  alias Tuist.Automations
+  alias Tuist.MCP.Components.Tools.AutomationAlertTools
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "Get an automation alert. The alert_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/settings/automations/{id}."
+
+  @impl EMCP.Tool
+  def call(conn, %{"alert_id" => alert_id}) do
+    alert_id = MCPTool.resource_id(alert_id)
+
+    case MCPTool.load_and_authorize(
+           Automations.get_alert(alert_id),
+           conn.assigns,
+           :read,
+           :automation_alert,
+           "Automation alert not found: #{alert_id}"
+         ) do
+      {:ok, alert, _project} -> MCPTool.json_response(AutomationAlertTools.serialize(alert), __MODULE__)
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListAutomationAlertRevisions do
+  @moduledoc """
+  List an automation alert's revision history.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_automation_alert_revisions",
+    title: "List Automation Alert Revisions",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "alert_id" => %{"type" => "string", "description" => "The alert ID, or a Tuist dashboard URL."},
+        "before" => %{"type" => "string", "description" => "The revision ID to continue before."},
+        "page_size" => %{"type" => "integer", "description" => "Results per page, up to 100."}
+      },
+      "required" => ["alert_id"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "revisions" => %{
+          "type" => "array",
+          "items" => Tuist.MCP.Components.Tools.AutomationAlertTools.revision_schema()
+        },
+        "next_before" => %{"type" => ["string", "null"]}
+      },
+      "required" => ["revisions", "next_before"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Automations
+  alias Tuist.MCP.Components.Tools.AutomationAlertTools
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description, do: "List an automation alert's revision history."
+
+  @impl EMCP.Tool
+  def call(conn, %{"alert_id" => alert_id} = arguments) do
+    alert_id = MCPTool.resource_id(alert_id)
+
+    with {:ok, alert, _project} <-
+           MCPTool.load_and_authorize(
+             Automations.get_alert(alert_id),
+             conn.assigns,
+             :read,
+             :automation_alert,
+             "Automation alert not found: #{alert_id}"
+           ),
+         {:ok, before} <- revision_cursor(alert.id, Map.get(arguments, "before")) do
+      page_size = arguments |> Map.get("page_size", 20) |> max(1) |> min(100)
+      revisions = Automations.list_alert_revisions(alert.id, before: before, limit: page_size + 1)
+      {page, remaining} = Enum.split(revisions, page_size)
+
+      MCPTool.json_response(
+        %{
+          revisions: Enum.map(page, &AutomationAlertTools.serialize_revision/1),
+          next_before: if(remaining == [], do: nil, else: List.last(page).id)
+        },
+        __MODULE__
+      )
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Automation alert revision not found.")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _arguments), do: EMCP.Tool.error("Provide alert_id.")
+
+  defp revision_cursor(_alert_id, nil), do: {:ok, nil}
+  defp revision_cursor(alert_id, revision_id), do: Automations.get_alert_revision(alert_id, revision_id)
+end

--- a/server/lib/tuist/mcp/components/tools/get_organization.ex
+++ b/server/lib/tuist/mcp/components/tools/get_organization.ex
@@ -1,0 +1,118 @@
+defmodule Tuist.MCP.Components.Tools.GetOrganization do
+  @moduledoc """
+  Get an organization's member directory and, for administrators, pending invitations.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_organization",
+    title: "Get Organization",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The organization account handle."}
+      },
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "handle" => %{"type" => "string"},
+        "plan" => %{"type" => "string"},
+        "members" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "integer"},
+              "email" => %{"type" => "string"},
+              "name" => %{"type" => "string"},
+              "role" => %{"type" => "string"}
+            },
+            "required" => ["id", "email", "name", "role"],
+            "additionalProperties" => false
+          }
+        },
+        "invitations" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "integer"},
+              "invitee_email" => %{"type" => "string"},
+              "role" => %{"type" => "string"},
+              "expired" => %{"type" => "boolean"}
+            },
+            "required" => ["id", "invitee_email", "role", "expired"],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["id", "handle", "plan", "members", "invitations"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Accounts
+  alias Tuist.Billing
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description do
+    "Get an organization's members. Pending invitations are included only when the caller has the same administrator permission as the dashboard's Invitations tab. Invitation acceptance tokens are never returned."
+  end
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    with {:ok, account} <- MCPTool.resolve_and_authorize_account(arguments, conn.assigns, :read, :organization),
+         {:ok, organization} <- organization_for_account(account) do
+      MCPTool.json_response(
+        %{
+          id: organization.id,
+          handle: account.name,
+          plan: to_string(Billing.effective_plan(account)),
+          members: members(organization),
+          invitations: invitations(organization, account, conn.assigns)
+        },
+        __MODULE__
+      )
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  defp organization_for_account(%{organization_id: nil}), do: {:error, "Account is not an organization."}
+
+  defp organization_for_account(account) do
+    case Accounts.get_organization_by_id(account.organization_id, preload: [:invitations]) do
+      {:ok, organization} -> {:ok, organization}
+      _ -> {:error, "Organization not found."}
+    end
+  end
+
+  defp members(organization) do
+    organization
+    |> Accounts.get_organization_members_with_role()
+    |> Enum.map(fn {member, role} ->
+      %{id: member.id, email: member.email, name: member.account.name, role: role}
+    end)
+  end
+
+  defp invitations(organization, account, assigns) do
+    case MCPTool.authorize_account(assigns, account, :read, :invitation) do
+      {:ok, _account} ->
+        Enum.map(organization.invitations, fn invitation ->
+          %{
+            id: invitation.id,
+            invitee_email: invitation.invitee_email,
+            role: invitation.role,
+            expired: Accounts.invitation_expired?(invitation)
+          }
+        end)
+
+      {:error, _message} ->
+        []
+    end
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/get_project.ex
+++ b/server/lib/tuist/mcp/components/tools/get_project.ex
@@ -1,0 +1,58 @@
+defmodule Tuist.MCP.Components.Tools.GetProject do
+  @moduledoc """
+  Get a project's dashboard configuration.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_project",
+    title: "Get Project",
+    read_only_hint: true,
+    authorize: [action: :read, category: :project],
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle."
+        }
+      },
+      "required" => ["account_handle", "project_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "full_handle" => %{"type" => "string"},
+        "default_branch" => %{"type" => "string"},
+        "visibility" => %{"type" => "string", "enum" => ["private", "public"]},
+        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+        "repository_url" => %{"type" => ["string", "null"]}
+      },
+      "required" => ["id", "full_handle", "default_branch", "visibility", "build_system", "repository_url"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Projects
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "Get a project's dashboard configuration. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+
+  def execute(_conn, _args, project) do
+    {:ok,
+     %{
+       id: project.id,
+       full_handle: "#{project.account.name}/#{project.name}",
+       default_branch: project.default_branch,
+       visibility: to_string(project.visibility),
+       build_system: to_string(project.build_system),
+       repository_url: Projects.get_repository_url(project)
+     }}
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/preview_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/preview_tools.ex
@@ -1,0 +1,442 @@
+defmodule Tuist.MCP.Components.Tools.PreviewSerializer do
+  @moduledoc """
+  Shared output schema and serialization for the preview tools.
+
+  The shape mirrors `TuistWeb.API.PreviewsController`'s `map_preview/5` so the
+  HTTP resource and the tools describe a preview identically. The one
+  deliberate divergence is `url`: the controller overwrites it with the first
+  build's download URL on `show` to keep older client versions working, while the
+  tools always report the dashboard URL and leave the download URLs on
+  `builds[].url`, where an agent can tell the two apart.
+  """
+
+  alias Tuist.AppBuilds
+  alias Tuist.AppBuilds.Preview
+  alias Tuist.Environment
+  alias Tuist.MCP.Formatter
+  alias Tuist.Storage
+
+  @download_url_expires_in 3600
+
+  def download_url_expires_in, do: @download_url_expires_in
+
+  def supported_platform_values do
+    Preview
+    |> Ecto.Enum.mappings(:supported_platforms)
+    |> Keyword.keys()
+  end
+
+  @doc """
+  Casts client-supplied platform names to the schema's atoms.
+
+  Unknown values are rejected rather than converted, so a caller can neither
+  grow the atom table nor turn an invalid filter into an unfiltered read.
+  """
+  def cast_supported_platforms(nil), do: {:ok, nil}
+
+  def cast_supported_platforms(values) when is_list(values) do
+    names = Enum.map(values, &to_string/1)
+    supported_platforms = supported_platform_values()
+
+    if Enum.all?(names, fn name -> Enum.any?(supported_platforms, fn platform -> to_string(platform) == name end) end) do
+      {:ok, Enum.filter(supported_platforms, &(to_string(&1) in names))}
+    else
+      {:error, "supported_platforms contains an unsupported platform."}
+    end
+  end
+
+  def cast_supported_platforms(value), do: cast_supported_platforms([value])
+
+  def schema(opts \\ []) do
+    type = if Keyword.get(opts, :nullable, false), do: ["object", "null"], else: "object"
+
+    %{
+      "type" => type,
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "url" => %{"type" => "string"},
+        "device_url" => %{"type" => "string"},
+        "qr_code_url" => %{"type" => "string"},
+        "icon_url" => %{"type" => "string"},
+        "version" => %{"type" => ["string", "null"]},
+        "bundle_identifier" => %{"type" => ["string", "null"]},
+        "display_name" => %{"type" => ["string", "null"]},
+        "git_commit_sha" => %{"type" => ["string", "null"]},
+        "git_branch" => %{"type" => ["string", "null"]},
+        "track" => %{"type" => ["string", "null"]},
+        "supported_platforms" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "inserted_at" => %{"type" => "string"},
+        "created_from_ci" => %{"type" => "boolean"},
+        "created_by" => %{
+          "type" => ["object", "null"],
+          "properties" => %{
+            "id" => %{"type" => "integer"},
+            "handle" => %{"type" => "string"}
+          },
+          "required" => ["id", "handle"],
+          "additionalProperties" => false
+        },
+        "builds" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "url" => %{"type" => "string"},
+              "type" => %{"type" => "string"},
+              "supported_platforms" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "inserted_at" => %{"type" => "string"},
+              "binary_id" => %{"type" => ["string", "null"]},
+              "build_version" => %{"type" => ["string", "null"]}
+            },
+            "required" => [
+              "id",
+              "url",
+              "type",
+              "supported_platforms",
+              "inserted_at",
+              "binary_id",
+              "build_version"
+            ],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => [
+        "id",
+        "url",
+        "device_url",
+        "qr_code_url",
+        "icon_url",
+        "version",
+        "bundle_identifier",
+        "display_name",
+        "git_commit_sha",
+        "git_branch",
+        "track",
+        "supported_platforms",
+        "inserted_at",
+        "created_from_ci",
+        "created_by",
+        "builds"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize(preview, project) do
+    account = project.account
+    account_handle = account.name
+    project_handle = project.name
+    supported_platforms = preview.supported_platforms || []
+
+    %{
+      id: preview.id,
+      url: preview_url(account_handle, project_handle, preview.id),
+      device_url: device_url(preview, account_handle, project_handle, supported_platforms),
+      qr_code_url: preview_url(account_handle, project_handle, preview.id, "/qr-code.png"),
+      icon_url: preview_url(account_handle, project_handle, preview.id, "/icon.png"),
+      version: preview.version,
+      bundle_identifier: preview.bundle_identifier,
+      display_name: preview.display_name,
+      git_commit_sha: preview.git_commit_sha,
+      git_branch: preview.git_branch,
+      track: preview.track,
+      supported_platforms: Enum.map(supported_platforms, &to_string/1),
+      inserted_at: Formatter.iso8601(preview.inserted_at),
+      created_by: created_by(preview.created_by_account),
+      created_from_ci: created_from_ci?(preview.created_by_account),
+      builds: builds(preview, account_handle, project_handle, account)
+    }
+  end
+
+  defp builds(preview, account_handle, project_handle, account) do
+    preview.app_builds
+    |> List.wrap()
+    |> Enum.map(fn app_build ->
+      key =
+        AppBuilds.storage_key(%{
+          account_handle: account_handle,
+          project_handle: project_handle,
+          app_build: app_build
+        })
+
+      %{
+        id: app_build.id,
+        url: Storage.generate_download_url(key, account, expires_in: @download_url_expires_in),
+        type: to_string(app_build.type),
+        supported_platforms: Enum.map(app_build.supported_platforms || [], &to_string/1),
+        inserted_at: Formatter.iso8601(app_build.inserted_at),
+        binary_id: app_build.binary_id,
+        build_version: app_build.build_version
+      }
+    end)
+    |> Enum.sort_by(& &1.inserted_at, :desc)
+  end
+
+  defp created_by(nil), do: nil
+  defp created_by(account), do: %{id: account.id, handle: account.name}
+
+  defp created_from_ci?(nil), do: true
+  defp created_from_ci?(account), do: is_nil(account.user_id)
+
+  defp device_url(preview, account_handle, project_handle, [:android]) do
+    preview_url(account_handle, project_handle, preview.id, "/app.apk")
+  end
+
+  defp device_url(preview, account_handle, project_handle, _supported_platforms) do
+    manifest_url = preview_url(account_handle, project_handle, preview.id, "/manifest.plist")
+    "itms-services://?action=download-manifest&url=#{manifest_url}"
+  end
+
+  defp preview_url(account_handle, project_handle, preview_id, suffix \\ "") do
+    Environment.app_url(path: "/#{account_handle}/#{project_handle}/previews/#{preview_id}#{suffix}")
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListPreviews do
+  @moduledoc """
+  List previews (shareable app builds) for a project.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_previews",
+    title: "List Previews",
+    read_only_hint: true,
+    authorize: [action: :read, category: :preview],
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle."
+        },
+        "display_name" => %{
+          "type" => "string",
+          "description" => "Filter by the preview's display name."
+        },
+        "specifier" => %{
+          "type" => "string",
+          "description" => ~s{Filter by a git commit SHA, a branch name, or "latest" for the project's default branch.}
+        },
+        "supported_platforms" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "string",
+            "enum" => Enum.map(Tuist.MCP.Components.Tools.PreviewSerializer.supported_platform_values(), &to_string/1)
+          },
+          "description" => "Return previews supporting any of these platforms."
+        },
+        "distinct_field" => %{
+          "type" => "string",
+          "enum" => ["bundle_identifier"],
+          "description" =>
+            "Return only the latest preview per value of this field, so a project with several apps yields one preview each."
+        },
+        "page" => %{
+          "type" => "integer",
+          "description" => "Page number (default: 1)."
+        },
+        "page_size" => %{
+          "type" => "integer",
+          "description" => "Results per page (default: 20, max: 100)."
+        }
+      },
+      "required" => ["account_handle", "project_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "previews" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.PreviewSerializer.schema()},
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["previews", "pagination_metadata"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.AppBuilds
+  alias Tuist.MCP.Components.Tools.PreviewSerializer
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "List previews (shareable app builds) for a project. Each preview includes temporary download URLs for its builds, valid for #{div(PreviewSerializer.download_url_expires_in(), 60)} minutes. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+
+  def execute(_conn, args, project) do
+    with {:ok, supported_platforms} <- PreviewSerializer.cast_supported_platforms(Map.get(args, "supported_platforms")) do
+      {previews, meta} =
+        AppBuilds.list_previews(
+          %{
+            filters: build_filters(project, args),
+            order_by: [:inserted_at],
+            order_directions: [:desc],
+            page: MCPTool.page(args),
+            page_size: MCPTool.page_size(args)
+          },
+          distinct: distinct(args),
+          supported_platforms: supported_platforms,
+          preload: [:app_builds, :created_by_account]
+        )
+
+      {:ok,
+       %{
+         previews: Enum.map(previews, &PreviewSerializer.serialize(&1, project)),
+         pagination_metadata: MCPTool.pagination_metadata(meta)
+       }}
+    end
+  end
+
+  defp distinct(args) do
+    case Map.get(args, "distinct_field") do
+      "bundle_identifier" -> [:bundle_identifier]
+      _ -> []
+    end
+  end
+
+  # Mirrors `TuistWeb.API.PreviewsController.get_filters/2`: a preview without a
+  # bundle identifier cannot be installed, so it never belongs in a listing.
+  defp build_filters(project, args) do
+    filters = [
+      %{field: :project_id, op: :==, value: project.id},
+      %{field: :bundle_identifier, op: :not_empty, value: true}
+    ]
+
+    filters = specifier_filters(project, Map.get(args, "specifier")) ++ filters
+
+    case Map.get(args, "display_name") do
+      nil -> filters
+      display_name -> [%{field: :display_name, op: :==, value: display_name} | filters]
+    end
+  end
+
+  defp specifier_filters(_project, nil), do: []
+
+  defp specifier_filters(project, "latest") do
+    [%{field: :git_branch, op: :==, value: project.default_branch}]
+  end
+
+  defp specifier_filters(_project, specifier) do
+    if Regex.match?(~r/^[a-fA-F0-9]{40}$/, specifier) do
+      [%{field: :git_commit_sha, op: :==, value: specifier}]
+    else
+      [%{field: :git_branch, op: :==, value: specifier}]
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetPreview do
+  @moduledoc """
+  Get a single preview, including download URLs for each of its builds.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_preview",
+    title: "Get Preview",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "preview_id" => %{
+          "type" => "string",
+          "description" => "The ID of the preview, or a Tuist dashboard URL."
+        }
+      },
+      "required" => ["preview_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.PreviewSerializer.schema()
+
+  alias Tuist.AppBuilds
+  alias Tuist.MCP.Components.Tools.PreviewSerializer
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "Get detailed information about a specific preview, including temporary download URLs for its builds, valid for #{div(PreviewSerializer.download_url_expires_in(), 60)} minutes. The preview_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/previews/{id}."
+
+  def execute(conn, %{"preview_id" => preview_id}) do
+    preview_id = MCPTool.resource_id(preview_id)
+
+    with {:ok, preview, project} <-
+           MCPTool.load_and_authorize(
+             AppBuilds.preview_by_id(preview_id, preload: [:app_builds, :created_by_account]),
+             conn.assigns,
+             :read,
+             :preview,
+             "Preview not found: #{preview_id}"
+           ) do
+      {:ok, PreviewSerializer.serialize(preview, project)}
+    end
+  end
+
+  def execute(_conn, _args), do: {:error, "Provide preview_id."}
+end
+
+defmodule Tuist.MCP.Components.Tools.GetLatestPreview do
+  @moduledoc """
+  Get the latest preview on the same track as a running binary.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_latest_preview",
+    title: "Get Latest Preview",
+    read_only_hint: true,
+    authorize: [action: :read, category: :preview],
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user)."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle."
+        },
+        "binary_id" => %{
+          "type" => "string",
+          "description" => "A unique identifier for the running binary."
+        },
+        "build_version" => %{
+          "type" => "string",
+          "description" => "The build version of the running app."
+        }
+      },
+      "required" => ["account_handle", "project_handle", "binary_id", "build_version"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "preview" => Tuist.MCP.Components.Tools.PreviewSerializer.schema(nullable: true)
+      },
+      "required" => ["preview"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.AppBuilds
+  alias Tuist.MCP.Components.Tools.PreviewSerializer
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "Given the binary ID and build version of a running app, get the latest preview on the same track (same bundle identifier and git branch). Returns null when no matching build is known. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+
+  def execute(_conn, %{"binary_id" => binary_id, "build_version" => build_version}, project) do
+    case AppBuilds.latest_preview_for_binary_id_and_build_version(binary_id, build_version, project,
+           preload: [:app_builds, :created_by_account]
+         ) do
+      {:ok, preview} -> {:ok, %{preview: PreviewSerializer.serialize(preview, project)}}
+      {:error, :not_found} -> {:ok, %{preview: nil}}
+    end
+  end
+
+  def execute(_conn, _args, _project), do: {:error, "Provide binary_id and build_version."}
+end

--- a/server/lib/tuist/mcp/components/tools/project_notification_alert_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/project_notification_alert_tools.ex
@@ -1,0 +1,108 @@
+defmodule Tuist.MCP.Components.Tools.ListProjectNotificationAlerts do
+  @moduledoc """
+  List a project's notification alert rules.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_project_notification_alerts",
+    title: "List Project Notification Alerts",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "project_handle" => %{"type" => "string", "description" => "The project handle."}
+      },
+      "required" => ["account_handle", "project_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "alert_rules" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "name" => %{"type" => "string"},
+              "category" => %{"type" => "string"},
+              "metric" => %{"type" => "string"},
+              "deviation_percentage" => %{"type" => "number"},
+              "rolling_window_size" => %{"type" => ["integer", "null"]},
+              "git_branch" => %{"type" => ["string", "null"]},
+              "scheme" => %{"type" => "string"},
+              "bundle_name" => %{"type" => "string"},
+              "environment" => %{"type" => "string"},
+              "slack_channel_id" => %{"type" => ["string", "null"]},
+              "slack_channel_name" => %{"type" => ["string", "null"]},
+              "webhook_configured" => %{"type" => "boolean"},
+              "inserted_at" => %{"type" => "string"},
+              "updated_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "name",
+              "category",
+              "metric",
+              "deviation_percentage",
+              "rolling_window_size",
+              "git_branch",
+              "scheme",
+              "bundle_name",
+              "environment",
+              "slack_channel_id",
+              "slack_channel_name",
+              "webhook_configured",
+              "inserted_at",
+              "updated_at"
+            ],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["alert_rules"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.Alerts
+  alias Tuist.MCP.Formatter
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  @impl EMCP.Tool
+  def description, do: "List a project's notification alert rules. Webhook addresses are never returned."
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    case MCPTool.resolve_and_authorize_project(arguments, conn.assigns, :update, :project) do
+      {:ok, project} ->
+        MCPTool.json_response(
+          %{alert_rules: Enum.map(Alerts.get_project_alert_rules(project), &serialize/1)},
+          __MODULE__
+        )
+
+      {:error, message} ->
+        EMCP.Tool.error(message)
+    end
+  end
+
+  defp serialize(alert_rule) do
+    %{
+      id: alert_rule.id,
+      name: alert_rule.name,
+      category: to_string(alert_rule.category),
+      metric: to_string(alert_rule.metric),
+      deviation_percentage: alert_rule.deviation_percentage,
+      rolling_window_size: alert_rule.rolling_window_size,
+      git_branch: alert_rule.git_branch,
+      scheme: alert_rule.scheme,
+      bundle_name: alert_rule.bundle_name,
+      environment: to_string(alert_rule.environment),
+      slack_channel_id: alert_rule.slack_channel_id,
+      slack_channel_name: alert_rule.slack_channel_name,
+      webhook_configured: is_binary(alert_rule.slack_webhook_url) and alert_rule.slack_webhook_url != "",
+      inserted_at: Formatter.iso8601(alert_rule.inserted_at),
+      updated_at: Formatter.iso8601(alert_rule.updated_at)
+    }
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/runner_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/runner_tools.ex
@@ -1,0 +1,707 @@
+defmodule Tuist.MCP.Components.Tools.RunnerTools do
+  @moduledoc false
+
+  alias Tuist.FeatureFlags
+  alias Tuist.MCP.Formatter
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  def authorize_account(arguments, assigns) do
+    with {:ok, account} <- MCPTool.resolve_and_authorize_account(arguments, assigns, :read, :runners),
+         true <- FeatureFlags.runners_enabled?(account) do
+      {:ok, account}
+    else
+      false -> {:error, "Runners are not enabled for this account."}
+      {:error, _message} = error -> error
+    end
+  end
+
+  def authorize_profiles_account(arguments, assigns) do
+    with {:ok, account} <- MCPTool.resolve_and_authorize_account(arguments, assigns, :update, :account),
+         true <- FeatureFlags.runners_enabled?(account) do
+      {:ok, account}
+    else
+      false -> {:error, "Runners are not enabled for this account."}
+      {:error, _message} = error -> error
+    end
+  end
+
+  def job_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "workflow_job_id" => %{"type" => "integer"},
+        "repository" => %{"type" => "string"},
+        "workflow_run_id" => %{"type" => "integer"},
+        "workflow_name" => %{"type" => "string"},
+        "run_attempt" => %{"type" => "integer"},
+        "job_name" => %{"type" => "string"},
+        "head_branch" => %{"type" => "string"},
+        "head_sha" => %{"type" => "string"},
+        "status" => %{"type" => "string"},
+        "conclusion" => %{"type" => "string"},
+        "platform" => %{"type" => "string"},
+        "vcpus" => %{"type" => "integer"},
+        "memory_gb" => %{"type" => "integer"},
+        "requested_dispatch_label" => %{"type" => "string"},
+        "enqueued_at" => %{"type" => "string"},
+        "claimed_at" => %{"type" => ["string", "null"]},
+        "started_at" => %{"type" => ["string", "null"]},
+        "completed_at" => %{"type" => ["string", "null"]},
+        "log_archived_at" => %{"type" => ["string", "null"]},
+        "updated_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "workflow_job_id",
+        "repository",
+        "workflow_run_id",
+        "workflow_name",
+        "run_attempt",
+        "job_name",
+        "head_branch",
+        "head_sha",
+        "status",
+        "conclusion",
+        "platform",
+        "vcpus",
+        "memory_gb",
+        "requested_dispatch_label",
+        "enqueued_at",
+        "claimed_at",
+        "started_at",
+        "completed_at",
+        "log_archived_at",
+        "updated_at"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def workflow_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "workflow_name" => %{"type" => "string"},
+        "repository" => %{"type" => "string"},
+        "total_jobs" => %{"type" => "integer"},
+        "success_count" => %{"type" => "integer"},
+        "failure_count" => %{"type" => "integer"},
+        "cancelled_count" => %{"type" => "integer"},
+        "skipped_count" => %{"type" => "integer"},
+        "in_progress_count" => %{"type" => "integer"},
+        "avg_duration_ms" => %{"type" => ["number", "null"]},
+        "last_run_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "workflow_name",
+        "repository",
+        "total_jobs",
+        "success_count",
+        "failure_count",
+        "cancelled_count",
+        "skipped_count",
+        "in_progress_count",
+        "avg_duration_ms",
+        "last_run_at"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def profile_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "name" => %{"type" => "string"},
+        "platform" => %{"type" => "string", "enum" => ["linux", "macos"]},
+        "vcpus" => %{"type" => "integer"},
+        "memory_gb" => %{"type" => "integer"},
+        "xcode_version" => %{"type" => ["string", "null"]},
+        "protected" => %{"type" => "boolean"},
+        "inserted_at" => %{"type" => "string"},
+        "updated_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "name",
+        "platform",
+        "vcpus",
+        "memory_gb",
+        "xcode_version",
+        "protected",
+        "inserted_at",
+        "updated_at"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def job_step_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "number" => %{"type" => "integer"},
+        "name" => %{"type" => "string"},
+        "status" => %{"type" => "string"},
+        "conclusion" => %{"type" => "string"},
+        "started_at" => %{"type" => ["string", "null"]},
+        "completed_at" => %{"type" => ["string", "null"]}
+      },
+      "required" => ["number", "name", "status", "conclusion", "started_at", "completed_at"],
+      "additionalProperties" => false
+    }
+  end
+
+  def job_metric_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "timestamp" => %{"type" => "number"},
+        "cpu_usage_percent" => %{"type" => "number"},
+        "cpu_iowait_percent" => %{"type" => "number"},
+        "memory_used_bytes" => %{"type" => "integer"},
+        "memory_total_bytes" => %{"type" => "integer"},
+        "network_bytes_in" => %{"type" => "integer"},
+        "network_bytes_out" => %{"type" => "integer"},
+        "disk_used_bytes" => %{"type" => "integer"},
+        "disk_total_bytes" => %{"type" => "integer"}
+      },
+      "required" => [
+        "timestamp",
+        "cpu_usage_percent",
+        "cpu_iowait_percent",
+        "memory_used_bytes",
+        "memory_total_bytes",
+        "network_bytes_in",
+        "network_bytes_out",
+        "disk_used_bytes",
+        "disk_total_bytes"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def job_log_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "line_number" => %{"type" => "integer"},
+        "ts" => %{"type" => ["string", "null"]},
+        "message" => %{"type" => "string"}
+      },
+      "required" => ["line_number", "ts", "message"],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize_job(job) do
+    %{
+      workflow_job_id: job.workflow_job_id,
+      repository: job.repository,
+      workflow_run_id: job.workflow_run_id,
+      workflow_name: job.workflow_name,
+      run_attempt: job.run_attempt,
+      job_name: job.job_name,
+      head_branch: job.head_branch,
+      head_sha: job.head_sha,
+      status: job.status,
+      conclusion: job.conclusion,
+      platform: job.platform,
+      vcpus: job.vcpus,
+      memory_gb: job.memory_gb,
+      requested_dispatch_label: job.requested_dispatch_label,
+      enqueued_at: Formatter.iso8601(job.enqueued_at),
+      claimed_at: Formatter.iso8601(job.claimed_at),
+      started_at: Formatter.iso8601(job.started_at),
+      completed_at: Formatter.iso8601(job.completed_at),
+      log_archived_at: Formatter.iso8601(job.log_archived_at),
+      updated_at: Formatter.iso8601(job.updated_at)
+    }
+  end
+
+  def serialize_workflow(workflow) do
+    %{
+      workflow_name: workflow.workflow_name,
+      repository: workflow.repository,
+      total_jobs: workflow.total_jobs,
+      success_count: workflow.success_count,
+      failure_count: workflow.failure_count,
+      cancelled_count: workflow.cancelled_count,
+      skipped_count: workflow.skipped_count,
+      in_progress_count: workflow.in_progress_count,
+      avg_duration_ms: workflow.avg_duration_ms,
+      last_run_at: Formatter.iso8601(workflow.last_run_at)
+    }
+  end
+
+  def serialize_profile(profile) do
+    %{
+      id: profile.id,
+      name: profile.name,
+      platform: to_string(profile.platform),
+      vcpus: profile.vcpus,
+      memory_gb: profile.memory_gb,
+      xcode_version: profile.xcode_version,
+      protected: profile.protected,
+      inserted_at: Formatter.iso8601(profile.inserted_at),
+      updated_at: Formatter.iso8601(profile.updated_at)
+    }
+  end
+
+  def serialize_job_step(step) do
+    %{
+      number: step.number,
+      name: step.name,
+      status: step.status,
+      conclusion: step.conclusion,
+      started_at: Formatter.iso8601(step.started_at),
+      completed_at: Formatter.iso8601(step.completed_at)
+    }
+  end
+
+  def serialize_job_metric(metric), do: metric
+
+  def serialize_job_log(line) do
+    %{line_number: line.line_number, ts: Formatter.iso8601(line.ts), message: line.message}
+  end
+
+  def with_job(account, workflow_job_id, fun) do
+    case Tuist.Runners.Jobs.get_for_account(account.id, workflow_job_id) do
+      {:ok, job} -> fun.(job)
+      {:error, :not_found} -> {:error, "Runner job not found: #{workflow_job_id}"}
+    end
+  end
+
+  def jobs_options(arguments) do
+    Enum.flat_map(
+      [
+        :status,
+        :conclusion,
+        :repository,
+        :workflow_name,
+        :job_name,
+        :head_branch,
+        :platform,
+        :search,
+        :sort_by,
+        :sort_order
+      ],
+      fn key -> if value = Map.get(arguments, Atom.to_string(key)), do: [{key, value}], else: [] end
+    )
+  end
+
+  def workflows_options(arguments) do
+    Enum.flat_map([:repository, :workflow_name, :head_branch, :platform, :sort_by, :sort_order], fn key ->
+      if value = Map.get(arguments, Atom.to_string(key)), do: [{key, value}], else: []
+    end)
+  end
+
+  def pagination_metadata(page, page_size, total_count) do
+    total_pages = ceil(total_count / page_size)
+
+    %{
+      has_next_page: page < total_pages,
+      has_previous_page: page > 1,
+      total_count: total_count,
+      total_pages: total_pages,
+      current_page: page,
+      page_size: page_size
+    }
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerJobs do
+  @moduledoc """
+  List CI runner jobs for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_jobs",
+    title: "List Runner Jobs",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "page" => %{"type" => "integer", "description" => "Page number (default: 1)."},
+        "page_size" => %{"type" => "integer", "description" => "Results per page (default: 20, maximum: 100)."},
+        "status" => %{"type" => "string", "enum" => ["queued", "claimed", "running", "completed"]},
+        "conclusion" => %{"type" => "string", "enum" => ["success", "failure", "cancelled", "skipped"]},
+        "repository" => %{"type" => "string"},
+        "workflow_name" => %{"type" => "string"},
+        "job_name" => %{"type" => "string"},
+        "head_branch" => %{"type" => "string"},
+        "platform" => %{"type" => "string", "enum" => ["linux", "macos"]},
+        "search" => %{"type" => "string"},
+        "sort_by" => %{"type" => "string", "enum" => ["enqueued", "job", "workflow", "duration"]},
+        "sort_order" => %{"type" => "string", "enum" => ["asc", "desc"]}
+      },
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "jobs" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.job_schema()},
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["jobs", "pagination_metadata"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.Jobs
+
+  @impl EMCP.Tool
+  def description, do: "List CI runner jobs for an account."
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns) do
+      page = MCPTool.page(arguments)
+      page_size = MCPTool.page_size(arguments)
+      base_options = RunnerTools.jobs_options(arguments)
+      total_count = Jobs.count_for_account(account.id, base_options)
+
+      jobs =
+        Jobs.list_for_account(
+          account.id,
+          base_options ++ [limit: page_size, offset: (page - 1) * page_size]
+        )
+
+      MCPTool.json_response(
+        %{
+          jobs: Enum.map(jobs, &RunnerTools.serialize_job/1),
+          pagination_metadata: RunnerTools.pagination_metadata(page, page_size, total_count)
+        },
+        __MODULE__
+      )
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetRunnerJob do
+  @moduledoc """
+  Get a CI runner job for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_runner_job",
+    title: "Get Runner Job",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "workflow_job_id" => %{"type" => "integer", "description" => "The workflow job identifier."}
+      },
+      "required" => ["account_handle", "workflow_job_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.RunnerTools.job_schema()
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.Jobs
+
+  @impl EMCP.Tool
+  def description, do: "Get a CI runner job for an account."
+
+  @impl EMCP.Tool
+  def call(conn, %{"workflow_job_id" => workflow_job_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns),
+         {:ok, job} <- Jobs.get_for_account(account.id, workflow_job_id) do
+      MCPTool.json_response(RunnerTools.serialize_job(job), __MODULE__)
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Runner job not found: #{workflow_job_id}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _arguments), do: EMCP.Tool.error("Provide account_handle and workflow_job_id.")
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerWorkflows do
+  @moduledoc """
+  List CI runner workflows for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_workflows",
+    title: "List Runner Workflows",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "page" => %{"type" => "integer", "description" => "Page number (default: 1)."},
+        "page_size" => %{"type" => "integer", "description" => "Results per page (default: 20, maximum: 100)."},
+        "repository" => %{"type" => "string"},
+        "workflow_name" => %{"type" => "string"},
+        "head_branch" => %{"type" => "string"},
+        "platform" => %{"type" => "string", "enum" => ["linux", "macos"]},
+        "sort_by" => %{"type" => "string", "enum" => ["workflow", "success_rate", "jobs", "avg_duration"]},
+        "sort_order" => %{"type" => "string", "enum" => ["asc", "desc"]}
+      },
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "workflows" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.workflow_schema()},
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["workflows", "pagination_metadata"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.Jobs
+
+  @impl EMCP.Tool
+  def description, do: "List CI runner workflows for an account."
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns) do
+      page = MCPTool.page(arguments)
+      page_size = MCPTool.page_size(arguments)
+      base_options = RunnerTools.workflows_options(arguments)
+      total_count = Jobs.count_workflows_for_account(account.id, base_options)
+
+      workflows =
+        Jobs.list_workflows_for_account(
+          account.id,
+          base_options ++ [limit: page_size, offset: (page - 1) * page_size]
+        )
+
+      MCPTool.json_response(
+        %{
+          workflows: Enum.map(workflows, &RunnerTools.serialize_workflow/1),
+          pagination_metadata: RunnerTools.pagination_metadata(page, page_size, total_count)
+        },
+        __MODULE__
+      )
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerProfiles do
+  @moduledoc """
+  List CI runner profiles for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_profiles",
+    title: "List Runner Profiles",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."}
+      },
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "profiles" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.profile_schema()}
+      },
+      "required" => ["profiles"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.Profiles
+
+  @impl EMCP.Tool
+  def description, do: "List CI runner profiles for an account."
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_profiles_account(arguments, conn.assigns) do
+      profiles = account |> Profiles.list_for_account() |> Enum.map(&RunnerTools.serialize_profile/1)
+      MCPTool.json_response(%{profiles: profiles}, __MODULE__)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerJobSteps do
+  @moduledoc """
+  List the steps recorded for a CI runner job.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_job_steps",
+    title: "List Runner Job Steps",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "workflow_job_id" => %{"type" => "integer", "description" => "The workflow job identifier."}
+      },
+      "required" => ["account_handle", "workflow_job_id"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "steps" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.job_step_schema()}
+      },
+      "required" => ["steps"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.JobSteps
+
+  @impl EMCP.Tool
+  def description, do: "List the steps recorded for a CI runner job."
+
+  @impl EMCP.Tool
+  def call(conn, %{"workflow_job_id" => workflow_job_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns),
+         {:ok, response} <-
+           RunnerTools.with_job(account, workflow_job_id, fn job ->
+             {:ok, %{steps: Enum.map(JobSteps.list_for_job(job.workflow_job_id), &RunnerTools.serialize_job_step/1)}}
+           end) do
+      MCPTool.json_response(response, __MODULE__)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _arguments), do: EMCP.Tool.error("Provide account_handle and workflow_job_id.")
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerJobMetrics do
+  @moduledoc """
+  List machine metrics recorded for a CI runner job.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_job_metrics",
+    title: "List Runner Job Metrics",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "workflow_job_id" => %{"type" => "integer", "description" => "The workflow job identifier."}
+      },
+      "required" => ["account_handle", "workflow_job_id"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "metrics" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.job_metric_schema()}
+      },
+      "required" => ["metrics"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.JobMetrics
+
+  @impl EMCP.Tool
+  def description, do: "List machine metrics recorded for a CI runner job."
+
+  @impl EMCP.Tool
+  def call(conn, %{"workflow_job_id" => workflow_job_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns),
+         {:ok, response} <-
+           RunnerTools.with_job(account, workflow_job_id, fn job ->
+             {:ok,
+              %{metrics: Enum.map(JobMetrics.list_for_job(job.workflow_job_id), &RunnerTools.serialize_job_metric/1)}}
+           end) do
+      MCPTool.json_response(response, __MODULE__)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _arguments), do: EMCP.Tool.error("Provide account_handle and workflow_job_id.")
+end
+
+defmodule Tuist.MCP.Components.Tools.ListRunnerJobLogs do
+  @moduledoc """
+  List captured log lines for a CI runner job.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_runner_job_logs",
+    title: "List Runner Job Logs",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "workflow_job_id" => %{"type" => "integer", "description" => "The workflow job identifier."},
+        "offset" => %{"type" => "integer", "description" => "Zero-based log-line offset."},
+        "limit" => %{"type" => "integer", "description" => "Maximum number of lines, up to 500."}
+      },
+      "required" => ["account_handle", "workflow_job_id"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "lines" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.RunnerTools.job_log_schema()}
+      },
+      "required" => ["lines"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.RunnerTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Runners.JobLogs
+
+  @impl EMCP.Tool
+  def description, do: "List captured log lines for a CI runner job."
+
+  @impl EMCP.Tool
+  def call(conn, %{"workflow_job_id" => workflow_job_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- RunnerTools.authorize_account(arguments, conn.assigns),
+         {:ok, response} <-
+           RunnerTools.with_job(account, workflow_job_id, fn job ->
+             limit = arguments |> Map.get("limit", 200) |> max(1) |> min(500)
+             offset = arguments |> Map.get("offset", 0) |> max(0)
+
+             {:ok,
+              %{
+                lines:
+                  job.workflow_job_id
+                  |> JobLogs.list_for_job(limit: limit, offset: offset)
+                  |> Enum.map(&RunnerTools.serialize_job_log/1)
+              }}
+           end) do
+      MCPTool.json_response(response, __MODULE__)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  def call(_conn, _arguments), do: EMCP.Tool.error("Provide account_handle and workflow_job_id.")
+end

--- a/server/lib/tuist/mcp/components/tools/webhook_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/webhook_tools.ex
@@ -1,0 +1,401 @@
+defmodule Tuist.MCP.Components.Tools.WebhookTools do
+  @moduledoc false
+
+  alias Tuist.MCP.Formatter
+  alias Tuist.MCP.Tool, as: MCPTool
+
+  def authorize_account(arguments, assigns),
+    do: MCPTool.resolve_and_authorize_account(arguments, assigns, :update, :account)
+
+  def uuid_from_resource_id(value, resource_name) do
+    case value |> MCPTool.resource_id() |> Ecto.UUID.cast() do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, "#{resource_name} identifier must be a UUID."}
+    end
+  end
+
+  def endpoint_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "url" => %{"type" => "string"},
+        "signing_secret_last_four" => %{"type" => ["string", "null"]},
+        "event_types" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "inserted_at" => %{"type" => "string"},
+        "updated_at" => %{"type" => "string"}
+      },
+      "required" => ["id", "name", "url", "signing_secret_last_four", "event_types", "inserted_at", "updated_at"],
+      "additionalProperties" => false
+    }
+  end
+
+  def delivery_attempt_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "webhook_endpoint_id" => %{"type" => "string"},
+        "event_id" => %{"type" => "string"},
+        "event_type" => %{"type" => "string"},
+        "attempt" => %{"type" => "integer"},
+        "status" => %{"type" => "string", "enum" => ["delivered", "failed"]},
+        "request_body" => %{"type" => "string"},
+        "request_headers" => %{"type" => "string"},
+        "response_status" => %{"type" => "integer"},
+        "response_headers" => %{"type" => "string"},
+        "response_body" => %{"type" => "string"},
+        "error" => %{"type" => "string"},
+        "duration_ms" => %{"type" => "integer"},
+        "inserted_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "webhook_endpoint_id",
+        "event_id",
+        "event_type",
+        "attempt",
+        "status",
+        "request_body",
+        "request_headers",
+        "response_status",
+        "response_headers",
+        "response_body",
+        "error",
+        "duration_ms",
+        "inserted_at"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def cursor_pagination_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "has_next_page" => %{"type" => "boolean"},
+        "has_previous_page" => %{"type" => "boolean"},
+        "current_page" => %{"type" => ["integer", "null"]},
+        "page_size" => %{"type" => "integer"},
+        "total_count" => %{"type" => ["integer", "null"]},
+        "total_pages" => %{"type" => ["integer", "null"]},
+        "start_cursor" => %{"type" => ["string", "null"]},
+        "end_cursor" => %{"type" => ["string", "null"]}
+      },
+      "required" => [
+        "has_next_page",
+        "has_previous_page",
+        "current_page",
+        "page_size",
+        "total_count",
+        "total_pages",
+        "start_cursor",
+        "end_cursor"
+      ],
+      "additionalProperties" => false
+    }
+  end
+
+  def serialize_endpoint(endpoint) do
+    %{
+      id: endpoint.id,
+      name: endpoint.name,
+      url: endpoint.url,
+      signing_secret_last_four: endpoint.signing_secret_last_four,
+      event_types: endpoint.event_types,
+      inserted_at: Formatter.iso8601(endpoint.inserted_at),
+      updated_at: Formatter.iso8601(endpoint.updated_at)
+    }
+  end
+
+  def serialize_delivery_attempt(attempt) do
+    %{
+      id: attempt.id,
+      webhook_endpoint_id: attempt.webhook_endpoint_id,
+      event_id: attempt.event_id,
+      event_type: attempt.event_type,
+      attempt: attempt.attempt,
+      status: attempt.status,
+      request_body: attempt.request_body,
+      request_headers: attempt.request_headers,
+      response_status: attempt.response_status,
+      response_headers: attempt.response_headers,
+      response_body: attempt.response_body,
+      error: attempt.error,
+      duration_ms: attempt.duration_ms,
+      inserted_at: Formatter.iso8601(attempt.inserted_at)
+    }
+  end
+
+  def delivery_options(arguments) do
+    with :ok <- validate_cursors(arguments),
+         {:ok, start_datetime} <- parse_datetime(arguments, "start_datetime"),
+         {:ok, end_datetime} <- parse_datetime(arguments, "end_datetime") do
+      options =
+        Enum.reject(
+          [
+            page_size: MCPTool.page_size(arguments),
+            after: blank_to_nil(Map.get(arguments, "after")),
+            before: blank_to_nil(Map.get(arguments, "before")),
+            start_datetime: start_datetime,
+            end_datetime: end_datetime,
+            status: status(Map.get(arguments, "status")),
+            event_type: blank_to_nil(Map.get(arguments, "event_type")),
+            event_id_search: blank_to_nil(Map.get(arguments, "event_id_search"))
+          ],
+          fn {_key, value} -> is_nil(value) end
+        )
+
+      {:ok, options}
+    end
+  end
+
+  def pagination_metadata(metadata) do
+    %{
+      has_next_page: metadata.has_next_page?,
+      has_previous_page: metadata.has_previous_page?,
+      current_page: metadata.current_page,
+      page_size: metadata.page_size,
+      total_count: metadata.total_count,
+      total_pages: metadata.total_pages,
+      start_cursor: metadata.start_cursor,
+      end_cursor: metadata.end_cursor
+    }
+  end
+
+  defp validate_cursors(%{"after" => after_cursor, "before" => before_cursor})
+       when is_binary(after_cursor) and after_cursor != "" and is_binary(before_cursor) and before_cursor != "",
+       do: {:error, "Use only one of after or before."}
+
+  defp validate_cursors(_arguments), do: :ok
+
+  defp parse_datetime(arguments, key) do
+    case blank_to_nil(Map.get(arguments, key)) do
+      nil ->
+        {:ok, nil}
+
+      value ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> {:ok, datetime}
+          _ -> {:error, "#{key} must be an ISO 8601 datetime."}
+        end
+    end
+  end
+
+  defp status("delivered"), do: :delivered
+  defp status("failed"), do: :failed
+  defp status(_value), do: nil
+
+  defp blank_to_nil(value) when is_binary(value) and value != "", do: value
+  defp blank_to_nil(_value), do: nil
+end
+
+defmodule Tuist.MCP.Components.Tools.ListWebhookEndpoints do
+  @moduledoc """
+  List webhook endpoints for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_webhook_endpoints",
+    title: "List Webhook Endpoints",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{"account_handle" => %{"type" => "string", "description" => "The account handle."}},
+      "required" => ["account_handle"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "endpoints" => %{"type" => "array", "items" => Tuist.MCP.Components.Tools.WebhookTools.endpoint_schema()}
+      },
+      "required" => ["endpoints"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.WebhookTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Webhooks
+
+  @impl EMCP.Tool
+  def description, do: "List webhook endpoints for an account."
+
+  @impl EMCP.Tool
+  def call(conn, arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, account} <- WebhookTools.authorize_account(arguments, conn.assigns) do
+      endpoints = account.id |> Webhooks.list_endpoints() |> Enum.map(&WebhookTools.serialize_endpoint/1)
+      MCPTool.json_response(%{endpoints: endpoints}, __MODULE__)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetWebhookEndpoint do
+  @moduledoc """
+  Get a webhook endpoint for an account.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_webhook_endpoint",
+    title: "Get Webhook Endpoint",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "webhook_endpoint_id" => %{
+          "type" => "string",
+          "description" => "The webhook endpoint identifier or dashboard URL."
+        }
+      },
+      "required" => ["account_handle", "webhook_endpoint_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.WebhookTools.endpoint_schema()
+
+  alias Tuist.MCP.Components.Tools.WebhookTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Webhooks
+
+  @impl EMCP.Tool
+  def description, do: "Get a webhook endpoint for an account."
+
+  @impl EMCP.Tool
+  def call(conn, %{"webhook_endpoint_id" => endpoint_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, endpoint_id} <- WebhookTools.uuid_from_resource_id(endpoint_id, "Webhook endpoint"),
+         {:ok, account} <- WebhookTools.authorize_account(arguments, conn.assigns),
+         {:ok, endpoint} <- Webhooks.get_account_endpoint(endpoint_id, account.id) do
+      MCPTool.json_response(WebhookTools.serialize_endpoint(endpoint), __MODULE__)
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Webhook endpoint not found: #{endpoint_id}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.ListWebhookDeliveryAttempts do
+  @moduledoc """
+  List webhook delivery attempts for an endpoint.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "list_webhook_delivery_attempts",
+    title: "List Webhook Delivery Attempts",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "webhook_endpoint_id" => %{
+          "type" => "string",
+          "description" => "The webhook endpoint identifier or dashboard URL."
+        },
+        "page_size" => %{"type" => "integer", "description" => "Results per page (default: 20, maximum: 100)."},
+        "after" => %{"type" => "string", "description" => "Cursor for the next page."},
+        "before" => %{"type" => "string", "description" => "Cursor for the previous page."},
+        "start_datetime" => %{"type" => "string", "description" => "Inclusive ISO 8601 start time."},
+        "end_datetime" => %{"type" => "string", "description" => "Inclusive ISO 8601 end time."},
+        "status" => %{"type" => "string", "enum" => ["delivered", "failed"]},
+        "event_type" => %{"type" => "string"},
+        "event_id_search" => %{"type" => "string"}
+      },
+      "required" => ["account_handle", "webhook_endpoint_id"],
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "delivery_attempts" => %{
+          "type" => "array",
+          "items" => Tuist.MCP.Components.Tools.WebhookTools.delivery_attempt_schema()
+        },
+        "pagination_metadata" => Tuist.MCP.Components.Tools.WebhookTools.cursor_pagination_schema()
+      },
+      "required" => ["delivery_attempts", "pagination_metadata"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.Components.Tools.WebhookTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Webhooks
+
+  @impl EMCP.Tool
+  def description, do: "List webhook delivery attempts for an endpoint."
+
+  @impl EMCP.Tool
+  def call(conn, %{"webhook_endpoint_id" => endpoint_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, endpoint_id} <- WebhookTools.uuid_from_resource_id(endpoint_id, "Webhook endpoint"),
+         {:ok, account} <- WebhookTools.authorize_account(arguments, conn.assigns),
+         {:ok, endpoint} <- Webhooks.get_account_endpoint(endpoint_id, account.id),
+         {:ok, options} <- WebhookTools.delivery_options(arguments) do
+      {attempts, metadata} = Webhooks.list_deliveries(endpoint.id, options)
+
+      MCPTool.json_response(
+        %{
+          delivery_attempts: Enum.map(attempts, &WebhookTools.serialize_delivery_attempt/1),
+          pagination_metadata: WebhookTools.pagination_metadata(metadata)
+        },
+        __MODULE__
+      )
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Webhook endpoint not found: #{endpoint_id}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end
+
+defmodule Tuist.MCP.Components.Tools.GetWebhookDeliveryAttempt do
+  @moduledoc """
+  Get a webhook delivery attempt for an endpoint.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_webhook_delivery_attempt",
+    title: "Get Webhook Delivery Attempt",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{"type" => "string", "description" => "The account handle."},
+        "webhook_endpoint_id" => %{
+          "type" => "string",
+          "description" => "The webhook endpoint identifier or dashboard URL."
+        },
+        "delivery_attempt_id" => %{
+          "type" => "string",
+          "description" => "The delivery attempt identifier or dashboard URL."
+        }
+      },
+      "required" => ["account_handle", "webhook_endpoint_id", "delivery_attempt_id"],
+      "additionalProperties" => false
+    },
+    output_schema: Tuist.MCP.Components.Tools.WebhookTools.delivery_attempt_schema()
+
+  alias Tuist.MCP.Components.Tools.WebhookTools
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Webhooks
+
+  @impl EMCP.Tool
+  def description, do: "Get a webhook delivery attempt for an endpoint."
+
+  @impl EMCP.Tool
+  def call(conn, %{"webhook_endpoint_id" => endpoint_id, "delivery_attempt_id" => attempt_id} = arguments) do
+    with :ok <- MCPTool.validate_input(__MODULE__, arguments),
+         {:ok, endpoint_id} <- WebhookTools.uuid_from_resource_id(endpoint_id, "Webhook endpoint"),
+         {:ok, attempt_id} <- WebhookTools.uuid_from_resource_id(attempt_id, "Webhook delivery attempt"),
+         {:ok, account} <- WebhookTools.authorize_account(arguments, conn.assigns),
+         {:ok, endpoint} <- Webhooks.get_account_endpoint(endpoint_id, account.id),
+         {:ok, attempt} <- Webhooks.get_delivery_attempt(endpoint.id, attempt_id) do
+      MCPTool.json_response(WebhookTools.serialize_delivery_attempt(attempt), __MODULE__)
+    else
+      {:error, :not_found} -> EMCP.Tool.error("Webhook delivery attempt not found: #{attempt_id}")
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+end

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -20,9 +20,23 @@ defmodule Tuist.MCP.Server do
   @tools [
     Tools.GetGradleIntegrationGuide,
     Tools.ListAccounts,
+    Tools.GetOrganization,
+    Tools.ListAccountTokens,
+    Tools.GetAccountToken,
     Tools.CreateOrganization,
     Tools.CreateProject,
     Tools.AddOrganizationMember,
+    Tools.ListRunnerJobs,
+    Tools.GetRunnerJob,
+    Tools.ListRunnerJobSteps,
+    Tools.ListRunnerJobMetrics,
+    Tools.ListRunnerJobLogs,
+    Tools.ListRunnerWorkflows,
+    Tools.ListRunnerProfiles,
+    Tools.ListWebhookEndpoints,
+    Tools.GetWebhookEndpoint,
+    Tools.ListWebhookDeliveryAttempts,
+    Tools.GetWebhookDeliveryAttempt,
     Tools.ListXcodeBuilds,
     Tools.GetXcodeBuild,
     Tools.ListXcodeBuildTargets,
@@ -51,9 +65,18 @@ defmodule Tuist.MCP.Server do
     Tools.GetGeneration,
     Tools.ListCacheRuns,
     Tools.GetCacheRun,
+    Tools.ListAutomationAlerts,
+    Tools.GetAutomationAlert,
+    Tools.ListAutomationAlertRevisions,
+    Tools.ListProjectNotificationAlerts,
     Tools.ListXcodeModuleCacheTargets,
     Tools.ListXcodeTestTargets,
-    Tools.ListProjects
+    Tools.ListProjects,
+    Tools.GetProject,
+    Tools.ListProjectTokens,
+    Tools.ListPreviews,
+    Tools.GetPreview,
+    Tools.GetLatestPreview
   ]
 
   @prompts [
@@ -84,7 +107,7 @@ defmodule Tuist.MCP.Server do
   def server do
     EMCP.Server.new(
       name: "tuist",
-      version: "1.16.0",
+      version: "1.22.0",
       title: "Tuist",
       description: "Tuist project setup, build, cache, and test insights.",
       instructions: instructions(),

--- a/server/lib/tuist/mcp/tool.ex
+++ b/server/lib/tuist/mcp/tool.ex
@@ -1,6 +1,7 @@
 defmodule Tuist.MCP.Tool do
   @moduledoc false
 
+  alias Tuist.Accounts
   alias Tuist.MCP.Authorization
   alias Tuist.Projects
 
@@ -20,14 +21,20 @@ defmodule Tuist.MCP.Tool do
           quote do
             @impl EMCP.Tool
             def call(conn, args) do
-              Tuist.MCP.Tool.call_with_project(
-                conn,
-                args,
-                unquote(action),
-                unquote(category),
-                &execute/3,
-                __MODULE__
-              )
+              case Tuist.MCP.Tool.validate_input(__MODULE__, args) do
+                :ok ->
+                  Tuist.MCP.Tool.call_with_project(
+                    conn,
+                    args,
+                    unquote(action),
+                    unquote(category),
+                    &execute/3,
+                    __MODULE__
+                  )
+
+                {:error, message} ->
+                  EMCP.Tool.error(message)
+              end
             end
           end
 
@@ -35,7 +42,10 @@ defmodule Tuist.MCP.Tool do
           quote do
             @impl EMCP.Tool
             def call(conn, args) do
-              Tuist.MCP.Tool.respond(execute(conn, args), __MODULE__)
+              case Tuist.MCP.Tool.validate_input(__MODULE__, args) do
+                :ok -> Tuist.MCP.Tool.respond(execute(conn, args), __MODULE__)
+                {:error, message} -> EMCP.Tool.error(message)
+              end
             end
           end
       end
@@ -45,6 +55,7 @@ defmodule Tuist.MCP.Tool do
 
       @mcp_tool_name Keyword.fetch!(unquote(opts), :name)
       @mcp_tool_schema Keyword.fetch!(unquote(opts), :schema)
+      @mcp_tool_resolved_input_schema ExJsonSchema.Schema.resolve(@mcp_tool_schema)
       @mcp_tool_output_schema Tuist.MCP.Tool.validate_output_schema!(
                                 @mcp_tool_name,
                                 Keyword.fetch!(unquote(opts), :output_schema)
@@ -66,6 +77,8 @@ defmodule Tuist.MCP.Tool do
 
       @impl EMCP.Tool
       def input_schema, do: @mcp_tool_schema
+
+      def resolved_input_schema, do: @mcp_tool_resolved_input_schema
 
       def output_schema, do: @mcp_tool_output_schema
 
@@ -92,6 +105,15 @@ defmodule Tuist.MCP.Tool do
   def respond({:ok, data}, module), do: json_response(data, module)
   def respond({:error, message}, _module) when is_binary(message), do: EMCP.Tool.error(message)
   def respond({:error, other}, _module), do: EMCP.Tool.error(inspect(other))
+
+  def validate_input(module, arguments) when is_map(arguments) do
+    case ExJsonSchema.Validator.validate(module.resolved_input_schema(), arguments) do
+      :ok -> :ok
+      {:error, _errors} -> {:error, "Arguments do not match the tool schema."}
+    end
+  end
+
+  def validate_input(_module, _arguments), do: {:error, "Arguments do not match the tool schema."}
 
   def call_with_project(conn, args, action, category, execute_fn, module) do
     case resolve_and_authorize_project(args, conn.assigns, action, category) do
@@ -131,6 +153,26 @@ defmodule Tuist.MCP.Tool do
 
   def resolve_and_authorize_project(_arguments, _assigns, _action, _category) do
     {:error, "Provide account_handle and project_handle."}
+  end
+
+  def resolve_and_authorize_account(%{"account_handle" => account_handle}, assigns, action, category)
+      when is_binary(account_handle) do
+    case Accounts.get_account_by_handle(account_handle) do
+      nil -> {:error, "Account not found: #{account_handle}"}
+      account -> authorize_account(assigns, account, action, category)
+    end
+  end
+
+  def resolve_and_authorize_account(_arguments, _assigns, _action, _category) do
+    {:error, "Provide account_handle."}
+  end
+
+  def authorize_account(assigns, account, action, category) do
+    if Authorization.authorize_request(assigns, action, account, category) do
+      {:ok, account}
+    else
+      {:error, "You do not have access to account: #{account.name}"}
+    end
   end
 
   def authenticated_subject(assigns) when is_map(assigns) do

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -730,6 +730,9 @@ defmodule Tuist.Runners.Jobs do
       workflow_job_id: j.workflow_job_id,
       account_id: fragment("argMax(?, ?)", j.account_id, j.updated_at),
       fleet_name: fragment("argMax(?, ?)", j.fleet_name, j.updated_at),
+      platform: fragment("argMax(?, ?)", j.platform, j.updated_at),
+      vcpus: fragment("argMax(?, ?)", j.vcpus, j.updated_at),
+      memory_gb: fragment("argMax(?, ?)", j.memory_gb, j.updated_at),
       repository: fragment("argMax(?, ?)", j.repository, j.updated_at),
       workflow_run_id: fragment("argMax(?, ?)", j.workflow_run_id, j.updated_at),
       workflow_name: fragment("argMax(?, ?)", j.workflow_name, j.updated_at),
@@ -743,8 +746,10 @@ defmodule Tuist.Runners.Jobs do
       claimed_at: fragment("argMax(?, ?)", j.claimed_at, j.updated_at),
       started_at: fragment("argMax(?, ?)", j.started_at, j.updated_at),
       completed_at: fragment("argMax(?, ?)", j.completed_at, j.updated_at),
+      log_archived_at: fragment("argMax(?, ?)", j.log_archived_at, j.updated_at),
       pod_name: fragment("argMax(?, ?)", j.pod_name, j.updated_at),
       runner_name: fragment("argMax(?, ?)", j.runner_name, j.updated_at),
+      requested_dispatch_label: fragment("argMax(?, ?)", j.requested_dispatch_label, j.updated_at),
       updated_at: max(j.updated_at)
     })
   end

--- a/server/lib/tuist_web/api/schemas/automation_alert.ex
+++ b/server/lib/tuist_web/api/schemas/automation_alert.ex
@@ -3,6 +3,7 @@ defmodule TuistWeb.API.Schemas.AutomationAlert do
   An automation alert — a rule that evaluates a monitor condition and runs trigger/recovery actions.
   """
   alias OpenApiSpex.Schema
+  alias Tuist.Automations
   alias TuistWeb.API.Schemas.AutomationAlertAction
 
   require OpenApiSpex
@@ -43,10 +44,10 @@ defmodule TuistWeb.API.Schemas.AutomationAlert do
       monitor_type: alert.monitor_type,
       trigger_config: alert.trigger_config,
       cadence: alert.cadence,
-      trigger_actions: alert.trigger_actions,
+      trigger_actions: Enum.map(alert.trigger_actions, &Automations.redact_action/1),
       recovery_enabled: alert.recovery_enabled,
       recovery_config: alert.recovery_config,
-      recovery_actions: alert.recovery_actions
+      recovery_actions: Enum.map(alert.recovery_actions, &Automations.redact_action/1)
     }
   end
 end

--- a/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
+++ b/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
@@ -20,6 +20,34 @@ defmodule TuistWeb.API.AccountTokensController do
 
   tags ["Account tokens"]
 
+  @account_token_schema %Schema{
+    title: "AccountToken",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, description: "Token unique identifier."},
+      name: %Schema{type: :string, nullable: true, description: "Friendly name for the token."},
+      scopes: %Schema{
+        type: :array,
+        items: %Schema{type: :string, enum: AccountToken.valid_scopes()},
+        description: "Token scopes."
+      },
+      all_projects: %Schema{type: :boolean, description: "Whether token has access to all projects."},
+      expires_at: %Schema{
+        type: :string,
+        format: "date-time",
+        nullable: true,
+        description: "When the token expires."
+      },
+      inserted_at: %Schema{type: :string, format: "date-time", description: "When the token was created."},
+      project_handles: %Schema{
+        type: :array,
+        items: %Schema{type: :string},
+        description: "List of project handles the token can access when all_projects is false."
+      }
+    },
+    required: [:id, :scopes, :all_projects, :inserted_at]
+  }
+
   operation(:create,
     summary: "Create a new account token.",
     description:
@@ -184,32 +212,7 @@ defmodule TuistWeb.API.AccountTokensController do
           properties: %{
             tokens: %Schema{
               type: :array,
-              items: %Schema{
-                type: :object,
-                properties: %{
-                  id: %Schema{type: :string, description: "Token unique identifier."},
-                  name: %Schema{type: :string, nullable: true, description: "Friendly name for the token."},
-                  scopes: %Schema{
-                    type: :array,
-                    items: %Schema{type: :string, enum: AccountToken.valid_scopes()},
-                    description: "Token scopes."
-                  },
-                  all_projects: %Schema{type: :boolean, description: "Whether token has access to all projects."},
-                  expires_at: %Schema{
-                    type: :string,
-                    format: "date-time",
-                    nullable: true,
-                    description: "When the token expires."
-                  },
-                  inserted_at: %Schema{type: :string, format: "date-time", description: "When the token was created."},
-                  project_handles: %Schema{
-                    type: :array,
-                    items: %Schema{type: :string},
-                    description: "List of project handles the token can access (when all_projects is false)."
-                  }
-                },
-                required: [:id, :scopes, :all_projects, :inserted_at]
-              }
+              items: @account_token_schema
             },
             meta: TuistWeb.API.Schemas.PaginationMetadata
           },
@@ -247,6 +250,50 @@ defmodule TuistWeb.API.AccountTokensController do
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})
+    end
+  end
+
+  operation(:show,
+    summary: "Get an account token.",
+    operation_id: "getAccountToken",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The account handle."
+      ],
+      token_id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The token identifier."
+      ]
+    ],
+    responses: %{
+      ok: {"An account token.", "application/json", @account_token_schema},
+      not_found: {"The account token was not found", "application/json", Error},
+      unauthorized: {"You need to be authenticated to get the token", "application/json", Error},
+      forbidden: {"You need to be authorized to get the token", "application/json", Error}
+    }
+  )
+
+  def show(%{assigns: %{selected_account: selected_account}, params: %{token_id: token_id}} = conn, _params) do
+    current_user = Authentication.current_user(conn)
+
+    with :ok <- Authorization.authorize(:account_token_read, current_user, selected_account),
+         {:ok, token} <- Accounts.get_account_token(selected_account, token_id) do
+      json(conn, format_token(token))
+    else
+      {:error, :forbidden} ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{message: "The authenticated subject is not authorized to perform this action"})
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{message: "Account token not found"})
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/automations/alerts_controller.ex
+++ b/server/lib/tuist_web/controllers/api/automations/alerts_controller.ex
@@ -108,6 +108,75 @@ defmodule TuistWeb.API.Automations.AlertsController do
     end
   end
 
+  @revision_schema %Schema{
+    title: "AutomationAlertRevision",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      event: %Schema{type: :string, enum: ["created", "updated"]},
+      source: %Schema{type: :string},
+      actor: %Schema{
+        type: :object,
+        nullable: true,
+        properties: %{id: %Schema{type: :integer}, name: %Schema{type: :string}, email: %Schema{type: :string}},
+        required: [:id, :name, :email]
+      },
+      changes: %Schema{type: :object},
+      snapshot: %Schema{type: :object},
+      inserted_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [:id, :event, :source, :actor, :changes, :snapshot, :inserted_at]
+  }
+
+  operation(:index_revisions,
+    summary: "List an automation alert's revision history.",
+    operation_id: "listAutomationAlertRevisions",
+    parameters: [
+      account_handle: [in: :path, type: :string, required: true, description: "The handle of the account."],
+      project_handle: [in: :path, type: :string, required: true, description: "The handle of the project."],
+      alert_id: [in: :path, schema: %Schema{type: :string, format: :uuid}, required: true],
+      before: [in: :query, schema: %Schema{type: :string, format: :uuid}, required: false],
+      page_size: [in: :query, type: :integer, required: false, description: "Results per page, up to 100."]
+    ],
+    responses: %{
+      ok:
+        {"Automation alert revisions", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             revisions: %Schema{type: :array, items: @revision_schema},
+             next_before: %Schema{type: :string, format: :uuid, nullable: true}
+           },
+           required: [:revisions, :next_before]
+         }},
+      not_found: {"Not found", "application/json", Error},
+      forbidden: {"Forbidden", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_revisions(%{assigns: %{selected_project: project}, params: params} = conn, _params) do
+    with {:ok, alert} <- Automations.get_alert(params.alert_id),
+         true <- alert.project_id == project.id,
+         {:ok, before} <- revision_cursor(alert.id, Map.get(params, :before)) do
+      page_size = params |> Map.get(:page_size, 20) |> max(1) |> min(100)
+      revisions = Automations.list_alert_revisions(alert.id, before: before, limit: page_size + 1)
+      {page, remaining} = Enum.split(revisions, page_size)
+
+      json(conn, %{
+        revisions: Enum.map(page, &Automations.redact_revision/1),
+        next_before: if(remaining == [], do: nil, else: List.last(page).id)
+      })
+    else
+      {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{message: "Automation alert revision not found."})
+      false -> conn |> put_status(:not_found) |> json(%{message: "Automation alert not found."})
+    end
+  end
+
+  defp revision_cursor(_alert_id, nil), do: {:ok, nil}
+
+  defp revision_cursor(alert_id, revision_id), do: Automations.get_alert_revision(alert_id, revision_id)
+
   operation(:create,
     summary: "Create an automation alert.",
     operation_id: "createAutomationAlert",

--- a/server/lib/tuist_web/controllers/api/organizations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/organizations_controller.ex
@@ -291,24 +291,35 @@ defmodule TuistWeb.API.OrganizationsController do
           sso_provider: organization.sso_provider,
           sso_organization_id: organization.sso_organization_id,
           sso_enforced: organization.sso_enforced,
-          invitations:
-            Enum.map(
-              Tuist.Repo.preload(organization, invitations: [inviter: :account]).invitations,
-              &%{
-                id: &1.id,
-                invitee_email: &1.invitee_email,
-                inviter: %{
-                  id: &1.inviter.id,
-                  email: &1.inviter.email,
-                  name: &1.inviter.account.name
-                },
-                token: &1.token,
-                organization_id: &1.organization_id,
-                role: &1.role
-              }
-            )
+          invitations: invitations(organization, subject)
         })
     end
+  end
+
+  defp invitations(organization, subject) do
+    if Authorization.authorize(:invitation_read, subject, organization.account) == :ok do
+      organization
+      |> Tuist.Repo.preload(invitations: [inviter: :account])
+      |> Map.fetch!(:invitations)
+      |> Enum.map(&serialize_invitation/1)
+    else
+      []
+    end
+  end
+
+  defp serialize_invitation(invitation) do
+    %{
+      id: invitation.id,
+      invitee_email: invitation.invitee_email,
+      inviter: %{
+        id: invitation.inviter.id,
+        email: invitation.inviter.email,
+        name: invitation.inviter.account.name
+      },
+      token: invitation.token,
+      organization_id: invitation.organization_id,
+      role: invitation.role
+    }
   end
 
   operation(:usage,

--- a/server/lib/tuist_web/controllers/api/project_notification_alerts_controller.ex
+++ b/server/lib/tuist_web/controllers/api/project_notification_alerts_controller.ex
@@ -1,0 +1,102 @@
+defmodule TuistWeb.API.ProjectNotificationAlertsController do
+  use OpenApiSpex.ControllerSpecs
+  use TuistWeb, :controller
+
+  alias OpenApiSpex.Schema
+  alias Tuist.Alerts
+  alias TuistWeb.API.Responses
+  alias TuistWeb.API.Schemas.Error
+
+  plug(TuistWeb.Plugs.CastAndValidate,
+    json_render_error_v2: true,
+    render_error: TuistWeb.RenderAPIErrorPlug
+  )
+
+  plug(TuistWeb.Plugs.LoaderPlug)
+  plug(TuistWeb.API.Authorization.AuthorizationPlug, {:project, :project, :update})
+
+  tags ["Project Notification Alerts"]
+
+  @alert_rule_schema %Schema{
+    title: "ProjectNotificationAlert",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string},
+      category: %Schema{type: :string},
+      metric: %Schema{type: :string},
+      deviation_percentage: %Schema{type: :number},
+      rolling_window_size: %Schema{type: :integer, nullable: true},
+      git_branch: %Schema{type: :string, nullable: true},
+      scheme: %Schema{type: :string},
+      bundle_name: %Schema{type: :string},
+      environment: %Schema{type: :string},
+      slack_channel_id: %Schema{type: :string, nullable: true},
+      slack_channel_name: %Schema{type: :string, nullable: true},
+      webhook_configured: %Schema{type: :boolean},
+      inserted_at: %Schema{type: :string, format: "date-time"},
+      updated_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [
+      :id,
+      :name,
+      :category,
+      :metric,
+      :deviation_percentage,
+      :rolling_window_size,
+      :git_branch,
+      :scheme,
+      :bundle_name,
+      :environment,
+      :slack_channel_id,
+      :slack_channel_name,
+      :webhook_configured,
+      :inserted_at,
+      :updated_at
+    ]
+  }
+
+  operation(:index,
+    summary: "List a project's notification alert rules.",
+    operation_id: "listProjectNotificationAlerts",
+    parameters: [
+      account_handle: [in: :path, type: :string, required: true, description: "The handle of the account."],
+      project_handle: [in: :path, type: :string, required: true, description: "The handle of the project."]
+    ],
+    responses: %{
+      ok:
+        {"Project notification alert rules", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{alert_rules: %Schema{type: :array, items: @alert_rule_schema}},
+           required: [:alert_rules]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index(%{assigns: %{selected_project: project}} = conn, _params) do
+    json(conn, %{alert_rules: Enum.map(Alerts.get_project_alert_rules(project), &serialize/1)})
+  end
+
+  defp serialize(alert_rule) do
+    %{
+      id: alert_rule.id,
+      name: alert_rule.name,
+      category: to_string(alert_rule.category),
+      metric: to_string(alert_rule.metric),
+      deviation_percentage: alert_rule.deviation_percentage,
+      rolling_window_size: alert_rule.rolling_window_size,
+      git_branch: alert_rule.git_branch,
+      scheme: alert_rule.scheme,
+      bundle_name: alert_rule.bundle_name,
+      environment: to_string(alert_rule.environment),
+      slack_channel_id: alert_rule.slack_channel_id,
+      slack_channel_name: alert_rule.slack_channel_name,
+      webhook_configured: is_binary(alert_rule.slack_webhook_url) and alert_rule.slack_webhook_url != "",
+      inserted_at: alert_rule.inserted_at,
+      updated_at: alert_rule.updated_at
+    }
+  end
+end

--- a/server/lib/tuist_web/controllers/api/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runners_controller.ex
@@ -1,0 +1,566 @@
+defmodule TuistWeb.API.RunnersController do
+  use OpenApiSpex.ControllerSpecs
+  use TuistWeb, :controller
+
+  alias OpenApiSpex.Schema
+  alias Tuist.FeatureFlags
+  alias Tuist.Runners.JobLogs
+  alias Tuist.Runners.JobMetrics
+  alias Tuist.Runners.Jobs
+  alias Tuist.Runners.JobSteps
+  alias Tuist.Runners.Profiles
+  alias TuistWeb.API.Authorization.AuthorizationPlug
+  alias TuistWeb.API.Responses
+  alias TuistWeb.API.Schemas.Error
+  alias TuistWeb.API.Schemas.PaginationMetadata
+
+  plug(TuistWeb.Plugs.CastAndValidate,
+    json_render_error_v2: true,
+    render_error: TuistWeb.RenderAPIErrorPlug
+  )
+
+  plug(TuistWeb.Plugs.LoaderPlug)
+
+  # Profiles live on the account settings surface, where the dashboard
+  # requires account administrators even for the read-only table. The
+  # operational runner views intentionally remain visible to runner readers.
+  plug AuthorizationPlug, {:account, :account, :update} when action in [:index_profiles]
+
+  plug AuthorizationPlug,
+       {:account, :runners}
+       when action in [:index_jobs, :show_job, :index_job_steps, :index_job_metrics, :index_job_logs, :index_workflows]
+
+  tags ["Runners"]
+
+  @runner_job_schema %Schema{
+    title: "RunnerJob",
+    type: :object,
+    properties: %{
+      workflow_job_id: %Schema{type: :integer},
+      repository: %Schema{type: :string},
+      workflow_run_id: %Schema{type: :integer},
+      workflow_name: %Schema{type: :string},
+      run_attempt: %Schema{type: :integer},
+      job_name: %Schema{type: :string},
+      head_branch: %Schema{type: :string},
+      head_sha: %Schema{type: :string},
+      status: %Schema{type: :string},
+      conclusion: %Schema{type: :string},
+      platform: %Schema{type: :string},
+      vcpus: %Schema{type: :integer},
+      memory_gb: %Schema{type: :integer},
+      requested_dispatch_label: %Schema{type: :string},
+      enqueued_at: %Schema{type: :string, format: "date-time"},
+      claimed_at: %Schema{type: :string, format: "date-time", nullable: true},
+      started_at: %Schema{type: :string, format: "date-time", nullable: true},
+      completed_at: %Schema{type: :string, format: "date-time", nullable: true},
+      log_archived_at: %Schema{type: :string, format: "date-time", nullable: true},
+      updated_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [
+      :workflow_job_id,
+      :repository,
+      :workflow_run_id,
+      :workflow_name,
+      :run_attempt,
+      :job_name,
+      :head_branch,
+      :head_sha,
+      :status,
+      :conclusion,
+      :platform,
+      :vcpus,
+      :memory_gb,
+      :requested_dispatch_label,
+      :enqueued_at,
+      :updated_at
+    ]
+  }
+
+  @workflow_schema %Schema{
+    title: "RunnerWorkflow",
+    type: :object,
+    properties: %{
+      workflow_name: %Schema{type: :string},
+      repository: %Schema{type: :string},
+      total_jobs: %Schema{type: :integer},
+      success_count: %Schema{type: :integer},
+      failure_count: %Schema{type: :integer},
+      cancelled_count: %Schema{type: :integer},
+      skipped_count: %Schema{type: :integer},
+      in_progress_count: %Schema{type: :integer},
+      avg_duration_ms: %Schema{type: :number, nullable: true},
+      last_run_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [
+      :workflow_name,
+      :repository,
+      :total_jobs,
+      :success_count,
+      :failure_count,
+      :cancelled_count,
+      :skipped_count,
+      :in_progress_count,
+      :last_run_at
+    ]
+  }
+
+  @profile_schema %Schema{
+    title: "RunnerProfile",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :integer},
+      name: %Schema{type: :string},
+      platform: %Schema{type: :string, enum: ["linux", "macos"]},
+      vcpus: %Schema{type: :integer},
+      memory_gb: %Schema{type: :integer},
+      xcode_version: %Schema{type: :string, nullable: true},
+      protected: %Schema{type: :boolean},
+      inserted_at: %Schema{type: :string, format: "date-time"},
+      updated_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [:id, :name, :platform, :vcpus, :memory_gb, :protected, :inserted_at, :updated_at]
+  }
+
+  @job_step_schema %Schema{
+    title: "RunnerJobStep",
+    type: :object,
+    properties: %{
+      number: %Schema{type: :integer},
+      name: %Schema{type: :string},
+      status: %Schema{type: :string},
+      conclusion: %Schema{type: :string},
+      started_at: %Schema{type: :string, format: "date-time", nullable: true},
+      completed_at: %Schema{type: :string, format: "date-time", nullable: true}
+    },
+    required: [:number, :name, :status, :conclusion, :started_at, :completed_at]
+  }
+
+  @job_metric_schema %Schema{
+    title: "RunnerJobMetric",
+    type: :object,
+    properties: %{
+      timestamp: %Schema{type: :number},
+      cpu_usage_percent: %Schema{type: :number},
+      cpu_iowait_percent: %Schema{type: :number},
+      memory_used_bytes: %Schema{type: :integer},
+      memory_total_bytes: %Schema{type: :integer},
+      network_bytes_in: %Schema{type: :integer},
+      network_bytes_out: %Schema{type: :integer},
+      disk_used_bytes: %Schema{type: :integer},
+      disk_total_bytes: %Schema{type: :integer}
+    },
+    required: [
+      :timestamp,
+      :cpu_usage_percent,
+      :cpu_iowait_percent,
+      :memory_used_bytes,
+      :memory_total_bytes,
+      :network_bytes_in,
+      :network_bytes_out,
+      :disk_used_bytes,
+      :disk_total_bytes
+    ]
+  }
+
+  @job_log_schema %Schema{
+    title: "RunnerJobLogLine",
+    type: :object,
+    properties: %{
+      line_number: %Schema{type: :integer},
+      ts: %Schema{type: :string, format: "date-time", nullable: true},
+      message: %Schema{type: :string}
+    },
+    required: [:line_number, :ts, :message]
+  }
+
+  @account_parameters [
+    account_handle: [
+      in: :path,
+      type: :string,
+      required: true,
+      description: "The account handle."
+    ]
+  ]
+
+  @pagination_parameters [
+    page: [in: :query, type: :integer, required: false, description: "Page number (default: 1)."],
+    page_size: [in: :query, type: :integer, required: false, description: "Results per page (default: 20, maximum: 100)."]
+  ]
+
+  @job_filter_parameters @pagination_parameters ++
+                           [
+                             status: [
+                               in: :query,
+                               type: %Schema{type: :string, enum: ["queued", "claimed", "running", "completed"]},
+                               required: false
+                             ],
+                             conclusion: [
+                               in: :query,
+                               type: %Schema{type: :string, enum: ["success", "failure", "cancelled", "skipped"]},
+                               required: false
+                             ],
+                             repository: [in: :query, type: :string, required: false],
+                             workflow_name: [in: :query, type: :string, required: false],
+                             job_name: [in: :query, type: :string, required: false],
+                             head_branch: [in: :query, type: :string, required: false],
+                             platform: [
+                               in: :query,
+                               type: %Schema{type: :string, enum: ["linux", "macos"]},
+                               required: false
+                             ],
+                             search: [in: :query, type: :string, required: false],
+                             sort_by: [
+                               in: :query,
+                               type: %Schema{type: :string, enum: ["enqueued", "job", "workflow", "duration"]},
+                               required: false
+                             ],
+                             sort_order: [
+                               in: :query,
+                               type: %Schema{type: :string, enum: ["asc", "desc"]},
+                               required: false
+                             ]
+                           ]
+
+  @workflow_filter_parameters @pagination_parameters ++
+                                [
+                                  repository: [in: :query, type: :string, required: false],
+                                  workflow_name: [in: :query, type: :string, required: false],
+                                  head_branch: [in: :query, type: :string, required: false],
+                                  platform: [
+                                    in: :query,
+                                    type: %Schema{type: :string, enum: ["linux", "macos"]},
+                                    required: false
+                                  ],
+                                  sort_by: [
+                                    in: :query,
+                                    type: %Schema{
+                                      type: :string,
+                                      enum: ["workflow", "success_rate", "jobs", "avg_duration"]
+                                    },
+                                    required: false
+                                  ],
+                                  sort_order: [
+                                    in: :query,
+                                    type: %Schema{type: :string, enum: ["asc", "desc"]},
+                                    required: false
+                                  ]
+                                ]
+
+  operation(:index_jobs,
+    summary: "List runner jobs for an account.",
+    operation_id: "listRunnerJobs",
+    parameters: @account_parameters ++ @job_filter_parameters,
+    responses: %{
+      ok:
+        {"Runner jobs", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{jobs: %Schema{type: :array, items: @runner_job_schema}, pagination_metadata: PaginationMetadata},
+           required: [:jobs, :pagination_metadata]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runners are not enabled", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_jobs(%{assigns: %{selected_account: account}} = conn, params) do
+    if FeatureFlags.runners_enabled?(account) do
+      {page, page_size} = page_params(params)
+      options = job_options(params) ++ [limit: page_size, offset: (page - 1) * page_size]
+      total_count = Jobs.count_for_account(account.id, job_options(params))
+      jobs = Jobs.list_for_account(account.id, options)
+
+      json(conn, %{
+        jobs: Enum.map(jobs, &serialize_job/1),
+        pagination_metadata: pagination_metadata(page, page_size, total_count)
+      })
+    else
+      runners_unavailable(conn)
+    end
+  end
+
+  operation(:show_job,
+    summary: "Get a runner job.",
+    operation_id: "getRunnerJob",
+    parameters:
+      @account_parameters ++
+        [
+          workflow_job_id: [
+            in: :path,
+            type: :integer,
+            required: true,
+            description: "The workflow job identifier."
+          ]
+        ],
+    responses: %{
+      ok: {"Runner job", "application/json", @runner_job_schema},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runner job was not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def show_job(%{assigns: %{selected_account: account}, params: %{workflow_job_id: workflow_job_id}} = conn, _params) do
+    if FeatureFlags.runners_enabled?(account) do
+      case Jobs.get_for_account(account.id, workflow_job_id) do
+        {:ok, job} -> json(conn, serialize_job(job))
+        {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{message: "Runner job not found."})
+      end
+    else
+      runners_unavailable(conn)
+    end
+  end
+
+  operation(:index_job_steps,
+    summary: "List the steps for a runner job.",
+    operation_id: "listRunnerJobSteps",
+    parameters:
+      @account_parameters ++
+        [workflow_job_id: [in: :path, type: :integer, required: true, description: "The workflow job identifier."]],
+    responses: %{
+      ok:
+        {"Runner job steps", "application/json",
+         %Schema{type: :object, properties: %{steps: %Schema{type: :array, items: @job_step_schema}}, required: [:steps]}},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runner job was not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_job_steps(
+        %{assigns: %{selected_account: account}, params: %{workflow_job_id: workflow_job_id}} = conn,
+        _params
+      ) do
+    with_runner_job(conn, account, workflow_job_id, fn job ->
+      json(conn, %{steps: JobSteps.list_for_job(job.workflow_job_id)})
+    end)
+  end
+
+  operation(:index_job_metrics,
+    summary: "List machine metrics for a runner job.",
+    operation_id: "listRunnerJobMetrics",
+    parameters:
+      @account_parameters ++
+        [workflow_job_id: [in: :path, type: :integer, required: true, description: "The workflow job identifier."]],
+    responses: %{
+      ok:
+        {"Runner job metrics", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{metrics: %Schema{type: :array, items: @job_metric_schema}},
+           required: [:metrics]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runner job was not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_job_metrics(
+        %{assigns: %{selected_account: account}, params: %{workflow_job_id: workflow_job_id}} = conn,
+        _params
+      ) do
+    with_runner_job(conn, account, workflow_job_id, fn job ->
+      json(conn, %{metrics: JobMetrics.list_for_job(job.workflow_job_id)})
+    end)
+  end
+
+  operation(:index_job_logs,
+    summary: "List captured log lines for a runner job.",
+    description: "Returns log lines in display order. Page size defaults to 200 and is capped at 500.",
+    operation_id: "listRunnerJobLogs",
+    parameters:
+      @account_parameters ++
+        [
+          workflow_job_id: [in: :path, type: :integer, required: true, description: "The workflow job identifier."],
+          offset: [in: :query, type: :integer, required: false, description: "Zero-based log-line offset."],
+          limit: [in: :query, type: :integer, required: false, description: "Maximum number of lines, up to 500."]
+        ],
+    responses: %{
+      ok:
+        {"Runner job log lines", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{lines: %Schema{type: :array, items: @job_log_schema}},
+           required: [:lines]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runner job was not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_job_logs(%{assigns: %{selected_account: account}, params: %{workflow_job_id: workflow_job_id}} = conn, params) do
+    with_runner_job(conn, account, workflow_job_id, fn job ->
+      limit = params |> Map.get(:limit, 200) |> max(1) |> min(500)
+      offset = params |> Map.get(:offset, 0) |> max(0)
+      json(conn, %{lines: JobLogs.list_for_job(job.workflow_job_id, limit: limit, offset: offset)})
+    end)
+  end
+
+  operation(:index_workflows,
+    summary: "List runner workflows for an account.",
+    operation_id: "listRunnerWorkflows",
+    parameters: @account_parameters ++ @workflow_filter_parameters,
+    responses: %{
+      ok:
+        {"Runner workflows", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             workflows: %Schema{type: :array, items: @workflow_schema},
+             pagination_metadata: PaginationMetadata
+           },
+           required: [:workflows, :pagination_metadata]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runners are not enabled", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_workflows(%{assigns: %{selected_account: account}} = conn, params) do
+    if FeatureFlags.runners_enabled?(account) do
+      {page, page_size} = page_params(params)
+      options = workflow_options(params) ++ [limit: page_size, offset: (page - 1) * page_size]
+      total_count = Jobs.count_workflows_for_account(account.id, workflow_options(params))
+      workflows = Jobs.list_workflows_for_account(account.id, options)
+
+      json(conn, %{
+        workflows: Enum.map(workflows, &serialize_workflow/1),
+        pagination_metadata: pagination_metadata(page, page_size, total_count)
+      })
+    else
+      runners_unavailable(conn)
+    end
+  end
+
+  operation(:index_profiles,
+    summary: "List runner profiles for an account.",
+    operation_id: "listRunnerProfiles",
+    parameters: @account_parameters,
+    responses: %{
+      ok:
+        {"Runner profiles", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{profiles: %Schema{type: :array, items: @profile_schema}},
+           required: [:profiles]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Runners are not enabled", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_profiles(%{assigns: %{selected_account: account}} = conn, _params) do
+    if FeatureFlags.runners_enabled?(account) do
+      json(conn, %{profiles: account |> Profiles.list_for_account() |> Enum.map(&serialize_profile/1)})
+    else
+      runners_unavailable(conn)
+    end
+  end
+
+  defp page_params(params) do
+    page = params |> Map.get(:page, 1) |> max(1)
+    page_size = params |> Map.get(:page_size, 20) |> max(1) |> min(100)
+    {page, page_size}
+  end
+
+  defp job_options(params) do
+    Enum.flat_map(
+      [
+        :status,
+        :conclusion,
+        :repository,
+        :workflow_name,
+        :job_name,
+        :head_branch,
+        :platform,
+        :search,
+        :sort_by,
+        :sort_order
+      ],
+      fn key -> if value = Map.get(params, key), do: [{key, value}], else: [] end
+    )
+  end
+
+  defp workflow_options(params) do
+    Enum.flat_map([:repository, :workflow_name, :head_branch, :platform, :sort_by, :sort_order], fn key ->
+      if value = Map.get(params, key), do: [{key, value}], else: []
+    end)
+  end
+
+  defp pagination_metadata(page, page_size, total_count) do
+    total_pages = ceil(total_count / page_size)
+
+    %{
+      has_next_page: page < total_pages,
+      has_previous_page: page > 1,
+      current_page: page,
+      page_size: page_size,
+      total_count: total_count,
+      total_pages: total_pages
+    }
+  end
+
+  defp serialize_job(job) do
+    Map.take(job, [
+      :workflow_job_id,
+      :repository,
+      :workflow_run_id,
+      :workflow_name,
+      :run_attempt,
+      :job_name,
+      :head_branch,
+      :head_sha,
+      :status,
+      :conclusion,
+      :platform,
+      :vcpus,
+      :memory_gb,
+      :requested_dispatch_label,
+      :enqueued_at,
+      :claimed_at,
+      :started_at,
+      :completed_at,
+      :log_archived_at,
+      :updated_at
+    ])
+  end
+
+  defp serialize_workflow(workflow),
+    do:
+      Map.take(workflow, [
+        :workflow_name,
+        :repository,
+        :total_jobs,
+        :success_count,
+        :failure_count,
+        :cancelled_count,
+        :skipped_count,
+        :in_progress_count,
+        :avg_duration_ms,
+        :last_run_at
+      ])
+
+  defp serialize_profile(profile) do
+    Map.take(profile, [:id, :name, :platform, :vcpus, :memory_gb, :xcode_version, :protected, :inserted_at, :updated_at])
+  end
+
+  defp with_runner_job(conn, account, workflow_job_id, fun) do
+    if FeatureFlags.runners_enabled?(account) do
+      case Jobs.get_for_account(account.id, workflow_job_id) do
+        {:ok, job} -> fun.(job)
+        {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{message: "Runner job not found."})
+      end
+    else
+      runners_unavailable(conn)
+    end
+  end
+
+  defp runners_unavailable(conn),
+    do: conn |> put_status(:not_found) |> json(%{message: "Runners are not enabled for this account."})
+end

--- a/server/lib/tuist_web/controllers/api/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runners_controller.ex
@@ -14,12 +14,12 @@ defmodule TuistWeb.API.RunnersController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
+  plug(TuistWeb.Plugs.LoaderPlug)
+
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
   )
-
-  plug(TuistWeb.Plugs.LoaderPlug)
 
   # Profiles live on the account settings surface, where the dashboard
   # requires account administrators even for the read-only table. The

--- a/server/lib/tuist_web/controllers/api/webhooks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/webhooks_controller.ex
@@ -8,12 +8,13 @@ defmodule TuistWeb.API.WebhooksController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
+  plug(TuistWeb.Plugs.LoaderPlug)
+
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
   )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
   plug(TuistWeb.API.Authorization.AuthorizationPlug, {:account, :account, :update})
 
   tags ["Webhooks"]

--- a/server/lib/tuist_web/controllers/api/webhooks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/webhooks_controller.ex
@@ -1,0 +1,286 @@
+defmodule TuistWeb.API.WebhooksController do
+  use OpenApiSpex.ControllerSpecs
+  use TuistWeb, :controller
+
+  alias OpenApiSpex.Schema
+  alias Tuist.Webhooks
+  alias TuistWeb.API.Responses
+  alias TuistWeb.API.Schemas.Error
+  alias TuistWeb.API.Schemas.PaginationMetadata
+
+  plug(TuistWeb.Plugs.CastAndValidate,
+    json_render_error_v2: true,
+    render_error: TuistWeb.RenderAPIErrorPlug
+  )
+
+  plug(TuistWeb.Plugs.LoaderPlug)
+  plug(TuistWeb.API.Authorization.AuthorizationPlug, {:account, :account, :update})
+
+  tags ["Webhooks"]
+
+  @endpoint_schema %Schema{
+    title: "WebhookEndpoint",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string},
+      url: %Schema{type: :string, format: :uri},
+      signing_secret_last_four: %Schema{type: :string, nullable: true},
+      event_types: %Schema{type: :array, items: %Schema{type: :string}},
+      inserted_at: %Schema{type: :string, format: "date-time"},
+      updated_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [:id, :name, :url, :event_types, :inserted_at, :updated_at]
+  }
+
+  @delivery_attempt_schema %Schema{
+    title: "WebhookDeliveryAttempt",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      webhook_endpoint_id: %Schema{type: :string, format: :uuid},
+      event_id: %Schema{type: :string},
+      event_type: %Schema{type: :string},
+      attempt: %Schema{type: :integer},
+      status: %Schema{type: :string, enum: ["delivered", "failed"]},
+      request_body: %Schema{type: :string},
+      request_headers: %Schema{type: :string},
+      response_status: %Schema{type: :integer},
+      response_headers: %Schema{type: :string},
+      response_body: %Schema{type: :string},
+      error: %Schema{type: :string},
+      duration_ms: %Schema{type: :integer},
+      inserted_at: %Schema{type: :string, format: "date-time"}
+    },
+    required: [
+      :id,
+      :webhook_endpoint_id,
+      :event_id,
+      :event_type,
+      :attempt,
+      :status,
+      :request_body,
+      :request_headers,
+      :response_status,
+      :response_headers,
+      :response_body,
+      :error,
+      :duration_ms,
+      :inserted_at
+    ]
+  }
+
+  @account_parameters [account_handle: [in: :path, type: :string, required: true, description: "The account handle."]]
+  @endpoint_parameters [
+    webhook_endpoint_id: [
+      in: :path,
+      type: %Schema{type: :string, format: :uuid},
+      required: true,
+      description: "The webhook endpoint identifier."
+    ]
+  ]
+  @delivery_filter_parameters [
+    page_size: [in: :query, type: :integer, required: false, description: "Results per page (default: 20, maximum: 100)."],
+    after: [in: :query, type: :string, required: false, description: "Cursor for the next page."],
+    before: [in: :query, type: :string, required: false, description: "Cursor for the previous page."],
+    start_datetime: [in: :query, type: %Schema{type: :string, format: "date-time"}, required: false],
+    end_datetime: [in: :query, type: %Schema{type: :string, format: "date-time"}, required: false],
+    status: [in: :query, type: %Schema{type: :string, enum: ["delivered", "failed"]}, required: false],
+    event_type: [in: :query, type: :string, required: false],
+    event_id_search: [in: :query, type: :string, required: false]
+  ]
+
+  operation(:index,
+    summary: "List webhook endpoints for an account.",
+    operation_id: "listWebhookEndpoints",
+    parameters: @account_parameters,
+    responses: %{
+      ok:
+        {"Webhook endpoints", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{endpoints: %Schema{type: :array, items: @endpoint_schema}},
+           required: [:endpoints]
+         }},
+      forbidden: {"Forbidden", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index(%{assigns: %{selected_account: account}} = conn, _params) do
+    json(conn, %{endpoints: account.id |> Webhooks.list_endpoints() |> Enum.map(&serialize_endpoint/1)})
+  end
+
+  operation(:show,
+    summary: "Get a webhook endpoint.",
+    operation_id: "getWebhookEndpoint",
+    parameters:
+      @account_parameters ++
+        [webhook_endpoint_id: [in: :path, type: %Schema{type: :string, format: :uuid}, required: true]],
+    responses: %{
+      ok: {"Webhook endpoint", "application/json", @endpoint_schema},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Webhook endpoint not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def show(%{assigns: %{selected_account: account}, params: %{webhook_endpoint_id: endpoint_id}} = conn, _params) do
+    case Webhooks.get_account_endpoint(endpoint_id, account.id) do
+      {:ok, endpoint} -> json(conn, serialize_endpoint(endpoint))
+      {:error, :not_found} -> not_found(conn, "Webhook endpoint not found.")
+    end
+  end
+
+  operation(:index_delivery_attempts,
+    summary: "List delivery attempts for a webhook endpoint.",
+    operation_id: "listWebhookDeliveryAttempts",
+    parameters: @account_parameters ++ @endpoint_parameters ++ @delivery_filter_parameters,
+    responses: %{
+      ok:
+        {"Webhook delivery attempts", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             delivery_attempts: %Schema{type: :array, items: @delivery_attempt_schema},
+             pagination_metadata: PaginationMetadata
+           },
+           required: [:delivery_attempts, :pagination_metadata]
+         }},
+      bad_request: {"Invalid cursor parameters", "application/json", Error},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Webhook endpoint not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def index_delivery_attempts(
+        %{assigns: %{selected_account: account}, params: %{webhook_endpoint_id: endpoint_id}} = conn,
+        params
+      ) do
+    with {:ok, endpoint} <- Webhooks.get_account_endpoint(endpoint_id, account.id),
+         {:ok, options} <- delivery_options(params),
+         {attempts, metadata} <- Webhooks.list_deliveries(endpoint.id, options) do
+      json(conn, %{
+        delivery_attempts: Enum.map(attempts, &serialize_delivery_attempt/1),
+        pagination_metadata: pagination_metadata(metadata)
+      })
+    else
+      {:error, :not_found} ->
+        not_found(conn, "Webhook endpoint not found.")
+
+      {:error, :invalid_cursor_parameters} ->
+        conn |> put_status(:bad_request) |> json(%{message: "Use only one of after or before."})
+    end
+  end
+
+  operation(:show_delivery_attempt,
+    summary: "Get a webhook delivery attempt.",
+    operation_id: "getWebhookDeliveryAttempt",
+    parameters:
+      @account_parameters ++
+        @endpoint_parameters ++
+        [delivery_attempt_id: [in: :path, type: %Schema{type: :string, format: :uuid}, required: true]],
+    responses: %{
+      ok: {"Webhook delivery attempt", "application/json", @delivery_attempt_schema},
+      forbidden: {"Forbidden", "application/json", Error},
+      not_found: {"Webhook delivery attempt not found", "application/json", Error},
+      too_many_requests: Responses.authorization_throttled()
+    }
+  )
+
+  def show_delivery_attempt(
+        %{
+          assigns: %{selected_account: account},
+          params: %{webhook_endpoint_id: endpoint_id, delivery_attempt_id: attempt_id}
+        } = conn,
+        _params
+      ) do
+    with {:ok, endpoint} <- Webhooks.get_account_endpoint(endpoint_id, account.id),
+         {:ok, attempt} <- Webhooks.get_delivery_attempt(endpoint.id, attempt_id) do
+      json(conn, serialize_delivery_attempt(attempt))
+    else
+      {:error, :not_found} -> not_found(conn, "Webhook delivery attempt not found.")
+    end
+  end
+
+  defp delivery_options(%{after: after_cursor, before: before_cursor})
+       when is_binary(after_cursor) and after_cursor != "" and is_binary(before_cursor) and before_cursor != "",
+       do: {:error, :invalid_cursor_parameters}
+
+  defp delivery_options(params) do
+    options =
+      Enum.reject(
+        [
+          page_size: params |> Map.get(:page_size, 20) |> max(1) |> min(100),
+          after: Map.get(params, :after),
+          before: Map.get(params, :before),
+          start_datetime: datetime_param(params, :start_datetime),
+          end_datetime: datetime_param(params, :end_datetime),
+          status: status_param(params),
+          event_type: Map.get(params, :event_type),
+          event_id_search: Map.get(params, :event_id_search)
+        ],
+        fn {_key, value} -> is_nil(value) end
+      )
+
+    {:ok, options}
+  end
+
+  defp datetime_param(params, key) do
+    case Map.get(params, key) do
+      %DateTime{} = datetime ->
+        datetime
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> datetime
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp status_param(%{status: "delivered"}), do: :delivered
+  defp status_param(%{status: "failed"}), do: :failed
+  defp status_param(_params), do: nil
+
+  defp pagination_metadata(metadata) do
+    %{
+      has_next_page: metadata.has_next_page?,
+      has_previous_page: metadata.has_previous_page?,
+      current_page: metadata.current_page,
+      page_size: metadata.page_size,
+      total_count: metadata.total_count,
+      total_pages: metadata.total_pages,
+      start_cursor: metadata.start_cursor,
+      end_cursor: metadata.end_cursor
+    }
+  end
+
+  defp serialize_endpoint(endpoint),
+    do: Map.take(endpoint, [:id, :name, :url, :signing_secret_last_four, :event_types, :inserted_at, :updated_at])
+
+  defp serialize_delivery_attempt(attempt) do
+    Map.take(attempt, [
+      :id,
+      :webhook_endpoint_id,
+      :event_id,
+      :event_type,
+      :attempt,
+      :status,
+      :request_body,
+      :request_headers,
+      :response_status,
+      :response_headers,
+      :response_body,
+      :error,
+      :duration_ms,
+      :inserted_at
+    ])
+  end
+
+  defp not_found(conn, message), do: conn |> put_status(:not_found) |> json(%{message: message})
+end

--- a/server/lib/tuist_web/live/runner_job_live.ex
+++ b/server/lib/tuist_web/live/runner_job_live.ex
@@ -36,7 +36,7 @@ defmodule TuistWeb.RunnerJobLive do
         _session,
         %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket
       ) do
-    if Authorization.authorize(:account_dashboard_read, current_user, selected_account) != :ok or
+    if Authorization.authorize(:runners_read, current_user, selected_account) != :ok or
          not FeatureFlags.runners_enabled?(selected_account) do
       raise NotFoundError,
             dgettext(
@@ -1075,9 +1075,9 @@ defmodule TuistWeb.RunnerJobLive do
     assign(socket, :interactive, interactive_state(selected_account, current_user, job, vnc_token, shell_token))
   end
 
-  # `:runners_interactive_access`, not the page's `:account_dashboard_read`:
+  # `:runners_interactive_access`, not the page's `:runners_read`:
   # attaching to a running VM executes commands on it, so it stays with members
-  # that can write even when the account is public.
+  # that can write.
   #
   # Resolved per call rather than read off the socket. `InteractiveSessions`
   # mints tokens without authorizing, and a socket outlives the role that

--- a/server/lib/tuist_web/live/runner_jobs_live.ex
+++ b/server/lib/tuist_web/live/runner_jobs_live.ex
@@ -27,7 +27,7 @@ defmodule TuistWeb.RunnerJobsLive do
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
-    if Authorization.authorize(:account_dashboard_read, current_user, selected_account) != :ok or
+    if Authorization.authorize(:runners_read, current_user, selected_account) != :ok or
          not FeatureFlags.runners_enabled?(selected_account) do
       raise TuistWeb.Errors.NotFoundError,
             dgettext("dashboard_runners", "The page you are looking for doesn't exist or has been moved.")

--- a/server/lib/tuist_web/live/runner_workflow_live.ex
+++ b/server/lib/tuist_web/live/runner_workflow_live.ex
@@ -24,7 +24,7 @@ defmodule TuistWeb.RunnerWorkflowLive do
         _session,
         %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket
       ) do
-    if Authorization.authorize(:account_dashboard_read, current_user, selected_account) != :ok or
+    if Authorization.authorize(:runners_read, current_user, selected_account) != :ok or
          not FeatureFlags.runners_enabled?(selected_account) do
       raise TuistWeb.Errors.NotFoundError,
             dgettext("dashboard_runners", "The page you are looking for doesn't exist or has been moved.")

--- a/server/lib/tuist_web/live/runner_workflows_live.ex
+++ b/server/lib/tuist_web/live/runner_workflows_live.ex
@@ -19,7 +19,7 @@ defmodule TuistWeb.RunnerWorkflowsLive do
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
-    if Authorization.authorize(:account_dashboard_read, current_user, selected_account) != :ok or
+    if Authorization.authorize(:runners_read, current_user, selected_account) != :ok or
          not FeatureFlags.runners_enabled?(selected_account) do
       raise TuistWeb.Errors.NotFoundError,
             dgettext("dashboard_runners", "The page you are looking for doesn't exist or has been moved.")

--- a/server/lib/tuist_web/live/runners_live.ex
+++ b/server/lib/tuist_web/live/runners_live.ex
@@ -29,7 +29,7 @@ defmodule TuistWeb.RunnersLive do
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: selected_account, current_user: current_user}} = socket) do
-    if Authorization.authorize(:account_dashboard_read, current_user, selected_account) != :ok or
+    if Authorization.authorize(:runners_read, current_user, selected_account) != :ok or
          not FeatureFlags.runners_enabled?(selected_account) do
       raise TuistWeb.Errors.NotFoundError,
             dgettext("dashboard_runners", "The page you are looking for doesn't exist or has been moved.")

--- a/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
@@ -15,15 +15,31 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
   def init(:test), do: :test
   def init(:build), do: :build
   def init(:automation_alert), do: :automation_alert
+  def init({:account, :runners}), do: {:account, :runners}
+  def init({:account, :account, :update}), do: {:account, :account, :update}
+  def init({:project, :project, :update}), do: {:project, :project, :update}
 
   def init(opts) when is_list(opts) do
     opts
   end
 
   @project_categories [:run, :bundle, :cache, :preview, :test, :build, :automation_alert]
+  @account_categories [:runners]
 
   def call(conn, category) when category in @project_categories do
     authorize_project(conn, category)
+  end
+
+  def call(conn, {:account, category}) when category in @account_categories do
+    authorize_account(conn, category)
+  end
+
+  def call(conn, {:account, :account, action}) when action == :update do
+    authorize_account(conn, :account, action)
+  end
+
+  def call(conn, {:project, :project, action}) when action == :update do
+    authorize_project(conn, :project, action: action)
   end
 
   def call(conn, opts) do
@@ -33,7 +49,7 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
 
   def authorize_project(%{assigns: %{selected_project: selected_project}} = conn, category, opts \\ []) do
     caching = Keyword.get(opts, :caching, false)
-    action = get_action(conn)
+    action = Keyword.get(opts, :action, get_action(conn))
     subject = Authentication.authenticated_subject(conn)
 
     cache_key = [
@@ -63,6 +79,17 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
       end
 
     if authorized? do
+      conn
+    else
+      deny(conn, subject, action, category)
+    end
+  end
+
+  defp authorize_account(%{assigns: %{selected_account: selected_account}} = conn, category, action \\ nil) do
+    action = action || get_action(conn)
+    subject = Authentication.authenticated_subject(conn)
+
+    if authorize(subject, action, selected_account, category) do
       conn
     else
       deny(conn, subject, action, category)

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -546,7 +546,28 @@ defmodule TuistWeb.Router do
       scope "/tokens" do
         post "/", AccountTokensController, :create
         get "/", AccountTokensController, :index
+        get "/:token_id", AccountTokensController, :show
         delete "/:token_name", AccountTokensController, :delete
+      end
+
+      scope "/runners" do
+        get "/jobs", RunnersController, :index_jobs
+        get "/jobs/:workflow_job_id", RunnersController, :show_job
+        get "/jobs/:workflow_job_id/steps", RunnersController, :index_job_steps
+        get "/jobs/:workflow_job_id/metrics", RunnersController, :index_job_metrics
+        get "/jobs/:workflow_job_id/logs", RunnersController, :index_job_logs
+        get "/workflows", RunnersController, :index_workflows
+        get "/profiles", RunnersController, :index_profiles
+      end
+
+      scope "/webhooks" do
+        get "/", WebhooksController, :index
+        get "/:webhook_endpoint_id", WebhooksController, :show
+        get "/:webhook_endpoint_id/delivery-attempts", WebhooksController, :index_delivery_attempts
+
+        get "/:webhook_endpoint_id/delivery-attempts/:delivery_attempt_id",
+            WebhooksController,
+            :show_delivery_attempt
       end
     end
 
@@ -651,9 +672,12 @@ defmodule TuistWeb.Router do
           get "/", Automations.AlertsController, :index
           post "/", Automations.AlertsController, :create
           get "/:alert_id", Automations.AlertsController, :show
+          get "/:alert_id/revisions", Automations.AlertsController, :index_revisions
           put "/:alert_id", Automations.AlertsController, :update
           delete "/:alert_id", Automations.AlertsController, :delete
         end
+
+        get "/notification-alerts", ProjectNotificationAlertsController, :index
 
         scope "/builds" do
           get "/", BuildsController, :index

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -225,10 +225,43 @@ Every operation has fixed limits for concurrency, duration, traversal, bytes rea
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
 | `list_accounts` | List personal and organization account handles available to the authenticated user, including whether each account can create projects. | None |
+| `get_organization` | Get an organization's member directory. Pending invitations require the same administrator permission as the dashboard; invitation acceptance tokens are never returned. | `account_handle` |
 | `create_organization` | Create a Tuist organization for the authenticated user. | `handle` |
 | `create_project` | Create a Tuist project under an account the authenticated user can access. | `account_handle`, `project_handle` |
 | `add_organization_member` | Add an existing Tuist user to an organization or update an existing member's role. Accepts `user` (the default), `admin`, or `viewer`, where a viewer can read dashboards and runs but cannot change anything. | `organization_handle`, `email` |
 | `list_projects` | List all projects accessible to the authenticated user. | None |
+| `get_project` | Get a project's configuration and connected repository URL. | `account_handle`, `project_handle` |
+
+#### Account tokens
+
+| Tool | Description | Required parameters |
+|------|-------------|---------------------|
+| `list_account_tokens` | List account token metadata without exposing token values. | `account_handle` |
+| `get_account_token` | Get account token metadata without exposing its value. | `account_handle`, `token_id` |
+| `list_project_tokens` | List project token metadata without exposing token values. | `account_handle`, `project_handle` |
+
+#### Continuous-integration runners
+
+| Tool | Description | Required parameters |
+|------|-------------|---------------------|
+| `list_runner_jobs` | List continuous-integration runner jobs for an account. | `account_handle` |
+| `get_runner_job` | Get a continuous-integration runner job. | `account_handle`, `workflow_job_id` |
+| `list_runner_job_steps` | List the steps recorded for a continuous-integration runner job. | `account_handle`, `workflow_job_id` |
+| `list_runner_job_metrics` | List machine metrics recorded for a continuous-integration runner job. | `account_handle`, `workflow_job_id` |
+| `list_runner_job_logs` | List up to 500 captured log lines for a continuous-integration runner job. | `account_handle`, `workflow_job_id` |
+| `list_runner_workflows` | List continuous-integration workflow rollups for an account. | `account_handle` |
+| `list_runner_profiles` | List continuous-integration runner profiles for an account. Requires the same administrator permission as the dashboard settings page. | `account_handle` |
+
+#### Webhooks
+
+Webhook tools use the same administrator-only permission as the dashboard. Delivery attempts contain the request and response data recorded for the endpoint, but never the endpoint signing secret.
+
+| Tool | Description | Required parameters |
+|------|-------------|---------------------|
+| `list_webhook_endpoints` | List webhook endpoints for an account. | `account_handle` |
+| `get_webhook_endpoint` | Get a webhook endpoint. | `account_handle`, `webhook_endpoint_id` |
+| `list_webhook_delivery_attempts` | List delivery attempts for an endpoint. | `account_handle`, `webhook_endpoint_id` |
+| `get_webhook_delivery_attempt` | Get a delivery attempt. | `account_handle`, `webhook_endpoint_id`, `delivery_attempt_id` |
 
 #### Xcode builds
 
@@ -290,6 +323,23 @@ Every operation has fixed limits for concurrency, duration, traversal, bytes rea
 | `list_cache_runs` | List cache runs for a project. | `account_handle`, `project_handle` |
 | `get_cache_run` | Get detailed information about a specific cache run. | `cache_run_id` |
 | `list_xcode_module_cache_targets` | List module cache targets for a generation or cache run, showing per-target cache hit/miss status and diagnostic component hashes, including additional hashing inputs. | `run_id` |
+
+#### Previews
+
+| Tool | Description | Required parameters |
+|------|-------------|---------------------|
+| `list_previews` | List shareable app previews for a project. | `account_handle`, `project_handle` |
+| `get_preview` | Get a preview and temporary download URLs for its builds. | `preview_id` |
+| `get_latest_preview` | Find the latest preview for a running app binary. | `account_handle`, `project_handle`, `binary_id`, `build_version` |
+
+#### Automations
+
+| Tool | Description | Required parameters |
+|------|-------------|---------------------|
+| `list_automation_alerts` | List automation alerts for a project. | `account_handle`, `project_handle` |
+| `get_automation_alert` | Get an automation alert. | `alert_id` |
+| `list_automation_alert_revisions` | List the revision history for an automation alert. Action credentials are redacted. | `alert_id` |
+| `list_project_notification_alerts` | List project notification alert rules. Requires the same administrator permission as the dashboard settings page. Webhook addresses are redacted. | `account_handle`, `project_handle` |
 
 ### Prompts
 

--- a/server/priv/marketing/changelog/2026.08.28-dashboard-read-apis.md
+++ b/server/priv/marketing/changelog/2026.08.28-dashboard-read-apis.md
@@ -1,9 +1,9 @@
 ---
-title: Inspect dashboard data from coding agents
-description: "Coding agents can now read projects, previews, automations, continuous-integration runners, webhooks, and token metadata through the same authenticated interfaces as the dashboard."
+title: Expand read parity across platform interfaces
+description: "Coding agents can now read projects, previews, automations, continuous-integration runners, webhooks, and token metadata through consistent platform interfaces."
 category: "Product"
 ---
 
-Coding agents can now inspect the project configuration, shareable previews, automation alerts and their revision history, notification alert rules, continuous-integration runner activity including job logs, steps, and machine metrics, webhook delivery history, and account and project token metadata that you already see in the dashboard. The new read tools follow the same permissions as their dashboard counterparts. Token values remain unavailable after their one-time reveal, webhook signing secrets and encrypted automation action credentials are never returned, and webhook delivery data remains restricted to account administrators.
+The platform's programmatic interfaces now provide read parity for project configuration, shareable previews, automation alerts and their revision history, notification alert rules, continuous-integration runner activity including job logs, steps, and machine metrics, webhook delivery history, and account and project token metadata. Each operation follows the authorization policy of its platform domain. Token values remain unavailable after their one-time reveal, webhook signing secrets and encrypted automation action credentials are never returned, and webhook delivery data remains restricted to account administrators.
 
 This makes it easier to investigate a project or audit its configuration from an agent without copying identifiers or sensitive token values into a conversation.

--- a/server/priv/marketing/changelog/2026.08.28-dashboard-read-apis.md
+++ b/server/priv/marketing/changelog/2026.08.28-dashboard-read-apis.md
@@ -1,0 +1,9 @@
+---
+title: Inspect dashboard data from coding agents
+description: "Coding agents can now read projects, previews, automations, continuous-integration runners, webhooks, and token metadata through the same authenticated interfaces as the dashboard."
+category: "Product"
+---
+
+Coding agents can now inspect the project configuration, shareable previews, automation alerts and their revision history, notification alert rules, continuous-integration runner activity including job logs, steps, and machine metrics, webhook delivery history, and account and project token metadata that you already see in the dashboard. The new read tools follow the same permissions as their dashboard counterparts. Token values remain unavailable after their one-time reveal, webhook signing secrets and encrypted automation action credentials are never returned, and webhook delivery data remains restricted to account administrators.
+
+This makes it easier to investigate a project or audit its configuration from an agent without copying identifiers or sensitive token values into a conversation.

--- a/server/test/tuist/accounts/account_token_test.exs
+++ b/server/test/tuist/accounts/account_token_test.exs
@@ -14,6 +14,7 @@ defmodule Tuist.Accounts.AccountTokenTest do
                "account:members:write",
                "account:registry:read",
                "account:registry:write",
+               "account:runners:read",
                "project:previews:read",
                "project:previews:write",
                "project:admin:read",
@@ -44,6 +45,10 @@ defmodule Tuist.Accounts.AccountTokenTest do
                "project:builds:write",
                "project:runs:write"
              ]
+    end
+
+    test "includes runner reads in the coding-agent scope" do
+      assert "account:runners:read" in AccountToken.expand_scopes([AccountToken.mcp_scope()])
     end
   end
 

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -778,6 +778,18 @@ defmodule Tuist.AuthorizationTest do
     assert Authorization.authorize(:runners_read, user, account) == {:error, :forbidden}
   end
 
+  test "can.read.account.runners when an account token has runner read scope" do
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+
+    subject = %AuthenticatedAccount{
+      account: account,
+      scopes: ["account:runners:read"]
+    }
+
+    assert Authorization.authorize(:runners_read, subject, account) == :ok
+  end
+
   test "can.read.account.organization when the subject is a user that is admin of an organization" do
     # Given
     organization = AccountsFixtures.organization_fixture()

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -28,16 +28,16 @@ defmodule Tuist.AuthorizationTest do
     assert Authorization.authorize(:account_dashboard_read, nil, account) == {:error, :forbidden}
   end
 
-  test "cannot.read.runners on a public account when the subject is not a member" do
-    # Given — a public account exposes its dashboards, but attaching to a
-    # running VM over VNC/shell stays members-only.
+  test "can.read.runners on a public account when the subject is not a member" do
+    # A public account exposes runner state, but attaching to a running virtual
+    # machine remains members-only through the separate interactive permission.
     account = AccountsFixtures.organization_fixture(preload: [:account]).account
     {:ok, public_account} = Accounts.update_account_visibility(account, :public)
     non_member = AccountsFixtures.user_fixture()
 
     # Then
-    assert Authorization.authorize(:runners_read, nil, public_account) == {:error, :forbidden}
-    assert Authorization.authorize(:runners_read, non_member, public_account) == {:error, :forbidden}
+    assert Authorization.authorize(:runners_read, nil, public_account) == :ok
+    assert Authorization.authorize(:runners_read, non_member, public_account) == :ok
     assert Authorization.authorize(:account_dashboard_read, non_member, public_account) == :ok
   end
 
@@ -788,6 +788,42 @@ defmodule Tuist.AuthorizationTest do
     }
 
     assert Authorization.authorize(:runners_read, subject, account) == :ok
+  end
+
+  test "can.read.account.runners when an account token has the coding-agent scope" do
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+
+    subject = %AuthenticatedAccount{
+      account: account,
+      scopes: ["mcp"]
+    }
+
+    assert Authorization.authorize(:runners_read, subject, account) == :ok
+  end
+
+  test "cannot.read.account.runners when an account token lacks a runner read scope" do
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+
+    subject = %AuthenticatedAccount{
+      account: account,
+      scopes: ["project:admin:read"]
+    }
+
+    assert Authorization.authorize(:runners_read, subject, account) == {:error, :forbidden}
+  end
+
+  test "cannot.read.account.runners when an account token targets another private account" do
+    account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+    subject = %AuthenticatedAccount{
+      account: account,
+      scopes: ["account:runners:read"]
+    }
+
+    assert Authorization.authorize(:runners_read, subject, other_account) == {:error, :forbidden}
   end
 
   test "can.read.account.organization when the subject is a user that is admin of an organization" do

--- a/server/test/tuist/mcp/authorization_test.exs
+++ b/server/test/tuist/mcp/authorization_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.MCP.AuthorizationTest do
   use Mimic
 
   alias Tuist.Accounts.AuthenticatedAccount
+  alias Tuist.MCP.Authorization, as: MCPAuthorization
   alias Tuist.MCP.Components.Tools.GetTestRun
   alias Tuist.MCP.Components.Tools.UpdateTestCase
   alias Tuist.Tests
@@ -155,6 +156,37 @@ defmodule Tuist.MCP.AuthorizationTest do
         })
 
       assert %{"isError" => true} = result
+    end
+  end
+
+  describe "runner reads" do
+    test "accepts the runner scope and the coding-agent scope for the token's own account", %{project: project} do
+      for scopes <- [["account:runners:read"], ["mcp"]] do
+        subject = %AuthenticatedAccount{account: project.account, scopes: scopes}
+
+        assert MCPAuthorization.authorize_request(%{current_subject: subject}, :read, project.account, :runners)
+      end
+    end
+
+    test "refuses an account token without runner read scope", %{project: project} do
+      subject = %AuthenticatedAccount{account: project.account, scopes: ["project:admin:read"]}
+
+      refute MCPAuthorization.authorize_request(%{current_subject: subject}, :read, project.account, :runners)
+    end
+
+    test "refuses an account token with runner read scope for a different private account", %{project: project} do
+      other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+      subject = %AuthenticatedAccount{account: project.account, scopes: ["account:runners:read"]}
+
+      refute MCPAuthorization.authorize_request(%{current_subject: subject}, :read, other_account, :runners)
+    end
+
+    test "allows an authenticated caller to read a public account's runner state", %{project: project} do
+      {:ok, public_account} = Tuist.Accounts.update_account_visibility(project.account, :public)
+      other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+      subject = %AuthenticatedAccount{account: other_account, scopes: []}
+
+      assert MCPAuthorization.authorize_request(%{current_subject: subject}, :read, public_account, :runners)
     end
   end
 end

--- a/server/test/tuist/mcp/components/tools/account_token_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/account_token_tools_test.exs
@@ -1,0 +1,95 @@
+defmodule Tuist.MCP.Components.Tools.AccountTokenToolsTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias Tuist.Accounts
+  alias Tuist.MCP.Components.Tools.GetAccountToken
+  alias Tuist.MCP.Components.Tools.ListAccountTokens
+  alias Tuist.MCP.Components.Tools.ListProjectTokens
+  alias Tuist.Projects
+
+  describe "list_account_tokens" do
+    test "returns non-secret token metadata" do
+      account = %{id: 1, name: "acme"}
+      token = token_fixture()
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :account_token_read, :subject, ^account -> :ok end)
+
+      stub(Accounts, :list_account_tokens, fn ^account, _attrs ->
+        {[token], pagination_metadata()}
+      end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListAccountTokens.call(conn, %{"account_handle" => "acme"})
+
+      assert %{
+               "tokens" => [%{"id" => "token-1", "name" => "build-insights", "project_handles" => ["app"]}]
+             } = JSON.decode!(text)
+    end
+  end
+
+  describe "get_account_token" do
+    test "returns one token without its secret" do
+      account = %{id: 1, name: "acme"}
+      token = token_fixture()
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :account_token_read, :subject, ^account -> :ok end)
+      stub(Accounts, :get_account_token, fn ^account, "token-1" -> {:ok, token} end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetAccountToken.call(conn, %{"account_handle" => "acme", "token_id" => "token-1"})
+
+      assert JSON.decode!(text)["id"] == "token-1"
+    end
+  end
+
+  describe "list_project_tokens" do
+    test "returns project token metadata after account authorization" do
+      account = %{id: 1, name: "acme"}
+      project = %{id: 2, name: "app", account: account}
+      project_token = %{id: "project-token-1", inserted_at: ~U[2026-01-01 12:00:00Z]}
+
+      stub(Projects, :get_project_by_account_and_project_handles, fn "acme", "app" -> project end)
+      stub(Tuist.Authorization, :authorize, fn :account_token_read, :subject, ^account -> :ok end)
+      stub(Projects, :get_project_tokens, fn ^project -> [project_token] end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListProjectTokens.call(conn, %{"account_handle" => "acme", "project_handle" => "app"})
+
+      assert JSON.decode!(text) == %{
+               "tokens" => [%{"id" => "project-token-1", "inserted_at" => "2026-01-01T12:00:00Z"}]
+             }
+    end
+  end
+
+  defp token_fixture do
+    %{
+      id: "token-1",
+      name: "build-insights",
+      scopes: ["project:builds:read"],
+      all_projects: false,
+      expires_at: nil,
+      inserted_at: ~U[2026-01-01 12:00:00Z],
+      projects: [%{name: "app"}]
+    }
+  end
+
+  defp pagination_metadata do
+    %{
+      has_next_page?: false,
+      has_previous_page?: false,
+      total_count: 1,
+      total_pages: 1,
+      current_page: 1,
+      page_size: 20
+    }
+  end
+end

--- a/server/test/tuist/mcp/components/tools/create_project_test.exs
+++ b/server/test/tuist/mcp/components/tools/create_project_test.exs
@@ -44,8 +44,10 @@ defmodule Tuist.MCP.Components.Tools.CreateProjectTest do
           "build_system" => "unknown"
         })
 
-      assert %{"content" => [%{"type" => "text", "text" => "is invalid"}], "isError" => true} =
-               result
+      assert %{
+               "content" => [%{"type" => "text", "text" => "Arguments do not match the tool schema."}],
+               "isError" => true
+             } = result
     end
 
     test "does not reveal inaccessible accounts" do

--- a/server/test/tuist/mcp/components/tools/get_gradle_integration_guide_test.exs
+++ b/server/test/tuist/mcp/components/tools/get_gradle_integration_guide_test.exs
@@ -37,7 +37,7 @@ defmodule Tuist.MCP.Components.Tools.GetGradleIntegrationGuideTest do
     end
 
     test "defaults to the deployment serving the tool" do
-      result = GetGradleIntegrationGuide.call(%Plug.Conn{}, %{"server_url" => nil})
+      result = GetGradleIntegrationGuide.call(%Plug.Conn{}, %{})
 
       assert result["structuredContent"]["guide"] =~ "tuist auth whoami --url http://localhost:8080"
       assert result["structuredContent"]["guide"] =~ "allowInsecureProtocol = true"

--- a/server/test/tuist/mcp/components/tools/preview_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/preview_tools_test.exs
@@ -1,0 +1,10 @@
+defmodule Tuist.MCP.Components.Tools.PreviewToolsTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.MCP.Components.Tools.PreviewSerializer
+
+  test "rejects an unsupported platform instead of removing the filter" do
+    assert {:error, "supported_platforms contains an unsupported platform."} =
+             PreviewSerializer.cast_supported_platforms(["not-a-platform"])
+  end
+end

--- a/server/test/tuist/mcp/components/tools/project_and_automation_alert_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/project_and_automation_alert_tools_test.exs
@@ -1,0 +1,146 @@
+defmodule Tuist.MCP.Components.Tools.ProjectAndAutomationAlertToolsTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias Tuist.Automations
+  alias Tuist.Automations.Alerts.Revision
+  alias Tuist.MCP.Components.Tools.GetAutomationAlert
+  alias Tuist.MCP.Components.Tools.GetProject
+  alias Tuist.MCP.Components.Tools.ListAutomationAlerts
+  alias Tuist.Projects
+
+  describe "get_project" do
+    test "returns dashboard configuration" do
+      account = %{id: 1, name: "acme"}
+
+      project = %{
+        id: 2,
+        account: account,
+        name: "app",
+        default_branch: "main",
+        visibility: :private,
+        build_system: :xcode
+      }
+
+      stub(Projects, :get_project_by_account_and_project_handles, fn "acme", "app" -> project end)
+      stub(Tuist.Authorization, :authorize, fn :project_read, :subject, ^project -> :ok end)
+      stub(Projects, :get_repository_url, fn ^project -> "https://github.com/acme/app" end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetProject.call(conn, %{"account_handle" => "acme", "project_handle" => "app"})
+
+      assert JSON.decode!(text) == %{
+               "build_system" => "xcode",
+               "default_branch" => "main",
+               "full_handle" => "acme/app",
+               "id" => 2,
+               "repository_url" => "https://github.com/acme/app",
+               "visibility" => "private"
+             }
+    end
+  end
+
+  describe "list_automation_alerts" do
+    test "returns alerts for the authorized project" do
+      project = %{id: 1, name: "app"}
+      alert = alert_fixture(project.id)
+
+      stub(Projects, :get_project_by_account_and_project_handles, fn "acme", "app" -> project end)
+      stub(Tuist.Authorization, :authorize, fn :automation_alert_read, :subject, ^project -> :ok end)
+      stub(Automations, :list_alerts, fn 1 -> [alert] end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListAutomationAlerts.call(conn, %{"account_handle" => "acme", "project_handle" => "app"})
+
+      assert %{"alerts" => [%{"id" => "alert-1", "name" => "Flaky test detection"}]} = JSON.decode!(text)
+
+      refute get_in(JSON.decode!(text), ["alerts", Access.at(0), "trigger_actions", Access.at(1), "webhook_url_encrypted"])
+    end
+  end
+
+  describe "get_automation_alert" do
+    test "returns an authorized alert" do
+      project = %{id: 1, name: "app"}
+      alert = alert_fixture(project.id)
+
+      stub(Automations, :get_alert, fn "alert-1" -> {:ok, alert} end)
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :automation_alert_read, :subject, ^project -> :ok end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetAutomationAlert.call(conn, %{"alert_id" => "alert-1"})
+
+      assert %{"id" => "alert-1", "monitor_type" => "flaky_run_count"} = JSON.decode!(text)
+    end
+
+    test "accepts a dashboard URL" do
+      project = %{id: 1, name: "app"}
+      alert = alert_fixture(project.id)
+
+      stub(Automations, :get_alert, fn "alert-1" -> {:ok, alert} end)
+      stub(Projects, :get_project_by_id, fn 1 -> project end)
+      stub(Tuist.Authorization, :authorize, fn :automation_alert_read, :subject, ^project -> :ok end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetAutomationAlert.call(conn, %{
+                 "alert_id" => "https://tuist.dev/acme/app/settings/automations/alert-1"
+               })
+
+      assert JSON.decode!(text)["id"] == "alert-1"
+    end
+  end
+
+  describe "automation revision redaction" do
+    test "removes encrypted webhook fields from snapshots and changes" do
+      revision = %Revision{
+        id: "revision-1",
+        event: "updated",
+        source: "dashboard",
+        actor: %{id: 1, email: "user@example.com", account: %{name: "user"}},
+        snapshot: %{
+          "trigger_actions" => [%{"type" => "send_slack", "webhook_url_encrypted" => "ciphertext"}]
+        },
+        changes: %{
+          "recovery_actions" => %{
+            "from" => [%{"type" => "send_slack", "webhook_url_encrypted" => "old"}],
+            "to" => [%{"type" => "send_slack", "webhook_url_encrypted" => "new"}]
+          }
+        },
+        inserted_at: ~U[2026-08-28 10:00:00Z]
+      }
+
+      redacted = Automations.redact_revision(revision)
+
+      refute get_in(redacted, [:snapshot, "trigger_actions", Access.at(0), "webhook_url_encrypted"])
+      refute get_in(redacted, [:changes, "recovery_actions", "from", Access.at(0), "webhook_url_encrypted"])
+      refute get_in(redacted, [:changes, "recovery_actions", "to", Access.at(0), "webhook_url_encrypted"])
+    end
+  end
+
+  defp alert_fixture(project_id) do
+    %{
+      id: "alert-1",
+      project_id: project_id,
+      name: "Flaky test detection",
+      enabled: true,
+      monitor_type: "flaky_run_count",
+      trigger_config: %{"threshold" => 3},
+      cadence: "5m",
+      trigger_actions: [
+        %{"type" => "add_label", "label" => "flaky"},
+        %{"type" => "send_slack", "channel" => "C123", "message" => "Alert", "webhook_url_encrypted" => "ciphertext"}
+      ],
+      recovery_enabled: true,
+      recovery_config: %{"window" => "14d"},
+      recovery_actions: [%{"type" => "remove_label", "label" => "flaky"}]
+    }
+  end
+end

--- a/server/test/tuist/mcp/components/tools/runner_and_webhook_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/runner_and_webhook_tools_test.exs
@@ -86,14 +86,17 @@ defmodule Tuist.MCP.Components.Tools.RunnerAndWebhookToolsTest do
 
       stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
       stub(Tuist.Authorization, :authorize, fn :account_update, :subject, ^account -> :ok end)
-      stub(Webhooks, :get_account_endpoint, fn "endpoint-1", 1 -> {:ok, endpoint} end)
+      stub(Webhooks, :get_account_endpoint, fn "0d574fe6-8908-4c8f-9413-b1d54a4aa465", 1 -> {:ok, endpoint} end)
 
       conn = %Plug.Conn{assigns: %{current_subject: :subject}}
 
       assert %{"content" => [%{"type" => "text", "text" => text}]} =
-               GetWebhookEndpoint.call(conn, %{"account_handle" => "acme", "webhook_endpoint_id" => "endpoint-1"})
+               GetWebhookEndpoint.call(conn, %{
+                 "account_handle" => "acme",
+                 "webhook_endpoint_id" => "0d574fe6-8908-4c8f-9413-b1d54a4aa465"
+               })
 
-      assert JSON.decode!(text)["id"] == "endpoint-1"
+      assert JSON.decode!(text)["id"] == "0d574fe6-8908-4c8f-9413-b1d54a4aa465"
     end
 
     test "rejects an invalid endpoint identifier before the database lookup" do
@@ -140,7 +143,7 @@ defmodule Tuist.MCP.Components.Tools.RunnerAndWebhookToolsTest do
 
   defp webhook_endpoint_fixture do
     %{
-      id: "endpoint-1",
+      id: "0d574fe6-8908-4c8f-9413-b1d54a4aa465",
       name: "Build notifications",
       url: "https://example.com/hooks/builds",
       signing_secret: "plaintext-signing-secret",

--- a/server/test/tuist/mcp/components/tools/runner_and_webhook_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/runner_and_webhook_tools_test.exs
@@ -1,0 +1,153 @@
+defmodule Tuist.MCP.Components.Tools.RunnerAndWebhookToolsTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias Tuist.Accounts
+  alias Tuist.FeatureFlags
+  alias Tuist.MCP.Components.Tools.GetRunnerJob
+  alias Tuist.MCP.Components.Tools.GetWebhookEndpoint
+  alias Tuist.MCP.Components.Tools.ListRunnerJobs
+  alias Tuist.MCP.Components.Tools.ListWebhookEndpoints
+  alias Tuist.Runners.Jobs
+  alias Tuist.Webhooks
+
+  describe "list_runner_jobs" do
+    test "uses the runner permission and account-scoped query" do
+      account = %{id: 1, name: "acme"}
+      job = runner_job_fixture()
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :runners_read, :subject, ^account -> :ok end)
+      stub(FeatureFlags, :runners_enabled?, fn ^account -> true end)
+      stub(Jobs, :count_for_account, fn 1, [] -> 1 end)
+      stub(Jobs, :list_for_account, fn 1, [limit: 20, offset: 0] -> [job] end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListRunnerJobs.call(conn, %{"account_handle" => "acme"})
+
+      assert %{"jobs" => [%{"workflow_job_id" => 42, "repository" => "acme/app"}]} = JSON.decode!(text)
+
+      refute JSON.decode!(text)["jobs"] |> hd() |> Map.has_key?("fleet_name")
+      refute JSON.decode!(text)["jobs"] |> hd() |> Map.has_key?("pod_name")
+      refute JSON.decode!(text)["jobs"] |> hd() |> Map.has_key?("runner_name")
+    end
+  end
+
+  describe "get_runner_job" do
+    test "uses the account-scoped job lookup" do
+      account = %{id: 1, name: "acme"}
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :runners_read, :subject, ^account -> :ok end)
+      stub(FeatureFlags, :runners_enabled?, fn ^account -> true end)
+      stub(Jobs, :get_for_account, fn 1, 42 -> {:ok, runner_job_fixture()} end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetRunnerJob.call(conn, %{"account_handle" => "acme", "workflow_job_id" => 42})
+
+      assert JSON.decode!(text)["workflow_job_id"] == 42
+    end
+
+    test "rejects malformed arguments before querying runner data" do
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{
+               "content" => [%{"type" => "text", "text" => "Arguments do not match the tool schema."}],
+               "isError" => true
+             } =
+               GetRunnerJob.call(conn, %{"account_handle" => "acme", "workflow_job_id" => "42"})
+    end
+  end
+
+  describe "webhook endpoint tools" do
+    test "use the same administrative account permission as the dashboard and never return the signing secret" do
+      account = %{id: 1, name: "acme"}
+      endpoint = webhook_endpoint_fixture()
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :account_update, :subject, ^account -> :ok end)
+      stub(Webhooks, :list_endpoints, fn 1 -> [endpoint] end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               ListWebhookEndpoints.call(conn, %{"account_handle" => "acme"})
+
+      refute inspect(JSON.decode!(text)) =~ "plaintext-signing-secret"
+    end
+
+    test "scopes an endpoint identifier to the authorized account" do
+      account = %{id: 1, name: "acme"}
+      endpoint = webhook_endpoint_fixture()
+
+      stub(Accounts, :get_account_by_handle, fn "acme" -> account end)
+      stub(Tuist.Authorization, :authorize, fn :account_update, :subject, ^account -> :ok end)
+      stub(Webhooks, :get_account_endpoint, fn "endpoint-1", 1 -> {:ok, endpoint} end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} =
+               GetWebhookEndpoint.call(conn, %{"account_handle" => "acme", "webhook_endpoint_id" => "endpoint-1"})
+
+      assert JSON.decode!(text)["id"] == "endpoint-1"
+    end
+
+    test "rejects an invalid endpoint identifier before the database lookup" do
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{
+               "content" => [%{"type" => "text", "text" => "Webhook endpoint identifier must be a UUID."}],
+               "isError" => true
+             } =
+               GetWebhookEndpoint.call(conn, %{
+                 "account_handle" => "acme",
+                 "webhook_endpoint_id" => "https://tuist.dev/acme/webhooks"
+               })
+    end
+  end
+
+  defp runner_job_fixture do
+    %{
+      workflow_job_id: 42,
+      repository: "acme/app",
+      workflow_run_id: 7,
+      workflow_name: "Test",
+      run_attempt: 1,
+      job_name: "Unit tests",
+      head_branch: "main",
+      head_sha: "abc",
+      status: "completed",
+      conclusion: "success",
+      fleet_name: "linux",
+      platform: "linux",
+      vcpus: 4,
+      memory_gb: 16,
+      requested_dispatch_label: "tuist-linux",
+      pod_name: "pod",
+      runner_name: "runner",
+      enqueued_at: ~U[2026-08-28 10:00:00Z],
+      claimed_at: nil,
+      started_at: ~U[2026-08-28 10:00:01Z],
+      completed_at: ~U[2026-08-28 10:01:00Z],
+      log_archived_at: nil,
+      updated_at: ~U[2026-08-28 10:01:00Z]
+    }
+  end
+
+  defp webhook_endpoint_fixture do
+    %{
+      id: "endpoint-1",
+      name: "Build notifications",
+      url: "https://example.com/hooks/builds",
+      signing_secret: "plaintext-signing-secret",
+      signing_secret_last_four: "abcd",
+      event_types: ["build.created"],
+      inserted_at: ~U[2026-08-28 10:00:00Z],
+      updated_at: ~U[2026-08-28 10:00:00Z]
+    }
+  end
+end

--- a/server/test/tuist/mcp/server_test.exs
+++ b/server/test/tuist/mcp/server_test.exs
@@ -17,9 +17,23 @@ defmodule Tuist.MCP.ServerTest do
 
       assert "get_gradle_integration_guide" in tool_names
       assert "list_accounts" in tool_names
+      assert "get_organization" in tool_names
+      assert "list_account_tokens" in tool_names
+      assert "get_account_token" in tool_names
       assert "create_organization" in tool_names
       assert "create_project" in tool_names
       assert "add_organization_member" in tool_names
+      assert "list_runner_jobs" in tool_names
+      assert "get_runner_job" in tool_names
+      assert "list_runner_job_steps" in tool_names
+      assert "list_runner_job_metrics" in tool_names
+      assert "list_runner_job_logs" in tool_names
+      assert "list_runner_workflows" in tool_names
+      assert "list_runner_profiles" in tool_names
+      assert "list_webhook_endpoints" in tool_names
+      assert "get_webhook_endpoint" in tool_names
+      assert "list_webhook_delivery_attempts" in tool_names
+      assert "get_webhook_delivery_attempt" in tool_names
       assert "list_xcode_builds" in tool_names
       assert "get_xcode_build" in tool_names
       assert "list_xcode_build_targets" in tool_names
@@ -42,10 +56,19 @@ defmodule Tuist.MCP.ServerTest do
       assert "get_generation" in tool_names
       assert "list_cache_runs" in tool_names
       assert "get_cache_run" in tool_names
+      assert "list_automation_alerts" in tool_names
+      assert "get_automation_alert" in tool_names
+      assert "list_automation_alert_revisions" in tool_names
+      assert "list_project_notification_alerts" in tool_names
       assert "list_xcode_module_cache_targets" in tool_names
       assert "list_test_case_run_attachments" in tool_names
       assert "list_projects" in tool_names
-      assert server.version == "1.16.0"
+      assert "get_project" in tool_names
+      assert "list_project_tokens" in tool_names
+      assert "list_previews" in tool_names
+      assert "get_preview" in tool_names
+      assert "get_latest_preview" in tool_names
+      assert server.version == "1.22.0"
       assert server.instructions =~ "agent_auth.skill"
       assert server.instructions =~ "identity-assertion exchange"
       assert server.instructions =~ "enter the code on the Tuist page"

--- a/server/test/tuist/mcp/tool_test.exs
+++ b/server/test/tuist/mcp/tool_test.exs
@@ -77,6 +77,17 @@ defmodule Tuist.MCP.ToolTest do
     end
   end
 
+  describe "validate_input/2" do
+    test "accepts valid tool arguments" do
+      assert :ok = Tool.validate_input(ListBundles, %{"account_handle" => "acme", "project_handle" => "app"})
+    end
+
+    test "rejects an argument that does not match the declared schema" do
+      assert {:error, "Arguments do not match the tool schema."} =
+               Tool.validate_input(ListBundles, %{"account_handle" => "acme", "project_handle" => 1})
+    end
+  end
+
   describe "descriptor/1" do
     test "attaches the output schema without validating it at request time" do
       descriptor = Tool.descriptor(ListBundles)

--- a/server/test/tuist_web/controllers/api/account_tokens_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/account_tokens_controller_test.exs
@@ -245,6 +245,43 @@ defmodule TuistWeb.API.AccountTokensControllerTest do
     end
   end
 
+  describe "GET /accounts/:account_handle/tokens/:token_id" do
+    test "returns the account token", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+
+      token =
+        AccountsFixtures.account_token_fixture(
+          account: user.account,
+          name: "dashboard-token",
+          scopes: ["project:cache:read"]
+        )
+
+      conn =
+        conn
+        |> TuistWeb.Authentication.put_current_user(user)
+        |> get("/api/accounts/#{user.account.name}/tokens/#{token.id}")
+
+      assert %{
+               "id" => token.id,
+               "name" => "dashboard-token",
+               "scopes" => ["project:cache:read"]
+             } = json_response(conn, :ok)
+    end
+
+    test "returns not found when the token belongs to another account", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      other_user = AccountsFixtures.user_fixture(preload: [:account])
+      token = AccountsFixtures.account_token_fixture(account: other_user.account)
+
+      conn =
+        conn
+        |> TuistWeb.Authentication.put_current_user(user)
+        |> get("/api/accounts/#{user.account.name}/tokens/#{token.id}")
+
+      assert %{"message" => "Account token not found"} = json_response(conn, :not_found)
+    end
+  end
+
   describe "DELETE /accounts/:account_handle/tokens/:token_name" do
     test "revokes token by name", %{conn: conn} do
       # Given

--- a/server/test/tuist_web/controllers/api/account_tokens_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/account_tokens_controller_test.exs
@@ -261,8 +261,10 @@ defmodule TuistWeb.API.AccountTokensControllerTest do
         |> TuistWeb.Authentication.put_current_user(user)
         |> get("/api/accounts/#{user.account.name}/tokens/#{token.id}")
 
+      token_id = token.id
+
       assert %{
-               "id" => token.id,
+               "id" => ^token_id,
                "name" => "dashboard-token",
                "scopes" => ["project:cache:read"]
              } = json_response(conn, :ok)

--- a/server/test/tuist_web/controllers/api/automations/alerts_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/automations/alerts_controller_test.exs
@@ -37,13 +37,30 @@ defmodule TuistWeb.API.Automations.AlertsControllerTest do
 
     test "lists alerts for a project", %{conn: conn, project: project} do
       a1 = AutomationsFixtures.automation_alert_fixture(project: project, name: "First")
-      a2 = AutomationsFixtures.automation_alert_fixture(project: project, name: "Second")
+
+      a2 =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          name: "Second",
+          trigger_actions: [
+            %{
+              "type" => "send_slack",
+              "channel" => "C123",
+              "message" => "Alert",
+              "webhook_url_encrypted" => "ciphertext"
+            }
+          ]
+        )
+
       _other = AutomationsFixtures.automation_alert_fixture()
 
       response = conn |> get(api_path(project)) |> json_response(:ok)
 
       ids = Enum.map(response["alerts"], & &1["id"])
       assert MapSet.new(ids) == MapSet.new([a1.id, a2.id])
+
+      second = Enum.find(response["alerts"], &(&1["id"] == a2.id))
+      refute get_in(second, ["trigger_actions", Access.at(0), "webhook_url_encrypted"])
     end
   end
 

--- a/server/test/tuist_web/controllers/api/organizations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/organizations_controller_test.exs
@@ -164,6 +164,26 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       assert Enum.find(response["members"], &(&1["id"] == viewer.id))["role"] == "viewer"
     end
 
+    test "does not return invitations to an organization member without invitation read access", %{conn: conn, user: user} do
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      member = AccountsFixtures.user_fixture(email: "tuist-member@tuist.io")
+      Accounts.add_user_to_organization(member, organization)
+
+      {:ok, _invitation} =
+        Accounts.invite_user_to_organization(
+          "invited-viewer@tuist.io",
+          %{inviter: user, to: organization, url: fn token -> token end},
+          role: :viewer
+        )
+
+      conn =
+        conn
+        |> Authentication.put_current_user(member)
+        |> get(~p"/api/organizations/tuist-org")
+
+      assert json_response(conn, :ok)["invitations"] == []
+    end
+
     test "returns an organization with an active pro plan", %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)

--- a/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
@@ -2,6 +2,8 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
   use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
+  alias Tuist.Accounts
+  alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.FeatureFlags
   alias Tuist.Runners.Jobs
   alias Tuist.Webhooks
@@ -32,6 +34,59 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
     refute Map.has_key?(hd(response["jobs"]), "fleet_name")
     refute Map.has_key?(hd(response["jobs"]), "pod_name")
     refute Map.has_key?(hd(response["jobs"]), "runner_name")
+  end
+
+  test "allows an account token with runner read scope to list its account's jobs", %{conn: conn, account: account} do
+    stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+    stub(Jobs, :count_for_account, fn ^account.id, [] -> 0 end)
+    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [] end)
+
+    response =
+      conn
+      |> assign(:current_subject, %AuthenticatedAccount{account: account, scopes: ["account:runners:read"]})
+      |> get(~p"/api/accounts/#{account.name}/runners/jobs")
+      |> json_response(:ok)
+
+    assert response["jobs"] == []
+  end
+
+  test "forbids an account token without runner read scope", %{conn: conn, account: account} do
+    response =
+      conn
+      |> assign(:current_subject, %AuthenticatedAccount{account: account, scopes: ["project:admin:read"]})
+      |> get(~p"/api/accounts/#{account.name}/runners/jobs")
+      |> json_response(:forbidden)
+
+    assert response["message"] =~ "not authorized"
+  end
+
+  test "forbids an account token with runner read scope from another private account", %{conn: conn, account: account} do
+    other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+    response =
+      conn
+      |> assign(:current_subject, %AuthenticatedAccount{account: account, scopes: ["account:runners:read"]})
+      |> get(~p"/api/accounts/#{other_account.name}/runners/jobs")
+      |> json_response(:forbidden)
+
+    assert response["message"] =~ "not authorized"
+  end
+
+  test "allows authenticated callers to list jobs for a public account", %{conn: conn, account: account} do
+    {:ok, account} = Accounts.update_account_visibility(account, :public)
+    other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+    stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+    stub(Jobs, :count_for_account, fn ^account.id, [] -> 0 end)
+    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [] end)
+
+    response =
+      conn
+      |> assign(:current_subject, %AuthenticatedAccount{account: other_account, scopes: []})
+      |> get(~p"/api/accounts/#{account.name}/runners/jobs")
+      |> json_response(:ok)
+
+    assert response["jobs"] == []
   end
 
   test "lists webhook endpoints without their signing secrets", %{conn: conn, user: user, account: account} do

--- a/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
@@ -20,9 +20,10 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
     user: user,
     account: account
   } do
+    account_id = account.id
     stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
-    stub(Jobs, :count_for_account, fn ^account.id, [] -> 1 end)
-    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [runner_job()] end)
+    stub(Jobs, :count_for_account, fn ^account_id, [] -> 1 end)
+    stub(Jobs, :list_for_account, fn ^account_id, [limit: 20, offset: 0] -> [runner_job()] end)
 
     response =
       conn
@@ -37,9 +38,10 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
   end
 
   test "allows an account token with runner read scope to list its account's jobs", %{conn: conn, account: account} do
+    account_id = account.id
     stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
-    stub(Jobs, :count_for_account, fn ^account.id, [] -> 0 end)
-    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [] end)
+    stub(Jobs, :count_for_account, fn ^account_id, [] -> 0 end)
+    stub(Jobs, :list_for_account, fn ^account_id, [limit: 20, offset: 0] -> [] end)
 
     response =
       conn
@@ -75,10 +77,11 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
   test "allows authenticated callers to list jobs for a public account", %{conn: conn, account: account} do
     {:ok, account} = Accounts.update_account_visibility(account, :public)
     other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    account_id = account.id
 
     stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
-    stub(Jobs, :count_for_account, fn ^account.id, [] -> 0 end)
-    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [] end)
+    stub(Jobs, :count_for_account, fn ^account_id, [] -> 0 end)
+    stub(Jobs, :list_for_account, fn ^account_id, [limit: 20, offset: 0] -> [] end)
 
     response =
       conn
@@ -90,6 +93,8 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
   end
 
   test "lists webhook endpoints without their signing secrets", %{conn: conn, user: user, account: account} do
+    account_id = account.id
+
     endpoint = %{
       id: Ecto.UUID.generate(),
       name: "Build notifications",
@@ -101,7 +106,7 @@ defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
       updated_at: ~U[2026-08-28 10:00:00Z]
     }
 
-    stub(Webhooks, :list_endpoints, fn ^account.id -> [endpoint] end)
+    stub(Webhooks, :list_endpoints, fn ^account_id -> [endpoint] end)
 
     response =
       conn

--- a/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runners_and_webhooks_controller_test.exs
@@ -1,0 +1,89 @@
+defmodule TuistWeb.API.RunnersAndWebhooksControllerTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias Tuist.FeatureFlags
+  alias Tuist.Runners.Jobs
+  alias Tuist.Webhooks
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistWeb.Authentication
+
+  setup do
+    user = AccountsFixtures.user_fixture(preload: [:account])
+    %{user: user, account: user.account}
+  end
+
+  test "lists account-scoped runner jobs without internal runtime identifiers", %{
+    conn: conn,
+    user: user,
+    account: account
+  } do
+    stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
+    stub(Jobs, :count_for_account, fn ^account.id, [] -> 1 end)
+    stub(Jobs, :list_for_account, fn ^account.id, [limit: 20, offset: 0] -> [runner_job()] end)
+
+    response =
+      conn
+      |> Authentication.put_current_user(user)
+      |> get(~p"/api/accounts/#{account.name}/runners/jobs")
+      |> json_response(:ok)
+
+    assert [%{"workflow_job_id" => 42, "platform" => "linux"}] = response["jobs"]
+    refute Map.has_key?(hd(response["jobs"]), "fleet_name")
+    refute Map.has_key?(hd(response["jobs"]), "pod_name")
+    refute Map.has_key?(hd(response["jobs"]), "runner_name")
+  end
+
+  test "lists webhook endpoints without their signing secrets", %{conn: conn, user: user, account: account} do
+    endpoint = %{
+      id: Ecto.UUID.generate(),
+      name: "Build notifications",
+      url: "https://example.com/hooks/builds",
+      signing_secret: "plaintext-signing-secret",
+      signing_secret_last_four: "abcd",
+      event_types: ["build.created"],
+      inserted_at: ~U[2026-08-28 10:00:00Z],
+      updated_at: ~U[2026-08-28 10:00:00Z]
+    }
+
+    stub(Webhooks, :list_endpoints, fn ^account.id -> [endpoint] end)
+
+    response =
+      conn
+      |> Authentication.put_current_user(user)
+      |> get(~p"/api/accounts/#{account.name}/webhooks")
+      |> json_response(:ok)
+
+    assert [%{"id" => id, "signing_secret_last_four" => "abcd"}] = response["endpoints"]
+    assert id == endpoint.id
+    refute inspect(response) =~ "plaintext-signing-secret"
+  end
+
+  defp runner_job do
+    %{
+      workflow_job_id: 42,
+      repository: "acme/app",
+      workflow_run_id: 7,
+      workflow_name: "Test",
+      run_attempt: 1,
+      job_name: "Unit tests",
+      head_branch: "main",
+      head_sha: "abc",
+      status: "completed",
+      conclusion: "success",
+      fleet_name: "linux-internal",
+      platform: "linux",
+      vcpus: 4,
+      memory_gb: 16,
+      requested_dispatch_label: "tuist-linux",
+      pod_name: "runner-pod",
+      runner_name: "runner-1",
+      enqueued_at: ~U[2026-08-28 10:00:00Z],
+      claimed_at: nil,
+      started_at: ~U[2026-08-28 10:00:01Z],
+      completed_at: ~U[2026-08-28 10:01:00Z],
+      log_archived_at: nil,
+      updated_at: ~U[2026-08-28 10:01:00Z]
+    }
+  end
+end

--- a/server/test/tuist_web/controllers/mcp_controller_test.exs
+++ b/server/test/tuist_web/controllers/mcp_controller_test.exs
@@ -245,7 +245,7 @@ defmodule TuistWeb.MCPControllerTest do
       assert response["id"] == 2
 
       tools = response["result"]["tools"]
-      assert length(tools) == 37
+      assert length(tools) == 60
       assert "search_tuist" in Enum.map(tools, & &1["name"])
 
       for tool <- tools do

--- a/server/test/tuist_web/live/account_tokens_live_test.exs
+++ b/server/test/tuist_web/live/account_tokens_live_test.exs
@@ -385,6 +385,7 @@ defmodule TuistWeb.AccountTokensLiveTest do
              "account:members:write",
              "account:registry:read",
              "account:registry:write",
+             "account:runners:read",
              "project:admin:read",
              "project:admin:write",
              "project:builds:read",


### PR DESCRIPTION
## What changed

This adds read parity for dashboard data across server endpoints and [Model Context Protocol](https://modelcontextprotocol.io/) tools. It covers account and project tokens, organizations, projects, previews, automation alerts and revisions, notification alerts, continuous-integration runners, webhook endpoints, and delivery attempts. The generated command-line client is updated from the server schema.

## Why

Several platform domains were available only through the dashboard, requiring coding agents and integrations to use a different interface for the same read-only information.

## Approach

The new endpoints and tools use the platform-domain authorization rules that already govern the dashboard rather than introducing a dashboard permission. Runner views, server endpoints, and tools now share `runners:read`; account tokens can be granted the scoped `account:runners:read` permission. Tool inputs are schema-validated, nested resources are resolved within their owning account or project, and secret or internal runtime fields are omitted from responses.

## Impact

Users can inspect the same configuration and operational data through supported programmatic interfaces, subject to the same authorization boundaries. Token values, webhook signing secrets, encrypted automation credentials, and internal runner identifiers remain unavailable.

## Validation

- `mise run generate-api-cli-code`
- `mise exec -- mix format` for the changed server files
- `mise exec -- mix compile`
- `git diff --check`

Focused tests could not run because the local PostgreSQL instance rejected connections with `FATAL 53300 too_many_connections`. The application started locally, but browser automation was unavailable in this workspace. This change affects authorization behavior only and does not change the runner dashboard’s visual presentation, so no useful before-and-after screenshot could be captured.
