### PR TITLE
fix(infra): build the Linux runner image on tuist-linux-large

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1348,7 +1348,7 @@ jobs:
     name: Release Linux runner image
     needs: check-releases
     if: needs.check-releases.outputs.linux-runner-image-should-release == 'true'
-    runs-on: tuist-linux
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `Release Linux runner image` job failed on 2026-08-31 with "The self-hosted runner lost communication with the server", which blocked the [Server Production Deployment run](https://github.com/tuist/tuist/actions/runs/33373918767/job/99433672934). This moves that one job from `tuist-linux` (2 vCPU / 8 GiB) to `tuist-linux-large` (4 vCPU / 16 GiB).

### Root cause

The runner container crashed 52 seconds into `docker buildx build`, with `exitCode 255`, `signal 0`, `reason=Error`. The controller's own decode table classifies that as a crash, distinct from a host cgroup OOM (137 + `OOMKilled`), a guest OOM (137 + `Error`), or a deletion (signal 15).

The in-VM vitals sampler rules memory out and names the cause. Across the entire job, memory stayed flat at roughly 8.9 GiB available of about 9.9 GiB, with `oom=0 oom_kill=0` and `mem.psi.some.avg10=0.00`. CPU is what saturated:

| time | cpu.busy | cpu.psi.some.avg10 | load (2 vCPU) |
| --- | --- | --- | --- |
| 08:54:27 | 26% | 3.09 | 1.37 |
| 08:54:46 | 60% | 21.34 | 2.35 |
| 08:55:03 | 98% | 46.70 | 3.12 |
| 08:55:13 | 95% | 66.17 | 3.59 |
| 08:55:17 | last log line, runner dies | | |

A `cpu.psi.some.avg10` of 66 means tasks were stalled waiting for CPU roughly two thirds of the time, at load 3.59 on 2 vCPUs. GitHub then waited out the job's lock and reported the lost runner at 09:04:21, so the roughly nine minute gap in the run is GitHub's timeout, not build time.

`tuist-linux` resolves to the default 2 vCPU / 8 GiB shape, and this is the heaviest Docker build on that label. BuildKit runs three stages concurrently: the Go stage (`go test` plus build), the `android-sdk` JDK stage, and the Ubuntu stage with a large `apt install`. The Android stage selects platforms and build-tools by version floor rather than a pin, so it currently resolves to 16 platforms plus 6 build-tools, about 1.5 GB, and grows with every Google release.

### Why this fix and not another

The failure is marginal rather than consistently broken. The retry at 10:48 succeeded in about 4 minutes on the identical shape once the fleet was quieter, and the job last succeeded on 2026-08-18 in 7m34s. So the build itself is not wrong, it is simply sized for more cores than the default shape has, and the fix is capacity.

Alternatives that were considered and rejected for this PR:

- Trimming the Android SDK stage would reduce the work, but the growth is unbounded by design and would need a ceiling or a pin, which is a behavioural change to what the runner image ships to customers. Worth doing separately, not as an incident fix.
- Raising `timeout-minutes` does nothing, since the runner crashed rather than ran long.
- Adding build caching would help steady state but not the cold path that failed here.

The workload is CPU and IO bound rather than memory bound, so the point of the larger shape is the cores, not the RAM. `tuist-linux-large` already backs the sibling Docker build jobs, so this introduces no new pool.

### Impact

This job sits on the production deployment's critical path, so a marginal failure here blocks the whole cascade. Doubling the cores takes the concurrent-stage load off a 2-core box. The cost is one job moving to a larger shape on releases that touch `infra/linux-runner-image/`, which is infrequent: the job is skipped on almost every run.

### Validation

- The diff is a single line. The other 9 `runs-on: tuist-linux` jobs in the same workflow are unchanged, confirmed by grep.
- `tuist-linux-large` was confirmed against production dispatch records to resolve to 4 vCPU / 16 GiB, and is already in use by 10 jobs across the workflows.
- The diagnosis above comes from the controller's pod termination log, the in-VM vitals stream, Kubernetes events, and node conditions. Node memory and disk pressure were clean and the node stayed Ready throughout, so an eviction and a host OOM are both excluded.

End to end validation is the next release run that touches `infra/linux-runner-image/`, since this job only fires then.

### How to test locally

This changes only which runner shape a CI job requests, so there is nothing to run locally. Verify by inspection:

```
git diff main -- .github/workflows/server-production-deployment.yml
```

The change should be the single `runs-on` line on the `release-linux-runner-image` job. To confirm the label resolves to the intended shape, check that other jobs already using `tuist-linux-large` land on 4 vCPU / 16 GiB pods:

```
grep -n "runs-on: tuist-linux-large" .github/workflows/*.yml
```
