### PR TITLE
Add support for Xcode projects in dependencies inspection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -468,6 +468,7 @@ tuistInspectCommandDependencies.append(contentsOf: [
     "TuistXCResultService", "TuistCI", "TuistProcess", "TuistConfig", "TuistXcodeBuildProducts",
     "TuistRootDirectoryLocator", "TuistMachineMetrics", "TuistCASAnalytics",
     xcodeGraphDependency,
+    xcodeGraphMapperDependency,
     commandDependency,
 ])
 #endif

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1574,6 +1574,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "Mockable"),
                     .external(name: "Command"),
                     .target(name: Module.xcodeGraph.targetName),
+                    .target(name: Module.xcodeGraphMapper.targetName),
                 ]
             }
         if self != .projectDescription, self != .projectAutomation {

--- a/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
@@ -7,7 +7,7 @@
         static var configuration: CommandConfiguration {
             CommandConfiguration(
                 commandName: "dependencies",
-                abstract: "Inspects implicit and redundant dependencies in Tuist projects, failing when issues are found."
+                abstract: "Inspects implicit and redundant dependencies in your project, failing when issues are found."
             )
         }
 

--- a/cli/Sources/TuistInspectCommand/Services/InspectDependenciesCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectDependenciesCommandService.swift
@@ -9,20 +9,30 @@
     import TuistLogging
     import TuistSupport
     import XcodeGraph
+    import XcodeGraphMapper
 
     struct InspectDependenciesCommandService {
         private let configLoader: ConfigLoading
         private let generatorFactory: GeneratorFactorying
         private let graphImportsLinter: GraphImportsLinting
+        private let manifestLoader: ManifestLoading
+        private let xcodeGraphMapper: XcodeGraphMapping
+        private let localPackageProductsMapper: LocalPackageProductsMapping
 
         init(
             generatorFactory: GeneratorFactorying = GeneratorFactory(),
             configLoader: ConfigLoading = ConfigLoader(),
-            graphImportsLinter: GraphImportsLinting = GraphImportsLinter()
+            graphImportsLinter: GraphImportsLinting = GraphImportsLinter(),
+            manifestLoader: ManifestLoading = ManifestLoader.current,
+            xcodeGraphMapper: XcodeGraphMapping = XcodeGraphMapper(),
+            localPackageProductsMapper: LocalPackageProductsMapping = LocalPackageProductsMapper()
         ) {
             self.configLoader = configLoader
             self.generatorFactory = generatorFactory
             self.graphImportsLinter = graphImportsLinter
+            self.manifestLoader = manifestLoader
+            self.xcodeGraphMapper = xcodeGraphMapper
+            self.localPackageProductsMapper = localPackageProductsMapper
         }
 
         func run(
@@ -31,11 +41,17 @@
         ) async throws {
             let path = try await Environment.current.pathRelativeToWorkingDirectory(path)
             let config = try await configLoader.loadConfig(path: path)
-            let generator = generatorFactory.defaultGenerator(config: config, includedTargets: [])
-            let graph = try await generator.load(
-                path: path,
-                options: config.project.generatedProject?.generationOptions
-            )
+            let isGeneratedProject = try await manifestLoader.hasRootManifest(at: path)
+            let graph: XcodeGraph.Graph
+            if isGeneratedProject {
+                let generator = generatorFactory.defaultGenerator(config: config, includedTargets: [])
+                graph = try await generator.load(
+                    path: path,
+                    options: config.project.generatedProject?.generationOptions
+                )
+            } else {
+                graph = try await xcodeGraphMapper.map(at: path)
+            }
             let graphTraverser = GraphTraverser(graph: graph)
 
             var implicitIssues: [InspectImportsIssue] = []
@@ -43,7 +59,13 @@
             var checksRun: [String] = []
 
             if inspectionTypes.contains(.implicit) {
-                implicitIssues = try await collectImplicitIssues(graphTraverser: graphTraverser)
+                let implicitGraph = isGeneratedProject ? graph : try await localPackageProductsMapper.map(
+                    graph: graph,
+                    disableSandbox: config.project.disableSandbox
+                )
+                implicitIssues = try await collectImplicitIssues(
+                    graphTraverser: isGeneratedProject ? graphTraverser : GraphTraverser(graph: implicitGraph)
+                )
                 checksRun.append("implicit")
             }
 

--- a/cli/Sources/TuistInspectCommand/Services/LocalPackageProductsMapper.swift
+++ b/cli/Sources/TuistInspectCommand/Services/LocalPackageProductsMapper.swift
@@ -1,0 +1,61 @@
+#if os(macOS)
+    import Foundation
+    import Mockable
+    import Path
+    import TuistLoader
+    import XcodeGraph
+
+    @Mockable
+    protocol LocalPackageProductsMapping {
+        func map(graph: Graph, disableSandbox: Bool) async throws -> Graph
+    }
+
+    struct LocalPackageProductsMapper: LocalPackageProductsMapping {
+        private let manifestLoader: ManifestLoading
+
+        init(manifestLoader: ManifestLoading = ManifestLoader.current) {
+            self.manifestLoader = manifestLoader
+        }
+
+        func map(graph: Graph, disableSandbox: Bool) async throws -> Graph {
+            let packagePaths = Set(
+                graph.projects.values
+                    .flatMap(\.packages)
+                    .compactMap { package -> AbsolutePath? in
+                        switch package {
+                        case let .local(path: path):
+                            return graph.projects[path] == nil ? nil : path
+                        case .remote:
+                            return nil
+                        }
+                    }
+            )
+            guard !packagePaths.isEmpty else { return graph }
+
+            var productDependencies: [String: Set<GraphDependency>] = [:]
+            for packagePath in packagePaths.sorted() {
+                let packageInfo = try await manifestLoader.loadPackage(at: packagePath, disableSandbox: disableSandbox)
+                for product in packageInfo.products {
+                    productDependencies[product.name, default: []].formUnion(
+                        product.targets.map { GraphDependency.target(name: $0, path: packagePath) }
+                    )
+                }
+            }
+
+            var graph = graph
+            graph.dependencies = graph.dependencies.mapValues { dependencies in
+                Set(
+                    dependencies.flatMap { dependency -> Set<GraphDependency> in
+                        guard case let .packageProduct(_, product, _) = dependency,
+                              let targets = productDependencies[product]
+                        else {
+                            return [dependency]
+                        }
+                        return targets
+                    }
+                )
+            }
+            return graph
+        }
+    }
+#endif

--- a/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
@@ -221,6 +221,17 @@ struct LintAcceptanceTests {
         }
     }
 
+    @Test(.withFixture("xcode_project_with_packages_and_tests"), .withMockedDependencies())
+    func xcode_project_with_packages() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        try await TuistTest.run(InspectDependenciesCommand.self, ["--path", fixtureDirectory.pathString])
+        TuistTest.expectLogs(
+            "We did not find any dependency issues in your project (checked: implicit, redundant).",
+            at: .info,
+            <=
+        )
+    }
+
     @Test(.disabled(), .withFixture("generated_framework_with_macros_and_tests"), .withMockedDependencies())
     func framework_with_macros_redundant_imports() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Mockable
 import Path
 import Testing
+import TSCUtility
 import TuistConfig
 import TuistConfigLoader
 import TuistCore
@@ -20,16 +21,23 @@ struct InspectDependenciesCommandServiceTests {
     private let targetScanner: MockTargetImportsScanning
     private let subject: InspectDependenciesCommandService
     private let generator: MockGenerating
+    private let manifestLoader: MockManifestLoading
+    private let xcodeGraphMapper: MockXcodeGraphMapping
 
     init() throws {
         configLoader = MockConfigLoading()
         generatorFactory = MockGeneratorFactorying()
         targetScanner = MockTargetImportsScanning()
         generator = MockGenerating()
+        manifestLoader = MockManifestLoading()
+        xcodeGraphMapper = MockXcodeGraphMapping()
         subject = InspectDependenciesCommandService(
             generatorFactory: generatorFactory,
             configLoader: configLoader,
-            graphImportsLinter: GraphImportsLinter(targetScanner: targetScanner)
+            graphImportsLinter: GraphImportsLinter(targetScanner: targetScanner),
+            manifestLoader: manifestLoader,
+            xcodeGraphMapper: xcodeGraphMapper,
+            localPackageProductsMapper: LocalPackageProductsMapper(manifestLoader: manifestLoader)
         )
     }
 
@@ -58,6 +66,7 @@ struct InspectDependenciesCommandServiceTests {
         let graph = Graph.test(path: path, projects: [path: project])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -99,6 +108,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["FeatureA", "SharedCore"]))
@@ -138,6 +148,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -170,6 +181,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -199,6 +211,7 @@ struct InspectDependenciesCommandServiceTests {
         let loadCounter = LoadCounter()
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willProduce { _, _ in
             loadCounter.count += 1
@@ -227,6 +240,7 @@ struct InspectDependenciesCommandServiceTests {
         let graph = Graph.test(path: path, projects: [path: project])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -284,6 +298,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["TestTargetDependency"]))
@@ -329,6 +344,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["BinaryKit"]))
@@ -365,6 +381,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["BinaryKit"]))
@@ -393,6 +410,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -425,6 +443,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -461,6 +480,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set([]))
@@ -485,6 +505,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
@@ -526,6 +547,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set([]))
@@ -558,6 +580,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(bundleFramework), reachableModules: .any).willReturn(Set([]))
@@ -595,6 +618,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set([]))
@@ -640,6 +664,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(appExtension), reachableModules: .any).willReturn(Set([]))
@@ -681,6 +706,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(watch2Extension), reachableModules: .any).willReturn(Set([]))
@@ -712,6 +738,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(watchApp), reachableModules: .any).willReturn(Set([]))
@@ -742,6 +769,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(watchApp), reachableModules: .any).willReturn(Set([]))
@@ -772,6 +800,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(watchApp), reachableModules: .any).willReturn(Set([]))
@@ -801,6 +830,7 @@ struct InspectDependenciesCommandServiceTests {
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(framework), reachableModules: .any).willReturn(Set([]))
@@ -840,6 +870,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(projectPath)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(projectPath)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(projectPath), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(feature), reachableModules: .any).willReturn(Set([]))
@@ -883,6 +914,7 @@ struct InspectDependenciesCommandServiceTests {
         )
 
         given(configLoader).loadConfig(path: .value(projectPath)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(projectPath)).willReturn(true)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(projectPath), options: .any).willReturn(graph)
         given(targetScanner).imports(for: .value(feature), reachableModules: .any).willReturn(Set(["UIComponent"]))
@@ -890,5 +922,111 @@ struct InspectDependenciesCommandServiceTests {
 
         // When / Then
         try await subject.run(path: projectPath.pathString, inspectionTypes: [.redundant])
+    }
+
+    // MARK: - Xcode Project Tests
+
+    @Test
+    func runOnAnXcodeProjectFailsOnImplicitIssues() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let config = Tuist.test()
+        let app = Target.test(name: "App", product: .app)
+        let framework = Target.test(name: "Framework", product: .framework)
+        let project = Project.test(path: path, targets: [app, framework])
+        let graph = Graph.test(path: path, projects: [path: project])
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(false)
+        given(xcodeGraphMapper).map(at: .value(path)).willReturn(graph)
+        given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["Framework"]))
+        given(targetScanner).imports(for: .value(framework), reachableModules: .any).willReturn(Set([]))
+
+        // When / Then
+        await #expect(
+            throws: InspectImportsServiceError.issuesFound(implicit: [.init(
+                target: app.productName,
+                dependencies: [framework.productName]
+            )])
+        ) {
+            try await subject.run(path: path.pathString, inspectionTypes: [.implicit])
+        }
+    }
+
+    @Test
+    func runOnAnXcodeProjectDoesntReportImportsOfALocalPackageProductAsImplicit() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let packagePath = try AbsolutePath(validating: "/project/Packages/Feature")
+        let config = Tuist.test()
+        let app = Target.test(name: "App", product: .app)
+        let featureCore = Target.test(name: "FeatureCore", product: .staticFramework)
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: Project.test(path: path, targets: [app], packages: [.local(path: packagePath)]),
+                packagePath: Project.test(path: packagePath, targets: [featureCore]),
+            ],
+            dependencies: [
+                .target(name: app.name, path: path): Set([
+                    .packageProduct(path: path, product: "Feature", type: .runtime),
+                ]),
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(false)
+        given(xcodeGraphMapper).map(at: .value(path)).willReturn(graph)
+        given(manifestLoader).loadPackage(at: .value(packagePath), disableSandbox: .any)
+            .willReturn(
+                PackageInfo(
+                    name: "Feature",
+                    products: [.init(name: "Feature", type: .library(.automatic), targets: ["FeatureCore"])],
+                    targets: [],
+                    traits: nil,
+                    dependencies: [],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil,
+                    toolsVersion: Version(5, 9, 0)
+                )
+            )
+        given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["FeatureCore"]))
+        given(targetScanner).imports(for: .value(featureCore), reachableModules: .any).willReturn(Set([]))
+
+        // When / Then
+        try await subject.run(path: path.pathString, inspectionTypes: [.implicit])
+    }
+
+    @Test
+    func runOnAnXcodeProjectDoesntReportLocalPackageProductsAsRedundant() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let packagePath = try AbsolutePath(validating: "/project/Packages/Feature")
+        let config = Tuist.test()
+        let app = Target.test(name: "App", product: .app)
+        let featureUI = Target.test(name: "FeatureUI", product: .staticFramework)
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: Project.test(path: path, targets: [app], packages: [.local(path: packagePath)]),
+                packagePath: Project.test(path: packagePath, targets: [featureUI]),
+            ],
+            dependencies: [
+                .target(name: app.name, path: path): Set([
+                    .packageProduct(path: path, product: "Feature", type: .runtime),
+                ]),
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(manifestLoader).hasRootManifest(at: .value(path)).willReturn(false)
+        given(xcodeGraphMapper).map(at: .value(path)).willReturn(graph)
+        given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(featureUI), reachableModules: .any).willReturn(Set([]))
+
+        // When / Then
+        try await subject.run(path: path.pathString, inspectionTypes: [.redundant])
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Inspect/LocalPackageProductsMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/LocalPackageProductsMapperTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Mockable
+import Path
+import Testing
+import TSCUtility
+import TuistLoader
+import TuistSupport
+import TuistTesting
+import XcodeGraph
+
+@testable import TuistInspectCommand
+
+struct LocalPackageProductsMapperTests {
+    private let manifestLoader = MockManifestLoading()
+    private let subject: LocalPackageProductsMapper
+
+    init() {
+        subject = LocalPackageProductsMapper(manifestLoader: manifestLoader)
+    }
+
+    @Test func mapReplacesPackageProductsWithTheTargetsTheyVend() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let packagePath = try AbsolutePath(validating: "/project/Packages/Feature")
+        let app = Target.test(name: "App", product: .app)
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: Project.test(path: path, targets: [app], packages: [.local(path: packagePath)]),
+                packagePath: Project.test(
+                    path: packagePath,
+                    targets: [Target.test(name: "FeatureCore"), Target.test(name: "FeatureUI")]
+                ),
+            ],
+            dependencies: [
+                .target(name: app.name, path: path): [
+                    .packageProduct(path: path, product: "Feature", type: .runtime),
+                ],
+            ]
+        )
+        given(manifestLoader).loadPackage(at: .value(packagePath), disableSandbox: .value(false))
+            .willReturn(
+                packageInfo(products: [.init(name: "Feature", type: .library(.automatic), targets: ["FeatureCore", "FeatureUI"])])
+            )
+
+        // When
+        let got = try await subject.map(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.dependencies == [
+            .target(name: app.name, path: path): [
+                .target(name: "FeatureCore", path: packagePath),
+                .target(name: "FeatureUI", path: packagePath),
+            ],
+        ])
+    }
+
+    @Test func mapKeepsProductsThatNoLocalPackageVends() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let packagePath = try AbsolutePath(validating: "/project/Packages/Feature")
+        let app = Target.test(name: "App", product: .app)
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: Project.test(path: path, targets: [app], packages: [.local(path: packagePath)]),
+                packagePath: Project.test(path: packagePath, targets: [Target.test(name: "FeatureCore")]),
+            ],
+            dependencies: [
+                .target(name: app.name, path: path): [
+                    .packageProduct(path: path, product: "Alamofire", type: .runtime),
+                ],
+            ]
+        )
+        given(manifestLoader).loadPackage(at: .value(packagePath), disableSandbox: .value(false))
+            .willReturn(packageInfo(products: [.init(name: "Feature", type: .library(.automatic), targets: ["FeatureCore"])]))
+
+        // When
+        let got = try await subject.map(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.dependencies == graph.dependencies)
+    }
+
+    @Test func mapDoesntLoadPackagesThatAreNotPartOfTheGraph() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let packagePath = try AbsolutePath(validating: "/project/Packages/Feature")
+        let app = Target.test(name: "App", product: .app)
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: Project.test(path: path, targets: [app], packages: [.local(path: packagePath)]),
+            ],
+            dependencies: [
+                .target(name: app.name, path: path): [
+                    .packageProduct(path: path, product: "Feature", type: .runtime),
+                ],
+            ]
+        )
+
+        // When
+        let got = try await subject.map(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.dependencies == graph.dependencies)
+        verify(manifestLoader).loadPackage(at: .any, disableSandbox: .any).called(0)
+    }
+
+    private func packageInfo(products: [PackageInfo.Product]) -> PackageInfo {
+        PackageInfo(
+            name: "Feature",
+            products: products,
+            targets: [],
+            traits: nil,
+            dependencies: [],
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil,
+            toolsVersion: Version(5, 9, 0)
+        )
+    }
+}

--- a/server/cla/signatures.json
+++ b/server/cla/signatures.json
@@ -1,7 +1,7 @@
 {
   "signedContributors": [
     {
-      "name": "Yusuf Özgül",
+      "name": "Yusuf \u00d6zg\u00fcl",
       "id": 26109252,
       "comment_id": "",
       "created_at": "2025-09-04T00:00:00Z",
@@ -53,6 +53,14 @@
       "id": 961874,
       "comment_id": "",
       "created_at": "2026-06-01T18:07:56Z",
+      "repoId": 250427618,
+      "pullRequestNo": null
+    },
+    {
+      "name": "Gorbenko Roman",
+      "id": 45801227,
+      "comment_id": "",
+      "created_at": "2026-08-29T18:16:28Z",
       "repoId": 250427618,
       "pullRequestNo": null
     }

--- a/server/priv/docs/en/guides/features/projects/inspect/implicit-dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/inspect/implicit-dependencies.md
@@ -17,6 +17,8 @@ tuist inspect dependencies --only implicit
 
 If the command detects any implicit imports, it exits with an exit code other than zero.
 
+The command works with generated projects, Swift packages, and raw Xcode projects and workspaces. Tuist decides how to load the project graph based on what it finds at the given path: a `Project.swift` or `Workspace.swift` manifest, a `Package.swift` manifest, or an `.xcodeproj`/`.xcworkspace`.
+
 > [!TIP]
 > **Validate In Ci**
 >


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/12702>

`tuist inspect dependencies` required a Tuist manifest, so it failed with `Manifest not found` on raw Xcode projects. It now falls back to `XcodeGraphMapper` when no root manifest is found, so both checks also run on `.xcodeproj` and `.xcworkspace`.

Local Swift packages are referenced through their products, which the graph represents as `packageProduct` dependencies pointing at no target — without resolving them, every import of a local package looks implicit. `LocalPackageProductsMapper` replaces them with the targets each product vends. It's applied only to the implicit check, since a target depends on a whole product and can't drop its individual targets.

**Validation:** unit tests for the mapper and both checks, an acceptance test on the `xcode_project_with_packages_and_tests` fixture, and manual runs on workspaces, Objective-C targets and local packages whose product name differs from its target names.

### How to test locally

Any raw Xcode project works, but the fixture in this repo already covers the interesting case:

```bash
tuist inspect dependencies --path examples/xcode/xcode_project_with_packages_and_tests

It has two local packages, and App depends on the LibraryA product — the command should report no issues.

To see detection working, copy the fixture elsewhere, add a file to the App folder with import LibraryB (a package App doesn't depend on), and run the command again:

App implicitly depends on: LibraryB