### PR TITLE
feat(cli): pull cached binaries for generated projects

### DIFF
--- a/cli/Sources/TuistCacheCommand/CacheCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CacheCommand.swift
@@ -15,7 +15,7 @@ public struct CacheCommand: AsyncParsableCommand {
 
     private static var subcommands: [ParsableCommand.Type] {
         #if os(macOS)
-            [CacheWarmCommand.self, CacheConfigCommand.self]
+            [CacheWarmCommand.self, CachePullCommand.self, CacheConfigCommand.self]
         #else
             [CacheConfigCommand.self]
         #endif

--- a/cli/Sources/TuistCacheCommand/CachePullCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CachePullCommand.swift
@@ -1,0 +1,47 @@
+#if os(macOS)
+    import ArgumentParser
+    import Foundation
+    import TuistEnvKey
+    import TuistExtension
+
+    public struct CachePullCommand: AsyncParsableCommand {
+        public init() {}
+
+        public static var configuration: CommandConfiguration {
+            CommandConfiguration(
+                commandName: "pull",
+                _superCommandName: "cache",
+                abstract: "Pulls cached binaries for the current project graph."
+            )
+        }
+
+        @Option(
+            name: .shortAndLong,
+            help: "The path to the directory that contains the project whose binaries will be pulled.",
+            completion: .directory,
+            envKey: .cachePath
+        )
+        var path: String?
+
+        @Option(
+            name: .shortAndLong,
+            help: "Configuration to use when calculating binary cache hashes.",
+            envKey: .cacheConfiguration
+        )
+        var configuration: String?
+
+        @Argument(
+            help: "A list of targets or target tags whose binaries, including their dependencies, will be pulled. If no target is specified, all cacheable targets are pulled.",
+            envKey: .cacheTargets
+        )
+        var targets: [String] = []
+
+        public func run() async throws {
+            try await Extension.cachePullService.run(
+                path: path,
+                configuration: configuration,
+                targets: Set(targets)
+            )
+        }
+    }
+#endif

--- a/cli/Sources/TuistExtension/Extension.swift
+++ b/cli/Sources/TuistExtension/Extension.swift
@@ -20,6 +20,14 @@ public protocol CacheServicing {
     ) async throws
 }
 
+public protocol CachePullServicing {
+    func run(
+        path: String?,
+        configuration: String?,
+        targets: Set<String>
+    ) async throws
+}
+
 public struct EmptyHashCacheService: HashCacheServicing {
     public init() {}
     public func run(
@@ -46,7 +54,22 @@ public struct EmptyCacheService: CacheServicing {
     }
 }
 
+public struct EmptyCachePullService: CachePullServicing {
+    public init() {}
+
+    public func run(
+        path _: String?,
+        configuration _: String?,
+        targets _: Set<String>
+    ) async throws {
+        print(
+            "Caching is currently not opensourced. Please, report issues with caching on GitHub and the Tuist team will take a look."
+        )
+    }
+}
+
 public enum Extension {
     @TaskLocal public static var hashCacheService: HashCacheServicing = EmptyHashCacheService()
     @TaskLocal public static var cacheService: CacheServicing = EmptyCacheService()
+    @TaskLocal public static var cachePullService: CachePullServicing = EmptyCachePullService()
 }

--- a/cli/Sources/TuistKit/Commands/Cache/CachePullCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CachePullCommandService.swift
@@ -1,0 +1,158 @@
+#if canImport(TuistCacheEE)
+    import Foundation
+    import Path
+    import TuistCache
+    import TuistCacheEE
+    import TuistConfig
+    import TuistConfigLoader
+    import TuistCore
+    import TuistEnvironment
+    import TuistExtension
+    import TuistHasher
+    import TuistLoader
+    import TuistLogging
+    import TuistServer
+    import XcodeGraph
+
+    enum CachePullCommandServiceError: LocalizedError, Equatable {
+        case generatedProjectNotFound(AbsolutePath)
+        case targetsNotFound([String])
+        case noCacheableTargets([String])
+
+        var errorDescription: String? {
+            switch self {
+            case let .generatedProjectNotFound(path):
+                return "We couldn't find a generated project at \(path.pathString). Binary caching only works with generated projects."
+            case let .targetsNotFound(targets):
+                return "We couldn't find the requested targets in the graph: \(targets.joined(separator: ", "))."
+            case let .noCacheableTargets(targets):
+                return "The requested targets don't include any cacheable binaries: \(targets.joined(separator: ", "))."
+            }
+        }
+    }
+
+    public struct CachePullCommandService: CachePullServicing {
+        private let generatorFactory: CacheGeneratorFactorying
+        private let cacheGraphContentHasher: CacheGraphContentHashing
+        private let cacheStorageFactory: CacheStorageFactorying
+        private let configLoader: ConfigLoading
+        private let manifestLoader: ManifestLoading
+
+        public init(contentHasher: ContentHashing = CachedContentHasher()) {
+            self.init(
+                generatorFactory: CacheGeneratorFactory(contentHasher: contentHasher),
+                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
+                cacheStorageFactory: Extension.cacheStorageFactory,
+                configLoader: ConfigLoader(),
+                manifestLoader: ManifestLoader.current
+            )
+        }
+
+        init(
+            generatorFactory: CacheGeneratorFactorying,
+            cacheGraphContentHasher: CacheGraphContentHashing,
+            cacheStorageFactory: CacheStorageFactorying,
+            configLoader: ConfigLoading,
+            manifestLoader: ManifestLoading
+        ) {
+            self.generatorFactory = generatorFactory
+            self.cacheGraphContentHasher = cacheGraphContentHasher
+            self.cacheStorageFactory = cacheStorageFactory
+            self.configLoader = configLoader
+            self.manifestLoader = manifestLoader
+        }
+
+        public func run(
+            path directory: String?,
+            configuration: String?,
+            targets: Set<String>
+        ) async throws {
+            let path = try await Environment.current.pathRelativeToWorkingDirectory(directory)
+            guard try await manifestLoader.hasRootManifest(at: path) else {
+                throw CachePullCommandServiceError.generatedProjectNotFound(path)
+            }
+
+            let config = try await configLoader.loadConfig(path: path)
+            let generator = generatorFactory.binaryCacheWarmingPreload(
+                config: config,
+                targetsToBinaryCache: []
+            )
+            let graph = try await generator.load(
+                path: path,
+                options: config.project.generatedProject?.generationOptions
+            )
+            let hashes = try await cacheGraphContentHasher.contentHashes(
+                for: graph,
+                configuration: configuration,
+                defaultConfiguration: config.project.generatedProject?.generationOptions.defaultConfiguration,
+                excludedTargets: [],
+                destination: nil
+            )
+            let selectedHashes = try selectedHashes(
+                from: hashes,
+                graph: graph,
+                requestedTargets: targets
+            )
+
+            guard !selectedHashes.isEmpty else {
+                if !targets.isEmpty {
+                    throw CachePullCommandServiceError.noCacheableTargets(targets.sorted())
+                }
+                Logger.current.info("The project contains no cacheable targets")
+                return
+            }
+
+            let items = Set(selectedHashes.map {
+                CacheStorableItem(name: $0.key.target.name, hash: $0.value.hash)
+            })
+            let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+            let pulledBinaries = try await cacheStorage.fetch(items, cacheCategory: .binaries)
+            let pulledItems = Set(pulledBinaries.keys.map {
+                CacheStorableItem(name: $0.name, hash: $0.hash)
+            })
+            let missingItems = items.subtracting(pulledItems)
+
+            logSummary(pulledBinaries: pulledBinaries, missingItems: missingItems)
+        }
+
+        private func selectedHashes(
+            from hashes: [GraphTarget: TargetContentHash],
+            graph: Graph,
+            requestedTargets: Set<String>
+        ) throws -> [GraphTarget: TargetContentHash] {
+            guard !requestedTargets.isEmpty else { return hashes }
+
+            let graphTraverser = GraphTraverser(graph: graph)
+            let requestedGraphTargets = graphTraverser.filterIncludedTargets(
+                basedOn: graphTraverser.allTargets(),
+                testPlan: nil,
+                includedTargets: Set(requestedTargets.map { TargetQuery(stringLiteral: $0) }),
+                excludedTargets: []
+            )
+            guard !requestedGraphTargets.isEmpty else {
+                throw CachePullCommandServiceError.targetsNotFound(requestedTargets.sorted())
+            }
+
+            let nonTestRoots = requestedGraphTargets.filter { !$0.target.product.testsBundle }
+            guard !nonTestRoots.isEmpty else {
+                throw CachePullCommandServiceError.noCacheableTargets(requestedTargets.sorted())
+            }
+
+            let selectedTargets = graphTraverser
+                .allTargetDependencies(traversingFromTargets: Array(nonTestRoots))
+                .union(nonTestRoots)
+            return hashes.filter { selectedTargets.contains($0.key) }
+        }
+
+        private func logSummary(
+            pulledBinaries: [CacheItem: AbsolutePath],
+            missingItems: Set<CacheStorableItem>
+        ) {
+            let localCount = pulledBinaries.keys.count(where: { $0.source == .local })
+            let remoteCount = pulledBinaries.keys.count(where: { $0.source == .remote })
+            Logger.current.info(
+                "Pulled \(remoteCount) binaries, found \(localCount) locally, and missed \(missingItems.count)."
+            )
+        }
+    }
+#endif

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -114,7 +114,10 @@ func initNoora(jsonThroughNoora: Bool = false) -> Noora {
         #if canImport(TuistCacheEE)
             try await Extension.$cacheService
                 .withValue(CacheWarmCommandService()) {
-                    try await action()
+                    try await Extension.$cachePullService
+                        .withValue(CachePullCommandService()) {
+                            try await action()
+                        }
                 }
         #else
             try await action()

--- a/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -985,6 +985,27 @@ struct CommandEnvironmentVariableTests {
         }
     }
 
+    @Test(.withMockedEnvironment()) func cachePullCommandUsesEnvVars() throws {
+        setVariable(.cacheConfiguration, value: "CacheConfig")
+        setVariable(.cachePath, value: "/cache/path")
+        setVariable(.cacheTargets, value: "Fmk1,Fmk2")
+
+        let commandWithEnvVars = try CachePullCommand.parse([])
+        #expect(commandWithEnvVars.configuration == "CacheConfig")
+        #expect(commandWithEnvVars.path == "/cache/path")
+        #expect(commandWithEnvVars.targets == ["Fmk1", "Fmk2"])
+
+        let commandWithArgs = try CachePullCommand.parse([
+            "--configuration", "CacheConfig",
+            "--path", "/cache/path",
+            "--",
+            "Fmk1", "Fmk2",
+        ])
+        #expect(commandWithArgs.configuration == "CacheConfig")
+        #expect(commandWithArgs.path == "/cache/path")
+        #expect(commandWithArgs.targets == ["Fmk1", "Fmk2"])
+    }
+
     @Test(.withMockedEnvironment()) func tuistVariablesFiltersTuistAndCIOnly() throws {
         Environment.mocked?.variables = [
             "TUIST_FOO": "1",

--- a/cli/Tests/TuistKitTests/Services/Cache/CachePullCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CachePullCommandServiceTests.swift
@@ -1,0 +1,223 @@
+#if canImport(TuistCacheEE)
+    import Foundation
+    import Mockable
+    import Path
+    import Testing
+    import TuistCache
+    import TuistConfig
+    import TuistConfigLoader
+    import TuistCore
+    import TuistEnvironment
+    import TuistEnvironmentTesting
+    import TuistHasher
+    import TuistLoader
+    import TuistServer
+    import TuistTesting
+    import XcodeGraph
+
+    @testable import TuistCacheEE
+    @testable import TuistKit
+
+    struct CachePullCommandServiceTests {
+        private let config = Tuist.test()
+        private let cacheStorage = MockCacheStoring()
+        private let cacheStorageFactory = MockCacheStorageFactorying()
+        private let generatorFactory = MockCacheGeneratorFactorying()
+        private let generator = MockGenerating()
+        private let cacheGraphContentHasher = MockCacheGraphContentHashing()
+        private let configLoader = MockConfigLoading()
+        private let manifestLoader = MockManifestLoading()
+
+        @Test(.withMockedEnvironment()) func run_pullsCacheableBinaries() async throws {
+            let (path, graph, target, hash) = try configureGraph()
+            let cacheItem = CacheItem.test(
+                name: target.target.name,
+                hash: hash,
+                source: .remote,
+                cacheCategory: .binaries
+            )
+            given(cacheStorage)
+                .fetch(
+                    .value(Set([CacheStorableItem(name: target.target.name, hash: hash)])),
+                    cacheCategory: .value(.binaries)
+                )
+                .willReturn([cacheItem: path])
+
+            try await subject.run(
+                path: path.pathString,
+                configuration: nil,
+                targets: []
+            )
+
+            verify(cacheStorage)
+                .fetch(
+                    .value(Set([CacheStorableItem(name: target.target.name, hash: hash)])),
+                    cacheCategory: .value(.binaries)
+                )
+                .called(1)
+            verify(cacheStorageFactory)
+                .cacheStorage(config: .value(config))
+                .called(1)
+            verify(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .value(graph),
+                    configuration: .value(nil),
+                    defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
+                    excludedTargets: .value([]),
+                    destination: .value(nil)
+                )
+                .called(1)
+        }
+
+        @Test(.withMockedEnvironment()) func run_pullsSelectedTargetAndItsDependencies() async throws {
+            let path = try AbsolutePath(validating: "/project")
+            let dependency = Target.test(name: "Dependency", product: .framework)
+            let target = Target.test(
+                name: "Feature",
+                product: .framework,
+                dependencies: [.target(name: dependency.name)]
+            )
+            let project = Project.test(path: path, targets: [target, dependency])
+            let graph = Graph.test(
+                path: path,
+                projects: [path: project],
+                dependencies: [
+                    .target(name: target.name, path: path): [.target(name: dependency.name, path: path)],
+                ]
+            )
+            let featureTarget = GraphTarget(path: path, target: target, project: project)
+            let dependencyTarget = GraphTarget(path: path, target: dependency, project: project)
+            let featureHash = "feature-hash"
+            let dependencyHash = "dependency-hash"
+            configure(
+                path: path,
+                graph: graph,
+                hashes: [
+                    featureTarget: .test(hash: featureHash),
+                    dependencyTarget: .test(hash: dependencyHash),
+                ]
+            )
+            let items = Set([
+                CacheStorableItem(name: target.name, hash: featureHash),
+                CacheStorableItem(name: dependency.name, hash: dependencyHash),
+            ])
+            given(cacheStorage)
+                .fetch(.value(items), cacheCategory: .value(.binaries))
+                .willReturn([
+                    .test(name: target.name, hash: featureHash, source: .remote, cacheCategory: .binaries): path,
+                    .test(name: dependency.name, hash: dependencyHash, source: .local, cacheCategory: .binaries): path,
+                ])
+
+            try await subject.run(
+                path: path.pathString,
+                configuration: nil,
+                targets: [target.name]
+            )
+
+            verify(cacheStorage)
+                .fetch(.value(items), cacheCategory: .value(.binaries))
+                .called(1)
+        }
+
+        @Test(.withMockedEnvironment()) func run_throwsWhenRequestedTargetsDoNotExist() async throws {
+            let (path, graph, _, _) = try configureGraph()
+
+            await #expect(throws: CachePullCommandServiceError.targetsNotFound(["Missing"])) {
+                try await subject.run(
+                    path: path.pathString,
+                    configuration: nil,
+                    targets: ["Missing"]
+                )
+            }
+
+            verify(cacheStorage)
+                .fetch(.any, cacheCategory: .any)
+                .called(0)
+            verify(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .value(graph),
+                    configuration: .value(nil),
+                    defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
+                    excludedTargets: .value([]),
+                    destination: .value(nil)
+                )
+                .called(1)
+        }
+
+        @Test(.withMockedEnvironment()) func run_allowsMissingBinaries() async throws {
+            let (path, _, _, _) = try configureGraph()
+            given(cacheStorage)
+                .fetch(.any, cacheCategory: .value(.binaries))
+                .willReturn([:])
+
+            try await subject.run(
+                path: path.pathString,
+                configuration: nil,
+                targets: []
+            )
+
+            verify(cacheStorage)
+                .fetch(.any, cacheCategory: .value(.binaries))
+                .called(1)
+        }
+
+        private func configureGraph() throws -> (AbsolutePath, Graph, GraphTarget, String) {
+            let path = try AbsolutePath(validating: "/project")
+            let target = Target.test(name: "Feature", product: .framework)
+            let project = Project.test(path: path, targets: [target])
+            let graph = Graph.test(path: path, projects: [path: project])
+            let graphTarget = GraphTarget(path: path, target: target, project: project)
+            let hash = "feature-hash"
+            configure(
+                path: path,
+                graph: graph,
+                hashes: [graphTarget: .test(hash: hash)]
+            )
+            return (path, graph, graphTarget, hash)
+        }
+
+        private func configure(
+            path: AbsolutePath,
+            graph: Graph,
+            hashes: [GraphTarget: TargetContentHash]
+        ) {
+            given(manifestLoader)
+                .hasRootManifest(at: .value(path))
+                .willReturn(true)
+            given(configLoader)
+                .loadConfig(path: .value(path))
+                .willReturn(config)
+            given(generatorFactory)
+                .binaryCacheWarmingPreload(
+                    config: .value(config),
+                    targetsToBinaryCache: .value([])
+                )
+                .willReturn(generator)
+            given(generator)
+                .load(path: .value(path), options: .value(config.project.generatedProject?.generationOptions))
+                .willReturn(graph)
+            given(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .value(graph),
+                    configuration: .value(nil),
+                    defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
+                    excludedTargets: .value([]),
+                    destination: .value(nil)
+                )
+                .willReturn(hashes)
+            given(cacheStorageFactory)
+                .cacheStorage(config: .value(config))
+                .willReturn(cacheStorage)
+        }
+
+        private var subject: CachePullCommandService {
+            CachePullCommandService(
+                generatorFactory: generatorFactory,
+                cacheGraphContentHasher: cacheGraphContentHasher,
+                cacheStorageFactory: cacheStorageFactory,
+                configLoader: configLoader,
+                manifestLoader: manifestLoader
+            )
+        }
+    }
+#endif

--- a/server/priv/marketing/changelog/2026.08.28-pull-cache-binaries.md
+++ b/server/priv/marketing/changelog/2026.08.28-pull-cache-binaries.md
@@ -1,0 +1,9 @@
+---
+title: Pull cache binaries from generated projects
+description: "Download cached binaries for a generated project graph with tuist cache pull."
+category: "Product"
+---
+
+`tuist cache pull` now downloads cached binaries directly for a generated project. It calculates hashes from the current graph and fetches either every cacheable target or the requested targets with their dependencies.
+
+Missing binaries are reported in the summary, allowing project setup to continue with the artifacts that are available.


### PR DESCRIPTION
> Adds `tuist cache pull` so generated projects can populate the binary cache without separately calculating hashes.

### How to test locally

- `mise run cli:lint --fix`
- With a generated project whose binary cache contains artifacts, run `tuist cache pull` to pull every cacheable target, or `tuist cache pull FeatureKit` to include that target and its dependencies.
- The focused `xcodebuild test` run was attempted, but an Xcode software development kit statistics-cache process stalled before compilation.
