### PR TITLE
fix(kura): route RocksDB's C++ allocations through jemalloc

### DIFF
--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "tokio",
  "tokio-rustls",

--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -52,8 +52,17 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "jso
 uuid = { version = "1.18.1", features = ["serde", "v7"] }
 zstd = "0.13"
 
+# `unprefixed_malloc_on_supported_platforms` builds jemalloc without the `_rjem_` symbol prefix, so
+# the binary's own `malloc`/`free` are jemalloc's and interpose libc's for the whole process. Without
+# it only Rust allocations reach jemalloc: rocksdb's C++ (and aws-lc's C) went to glibc malloc, whose
+# per-thread arenas retain freed memory for the process lifetime, outside the jemalloc decay tuning
+# in main.rs and invisible to kura_jemalloc_* (tuist/tuist#12699). The equivalent `rocksdb`
+# `jemalloc` cargo feature was not used because under Bazel rocksdb's C++ is compiled as a
+# cc_library (MODULE.bazel) that cargo features never reach; the interposition is the actual fix
+# and applies identically to both build paths.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["stats"] }
+tikv-jemallocator = { version = "0.6.0", features = ["stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-sys = "0.6.0"
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 
 [dev-dependencies]

--- a/kura/src/main.rs
+++ b/kura/src/main.rs
@@ -10,11 +10,14 @@ union JemallocConfigPointer {
 
 // Keep allocator page reclamation independent of subsequent allocation
 // traffic so a burst can return memory while the service is otherwise idle.
-// tikv-jemallocator uses a prefixed jemalloc build by default and documents
-// this exact symbol for setting its boot-time configuration.
+// jemalloc reads its boot-time configuration from this documented symbol. On
+// linux-gnu the build is unprefixed (see Cargo.toml), so the symbol is the
+// plain `malloc_conf`; everywhere else tikv-jemalloc-sys keeps the `_rjem_`
+// prefix.
 #[cfg(target_os = "linux")]
 #[used]
-#[unsafe(export_name = "_rjem_malloc_conf")]
+#[cfg_attr(target_env = "gnu", unsafe(export_name = "malloc_conf"))]
+#[cfg_attr(not(target_env = "gnu"), unsafe(export_name = "_rjem_malloc_conf"))]
 static JEMALLOC_MALLOC_CONF: Option<&'static std::ffi::c_char> = Some(unsafe {
     JemallocConfigPointer {
         bytes: &b"background_thread:true,max_background_threads:1,dirty_decay_ms:4000,muzzy_decay_ms:4000\0"[0],
@@ -80,6 +83,19 @@ fn verify_jemalloc_configuration() -> Result<(), String> {
         return Err(format!(
             "expected 4000ms decay, dirty={dirty_decay_ms}ms muzzy={muzzy_decay_ms}ms"
         ));
+    }
+
+    // The `malloc` that shared libraries (libstdc++ for rocksdb's C++) resolve
+    // at load time must be jemalloc's, otherwise their allocations land in
+    // glibc arenas that neither the decay tuning above nor the memory-pressure
+    // trims can reclaim. RTLD_DEFAULT follows the same lookup order as their
+    // PLT resolution, so it sees the interposition (or its absence) as they do.
+    #[cfg(target_env = "gnu")]
+    {
+        let resolved = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"malloc".as_ptr()) };
+        if resolved as *const () != tikv_jemalloc_sys::malloc as *const () {
+            return Err("libc malloc is not interposed by jemalloc".into());
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes #12699

## What changed

- `kura/Cargo.toml`: `tikv-jemallocator` gains the `unprefixed_malloc_on_supported_platforms` feature (and `tikv-jemalloc-sys` becomes a direct dependency for the boot check below). jemalloc is now built without the `_rjem_` prefix, so the kura executable defines and exports `malloc`/`free`/`realloc`/`calloc`/`posix_memalign`/`malloc_usable_size`, and every shared library in the process (libstdc++ for RocksDB's C++, libc itself) resolves them to jemalloc.
- `kura/src/main.rs`: the boot-time jemalloc configuration is exported under the unprefixed `malloc_conf` symbol on linux-gnu (`_rjem_malloc_conf` elsewhere), and `verify_jemalloc_configuration` additionally asserts that `dlsym(RTLD_DEFAULT, "malloc")` is jemalloc's `malloc`, i.e. the interposition shared libraries see is in place. Kura already refuses to boot when its allocator configuration is not active; this extends that guard to the property this PR depends on.

## Why

As diagnosed in #12699, `kura_process_resident_anon_bytes` ratchets up on write-active nodes while `kura_jemalloc_resident_bytes` stays flat. RocksDB's C++ (`operator new` → libstdc++ → libc `malloc`) never reached jemalloc: it allocated from glibc, whose per-thread arenas (up to `8 × nproc`, 64 MiB each) keep freed memory on their free lists for the life of the process. That memory sits outside kura's `dirty_decay_ms`/`muzzy_decay_ms` tuning, outside the `kura_jemalloc_*` metrics, and outside anything the memory-pressure trims can reclaim, so a long-lived node would degrade its hit rate and still grow until OOM.

### Why not the `rocksdb` crate's `jemalloc` feature

The issue proposed enabling `rocksdb = { features = ["jemalloc"] }`. That feature works by pulling in `tikv-jemalloc-sys` with the same `unprefixed_malloc_on_supported_platforms` flag — the interposition *is* the mechanism — and additionally defining `ROCKSDB_JEMALLOC` when the crate's build script compiles RocksDB, which only enables jemalloc-aware extras (the nodump allocator, `DumpMallocStats`), not allocation routing. The production binary is built with Bazel (`kura-runtime-image.yml`), where RocksDB's C++ is a first-class `cc_library` in `MODULE.bazel` that cargo features never reach, so the rocksdb feature would have produced a cargo-built binary and a Bazel-built binary that differ in how RocksDB was compiled. Enabling the flag on our own jemalloc dependency gives both build paths exactly the same fix, with no change to how RocksDB is compiled.

### Boot-check subtlety

A naive check `libc::malloc as *const () == tikv_jemalloc_sys::malloc as *const ()` is constant-folded by the compiler once the crate is unprefixed (both name the same symbol), so it cannot observe a link that failed to export `malloc` to the dynamic symbol table. `dlsym(RTLD_DEFAULT, "malloc")` follows the same global lookup order the dynamic linker uses for libstdc++'s PLT, so it fails exactly when RocksDB's allocations would fall back to glibc.

## Impact

- `kura_jemalloc_resident_bytes` becomes a true measure of process heap instead of the Rust-only slice; anon RSS now tracks it within tens of MiB.
- The existing jemalloc reclaim tuning (background thread, 4 s decay) applies to RocksDB flush/compaction bursts, so memory returns after a burst instead of being retained per arena.
- On linux-gnu the jemalloc environment override is now `MALLOC_CONF` (was `_RJEM_MALLOC_CONF`); nothing in the repo set either.
- No on-disk, wire, or config changes; rolling out mixed versions is unaffected.

## Validation

**Build paths.** cargo (`kura/Dockerfile`, bookworm) and Bazel mirroring `kura-runtime-image.yml` (ubuntu 24.04 container, `mise install rust bazel`, `bazel build --define=kura_deny_warnings=true //:kura`, `bazel test //:kura_bin_test`) both succeed with warnings denied; `jemalloc_boot_configuration_is_active` passes on Linux under Bazel (it now includes the interposition assertion). `readelf --dyn-syms` on both binaries shows `malloc/free/realloc/calloc/posix_memalign/malloc_usable_size` as `GLOBAL DEFAULT` definitions and `nm` shows `D malloc_conf`; the unmodified binary has `U malloc` and `_rjem_malloc`. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean on macOS.

**A/B on k01** (single-node k3s, throwaway `KuraInstance`, cold PVC each run, 16 client threads for 10 minutes doing 512 KiB inline key-value PUTs + 256 KiB CAS POSTs — ~30k + ~15k requests, ~23–26 GB — sampling `/metrics` and `/proc/<pid>/smaps` every 30 s; glibc arenas identified as 64 MiB-aligned `rw-p`+`---p` pairs):

| build | glibc arenas during load | arena RSS | anon − jemalloc resident (during load) | after load |
|---|---|---|---|---|
| main (glibc) | 37 → 39 | 90 → 113 MiB, never released | 93 → 189 MiB, rising | 219 MiB anon vs 77 MiB jemalloc: 142 MiB retained in arenas |
| this PR, cargo build | 0 | 0 | 30–40 MiB, flat | 157 MiB anon vs 115 MiB jemalloc |
| this PR, Bazel build in `Dockerfile.release` | 0 | 0 | −4 … 17 MiB, flat | 111 MiB anon vs 106 MiB jemalloc |

The baseline reproduces the production signature from the issue (arena count stable, per-arena residency growing, retained after the burst); on the fixed builds no glibc arena is ever created and RSS returns with jemalloc's decay after the load stops. Both fixed images also pass the new boot check when started standalone (`docker run` reaches config validation).

## Follow-ups (not in this PR)

- Issue proposal 3 (alert on `kura_process_resident_anon_bytes / kura_memory_soft_limit_bytes`) lives in Grafana, not in this repo.
- `MALLOC_ARENA_MAX` is no longer needed for kura; other glibc-linked services in the clusters are still exposed to the arena/nproc mismatch noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
