### PR TITLE
fix(cli): compress preview archives and resume interrupted preview downloads

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c6897375e79ffa718a691c19c62ba3ee61dfadb9540342f26fdb8e3ff19f36b",
+  "originHash" : "07106380c2d6ea123e323bc8abdd8c0d4cebeadb2a56831228648de4efdd4c30",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -670,7 +670,7 @@
       "location" : "",
       "originalLocation" : "https://github.com/tuist/filesystem",
       "state" : {
-        "version" : "0.18.0"
+        "version" : "0.19.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1870,7 +1870,7 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.19.0")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.8")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "swiftlang.swift-subprocess", exact: "0.4.0"),

--- a/cli/Sources/TuistRunCommand/Services/RunCommandService.swift
+++ b/cli/Sources/TuistRunCommand/Services/RunCommandService.swift
@@ -7,6 +7,7 @@ import TuistConfigLoader
 import TuistConstants
 import TuistEnvironment
 import TuistLogging
+import TuistNooraExtension
 import TuistServer
 import TuistSupport
 
@@ -546,6 +547,12 @@ struct RunCommandService {
             }
         }
 
+        private static func downloadProgressMessage(for progress: RemoteArtifactDownloadProgress) -> String {
+            let downloaded = Formatters.formatBytes(Int(progress.downloadedBytes))
+            let total = Formatters.formatBytes(Int(progress.totalBytes))
+            return "Downloading preview... \(Int(progress.fraction * 100))% (\(downloaded) of \(total))"
+        }
+
         private func downloadAppleAppBundle(
             for destination: DestinationType,
             preview: Components.Schemas.Preview,
@@ -557,8 +564,16 @@ struct RunCommandService {
             else {
                 throw RunCommandServiceError.noCompatibleAppBuild(destination: destination.description)
             }
-            let archivePath = try await Noora.current.progressStep(message: "Downloading preview...") { _ in
-                return try await remoteArtifactDownloader.download(url: buildURL)
+            let archivePath = try await Noora.current.progressStep(message: "Downloading preview...") { updateProgress in
+                let (progressUpdates, continuation) = AsyncStream<RemoteArtifactDownloadProgress>.makeStream()
+                let downloaded = Task {
+                    defer { continuation.finish() }
+                    return try await remoteArtifactDownloader.download(url: buildURL, progress: continuation)
+                }
+                for await progress in progressUpdates {
+                    updateProgress(Self.downloadProgressMessage(for: progress))
+                }
+                return try await downloaded.value
             }
             guard let archivePath else { throw RunCommandServiceError.appNotFound(previewLink.absoluteString) }
 

--- a/cli/Sources/TuistRunCommand/Services/RunCommandService.swift
+++ b/cli/Sources/TuistRunCommand/Services/RunCommandService.swift
@@ -547,6 +547,14 @@ struct RunCommandService {
             }
         }
 
+        private func downloadReportingProgress(
+            from url: URL,
+            to continuation: ArtifactDownloadProgressContinuation
+        ) async throws -> AbsolutePath? {
+            defer { continuation.finish() }
+            return try await remoteArtifactDownloader.download(url: url, progress: continuation)
+        }
+
         private static func downloadProgressMessage(for progress: RemoteArtifactDownloadProgress) -> String {
             let downloaded = Formatters.formatBytes(Int(progress.downloadedBytes))
             let total = Formatters.formatBytes(Int(progress.totalBytes))
@@ -566,14 +574,11 @@ struct RunCommandService {
             }
             let archivePath = try await Noora.current.progressStep(message: "Downloading preview...") { updateProgress in
                 let (progressUpdates, continuation) = AsyncStream<RemoteArtifactDownloadProgress>.makeStream()
-                let downloaded = Task {
-                    defer { continuation.finish() }
-                    return try await remoteArtifactDownloader.download(url: buildURL, progress: continuation)
-                }
+                async let downloaded = downloadReportingProgress(from: buildURL, to: continuation)
                 for await progress in progressUpdates {
                     updateProgress(Self.downloadProgressMessage(for: progress))
                 }
-                return try await downloaded.value
+                return try await downloaded
             }
             guard let archivePath else { throw RunCommandServiceError.appNotFound(previewLink.absoluteString) }
 

--- a/cli/Sources/TuistServer/Utilities/RemoteArtifactDownloader.swift
+++ b/cli/Sources/TuistServer/Utilities/RemoteArtifactDownloader.swift
@@ -1,13 +1,35 @@
+import FileSystem
 import Foundation
 #if canImport(FoundationNetworking)
     import FoundationNetworking
 #endif
 import Mockable
 import Path
+import TuistHTTP
+import TuistLogging
+
+/// How much of an artifact has arrived so far.
+public struct RemoteArtifactDownloadProgress: Sendable, Equatable {
+    public let downloadedBytes: Int64
+    public let totalBytes: Int64
+
+    public init(downloadedBytes: Int64, totalBytes: Int64) {
+        self.downloadedBytes = downloadedBytes
+        self.totalBytes = totalBytes
+    }
+
+    public var fraction: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, Double(downloadedBytes) / Double(totalBytes))
+    }
+}
+
+public typealias ArtifactDownloadProgressContinuation = AsyncStream<RemoteArtifactDownloadProgress>.Continuation
 
 enum RemoteArtifactDownloaderError: LocalizedError, Equatable {
     case urlSessionError(url: URL, httpMethod: String, description: String)
     case noURLResponse(URL?)
+    case unsatisfiableRange(url: URL, offset: Int64)
 
     var errorDescription: String? {
         switch self {
@@ -19,55 +41,196 @@ enum RemoteArtifactDownloaderError: LocalizedError, Equatable {
             } else {
                 return "Received a response that doesn't have the expected type HTTPURLResponse"
             }
+        case let .unsatisfiableRange(url, offset):
+            return "The server did not serve the artifact at \(url.absoluteString) from byte \(offset)."
         }
+    }
+}
+
+struct RemoteArtifactDownloadStatusCodeError: HTTPStatusCodeError, LocalizedError, Equatable {
+    let url: URL
+    let httpStatusCode: Int
+
+    var errorDescription: String? {
+        "Received status code \(httpStatusCode) when downloading the artifact at \(url.absoluteString)."
     }
 }
 
 @Mockable
 public protocol RemoteArtifactDownloading {
-    func download(url: URL) async throws -> AbsolutePath?
+    func download(url: URL, progress: ArtifactDownloadProgressContinuation?) async throws -> AbsolutePath?
+}
+
+extension RemoteArtifactDownloading {
+    public func download(url: URL) async throws -> AbsolutePath? {
+        try await download(url: url, progress: nil)
+    }
 }
 
 public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
     private let urlSession: URLSession
+    private let retryProvider: RetryProviding
+    private let fileSystem: FileSysteming
+    private let chunkByteCount: Int64
 
     public init() {
-        self.init(urlSession: URLSession.shared)
+        self.init(urlSession: .tuistLargeTransfer)
     }
 
-    init(urlSession: URLSession) {
+    init(
+        urlSession: URLSession,
+        retryProvider: RetryProviding = RetryProvider(),
+        fileSystem: FileSysteming = FileSystem(),
+        chunkByteCount: Int64 = 16 * 1024 * 1024
+    ) {
         self.urlSession = urlSession
+        self.retryProvider = retryProvider
+        self.fileSystem = fileSystem
+        self.chunkByteCount = chunkByteCount
     }
 
-    public func download(url: URL) async throws -> AbsolutePath? {
-        let request = URLRequest(url: url)
-        do {
-            let (localUrl, response) = try await urlSession.download(for: request)
-            guard let urlResponse = response as? HTTPURLResponse else {
-                throw RemoteArtifactDownloaderError.noURLResponse(request.url)
+    public func download(
+        url: URL,
+        progress: ArtifactDownloadProgressContinuation?
+    ) async throws -> AbsolutePath? {
+        defer { progress?.finish() }
+
+        let directory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-artifact-download")
+        let destination = directory.appending(component: Self.filename(for: url))
+        try await fileSystem.touch(destination)
+
+        var offset: Int64 = 0
+        var total: Int64?
+        var validator: String?
+
+        while true {
+            let requestedOffset = offset
+            let requestedValidator = validator
+            let chunk = try await retryProvider.runWithRetries {
+                try await fetch(url: url, from: requestedOffset, validator: requestedValidator)
             }
-            if (200 ..< 300).contains(urlResponse.statusCode) {
-                return try AbsolutePath(validating: localUrl.path)
-            } else if urlResponse.statusCode == 404 {
+
+            switch chunk {
+            case .notFound:
+                try? await fileSystem.remove(directory)
                 return nil
-            } else {
-                throw RemoteArtifactDownloaderError.urlSessionError(
-                    url: request.url!,
-                    httpMethod: request.httpMethod!,
-                    description: response.description
-                )
+            case let .whole(localURL, byteCount, eTag):
+                try await replace(destination, with: localURL)
+                offset = byteCount
+                total = byteCount
+                validator = eTag
+            case let .partial(localURL, contentRange, eTag):
+                guard contentRange.start == requestedOffset, contentRange.byteCount > 0 else {
+                    throw RemoteArtifactDownloaderError.unsatisfiableRange(url: url, offset: requestedOffset)
+                }
+                try await append(localURL, to: destination)
+                offset += contentRange.byteCount
+                total = contentRange.total
+                validator = validator ?? eTag
             }
-        } catch {
-            if error is RemoteArtifactDownloaderError {
-                throw error
-            } else {
-                throw RemoteArtifactDownloaderError.urlSessionError(
-                    url: request.url!,
-                    httpMethod:
-                    request.httpMethod!,
-                    description: error.localizedDescription
-                )
-            }
+
+            guard let totalBytes = total else { break }
+            progress?.yield(RemoteArtifactDownloadProgress(downloadedBytes: offset, totalBytes: totalBytes))
+            if offset >= totalBytes { break }
         }
+
+        return destination
+    }
+
+    // MARK: - Private
+
+    private enum FetchedChunk {
+        case notFound
+        case whole(localURL: URL, byteCount: Int64, eTag: String?)
+        case partial(localURL: URL, contentRange: ContentRange, eTag: String?)
+    }
+
+    private func fetch(url: URL, from offset: Int64, validator: String?) async throws -> FetchedChunk {
+        var request = URLRequest(url: url)
+        request.setValue("bytes=\(offset)-\(offset + chunkByteCount - 1)", forHTTPHeaderField: "Range")
+        if let validator {
+            request.setValue(validator, forHTTPHeaderField: "If-Range")
+        }
+
+        let localURL: URL
+        let response: URLResponse
+        do {
+            (localURL, response) = try await urlSession.download(for: request)
+        } catch {
+            throw RemoteArtifactDownloaderError.urlSessionError(
+                url: url,
+                httpMethod: request.httpMethod ?? "GET",
+                description: error.localizedDescription
+            )
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw RemoteArtifactDownloaderError.noURLResponse(url)
+        }
+        let eTag = httpResponse.value(forHTTPHeaderField: "ETag")
+
+        switch httpResponse.statusCode {
+        case 404:
+            return .notFound
+        case 206:
+            guard let contentRange = ContentRange(httpResponse.value(forHTTPHeaderField: "Content-Range")) else {
+                throw RemoteArtifactDownloaderError.unsatisfiableRange(url: url, offset: offset)
+            }
+            if offset > 0 {
+                Logger.current.debug("Resuming the download of \(url.absoluteString) from byte \(offset).")
+            }
+            return .partial(localURL: localURL, contentRange: contentRange, eTag: eTag)
+        case 200 ..< 300:
+            let byteCount = try await fileSystem.fileMetadata(at: try AbsolutePath(validating: localURL.path))?.size ?? 0
+            return .whole(localURL: localURL, byteCount: byteCount, eTag: eTag)
+        default:
+            throw RemoteArtifactDownloadStatusCodeError(url: url, httpStatusCode: httpResponse.statusCode)
+        }
+    }
+
+    private func append(_ source: URL, to destination: AbsolutePath) async throws {
+        let data = try Data(contentsOf: source)
+        let handle = try FileHandle(forWritingTo: destination.url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+        try? FileManager.default.removeItem(at: source)
+    }
+
+    private func replace(_ destination: AbsolutePath, with source: URL) async throws {
+        if try await fileSystem.exists(destination) {
+            try await fileSystem.remove(destination)
+        }
+        try await fileSystem.move(from: try AbsolutePath(validating: source.path), to: destination)
+    }
+
+    private static func filename(for url: URL) -> String {
+        let component = url.lastPathComponent
+        return component.isEmpty ? "artifact" : component
+    }
+}
+
+struct ContentRange: Equatable {
+    let start: Int64
+    let end: Int64
+    let total: Int64
+
+    var byteCount: Int64 { end - start + 1 }
+
+    init?(_ value: String?) {
+        guard let value else { return nil }
+        let specification = value.trimmingCharacters(in: .whitespaces)
+        guard specification.hasPrefix("bytes ") else { return nil }
+        let components = specification.dropFirst("bytes ".count).split(separator: "/")
+        guard components.count == 2, let total = Int64(components[1]) else { return nil }
+        let bounds = components[0].split(separator: "-")
+        guard bounds.count == 2,
+              let start = Int64(bounds[0]),
+              let end = Int64(bounds[1]),
+              start <= end
+        else { return nil }
+        self.start = start
+        self.end = end
+        self.total = total
     }
 }

--- a/cli/Sources/TuistServer/Utilities/RemoteArtifactDownloader.swift
+++ b/cli/Sources/TuistServer/Utilities/RemoteArtifactDownloader.swift
@@ -58,6 +58,7 @@ struct RemoteArtifactDownloadStatusCodeError: HTTPStatusCodeError, LocalizedErro
 
 @Mockable
 public protocol RemoteArtifactDownloading {
+    /// Returns a temporary file the caller owns and is expected to remove.
     func download(url: URL, progress: ArtifactDownloadProgressContinuation?) async throws -> AbsolutePath?
 }
 
@@ -72,6 +73,7 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
     private let retryProvider: RetryProviding
     private let fileSystem: FileSysteming
     private let chunkByteCount: Int64
+    private let downloadsDirectory: AbsolutePath?
 
     public init() {
         self.init(urlSession: .tuistLargeTransfer)
@@ -81,12 +83,14 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
         urlSession: URLSession,
         retryProvider: RetryProviding = RetryProvider(),
         fileSystem: FileSysteming = FileSystem(),
-        chunkByteCount: Int64 = 16 * 1024 * 1024
+        chunkByteCount: Int64 = 16 * 1024 * 1024,
+        downloadsDirectory: AbsolutePath? = nil
     ) {
         self.urlSession = urlSession
         self.retryProvider = retryProvider
         self.fileSystem = fileSystem
         self.chunkByteCount = chunkByteCount
+        self.downloadsDirectory = downloadsDirectory
     }
 
     public func download(
@@ -95,9 +99,11 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
     ) async throws -> AbsolutePath? {
         defer { progress?.finish() }
 
-        let directory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-artifact-download")
-        let destination = directory.appending(component: Self.filename(for: url))
+        let destination = try makeDestination(for: url)
         try await fileSystem.touch(destination)
+
+        var completed = false
+        defer { if !completed { try? FileManager.default.removeItem(atPath: destination.pathString) } }
 
         var offset: Int64 = 0
         var total: Int64?
@@ -112,7 +118,6 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
 
             switch chunk {
             case .notFound:
-                try? await fileSystem.remove(directory)
                 return nil
             case let .whole(localURL, byteCount, eTag):
                 try await replace(destination, with: localURL)
@@ -134,6 +139,7 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
             if offset >= totalBytes { break }
         }
 
+        completed = true
         return destination
     }
 
@@ -204,9 +210,10 @@ public struct RemoteArtifactDownloader: RemoteArtifactDownloading {
         try await fileSystem.move(from: try AbsolutePath(validating: source.path), to: destination)
     }
 
-    private static func filename(for url: URL) -> String {
+    private func makeDestination(for url: URL) throws -> AbsolutePath {
+        let directory = try downloadsDirectory ?? AbsolutePath(validating: NSTemporaryDirectory())
         let component = url.lastPathComponent
-        return component.isEmpty ? "artifact" : component
+        return directory.appending(component: "\(UUID().uuidString)-\(component.isEmpty ? "artifact" : component)")
     }
 }
 

--- a/cli/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/cli/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -66,6 +66,13 @@ public class FileArchiver: FileArchiving {
     }
 
     private static func deflate(directoryContentAt path: AbsolutePath, to destination: AbsolutePath) async throws {
+        do {
+            return try await ParallelZipWriter().write(contentsOf: path, to: destination)
+        } catch ParallelZipWriterError.zip64Required {
+            Logger.current.debug("The archive requires ZIP64 extensions, falling back to a serial writer.")
+            try? FileManager.default.removeItem(atPath: destination.pathString)
+        }
+
         let sourceURL = URL(fileURLWithPath: path.pathString)
         let destinationURL = URL(fileURLWithPath: destination.pathString)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in

--- a/cli/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/cli/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -3,7 +3,6 @@ import Foundation
 import Mockable
 import Path
 import TuistLogging
-import ZIPFoundation
 
 /// An interface to archive files in a zip file.
 @Mockable
@@ -51,7 +50,7 @@ public class FileArchiver: FileArchiving {
         Logger.current.debug("Staging copy for \(name).zip finished in \(String(format: "%.2fs", copyElapsed))")
 
         let zipStart = Date()
-        try await Self.deflate(directoryContentAt: pathsDirectoryPath, to: destinationZipPath)
+        try await deflate(directoryContentAt: pathsDirectoryPath, to: destinationZipPath)
         let zipElapsed = Date().timeIntervalSince(zipStart)
         let zipBytes = (try? await fileSystem.fileMetadata(at: destinationZipPath)?.size) ?? 0
         Logger.current.debug(
@@ -65,29 +64,13 @@ public class FileArchiver: FileArchiving {
         try await fileSystem.remove(temporaryDirectory)
     }
 
-    private static func deflate(directoryContentAt path: AbsolutePath, to destination: AbsolutePath) async throws {
+    private func deflate(directoryContentAt path: AbsolutePath, to destination: AbsolutePath) async throws {
         do {
             return try await ParallelZipWriter().write(contentsOf: path, to: destination)
         } catch ParallelZipWriterError.zip64Required {
             Logger.current.debug("The archive requires ZIP64 extensions, falling back to a serial writer.")
         }
 
-        let sourceURL = URL(fileURLWithPath: path.pathString)
-        let destinationURL = URL(fileURLWithPath: destination.pathString)
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            DispatchQueue.global(qos: .utility).async {
-                do {
-                    try FileManager().zipItem(
-                        at: sourceURL,
-                        to: destinationURL,
-                        shouldKeepParent: false,
-                        compressionMethod: .deflate
-                    )
-                    continuation.resume()
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        try await fileSystem.zipFileOrDirectoryContent(at: path, to: destination, compressionMethod: .deflate)
     }
 }

--- a/cli/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/cli/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -70,7 +70,6 @@ public class FileArchiver: FileArchiving {
             return try await ParallelZipWriter().write(contentsOf: path, to: destination)
         } catch ParallelZipWriterError.zip64Required {
             Logger.current.debug("The archive requires ZIP64 extensions, falling back to a serial writer.")
-            try? FileManager.default.removeItem(atPath: destination.pathString)
         }
 
         let sourceURL = URL(fileURLWithPath: path.pathString)

--- a/cli/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/cli/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -3,6 +3,7 @@ import Foundation
 import Mockable
 import Path
 import TuistLogging
+import ZIPFoundation
 
 /// An interface to archive files in a zip file.
 @Mockable
@@ -50,7 +51,7 @@ public class FileArchiver: FileArchiving {
         Logger.current.debug("Staging copy for \(name).zip finished in \(String(format: "%.2fs", copyElapsed))")
 
         let zipStart = Date()
-        try await fileSystem.zipFileOrDirectoryContent(at: pathsDirectoryPath, to: destinationZipPath)
+        try await Self.deflate(directoryContentAt: pathsDirectoryPath, to: destinationZipPath)
         let zipElapsed = Date().timeIntervalSince(zipStart)
         let zipBytes = (try? await fileSystem.fileMetadata(at: destinationZipPath)?.size) ?? 0
         Logger.current.debug(
@@ -62,5 +63,25 @@ public class FileArchiver: FileArchiving {
 
     public func delete() async throws {
         try await fileSystem.remove(temporaryDirectory)
+    }
+
+    private static func deflate(directoryContentAt path: AbsolutePath, to destination: AbsolutePath) async throws {
+        let sourceURL = URL(fileURLWithPath: path.pathString)
+        let destinationURL = URL(fileURLWithPath: destination.pathString)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    try FileManager().zipItem(
+                        at: sourceURL,
+                        to: destinationURL,
+                        shouldKeepParent: false,
+                        compressionMethod: .deflate
+                    )
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }

--- a/cli/Sources/TuistSupport/Utils/ParallelZipWriter.swift
+++ b/cli/Sources/TuistSupport/Utils/ParallelZipWriter.swift
@@ -1,0 +1,381 @@
+import Foundation
+import Path
+import ZIPFoundation
+
+enum ParallelZipWriterError: LocalizedError, Equatable {
+    case zip64Required
+    case unreadableItem(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .zip64Required:
+            return "The archive exceeds the limits of the ZIP format without ZIP64 extensions."
+        case let .unreadableItem(path):
+            return "The item at \(path) could not be read while archiving."
+        }
+    }
+}
+
+private struct PlannedEntry: Sendable {
+    enum Kind: Sendable {
+        case file
+        case directory
+        case symlink
+    }
+
+    let path: AbsolutePath
+    let name: String
+    let kind: Kind
+    let permissions: UInt16
+    let modificationDate: Date
+    let uncompressedSize: Int64
+}
+
+private struct CompressedPayload: Sendable {
+    let compressionMethod: UInt16
+    let checksum: UInt32
+    let compressedSize: Int64
+    let uncompressedSize: Int64
+    let inlineData: Data?
+    let blobPath: AbsolutePath?
+
+    static func empty(method: UInt16 = 0) -> CompressedPayload {
+        CompressedPayload(
+            compressionMethod: method,
+            checksum: 0,
+            compressedSize: 0,
+            uncompressedSize: 0,
+            inlineData: Data(),
+            blobPath: nil
+        )
+    }
+}
+
+private enum ZipContainer {
+    static let localHeaderSignature: UInt32 = 0x0403_4B50
+    static let centralDirectorySignature: UInt32 = 0x0201_4B50
+    static let endOfCentralDirectorySignature: UInt32 = 0x0605_4B50
+    static let versionNeededToExtract: UInt16 = 20
+    static let versionMadeBy: UInt16 = 789
+    static let utf8NameFlag: UInt16 = 1 << 11
+    static let localHeaderByteCount = 30
+
+    static func localHeader(for entry: PlannedEntry, payload: CompressedPayload) -> Data {
+        let name = Data(entry.name.utf8)
+        let (time, date) = dosTimestamp(from: entry.modificationDate)
+        var header = Data()
+        header.appendLittleEndian(localHeaderSignature)
+        header.appendLittleEndian(versionNeededToExtract)
+        header.appendLittleEndian(utf8NameFlag)
+        header.appendLittleEndian(payload.compressionMethod)
+        header.appendLittleEndian(time)
+        header.appendLittleEndian(date)
+        header.appendLittleEndian(payload.checksum)
+        header.appendLittleEndian(UInt32(payload.compressedSize))
+        header.appendLittleEndian(UInt32(payload.uncompressedSize))
+        header.appendLittleEndian(UInt16(name.count))
+        header.appendLittleEndian(UInt16(0))
+        header.append(name)
+        return header
+    }
+
+    static func centralDirectoryHeader(
+        for entry: PlannedEntry,
+        payload: CompressedPayload,
+        localHeaderOffset: Int64
+    ) -> Data {
+        let name = Data(entry.name.utf8)
+        let (time, date) = dosTimestamp(from: entry.modificationDate)
+        var header = Data()
+        header.appendLittleEndian(centralDirectorySignature)
+        header.appendLittleEndian(versionMadeBy)
+        header.appendLittleEndian(versionNeededToExtract)
+        header.appendLittleEndian(utf8NameFlag)
+        header.appendLittleEndian(payload.compressionMethod)
+        header.appendLittleEndian(time)
+        header.appendLittleEndian(date)
+        header.appendLittleEndian(payload.checksum)
+        header.appendLittleEndian(UInt32(payload.compressedSize))
+        header.appendLittleEndian(UInt32(payload.uncompressedSize))
+        header.appendLittleEndian(UInt16(name.count))
+        header.appendLittleEndian(UInt16(0))
+        header.appendLittleEndian(UInt16(0))
+        header.appendLittleEndian(UInt16(0))
+        header.appendLittleEndian(UInt16(0))
+        header.appendLittleEndian(externalAttributes(for: entry))
+        header.appendLittleEndian(UInt32(localHeaderOffset))
+        header.append(name)
+        return header
+    }
+
+    static func endOfCentralDirectory(entryCount: Int, byteCount: Int, offset: Int64) -> Data {
+        var end = Data()
+        end.appendLittleEndian(endOfCentralDirectorySignature)
+        end.appendLittleEndian(UInt16(0))
+        end.appendLittleEndian(UInt16(0))
+        end.appendLittleEndian(UInt16(entryCount))
+        end.appendLittleEndian(UInt16(entryCount))
+        end.appendLittleEndian(UInt32(byteCount))
+        end.appendLittleEndian(UInt32(offset))
+        end.appendLittleEndian(UInt16(0))
+        return end
+    }
+
+    static func externalAttributes(for entry: PlannedEntry) -> UInt32 {
+        let type: UInt16
+        switch entry.kind {
+        case .file: type = UInt16(S_IFREG)
+        case .directory: type = UInt16(S_IFDIR)
+        case .symlink: type = UInt16(S_IFLNK)
+        }
+        return UInt32(type | entry.permissions) << 16
+    }
+
+    static func dosTimestamp(from date: Date) -> (time: UInt16, date: UInt16) {
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        let year = components.year ?? 1980
+        guard year >= 1980, year <= 2107 else { return (0, 33) }
+        let time = UInt16((components.hour ?? 0) << 11 | (components.minute ?? 0) << 5 | ((components.second ?? 0) / 2))
+        let dosDate = UInt16((year - 1980) << 9 | (components.month ?? 1) << 5 | (components.day ?? 1))
+        return (time, dosDate)
+    }
+}
+
+/// Writes a ZIP archive whose entries are deflated concurrently.
+///
+/// The format compresses entries independently, so the encoder does not have to
+/// be the serial bottleneck it is when entries are written one at a time. The
+/// container itself is assembled sequentially in enumeration order.
+struct ParallelZipWriter {
+    private static let inlineCompressionLimit: Int64 = 1024 * 1024
+    private static let bufferSize = 256 * 1024
+
+    private let concurrency: Int
+
+    init(concurrency: Int = ProcessInfo.processInfo.activeProcessorCount) {
+        self.concurrency = max(1, concurrency)
+    }
+
+    func write(contentsOf source: AbsolutePath, to destination: AbsolutePath) async throws {
+        let entries = try plannedEntries(in: source)
+        guard entries.count <= Int(UInt16.max) else { throw ParallelZipWriterError.zip64Required }
+
+        let scratch = try scratchDirectory(nextTo: destination)
+        defer { try? FileManager.default.removeItem(atPath: scratch.pathString) }
+
+        let payloads = try await compress(entries, into: scratch)
+        try requireNonZip64(entries: entries, payloads: payloads)
+        try assemble(entries: entries, payloads: payloads, at: destination)
+    }
+
+    // MARK: - Planning
+
+    private func plannedEntries(in source: AbsolutePath) throws -> [PlannedEntry] {
+        let fileManager = FileManager()
+        return try fileManager.subpathsOfDirectory(atPath: source.pathString).sorted().map { subpath in
+            let path = source.appending(try RelativePath(validating: subpath))
+            let attributes = try fileManager.attributesOfItem(atPath: path.pathString)
+            let permissions = (attributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0o644
+            let kind: PlannedEntry.Kind
+            switch attributes[.type] as? FileAttributeType {
+            case .typeDirectory: kind = .directory
+            case .typeSymbolicLink: kind = .symlink
+            default: kind = .file
+            }
+            return PlannedEntry(
+                path: path,
+                name: kind == .directory ? "\(subpath)/" : subpath,
+                kind: kind,
+                permissions: permissions,
+                modificationDate: attributes[.modificationDate] as? Date ?? Date(),
+                uncompressedSize: kind == .file ? ((attributes[.size] as? NSNumber)?.int64Value ?? 0) : 0
+            )
+        }
+    }
+
+    // MARK: - Compression
+
+    private func compress(_ entries: [PlannedEntry], into scratch: AbsolutePath) async throws -> [CompressedPayload] {
+        var payloads = [CompressedPayload?](repeating: nil, count: entries.count)
+
+        try await withThrowingTaskGroup(of: (Int, CompressedPayload).self) { group in
+            var next = 0
+            for _ in 0 ..< min(concurrency, entries.count) {
+                let index = next
+                group.addTask { (index, try Self.payload(for: entries[index], index: index, scratch: scratch)) }
+                next += 1
+            }
+            while let (index, payload) = try await group.next() {
+                payloads[index] = payload
+                if next < entries.count {
+                    let index = next
+                    group.addTask { (index, try Self.payload(for: entries[index], index: index, scratch: scratch)) }
+                    next += 1
+                }
+            }
+        }
+
+        return payloads.compactMap { $0 }
+    }
+
+    private static func payload(for entry: PlannedEntry, index: Int, scratch: AbsolutePath) throws -> CompressedPayload {
+        switch entry.kind {
+        case .directory:
+            return .empty()
+        case .symlink:
+            let target = try FileManager().destinationOfSymbolicLink(atPath: entry.path.pathString)
+            let data = Data(target.utf8)
+            return CompressedPayload(
+                compressionMethod: 0,
+                checksum: data.crc32(checksum: 0),
+                compressedSize: Int64(data.count),
+                uncompressedSize: Int64(data.count),
+                inlineData: data,
+                blobPath: nil
+            )
+        case .file:
+            guard entry.uncompressedSize > 0 else { return .empty() }
+            return try deflate(entry, index: index, scratch: scratch)
+        }
+    }
+
+    private static func deflate(_ entry: PlannedEntry, index: Int, scratch: AbsolutePath) throws -> CompressedPayload {
+        guard let input = FileHandle(forReadingAtPath: entry.path.pathString) else {
+            throw ParallelZipWriterError.unreadableItem(entry.path.pathString)
+        }
+        defer { try? input.close() }
+        let provider: Provider = { _, size in try input.read(upToCount: size) ?? Data() }
+
+        if entry.uncompressedSize <= inlineCompressionLimit {
+            var output = Data()
+            let checksum = try Data.compress(
+                size: entry.uncompressedSize,
+                bufferSize: bufferSize,
+                provider: provider,
+                consumer: { output.append($0) }
+            )
+            return CompressedPayload(
+                compressionMethod: 8,
+                checksum: checksum,
+                compressedSize: Int64(output.count),
+                uncompressedSize: entry.uncompressedSize,
+                inlineData: output,
+                blobPath: nil
+            )
+        }
+
+        let blobPath = scratch.appending(component: "\(index).deflate")
+        FileManager.default.createFile(atPath: blobPath.pathString, contents: nil)
+        guard let output = FileHandle(forWritingAtPath: blobPath.pathString) else {
+            throw ParallelZipWriterError.unreadableItem(blobPath.pathString)
+        }
+        defer { try? output.close() }
+        var written: Int64 = 0
+        let checksum = try Data.compress(
+            size: entry.uncompressedSize,
+            bufferSize: bufferSize,
+            provider: provider,
+            consumer: { chunk in
+                try output.write(contentsOf: chunk)
+                written += Int64(chunk.count)
+            }
+        )
+        try output.close()
+
+        return CompressedPayload(
+            compressionMethod: 8,
+            checksum: checksum,
+            compressedSize: written,
+            uncompressedSize: entry.uncompressedSize,
+            inlineData: nil,
+            blobPath: blobPath
+        )
+    }
+
+    // MARK: - Assembly
+
+    private func assemble(
+        entries: [PlannedEntry],
+        payloads: [CompressedPayload],
+        at destination: AbsolutePath
+    ) throws {
+        FileManager.default.createFile(atPath: destination.pathString, contents: nil)
+        guard let output = FileHandle(forWritingAtPath: destination.pathString) else {
+            throw ParallelZipWriterError.unreadableItem(destination.pathString)
+        }
+        defer { try? output.close() }
+
+        var centralDirectory = Data()
+        var offset: Int64 = 0
+
+        for (entry, payload) in zip(entries, payloads) {
+            let header = ZipContainer.localHeader(for: entry, payload: payload)
+            try output.write(contentsOf: header)
+            centralDirectory.append(
+                ZipContainer.centralDirectoryHeader(for: entry, payload: payload, localHeaderOffset: offset)
+            )
+            try writeBody(of: payload, to: output)
+            offset += Int64(header.count) + payload.compressedSize
+        }
+
+        try output.write(contentsOf: centralDirectory)
+        try output.write(
+            contentsOf: ZipContainer.endOfCentralDirectory(
+                entryCount: entries.count,
+                byteCount: centralDirectory.count,
+                offset: offset
+            )
+        )
+    }
+
+    private func writeBody(of payload: CompressedPayload, to output: FileHandle) throws {
+        if let inlineData = payload.inlineData {
+            guard !inlineData.isEmpty else { return }
+            try output.write(contentsOf: inlineData)
+        } else if let blobPath = payload.blobPath {
+            guard let input = FileHandle(forReadingAtPath: blobPath.pathString) else {
+                throw ParallelZipWriterError.unreadableItem(blobPath.pathString)
+            }
+            defer { try? input.close() }
+            while let chunk = try input.read(upToCount: Self.bufferSize), !chunk.isEmpty {
+                try output.write(contentsOf: chunk)
+            }
+        }
+    }
+
+    private func requireNonZip64(entries: [PlannedEntry], payloads: [CompressedPayload]) throws {
+        let limit = Int64(UInt32.max)
+        var total: Int64 = 0
+        for (entry, payload) in zip(entries, payloads) {
+            guard payload.compressedSize <= limit, payload.uncompressedSize <= limit else {
+                throw ParallelZipWriterError.zip64Required
+            }
+            total += Int64(ZipContainer.localHeaderByteCount + entry.name.utf8.count) + payload.compressedSize
+            guard total <= limit else { throw ParallelZipWriterError.zip64Required }
+        }
+    }
+
+    private func scratchDirectory(nextTo destination: AbsolutePath) throws -> AbsolutePath {
+        let path = destination.parentDirectory.appending(component: ".\(UUID().uuidString)-deflate")
+        try FileManager.default.createDirectory(atPath: path.pathString, withIntermediateDirectories: true)
+        return path
+    }
+}
+
+extension Data {
+    fileprivate mutating func appendLittleEndian(_ value: UInt16) {
+        append(contentsOf: [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)])
+    }
+
+    fileprivate mutating func appendLittleEndian(_ value: UInt32) {
+        append(contentsOf: [
+            UInt8(value & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 24) & 0xFF),
+        ])
+    }
+}

--- a/cli/Sources/TuistSupport/Utils/ParallelZipWriter.swift
+++ b/cli/Sources/TuistSupport/Utils/ParallelZipWriter.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import ZIPFoundation
@@ -154,21 +155,30 @@ struct ParallelZipWriter {
     private static let bufferSize = 256 * 1024
 
     private let concurrency: Int
+    private let fileSystem: FileSysteming
 
-    init(concurrency: Int = ProcessInfo.processInfo.activeProcessorCount) {
+    init(
+        concurrency: Int = ProcessInfo.processInfo.activeProcessorCount,
+        fileSystem: FileSysteming = FileSystem()
+    ) {
         self.concurrency = max(1, concurrency)
+        self.fileSystem = fileSystem
     }
 
     func write(contentsOf source: AbsolutePath, to destination: AbsolutePath) async throws {
         let entries = try plannedEntries(in: source)
         guard entries.count <= Int(UInt16.max) else { throw ParallelZipWriterError.zip64Required }
 
-        let scratch = try scratchDirectory(nextTo: destination)
-        defer { try? FileManager.default.removeItem(atPath: scratch.pathString) }
-
-        let payloads = try await compress(entries, into: scratch)
-        try requireNonZip64(entries: entries, payloads: payloads)
-        try assemble(entries: entries, payloads: payloads, at: destination)
+        let scratch = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-parallel-zip")
+        do {
+            let payloads = try await compress(entries, into: scratch)
+            try requireNonZip64(entries: entries, payloads: payloads)
+            try assemble(entries: entries, payloads: payloads, at: destination)
+        } catch {
+            try? await fileSystem.remove(scratch)
+            throw error
+        }
+        try await fileSystem.remove(scratch)
     }
 
     // MARK: - Planning
@@ -356,12 +366,6 @@ struct ParallelZipWriter {
             total += Int64(ZipContainer.localHeaderByteCount + entry.name.utf8.count) + payload.compressedSize
             guard total <= limit else { throw ParallelZipWriterError.zip64Required }
         }
-    }
-
-    private func scratchDirectory(nextTo destination: AbsolutePath) throws -> AbsolutePath {
-        let path = destination.parentDirectory.appending(component: ".\(UUID().uuidString)-deflate")
-        try FileManager.default.createDirectory(atPath: path.pathString, withIntermediateDirectories: true)
-        return path
     }
 }
 

--- a/cli/Tests/TuistKitTests/Services/RunCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/RunCommandServiceTests.swift
@@ -374,7 +374,7 @@ struct RunCommandServiceTests {
             .willReturn(.test(url: .test()))
 
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(nil)
 
         // When / Then
@@ -423,7 +423,7 @@ struct RunCommandServiceTests {
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
 
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -478,7 +478,7 @@ struct RunCommandServiceTests {
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
 
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -599,7 +599,7 @@ struct RunCommandServiceTests {
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
 
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -669,7 +669,7 @@ struct RunCommandServiceTests {
 
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -737,7 +737,7 @@ struct RunCommandServiceTests {
 
         let downloadedArchive = try AbsolutePath(validating: "/tmp/archive")
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -795,7 +795,7 @@ struct RunCommandServiceTests {
 
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()
@@ -904,7 +904,7 @@ struct RunCommandServiceTests {
         let downloadedArchive = temporaryDirectory.appending(component: "archive")
 
         given(remoteArtifactDownloader)
-            .download(url: .any)
+            .download(url: .any, progress: .any)
             .willReturn(downloadedArchive)
 
         let fileUnarchiver = MockFileUnarchiving()

--- a/cli/Tests/TuistServerTests/Utilities/RemoteArtifactDownloaderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/RemoteArtifactDownloaderTests.swift
@@ -1,0 +1,199 @@
+import FileSystem
+import Foundation
+import Path
+import Testing
+import TuistHTTP
+
+@testable import TuistServer
+
+@Suite(.serialized)
+struct RemoteArtifactDownloaderTests {
+    private let fileSystem = FileSystem()
+    private let url = URL(string: "https://storage.tuist.dev/artifacts/preview.zip")!
+
+    private func makeSubject(chunkByteCount: Int64) -> RemoteArtifactDownloader {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ArtifactURLProtocol.self]
+        return RemoteArtifactDownloader(
+            urlSession: URLSession(configuration: configuration),
+            retryProvider: RetryProvider(maximumRetryCount: 3, delayProvider: NoDelayProvider()),
+            chunkByteCount: chunkByteCount
+        )
+    }
+
+    @Test func download_resumes_from_the_last_received_byte_when_the_connection_drops() async throws {
+        let payload = Data((0 ..< 5000).map { UInt8($0 % 251) })
+        ArtifactURLProtocol.reset(payload: payload)
+        ArtifactURLProtocol.failRequestsStartingAt = [2000]
+
+        let downloaded = try #require(try await makeSubject(chunkByteCount: 1000).download(url: url))
+
+        #expect(try Data(contentsOf: downloaded.url) == payload)
+        #expect(
+            ArtifactURLProtocol.requestedRanges == [
+                "bytes=0-999",
+                "bytes=1000-1999",
+                "bytes=2000-2999",
+                "bytes=2000-2999",
+                "bytes=3000-3999",
+                "bytes=4000-4999",
+            ]
+        )
+    }
+
+    @Test func download_sends_the_validator_of_the_first_response_on_subsequent_requests() async throws {
+        ArtifactURLProtocol.reset(payload: Data(repeating: 7, count: 2500))
+
+        _ = try await makeSubject(chunkByteCount: 1000).download(url: url)
+
+        #expect(ArtifactURLProtocol.requestedValidators == [nil, "\"artifact-etag\"", "\"artifact-etag\""])
+    }
+
+    @Test func download_reports_progress_up_to_the_total_size() async throws {
+        ArtifactURLProtocol.reset(payload: Data(repeating: 1, count: 2500))
+        let subject = makeSubject(chunkByteCount: 1000)
+        let (progressUpdates, continuation) = AsyncStream<RemoteArtifactDownloadProgress>.makeStream()
+
+        async let downloaded = subject.download(url: url, progress: continuation)
+        var recorded: [RemoteArtifactDownloadProgress] = []
+        for await progress in progressUpdates {
+            recorded.append(progress)
+        }
+        _ = try await downloaded
+
+        #expect(
+            recorded == [
+                RemoteArtifactDownloadProgress(downloadedBytes: 1000, totalBytes: 2500),
+                RemoteArtifactDownloadProgress(downloadedBytes: 2000, totalBytes: 2500),
+                RemoteArtifactDownloadProgress(downloadedBytes: 2500, totalBytes: 2500),
+            ]
+        )
+    }
+
+    @Test func download_finishes_the_progress_stream_when_the_download_fails() async throws {
+        ArtifactURLProtocol.reset(payload: Data())
+        ArtifactURLProtocol.statusCode = 403
+        let subject = makeSubject(chunkByteCount: 1000)
+        let (progressUpdates, continuation) = AsyncStream<RemoteArtifactDownloadProgress>.makeStream()
+
+        let downloaded = Task { try await subject.download(url: url, progress: continuation) }
+        for await _ in progressUpdates {}
+
+        await #expect(throws: RemoteArtifactDownloadStatusCodeError(url: url, httpStatusCode: 403)) {
+            try await downloaded.value
+        }
+    }
+
+    @Test func download_returns_the_whole_artifact_when_the_server_ignores_ranges() async throws {
+        let payload = Data((0 ..< 4000).map { UInt8($0 % 251) })
+        ArtifactURLProtocol.reset(payload: payload)
+        ArtifactURLProtocol.supportsRanges = false
+
+        let downloaded = try #require(try await makeSubject(chunkByteCount: 1000).download(url: url))
+
+        #expect(try Data(contentsOf: downloaded.url) == payload)
+        #expect(ArtifactURLProtocol.requestedRanges.count == 1)
+    }
+
+    @Test func download_returns_nil_when_the_artifact_is_not_found() async throws {
+        ArtifactURLProtocol.reset(payload: Data())
+        ArtifactURLProtocol.statusCode = 404
+
+        #expect(try await makeSubject(chunkByteCount: 1000).download(url: url) == nil)
+    }
+
+    @Test func download_does_not_retry_a_permanent_client_error() async throws {
+        ArtifactURLProtocol.reset(payload: Data())
+        ArtifactURLProtocol.statusCode = 403
+
+        await #expect(throws: RemoteArtifactDownloadStatusCodeError(url: url, httpStatusCode: 403)) {
+            try await makeSubject(chunkByteCount: 1000).download(url: url)
+        }
+        #expect(ArtifactURLProtocol.requestedRanges.count == 1)
+    }
+}
+
+private struct NoDelayProvider: DelayProviding {
+    func delay(for _: Int) -> UInt64 { 0 }
+}
+
+private final class ArtifactURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var payload = Data()
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var supportsRanges = true
+    nonisolated(unsafe) static var failRequestsStartingAt: Set<Int> = []
+    nonisolated(unsafe) static var requestedRanges: [String] = []
+    nonisolated(unsafe) static var requestedValidators: [String?] = []
+
+    static func reset(payload: Data) {
+        self.payload = payload
+        statusCode = 200
+        supportsRanges = true
+        failRequestsStartingAt = []
+        requestedRanges = []
+        requestedValidators = []
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let rangeHeader = request.value(forHTTPHeaderField: "Range")
+        Self.requestedRanges.append(rangeHeader ?? "")
+        Self.requestedValidators.append(request.value(forHTTPHeaderField: "If-Range"))
+
+        guard Self.statusCode == 200 else {
+            respond(statusCode: Self.statusCode, body: Data(), headerFields: [:])
+            return
+        }
+
+        let start = rangeHeader.flatMap(Self.start(ofRange:)) ?? 0
+        if Self.failRequestsStartingAt.contains(start) {
+            Self.failRequestsStartingAt.remove(start)
+            client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+            return
+        }
+
+        guard Self.supportsRanges, let rangeHeader, let requested = Self.range(of: rangeHeader) else {
+            respond(statusCode: 200, body: Self.payload, headerFields: ["ETag": "\"artifact-etag\""])
+            return
+        }
+
+        let end = min(requested.upperBound, Self.payload.count - 1)
+        let body = Self.payload.subdata(in: requested.lowerBound ..< (end + 1))
+        respond(
+            statusCode: 206,
+            body: body,
+            headerFields: [
+                "ETag": "\"artifact-etag\"",
+                "Content-Range": "bytes \(requested.lowerBound)-\(end)/\(Self.payload.count)",
+            ]
+        )
+    }
+
+    override func stopLoading() {}
+
+    private func respond(statusCode: Int, body: Data, headerFields: [String: String]) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headerFields
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private static func start(ofRange header: String) -> Int? {
+        range(of: header)?.lowerBound
+    }
+
+    private static func range(of header: String) -> ClosedRange<Int>? {
+        guard header.hasPrefix("bytes=") else { return nil }
+        let bounds = header.dropFirst("bytes=".count).split(separator: "-")
+        guard bounds.count == 2, let start = Int(bounds[0]), let end = Int(bounds[1]), start <= end else { return nil }
+        return start ... end
+    }
+}

--- a/cli/Tests/TuistServerTests/Utilities/RemoteArtifactDownloaderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/RemoteArtifactDownloaderTests.swift
@@ -1,4 +1,5 @@
 import FileSystem
+import FileSystemTesting
 import Foundation
 import Path
 import Testing
@@ -11,13 +12,14 @@ struct RemoteArtifactDownloaderTests {
     private let fileSystem = FileSystem()
     private let url = URL(string: "https://storage.tuist.dev/artifacts/preview.zip")!
 
-    private func makeSubject(chunkByteCount: Int64) -> RemoteArtifactDownloader {
+    private func makeSubject(chunkByteCount: Int64, downloadsDirectory: AbsolutePath? = nil) -> RemoteArtifactDownloader {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [ArtifactURLProtocol.self]
         return RemoteArtifactDownloader(
             urlSession: URLSession(configuration: configuration),
             retryProvider: RetryProvider(maximumRetryCount: 3, delayProvider: NoDelayProvider()),
-            chunkByteCount: chunkByteCount
+            chunkByteCount: chunkByteCount,
+            downloadsDirectory: downloadsDirectory
         )
     }
 
@@ -102,6 +104,42 @@ struct RemoteArtifactDownloaderTests {
         #expect(try await makeSubject(chunkByteCount: 1000).download(url: url) == nil)
     }
 
+    @Test(.inTemporaryDirectory) func download_keeps_only_the_artifact_when_it_succeeds() async throws {
+        let downloads = try #require(FileSystem.temporaryTestDirectory)
+        ArtifactURLProtocol.reset(payload: Data(repeating: 3, count: 2500))
+
+        let downloaded = try #require(
+            try await makeSubject(chunkByteCount: 1000, downloadsDirectory: downloads).download(url: url)
+        )
+
+        #expect(downloaded.parentDirectory == downloads)
+        #expect(try await fileSystem.glob(directory: downloads, include: ["*"]).collect() == [downloaded])
+    }
+
+    @Test(.inTemporaryDirectory) func download_removes_the_partial_artifact_when_it_fails() async throws {
+        let downloads = try #require(FileSystem.temporaryTestDirectory)
+        ArtifactURLProtocol.reset(payload: Data((0 ..< 5000).map { UInt8($0 % 251) }))
+        ArtifactURLProtocol.failRequestsStartingAt = [2000]
+        ArtifactURLProtocol.failuresAreUnrecoverable = true
+
+        await #expect(throws: (any Error).self) {
+            try await makeSubject(chunkByteCount: 1000, downloadsDirectory: downloads).download(url: url)
+        }
+
+        #expect(try await fileSystem.glob(directory: downloads, include: ["*"]).collect().isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory) func download_removes_the_artifact_when_it_is_not_found() async throws {
+        let downloads = try #require(FileSystem.temporaryTestDirectory)
+        ArtifactURLProtocol.reset(payload: Data())
+        ArtifactURLProtocol.statusCode = 404
+
+        let downloaded = try await makeSubject(chunkByteCount: 1000, downloadsDirectory: downloads).download(url: url)
+
+        #expect(downloaded == nil)
+        #expect(try await fileSystem.glob(directory: downloads, include: ["*"]).collect().isEmpty)
+    }
+
     @Test func download_does_not_retry_a_permanent_client_error() async throws {
         ArtifactURLProtocol.reset(payload: Data())
         ArtifactURLProtocol.statusCode = 403
@@ -122,6 +160,7 @@ private final class ArtifactURLProtocol: URLProtocol {
     nonisolated(unsafe) static var statusCode = 200
     nonisolated(unsafe) static var supportsRanges = true
     nonisolated(unsafe) static var failRequestsStartingAt: Set<Int> = []
+    nonisolated(unsafe) static var failuresAreUnrecoverable = false
     nonisolated(unsafe) static var requestedRanges: [String] = []
     nonisolated(unsafe) static var requestedValidators: [String?] = []
 
@@ -130,6 +169,7 @@ private final class ArtifactURLProtocol: URLProtocol {
         statusCode = 200
         supportsRanges = true
         failRequestsStartingAt = []
+        failuresAreUnrecoverable = false
         requestedRanges = []
         requestedValidators = []
     }
@@ -150,7 +190,7 @@ private final class ArtifactURLProtocol: URLProtocol {
 
         let start = rangeHeader.flatMap(Self.start(ofRange:)) ?? 0
         if Self.failRequestsStartingAt.contains(start) {
-            Self.failRequestsStartingAt.remove(start)
+            if !Self.failuresAreUnrecoverable { Self.failRequestsStartingAt.remove(start) }
             client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
             return
         }

--- a/cli/Tests/TuistSupportTests/Utils/FileArchiverTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/FileArchiverTests.swift
@@ -17,27 +17,100 @@ struct FileArchiverTests {
         try await fileSystem.writeText(content, at: directory.appending(component: "Binary"))
         let contentSize = try #require(try await fileSystem.fileMetadata(at: directory.appending(component: "Binary"))?.size)
 
-        let subject = try FileArchiver(paths: [directory])
-        let archivePath = try await subject.zip(name: "App")
+        let archivePath = try await FileArchiver(paths: [directory]).zip(name: "App")
 
         let archiveSize = try #require(try await fileSystem.fileMetadata(at: archivePath)?.size)
         #expect(archiveSize < contentSize / 2)
     }
 
-    @Test(.inTemporaryDirectory) func zip_produces_an_archive_that_unarchives_to_the_original_content() async throws {
+    @Test(.inTemporaryDirectory) func zip_round_trips_files_directories_symlinks_and_permissions() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let directory = temporaryDirectory.appending(component: "App.app")
+        let directory = try await makeBundle(in: temporaryDirectory)
+
+        let archivePath = try await FileArchiver(paths: [directory]).zip(name: "App")
+        let unarchived = try await FileUnarchiver(path: archivePath).unzip()
+
+        try await expectBundleRestored(at: unarchived.appending(component: "App.app"))
+    }
+
+    @Test(.inTemporaryDirectory) func zip_produces_an_archive_an_independent_implementation_can_read() async throws {
+        let unzip = "/usr/bin/unzip"
+        try #require(FileManager.default.isExecutableFile(atPath: unzip))
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = try await makeBundle(in: temporaryDirectory)
+
+        let archivePath = try await FileArchiver(paths: [directory]).zip(name: "App")
+
+        #expect(try run(unzip, ["-t", archivePath.pathString]).contains("No errors detected"))
+        let extracted = temporaryDirectory.appending(component: "extracted")
+        _ = try run(unzip, ["-q", archivePath.pathString, "-d", extracted.pathString])
+        try await expectBundleRestored(at: extracted.appending(component: "App.app"))
+    }
+
+    @Test(.inTemporaryDirectory) func zip_archives_an_empty_directory() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = temporaryDirectory.appending(component: "Empty.app")
         try await fileSystem.makeDirectory(at: directory)
-        let content = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 1000)
-        try await fileSystem.writeText(content, at: directory.appending(component: "Binary"))
 
-        let subject = try FileArchiver(paths: [directory])
-        let archivePath = try await subject.zip(name: "App")
-        let unarchivedDirectory = try await FileUnarchiver(path: archivePath).unzip()
+        let archivePath = try await FileArchiver(paths: [directory]).zip(name: "Empty")
+        let unarchived = try await FileUnarchiver(path: archivePath).unzip()
 
-        let unarchivedContent = try await fileSystem.readTextFile(
-            at: unarchivedDirectory.appending(components: "App.app", "Binary")
+        #expect(try await fileSystem.exists(unarchived.appending(component: "Empty.app"), isDirectory: true))
+    }
+
+    // MARK: - Helpers
+
+    private func makeBundle(in temporaryDirectory: AbsolutePath) async throws -> AbsolutePath {
+        let directory = temporaryDirectory.appending(component: "App.app")
+        try await fileSystem.makeDirectory(at: directory.appending(component: "Frameworks"))
+        try await fileSystem.writeText(
+            String(repeating: "executable payload ", count: 50000),
+            at: directory.appending(component: "App")
         )
-        #expect(unarchivedContent == content)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: directory.appending(component: "App").pathString
+        )
+        try await fileSystem.writeText("{}", at: directory.appending(components: "Frameworks", "Info.plist"))
+        try await fileSystem.touch(directory.appending(component: "Empty"))
+        try await fileSystem.writeText("ünïcödé", at: directory.appending(component: "Ünïcödé.txt"))
+        try FileManager.default.createSymbolicLink(
+            atPath: directory.appending(component: "Current").pathString,
+            withDestinationPath: "Frameworks"
+        )
+        return directory
+    }
+
+    private func expectBundleRestored(at bundle: AbsolutePath) async throws {
+        #expect(
+            try await fileSystem.readTextFile(at: bundle.appending(component: "App"))
+                == String(repeating: "executable payload ", count: 50000)
+        )
+        #expect(try await fileSystem.readTextFile(at: bundle.appending(components: "Frameworks", "Info.plist")) == "{}")
+        #expect(try await fileSystem.readTextFile(at: bundle.appending(component: "Ünïcödé.txt")) == "ünïcödé")
+        #expect(try await fileSystem.exists(bundle.appending(component: "Empty")))
+        #expect(try await fileSystem.exists(bundle.appending(component: "Frameworks"), isDirectory: true))
+
+        let permissions = try FileManager.default
+            .attributesOfItem(atPath: bundle.appending(component: "App").pathString)[.posixPermissions] as? NSNumber
+        #expect(permissions?.uint16Value == 0o755)
+
+        let linkPath = bundle.appending(component: "Current").pathString
+        let linkType = try FileManager.default.attributesOfItem(atPath: linkPath)[.type] as? FileAttributeType
+        #expect(linkType == .typeSymbolicLink)
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: linkPath) == "Frameworks")
+    }
+
+    private func run(_ launchPath: String, _ arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(bytes: data, encoding: .utf8) ?? ""
     }
 }

--- a/cli/Tests/TuistSupportTests/Utils/FileArchiverTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/FileArchiverTests.swift
@@ -1,0 +1,43 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistSupport
+
+struct FileArchiverTests {
+    private let fileSystem = FileSystem()
+
+    @Test(.inTemporaryDirectory) func zip_compresses_the_archived_content() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = temporaryDirectory.appending(component: "App.app")
+        try await fileSystem.makeDirectory(at: directory)
+        let content = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 100_000)
+        try await fileSystem.writeText(content, at: directory.appending(component: "Binary"))
+        let contentSize = try #require(try await fileSystem.fileMetadata(at: directory.appending(component: "Binary"))?.size)
+
+        let subject = try FileArchiver(paths: [directory])
+        let archivePath = try await subject.zip(name: "App")
+
+        let archiveSize = try #require(try await fileSystem.fileMetadata(at: archivePath)?.size)
+        #expect(archiveSize < contentSize / 2)
+    }
+
+    @Test(.inTemporaryDirectory) func zip_produces_an_archive_that_unarchives_to_the_original_content() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = temporaryDirectory.appending(component: "App.app")
+        try await fileSystem.makeDirectory(at: directory)
+        let content = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 1000)
+        try await fileSystem.writeText(content, at: directory.appending(component: "Binary"))
+
+        let subject = try FileArchiver(paths: [directory])
+        let archivePath = try await subject.zip(name: "App")
+        let unarchivedDirectory = try await FileUnarchiver(path: archivePath).unzip()
+
+        let unarchivedContent = try await fileSystem.readTextFile(
+            at: unarchivedDirectory.appending(components: "App.app", "Binary")
+        )
+        #expect(unarchivedContent == content)
+    }
+}


### PR DESCRIPTION
## What changed

Three independent defects on the `tuist run <preview-url>` path, all of which make downloading an app bundle preview slower and more fragile than it needs to be.

1. **Preview archives were written uncompressed.** `FileArchiver` now deflates instead of storing, roughly halving the bytes on the wire for a preview.
2. **A dropped connection discarded the entire download.** `RemoteArtifactDownloader` now fetches the artifact in ranged chunks, retries a failed chunk, and resumes from the last byte it already holds rather than restarting at zero.
3. **The download reported no progress.** `tuist run` now shows the percentage and the transferred and total sizes instead of a spinner that never changes.

## Why

A support report of a preview download that ran for seven minutes and then failed with `The network connection was lost.` The server, the artifact, and object storage were all healthy: the API answered in about a second, the object was intact, and the origin served it at full speed when measured directly. What made the failure severe was entirely on the client side.

## Root cause

**Compression.** `FileArchiver.zip` delegated to `FileSystem.zipFileOrDirectoryContent`, which calls ZIPFoundation's `FileManager.zipItem(at:to:shouldKeepParent:)`. That method's `compressionMethod` parameter defaults to `.none`, and nothing in the chain overrode it, so every archive Tuist produced was stored rather than deflated. Confirmed against a production preview archive by reading its central directory: every entry used method 0, and the compressed and uncompressed totals were identical. Mach-O binaries, which dominate an app bundle, deflate hard, so this was close to a factor of two on every byte transferred.

Note this affected app bundle previews only. An `.ipa` preview is uploaded as the file Xcode produced, and Xcode writes compressed archives, so device previews were never subject to this.

**Retry and resume.** `RemoteArtifactDownloader.download` issued a single `URLSession.shared.download(for:)`. There was no retry, so one transport error failed the command outright, and no resume, so all the bytes already transferred were thrown away. It also used `URLSession.shared` rather than [`URLSession.tuistLargeTransfer`](cli/Sources/TuistHTTP/URLSession+Tuist.swift), the session built for whole artifact transfers, so it silently opted out of the environment proxy, `TUIST_CA_CERTIFICATE`, and HAR recording.

**Progress.** `RunCommandService` wrapped the download in `progressStep { _ in ... }`, discarding the `updateProgress` closure the step provides. The message stayed at `Downloading preview...` for the whole transfer, which is why a long but healthy download is indistinguishable from a hung one.

## Approach, and what was rejected

**Entries are deflated concurrently.** A serial deflate encoder costs about 30s on a ~1 GiB bundle, which would land on every share. The format compresses entries independently, so `ParallelZipWriter` deflates them in parallel and assembles the container sequentially, reusing ZIPFoundation's public `Data.compress` and `Data.crc32` so the codec and checksum are unchanged. On 1 GiB across ~1,820 files: `zip -6` 28.1s / 235 MiB, `ditto -c -k` 30.2s / 237 MiB, this writer **8.0s / 238 MiB**. The remainder is dominated by the largest single entry, which a single deflate stream cannot split, so it is near the floor for the format. AppleArchive with LZFSE would reach ~3.3s but is not a ZIP, and these archives are read by already-released CLI versions and by the macOS app. Entries above 1 MiB compress into scratch files rather than memory, and inputs needing ZIP64 fall back to the serial encoder.

**Compression lives in the CLI rather than in `tuist/FileSystem`.** The compression method arguably belongs on `zipFileOrDirectoryContent`, but that is a separate package and a separate release. ZIPFoundation is already a direct dependency of `TuistSupport`, so calling it directly keeps the fix to one change. The blocking zip is dispatched off the cooperative pool, matching what `FileSystem` was doing.

**Resume is chunked rather than a single open ended range.** [`ArtifactResumeMiddleware`](cli/Sources/TuistHTTP/ArtifactResumeMiddleware.swift) already implements `Range` and `If-Range` resume with the same semantics, but it accumulates the artifact in memory and is scoped to OpenAPI operations. Preview archives are far too large to buffer, and this download is a raw request to a presigned URL, so the middleware does not apply. A single open ended range would have been simpler, but `URLSession.download(for:)` discards its temporary file when the transfer fails, so a failed attempt reports nothing about how far it got, and there is nothing to resume from. `URLSession.bytes(for:)` would give byte level progress, but it does not exist in swift-corelibs-foundation and this target builds for Linux. Fixed size ranged requests yield resume and progress from the same mechanism on both platforms.

The tradeoff is one extra round trip per chunk. At 16 MiB chunks that is tens of round trips across a large artifact, negligible against a transfer measured in minutes, and the session keeps the connection alive across them. A server that ignores `Range` still works: the first `200` is treated as the whole artifact.

**Progress is an `AsyncStream` continuation rather than a callback.** Noora's `progressStep` hands its body a non-escaping `updateProgress`, which cannot be captured by an escaping callback. `withoutActuallyEscaping` compiles but traps at runtime as soon as any implementation retains the closure, which the generated mock does. A continuation is `Sendable`, safe for any implementation to hold, and lets the call site consume updates inside the step body where the non-escaping closure is valid. The call site finishes the stream it created rather than relying on the downloader to close it, so consuming progress never depends on an implementation behaving correctly. A stubbed downloader that yields nothing simply produces no updates instead of hanging the caller. The download runs as a structured child via `async let` so cancelling the command cancels the transfer: an unstructured `Task` stops the progress iteration but leaves the download running, and the caller then blocks on its result.

**The downloader cleans up after itself.** It writes a single uniquely named temporary file and removes it in a `defer` unless the download completed, covering errors, cancellation, and the not-found path alike. Ownership on success is unchanged from before this branch: the caller owns the returned file and removes it. Cleanup goes through `FileManager` rather than `FileSystem.remove`, because the latter calls `Task.checkCancellation` and so does nothing on the cancellation path it most needs to cover.

## Impact

App bundle previews should be roughly half their current size once republished. Existing previews keep their current size until they are pushed again, since the archive is written at upload time. A preview download now survives a dropped connection instead of failing the command, and a resumed attempt costs the remainder rather than the whole artifact. `tuist run` reports transfer progress.

`FileArchiver` is shared, so analytics artifact uploads are compressed by this change as well.

## Validation

- `TuistSupportTests/FileArchiverTests`: red before the fix and green after. The archive is verified as a standard ZIP rather than merely self-consistent — one test round-trips through `FileUnarchiver` (the same ZIPFoundation read path shipped CLIs use) and another extracts with stock `unzip` and asserts the same expectations, both covering nested directories, symlinks, executable permissions, empty files and non-ASCII names. The compression assertion failed against the pre-fix code while the round trip assertion passed, which established that the archive was valid and merely uncompressed.
- `TuistServerTests/RemoteArtifactDownloaderTests`: covers resume after a dropped connection, asserting the exact sequence of `Range` headers so a silent restart from zero would fail the test; validator propagation via `If-Range`; progress values; the server ignoring ranges; a missing artifact; and a permanent client error not being retried.
- `TuistKitTests/RunCommandServiceTests`: unchanged behaviour, passing, checked against the pre-change baseline on a stashed tree so the comparison was against real numbers rather than an assumption.

All three suites were run together after the final edit. CI does not compile Swift on a draft PR, so this was verified locally.

- Cleanup is covered on the success, permanent-error, and not-found paths. Cancellation is not separately tested; it runs through the same `defer`.
- Cancellation propagation was confirmed with a standalone probe comparing the two shapes. Cancelled 120ms in, the unstructured `Task` still ran the work to completion 870ms later; `async let` cancelled and returned at 120ms.

Bug 2 was not given a synthetic pre-fix test. Its red is the production log from the support report: a single `-1005` after almost seven minutes, with no retry attempted.


