### PR TITLE
fix(server): bump the xcresult NIF's Command to a release that does not park a thread per stuck parse

### DIFF
--- a/server/native/xcresult_nif/Package.resolved
+++ b/server/native/xcresult_nif/Package.resolved
@@ -1,10 +1,11 @@
 {
-  "originHash" : "8aecb7efffb545661361ba528935d388d595ea06503622713fa85a08b59803c1",
+  "originHash" : "7fc124d1e4cc958764153a559cb57ecbbc6a30f1a5ebd6c6bd2dd0ab894e28ac",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "version" : "1.3.0"
       }
@@ -13,6 +14,7 @@
       "identity" : "apple.swift-collections",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "version" : "1.4.1"
       }
@@ -21,14 +23,16 @@
       "identity" : "apple.swift-log",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-log",
       "state" : {
-        "version" : "1.11.0"
+        "version" : "1.15.0"
       }
     },
     {
       "identity" : "apple.swift-nio",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-nio",
       "state" : {
         "version" : "2.97.1"
       }
@@ -37,6 +41,7 @@
       "identity" : "apple.swift-system",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/apple/swift-system.git",
       "state" : {
         "version" : "1.6.4"
       }
@@ -45,14 +50,25 @@
       "identity" : "kolos65.Mockable",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/Kolos65/Mockable",
       "state" : {
         "version" : "0.6.2"
+      }
+    },
+    {
+      "identity" : "pointfreeco.xctest-dynamic-overlay",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "version" : "1.13.1"
       }
     },
     {
       "identity" : "swiftlang.swift-syntax",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "version" : "602.0.0"
       }
@@ -62,7 +78,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.0"
+        "version" : "0.14.10"
       }
     },
     {
@@ -77,6 +93,7 @@
       "identity" : "tuist.Path",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/Path",
       "state" : {
         "version" : "0.3.8"
       }
@@ -85,17 +102,9 @@
       "identity" : "tuist.zipfoundation",
       "kind" : "registry",
       "location" : "",
+      "originalLocation" : "https://github.com/tuist/ZIPFoundation",
       "state" : {
         "version" : "0.9.21"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/server/native/xcresult_nif/Package.swift
+++ b/server/native/xcresult_nif/Package.swift
@@ -18,7 +18,15 @@ let package = Package(
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
-        .package(id: "tuist.Command", from: "0.12.0"),
+        // 0.14.4 is the floor, not cosmetic: every release before it waits on the
+        // subprocess with a blocking `process.waitUntilExit()` inside the task, so a
+        // child that outlives its cancellation parks a Swift cooperative-pool thread
+        // for the life of the process. The pool is about as wide as the machine has
+        // cores, and this NIF runs one parse per slot, so each parked thread
+        // permanently costs the processor a parse slot. Pinned at 0.14.0, production
+        // decayed from six concurrent parses to three over a Pod's lifetime.
+        // Upstream fix: tuist/Command#249. Kept in step with the root Package.swift.
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.9")),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],
     targets: [


### PR DESCRIPTION
## What changed

`server/native/xcresult_nif` moves `tuist.Command` from a floor of `0.12.0` (resolved at **0.14.0**) to `.upToNextMajor(from: "0.14.9")`, resolving to **0.14.10**.

## Why

The xcresult processor loses a parse slot every time a parse outlives its cancellation, and never gets it back until the Pod restarts. On 2026-08-31 both production processors had decayed from six concurrent parses to three over a 69 hour Pod lifetime, leaving a `process_xcresult` queue 3,000 jobs deep and a day of test runs unprocessed. Deleting the Pods restored both to six.

## Root cause

The pinned dependency, not our code.

`Package.swift` asked for `from: "0.12.0"` and `Package.resolved` had it pinned at 0.14.0, so every rebuild kept using it. In releases before 0.14.4, `CommandRunner.run` waits for the subprocess with a blocking `process.waitUntilExit()` inside the task body:

```swift
try process.run()
process.waitUntilExit()
```

That parks a Swift cooperative-pool thread until the child exits, and cancellation only sends SIGTERM — so a child that ignores it parks that thread for the life of the process. The pool is about as wide as the machine has cores, and this NIF runs one parse per slot, so **each parked thread permanently costs the processor a parse slot**. Six slots against six cores, and the decay to three and then to zero follows directly.

Upstream already fixed this in [tuist/Command#249](https://github.com/tuist/Command/pull/249) — *"replace blocking waitUntilExit with async terminationHandler to prevent thread starvation"* — released in 0.14.4. We simply never picked it up: the floor was old enough that the stale resolved pin remained valid, so nothing ever forced a move.

The root `Package.swift` has been on `0.14.8`/0.14.9 for a while, so the CLI was never exposed. This NIF was the only consumer left behind.

## Why this rather than patching Command

I started out writing a SIGKILL escalation for `CommandRunner`, on the theory that an uncooperative child holds an `AsyncResourceLimiter` permit forever. That theory was built by reading Command's `main`, and it does not describe what production runs: 0.14.0 has no `AsyncResourceLimiter` at all (it arrives in 0.14.9) and no async continuation to park on. The real mechanism in the deployed version is plain thread starvation, and it already has an upstream fix. Bumping is the whole change.

## Impact

Also picks up the subprocess concurrency limiter from [#275](https://github.com/tuist/Command/pull/275), which bounds concurrent children so their pipe file descriptors cannot exhaust the process's descriptor table. Its cap is `min(256, (RLIMIT_NOFILE - 32) / 6)`, far above the six concurrent parses this NIF runs, so it is headroom rather than a new constraint.

Resolved with `--replace-scm-with-registry` so every pin stays on registry resolution — plain `swift package resolve` silently rewrites the whole file to source-control identities. The only identity that moves is `xctest-dynamic-overlay`, a test-only transitive of Mockable that was the file's single `remoteSourceControl` pin and now sits on the registry with everything else.

## Validation

- `./build.sh` links the Swift dylib and C bridge against 0.14.10.
- `Tuist.Processor.XCResultNIF.parse/2` parses `cli/Tests/Fixtures/test-with-repetitions.xcresult` end to end through the rebuilt NIF: status `success`, 1 module, 2 cases.
- `mix test test/tuist/processor/` — 19 passed.
- Verified every pin in `Package.resolved` is still `kind: registry`.

Not validated: that the decay is gone in production, which needs a Pod to run past the ~24-48h mark on this build.

**Gotcha for reviewers:** a locally built NIF has to be removed before running the Elixir tests. With `server/priv/native` present, Mimic cannot rename the module and every stubbed test dies on `:on_load_failure`, because `ERL_NIF_INIT` hardcodes the module name.

## Related

Pairs with #12718, which exposes `tuist_oban_node_executing_jobs_count` against `tuist_oban_node_queue_limit` so this decay is visible while it happens rather than after throughput reaches zero. #12720 (stop the node once every slot is gone) was closed in favour of this — with the underlying leak fixed, bounding the damage is not the right layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)