### PR TITLE
fix(infra): keep mark-ovh's verified rename alive across transient OVH errors

### DIFF
--- a/mise/tasks/baremetal/mark-ovh.sh
+++ b/mise/tasks/baremetal/mark-ovh.sh
@@ -64,7 +64,7 @@ ovh() {
   curl "${args[@]}"
 }
 
-service_id="$(ovh GET "/dedicated/server/${service}/serviceInfos" | grep -o '"serviceId":[0-9]*' | grep -o '[0-9]*' | head -1)"
+service_id="$(ovh GET "/dedicated/server/${service}/serviceInfos" | grep -o '"serviceId":[0-9]*' | grep -o '[0-9]*' | head -1 || true)"
 [ -z "$service_id" ] && { echo "could not resolve serviceId for ${service} (check creds / OVH_API_BASE entity)" >&2; exit 1; }
 
 # displayName lives on the service resource; OVH's /service/{id} API takes it
@@ -80,8 +80,13 @@ service_id="$(ovh GET "/dedicated/server/${service}/serviceInfos" | grep -o '"se
 # and looks like a broken adoption filter. One production box reached the fleet
 # in exactly that state.
 for attempt in 1 2 3 4 5 6; do
-  ovh PUT "/service/${service_id}" "{\"resource\":{\"displayName\":\"${display_name}\"}}" >/dev/null
-  observed="$(ovh GET "/service/${service_id}" | tr ',' '\n' | grep -o '"displayName":"[^"]*"' | head -1 | cut -d'"' -f4)"
+  # A transient OVH 5xx counts as one failed attempt, not the end of the loop:
+  # `ovh` runs curl -f under `set -e`, so an unguarded call aborts the script
+  # with a bare curl exit code over a write that may well have landed.
+  if ! ovh PUT "/service/${service_id}" "{\"resource\":{\"displayName\":\"${display_name}\"}}" >/dev/null; then
+    echo "  PUT /service/${service_id} failed on attempt ${attempt}; retrying" >&2
+  fi
+  observed="$(ovh GET "/service/${service_id}" | tr ',' '\n' | grep -o '"displayName":"[^"]*"' | head -1 | cut -d'"' -f4 || true)"
   if [ "$observed" = "$display_name" ]; then
     echo "✓ OVH ${service} (service ${service_id}) displayName set to '${display_name}'"
     exit 0


### PR DESCRIPTION
Re-marking the production `ap-southeast` Kura box surfaced a defect in the very script that is supposed to make that operation trustworthy.

### Background

`mise/tasks/baremetal/mark-ovh.sh` sets an OVH dedicated server's service displayName so a CAPI fleet can adopt it by `adoptDisplayNamePrefix`. OVH answers `PUT /service/{id}` with HTTP 200 and a null body whether or not the rename applied, and silently discards it while a task is pending on the server, which is exactly when `prep-ovh` calls it. The script therefore writes, reads back, and retries up to six times before failing loudly, so a discarded rename cannot print a success tick.

### Root cause

That retry loop could not survive the errors it exists to absorb. `ovh()` runs `curl -f` under `set -euo pipefail`, so a transient 5xx on either the PUT or the read-back GET aborted the whole script mid-loop with a bare `curl: (22)` and a non-zero exit, rather than counting as one failed attempt.

Hit for real while re-marking `ns5036444.ip-15-235-229.net`, the box backing the production `ap-southeast` Kura cache region: the PUT landed, the verification GET returned 500, and the task exited 22 having reported nothing. The write had actually applied.

That is the same false signal the read-back was added to eliminate, only inverted, and inverted in the more dangerous direction: it reports a rename that *did* apply as a failure. On a box serving a live customer-facing cache region that invites an operator to escalate to a Machine delete, which is precisely the outcome the marker exists to prevent. A replacement Machine would find nothing matching the prefix, the fleet would park at 0/1, and per `infra/cluster-api-provider-tuist/AGENTS.md` that also wedges `helm --wait` into an `--atomic` rollback.

### What changed

An API error inside the loop is now one failed attempt instead of the end of the loop, so the six retries cover transient failures as intended and the exit code is trustworthy on its own.

The `service_id` resolution is guarded the same way. It had the identical problem: the assignment aborted on the bare curl exit before the script's own "could not resolve serviceId (check creds / OVH_API_BASE entity)" hint could print, leaving a diagnostic the author had already written unreachable.

The obvious alternative, dropping `-f` from `curl` so calls never fail, was rejected: the script would then treat an HTML error page as a response body and the read-back would compare garbage against the expected name. Keeping `-f` and handling failure per attempt preserves the loud-failure guarantee that is the whole point of the read-back.

### Impact

Operator-facing only, with no runtime or deploy path involved. `baremetal:mark-ovh`, and `baremetal:prep-ovh` which calls it as its final step, now report the actual outcome instead of aborting on a transient API blip.

### Operational note

The box that prompted this is already fixed, independently of this PR. `ns5036444.ip-15-235-229.net` (service 10269958) now reads back `displayName: tuist-kura-ovh-production-ap-southeast`, confirmed by an independent `GET /service/{id}` after the task's own verification. Its Machine was never touched and is still Ready with an unchanged creationTimestamp.

All eight boxes on the account were audited against their fleets' `adoptDisplayNamePrefix` plus offer and datacenter, across `ovhFleets` and the singular `ovhFleet` in `values-managed-{production,staging,canary}.yaml`. That one box was the only mismatch. The other seven match, every enabled fleet is `replicas: 1` with exactly one matching box, and the prefixes are mutually disjoint, so no cross-env box can be claimed by the wrong fleet. That last point matters because all three environments' reconcilers share the one OVH account.

Worth considering as a follow-up, deliberately not in this PR: `adoptDisplayNamePrefix` is a mutable, human-set string on a third-party API with no reconciler-side drift detection, and `Status.ServiceName` masks a wrong name indefinitely, so the next occurrence would again only surface at the worst possible moment. A periodic assertion that each claimed box still matches its fleet's prefix would turn that silent trap into an alert.

### How to test locally

Needs the OVH API triple from 1Password with `PUT /service/*` scope. Note that `mark-ovh.sh` reads the credentials from the environment directly and ignores `PREP_NAMESPACE`, unlike `prep-ovh.sh` which derives the vault from it.

```bash
export OVH_APPLICATION_KEY="$(op read 'op://tuist-k8s-production/OVH_API/application-key')" OVH_APPLICATION_SECRET="$(op read 'op://tuist-k8s-production/OVH_API/application-secret')" OVH_CONSUMER_KEY="$(op read 'op://tuist-k8s-production/OVH_API/consumer-key')" && mise run baremetal:mark-ovh ns5036444.ip-15-235-229.net tuist-kura-ovh-production-ap-southeast
```

Validation actually run against the live `ovh-us` account:

- `shellcheck` and `bash -n` both clean.
- Idempotent re-run against the real box prints the tick and exits 0.
- An unresolvable service name still exits 1, now with the intended "check creds / OVH_API_BASE entity" diagnostic rather than only a bare curl exit code.
