### PR TITLE
fix(server): stop an xcresult processor that has lost every parse slot

### DIFF
--- a/server/lib/tuist/processor/xcresult_nif.ex
+++ b/server/lib/tuist/processor/xcresult_nif.ex
@@ -96,7 +96,24 @@ defmodule Tuist.Processor.XCResultNIF do
     decompress_archive_nif(source_path, destination_dir)
   end
 
+  @doc """
+  Number of parses the native side abandoned at its outer deadline.
+
+  A parse that reaches that deadline did not unwind when cancelled, so
+  the native side returns without it: its task, its subprocess permit and
+  its `xcresulttool` child stay alive and the parse slot they occupied is
+  gone until the OS process restarts. The count only ever grows, and it
+  is the node's lost concurrency.
+  """
+  def abandoned_parses do
+    abandoned_parses_nif()
+  end
+
   defp parse_nif(_xcresult_path, _root_directory) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  defp abandoned_parses_nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -17,6 +17,7 @@ defmodule Tuist.Processor.XCResultProcessor do
   consume the queue in-process like every other queue.
   """
 
+  alias Tuist.Environment
   alias Tuist.Processor.XCResultNIF
   alias Tuist.Storage
 
@@ -36,7 +37,7 @@ defmodule Tuist.Processor.XCResultProcessor do
     OpenTelemetry.Tracer.with_span "xcresult.process_local" do
       set_span_attribute("file.size", archive_size(archive_path))
 
-      bucket = Keyword.get(opts, :s3_bucket) || Tuist.Environment.s3_bucket_name()
+      bucket = Keyword.get(opts, :s3_bucket) || Environment.s3_bucket_name()
       temp_dir = make_temp_dir()
 
       try do
@@ -156,9 +157,45 @@ defmodule Tuist.Processor.XCResultProcessor do
         |> XCResultNIF.parse(root_dir)
         |> normalize_parse_error(xcresult_path)
 
+      if match?({:error, :parse_timeout}, result), do: stop_when_capacity_is_gone()
+
       status = if match?({:ok, _}, result), do: :ok, else: :error
       {result, %{status: status}}
     end)
+  end
+
+  # A parse that times out has either unwound cleanly, costing nothing
+  # beyond its own job, or been abandoned at the native outer deadline,
+  # which retires its slot for the life of the OS process. Only the
+  # second kind accumulates, and the native counter is the only place it
+  # shows: a retired slot leaves no trace in the BEAM's memory or
+  # scheduler accounting, and no Oban gauge moves until the last slot is
+  # gone. On 2026-08-31 both production processors decayed from six
+  # concurrent parses to three over a 69 hour Pod lifetime, and the first
+  # signal anyone saw was a queue 3000 jobs deep.
+  #
+  # Once as many slots have been retired as the queue is allowed to run,
+  # this node has no capacity left: every job it claims from here is
+  # destroyed, and no amount of waiting returns a slot. Stopping hands
+  # that to launchd, which restarts the release with a clean process —
+  # the same recovery an operator performs by hand, without the day of
+  # unprocessed runs it currently takes to notice.
+  defp stop_when_capacity_is_gone do
+    if Environment.xcresult_processor_mode?() do
+      concurrency = Environment.process_xcresult_queue_concurrency()
+      abandoned = XCResultNIF.abandoned_parses()
+
+      if abandoned >= concurrency do
+        Logger.error(
+          "xcresult parse slots retired by abandoned parses: #{abandoned} of #{concurrency}. " <>
+            "Stopping so launchd restarts this node with a clean process."
+        )
+
+        System.stop(1)
+      end
+    end
+
+    :ok
   end
 
   # The NIF reports a failure as a JSON blob whose message embeds the

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -16,6 +16,26 @@ private enum ParseOutcome: Sendable {
 /// Seconds a parse may run before it cancels itself.
 private let timeoutSeconds = 600
 
+/// Parses abandoned at the outer deadline, for the life of this process.
+///
+/// Reaching that deadline means the parse did not unwind when cancelled,
+/// so returning leaves its task, its `CommandRunner` permit and its
+/// `xcresulttool` child running with no handle left to reach them. The
+/// slot the parse occupied is gone until the OS process restarts, and
+/// nothing in the BEAM's own accounting records that: a leaked slot is
+/// invisible to `erlang:memory/0`, to the scheduler counters and to
+/// every Oban gauge until throughput has already reached zero.
+///
+/// Counting them is what makes the loss measurable from Elixir, and
+/// what lets the node decide it has no capacity left to lose.
+private let abandonedParses = OSAllocatedUnfairLock<Int32>(initialState: 0)
+
+/// Number of parses this process has abandoned at the outer deadline.
+@_cdecl("xcresult_abandoned_parses")
+public func xcresultAbandonedParses() -> Int32 {
+    abandonedParses.withLock { $0 }
+}
+
 /// Seconds a cancelled parse is given to unwind before the caller gives up on
 /// it. Cancellation reaches the `xcresulttool`/`sips` child through Command's
 /// `continuation.onTermination`, which terminates the process; a child that
@@ -54,6 +74,7 @@ public func parseXCResult(
     let deadline = DispatchTime.now() + .seconds(timeoutSeconds + cancellationGraceSeconds)
     guard semaphore.wait(timeout: deadline) == .success else {
         task.cancel()
+        abandonedParses.withLock { $0 += 1 }
         return write(
             timedOutMessage(path: path, seconds: timeoutSeconds),
             outputPtr: outputPtr,

--- a/server/native/xcresult_nif/nif_bridge.c
+++ b/server/native/xcresult_nif/nif_bridge.c
@@ -24,6 +24,23 @@ extern int decompress_archive(
     int *error_len
 );
 
+extern int xcresult_abandoned_parses(void);
+
+/* Parses the Swift side gave up waiting on. Each one has permanently
+ * retired a parse slot in this OS process, so the count is how much
+ * capacity this node has lost. Cheap and non-blocking, so it stays off
+ * the dirty schedulers the parse itself runs on. */
+static ERL_NIF_TERM abandoned_parses_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    (void)argv;
+
+    if (argc != 0) {
+        return enif_make_badarg(env);
+    }
+
+    return enif_make_int(env, xcresult_abandoned_parses());
+}
+
 static ERL_NIF_TERM parse_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     if (argc != 2) {
@@ -156,7 +173,8 @@ static ERL_NIF_TERM decompress_archive_nif(ErlNifEnv *env, int argc, const ERL_N
 
 static ErlNifFunc nif_funcs[] = {
     {"parse_nif", 2, parse_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"decompress_archive_nif", 2, decompress_archive_nif, ERL_NIF_DIRTY_JOB_IO_BOUND}
+    {"decompress_archive_nif", 2, decompress_archive_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"abandoned_parses_nif", 0, abandoned_parses_nif, 0}
 };
 
 ERL_NIF_INIT(Elixir.Tuist.Processor.XCResultNIF, nif_funcs, NULL, NULL, NULL, NULL)

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -615,4 +615,72 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert new_dirs == []
     end
   end
+
+  describe "capacity lost to abandoned parses" do
+    defp expect_parse_timeout do
+      expect(XCResultNIF, :parse, fn xcresult_path, _root_dir ->
+        {:error, JSON.encode!(%{"error" => "xcresult parsing timed out after 600s at #{xcresult_path}"})}
+      end)
+    end
+
+    test "stops the node once abandoned parses have retired every slot" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      stub(Tuist.Environment, :xcresult_processor_mode?, fn -> true end)
+      stub(Tuist.Environment, :process_xcresult_queue_concurrency, fn -> 6 end)
+      stub(XCResultNIF, :abandoned_parses, fn -> 6 end)
+      expect_parse_timeout()
+
+      test_pid = self()
+      expect(System, :stop, fn status -> send(test_pid, {:stopped, status}) end)
+
+      assert {:error, :parse_timeout} = XCResultProcessor.process_local(fixture_zip)
+      assert_received {:stopped, 1}
+    end
+
+    # Stopping on the first abandoned parse would restart the node for a
+    # single pathological bundle and take the jobs on every healthy slot
+    # down with it. Only a node with nothing left to lose is worth
+    # recycling.
+    test "keeps running while it still has slots" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      stub(Tuist.Environment, :xcresult_processor_mode?, fn -> true end)
+      stub(Tuist.Environment, :process_xcresult_queue_concurrency, fn -> 6 end)
+      stub(XCResultNIF, :abandoned_parses, fn -> 5 end)
+      expect_parse_timeout()
+      reject(&System.stop/1)
+
+      assert {:error, :parse_timeout} = XCResultProcessor.process_local(fixture_zip)
+    end
+
+    # Self-hosted macOS installs run this queue inside the same BEAM as
+    # the web server, where stopping the node would take the whole
+    # install down over one parse.
+    test "never stops a node that is not a dedicated processor" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      stub(Tuist.Environment, :xcresult_processor_mode?, fn -> false end)
+      expect_parse_timeout()
+      reject(&XCResultNIF.abandoned_parses/0)
+      reject(&System.stop/1)
+
+      assert {:error, :parse_timeout} = XCResultProcessor.process_local(fixture_zip)
+    end
+
+    test "leaves a successful parse alone" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      stub(Tuist.Environment, :xcresult_processor_mode?, fn -> true end)
+      expect(XCResultNIF, :parse, fn _path, _root -> {:ok, %{"test_modules" => []}} end)
+      reject(&XCResultNIF.abandoned_parses/0)
+      reject(&System.stop/1)
+
+      assert {:ok, _} = XCResultProcessor.process_local(fixture_zip)
+    end
+  end
 end


### PR DESCRIPTION
Draft — the bounded-damage approach and the stop threshold are the parts worth arguing about before this lands.

## The bug

An xcresult parse that reaches the NIF's outer deadline (600s + 30s grace) is **abandoned**. [`parse_xcresult`](../blob/claude/xcresult-nif-slot-leak/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift) cancels the task and returns, but Swift cancellation is cooperative: the task, its shared `CommandRunner` subprocess permit, and its `xcresulttool` child all keep running, and there is no handle left to reach them.

The slot that parse occupied never comes back. Because the loss lives in the Swift runtime, it is invisible to the BEAM — nothing in `erlang:memory/0`, the scheduler counters, or any Oban gauge moves until the last slot is gone.

## What it looked like in production

Capacity decays with Pod uptime:

| pod generation | timeouts | lifetime |
|---|---|---|
| `74d7f746c8-59wzn` / `-7mb7q` | 1 / 2 | ~2h |
| `6f4bcfc59c-q6mhx` | 13 | ~14h |
| `67fb48d8b9-z487d` | 670 | ~69h |
| `67fb48d8b9-kg729` | 429 | ~69h |

On 2026-08-31 both production processors were running **3** concurrent parses against a configured limit of **6**. Deleting the Pods restored both to 6 immediately. The first signal anyone saw was a `process_xcresult` queue 3,000 jobs deep with a day of test runs unprocessed — Sentry `TUIST-4JE` had been firing since 08-26.

Frequent deploys had been masking this for weeks by rolling the Pods before saturation. The processor image stopped rolling around 08-28 and the leak ran out of runway.

## What this changes

Count abandoned parses in the NIF, expose them to Elixir, and stop the node once as many slots have been retired as the queue is allowed to run. At that point the node has no capacity left: every job it claims is destroyed, and no amount of waiting returns a slot. Stopping hands it to launchd, which restarts the release with a clean process — the same recovery an operator does by hand today.

## Decisions worth reviewing

**Stopping at the limit, not on the first abandoned parse.** One pathological bundle should not recycle a node and take the jobs on every healthy slot with it. A node with nothing left to lose is the only one worth restarting. If you would rather it recycled earlier (say at half capacity, trading a few in-flight jobs for a shorter degraded window), that is a one-line change.

**Confined to dedicated processor mode.** A self-hosted macOS install runs this queue inside its web server BEAM, where stopping the node would take the whole install down over one parse.

**This bounds the damage; it does not remove the leak.** Closing it properly means escalating past `Process.terminate()`'s SIGTERM to a SIGKILL for a child that will not unwind. That lives in the `Command` package's runner ([`CommandRunner.swift`](https://github.com/tuist/Command) — `continuation.onTermination` sends SIGTERM and then waits forever), not here. Worth a follow-up upstream.

## Related

Pairs with #12718, which exposes `tuist_oban_node_executing_jobs_count` against `tuist_oban_node_queue_limit` so the decay is visible from the outside while it is happening. This PR is the node noticing it about itself; that one is the alert.

Also worth noting separately: the fleet has exactly 6 dirty CPU schedulers against a queue limit of 6, a 1:1 coupling with no headroom. Not addressed here.

## Validation

- `mix test test/tuist/processor/xcresult_processor_test.exs` — 23 tests. New coverage: stop at the limit, no stop while slots remain, no NIF call or stop outside processor mode, successful parse left alone.
- `./build.sh` links the Swift dylib and C bridge cleanly.
- `Tuist.Processor.XCResultNIF.abandoned_parses/0` returns `0` against the freshly built NIF (end-to-end through the new C export).
- `mix credo` clean on both changed modules.

Not validated: the stop path itself firing in production, which needs a real abandoned parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)