### PR TITLE
feat(infra): add the Kura customer overview dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-customer-overview.json
+++ b/infra/grafana-dashboards/tuist-kura-customer-overview.json
@@ -1,0 +1,1138 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "dbfwllgyul4o3kf"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "One row per Kura pod (tenant instance replica) with the five service signals (faults, responsiveness, shedding, hit-rate drift, retention horizon) and a hard readiness gate, coloured by threshold. Built on kura_* metrics joined to kura_node_info.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(8 * max by (tenant_id, region, pod) ((1 - kura_ready_state{cluster=~\"tuist-$env\"}) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) + 4 * max by (tenant_id, region, pod) ((kura_backfill_initial_cycle_mode{cluster=~\"tuist-$env\"} == bool 2) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) + 2 * (sum by (tenant_id, region, pod) (rate(kura_peer_connection_failures_total_total{cluster=~\"tuist-$env\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) \u003e bool 0) + 1 * max by (tenant_id, region, pod) ((kura_memory_pressure_state{cluster=~\"tuist-$env\"} == bool 2) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})), \"replica\", \"$1\", \"pod\", \"^kura-.+?-((?:[a-z]{2}-[a-z]+(?:-[0-9]+)?|scw-fr-par)-[0-9]+)$\")",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "G"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "(sum by (tenant_id, region, pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\", status=~\"5..\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) or 0 * sum by (tenant_id, region, pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))) / sum by (tenant_id, region, pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.95, sum by (tenant_id, region, pod, le) (rate(kura_public_request_latency_seconds_bucket{cluster=~\"tuist-$env\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "(sum by (tenant_id, region, pod) (rate(kura_capacity_sheds_total_total{cluster=~\"tuist-$env\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) or 0 * sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))) / sum by (tenant_id, region, pod) ((sum by (cluster, instance) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\"}[$__range])) + (sum by (cluster, instance) (rate(kura_artifact_writes_total_total{cluster=~\"tuist-$env\"}[$__range])) or 0 * sum by (cluster, instance) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\"}[$__range]))) + (sum by (cluster, instance) (rate(kura_capacity_sheds_total_total{cluster=~\"tuist-$env\"}[$__range])) or 0 * sum by (cluster, instance) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\"}[$__range])))) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "((sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", result=\"ok\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) / sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", result=~\"ok|not_found\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))) - (sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", result=\"ok\"}[7d]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) / sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", result=~\"ok|not_found\"}[7d]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})))) and sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", result=~\"ok|not_found\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) \u003e 0.5",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.5, sum by (tenant_id, region, pod, le) (rate(kura_segment_shed_age_seconds_bucket{cluster=~\"tuist-$env\"}[7d]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))) / 3600",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (tenant_id, region, pod) (increase(kube_pod_container_status_restarts_total{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\"}[6h]) * on (cluster, pod) group_left(tenant_id, region) max by (cluster, pod, tenant_id, region) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"}))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "H"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (tenant_id, region, pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) + (sum by (tenant_id, region, pod) (rate(kura_artifact_reads_total_total{cluster=~\"tuist-$env\", producer=\"reapi\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})) or 0 * sum by (tenant_id, region, pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__range]) * on (cluster, instance) group_left(tenant_id, region, pod) max by (cluster, instance, tenant_id, region, pod) (kura_node_info{cluster=~\"tuist-$env\", region=~\"$region\"})))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "I"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "filterFieldsByName",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(tenant_id|region|pod|replica|Value #[A-EGHI])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "group": "merge",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "indexByName": {
+                        "Value #A": 3,
+                        "Value #B": 4,
+                        "Value #C": 5,
+                        "Value #D": 6,
+                        "Value #E": 7,
+                        "Value #G": 2,
+                        "Value #H": 8,
+                        "Value #I": 9,
+                        "pod": 98,
+                        "region": 99,
+                        "replica": 1,
+                        "tenant_id": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Each column is one of the five Kura service signals plus the hard gate. Ratios use the dashboard time range as their window (default 1h); the hit-rate baseline is 7d. `idle` = no traffic in the window, not green.",
+          "id": 1,
+          "links": [],
+          "title": "Overview",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Gate"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "red",
+                              "value": 4
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "green",
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "from": 1,
+                              "result": {
+                                "color": "orange",
+                                "text": "memory critical"
+                              },
+                              "to": 1
+                            },
+                            "type": "range"
+                          },
+                          {
+                            "options": {
+                              "from": 2,
+                              "result": {
+                                "color": "orange",
+                                "text": "peer failures"
+                              },
+                              "to": 3
+                            },
+                            "type": "range"
+                          },
+                          {
+                            "options": {
+                              "from": 4,
+                              "result": {
+                                "color": "red",
+                                "text": "backfill degraded"
+                              },
+                              "to": 7
+                            },
+                            "type": "range"
+                          },
+                          {
+                            "options": {
+                              "from": 8,
+                              "result": {
+                                "color": "red",
+                                "text": "NOT READY"
+                              },
+                              "to": 99
+                            },
+                            "type": "range"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fault %"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.001
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "color": "text",
+                                "text": "idle"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 TTFB"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.25
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "color": "text",
+                                "text": "idle"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Shed %"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.001
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "color": "text",
+                                "text": "idle"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Hit-rate Δ"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": -0.2
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.05
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 110
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "color": "text",
+                                "text": "idle"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Shed age p50"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "h"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 24
+                            },
+                            {
+                              "color": "green",
+                              "value": 72
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "color": "text",
+                                "text": "no eviction 7d"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Restarts 6h"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "red",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #I"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "req/s"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "reqps"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "text",
+                              "value": 0
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tenant_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Customer"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 170
+                      },
+                      {
+                        "id": "links",
+                        "value": [
+                          {
+                            "targetBlank": false,
+                            "title": "Open in Tuist Kura (customer)",
+                            "url": "/d/tuist-kura/tuist-kura?var-cluster=tuist-${env}\u0026var-tenant=${__data.fields.Customer}\u0026var-region=${__data.fields.region}\u0026var-instance=All\u0026var-pod=All\u0026${__url_time_range}"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom.viz",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "pod"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom.viz",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "replica"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Pod"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "links",
+                        "value": [
+                          {
+                            "targetBlank": false,
+                            "title": "Open in Tuist Kura / Pod",
+                            "url": "/d/ddfsumc1ibvuo0e/tuist-kura-pod?var-env=${env}\u0026var-pod=${__data.fields.pod}\u0026${__url_time_range}"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Gate",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 101
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Restarts 6h",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 119
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "p95 TTFB",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 121
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Customer"
+                  }
+                ]
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 2,
+          "links": [],
+          "title": "How to read this table",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "\n| Column | Answers | Green / Amber / Red | Where to drill |\n|---|---|---|---|\n| **Gate** | Is the instance fundamentally healthy? | OK / peer failures, memory critical / backfill degraded, NOT READY | Tuist Kura / Pod → readiness, backfill, outbox |\n| **Fault %** | Is Kura failing requests it should have served? (5xx on public routes; 404 miss and 429 shed excluded) | \u003c 0.1 % / 0.1–1 % / \u003e 1 % | Tuist Kura → HTTP Status Rate, Internal/Peer traffic; `kura_auth_decisions_total_total{result=\"unavailable\"}` |\n| **p95 TTFB** | Is the node answering promptly, independent of the client's network? | \u003c 250 ms / 250 ms–1 s / \u003e 1 s | `kura_public_request_latency_seconds` by `transport`, `route`; FD waits; response-stream waiters |\n| **Shed %** | Is capacity turning users away? | 0 / \u003c 1 % / ≥ 1 % | `sum by (pod, kind) (rate(kura_capacity_sheds_total_total[5m]))` names the limit; `kura_memory_pressure_state` |\n| **Hit-rate Δ** | Is the cache silently less useful than it was for this customer? (vs its own 7d baseline) | \u003e −5 pt / −5…−20 pt / \u003c −20 pt | `kura_manifest_index_entries` (sudden drop = index zeroed), `kura_segment_evicted_artifacts_total_total` |\n| **Shed age p50** | How soon after a write can content be evicted — is the claim big enough? (7d window) | \u003e 3 d / 1–3 d / \u003c 1 d | Claim size / plan retention floor; `kura_segment_shed_age_seconds` |\n| **Restarts 6h** | Liveness / OOM restart loop? | 0 / 1 / ≥ 2 | `kube_pod_container_status_last_terminated_reason`, pod logs |\n\n* Windows: ratio columns use the dashboard time range (`$__range`, default 1h). Shed age uses 7d (the histogram only gets a sample when a 512 MiB segment rotates out of a full ring, and it was introduced in kura 0.29.0); restarts 6h.\n* `idle` = no traffic in the window. It is not green — nothing was measured.\n* The `scw-fr-par-runners` region hosts many tenants on one node, so Shed % and Shed age move together for all its rows.\n* Rows are `(customer, pod)`; the Pod column shows the name without its `kura-\u003ccustomer\u003e-` prefix (region + replica ordinal); the link carries the full pod name. Labels come from `kura_node_info`; every column joins on `(cluster, instance)` (restarts on `(cluster, pod)`). The Region variable still filters rows.\n",
+                "mode": "markdown"
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 18,
+              "width": 24,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 18
+            }
+          }
+        ]
+      }
+    },
+    "links": [
+      {
+        "asDropdown": false,
+        "icon": "dashboard",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": [],
+        "targetBlank": false,
+        "title": "Tuist Kura",
+        "tooltip": "",
+        "type": "link",
+        "url": "/d/tuist-kura/tuist-kura"
+      },
+      {
+        "asDropdown": false,
+        "icon": "dashboard",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": [],
+        "targetBlank": false,
+        "title": "Tuist Kura / Pod",
+        "tooltip": "",
+        "type": "link",
+        "url": "/d/ddfsumc1ibvuo0e/tuist-kura-pod"
+      }
+    ],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "tuist",
+      "kura"
+    ],
+    "timeSettings": {
+      "autoRefresh": "1m",
+      "autoRefreshIntervals": [
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-1h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Tuist Kura / Customer Overview",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "grafanacloud-tuist-prom",
+            "value": "grafanacloud-prom"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Data Source",
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "allowCustomValue": false,
+          "current": {
+            "text": "production",
+            "value": "production"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Environment",
+          "multi": false,
+          "name": "env",
+          "options": [],
+          "query": "production,canary,staging",
+          "skipUrlSync": false,
+          "valuesFormat": "csv"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allValue": ".*",
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "definition": "label_values(kura_node_info{cluster=~\"tuist-$env\"}, region)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Region",
+          "multi": true,
+          "name": "region",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "$datasource"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(kura_node_info{cluster=~\"tuist-$env\"}, region)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds the **Tuist Kura / Customer Overview** dashboard (`infra/grafana-dashboards/tuist-kura-customer-overview.json`, `dashboard.grafana.app/v2`): a single table with one row per Kura pod (`customer × replica`) and a coloured cell per service signal, so a degraded customer instance stands out without opening the per-tenant dashboards.

Columns (thresholds green / amber / red):

| Column | Signal | Thresholds |
|---|---|---|
| Gate | bitmask: not Ready · backfill initial cycle degraded · peer-plane failures · memory pressure critical | value-mapped; red overrides every other column |
| Fault % | 5xx on public routes ÷ public requests (404 miss and 429 shed excluded) | 0.1 % / 1 % |
| p95 TTFB | `kura_public_request_latency_seconds` p95 — measures the node, not the client link | 250 ms / 1 s |
| Shed % | `kura_capacity_sheds_total` ÷ (reads + writes + sheds) | 0.1 % / 1 % |
| Hit-rate Δ | hit ratio in the dashboard window minus the pod's own 7-day ratio; hidden below 0.5 reads/s | −5 pt / −20 pt |
| Shed age p50 | `kura_segment_shed_age_seconds` median over 7 d — how young evicted content is | 72 h / 24 h (inverted) |
| Restarts 6h | `kube_pod_container_status_restarts_total` | 1 / 2 |
| req/s | public HTTP + REAPI read rate (context, uncoloured) |  |

Variables: `datasource`, `env` (→ `cluster=~"tuist-$env"`), `region` (multi). Ratio windows use `$__range`; the Customer cell links to *Tuist Kura* (`var-cluster`/`var-tenant`/`var-region`), the Pod cell to *Tuist Kura / Pod* (`var-env`/`var-pod`, full pod name). A markdown panel below the table documents each column and where to drill down.

## Why

Kura has ~160 runtime metric families and four dashboards, but no view that answers "which customer is Kura serving badly right now?". An SLO over Kura alone does not work — the service does not own the whole user flow — so this is deliberately a set of per-instance SLIs: faults, responsiveness, saturation, cache effectiveness, retention horizon, plus a hard readiness gate.

Design choices worth knowing when editing:

- **Rows are pods, not tenant-regions.** `tenant_id`/`region`/`pod` exist only on `kura_node_info`, so every query joins `* on (cluster, instance) group_left(tenant_id, region, pod)` (restarts join on `(cluster, pod)`). The short Pod name is produced by a `label_replace` on the Gate query (`kura-<customer>-` stripped; the region-shaped tail keeps hyphenated handles intact); `pod` and `region` stay in the frame hidden so the links can read them.
- **Nine instant table queries merged in Grafana** (`filterFieldsByName → merge → organize`). The field filter must list every `Value #<ref>` — dropping one silently removes that column.
- **404 and 429 are not faults.** Misses are the cache working; sheds get their own column so a full node does not read as broken.
- **Hit-rate Δ is relative to the pod's own baseline**, because absolute hit rates differ per customer; it is the signal for silent degradations such as a zeroed manifest index.
- **Shed age needs a segment rotation** (512 MiB of writes out of a full ring) and the histogram only shipped in kura 0.29.0, so `no eviction 7d` is expected for small tenants and freshly restarted pods; a ring-fullness column was dropped as it is 100 % for any warm instance.
- Idle rows (no traffic in the window) map to `idle`, not green.

## Validation

- Every PromQL expression was run as an instant query against `grafanacloud-prom` (production) and returns one row per pod; the merge keys (`tenant_id`, `region`, `pod`) line up across all nine queries.
- Imported into Grafana Cloud, adjusted in the UI (Grafana saved this branch), and cross-checked that the Gate column, the short Pod names and both drill-down links resolve.
- Dashboard JSON generated from a script and converted to the v2 resource shape modelled on `registry-service.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
