### PR TITLE
fix(swifterpm,cli): copy native checkouts on continuous integration

### DIFF
--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -658,11 +658,12 @@ enum WorkspaceRestorer {
 
             try await fileSystem.move(from: checkout.absolutePath, to: destination.absolutePath)
             do {
-                try await fileSystem.createSymbolicLink(
-                    from: checkout.absolutePath,
-                    to: destination.absolutePath
+                try await fileSystem.replaceWithCachedDirectory(
+                    source: destination,
+                    destination: checkout
                 )
             } catch {
+                try? await fileSystem.remove(checkout.absolutePath)
                 try? await fileSystem.move(from: destination.absolutePath, to: checkout.absolutePath)
                 throw error
             }

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -217,6 +217,92 @@ struct ResolveTests {
     }
 
     @Test
+    func coldResolutionCopiesCheckoutsInContinuousIntegration() async throws {
+        try await Environment.$values.withValue(["CI": "1"]) {
+            try await withTemporaryDirectory { root in
+                let dependency = root.appendingPathComponent("Dependency")
+                try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+                try await initGitDependency(at: dependency, tags: ["1.0.0"])
+
+                let package = root.appendingPathComponent("App")
+                try await writeAppPackageManifest(at: package, dependencyURL: dependency.path)
+                let cacheDirectory = root.appendingPathComponent("cache")
+                let scratch = root.appendingPathComponent("scratch")
+
+                let result = try await SwifterPM().resolve(
+                    .init(
+                        packageDirectory: package,
+                        cacheDirectory: cacheDirectory,
+                        scratchDirectory: scratch,
+                        disableSandbox: true,
+                        quiet: true
+                    ))
+
+                #expect(result.pins.map(\.identity) == ["dependency"])
+                let pin = try #require(
+                    try await ResolvedFile.read(packageDir: package).pins.first
+                )
+                let checkout = scratch
+                    .appendingPathComponent("checkouts")
+                    .appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+                #expect(fileSystem.isDirectoryAndNotSymlink(checkout))
+                #expect(try await fileSystem.exists(checkout.appendingPathComponent("Package.swift").absolutePath))
+
+                try await fileSystem.remove(cacheDirectory.absolutePath)
+                #expect(try await fileSystem.exists(checkout.appendingPathComponent("Package.swift").absolutePath))
+            }
+        }
+    }
+
+    @Test
+    func coldResolutionRepairsDanglingCheckoutsInContinuousIntegration() async throws {
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tags: ["1.0.0"])
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(at: package, dependencyURL: dependency.path)
+            let cacheDirectory = root.appendingPathComponent("cache")
+            let scratch = root.appendingPathComponent("scratch")
+
+            try await Environment.withCachedDirectoryMaterialization(.symlink) {
+                _ = try await SwifterPM().resolve(
+                    .init(
+                        packageDirectory: package,
+                        cacheDirectory: cacheDirectory,
+                        scratchDirectory: scratch,
+                        disableSandbox: true,
+                        quiet: true
+                    ))
+            }
+
+            let pin = try #require(
+                try await ResolvedFile.read(packageDir: package).pins.first
+            )
+            let checkout = scratch
+                .appendingPathComponent("checkouts")
+                .appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+            let cache = try await Cache(root: cacheDirectory)
+            try await fileSystem.remove((try cache.sourcePath(pin: pin)).absolutePath)
+
+            try await Environment.$values.withValue(["CI": "1"]) {
+                _ = try await SwifterPM().resolve(
+                    .init(
+                        packageDirectory: package,
+                        cacheDirectory: cacheDirectory,
+                        scratchDirectory: scratch,
+                        disableSandbox: true,
+                        quiet: true
+                    ))
+            }
+
+            #expect(fileSystem.isDirectoryAndNotSymlink(checkout))
+            #expect(try await fileSystem.exists(checkout.appendingPathComponent("Package.swift").absolutePath))
+        }
+    }
+
+    @Test
     func nativeColdPathIsUsedWhenTheSharedCacheOnlyContainsOtherPackages() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("App")


### PR DESCRIPTION
## What changed

- Copy checkouts created by native dependency resolution when running on continuous integration runners.
- Added regression coverage for both a fresh dependency installation and a legacy dangling checkout restored from a `.build` cache.

## Why

The persistent dependency cache must not leave project `.build` directories dependent on machine-local cache paths.

## Root cause

Native dependency resolution moved fresh checkouts into SwifterPM’s shared cache, then always recreated them as symbolic links. A cached `.build` directory therefore contained links to a machine-local path. On a later continuous integration runner, those links were dangling and Tuist could not load the `abseil-cpp-binary` manifest.

## Approach

Reuse the existing cached-directory materialization policy for native checkouts. It copies on continuous integration runners, preserving a self-contained `.build` cache, while retaining symbolic links locally.

The regression test also starts with a legacy dangling checkout, removes its shared-cache source, and verifies that one `tuist install` repairs it.

## Impact

Jobs that run `tuist install` before `tuist generate` self-heal affected `.build` directories without clearing the cache. Jobs that invoke only `tuist generate` must add one `tuist install` step, because generation intentionally reads an existing dependency workspace rather than resolving dependencies.

## Validation

- `swift test --package-path swifterpm --filter ResolveTests/coldResolutionRepairsDanglingCheckoutsInContinuousIntegration`
- `swift test --package-path swifterpm` (188 tests passed)