### PR TITLE
fix(cli): link transitive cached framework dependencies

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -29,6 +29,7 @@ public class GraphTraverser: GraphTraversing {
     private let conditionalTargets: Set<GraphDependency>
     private let precompiledSwiftMacroExecutablesCache = GraphCache<GraphDependency, Set<String>>()
     private let precompiledDynamicLibrariesAndFrameworksCache = GraphCache<GraphDependency, [GraphDependency]>()
+    private let precompiledDependenciesLinkedThroughStaticTargetsCache = GraphCache<GraphDependency, Set<GraphDependency>>()
     private let linkableDependenciesCache = GraphCache<LinkableDependenciesKey, Set<GraphDependencyReference>>()
     private let searchablePathDependenciesCache = GraphCache<GraphDependency, Set<GraphDependencyReference>>()
     private let transitiveStaticDependenciesCache = GraphCache<GraphDependency, Set<GraphDependency>>()
@@ -713,17 +714,13 @@ public class GraphTraverser: GraphTraversing {
                 }
 
             let staticDependenciesPrecompiledLibrariesAndFrameworks =
-                transitiveStaticTargetReferences.flatMap { dependency in
-                    self.graph.dependencies[dependency, default: []]
-                        .lazy
-                        .filter { $0.isPrecompiled && $0.isLinkable }
-                }
+                precompiledDependenciesLinkedThroughStaticTargets(from: targetGraphDependency)
 
             let allDependencies =
                 (
                     transitiveStaticTargetReferences
                         + staticDependenciesDynamicLibrariesAndFrameworks
-                        + staticDependenciesPrecompiledLibrariesAndFrameworks
+                        + Array(staticDependenciesPrecompiledLibrariesAndFrameworks)
                 )
 
             references.formUnion(
@@ -911,6 +908,31 @@ public class GraphTraverser: GraphTraversing {
         let result: [GraphDependency] = precompiled.union(precompiledDependencies)
             .filter(\.isPrecompiledDynamicAndLinkable)
         precompiledDynamicLibrariesAndFrameworksCache[cacheKey] = result
+        return result
+    }
+
+    private func precompiledDependenciesLinkedThroughStaticTargets(
+        from rootDependency: GraphDependency
+    ) -> Set<GraphDependency> {
+        if let cached = precompiledDependenciesLinkedThroughStaticTargetsCache[rootDependency] {
+            return cached
+        }
+
+        let directPrecompiledDependencies = Set(
+            transitiveStaticDependencies(from: rootDependency).flatMap { dependency in
+                self.graph.dependencies[dependency, default: []]
+                    .lazy
+                    .filter { $0.isPrecompiled && $0.isLinkable }
+            }
+        )
+
+        let result = directPrecompiledDependencies.union(
+            filterDependencies(
+                from: directPrecompiledDependencies,
+                test: \.isPrecompiledDynamicAndLinkable
+            )
+        )
+        precompiledDependenciesLinkedThroughStaticTargetsCache[rootDependency] = result
         return result
     }
 
@@ -2233,6 +2255,9 @@ extension GraphTraverser {
                         if child.isPrecompiled, child.isLinkable { admit(child) }
                     }
                 }
+            }
+            for dependency in precompiledDependenciesLinkedThroughStaticTargets(from: from) {
+                admit(dependency)
             }
         }
 

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3429,6 +3429,57 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_linkableDependencies_includeTransitiveDynamicCachedDependenciesOfStaticFrameworks() throws {
+        // App -> StaticFeature -> CachedFeature -> CachedModels
+        //
+        // CachedFeature's public API can expose CachedModels types. The application therefore needs
+        // both cached dynamic frameworks in its link phase, despite CachedFeature being reached through
+        // a static framework.
+        let app = Target.test(name: "App", product: .app)
+        let staticFeature = Target.test(name: "StaticFeature", product: .staticFramework)
+        let cachedFeaturePath = try AbsolutePath(validating: "/path/to/frameworks/CachedFeature.xcframework")
+        let cachedModelsPath = try AbsolutePath(validating: "/path/to/frameworks/CachedModels.xcframework")
+        let cachedFeature = GraphDependency.testXCFramework(
+            path: cachedFeaturePath,
+            linking: .dynamic
+        )
+        let cachedModels = GraphDependency.testXCFramework(
+            path: cachedModelsPath,
+            linking: .dynamic
+        )
+        let cachedImplementation = GraphDependency.testXCFramework(
+            path: "/path/to/frameworks/CachedImplementation.xcframework",
+            linking: .static
+        )
+        let project = Project.test(path: "/path/project", targets: [app, staticFeature])
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: app.name, path: project.path): [
+                    .target(name: staticFeature.name, path: project.path),
+                ],
+                .target(name: staticFeature.name, path: project.path): [cachedFeature],
+                cachedFeature: [cachedModels, cachedImplementation],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let result = try subject.linkableDependencies(path: project.path, name: app.name)
+        let searchPathDependencies = subject.precompiledSearchPathDependencies(path: project.path, name: app.name)
+
+        // Then
+        XCTAssertEqual(result.sorted(), [
+            .product(target: "StaticFeature", productName: "StaticFeature.framework"),
+            GraphDependencyReference(cachedFeature),
+            GraphDependencyReference(cachedModels),
+        ])
+        XCTAssertEqual(searchPathDependencies.precompiledPaths, [
+            cachedFeaturePath,
+            cachedModelsPath,
+        ])
+    }
+
     func test_linkableDependencies_doNotIncludeTransitivePrecompiledDependenciesOfDynamicFrameworks() throws {
         // Given
         // App > DynamicFramework > PrecompiledDynamicFramework


### PR DESCRIPTION
> Ensures final consumers link dynamically linked cached frameworks that are reached through static targets.

## What changed

- Traverse dynamically linked cached frameworks transitively when they are reached through static targets.
- Use that same dependency set for the link phase and framework search paths.
- Memoize the dependency set per root target to avoid repeated graph walks.
- Add a regression test that keeps static artifacts behind a dynamic cached framework out of both sets.

## Root cause

The graph traversal only collected directly declared cached frameworks behind static targets. A dynamically linked cached framework could therefore expose symbols from another cached framework that was embedded but missing from the final link phase.

## Approach

A shared, memoized traversal collects directly reachable precompiled artifacts and their dynamically linked descendants. Both link dependency generation and framework search-path generation use that traversal, so the linker can resolve every newly added framework without recomputing the closure.

## Impact

Projects using cached binary frameworks can link symbols exposed through dynamically linked transitive dependencies. Static artifacts behind a dynamic cached framework remain excluded from the final link phase.

### How to test locally

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistCoreTests/GraphTraverserTests`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistCoreTests/PrecompiledSearchPathsDifferentialTests`
- `mise run cli:lint`
