### PR TITLE
feat(server): add a 64 GB Linux runner shape and reserve hosts for it

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -716,7 +716,9 @@ runnersFleetLinux:
   name: runners-linux
   pools: []
   # Shape-keyed pools backing Runner Profiles. Keep in sync with
-  # `:runner_linux_shapes` in `server/config/config.exs`. Long-tail
+  # `:runner_linux_shapes` in `server/config/config.exs`, minus the
+  # 64 GB ceiling shape: this env's AX42-U host has 64 GB total, so the
+  # shape would render a pool that can never place a Pod. Long-tail
   # shapes scale to zero; the default shape keeps a warm floor since it
   # absorbs `tuist-default` + `linux` default-profile traffic.
   # Resolved at deploy time from the latest `linux-runner-image@` git tag.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1427,11 +1427,20 @@ runnersFleetLinux:
     - { vcpus: 16, memoryGb: 32 }
     # Ceiling shape, production-only: 64 GiB + the kata RuntimeClass's
     # 2.5 GiB podFixed overhead is 66.5 GiB of a host, which only the
-    # AX162-R's 256 GB seats (three per box, using 48 of its 96
-    # threads). Staging and canary run 64 GB AX42-U boxes, so the shape
-    # is absent from their catalogs rather than offered and left Pending
-    # forever. Asked for by Android builds, whose Gradle + Kotlin daemons
-    # exhaust the 32 GB shape.
+    # AX162-R's 256 GB seats. Staging and canary run 64 GB AX42-U boxes,
+    # so the shape is absent from their catalogs rather than offered and
+    # left Pending forever. Asked for by Android builds, whose Gradle +
+    # Kotlin daemons exhaust the 32 GB shape.
+    #
+    # 16 rather than 32 vCPU. At 66.5 GiB a Pod the host is memory-bound
+    # at 3 seats, and three 32 vCPU Pods would want 96.75 of its 94
+    # allocatable CPUs, so a 32 vCPU rung buys CPU by giving up the third
+    # seat and idling 90 GiB instead. 24 is the most vCPU that still fits
+    # 3 (72.75 of 94), and is the shape to reach for if a CPU-bound
+    # workload ever asks. The host's own ratio is ~2.4 GB per thread, so
+    # a 4 GB/vCPU rung leaving CPU unclaimed is the catalog working as
+    # intended, not a mis-sizing: it is the memory reservation that is
+    # scarce on this fleet, and this rung is bought for memory.
     - { vcpus: 16, memoryGb: 64 }
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1426,21 +1426,30 @@ runnersFleetLinux:
     - { vcpus: 8, memoryGb: 32 }
     - { vcpus: 16, memoryGb: 32 }
     # Ceiling shape, production-only: 64 GiB + the kata RuntimeClass's
-    # 2.5 GiB podFixed overhead is 66.5 GiB of a host, which only the
-    # AX162-R's 256 GB seats. Staging and canary run 64 GB AX42-U boxes,
-    # so the shape is absent from their catalogs rather than offered and
+    # 2.5 GiB podFixed overhead is 66.5 GiB per Pod. That seats 3 to an
+    # AX162-R and exactly 1 to the OVH RISE-L this fleet is moving to
+    # (16c/32t, 128 GB — see ovhFleets.runners-linux above), so the shape
+    # survives the migration but stops being a small slice of a host.
+    # Staging and canary run 64 GB AX42-U boxes and cannot seat it at
+    # all, so it is absent from their catalogs rather than offered and
     # left Pending forever. Asked for by Android builds, whose Gradle +
     # Kotlin daemons exhaust the 32 GB shape.
     #
-    # 16 rather than 32 vCPU. At 66.5 GiB a Pod the host is memory-bound
-    # at 3 seats, and three 32 vCPU Pods would want 96.75 of its 94
-    # allocatable CPUs, so a 32 vCPU rung buys CPU by giving up the third
-    # seat and idling 90 GiB instead. 24 is the most vCPU that still fits
-    # 3 (72.75 of 94), and is the shape to reach for if a CPU-bound
-    # workload ever asks. The host's own ratio is ~2.4 GB per thread, so
-    # a 4 GB/vCPU rung leaving CPU unclaimed is the catalog working as
-    # intended, not a mis-sizing: it is the memory reservation that is
-    # scarce on this fleet, and this rung is bought for memory.
+    # 16 rather than 32 vCPU. A 32 vCPU Pod costs 32.25 CPUs with the
+    # kata overhead, which does not fit a RISE-L's 32 threads at all — no
+    # kubelet reserve makes 32.25 <= 32 — so that rung would be
+    # unschedulable on the incoming fleet. On an AX162-R it also gives up
+    # a seat: three would want 96.75 of the 94 allocatable CPUs, leaving
+    # 2 seats and 90 GiB idle where 16 vCPU leaves 3 seats and spare CPU.
+    # 24 vCPU is the most that still fits 3 there (72.75 of 94), and is
+    # the shape to reach for if a CPU-bound workload asks while those
+    # boxes are in service.
+    #
+    # Leaving CPU unclaimed is the catalog working as intended rather
+    # than a mis-sizing. A host is ~2.4 GB per thread against rungs of 2
+    # and 4 GB/vCPU, and kata pins guest RAM (request == limit == the
+    # shape), so memory reservation is what runs out on this fleet while
+    # CPU does not. This rung is bought for memory and priced for it.
     - { vcpus: 16, memoryGb: 64 }
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1425,6 +1425,14 @@ runnersFleetLinux:
     - { vcpus: 8, memoryGb: 16 }
     - { vcpus: 8, memoryGb: 32 }
     - { vcpus: 16, memoryGb: 32 }
+    # Ceiling shape, production-only: 64 GiB + the kata RuntimeClass's
+    # 2.5 GiB podFixed overhead is 66.5 GiB of a host, which only the
+    # AX162-R's 256 GB seats (three per box, using 48 of its 96
+    # threads). Staging and canary run 64 GB AX42-U boxes, so the shape
+    # is absent from their catalogs rather than offered and left Pending
+    # forever. Asked for by Android builds, whose Gradle + Kotlin daemons
+    # exhaust the 32 GB shape.
+    - { vcpus: 16, memoryGb: 64 }
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -916,7 +916,9 @@ runnersFleetLinux:
   # resolves the profile's (vcpus, memory_gb) to one of these CRs. Keep
   # this list in sync with `:runner_linux_shapes` in
   # `server/config/config.exs` — the same catalog from two sides (Helm
-  # renders the pools; the server validates + addresses them).
+  # renders the pools; the server validates + addresses them) — minus
+  # the 64 GB ceiling shape, which needs production's AX162-R hosts and
+  # would render a pool no 64 GB AX42-U can ever place a Pod on.
   # Resolved at deploy time from the latest `linux-runner-image@` git tag
   # (server-deployment.yml passes `tuist-linux-runner:<version>` via --set).
   shapeRunnerImage: ""

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -109,26 +109,41 @@ independent workqueues:
     memory and oversubscribes CPU by design, and those hosts are
     homogeneous, so the byte budget is already exact there.
 
-    **Node reservation.** A shape needing more than one guest slot on a
-    single host cannot accumulate them on its own. kube-scheduler does
-    not hold its queue on an unschedulable Pod, so each slot that frees
-    is taken by the next smaller Pod that fits, and the large Pod waits
-    for a coincidence of two simultaneously-free slots that a steady
+    **Node reservation.** Runs on BOTH fleets. A shape needing more of a
+    host than any single smaller Pod does cannot accumulate the room on
+    its own. kube-scheduler does not hold its queue on an unschedulable
+    Pod, so each slot that frees is taken by the next smaller Pod that
+    fits, and the large Pod waits for a coincidence that a steady
     trickle of small jobs prevents. The cross-pool reclaim does not help
     either: it reclaims speculative warm capacity, and the Pod winning
     the race is backed by real queued work, the one tier that never
     yields.
 
+    On darwin the unit is guest slots: a 12 vCPU Pod needs both of an
+    M4-XL's. On linux it is memory: a 64 GiB shape costs a third of an
+    AX162-R (64 GiB plus the kata RuntimeClass's 2.5 GiB podFixed), so
+    it needs a contiguous third of a host that 8 and 16 GiB Pods keep
+    carving up. The linux drain is progressive rather than all-or-
+    nothing — the taint stops new Pods landing, running jobs finish and
+    free their memory, and the starved Pod is placed the moment its
+    shape fits rather than when the host is empty.
+
+    `fleetNodeSelector` addresses each platform's hosts by the labels
+    that platform's Pods select on (`tuist.dev/fleet` on darwin,
+    `node.cluster.x-k8s.io/pool` on linux, both paired with
+    `kubernetes.io/os`), so the reservation and the scheduler always
+    agree on which hosts a fleet has.
+
     A reservation is only taken for a shape that is LARGE relative to
     the fleet: this shape must get fewer seats on the candidate host
     than the fleet's most granular shape does. That is exactly the case
     where the seats it needs are the ones smaller Pods keep taking. On a
-    homogeneous fleet whose hosts hold one guest (staging, canary) the
-    test never passes, so the mechanism is inert there — nothing can
-    accumulate when the shape already fits a single seat, and reserving
-    a one-host fleet would take every pool out of service until it
-    cleared. Waiting is correct there, and the allocator's cross-pool
-    reclaim already arranges it.
+    homogeneous fleet whose hosts hold one guest (the macOS side of
+    staging, canary) the test never passes, so the mechanism is inert
+    there — nothing can accumulate when the shape already fits a single
+    seat, and reserving a one-host fleet would take every pool out of
+    service until it cleared. Waiting is correct there, and the
+    allocator's cross-pool reclaim already arranges it.
 
     When a qualifying Pod has sat unscheduled past `reservationGrace`
     (2m), the RunnerPool reconciler taints one eligible host
@@ -137,9 +152,12 @@ independent workqueues:
     admitting everyone else while its seats accumulate. Running jobs are
     waited out, never evicted; only idle Pods of other pools are
     retired. The taint is removed when the Pod lands or after
-    `reservationTimeout` (15m), and at most one host is held fleet-wide
-    (`maxFleetReservations`), since a reservation is capacity withdrawn
-    from the small shapes while it converges.
+    `reservationTimeout` (15m), and at most one host is held per fleet
+    (`maxFleetReservations`; the count is taken over the pool's own
+    fleet nodes, so darwin and linux hold separate budgets), since a
+    reservation is capacity withdrawn from the small shapes while it
+    converges. On the two-host production Linux fleet that is half the
+    hosts closed to new Pods, which is why the cap stays at one.
 
     A timed-out release rests the host for `reservationCooldown` (15m)
     via a `tuist.dev/reservation-cooldown-until` annotation. Without it

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -120,13 +120,22 @@ independent workqueues:
     yields.
 
     On darwin the unit is guest slots: a 12 vCPU Pod needs both of an
-    M4-XL's. On linux it is memory: a 64 GiB shape costs a third of an
-    AX162-R (64 GiB plus the kata RuntimeClass's 2.5 GiB podFixed), so
-    it needs a contiguous third of a host that 8 and 16 GiB Pods keep
-    carving up. The linux drain is progressive rather than all-or-
-    nothing — the taint stops new Pods landing, running jobs finish and
-    free their memory, and the starved Pod is placed the moment its
-    shape fits rather than when the host is empty.
+    M4-XL's. On linux it is memory: a 64 GiB shape costs 66.5 GiB (the
+    shape plus the kata RuntimeClass's 2.5 GiB podFixed), a third of an
+    AX162-R and over half of the OVH RISE-L the fleet is moving to, so
+    it needs a contiguous block that 8 and 16 GiB Pods keep carving up.
+    The linux drain is progressive rather than all-or-nothing — the
+    taint stops new Pods landing, running jobs finish and free their
+    memory, and the starved Pod is placed the moment its shape fits
+    rather than when the host is empty.
+
+    A reservation is never taken on a fleet with fewer than two healthy
+    hosts (`healthyNodes`). The taint is NoSchedule for every pool but
+    the reserving one, so on a single-host fleet it would stop dispatch
+    outright until it cleared. The granularity guard below does not
+    cover that case on linux — a 64 GiB shape is genuinely coarse even
+    on a lone host, so it passes — and the linux fleet is small enough
+    for one host to be a real configuration.
 
     `fleetNodeSelector` addresses each platform's hosts by the labels
     that platform's Pods select on (`tuist.dev/fleet` on darwin,
@@ -156,8 +165,9 @@ independent workqueues:
     (`maxFleetReservations`; the count is taken over the pool's own
     fleet nodes, so darwin and linux hold separate budgets), since a
     reservation is capacity withdrawn from the small shapes while it
-    converges. On the two-host production Linux fleet that is half the
-    hosts closed to new Pods, which is why the cap stays at one.
+    converges. On the production Linux fleet, a handful of bare-metal
+    boxes, one reservation is already a large share of it, which is why
+    the cap stays at one and why `healthyNodes` floors it.
 
     A timed-out release rests the host for `reservationCooldown` (15m)
     via a `tuist.dev/reservation-cooldown-until` annotation. Without it

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -27,7 +27,7 @@ import (
 // gives the memory budget the pool's shapes compete for.
 const fleetNodePoolLabel = "node.cluster.x-k8s.io/pool"
 
-// macosFleetLabel + macosNodeOSLabel identify the Mac mini hosts
+// macosFleetLabel + nodeOSLabel identify the Mac mini hosts
 // claimed by a macOS RunnerPool's fleetSelector. tuist.dev/fleet is
 // stamped by the runners-fleet's MachineDeployment (and matched by
 // the macOS runner Pods' nodeSelector); kubernetes.io/os=darwin
@@ -35,13 +35,16 @@ const fleetNodePoolLabel = "node.cluster.x-k8s.io/pool"
 // actually admit gives the slot budget the macOS Xcode pools compete
 // for.
 //
+// nodeOSLabel is not macOS-only: the reservation path pairs it with
+// fleetNodePoolLabel to address the Linux fleet's bare-metal hosts.
+//
 // One fleet label can span several MachineDeployments — that is how a
 // mixed-SKU fleet is expressed (M2-L at one guest per host next to
 // M4-XL at two), so the node set behind a fleetSelector is NOT
 // homogeneous and its capacity is not its cardinality.
 const (
 	macosFleetLabel   = "tuist.dev/fleet"
-	macosNodeOSLabel  = "kubernetes.io/os"
+	nodeOSLabel       = "kubernetes.io/os"
 	macosNodeOSDarwin = "darwin"
 )
 
@@ -360,8 +363,8 @@ func (r *AutoscalerReconciler) shapePlacementCaps(
 
 	var nodes corev1.NodeList
 	if err := r.List(ctx, &nodes, client.MatchingLabels{
-		macosFleetLabel:  pool.Spec.FleetSelector,
-		macosNodeOSLabel: macosNodeOSDarwin,
+		macosFleetLabel: pool.Spec.FleetSelector,
+		nodeOSLabel:     macosNodeOSDarwin,
 	}); err != nil {
 		return nil, fmt.Errorf("list macOS fleet nodes for shape caps: %w", err)
 	}
@@ -616,8 +619,8 @@ func (r *AutoscalerReconciler) fleetAllocatableMemory(ctx context.Context, fleet
 func (r *AutoscalerReconciler) macosFleetAllocatableMemory(ctx context.Context, fleetSelector string) (int64, error) {
 	var nodes corev1.NodeList
 	if err := r.List(ctx, &nodes, client.MatchingLabels{
-		macosFleetLabel:  fleetSelector,
-		macosNodeOSLabel: macosNodeOSDarwin,
+		macosFleetLabel: fleetSelector,
+		nodeOSLabel:     macosNodeOSDarwin,
 	}); err != nil {
 		return 0, fmt.Errorf("list macOS fleet nodes: %w", err)
 	}

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -567,8 +567,8 @@ func macosNodeWithGuests(name, fleetSelector string, guests int64) *corev1.Node 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				macosFleetLabel:  fleetSelector,
-				macosNodeOSLabel: macosNodeOSDarwin,
+				macosFleetLabel: fleetSelector,
+				nodeOSLabel:     macosNodeOSDarwin,
 			},
 		},
 		Status: corev1.NodeStatus{

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -20,10 +20,11 @@ import (
 // of a host than any single small Pod does. An M4-XL seats two 6 vCPU
 // guests or one 12 vCPU guest, so a 12 vCPU Pod needs BOTH of a host's
 // slots free at the same instant. The Linux fleet is the same problem at
-// a different granularity: a 64 GiB shape costs a third of an AX162-R,
-// so it needs a contiguous third of a host that a steady trickle of 8
-// and 16 GiB Pods keeps carving up. Nothing in Kubernetes arranges
-// either on its own:
+// a different granularity: a 64 GiB shape costs 66.5 GiB with the kata
+// overhead — a third of an AX162-R, over half of the OVH RISE-L the
+// fleet is moving to — so it needs a contiguous block that a steady
+// trickle of 8 and 16 GiB Pods keeps carving up. Nothing in Kubernetes
+// arranges either on its own:
 //
 //   - kube-scheduler does not hold a queue on an unschedulable Pod. The
 //     large Pod is attempted, fails the CPU filter, and is set aside;
@@ -92,8 +93,10 @@ const (
 	// it converges, so this stays at one. On macOS a second concurrent
 	// drain would hold two hosts, up to 4 of the 13-slot production
 	// fleet, to serve two large jobs. On Linux the argument is sharper
-	// still: that fleet is two AX162-R hosts, so one reservation is
-	// already half of it taken out of general circulation.
+	// still: that fleet is a handful of bare-metal boxes, so a single
+	// reservation is already a large share of it out of circulation.
+	// `healthyNodes` puts a floor under that — the last host is never
+	// taken.
 	//
 	// A held Linux host is not idled, only closed to new Pods — running
 	// jobs finish and free memory progressively, and the starved Pod
@@ -168,6 +171,24 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		return err
 	}
 	if reservationCount(fresh) >= maxFleetReservations {
+		return nil
+	}
+	// Never close the fleet. The taint is NoSchedule for every pool but
+	// this one, so on a single-host fleet a reservation stops dispatch
+	// outright until it clears — up to reservationTimeout, and again
+	// after each cooldown.
+	//
+	// pickReservationTarget's granularity guard does not cover this. It
+	// asks whether the shape is coarse relative to its siblings, which
+	// on Linux a 64 GiB shape genuinely is even on a lone host, so it
+	// passes. The guard only happens to cover the one-host macOS fleets
+	// because a single-guest host gives every shape exactly one seat.
+	//
+	// Waiting is the right behaviour here, and it is the same conclusion
+	// the one-guest fleets reach: nothing a drain produces is worth the
+	// fleet being shut to everyone else, and the allocator's cross-pool
+	// reclaim is the mechanism that frees room on a fleet this small.
+	if healthyNodes(fresh) < 2 {
 		return nil
 	}
 
@@ -632,4 +653,17 @@ func reservationAge(node *corev1.Node, now time.Time) time.Duration {
 // conflict instead, and the next reconcile recomputes from fresh state.
 func optimisticPatch(base client.Object) client.Patch {
 	return client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+}
+
+// healthyNodes counts a fleet's hosts that could take work right now.
+// Reserving is only safe while at least one other host remains to serve
+// every other pool.
+func healthyNodes(nodes []corev1.Node) int {
+	count := 0
+	for i := range nodes {
+		if nodeFilterReason(&nodes[i]) == "" {
+			count++
+		}
+	}
+	return count
 }

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -16,11 +16,14 @@ import (
 
 // Node reservation: draining one host to fit a Pod that no host can seat.
 //
-// A macOS fleet mixes guest shapes on the same hosts, and the large ones
-// need more than one guest slot on a single host. An M4-XL seats two
-// 6 vCPU guests or one 12 vCPU guest, so a 12 vCPU Pod needs BOTH of a
-// host's slots free at the same instant. Nothing in Kubernetes arranges
-// that on its own:
+// Both fleets mix shapes on the same hosts, and the large ones need more
+// of a host than any single small Pod does. An M4-XL seats two 6 vCPU
+// guests or one 12 vCPU guest, so a 12 vCPU Pod needs BOTH of a host's
+// slots free at the same instant. The Linux fleet is the same problem at
+// a different granularity: a 64 GiB shape costs a third of an AX162-R,
+// so it needs a contiguous third of a host that a steady trickle of 8
+// and 16 GiB Pods keeps carving up. Nothing in Kubernetes arranges
+// either on its own:
 //
 //   - kube-scheduler does not hold a queue on an unschedulable Pod. The
 //     large Pod is attempted, fails the CPU filter, and is set aside;
@@ -81,11 +84,20 @@ const (
 	reservationCooldownAnnotation = "tuist.dev/reservation-cooldown-until"
 	reservationCooldown           = 15 * time.Minute
 
-	// maxFleetReservations is how many hosts may be held across the whole
-	// fleet at once. Every reservation is capacity withdrawn from the
-	// small shapes while it converges, so this stays at one: a second
-	// concurrent drain would hold two hosts at once, up to 4 of the
-	// 13-slot production fleet, to serve two large jobs.
+	// maxFleetReservations is how many hosts may be held at once. The
+	// count is taken over the pool's OWN fleet nodes, so each fleet gets
+	// its own budget and a macOS reservation never blocks a Linux one.
+	//
+	// Every reservation is capacity withdrawn from the small shapes while
+	// it converges, so this stays at one. On macOS a second concurrent
+	// drain would hold two hosts, up to 4 of the 13-slot production
+	// fleet, to serve two large jobs. On Linux the argument is sharper
+	// still: that fleet is two AX162-R hosts, so one reservation is
+	// already half of it taken out of general circulation.
+	//
+	// A held Linux host is not idled, only closed to new Pods — running
+	// jobs finish and free memory progressively, and the starved Pod
+	// lands the moment its shape fits rather than when the host is empty.
 	maxFleetReservations = 1
 )
 
@@ -100,13 +112,6 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 	pool *tuistv1.RunnerPool,
 	pods []corev1.Pod,
 ) error {
-	// darwin only. Linux runner Pods are kata sandboxes on homogeneous
-	// bare-metal hosts an order of magnitude larger than any shape, so a
-	// shape never needs a host drained to fit.
-	if pool.Spec.OS != macosNodeOSDarwin {
-		return nil
-	}
-
 	logger := log.FromContext(ctx)
 	now := r.now()
 
@@ -402,8 +407,8 @@ func (r *RunnerPoolReconciler) releaseReservation(
 	return nil
 }
 
-// fleetNodes lists the macOS hosts behind a pool's fleet selector, the
-// same set the autoscaler sizes its budget from. Cached read: fine for
+// fleetNodes lists the hosts behind a pool's fleet selector, the same
+// set the autoscaler sizes its budget from. Cached read: fine for
 // deciding whether this pool already holds a reservation, and for
 // releasing one.
 func (r *RunnerPoolReconciler) fleetNodes(ctx context.Context, pool *tuistv1.RunnerPool) ([]corev1.Node, error) {
@@ -416,13 +421,33 @@ func (r *RunnerPoolReconciler) fleetNodesFrom(
 	pool *tuistv1.RunnerPool,
 ) ([]corev1.Node, error) {
 	var nodes corev1.NodeList
-	if err := reader.List(ctx, &nodes, client.MatchingLabels{
-		macosFleetLabel:  pool.Spec.FleetSelector,
-		macosNodeOSLabel: macosNodeOSDarwin,
-	}); err != nil {
+	if err := reader.List(ctx, &nodes, fleetNodeSelector(pool)); err != nil {
 		return nil, fmt.Errorf("list fleet nodes: %w", err)
 	}
 	return nodes.Items, nil
+}
+
+// fleetNodeSelector addresses the hosts a pool's Pods can actually land
+// on. It mirrors the nodeSelector `podtemplate.schedulingFor` stamps on
+// those Pods, so the reservation reasons about exactly the node set the
+// scheduler considers; the two would otherwise be free to disagree about
+// which hosts belong to a fleet.
+//
+// Anything other than linux falls through to darwin, matching that same
+// function's fallback and the CRD's `os` default.
+func fleetNodeSelector(pool *tuistv1.RunnerPool) client.MatchingLabels {
+	switch pool.Spec.OS {
+	case "linux":
+		return client.MatchingLabels{
+			fleetNodePoolLabel: pool.Spec.FleetSelector,
+			nodeOSLabel:        "linux",
+		}
+	default:
+		return client.MatchingLabels{
+			macosFleetLabel: pool.Spec.FleetSelector,
+			nodeOSLabel:     macosNodeOSDarwin,
+		}
+	}
 }
 
 // apiReader is the uncached client, used on the one path where a stale
@@ -485,10 +510,6 @@ func (r *RunnerPoolReconciler) releaseOrphanedReservations(
 // from the delete path, which returns before the ordinary reservation
 // reconciliation and would otherwise strand the taint.
 func (r *RunnerPoolReconciler) ReleaseReservationsForPool(ctx context.Context, pool *tuistv1.RunnerPool) error {
-	if pool.Spec.OS != macosNodeOSDarwin {
-		return nil
-	}
-
 	nodes, err := r.fleetNodes(ctx, pool)
 	if err != nil {
 		return err

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -40,8 +40,8 @@ func m4Node(name string) *corev1.Node {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				macosFleetLabel:  reservationFleet,
-				macosNodeOSLabel: macosNodeOSDarwin,
+				macosFleetLabel: reservationFleet,
+				nodeOSLabel:     macosNodeOSDarwin,
 			},
 		},
 		Status: corev1.NodeStatus{
@@ -98,6 +98,61 @@ func smallPool() *tuistv1.RunnerPool {
 			FleetSelector: reservationFleet,
 			PodCPUMilli:   6000,
 			PodMemoryMB:   14336,
+		},
+	}
+}
+
+const (
+	linuxReservationFleet = "runners-linux"
+	linuxSmallPoolName    = "runner-pool-linux-2vcpu-8gb"
+)
+
+// linuxLargePool is the 64 GB ceiling shape. It costs a third of an
+// AX162-R, which is what makes it starvable behind smaller Pods.
+func linuxLargePool() *tuistv1.RunnerPool {
+	return &tuistv1.RunnerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "runner-pool-linux-16vcpu-64gb", Namespace: "runners"},
+		Spec: tuistv1.RunnerPoolSpec{
+			OS:            "linux",
+			FleetSelector: linuxReservationFleet,
+			PodCPUMilli:   16000,
+			PodMemoryMB:   65536,
+		},
+	}
+}
+
+// linuxSmallPool is the default 2 vCPU / 8 GB shape the large one
+// competes with for the same hosts.
+func linuxSmallPool() *tuistv1.RunnerPool {
+	return &tuistv1.RunnerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: linuxSmallPoolName, Namespace: "runners"},
+		Spec: tuistv1.RunnerPoolSpec{
+			OS:            "linux",
+			FleetSelector: linuxReservationFleet,
+			PodCPUMilli:   2000,
+			PodMemoryMB:   8192,
+		},
+	}
+}
+
+// ax162Node carries the production AX162-R's allocatable, which is well
+// short of its 256 GB of installed memory once kube and system
+// reservations come off.
+func ax162Node(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				fleetNodePoolLabel: linuxReservationFleet,
+				nodeOSLabel:        "linux",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewQuantity(94, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(227571*1024*1024, resource.BinarySI),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }
@@ -328,19 +383,163 @@ func TestReservation_PrefersTheHostThatConvergesSoonest(t *testing.T) {
 
 // Linux fleets opt out: those hosts are far larger than any shape, so a
 // shape never needs one drained to fit.
-func TestReservation_SkipsLinuxPools(t *testing.T) {
-	pool := largePool()
-	pool.Spec.OS = "linux"
-	node := m4Node("m4-0")
+// The Linux equivalent of the scenario above. A 64 GiB shape costs a
+// third of an AX162-R, so it needs a contiguous third of a host that a
+// trickle of 8 GiB Pods keeps carving up — the same starvation the macOS
+// 12 vCPU shape hits, at a different granularity.
+func TestReservation_HoldsALinuxHostForAStarvedShape(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, smallPool(), node, starved)
+	r := reservationReconciler(pool, linuxSmallPool(), node, starved,
+		placedPod("small-0", linuxSmallPoolName, "bm-0", "acme"),
+	)
+
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}
 
-	if isReserved(nodeByName(t, r, "m4-0")) {
-		t.Fatal("Linux pools must not take reservations")
+	got := nodeByName(t, r, "bm-0")
+	if !isReserved(got) {
+		t.Fatalf("node was not reserved: %+v", got.Spec.Taints)
+	}
+	for _, taint := range got.Spec.Taints {
+		if taint.Key != podtemplate.ReservationTaintKey {
+			continue
+		}
+		if taint.Value != podtemplate.ReservationValue(pool.Name) {
+			t.Errorf("taint value = %q, want the starved pool", taint.Value)
+		}
+		// NoSchedule and not NoExecute: the drain is progressive. Jobs
+		// already running on the host finish and free their memory, and
+		// the starved Pod lands as soon as its shape fits.
+		if taint.Effect != corev1.TaintEffectNoSchedule {
+			t.Errorf("taint effect = %q, want NoSchedule so running jobs survive", taint.Effect)
+		}
+	}
+}
+
+// A pool addresses its fleet by the labels its own Pods select on:
+// `tuist.dev/fleet` on darwin, `node.cluster.x-k8s.io/pool` on linux.
+// Both fleets live in one cluster and nothing stops an operator naming
+// them alike, so the two hosts here carry the SAME fleet value under
+// their respective labels. A selector keyed on the fleet name alone
+// would hand each platform the other's host to drain.
+func TestFleetNodes_AddressEachPlatformsHostsSeparately(t *testing.T) {
+	mac := m4Node("m4-0")
+	mac.Labels[macosFleetLabel] = linuxReservationFleet
+	bare := ax162Node("bm-0")
+
+	macPool := largePool()
+	macPool.Spec.FleetSelector = linuxReservationFleet
+
+	r := reservationReconciler(macPool, linuxLargePool(), mac, bare)
+
+	linuxNodes, err := r.fleetNodes(context.Background(), linuxLargePool())
+	if err != nil {
+		t.Fatalf("fleetNodes(linux): %v", err)
+	}
+	if got := nodeNames(linuxNodes); len(got) != 1 || got[0] != "bm-0" {
+		t.Errorf("linux fleet = %v, want just the bare-metal host", got)
+	}
+
+	macNodes, err := r.fleetNodes(context.Background(), macPool)
+	if err != nil {
+		t.Fatalf("fleetNodes(darwin): %v", err)
+	}
+	if got := nodeNames(macNodes); len(got) != 1 || got[0] != "m4-0" {
+		t.Errorf("darwin fleet = %v, want just the Mac mini", got)
+	}
+}
+
+func nodeNames(nodes []corev1.Node) []string {
+	names := make([]string, 0, len(nodes))
+	for i := range nodes {
+		names = append(names, nodes[i].Name)
+	}
+	return names
+}
+
+// The drain is what makes the reservation useful on Linux, where a host
+// carries many small Pods rather than two. `isIdle` reads the poller's
+// exit, so an unclaimed Pod is retired and a claimed one is waited out.
+func TestReservation_RetiresIdleLinuxPodsButNeverRunningJobs(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{reservationAtAnnotation: reservationNow.Format(time.RFC3339)}
+
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+	idle := placedPod("small-idle", linuxSmallPoolName, "bm-0", "")
+	owned := placedPod("small-owned", linuxSmallPoolName, "bm-0", "acme")
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, starved, idle, owned)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	remaining := &corev1.PodList{}
+	if err := r.List(context.Background(), remaining, client.InNamespace("runners")); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	names := map[string]bool{}
+	for i := range remaining.Items {
+		names[remaining.Items[i].Name] = true
+	}
+
+	if names["small-idle"] {
+		t.Error("an idle Pod of another pool should have been retired to clear memory")
+	}
+	if !names["small-owned"] {
+		t.Error("a Pod running a customer job must never be evicted by a reservation")
+	}
+}
+
+// The "large relative to the fleet" guard is platform-neutral. The
+// default 2 vCPU / 8 GiB shape gets as many seats on a host as anything
+// else does, so queueing behind other Pods is ordinary contention and
+// draining a host for it would take a third of the Linux fleet out of
+// service to no end.
+func TestReservation_SkipsLinuxShapesThatAreNotLarge(t *testing.T) {
+	pool := linuxSmallPool()
+	node := ax162Node("bm-0")
+	starved := pendingPod("small-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, linuxLargePool(), node, starved)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "bm-0")) {
+		t.Fatal("the fleet's most granular shape must not reserve")
+	}
+}
+
+// A deleted Linux pool has to hand its host back on the delete path.
+// The orphan sweep is only a backstop, and it runs from OTHER pools'
+// reconciles — on a fleet whose remaining pools are all scaled to zero
+// it may not run promptly.
+func TestReservation_ReleasedWhenTheOwningLinuxPoolIsDeleted(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+
+	r := reservationReconciler(pool, node)
+	if err := r.ReleaseReservationsForPool(context.Background(), pool); err != nil {
+		t.Fatalf("ReleaseReservationsForPool: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "bm-0")) {
+		t.Fatal("a deleting Linux pool must release the host it held")
 	}
 }
 

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -186,9 +186,14 @@ func TestReservation_HoldsAHostForAStarvedShape(t *testing.T) {
 	node := m4Node("m4-0")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, smallPool(), node, starved,
+	r := reservationReconciler(pool, smallPool(), node, m4Node("m4-1"), starved,
 		placedPod("small-0", "macos-26-6", "m4-0", "acme"),
 		placedPod("small-1", "macos-26-6", "m4-0", "acme"),
+		// m4-1 keeps the fleet above the last-host floor and is busier,
+		// so m4-0 stays the host that converges soonest.
+		placedPod("small-2", "macos-26-6", "m4-1", "acme"),
+		placedPod("small-3", "macos-26-6", "m4-1", "acme"),
+		placedPod("small-4", "macos-26-6", "m4-1", "acme"),
 	)
 
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
@@ -392,8 +397,12 @@ func TestReservation_HoldsALinuxHostForAStarvedShape(t *testing.T) {
 	node := ax162Node("bm-0")
 	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
 
-	r := reservationReconciler(pool, linuxSmallPool(), node, starved,
+	r := reservationReconciler(pool, linuxSmallPool(), node, ax162Node("bm-1"), starved,
 		placedPod("small-0", linuxSmallPoolName, "bm-0", "acme"),
+		// bm-1 keeps the fleet above the last-host floor and is busier,
+		// so bm-0 stays the host that converges soonest.
+		placedPod("small-1", linuxSmallPoolName, "bm-1", "acme"),
+		placedPod("small-2", linuxSmallPoolName, "bm-1", "acme"),
 	)
 
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
@@ -497,6 +506,50 @@ func TestReservation_RetiresIdleLinuxPodsButNeverRunningJobs(t *testing.T) {
 	}
 	if !names["small-owned"] {
 		t.Error("a Pod running a customer job must never be evicted by a reservation")
+	}
+}
+
+// A reservation taints a host NoSchedule for every pool but its own, so
+// on a single-host fleet it stops job dispatch outright until it clears.
+// The granularity guard does not catch this on Linux: a 64 GB shape
+// genuinely IS coarser than its siblings on one big host, so it passes
+// that test and would close the fleet. Reachable in practice — the
+// Linux fleet is small and moving to smaller boxes.
+func TestReservation_NeverTakesTheFleetsLastHost(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, starved,
+		placedPod("small-0", linuxSmallPoolName, "bm-0", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "bm-0")) {
+		t.Fatal("reserving the fleet's only host closes it to every pool")
+	}
+}
+
+// A second host that is down is not a second host: reserving the one
+// still serving work closes the fleet just the same.
+func TestReservation_CountsOnlyHealthyHostsTowardTheFloor(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
+	down := ax162Node("bm-1")
+	down.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, down, starved,
+		placedPod("small-0", linuxSmallPoolName, "bm-0", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "bm-0")) {
+		t.Fatal("a NotReady sibling must not count as the host that keeps the fleet open")
 	}
 }
 
@@ -635,7 +688,11 @@ func TestReservation_ResumesAfterTheCooldownExpires(t *testing.T) {
 	}
 	starved := pendingPod("large-0", pool.Name, time.Hour)
 
-	r := reservationReconciler(pool, smallPool(), node, starved)
+	// m4-1 is busier, so the expired cooldown on m4-0 is the only thing
+	// that could keep it from being chosen.
+	r := reservationReconciler(pool, smallPool(), node, m4Node("m4-1"), starved,
+		placedPod("small-0", "macos-26-6", "m4-1", "acme"),
+	)
 	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
 		t.Fatalf("reconcileReservation: %v", err)
 	}

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -430,6 +430,11 @@ config :tuist, :runner_free_monthly_minutes, 100
 # cluster's pools and the server's catalog share one source of truth in
 # prod and can't drift. Exactly one entry should carry `default: true`
 # (preselected in the "new profile" form).
+#
+# A Linux shape is only runnable where a bare-metal host can seat it,
+# so like the macOS catalog below this list is per-environment on the
+# Helm side: the 64 GB shape needs an AX162-R and is not offered in
+# environments whose Linux fleet is 64 GB AX42-U only.
 config :tuist, :runner_linux_shapes, [
   %{vcpus: 1, memory_gb: 2},
   %{vcpus: 2, memory_gb: 4},
@@ -438,7 +443,8 @@ config :tuist, :runner_linux_shapes, [
   %{vcpus: 4, memory_gb: 16},
   %{vcpus: 8, memory_gb: 16},
   %{vcpus: 8, memory_gb: 32},
-  %{vcpus: 16, memory_gb: 32}
+  %{vcpus: 16, memory_gb: 32},
+  %{vcpus: 16, memory_gb: 64}
 ]
 
 # macOS shape catalog. Same role as `:runner_linux_shapes`. Managed

--- a/server/priv/marketing/changelog/2026.08.31-linux-runner-64-gb-shape.md
+++ b/server/priv/marketing/changelog/2026.08.31-linux-runner-64-gb-shape.md
@@ -1,0 +1,11 @@
+---
+title: A 64 GB Linux runner shape
+description: "Linux runner profiles can now pick a 16 vCPU / 64 GB machine, doubling the memory ceiling from the previous 32 GB top shape."
+category: "Product"
+---
+
+The Linux runner catalog topped out at 32 GB of memory. There is now a **16 vCPU / 64 GB** shape, the new ceiling.
+
+Pick it when you create or edit a Linux profile. Jobs that exhausted memory on the 32 GB shape — Android release builds running Gradle and Kotlin daemons are the common case — fit without tuning heap sizes down. Existing profiles keep the shape they were created with.
+
+Learn more in the [runner profiles documentation](https://tuist.dev/en/docs/guides/features/runners/profiles#machine-shapes).

--- a/server/priv/marketing/changelog/2026.08.31-linux-runner-64-gb-shape.md
+++ b/server/priv/marketing/changelog/2026.08.31-linux-runner-64-gb-shape.md
@@ -2,6 +2,7 @@
 title: A 64 GB Linux runner shape
 description: "Linux runner profiles can now pick a 16 vCPU / 64 GB machine, doubling the memory ceiling from the previous 32 GB top shape."
 category: "Product"
+pull_request: 12714
 ---
 
 The Linux runner catalog topped out at 32 GB of memory. There is now a **16 vCPU / 64 GB** shape, the new ceiling.


### PR DESCRIPTION
## What changed

Adds a **16 vCPU / 64 GB** shape to the Linux Runner Profiles catalog, doubling the memory ceiling from the previous 32 GB top shape, and extends the node reservation to the Linux fleet so that shape is not starved by smaller jobs.

Two commits:

**1. The shape**

- `server/config/config.exs` — the dev/test/CI catalog default gains the shape.
- `infra/helm/tuist/values-managed-production.yaml` — the production catalog gains it, which both renders the `RunnerPool` CR and injects the shape into the server via `TUIST_RUNNER_LINUX_SHAPES`.
- `values-managed-staging.yaml` / `values-managed-canary.yaml` — comments only, recording why those envs stay at 32 GB.
- A changelog entry.

**2. The reservation**

- `infra/runners-controller/controllers/reservation.go` — drops the darwin-only gate and addresses fleet nodes per platform.
- `infra/runners-controller/controllers/autoscaler_controller.go` — renames `macosNodeOSLabel` to `nodeOSLabel`, since both paths now use it.
- Tests and `AGENTS.md`.

**3. A last-host floor** — a separate commit, easy to drop if you disagree with it. See "Never closing the fleet" below.

## Why

A customer's Android release jobs do not fit on the 32 GB shape. Gradle's daemon, the Kotlin compile daemon, and a parallel R8/D8 pass hold heaps that a 32 GB machine cannot seat together, so the job dies rather than slows down. Nothing on our side gates memory per account — the shape catalog is global, so "enable > 32 GB for our account" is "add a > 32 GB shape to the catalog".

## Why 16 vCPU, and why production only

The ladder already alternates between doubling vCPUs and doubling memory (`8/32` → `16/32`), so `16/64` is the next rung, at the same 4 GB-per-vCPU ratio as the default shape.

The obvious objection is that it leaves CPU unclaimed. But 32 vCPU is not an option, and the reason is decisive: #12716 moves this fleet to OVH RISE-L boxes (16c/32t, 128 GB), and a 32 vCPU Pod costs **32.25 CPUs** with the kata overhead. No kubelet reserve makes that fit 32 threads. It would be unschedulable on the incoming hardware.

Even on the outgoing AX162-R it is the worse trade:

| shape | pod cost | seats / AX162-R | seats / RISE-L | CPU at full pack (AX162-R) | memory at full pack |
| --- | --- | --- | --- | --- | --- |
| 16 / 64 | 16.25 CPU, 66.5 GiB | **3** | **1** | 48.75 / 94 | 199.5 / 222.2 GiB |
| 24 / 64 | 24.25 CPU, 66.5 GiB | **3** | **1** | 72.75 / 94 | 199.5 / 222.2 GiB |
| 32 / 64 | 32.25 CPU, 66.5 GiB | **2** | **0** | 64.5 / 94 | 133 / 222.2 GiB |

Three 32 vCPU Pods want 96.75 CPUs against 94 allocatable, so that rung costs the third seat and idles 90 GiB. 24 is the most vCPU that still fits three, and the values comment notes it as the shape to reach for if a CPU-bound workload asks while those boxes are in service. (The seat loss only bites at three concurrent 64 GB Pods on one host; on a mixed host the small Pods' memory binds first either way.)

The unclaimed CPU is a fleet property, not something this shape introduces. The Linux hosts run at ~50% CPU requests against 92-98% memory requests, and actual usage is CPU 21-39% / memory ~52% — kata pins guest RAM, so every Pod reserves its whole shape whether or not the job touches it. A host is ~2.4 GB per thread against a catalog of 2 and 4 GB/vCPU rungs, so a 4 GB/vCPU shape leaving CPU spare is the ladder working as designed. The structural fix is decoupling the scheduler request from the kata limit, which `values-managed-production.yaml` already flags for the warm-floor sizing problem.

Billing reflects the choice through the existing per-platform formula: `(8 * 16 + 64) / 24` = 8 compute units per machine-minute, against 13.33 for a 32 vCPU rung. This rung is bought for memory, and is priced for it.

**Production only.** Staging and canary run AX42-U boxes with 64 GB **total** (51.7 GiB allocatable), so a 66.5 GiB Pod could never be placed there. `values-managed-common.yaml` already states the rule for that case, for the macOS catalog: leaving a shape in an env that cannot host it offers it in that env's Profiles dropdown and queues any job picking it forever. So the Linux catalog now diverges per environment exactly the way the macOS one already does. `config/config.exs` carries the full ladder as the dev/test/CI default, matching how the 12 vCPU macOS shape is declared there.

## Never closing the fleet

Enabling reservations on Linux opens a hole the macOS design never had to close. The taint is `NoSchedule` for every pool but the reserving one, so on a **single-host** fleet a reservation stops dispatch outright until it clears.

`pickReservationTarget`'s granularity guard does not catch this: it asks whether the shape is coarse relative to its siblings, and on Linux a 64 GiB shape genuinely is even on a lone host. It only happened to cover one-host macOS fleets because a single-guest host gives every shape exactly one seat, tripping `seats >= maxSeatsOnNode`.

That is reachable rather than theoretical — #12716 starts the OVH Linux fleet at one replica, where a 66.5 GiB Pod takes over half a host. So a reservation is now skipped when the fleet has fewer than two **healthy** hosts; a NotReady sibling is not a sibling that keeps the fleet open. Waiting is correct there, and it is the conclusion the one-guest fleets already reach.

This is its own commit so it can be dropped independently if you would rather keep the mechanism's semantics unchanged. Three existing macOS tests drove reservations from single-node fixtures and now carry an occupied sibling, kept busier than the target so each test still asserts on the host that converges soonest.

## What did not need changing

No code. The Helm template renders shape-keyed pools generically, the `RunnerPool` CRD has no memory ceiling, `Catalog` derives pool names and fleet resources from the configured list, and the docs table and Profiles dropdown are both generated from the catalog. Billing weights the shape through the existing per-platform formula: `(8 * 16 + 64) / 24` = 8 compute units per machine-minute, exactly double the 32 GB shape's memory contribution, with no Stripe work.

The pool scales to zero (`minWarmPoolFloor: 0`), so it costs nothing until an account creates a profile on it.

## Starvation, and why the current two hosts are enough

The 12 vCPU macOS shape hit exactly this and the answer was the node reservation in `reservation.go`. That mechanism was gated to darwin, on the reasoning that "Linux runner Pods are kata sandboxes on homogeneous bare-metal hosts an order of magnitude larger than any shape". A 64 GB Pod costs 66.5 GiB (64 GiB + the kata `podFixed` overhead) of an AX162-R's 222.2 GiB allocatable — roughly a third, not a tenth — so that reasoning no longer holds and the second commit removes the gate.

Without it the shape starves. kube-scheduler does not hold a queue on an unschedulable Pod, so every hole a finishing job opens goes to the next 8 or 16 GiB Pod that fits. Production is in that state right now:

| host | memory requests | free |
| --- | --- | --- |
| `...-c789j` | 225138Mi (98%) | 2.4 GiB |
| `...-qvm5w` | 211314Mi (92%) | 15.9 GiB |

Four `4vcpu-16gb` Pods are already Pending on `0/32 nodes are available: 2 Insufficient memory`, while CPU sits at ~50% on both hosts. Buying a third host would not fix this on its own — nothing stops small Pods carving up the new one the same way. With a reservation, two hosts are enough: the shape needs a third of one host, and the drain is what makes that third appear.

**What it took.** Almost nothing, because the mechanism was built platform-neutral below the gate. Runner Pods already carry the reservation toleration on both platforms, and `isIdle` is already Linux-aware — it reads the dispatch poller's exit, so an unclaimed Pod is retired and a claimed one is waited out. The real change is node addressing: `fleetNodeSelector` now picks the label set each platform's own Pods select on (`tuist.dev/fleet` on darwin, `node.cluster.x-k8s.io/pool` on linux, both paired with `kubernetes.io/os`), so the reservation and the scheduler cannot disagree about which hosts a fleet has. `macosNodeOSLabel` becomes `nodeOSLabel` now that both paths use it.

**The Linux drain is progressive.** The taint is `NoSchedule`, not `NoExecute`: running jobs finish and free their memory while new Pods stay off, and the starved Pod lands the moment 66.5 GiB is free rather than when the host is empty. That matters more here than on macOS, where a host has two slots and "drained" and "empty" are nearly the same thing.

**Guards carry over unchanged**, and they were already platform-neutral. A reservation is only taken for a shape that gets fewer seats on a candidate host than the fleet's most granular shape does, so the default 2 vCPU / 8 GB shape can never trigger one. `maxFleetReservations` stays at 1, counted over the pool's own fleet nodes so darwin and linux hold separate budgets — on a two-host Linux fleet one reservation is already half the hosts closed to new Pods, which is the reason not to raise it.

The staging/canary exclusion still stands, and by a wider margin than the values comments implied: the canary AX42-U advertises **51.7 GiB allocatable**, so a 66.5 GiB Pod is not merely tight there, it is impossible. No drain fixes that, which is the difference between a structural exclusion and a scheduling one.

## Validation

Rendered all three managed overlays with the CI value stack:

- Production: nine Linux pools, including `tuist-tuist-runner-pool-linux-16vcpu-64gb` at `podCPUMilli: 16000` / `podMemoryMB: 65536`, `replicas: 0`, `maxReplicas: 120`, and the shape present in `TUIST_RUNNER_LINUX_SHAPES`.
- Staging and canary: eight Linux pools each, no 64 GB entry.

`mix test test/tuist/runners/ test/tuist/docs_loader_test.exs test/tuist/marketing/` → 742/743. The single failure is `allowance_test.exs:485` (runner trial pricing), which reproduces unchanged with `config/config.exs` reverted, so it is pre-existing and unrelated.

`go test ./...` in `infra/runners-controller` passes. Every pre-existing macOS reservation test passes; three needed a second host in their fixture once the last-host floor landed. Four new tests cover the Linux path, and each was confirmed red before green by restoring the specific piece it pins: the reconcile gate, the delete-path gate, and the per-platform node selector. (The first version of the selector test passed for the wrong reason — the fleet names differed — so it was replaced with one that gives both hosts the same fleet name under their respective labels.)

Merging releases a new `tuist-runners-controller` image through the production cascade, since `infra/runners-controller/**` changed.

## Follow-up, not in this PR

While looking at the customer's build I chased their second question — the Metrics tab showing 0 GB memory and 100% storage — and found two bugs in the Linux sampler. Both need image releases, so they belong in their own PRs:

1. `infra/linux-runner-image/metrics-sampler.sh` reads `MemTotal` **once**, before the workload containers exist. The metrics sidecar is a native sidecar, so it starts while the kata sandbox is still at its 2 GiB base, before the runner and dind containers' memory is hot-added. Every later sample then computes `used = MemTotal(stale ~2 GiB) - MemAvailable(full guest)`, which goes negative and is clamped to 0. That is exactly the reported chart: a flat 0 line under a 2 GB y-axis, because the axis maximum is that same stale total. The macOS sampler does not have this — it derives used directly from `vm_stat` rather than by subtraction.
2. The same script `df`s `/var/lib/tuist-runner`, which is the JIT-handoff `emptyDir` mounted read-only into the metrics sidecar, not the filesystem the job writes to. `TUIST_RUNNER_DISK_PATH` is never set by the pod template, so it always falls back to that path, and the sidecar does not mount the `work` volume or the dind disk at all — it cannot see the job's real disk. The macOS sampler deliberately points at `/System/Volumes/Data` for this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





