### PR TITLE
fix(server): unbreak server CI — authenticate dependency fetches, drop unused Kura test aliases

### DIFF
--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -56,6 +56,29 @@ runs:
         key: ${{ inputs.mix-cache-key }}-${{ hashFiles('server/mix.lock') }}
         restore-keys: |
           ${{ inputs.mix-cache-restore-key }}
+    # `mix deps.get` fetches the `github:` / `git:` dependencies in mix.exs
+    # over anonymous https, which GitHub rate limits per source IP. The whole
+    # Linux runner fleet egresses from two bare-metal hosts, so that budget is
+    # shared across every job in the repo and, once crossed, whichever
+    # dependency happens to be fetched next fails with a credential prompt
+    # (`could not read Username for 'https://github.com'`) on a runner that
+    # has no tty. It is intermittent by nature: the repos and pinned SHAs are
+    # public and fetch fine from an unthrottled address.
+    #
+    # Authenticating lifts the fetches onto the token's own budget, the same
+    # reason `github-token` is already threaded to mise above.
+    - name: Authenticate github.com dependency fetches
+      shell: bash
+      env:
+        GH_DEP_TOKEN: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN || github.token }}
+      run: |
+        if [ -z "${GH_DEP_TOKEN}" ]; then
+          echo "::warning::No GitHub token available; dependency fetches stay anonymous."
+          exit 0
+        fi
+        git config --global \
+          url."https://x-access-token:${GH_DEP_TOKEN}@github.com/".insteadOf \
+          "https://github.com/"
     - name: Install dependencies
       shell: bash
       working-directory: server

--- a/server/test/tuist/kura/lifecycle_test.exs
+++ b/server/test/tuist/kura/lifecycle_test.exs
@@ -1168,7 +1168,7 @@ defmodule Tuist.Kura.LifecycleTest do
 
     test "tears the retired instance down once its drain window has elapsed" do
       account = account(plan: :enterprise)
-      source = active_instance(account)
+      _source = active_instance(account)
       _destination = active_instance_in(account, "eu-central")
       with_demand(account, 0)
       {:ok, _held} = PlacerRegions.put_primary(account, @region)

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -11,7 +11,6 @@ defmodule Tuist.KuraTest do
   alias Tuist.Kura.PlacerClaims
   alias Tuist.Kura.PlacerRegions
   alias Tuist.Kura.Provisioner
-  alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -8,7 +8,6 @@ defmodule TuistWeb.API.CacheControllerTest do
   alias Tuist.Billing
   alias Tuist.CacheActionItems
   alias Tuist.Kura.Demand
-  alias Tuist.Kura.PlacerRegions
   alias Tuist.Projects.Workers.CleanProjectWorker
   alias Tuist.Repo
   alias Tuist.Storage

--- a/server/test/tuist_web/live/cache_live_test.exs
+++ b/server/test/tuist_web/live/cache_live_test.exs
@@ -9,7 +9,6 @@ defmodule TuistWeb.CacheLiveTest do
   alias Tuist.Environment
   alias Tuist.Kura
   alias Tuist.Kura.SelfHostedClients
-  alias Tuist.Kura.Server
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   setup %{conn: conn} do


### PR DESCRIPTION
Server CI is red on `main` and every open PR, from **two independent breakages**. Both are fixed here, in a commit each, because neither can be demonstrated green while the other stands.

---

# 1. Dependency fetches are rate limited

## The symptom

Every server job — on `main` and on open PRs — has been failing since roughly 09:30 UTC today, in `setup-server-mix` at `mix deps.get`:

```
* Getting ex_aws_s3 (https://github.com/tuist/ex_aws_s3/ - 7f3278be...)
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
** (Mix) Command "git --git-dir=.git fetch --force --quiet --progress" failed
```

`Test`, `Test (oldest supported ClickHouse)`, `Seed` and `Docker build` all die here. The last green `main` run was 09:29; the two after it failed identically.

## It is not a broken pin

Both git dependencies in `server/mix.exs` are healthy:

| dependency | repo | pinned ref | resolves? | fetches anonymously? |
| --- | --- | --- | --- | --- |
| `heroicons` | `tailwindlabs/heroicons` — public, not archived | `v2.1.1` (`88ab3a0d`) | yes | yes |
| `ex_aws_s3` | `tuist/ex_aws_s3` — public, not archived | `7f3278be` | yes | yes |

I ran the exact failing `git fetch` for both from an unthrottled address — exit 0, full object counts.

**Which dependency fails moves between runs.** `heroicons` failed on one attempt and succeeded on the retry, where `ex_aws_s3` failed instead. That is the tell: it is whichever fetch happens to be next when the budget runs out, not a specific bad dependency. Re-running does not clear it.

## Why the whole repo, all at once

These jobs run on our own `tuist-linux-large` pool. Failures land on **different runner Pods** across it rather than clustering on one host, so the shared property is not a bad Pod — it is the egress.

The Linux fleet leaves from two bare-metal hosts, so GitHub sees every anonymous git fetch from every job in the repo as coming from two addresses, and rate limits them together. Authenticated traffic in the same jobs is completely unaffected — `actions/checkout`, the ~118 MB Actions cache restore, and mise all succeed. And mise only succeeds because it is **already** handed a token for exactly this reason: `setup-server-mix` has a `github-token` input documented as *"GitHub token used by mise to fetch tools (avoids rate limits)"*.

`mix deps.get` was the one path left fetching anonymously.

## The change

Thread the same token into git before `mix deps.get`, so dependency fetches run on the token's own budget:

```yaml
git config --global \
  url."https://x-access-token:${GH_DEP_TOKEN}@github.com/".insteadOf \
  "https://github.com/"
```

Absent a token the step emits a warning and leaves git untouched, so a caller that does not supply one is no worse off than today.

## Scope

This is a workaround for the symptom, and it is deliberately the smallest one. If the fleet is expected to sustain this volume of anonymous traffic, the egress side is worth a separate look — that is a fleet question rather than a CI one, and I have not touched it.

---

# 2. `--warnings-as-errors` aborts an otherwise-passing suite

Once a run gets past the fetch, `Test` fails like this:

```
Result: 7817 passed, 4 excluded
ERROR! Test suite aborted after successful execution due to warnings
while using the --warnings-as-errors option
```

Every test passes; four warnings abort it. Diffing the project-code warnings against the last green `main` run (09:29) isolates exactly four that are new, all introduced by #12645:

| file | warning |
| --- | --- |
| `cache_controller_test.exs:11` | unused alias `PlacerRegions` |
| `kura_test.exs:14` | unused alias `Regions` |
| `cache_live_test.exs:12` | unused alias `Server` |
| `lifecycle_test.exs:1171` | variable `source` is unused |

The three aliases have no remaining reference in their files. The fourth is a setup fixture whose binding is never read — the instance still has to be created for the retirement under test, so it becomes `_source`, matching the `_destination` on the line directly below. That test asserts `teardown_started_at`, which is what its name promises, so there is nothing it was meant to assert on `source` instead.

That green `main` run reported 1273 warnings of its own and passed, so warnings alone do not abort a suite — these four are in test files compiled as part of the run, which is what `--warnings-as-errors` acts on.

---

## Validation

`mix test` over the four affected files with `--warnings-as-errors`: 219 passed, no abort.

For the fetch fix, this PR's own server jobs are the test: a pull request runs the composite action from its own branch, so a green `Test` / `Seed` / `Docker build` here is the fix working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

