### PR TITLE
feat(server): alert on an Oban consumer losing its slots, before it loses all of them

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1141,6 +1141,70 @@ rather than a firing alert. That gap is deliberately left to the
 deadline is 600s plus a 30s cancellation grace, so a single legitimately
 slow job cannot reach it.
 
+### Remote processing consumer is losing its slots
+
+The rule above is correct and still fires too late. It turns positive
+only once a consumer has stopped completing work altogether, which on
+2026-08-31 was roughly a day after the decay started and about 3,000
+unprocessed test runs into it.
+
+That day both production xcresult processors were holding **3** in-flight
+jobs against a configured limit of **6**, with thousands of jobs
+`available` to fill the gap. Deleting the Pods restored both to 6
+immediately. The capacity had leaked away over the Pods' 69-hour
+lifetime: parses that hit the NIF's outer deadline never give their slot
+back, so a processor's usable concurrency only ever decreases. Sentry
+`TUIST-4JE` shows the same decay by generation — earlier Pods that lived
+0.5 to 16 hours logged 1 to 13 timeouts each, while the two that reached
+69 hours logged 670 and 429.
+
+A consumer at half capacity still completes jobs on the slots it has, so
+the liveness pair above, queue depth, queue age and `up` all read
+healthy. The gauges below are the only ones that move while there is
+still time to act.
+
+```promql
+max by (cluster, env, queue, node) (
+  tuist_oban_node_executing_jobs_count{cluster="tuist-production"}
+)
+< on (cluster, env, queue, node)
+max by (cluster, env, queue, node) (
+  tuist_oban_node_queue_limit{cluster="tuist-production"}
+)
+and on (cluster, env, queue)
+max by (cluster, env, queue) (
+  tuist_oban_queue_length_count{cluster="tuist-production", state="available"}
+) > 100
+```
+
+- Pending period: 15 minutes
+- Severity: warning
+- Summary: `{{ $labels.node }} is running below its configured
+  {{ $labels.queue }} concurrency while the queue has work waiting`
+
+The backlog clause is what makes this safe. A node under its limit is
+completely normal when there is nothing to run; it is only a defect when
+work is sitting `available` and the node still will not pick it up. 100
+is well above the transient depth a healthy fleet reaches between polls.
+
+Warning rather than critical, and a 15 minute pending period, because
+the whole point is that this fires with hours of headroom. The critical
+rule above stays as the backstop for the case where the decay is missed
+and throughput reaches zero.
+
+`executing` is counted from `oban_jobs.attempted_by` rather than from the
+producer's own in-memory state, because those two disagree in exactly the
+failing case and the table is the side that matches what an investigation
+greps for. Note that this does not contradict the "cannot be answered
+from the polling side" point above: that applies to the *completion*
+question, which has no usable index. Scoped to `state = 'executing'` the
+row set is tiny and the state index carries it — measured on production,
+0.23 ms and 22 shared buffers against a 5 second poll.
+
+The limit is a gauge rather than a constant in the expression because it
+is per environment: production runs `queueConcurrency: 6`, and the
+in-code default is 4.
+
 ### Swift registry catalog coverage deferred
 
 Same shape as the queue rule above, for the writer rather than a

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1098,11 +1098,42 @@ count by (cluster, env, queue, node) (
 ) > 0
 ```
 
-- Pending period: 5 minutes
+- Pending period: 20 minutes
 - Keep firing for: 5 minutes
 - Severity: critical
 - Summary: `{{ $labels.node }} has been taking {{ $labels.queue }} jobs
   without completing any for over 15 minutes`
+
+The pending period is 20 minutes rather than 5 because a Pod that is
+being drained satisfies this condition on its way out. It keeps a recent
+`last_attempt` while it stops completing, and its series does not vanish
+when the Pod does: the host-side `:9091` forwarder caches the guest's
+metrics, so a dead Pod's last sample outlives it.
+
+On 2026-08-31 this paged for `xcresult-processor-b24xg` about five
+minutes after a release deploy had already deleted it.
+`terminationGracePeriodSeconds` is 30, so the Pod was long gone and the
+entire firing window was stale data. Replayed against that window the
+condition holds for roughly 10 minutes; 20 is twice that, and a genuinely
+wedged consumer holds it for hours, so nothing real is lost.
+
+A pod-existence join on `kube_pod_status_phase` was tried and rejected.
+It only trims the tail — a terminating Pod is still `phase="Running"`,
+so replaying it still fired for 7 of the 10 minutes — and it would make a
+critical rule depend on kube-state-metrics, so the rule would go silently
+dead if KSM broke. That is the exact fourteen-hours-undetected failure
+this rule exists to prevent, traded for a little deploy noise.
+
+Two traps when triaging this, both hit on 2026-08-31:
+
+- **Check the Pod still exists** before treating it as a wedge:
+  `kubectl --context tuist-k8s-production get pods -n tuist | grep xcresult`.
+  A node named here that is not in that list is a stale page.
+- **Do not read a missing `completed` row as proof of a gap.** Completed
+  jobs are pruned aggressively; the table held 7 across a healthy fleet.
+  Use `tuist_oban_node_last_completion_timestamp_seconds`, or the hourly
+  `parse_timeout` rate off the `errors` array, which went 36/hr while
+  wedged to 4/hr once restored.
 
 The `count by` wrapper exists to give the threshold something to compare.
 The inner expression's own value is seconds since the node's last

--- a/server/lib/tuist/oban/prom_ex_plugin.ex
+++ b/server/lib/tuist/oban/prom_ex_plugin.ex
@@ -17,10 +17,20 @@ defmodule Tuist.Oban.PromExPlugin do
   consumer beside a working one leaves the queue draining normally. The
   `node_last_attempt/completion_timestamp_seconds` pair covers that case
   from the opposite direction, reported by each consumer about itself.
+
+  Both of those only turn positive once a consumer has already stopped
+  finishing work. `node_executing_jobs_count` against `node_queue_limit`
+  is the earlier signal: a consumer that has lost slots keeps completing
+  jobs on the ones it still holds, so every other gauge reads healthy
+  while its capacity decays. On 2026-08-31 both production xcresult
+  processors sat at 3 in-flight jobs against a configured limit of 6,
+  with a 3000-job backlog available to fill them; a restart restored
+  both to 6. A node below its own limit while the queue has work is
+  losing capacity, and it is visible long before throughput reaches zero.
   """
   use PromEx.Plugin
 
-  import Ecto.Query, only: [group_by: 3, select: 3]
+  import Ecto.Query, only: [group_by: 3, select: 3, where: 3]
 
   alias Tuist.Environment
 
@@ -34,6 +44,7 @@ defmodule Tuist.Oban.PromExPlugin do
 
   @queue_length_event [:prom_ex, :plugin, :oban, :queue, :length, :count]
   @queue_age_event [:prom_ex, :plugin, :oban, :queue, :oldest, :available, :age, :seconds]
+  @node_slots_event [:prom_ex, :plugin, :oban, :node, :slots]
 
   # Process-dict key holding the set of queues reported on the previous
   # poll, so a queue that drains to nothing still gets an explicit zero.
@@ -195,6 +206,25 @@ defmodule Tuist.Oban.PromExPlugin do
               "Age in seconds of the oldest job sitting in the `available` state for a queue (0 when nothing is available).",
             measurement: :age_seconds,
             tags: [:name, :queue]
+          ),
+          last_value(
+            @metric_prefix ++ [:node, :executing, :jobs, :count],
+            event_name: @node_slots_event,
+            description: "Number of jobs this node currently holds in the `executing` state for a queue.",
+            measurement: :executing,
+            tags: [:name, :queue, :node]
+          ),
+          # Emitted beside the count rather than baked into an alert
+          # threshold: the limit is per environment (production runs
+          # `queueConcurrency: 6`, the in-code default is 4), so a rule
+          # comparing the two stays correct when an environment is
+          # retuned.
+          last_value(
+            @metric_prefix ++ [:node, :queue, :limit],
+            event_name: @node_slots_event,
+            description: "Configured concurrency limit of a queue this node runs.",
+            measurement: :limit,
+            tags: [:name, :queue, :node]
           )
         ]
       )
@@ -232,12 +262,71 @@ defmodule Tuist.Oban.PromExPlugin do
           )
         end)
 
+        execute_node_slot_metrics(config, name)
+
         Process.put(@queues_seen_key, queues)
 
       _ ->
         :ok
     end
   end
+
+  # Counted from `oban_jobs` rather than from this node's producers so
+  # the number means "work this node is credited with" — the same
+  # `attempted_by` a stuck-consumer investigation greps for. A slot lost
+  # inside a stalled NIF stops producing rows here while the producer
+  # still believes it is occupied, which is exactly the divergence the
+  # gauge exists to expose.
+  defp execute_node_slot_metrics(config, name) do
+    limits = configured_queue_limits()
+
+    executing =
+      config
+      |> Oban.Repo.all(
+        Oban.Job
+        |> where([j], j.state == "executing")
+        |> where([j], fragment("?[1]", j.attempted_by) == ^config.node)
+        |> group_by([j], j.queue)
+        |> select([j], {j.queue, count(j.id)})
+      )
+      |> Map.new()
+
+    limits
+    |> Map.keys()
+    |> MapSet.new()
+    |> MapSet.union(MapSet.new(Map.keys(executing)))
+    |> Enum.each(fn queue ->
+      measurements =
+        case Map.fetch(limits, queue) do
+          {:ok, limit} -> %{executing: Map.get(executing, queue, 0), limit: limit}
+          :error -> %{executing: Map.get(executing, queue, 0)}
+        end
+
+      :telemetry.execute(@node_slots_event, measurements, %{name: name, queue: queue, node: config.node})
+    end)
+  end
+
+  # Keyed by the queue's string name to match what the `oban_jobs` scan
+  # returns; `String.to_existing_atom/1` on a queue name read back from
+  # the table would raise for a queue this node does not run.
+  # A queue can be configured as a bare integer, as opts carrying
+  # `:limit`, or as `false` to disable it. Only the ones that resolve to
+  # a number get a limit gauge; the rest still report their executing
+  # count, just without anything to compare it against.
+  defp configured_queue_limits do
+    configured_queue_opts()
+    |> Enum.flat_map(fn {queue, opts} ->
+      case queue_limit(opts) do
+        limit when is_integer(limit) -> [{to_string(queue), limit}]
+        _ -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp queue_limit(limit) when is_integer(limit), do: limit
+  defp queue_limit(opts) when is_list(opts), do: Keyword.get(opts, :limit)
+  defp queue_limit(_opts), do: nil
 
   # Every queue the gauges must report on this tick: the ones this node
   # runs, the ones the scan saw rows for (a queue delegated to another
@@ -273,15 +362,15 @@ defmodule Tuist.Oban.PromExPlugin do
     |> Enum.map(&elem(&1, 0))
   end
 
-  defp configured_queues do
+  defp configured_queues, do: Keyword.keys(configured_queue_opts())
+
+  defp configured_queue_opts do
     {_, opts} =
       Enum.find(Oban.config().plugins, {nil, [queues: Oban.config().queues]}, fn {plugin, _} ->
         plugin == Oban.Pro.Plugins.DynamicQueues
       end)
 
-    opts
-    |> Keyword.get(:queues, [])
-    |> Keyword.keys()
+    Keyword.get(opts, :queues, [])
   end
 
   defp include_zeros_for_missing_queue_states(query_result, queues) do

--- a/server/test/tuist/oban/prom_ex_plugin_test.exs
+++ b/server/test/tuist/oban/prom_ex_plugin_test.exs
@@ -1,10 +1,12 @@
 defmodule Tuist.Oban.PromExPluginTest do
   use TuistTestSupport.Cases.DataCase, async: false
+  use Mimic
 
   alias Tuist.Oban.PromExPlugin
 
   @length_event [:prom_ex, :plugin, :oban, :queue, :length, :count]
   @age_event [:prom_ex, :plugin, :oban, :queue, :oldest, :available, :age, :seconds]
+  @node_slots_event [:prom_ex, :plugin, :oban, :node, :slots]
 
   setup do
     handler_id = make_ref()
@@ -33,6 +35,17 @@ defmodule Tuist.Oban.PromExPluginTest do
       state: state,
       args: %{},
       scheduled_at: scheduled_at
+    })
+  end
+
+  defp insert_executing_job(queue, node) do
+    Tuist.Repo.insert!(%Oban.Job{
+      worker: "Tuist.TestWorker",
+      queue: queue,
+      state: "executing",
+      args: %{},
+      attempted_by: [node],
+      scheduled_at: DateTime.utc_now()
     })
   end
 
@@ -159,6 +172,78 @@ defmodule Tuist.Oban.PromExPluginTest do
 
       assert completion.event_name == [:oban, :job, :stop]
       assert attempt.event_name == [:oban, :job, :start]
+    end
+  end
+
+  describe "node slot metrics" do
+    test "reports how many slots this node is actually holding", %{handler_id: handler_id} do
+      attach_collector(handler_id, @node_slots_event)
+      node = Oban.config().node
+
+      insert_executing_job("process_xcresult", node)
+      insert_executing_job("process_xcresult", node)
+
+      PromExPlugin.execute_queue_metrics()
+
+      slots = collect(@node_slots_event)
+
+      assert {%{executing: 2}, meta} =
+               Enum.find(slots, fn {_, meta} -> meta.queue == "process_xcresult" end)
+
+      assert meta.node == node
+    end
+
+    # The gauge is only a leak signal if it counts this node's own slots.
+    # A sibling's in-flight jobs live in the same shared `oban_jobs`
+    # table, and counting them would make a node that holds nothing look
+    # busy.
+    test "counts only jobs this node attempted", %{handler_id: handler_id} do
+      attach_collector(handler_id, @node_slots_event)
+      node = Oban.config().node
+
+      insert_executing_job("process_xcresult", node)
+      insert_executing_job("process_xcresult", "some-other-processor-pod")
+
+      PromExPlugin.execute_queue_metrics()
+
+      slots = collect(@node_slots_event)
+
+      assert {%{executing: 1}, _} =
+               Enum.find(slots, fn {_, meta} -> meta.queue == "process_xcresult" end)
+    end
+
+    test "reports the queue limit alongside the count for a queue this node runs", %{handler_id: handler_id} do
+      attach_collector(handler_id, @node_slots_event)
+      node = Oban.config().node
+      config = Oban.config()
+
+      stub(Oban, :config, fn -> %{config | queues: [process_xcresult: [limit: 6]], plugins: []} end)
+
+      insert_executing_job("process_xcresult", node)
+
+      PromExPlugin.execute_queue_metrics()
+
+      slots = collect(@node_slots_event)
+
+      assert {%{executing: 1, limit: 6}, _} =
+               Enum.find(slots, fn {_, meta} -> meta.queue == "process_xcresult" end)
+    end
+
+    # Without an explicit zero the `last_value` gauge holds its final
+    # non-zero sample, so a node that has stopped taking work entirely
+    # would keep reporting a full complement of slots.
+    test "emits zero for a configured queue this node holds nothing on", %{handler_id: handler_id} do
+      attach_collector(handler_id, @node_slots_event)
+      config = Oban.config()
+
+      stub(Oban, :config, fn -> %{config | queues: [process_xcresult: [limit: 6]], plugins: []} end)
+
+      PromExPlugin.execute_queue_metrics()
+
+      slots = collect(@node_slots_event)
+
+      assert {%{executing: 0, limit: 6}, _} =
+               Enum.find(slots, fn {_, meta} -> meta.queue == "process_xcresult" end)
     end
   end
 end


### PR DESCRIPTION
## What changed

Adds two per-node Oban gauges, tagged with Oban's node name:

- `tuist_oban_node_executing_jobs_count{name,queue,node}`
- `tuist_oban_node_queue_limit{name,queue,node}`

and documents the alert rule that compares them in `infra/helm/k8s-monitoring/alerts.md`.

## Why

The existing `Remote processing queue consumer takes work but completes none` rule is correct, but it only turns positive once a consumer has stopped completing work altogether. During the 2026-08-31 xcresult incident that was roughly a day after the decay began and about 3,000 unprocessed test runs into it.

## Root cause it makes observable

Both production xcresult processors were holding **3** in-flight jobs against a configured limit of **6**, with thousands of jobs `available` to fill the gap. Deleting the Pods restored both to 6 immediately.

The capacity leaks. A parse that hits the NIF's outer deadline never gives its slot back, so a processor's usable concurrency only ever decreases across the Pod's lifetime. Sentry `TUIST-4JE` shows the same decay by generation: Pods that lived 0.5 to 16 hours logged 1 to 13 timeouts each, while the two that reached 69 hours logged 670 and 429.

The reason nothing caught it is that a consumer at half capacity still completes jobs on the slots it still has. The liveness pair, queue depth, queue age and `up` all read healthy throughout. These two gauges are the only ones that move while there is still time to act.

The leak itself is not fixed here; that is a separate change to the NIF. This PR is about seeing it coming.

## Design notes

**Counted from `oban_jobs.attempted_by`, not the producer's in-memory state.** Those two disagree in exactly the failing case, and the table is the side that matches what an investigation actually greps for.

**The limit is a gauge, not a constant in the alert expression.** It is per environment: production runs `queueConcurrency: 6`, the in-code default is 4. A rule comparing two series stays correct when an environment is retuned.

**Cost.** `alerts.md` notes that `attempted_by` is unindexed and the table is multi-gigabyte. That applies to the *completion* question; scoped to `state = 'executing'` the row set is tiny and the state index carries it. Verified against the production database:

```
Index Scan using oban_jobs_state_discarded_at_index on oban_jobs
  Index Cond: (state = 'executing')
  Filter: (attempted_by[1] = '...')
  Rows Removed by Filter: 13
Execution Time: 0.233 ms   Buffers: shared hit=22
```

0.23 ms against a 5 second poll.

**Alert shape.** The rule is gated on `available > 100` for the queue. A node under its limit is entirely normal when there is nothing to run; it is only a defect when work is waiting and the node still will not take it. It is a warning at a 15 minute pending period rather than a critical page, because the whole point is that it fires with hours of headroom; the existing critical rule stays as the backstop.

## Impact

Operators get a warning while a processor still has most of its capacity, instead of a critical page after throughput has already reached zero and a day of test runs has queued. No behaviour change to job processing.

Note the gauges have to be deployed before the Grafana rule can evaluate; the rule is documented here and created in the console, as with every other rule in that file.

## Validation

- `mix test test/tuist/oban/prom_ex_plugin_test.exs` — 13 tests, covering the per-node count, exclusion of a sibling node's jobs, the limit riding along for a queue the node runs, and an explicit zero for a node holding nothing (without which the `last_value` gauge would hold its final non-zero sample).
- `mix credo` clean on the changed file.
- Query plan verified against the production database, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)