### PR TITLE
fix(server): unbreak the runner trial allowance test and the bats install

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -87,28 +87,28 @@ url = "https://github.com/jdx/aube/releases/download/v1.6.2/aube-v1.6.2-x86_64-p
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/410174742"
 
 [[tools.bats]]
-version = "1.11.1"
+version = "1.12.0"
 backend = "aqua:bats-core/bats-core"
 
 [tools.bats."platforms.linux-arm64"]
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [tools.bats."platforms.linux-arm64-musl"]
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [tools.bats."platforms.linux-x64"]
-checksum = "blake3:68f3c29e21d03ad96d7bd5a133a5716e47a2d53a2f08886484cfea6c3fb86dc9"
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+checksum = "blake3:836a0963444ede10131984991c0f92219c84418b57c242b4ff5bc80d83daa9a3"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [tools.bats."platforms.linux-x64-musl"]
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [tools.bats."platforms.macos-arm64"]
-checksum = "blake3:68f3c29e21d03ad96d7bd5a133a5716e47a2d53a2f08886484cfea6c3fb86dc9"
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+checksum = "blake3:836a0963444ede10131984991c0f92219c84418b57c242b4ff5bc80d83daa9a3"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [tools.bats."platforms.macos-x64"]
-url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz"
+url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.12.0.tar.gz"
 
 [[tools.caddy]]
 version = "2.11.2"

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@
     age = "1.2.1"
     protoc = "32.1"
     "1password-cli" = "2.32.0"
-    bats = "1.11.1"
+    bats = "1.12.0"
     rclone = "1.73.3"
     jq = "1.8.1"
     oras = "1.3.0"

--- a/server/test/tuist/runners/allowance_test.exs
+++ b/server/test/tuist/runners/allowance_test.exs
@@ -483,8 +483,16 @@ defmodule Tuist.Runners.AllowanceTest do
     end
 
     test "prices nothing at all while the trial is still running", %{account: account} do
-      account = on_trial_since(account, DateTime.add(DateTime.utc_now(), -30, :day))
-      ran_minutes(account, DateTime.add(DateTime.utc_now(), -4, :hour), 180)
+      # This is the one trial case that takes the default window, which
+      # is the calendar month, so the trial only covers the whole of it
+      # when it started before the 1st. The clock is frozen because on
+      # the 31st a trial that started 30 days ago starts inside the
+      # month, and on the 1st a run four hours ago falls before it.
+      now = ~U[2024-01-17 12:00:00.000000Z]
+      stub(DateTime, :utc_now, fn -> now end)
+
+      account = on_trial_since(account, DateTime.add(now, -30, :day))
+      ran_minutes(account, DateTime.add(now, -4, :hour), 180)
 
       breakdown = Allowance.period_breakdown(account)
 


### PR DESCRIPTION
Two independent CI failures, neither of them a regression from application code. They are together in one PR because both had to be fixed for this branch to go green.

## 1. `Tuist.Runners.AllowanceTest` fails on the 31st of the month

The [Server workflow on `main`](https://github.com/tuist/tuist/actions/runs/33371008723) failed on "prices nothing at all while the trial is still running", in both the `Test` and `Test (oldest supported ClickHouse)` jobs:

```
1) test period_breakdown/1 runner trials prices nothing at all while the trial is still running
   test/tuist/runners/allowance_test.exs:485
   Assertion with == failed
   code:  assert row.included_minutes == nil
   left:  100
   right: nil
```

### What changed

The test now runs against a frozen clock rather than the real one, so the trial start and the run it records land at fixed points inside the window under test.

### Why

This is a calendar-boundary flake, and it reproduces on any 31st. It is the only case in the trials block that takes the default billing window, which falls back to the calendar month when the account has no subscription. Every other case in the block passes an explicit period and is unaffected.

The test started the trial at `now - 30 days`. Run on the 31st, that lands on the 1st at the current time of day, which is after `beginning_of_month` returns for the same month. `trial_window/3` clamps the window start to the later of the trial start and the period start, so the window opened partway into the period instead of covering it, `fully_covered?/3` returned false, and the macOS platform row carried `included_minutes: 100` instead of the `nil` the assertion expects. Production behaviour is correct in both cases: an account whose trial genuinely starts midway through a period can reach its allowance in the remainder of it.

The test carried a second latent edge in the other direction: between 00:00 and 04:00 UTC on the 1st, the `now - 4 hours` run falls before the period start, so `gross` would have read zero. Freezing the clock closes both, which is why it was preferred over the smaller fix of pinning only the trial start to before the month boundary. The approach follows the precedent set for the projection test in the same file in [#12651](https://github.com/tuist/tuist/pull/12651).

## 2. Gradle Cache Acceptance cannot install bats

Every job that installs bats through mise now dies before running anything:

```
Failed to install aqua:bats-core/bats-core@1.11.1: HTTP status client error
(400 Bad Request) for url
(https://codeload.github.com/bats-core/bats-core/tar.gz/refs/tags/v1.11.1)
```

### What changed

`bats` moves from 1.11.1 to 1.12.0 in the root `mise.toml`, with the `mise.lock` entry regenerated to match.

### Why

GitHub cannot generate the source tarball for the bats-core `v1.11.1` tag. The tag and its release both still exist upstream, and neighbouring tags serve fine, so this is GitHub failing on that one ref rather than anything bats-core changed:

| tag | codeload status |
| --- | --- |
| v1.10.0 | 200 |
| v1.11.0 | 200 |
| v1.11.1 | 400 |
| v1.12.0 | 200 |

`github.com/.../archive/refs/tags/v1.11.1.tar.gz`, which the lockfile points at and which redirects to codeload, returns 400 as well. Nothing on our side can retry around it while the pin stays where it is, so the pin has to move.

This is not caused by this branch. The same check fails identically on `main` ([run 33371008724](https://github.com/tuist/tuist/actions/runs/33371008724)) and on unrelated branches, with the first failure around 08:03 UTC today.

1.12.0 is the next release and archives normally. The repo's two `.bats` files use only `setup_file`, `teardown_file` and `@test`, none of which changed across the bump. The lockfile keeps checksums on the same two platforms it had them on before; it is one source tarball for every platform, which is why the previous entry carried a single hash under both.

## Another failure in that run, already fixed

`TuistWeb.PublicAccountLiveTest` also failed in the oldest-ClickHouse job on a duplicate SVG id, `paint0_radial_1989_22018`. That is already fixed on `main`: the run was on `d45fa7c03f`, and the commit immediately after it, [#12674](https://github.com/tuist/tuist/pull/12674), gave each project card background a unique id. Verified passing at current `HEAD`, so nothing here addresses it.

## Impact

No production code changes. One server test and one pinned tool version.

## How to test locally

The allowance test, from `server/`:

```
mix test test/tuist/runners/allowance_test.exs
```

22 of 22 pass, where before this change 21 of 22 passed on any 31st of the month. `mix format --check-formatted` and `mix credo --strict` are clean on the file.

The bats pin, from the repo root:

```
mise install --locked bats
```

This is the path the `mise-install` action takes in CI. It fails on `main` today and succeeds here. The installed binary reports `Bats 1.12.0` and `bats --count e2e/gradle_cache.bats e2e/module_cache_backward_compat.bats` finds all 3 tests.
