### PR TITLE
fix(server): bump Command to 0.14.10 in the xcresult NIF

### DIFF
--- a/server/native/xcresult_nif/Package.resolved
+++ b/server/native/xcresult_nif/Package.resolved
@@ -1,10 +1,11 @@
 {
-  "originHash" : "8aecb7efffb545661361ba528935d388d595ea06503622713fa85a08b59803c1",
+  "originHash" : "831c9a1beeb9f291ba7ac3bbc3d1d8ab3d2dc97126df851f91318737f12864b7",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "version" : "1.3.0"
       }
@@ -13,6 +14,7 @@
       "identity" : "apple.swift-collections",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "version" : "1.4.1"
       }
@@ -21,14 +23,16 @@
       "identity" : "apple.swift-log",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-log",
       "state" : {
-        "version" : "1.11.0"
+        "version" : "1.15.0"
       }
     },
     {
       "identity" : "apple.swift-nio",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio",
       "state" : {
         "version" : "2.97.1"
       }
@@ -37,6 +41,7 @@
       "identity" : "apple.swift-system",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-system.git",
       "state" : {
         "version" : "1.6.4"
       }
@@ -45,14 +50,25 @@
       "identity" : "kolos65.Mockable",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/Kolos65/Mockable",
       "state" : {
         "version" : "0.6.2"
+      }
+    },
+    {
+      "identity" : "pointfreeco.xctest-dynamic-overlay",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "version" : "1.13.1"
       }
     },
     {
       "identity" : "swiftlang.swift-syntax",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "version" : "602.0.0"
       }
@@ -62,7 +78,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.0"
+        "version" : "0.14.10"
       }
     },
     {
@@ -77,6 +93,7 @@
       "identity" : "tuist.Path",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/Path",
       "state" : {
         "version" : "0.3.8"
       }
@@ -85,17 +102,9 @@
       "identity" : "tuist.zipfoundation",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/ZIPFoundation",
       "state" : {
         "version" : "0.9.21"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/server/native/xcresult_nif/Package.swift
+++ b/server/native/xcresult_nif/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
-        .package(id: "tuist.Command", from: "0.12.0"),
+        .package(id: "tuist.Command", from: "0.14.9"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],
     targets: [


### PR DESCRIPTION
Follows Sentry [TUIST-4JQ](https://tuist.sentry.io/issues/TUIST-4JQ). Not marked as resolving it: see "What this does not fix" below.

## What changed

`server/native/xcresult_nif` moves `tuist.Command` from 0.14.0 to 0.14.10, and raises its floor from `from: "0.12.0"` to `from: "0.14.9"`. Two files, no source changes.

## Why

A production xcresult parse failed with:

```
{:error, {:parse_failed, "The operation couldn't be completed. Bad file descriptor"}}
```

That string, curly apostrophe included, is `NSError(domain: NSPOSIXErrorDomain, code: 9)`. I reproduced it byte for byte by handing `Foundation.Process` an invalid descriptor. So the throw is `try process.run()` inside Command's `CommandRunner`: `posix_spawn` refused the launch because a descriptor passed to the child was invalid. `xcresulttool` never ran, and the uploaded archive was fine. The job had already downloaded and extracted it, failing 70 seconds in, nowhere near the 600s parse deadline.

It reaches Sentry as an opaque sentence because the NIF reduces any thrown error to `error.localizedDescription`. A message arriving at `stable_parse_error/2` with no `<xcresult>` path in it is the tell that it is a raw thrown error rather than an `XCResultParserError`.

## Root cause

The NIF pinned Command 0.14.0, while the CLI's root graph was already on 0.14.9. Every release in between hardens exactly this path:

- 0.14.9 bounds concurrent subprocess launches against `RLIMIT_NOFILE`, so pipe descriptors cannot exhaust the table
- 0.14.9 cancels the producer task when the stream terminates, so a cancelled parse unwinds instead of parking forever
- 0.14.4 awaits the child through `terminationHandler` rather than blocking a thread in `waitUntilExit`
- 0.14.5 and 0.14.8 drop the `try!` on `getcwd`, which traps the Swift runtime and takes the whole BEAM down from inside a NIF
- 0.14.1 conforms `CommandError` to `LocalizedError`, so a non-zero `xcresulttool` exit reports its stderr instead of an opaque error code

The load that makes this bite is real: production runs `queueConcurrency: 6` across two replicas, and attachment conversion spawns one `sips` per PNG, so a UI test bundle means thousands of launches per job.

I could not reproduce the descriptor race on demand, and plain descriptor exhaustion does not produce it: under `EMFILE` on Darwin, `Pipe()` fails soft and the spawn still succeeds. What is certain is the throw site and that the pinned version predates all of the hardening for it.

## Why 0.14.10 rather than the newest release

Command 0.14.11 and later require Mockable 0.6.4, and the registry serves 0.6.2. Pinning higher would force a source-control dependency into a graph that is otherwise entirely registry-resolved. 0.14.10 carries every fix listed above.

The floor is 0.14.9 rather than 0.14.10 deliberately: it states the requirement, which is the descriptor bound, and it is already satisfied by the CLI's existing pin. `XCResultParser` compiles into the CLI binary, so a higher floor would have forced the root graph to re-resolve too. It does not move here.

## What this does not fix

0.14.10 still sends SIGTERM on cancellation and then waits on the termination handler indefinitely for a child that will not unwind, so an abandoned parse still holds two parent-side pipe descriptors and a live child for the life of the process. Escalating to SIGKILL belongs upstream in the Command package.

Worth reading alongside [#12720](https://github.com/tuist/tuist/pull/12720), which bounds the damage of that leak, and [#12718](https://github.com/tuist/tuist/pull/12718), which makes it visible while it is happening. One detail this PR corrects for both: #12720 attributes part of the leak to a "shared CommandRunner subprocess permit", but 0.14.0 has no limiter and therefore no permit. The same assumption sits in a comment in `XCResultNIF.swift`. After this bump the permit exists and that description becomes accurate.

## Impact

No behaviour change to job processing, and no source changes. The processor gains a bounded launch path, a non-blocking wait on child processes, and loses a `try!` that could take the BEAM down.

## How to test locally

```
cd server/native/xcresult_nif
swift build -c release --replace-scm-with-registry
swift test --replace-scm-with-registry
```

Both pass. The release build log shows `Compiling Command AsyncResourceLimiter.swift`, which confirms the descriptor bound is linked into `libXCResultNIF.dylib` rather than only present in the pin. The test run is 15 tests in 2 suites, including `cancellingACommandTerminatesItsRealChildProcess()` and `shellCommandsExecTheToolSoTheyStayCancellable()`, which cover the teardown path that changed most.

Note when re-resolving this package: use `swift package resolve --replace-scm-with-registry`, which is what `build.sh` and the `swift-test-xcresult` CI job do. A bare `swift package update` does not accept that flag and re-resolves the transitive graph through source control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
