### PR TITLE
fix(infra): support container jobs on Linux runners

### DIFF
--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -141,6 +141,14 @@ injected by the controller, with the socket mounted from a
 shared emptyDir. See `infra/runners-controller/AGENTS.md` for
 the sidecar Pod shape + lifecycle.
 
+`/home/runner/actions-runner/externals/` (the node runtimes the
+actions-runner tarball ships) is copied out of this image into a
+volume the sidecar mounts at the same path, because the runner
+bind-mounts it into `container:` job containers as `/__e` and
+dockerd resolves that path on its own side. Moving the runner
+root, or trimming externals from the image, breaks job containers
+— see "Why stage externals" in the controller doc.
+
 ## Build
 
 ```bash

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -926,6 +926,11 @@ Shape:
 - `work` emptyDir at `/home/runner/actions-runner/_work` (both
   containers) so `docker run -v $PWD:/x` paths resolve the same
   on either side.
+- `dind-externals` emptyDir at `/home/runner/actions-runner/externals`
+  (sidecar only), filled by the `dind-externals` init container —
+  the runner image running `cp -a` out of its own image layer into
+  the volume, staged at `/mnt/dind-externals` there so the mount
+  doesn't shadow the source. See "Why stage externals" below.
 - `dind-storage` emptyDir at `/mnt/dind-disk` (sidecar only).
   Plain node-disk emptyDir — holds a sparse `disk.img` the
   sidecar entrypoint loop-mounts as ext4 onto `/var/lib/docker`
@@ -941,6 +946,33 @@ Shape:
   starts dockerd to cover dockerd's own fd budget. Kata's
   microVM kernel defaults nofile=1024; without both, a docker
   build that walks a non-trivial `node_modules` tree EMFILEs.
+
+### Why stage externals? (job `container:` support)
+
+A workflow that declares `jobs.<id>.container` doesn't run its
+steps in the runner container at all: the runner asks dockerd to
+create a container and bind-mounts five well-known directories
+into it — work as `/__w`, temp as `/__t`, actions as `/__a`,
+tools as `/__o`, externals as `/__e`. Those source paths are
+resolved by **dockerd**, so they have to exist in the sidecar's
+mount namespace, not the runner's.
+
+Four of the five already do: temp, actions and tools default to
+`_work/_temp`, `_work/_actions` and `_work/_tool` (the runner image
+sets no `RUNNER_TOOL_CACHE` / `AGENT_TOOLSDIRECTORY`), all under the
+shared `work` volume. `externals` — the node runtimes every JS
+action executes under — ships in the runner image alone. Without
+the staged copy docker creates an empty directory for it daemon-
+side and every step in the job container dies on a missing
+`/__e/node2x/bin/node`, which is what made `container:` jobs
+unusable on the fleet while plain `docker` commands in a `run:`
+step worked fine.
+
+Same fix ARC ships as `init-dind-externals`. The copy runs before
+the sidecar, so it is in place by the time dockerd can serve a
+container and a runner image that stops shipping externals fails
+the Pod early rather than at job time. Cost is a per-Pod copy of
+the node runtimes at warm-up, off the job's critical path.
 
 ### Why loop-mount? (the virtio-fs / overlay2 gotcha)
 

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -76,6 +76,15 @@ const (
 	// the terminal sees the same filesystem, environment, and Docker
 	// socket as the running job.
 	shellSocketPath = "/home/runner/actions-runner/_work/.tuist-runner-shell.sock"
+	// externalsPath is the runner's `externals` directory — the node
+	// runtimes the runner bind-mounts into a job container as /__e.
+	// dockerd resolves that mount in the dind sidecar's namespace, so
+	// the directory has to exist there under the same path.
+	externalsPath = "/home/runner/actions-runner/externals"
+	// externalsStagePath is where the staging container mounts the
+	// shared externals volume. Deliberately not externalsPath, which
+	// would shadow the source being copied.
+	externalsStagePath = "/mnt/dind-externals"
 )
 
 // Build returns the Pod manifest the controller stamps on the API
@@ -281,6 +290,11 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 			}
 			volumes = append(volumes,
 				corev1.Volume{Name: "dind-sock", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				// Staging area for the runner image's externals
+				// directory, filled by the dind-externals init
+				// container below and mounted into the sidecar at
+				// the runner's own path.
+				corev1.Volume{Name: "dind-externals", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 				// Node-disk emptyDir holding a sparse disk.img file.
 				// The dind sidecar loop-mounts that file as an ext4
 				// filesystem onto /var/lib/docker so dockerd's
@@ -305,6 +319,38 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 				corev1.VolumeMount{Name: "dind-sock", MountPath: "/var/run"},
 			)
 			runnerEnv = append(runnerEnv, corev1.EnvVar{Name: "DOCKER_HOST", Value: "unix:///var/run/docker.sock"})
+			// A job that declares `jobs.<id>.container` (or a
+			// container action) doesn't run in the runner container:
+			// the runner asks dockerd to create a container and
+			// bind-mounts five well-known directories into it — work
+			// as /__w, temp as /__t, actions as /__a, tools as /__o,
+			// externals as /__e. Those paths are resolved by dockerd,
+			// i.e. in the sidecar's mount namespace, not the
+			// runner's. Four of the five live under _work (temp,
+			// actions and tools default to _work/_temp, _work/_actions
+			// and _work/_tool), which both containers already share.
+			// externals ships in the runner image alone, so docker
+			// creates an empty directory for it on the daemon side and
+			// every step in the job container dies on a missing
+			// /__e/node2x/bin/node.
+			//
+			// Stage it into a volume both sides mount, the way ARC's
+			// dind mode does (init-dind-externals). Runs before the
+			// sidecar so the copy is in place by the time dockerd can
+			// serve a container, and fails the Pod early if the image
+			// ever stops shipping externals.
+			initContainers = append(initContainers, corev1.Container{
+				Name:    "dind-externals",
+				Image:   pool.Spec.Image,
+				Command: []string{"sh", "-c"},
+				Args:    []string{"set -e && cp -a " + externalsPath + "/. " + externalsStagePath + "/"},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "dind-externals", MountPath: externalsStagePath},
+				},
+				// Root only to write the root-owned emptyDir; it runs
+				// our copy, never customer code.
+				SecurityContext: &corev1.SecurityContext{RunAsUser: ptr(int64(0))},
+			})
 			initContainers = append(initContainers, corev1.Container{
 				Name:  "dind",
 				Image: dindImage,
@@ -363,6 +409,7 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "dind-sock", MountPath: "/var/run"},
 					{Name: "work", MountPath: "/home/runner/actions-runner/_work"},
+					{Name: "dind-externals", MountPath: externalsPath},
 					{Name: "dind-storage", MountPath: "/mnt/dind-disk"},
 				},
 			})

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -1,6 +1,7 @@
 package podtemplate
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -363,16 +364,23 @@ func TestBuild_LinuxPodGetsDindSidecar(t *testing.T) {
 	// runner container. Mirrors the ARC pattern.
 	pod := build(t, basePool("linux"))
 
-	// Four init containers: the dind sidecar first (so its startupProbe
-	// gates the rest of the Pod), then the metrics and shell sidecars,
-	// then the poller.
-	if len(pod.Spec.InitContainers) != 4 {
-		t.Fatalf("InitContainers = %d, want 4 (dind sidecar + metrics sidecar + shell sidecar + poller)", len(pod.Spec.InitContainers))
+	// Five init containers: the externals staging copy, then the dind
+	// sidecar (whose startupProbe gates the rest of the Pod), then the
+	// metrics and shell sidecars, then the poller.
+	if len(pod.Spec.InitContainers) != 5 {
+		t.Fatalf("InitContainers = %d, want 5 (externals staging + dind sidecar + metrics sidecar + shell sidecar + poller)", len(pod.Spec.InitContainers))
 	}
-	dind := pod.Spec.InitContainers[0]
-	if dind.Name != "dind" {
-		t.Errorf("first initContainer Name = %q, want \"dind\" (must precede poller so docker is ready)", dind.Name)
+	names := make([]string, 0, len(pod.Spec.InitContainers))
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
 	}
+	// dind must still precede the poller so docker is up before a job
+	// can be claimed, and the staging copy must precede dind so the
+	// externals are in place before dockerd can serve a container.
+	if got, want := names, []string{"dind-externals", "dind", "metrics", "shell", "poller"}; !slices.Equal(got, want) {
+		t.Errorf("initContainer order = %v, want %v", got, want)
+	}
+	dind := initContainer(t, pod, "dind")
 	if dind.Image != testDindImage {
 		t.Errorf("sidecar Image = %q, want %q", dind.Image, testDindImage)
 	}
@@ -455,6 +463,53 @@ func TestBuild_LinuxPodGetsDindSidecar(t *testing.T) {
 	}
 }
 
+func TestBuild_LinuxDindSharesRunnerExternals(t *testing.T) {
+	// `jobs.<id>.container` makes the runner bind-mount its own
+	// externals directory into the job container as /__e, and dockerd
+	// resolves that path in the sidecar. Without the staged copy the
+	// daemon creates an empty directory there and every step in the
+	// container fails on a missing /__e/node2x/bin/node.
+	pod := build(t, basePool("linux"))
+
+	staging := initContainer(t, pod, "dind-externals")
+	// Copies from the runner image, so it must run that image.
+	if staging.Image != pod.Spec.Containers[0].Image {
+		t.Errorf("staging Image = %q, want the runner image %q", staging.Image, pod.Spec.Containers[0].Image)
+	}
+	// A plain init container: it has to finish, not linger like the
+	// native sidecars around it.
+	if staging.RestartPolicy != nil {
+		t.Errorf("staging RestartPolicy = %v, want nil (runs to completion)", *staging.RestartPolicy)
+	}
+	args := strings.Join(staging.Args, " ")
+	if !strings.Contains(args, "cp -a /home/runner/actions-runner/externals/. /mnt/dind-externals/") {
+		t.Errorf("staging args = %q, want a copy of the runner externals into the shared volume", args)
+	}
+	// Staging must not mount the volume over its own source.
+	if hasVolumeMount(staging.VolumeMounts, corev1.VolumeMount{Name: "dind-externals", MountPath: "/home/runner/actions-runner/externals"}) {
+		t.Errorf("staging mounts the volume over its copy source; got %+v", staging.VolumeMounts)
+	}
+	if !hasVolumeMount(staging.VolumeMounts, corev1.VolumeMount{Name: "dind-externals", MountPath: "/mnt/dind-externals"}) {
+		t.Errorf("staging missing the dind-externals mount; got %+v", staging.VolumeMounts)
+	}
+
+	// The sidecar sees them at the runner's own path, because that is
+	// the path the runner hands to docker.
+	dind := initContainer(t, pod, "dind")
+	externals := corev1.VolumeMount{Name: "dind-externals", MountPath: "/home/runner/actions-runner/externals"}
+	if !hasVolumeMount(dind.VolumeMounts, externals) {
+		t.Errorf("sidecar missing %+v; got %+v", externals, dind.VolumeMounts)
+	}
+	// The runner keeps the copy baked into its image; shadowing it
+	// with the staging volume would be a way to serve it a stale one.
+	if hasVolumeMount(pod.Spec.Containers[0].VolumeMounts, externals) {
+		t.Errorf("runner should not mount dind-externals over its own externals directory")
+	}
+	if !hasVolume(pod.Spec.Volumes, "dind-externals") {
+		t.Errorf("pod missing volume \"dind-externals\"; got %+v", pod.Spec.Volumes)
+	}
+}
+
 func TestBuild_LinuxDindRegistryMirror(t *testing.T) {
 	// With a mirror URL configured, dockerd launches with
 	// --registry-mirror plus a matching --insecure-registry (the
@@ -464,7 +519,7 @@ func TestBuild_LinuxDindRegistryMirror(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build returned error: %v", err)
 	}
-	args := strings.Join(pod.Spec.InitContainers[0].Args, " ")
+	args := strings.Join(initContainer(t, pod, "dind").Args, " ")
 	if !strings.Contains(args, "--registry-mirror="+mirror) {
 		t.Errorf("dind args missing --registry-mirror=%s; got %v", mirror, args)
 	}
@@ -477,7 +532,7 @@ func TestBuild_LinuxDindNoRegistryMirrorByDefault(t *testing.T) {
 	// Empty mirror → no --registry-mirror flag; dockerd pulls docker.io
 	// directly.
 	pod := build(t, basePool("linux"))
-	args := strings.Join(pod.Spec.InitContainers[0].Args, " ")
+	args := strings.Join(initContainer(t, pod, "dind").Args, " ")
 	if strings.Contains(args, "--registry-mirror") {
 		t.Errorf("dind args must not carry --registry-mirror when none configured; got %v", args)
 	}
@@ -729,6 +784,20 @@ func envValue(env []corev1.EnvVar, name string) string {
 		}
 	}
 	return ""
+}
+
+// initContainer returns the init container with the given name.
+// Looking them up by name rather than index keeps these tests from
+// churning every time a sidecar is added ahead of another.
+func initContainer(t *testing.T, pod *corev1.Pod, name string) corev1.Container {
+	t.Helper()
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("pod has no %q init container; got %+v", name, pod.Spec.InitContainers)
+	return corev1.Container{}
 }
 
 func hasVolumeMount(mounts []corev1.VolumeMount, want corev1.VolumeMount) bool {

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -275,7 +275,8 @@ defmodule Tuist.Docs.Sidebar do
             slug: "/en/guides/features/runners",
             items: [
               %Item{label: "Getting started", slug: "/en/guides/features/runners/getting-started"},
-              %Item{label: "Profiles", slug: "/en/guides/features/runners/profiles"}
+              %Item{label: "Profiles", slug: "/en/guides/features/runners/profiles"},
+              %Item{label: "Docker", slug: "/en/guides/features/runners/docker"}
             ]
           }
         ]

--- a/server/priv/docs/en/guides/features/runners/docker.md
+++ b/server/priv/docs/en/guides/features/runners/docker.md
@@ -1,0 +1,95 @@
+---
+{
+  "title": "Docker",
+  "titleTemplate": ":title · Runners · Features · Guides · Tuist",
+  "description": "Use Docker on Tuist Runners: build and run containers, container jobs, service containers, and private registries."
+}
+---
+# Docker {#docker}
+
+Linux runners come with Docker ready to use. Each job gets its own Docker daemon inside the job's virtual machine, and the `docker` CLI, Buildx, and Compose are preinstalled. You don't need a setup action, and you don't need `sudo`.
+
+```yaml
+jobs:
+  build:
+    runs-on: tuist-linux
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t my-app .
+      - run: docker run --rm my-app ./run-checks.sh
+```
+
+> [!NOTE]
+> **Linux only**
+>
+> macOS runners don't provide a Docker daemon. Use a Linux <.localized_link href="/guides/features/runners/profiles">profile</.localized_link> for jobs that need one.
+
+## Running a job in a container {#running-a-job-in-a-container}
+
+Point `container` at the image your job should run in. Tuist pulls it and runs every step inside it:
+
+```yaml
+jobs:
+  test:
+    runs-on: tuist-linux
+    container:
+      image: ghcr.io/my-org/android-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./gradlew test
+```
+
+## Service containers {#service-containers}
+
+`services` works the same way it does on GitHub-hosted runners. Services are reachable on `localhost` at their mapped ports:
+
+```yaml
+jobs:
+  test:
+    runs-on: tuist-linux
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - run: mix test
+```
+
+## Private registries {#private-registries}
+
+Authenticate with the registry's own login action, or `docker login`, before pulling or pushing:
+
+```yaml
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker pull ghcr.io/my-org/android-ci:latest
+```
+
+For a job-level `container`, pass the same credentials through the `credentials` key instead, as in the example above.
+
+## Image pulls {#image-pulls}
+
+Docker Hub pulls are served through a pull-through cache that Tuist operates, so jobs don't consume Docker Hub's anonymous rate limit. Images from other registries are pulled directly.
+
+Every job starts with an empty image store, so an image your workflow uses is pulled once per job rather than reused across jobs. If a job pulls a large custom image, keep the image small, or build it in the workflow with a cached Buildx builder:
+
+```yaml
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: my-app:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```


### PR DESCRIPTION
## What changed

Linux runner Pods now stage the runner image's `externals` directory into a `dind-externals` emptyDir that the dockerd sidecar mounts at the runner's own path, so job containers get a populated `/__e`. Adds a customer-facing Docker page to the Runners docs.

## Why

A support question — how to pull a custom Docker image in a workflow on a Linux profile — turned out to be a real gap rather than a documentation one. Plain `docker` commands in a `run:` step already work (the dind sidecar has been on for every Linux Pod since #10905, with `DOCKER_HOST` injected and the CLI, Buildx and Compose in the image), but a job that declares `jobs.<id>.container` could not run at all.

## Root cause

The runner does not execute a `container:` job in its own container. It asks dockerd to create one and bind-mounts five well-known directories into it: work as `/__w`, temp as `/__t`, actions as `/__a`, tools as `/__o`, externals as `/__e`. Those source paths are resolved by dockerd, so they have to exist in the sidecar's mount namespace, not the runner's.

Four of the five already did. Temp, actions and tools default to `_work/_temp`, `_work/_actions` and `_work/_tool` (the runner image sets no `RUNNER_TOOL_CACHE` or `AGENT_TOOLSDIRECTORY`), and the `work` volume is already shared with the sidecar. `externals` — the node runtimes every JS action executes under — ships in the runner image alone, so docker created an empty directory for it daemon-side and every step in the job container died on a missing `/__e/node2x/bin/node`.

It went unnoticed because the failure is specific to `container:`: nothing in this repo runs a `container:` job on a `tuist-` label (all three are on `ubuntu-latest`), so the shape had never been exercised on the fleet. `services:` was unaffected — service containers need no externals, and Pod containers share a network namespace, so mapped ports are reachable on localhost from the runner.

## Why this solution

Staging a copy is what ARC does in its dind mode (`init-dind-externals`), and it keeps the runner image the single source of the runner's own version. The init container runs the runner image, mounts the shared volume at `/mnt/dind-externals` so it does not shadow the source it copies from, and runs ahead of the sidecar so the copy is in place before dockerd can serve a container — and so a runner image that ever stops shipping externals fails the Pod at warm-up rather than at job time.

The alternative, baking externals into a custom dind image, removes the per-Pod copy but couples that image to `RUNNER_VERSION` and silently breaks the moment the two drift. A custom dind image is already a standing follow-up (for `e2fsprogs`); folding externals into it is worth revisiting there, with the version pinned from the same build arg.

## Impact

- `jobs.<id>.container` and container actions work on Linux profiles.
- Every Linux Pod pays a copy of the runner's node runtimes during warm-up, before the poller starts. This is warm-Pod startup, not job time — in steady state a job is claimed by an already-warm Pod. It does slightly extend the window in which a fresh Pod is not yet counted as warm capacity (`pollerRunning`), on top of the roughly 8 s the sidecar's own setup already takes.
- Controller-only change on the Pod shape; no CRD, chart or values change, and no runner image rebuild.

## Validation

- `go test ./...` and `go vet ./...` in `infra/runners-controller`. The updated podtemplate cases fail against the previous Pod shape (missing volume, missing sidecar mount, unstaged copy).
- Init containers are now looked up by name in the tests instead of by index, so inserting one ahead of another stops churning unrelated cases.
- `mix docs.validate_page` on the new Docker page, and `mix test test/tuist/docs_sidebar_test.exs` (6 passed), which asserts every sidebar slug resolves to a real page.
- Not yet exercised end to end on a live pool — worth running a `container:` job on staging once the controller image is rolled there before flipping this to ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

