### PR TITLE
fix(server): stop replaying xcresult parse timeouts that starve the processor fleet

### DIFF
--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -51,6 +51,28 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   # `failed_processing` once and cancel the job.
   @unprocessable_input_reasons [:bundle_invalid, :xcresult_not_found]
 
+  # A parse timeout is the one failure that costs a worker slot the full
+  # NIF deadline (10 minutes) before it reports anything, so it is also the
+  # one where the default five processing attempts are actively harmful.
+  #
+  # The parse is CPU-bound and the fleet is small (one VM per Mac mini, one
+  # in-flight parse per performance core), so replaying a bundle that just
+  # blew the deadline puts the same work back on the same saturated cores.
+  # Every replay is 10 more minutes that a parse which *would* have finished
+  # does not get, which pushes borderline bundles over the deadline, which
+  # enqueues more replays: the queue collapses to near-zero goodput while
+  # every tenant's parse times out. That is exactly what the 2026-08-29
+  # incident looked like — whatnot, pinterest and vinted all timing out
+  # together, jobs still on attempt 2 four hours after the run was uploaded.
+  #
+  # One retry is kept rather than none: a bundle can cross the deadline
+  # purely because the fleet was busy when it ran, and a second pass does
+  # succeed once the queue drains. Beyond that the honest answer is that we
+  # cannot parse this bundle in the budget we have, so mark the run
+  # `failed_processing` and cancel instead of burning four more slots on it.
+  @parse_timeout_attempts 2
+  @parse_timeout_backoff_seconds 900
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"test_run_id" => test_run_id}} = job) do
     OpenTelemetry.Tracer.with_span "xcresult.process" do
@@ -79,10 +101,14 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
           "Cancelling xcresult for test run #{test_run_id}: uploaded archive is unprocessable (#{inspect(reason)})"
         )
 
-        case safely_mark_test_run_failed(args) do
-          :ok -> {:cancel, reason}
-          {:error, mark_reason} -> {:error, mark_reason}
-        end
+        cancel_as_failed(args, reason)
+
+      {:error, :parse_timeout = reason} when attempt >= @parse_timeout_attempts ->
+        Logger.error(
+          "Cancelling xcresult for test run #{test_run_id}: parsing exceeded its timeout on #{attempt} attempts"
+        )
+
+        cancel_as_failed(args, reason)
 
       {:error, reason} ->
         handle_processing_error(args, attempt, reason)
@@ -90,11 +116,39 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   end
 
   @impl Oban.Worker
-  def backoff(%Oban.Job{attempt: attempt}) when attempt > 0 and attempt <= tuple_size(@processing_backoff_seconds) do
+  def backoff(%Oban.Job{errors: errors} = job) do
+    if parse_timeout?(errors) do
+      @parse_timeout_backoff_seconds
+    else
+      processing_backoff(job)
+    end
+  end
+
+  defp processing_backoff(%Oban.Job{attempt: attempt})
+       when attempt > 0 and attempt <= tuple_size(@processing_backoff_seconds) do
     elem(@processing_backoff_seconds, attempt - 1)
   end
 
-  def backoff(job), do: Oban.Worker.backoff(job)
+  defp processing_backoff(job), do: Oban.Worker.backoff(job)
+
+  # The transient-error ladder above starts at 30 seconds, which is the wrong
+  # shape for the one retry a parse timeout gets: the job has already spent
+  # the full deadline on a busy fleet, and coming back half a minute later
+  # re-runs the same work against the same busy cores. Wait out the in-flight
+  # parses it would otherwise compete with instead.
+  #
+  # Oban only exposes the previous failures as formatted strings, so this
+  # sniffs the reason out of the last one. A change in Oban's formatting
+  # costs us the longer wait and falls back to the ladder, which is what this
+  # path does today, so the retry cap never depends on the match.
+  defp parse_timeout?(errors) when is_list(errors) do
+    case List.last(errors) do
+      %{"error" => error} when is_binary(error) -> String.contains?(error, "parse_timeout")
+      _ -> false
+    end
+  end
+
+  defp parse_timeout?(_errors), do: false
 
   defp complete_processing(args) do
     # The run just finished on this (isolated, non-clustered) processor
@@ -120,6 +174,18 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   end
 
   defp handle_processing_error(_args, _attempt, reason), do: {:error, reason}
+
+  # Record the run as `failed_processing` and stop replaying the job. Cancel
+  # rather than error so the failure doesn't keep consuming attempts (and
+  # Sentry events) for something a replay cannot change; if marking the run
+  # fails we still return an error so the job retries and the run doesn't
+  # get stranded mid-processing.
+  defp cancel_as_failed(args, reason) do
+    case safely_mark_test_run_failed(args) do
+      :ok -> {:cancel, reason}
+      {:error, mark_reason} -> {:error, mark_reason}
+    end
+  end
 
   defp finalize_failed_processing(args) do
     with :ok <- safely_mark_test_run_failed(args),

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -554,12 +554,62 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     end
   end
 
+  describe "perform/1 parse timeouts" do
+    test "retries the first parse timeout", %{account: account, project: project} do
+      test_run_id = Ecto.UUID.generate()
+
+      expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
+      expect(XCResultProcessor, :process_local, fn _path, _opts -> {:error, :parse_timeout} end)
+
+      reject(&Tuist.Tests.create_test/1)
+
+      assert {:error, :parse_timeout} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 20))
+    end
+
+    test "stops replaying the bundle once the retry also times out", %{account: account, project: project} do
+      test_run_id = Ecto.UUID.generate()
+
+      expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
+      expect(XCResultProcessor, :process_local, fn _path, _opts -> {:error, :parse_timeout} end)
+
+      expect(Tuist.Tests, :create_test, fn attrs ->
+        assert attrs.id == test_run_id
+        assert attrs.status == "failed_processing"
+        {:ok, %{id: test_run_id}}
+      end)
+
+      assert {:cancel, :parse_timeout} =
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 2, 20))
+    end
+  end
+
   describe "backoff/1" do
     test "spaces processing retries and enters finalization immediately after the fifth failure" do
       assert [30, 120, 300, 600, 1] ==
                Enum.map(1..5, fn attempt ->
                  ProcessXcresultWorker.backoff(%Oban.Job{attempt: attempt, max_attempts: 20})
                end)
+    end
+
+    test "waits out the in-flight parses before retrying a timeout" do
+      job = %Oban.Job{
+        attempt: 1,
+        max_attempts: 20,
+        errors: [%{"attempt" => 1, "error" => "** (Oban.PerformError) ... failed with {:error, :parse_timeout}"}]
+      }
+
+      assert 900 == ProcessXcresultWorker.backoff(job)
+    end
+
+    test "keeps the transient ladder for failures that are not parse timeouts" do
+      job = %Oban.Job{
+        attempt: 1,
+        max_attempts: 20,
+        errors: [%{"attempt" => 1, "error" => "** (Oban.PerformError) ... failed with {:error, :bundle_invalid}"}]
+      }
+
+      assert 30 == ProcessXcresultWorker.backoff(job)
     end
   end
 


### PR DESCRIPTION
Mitigates an ongoing production incident in Xcode result bundle processing. There is no tracking issue; this came out of a Sentry anomaly alert on the production error rate.

## What changed

- Cap parse-timeout processing attempts at two in `ProcessXcresultWorker`. After the second timeout the run is marked `failed_processing` and the job is cancelled instead of being replayed three more times.
- Give that single retry a 900 second backoff instead of the 30 second transient error ladder.
- Extract the shared "mark the run failed and cancel" branch into `cancel_as_failed/2`, which the existing unprocessable input path now also uses.
- Add coverage for both the retry and the cancel path, plus the two new backoff branches.

## Why

Xcode result bundle parsing has been collapsing fleet wide. The `:parse_timeout` issue in Sentry went from roughly 60 events a day to 758 in the last 24 hours, and 1127 of its 1143 lifetime events landed in the last two days. It is marked escalating.

This is not one pathological customer bundle. Sampled failures came from three separate accounts on three different Xcode versions, so everybody's parses were timing out at once. The user visible effect is that test results stop landing: one sampled job was uploaded at 07:37 and was still on attempt two at 11:21, so nearly four hours with no results in the dashboard.

The database connection pool errors that fired alongside it (249 in a single hour) came entirely from the two xcresult processor pods, none from the web tier, so they were a symptom of the same saturation rather than a separate problem.

## Root cause

The native parser cancels itself at a fixed 600 second deadline. A bundle that blows that deadline occupies a worker slot for the full ten minutes and produces nothing.

The worker then returned `{:error, reason}` on each of its five processing attempts, so a single unparseable bundle cost 50 minutes of a core and emitted five Sentry events. Capacity is only 12 slots in total, two Mac minis running one virtual machine each at a concurrency of six.

At 758 timeouts a day that is roughly 126 core hours burned against 288 available, so about 44% of the fleet's entire parse capacity was producing nothing, and four fifths of that was replays. Those replays are themselves the offered load that keeps the queue from draining, which pushes borderline bundles past the deadline, which enqueues more replays. The loop sustains itself.

Worth noting what it was not. There was no processor deployment between 2026-08-28 and 2026-08-31, and the escalation started on 2026-08-29, so this is not a code regression in the parser. All pods were Running, the Postgres cluster was healthy, and the macOS fleet was fully ready. It is load growth meeting a fixed fleet, amplified by the retry policy.

## Approach

Retrying a parse timeout is close to pure waste. The work is bound by processor time and the deadline is a fixed wall clock budget, so replaying the same bundle puts the same work back on the same saturated cores. Cutting the replays removes most of the load that is driving the collapse, which is the fastest lever available in code.

One retry is kept rather than none. A bundle can cross the deadline purely because the fleet happened to be busy when it ran, and a second pass does succeed once the queue drains. Dropping to zero attempts would permanently fail runs that are fine on a healthy fleet.

The 30 second backoff was the wrong shape for that retry. Coming back half a minute after a ten minute timeout re-runs the same work against the same busy cores, which makes the retry decorative. 900 seconds lets it wait out the in-flight parses it would otherwise compete with.

Oban only exposes previous failures as formatted strings, so the backoff branch matches the reason out of the last error. If that formatting ever changes we lose the longer wait and fall back to the existing ladder, which is what this path does today. The retry cap itself never depends on the match.

Two things this deliberately does not do, both of which are capacity decisions rather than code:

- `queueConcurrency` is 6 on a six core virtual machine, and each parse shells out to `xcresulttool` several times. Those are multithreaded, so the fleet is probably oversubscribed and a lower number could raise throughput under overload. That needs per-parse duration data to pick well, and those traces go to Grafana Alloy rather than Sentry.
- The macOS fleet is two machines. Scaling it has a cost attached.

## Impact

Wasted slot time per unparseable bundle drops from 3000 seconds to 1200, a 60% reduction in the load driving the collapse. Sentry noise from this issue drops by a similar factor since each attempt emitted its own event.

Behaviour change worth flagging to reviewers: a run whose bundle times out twice is now marked `failed_processing` after roughly 20 minutes instead of staying pending for over an hour. That is a definitive answer sooner, but it is a state change users will see.

Cancelled jobs land in Oban's `cancelled` state, which is outside the worker's `states: :incomplete` uniqueness window, so a later upload for the same run can still enqueue normally.

## Validation

- `MIX_ENV=test mix compile` compiles clean, no new warnings.
- `mix credo lib/tuist/tests/workers/process_xcresult_worker.ex` reports no issues.
- `mix format --check-formatted` passes on both changed files.
- Exercised `backoff/1` directly against the compiled module: the existing ladder is unchanged at `[30, 120, 300, 600, 1]`, a parse timeout error returns `900`, a non-timeout error returns `30`, and a job with `nil` errors falls through safely to `120`.

The two new `perform/1` tests are written but have not been executed yet. The local Postgres instance was pinned at its 100 connection limit by other work on this machine, and freeing it needs a restart that would disrupt those sessions. They should run with the rest of the suite in continuous integration.

### How to test locally

```
cd server
mix test test/tuist/tests/workers/process_xcresult_worker_test.exs
```

The relevant cases are `perform/1 parse timeouts`, which covers retrying the first timeout and cancelling on the second, and the two new `backoff/1` cases covering the long timeout backoff and the unchanged ladder for every other failure.
