### PR TITLE
feat(swifterpm): add SWIFTERPM_GITHUB_TOKEN env var with highest priority

### DIFF
--- a/swifterpm/README.md
+++ b/swifterpm/README.md
@@ -58,6 +58,8 @@ Useful SwiftPM-shaped flags are supported, including `--package-path`, `--cache-
 
 Credentials for registries and binary artifact downloads are read from `~/.netrc`, from the `SWIFTPM_NETRC_DATA` environment variable, or from the file given by `--netrc-file`. Pass `--disable-netrc` to skip all of them. A `--netrc-file` that does not exist is an error rather than a silent fallback to unauthenticated requests.
 
+For GitHub API requests (archive downloads, release asset fetches), `swifterpm` reads a token from the environment in this order: `SWIFTERPM_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`. The dedicated `SWIFTERPM_GITHUB_TOKEN` variable lets CI workflows scope a separate credential for `swifterpm` without affecting other tools that read the generic variables. A host-scoped netrc credential for `api.github.com` takes precedence over all three environment tokens.
+
 By default, `swifterpm` copies cached directories into the project scratch directory during [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) and symlinks them elsewhere. Pass `--cached-directory-materialization=symlink` to preserve global-cache symlinks during continuous integration. The accepted values are `automatic`, `copy`, and `symlink`.
 
 > [!NOTE]

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -32,7 +32,7 @@ private actor GitHubTokenCache {
         loaded = true
 
         let env = ProcessInfo.processInfo.environment
-        if let token = env["GITHUB_TOKEN"] ?? env["GH_TOKEN"],
+        if let token = env["SWIFTERPM_GITHUB_TOKEN"] ?? env["GITHUB_TOKEN"] ?? env["GH_TOKEN"],
            !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             cachedToken = token
@@ -128,7 +128,7 @@ enum SourceControlLocations {
 /// provider's API. Without this, the HTTPS candidate added by `fetchCandidates` only works
 /// when an ambient credential (a `url.insteadOf` token rewrite, a credential helper, or
 /// ~/.netrc) is configured, so an SSH-declared private dependency keeps failing in CI even
-/// with a usable `GITHUB_TOKEN`/`GH_TOKEN`. Emitting an `http.<base>.extraheader` via `-c`
+/// with a usable `SWIFTERPM_GITHUB_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`. Emitting an `http.<base>.extraheader` via `-c`
 /// mirrors what `actions/checkout` does and keeps the token out of the on-disk git config.
 /// SSH candidates return no arguments so ssh-agent stays in charge, and when no token is
 /// available we add nothing so configured ambient credentials keep working unchanged.

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -31,10 +31,7 @@ private actor GitHubTokenCache {
         }
         loaded = true
 
-        let env = ProcessInfo.processInfo.environment
-        if let token = env["SWIFTERPM_GITHUB_TOKEN"] ?? env["GITHUB_TOKEN"] ?? env["GH_TOKEN"],
-           !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
+        if let token = GitHubAuth.envToken(from: ProcessInfo.processInfo.environment) {
             cachedToken = token
             return token
         }
@@ -52,6 +49,18 @@ private actor GitHubTokenCache {
 private let githubTokenCache = GitHubTokenCache()
 
 enum GitHubAuth {
+    private static let envKeys = ["SWIFTERPM_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"]
+
+    static func envToken(from environment: [String: String]) -> String? {
+        for key in envKeys {
+            if let value = environment[key] {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
     static func token() async -> String? {
         await githubTokenCache.token()
     }

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -386,13 +386,15 @@ enum HTTPAuthorization {
         // credential, so it must beat a generic SWIFTERPM_GITHUB_TOKEN /
         // GITHUB_TOKEN / GH_TOKEN that may be scoped to an unrelated repository — otherwise a
         // repo-scoped CI token shadows the netrc credential that can actually read
-        // a private release asset. This mirrors SwiftPM, whose download
-        // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
+        // a private release asset. SwiftPM's makeAuthorizationProvider actually
+        // ranks its environment token above netrc, but we keep netrc first here
+        // because GITHUB_TOKEN in CI is often repo-scoped and not valid for the
+        // host a netrc entry deliberately targets.
         if let header = await prioritizedHeader(
             isGitHub: isGitHub(url),
             netrcCredential: Environment.netrc.credential(for: url),
             keychain: { await KeychainAuthorization.credential(for: url) },
-            gitHubEnvToken: environment["SWIFTERPM_GITHUB_TOKEN"] ?? environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
+            gitHubEnvToken: GitHubAuth.envToken(from: environment)
         ) {
             return header
         }
@@ -416,7 +418,7 @@ enum HTTPAuthorization {
         if let credential = await keychain() {
             return basicHeader(credential)
         }
-        if isGitHub, let token = nonEmpty(gitHubEnvToken) {
+        if isGitHub, let token = gitHubEnvToken {
             return bearerHeader(token)
         }
         return nil
@@ -434,11 +436,6 @@ enum HTTPAuthorization {
 
     private static func bearerHeader(_ token: String) -> String {
         "Bearer \(token)"
-    }
-
-    private static func nonEmpty(_ value: String?) -> String? {
-        guard let value, !value.isEmpty else { return nil }
-        return value
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -383,8 +383,8 @@ enum HTTPAuthorization {
 
         // Explicit, host-scoped credentials win over an ambient GitHub token. A
         // `machine api.github.com` entry in a netrc file is a deliberate per-host
-        // credential, so it must beat a generic GITHUB_TOKEN /
-        // GH_TOKEN that may be scoped to an unrelated repository — otherwise a
+        // credential, so it must beat a generic SWIFTERPM_GITHUB_TOKEN /
+        // GITHUB_TOKEN / GH_TOKEN that may be scoped to an unrelated repository — otherwise a
         // repo-scoped CI token shadows the netrc credential that can actually read
         // a private release asset. This mirrors SwiftPM, whose download
         // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
@@ -392,7 +392,7 @@ enum HTTPAuthorization {
             isGitHub: isGitHub(url),
             netrcCredential: Environment.netrc.credential(for: url),
             keychain: { await KeychainAuthorization.credential(for: url) },
-            gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
+            gitHubEnvToken: environment["SWIFTERPM_GITHUB_TOKEN"] ?? environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
         ) {
             return header
         }

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -405,6 +405,22 @@ struct SupportTests {
     }
 
     @Test
+    func emptySwifterpmGitHubTokenFallsBackToGitHubToken() async throws {
+        let header = try await Environment.$values.withValue([
+            "SWIFTERPM_GITHUB_TOKEN": "",
+            "GITHUB_TOKEN": "github-token",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(
+                    for: URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1")!
+                )
+            }
+        }
+
+        #expect(header == "Bearer github-token")
+    }
+
+    @Test
     func ghTokenUsedWhenOtherGitHubTokensAbsent() async throws {
         let header = try await Environment.$values.withValue([
             "GH_TOKEN": "gh-token",

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -372,6 +372,54 @@ struct SupportTests {
     }
 
     @Test
+    func swifterpmGitHubTokenTakesPrecedenceOverGitHubToken() async throws {
+        let header = try await Environment.$values.withValue([
+            "SWIFTERPM_GITHUB_TOKEN": "swifterpm-token",
+            "GITHUB_TOKEN": "github-token",
+            "GH_TOKEN": "gh-token",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(
+                    for: URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1")!
+                )
+            }
+        }
+
+        #expect(header == "Bearer swifterpm-token")
+    }
+
+    @Test
+    func gitHubTokenUsedWhenSwifterpmGitHubTokenAbsent() async throws {
+        let header = try await Environment.$values.withValue([
+            "GITHUB_TOKEN": "github-token",
+            "GH_TOKEN": "gh-token",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(
+                    for: URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1")!
+                )
+            }
+        }
+
+        #expect(header == "Bearer github-token")
+    }
+
+    @Test
+    func ghTokenUsedWhenOtherGitHubTokensAbsent() async throws {
+        let header = try await Environment.$values.withValue([
+            "GH_TOKEN": "gh-token",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(
+                    for: URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1")!
+                )
+            }
+        }
+
+        #expect(header == "Bearer gh-token")
+    }
+
+    @Test
     func realpathFollowsSymlinksAndKeepsThePathWhenItCannotResolve() async throws {
         try await withTemporaryDirectory { directory in
             let target = directory.appendingPathComponent("Target")

--- a/swifterpm/swifterpm/bzlmod/swift_deps.bzl
+++ b/swifterpm/swifterpm/bzlmod/swift_deps.bzl
@@ -123,7 +123,7 @@ def _swift_deps_impl(module_ctx):
 _registry_attrs = {
     "netrc": attr.label(
         allow_single_file = True,
-        doc = "A `.netrc` file. Accepted for API compatibility; SwifterPM currently uses GITHUB_TOKEN or GH_TOKEN.",
+        doc = "A `.netrc` file. Accepted for API compatibility; SwifterPM currently uses SWIFTERPM_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN.",
     ),
     "registries": attr.label(
         allow_single_file = [".json"],

--- a/swifterpm/swifterpm/internal/swifterpm_tool_repo.bzl
+++ b/swifterpm/swifterpm/internal/swifterpm_tool_repo.bzl
@@ -278,7 +278,7 @@ swifterpm_tool_repo = repository_rule(
         ),
         "netrc": attr.label(
             allow_single_file = True,
-            doc = "Accepted for API compatibility. SwifterPM currently authenticates through GITHUB_TOKEN or GH_TOKEN.",
+            doc = "Accepted for API compatibility. SwifterPM currently authenticates through SWIFTERPM_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN.",
         ),
         "package_path": attr.string(
             mandatory = True,


### PR DESCRIPTION
Allow a dedicated token that takes precedence over GITHUB_TOKEN and GH_TOKEN so CI workflows can scope a separate credential for SwifterPM without affecting other tools that read the generic variables.