### PR TITLE
fix(infra): repair a Linux node that bootstrapped without the kata runtime

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -233,7 +233,8 @@ infra/cluster-api-provider-tuist/
 │       ├── ovhdedicatedmachine_controller.go
 │       ├── scalewayelasticmetalmachine_controller.go
 │       ├── linux_cloudinit.go       # shared self-join script + kubelet config (Layers 2+3)
-│       └── kubelet_config_drift.go  # zero-downtime re-push of kubelet config to Ready nodes
+│       ├── kubelet_config_drift.go  # zero-downtime re-push of kubelet config to Ready nodes
+│       └── kata_runtime_drift.go    # detect + repair a node that joined without the kata runtime
 ├── internal/
 │   ├── scaleway/     # Scaleway SDK wrapper
 │   ├── credentials/  # fleet SSH keys + per-machine kubelet identities
@@ -261,6 +262,78 @@ MachineSet scale-up rather than at deploy time — and Helm does not backfill
 the field onto a live template (it patches these CRs manifest-to-manifest,
 so a field the live object never received is never added). Prefer an
 optional field with a controller-side default over a required one.
+
+## Bootstrap-time capabilities, and the once-at-bootstrap trap
+
+The Linux self-join is rendered **once**, at bootstrap
+(`renderLinuxBootstrapScript`), by whichever provider pod holds the leader lease
+at that moment. Nothing re-runs it. That makes every capability the script
+installs a one-shot decision, and it fails in a way that looks like anything but
+a provisioning bug.
+
+During a rolling provider upgrade the chart applies the new provider Deployment
+and the fleet MachineDeployments in the same release. With `maxUnavailable: 0`
+the OUTGOING pod keeps the lease until it terminates, so a Machine created in
+that window is bootstrapped by the OLD build — which decodes the CR fine and
+silently drops any spec field its Go struct does not have. On 2026-08-31 that
+put `kataRuntime: true` boxes into production and canary bootstrapped by
+`capi-scaleway@0.27.0`: Ready nodes, right pool, right taints, every DaemonSet
+running, no error logged anywhere, and not one job taken — because the
+`kata-qemu` RuntimeClass selects on a node label the old self-join never wrote.
+It read as a scheduling bug for about an hour and was cleared by hand with
+`kubectl delete machine`.
+
+Two things follow, and both are load-bearing:
+
+**Ordering cannot fix this inside one Helm release.** A `pre-upgrade` hook runs
+before the new provider image is applied, and moving the fleet
+MachineDeployments into a `post-upgrade` hook would take them out of the release
+(hook resources are not tracked, and the default delete policy would reap them).
+Splitting the provider into its own release ahead of the chart would work but
+serializes every deploy behind a rollout that can wedge it. Convergence, not
+ordering, is the answer.
+
+**`strategy: OnDelete` means a spec change never rolls the fleet either.**
+Flipping a bootstrap-time field on an existing MachineDeployment reaches exactly
+zero live machines. So in-place repair is not just the nicer fix — it is the only
+mechanism that converges at all.
+
+### Adding a bootstrap-time capability
+
+Anything the self-join installs that the node's schedulability depends on needs
+all three of these, or it inherits the trap:
+
+1. **An observable on the Node.** The check must read what actually decides the
+   outcome — for kata that is the `katacontainers.io/kata-runtime` label the
+   RuntimeClass selects on, not a provider version or a status flag, so a node
+   that passes the check is one the scheduler will really place Pods on.
+2. **A check on the Ready path**, next to `reconcileLinuxKataRuntimeDrift`, that
+   reconciles that observable against the spec. Both paths render from one
+   `hostOptions` builder (`ovhdedicatedmachine_controller.go`) so a new field
+   reaches the bootstrap and the repair together rather than by remembering two
+   call sites.
+3. **A repair that is additive, never a re-bootstrap.** These boxes run live
+   jobs, and the Kura cache boxes hold local state a reinstall destroys. The kata
+   repair installs the runtime, registers the containerd handler, re-renders the
+   kubelet unit, and restarts *containerd only* — which does not kill running
+   containers, since their shims outlive it and reattach. It touches no apt
+   source, no kubelet install, no `/data` mount, and never the kubelet itself, so
+   it needs no drain. It also verifies the shim is really on disk **before** the
+   controller labels the Node: labelling an unrepaired box turns "no Pod ever
+   schedules" into "every Pod wedged in ContainerCreating", which is worse.
+
+Note the trap is not OVH-specific. `DediboxMachine` and
+`ScalewayElasticMetalMachine` share this renderer and the same once-at-bootstrap
+property; only `OVHDedicatedMachine` carries a bootstrap-time capability today.
+
+A repair that cannot complete must stay loud rather than retry quietly. The
+`KataRuntimeReady` condition is marked False the moment the gap is observed —
+before any SSH — and the `capt_node_kata_runtime_ready` gauge (0 = requested but
+missing) is what Grafana alerts on; the PromQL is in
+[`infra/helm/k8s-monitoring/values.yaml`](../helm/k8s-monitoring/values.yaml).
+`Machine.Status.Ready` is deliberately left alone: the node is a healthy
+Kubernetes node, and failing it would make CAPI churn a box that needs a
+two-minute in-place fix.
 
 ## Node extended resources
 
@@ -899,6 +972,26 @@ kubectl describe scalewayapplesiliconmachine <name>
 # transitions, drift-loop attempts, terminal-failure transitions)
 kubectl get events --field-selector involvedObject.kind=ScalewayAppleSiliconMachine
 ```
+
+### A Linux runner box is Ready but takes no jobs
+
+The box joins Ready, lands in the right pool with the right taint, runs every
+DaemonSet — and no runner Pod ever schedules on it. That is the once-at-bootstrap
+trap above, almost always because the Machine was bootstrapped by a provider
+build that predates the capability its spec asked for. Confirm in one read:
+
+```bash
+kubectl get ovhdedicatedmachine <name> -o jsonpath='{.status.conditions[?(@.type=="KataRuntimeReady")]}{"\n"}'
+kubectl get node <name> -o jsonpath='{.metadata.labels.katacontainers\.io/kata-runtime}{"\n"}'
+```
+
+`KataRuntimeReady=False/KataRuntimeMissing` means the provider has seen it and is
+repairing in place; it converges within a reconcile or two and needs no operator
+action. `KataRuntimeRepairFailed` carries the reason — an unreachable box, or one
+whose containerd cannot register the handler (its config predates `version = 3`,
+which the self-join refuses to join around). Do NOT `kubectl delete machine` to
+force a re-bootstrap: it wipes the box, and for a cache node it destroys the
+local state. Fix what the condition names and let the repair land.
 
 ### Make `kubectl logs`/`exec` work on a fleet node
 

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -333,13 +333,19 @@ Note the trap is not OVH-specific. `DediboxMachine` and
 property; only `OVHDedicatedMachine` carries a bootstrap-time capability today.
 
 A repair that cannot complete must stay loud rather than retry quietly. The
-`KataRuntimeReady` condition is marked False the moment the gap is observed —
-before any SSH — and the `capt_node_kata_runtime_ready` gauge (0 = requested but
-missing) is what Grafana alerts on; the PromQL is in
-[`infra/helm/k8s-monitoring/values.yaml`](../helm/k8s-monitoring/values.yaml).
-`Machine.Status.Ready` is deliberately left alone: the node is a healthy
-Kubernetes node, and failing it would make CAPI churn a box that needs a
+`KataRuntimeReady` condition is marked False the moment the gap is observed,
+before any SSH, and the `capt_node_kata_runtime_ready` gauge (0 = requested but
+missing) is what the **Runner Box Missing Kata Runtime** rule alerts on
+(Grafana Cloud, Alerts folder, `Runners` group, `for: 20m`, routed to Slack like
+its siblings). `Machine.Status.Ready` is deliberately left alone: the node is a
+healthy Kubernetes node, and failing it would make CAPI churn a box that needs a
 two-minute in-place fix.
+
+Alerts for this operator are Grafana-managed rules, created in Grafana Cloud
+rather than checked in: managed clusters run no Prometheus Operator, so there is
+no `PrometheusRule` to render. Add a new one alongside the existing `capt_*`
+rules in the `Runners` group and put the reasoning in the rule's own
+`description` annotation, which is where its siblings keep theirs.
 
 ## Node extended resources
 

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -318,9 +318,15 @@ all three of these, or it inherits the trap:
    kubelet unit, and restarts *containerd only* — which does not kill running
    containers, since their shims outlive it and reattach. It touches no apt
    source, no kubelet install, no `/data` mount, and never the kubelet itself, so
-   it needs no drain. It also verifies the shim is really on disk **before** the
-   controller labels the Node: labelling an unrepaired box turns "no Pod ever
-   schedules" into "every Pod wedged in ContainerCreating", which is worse.
+   it needs no drain, and it restarts unconditionally so that "the script exited
+   0" always means "the running daemon loaded this config" (a restart skipped
+   because the config file already looked right would let a stale daemon pass
+   every file check). Order the steps so that **nothing that advertises the box
+   to the scheduler runs before the proof**: here the runtime is verified first,
+   the kata-labelled kubelet unit is written last, and the controller patches the
+   live Node only on the script's exit status. Advertising an unrepaired box
+   turns "no Pod ever schedules" into "every Pod wedged in ContainerCreating",
+   which is harder to diagnose and burns the job instead of queueing it.
 
 Note the trap is not OVH-specific. `DediboxMachine` and
 `ScalewayElasticMetalMachine` share this renderer and the same once-at-bootstrap

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
@@ -1,0 +1,243 @@
+package linux
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
+	bootstrap "github.com/tuist/tuist/infra/macos-host-bootstrap"
+)
+
+// KataRuntimeSelectorLabel is the node label the kata-qemu RuntimeClass selects
+// on (infra/helm/tuist/templates/kata-qemu.yaml). It is the single observable
+// that decides whether a runner Pod can land on the box, which is why the drift
+// loop checks it rather than, say, the provider version that bootstrapped the
+// node: it is true by construction that a node carrying this label is one the
+// scheduler will place kata Pods on, and false by construction otherwise.
+const KataRuntimeSelectorLabel = "katacontainers.io/kata-runtime"
+
+// KataRuntimeReadyCondition reports whether a machine that asked for
+// spec.kataRuntime actually ended up on a box that can run microVM Pods.
+//
+// It exists because the failure it names is otherwise invisible. The self-join
+// is rendered exactly once, at bootstrap, by whichever provider pod happens to
+// hold the leader lease at that moment — which during a rolling provider upgrade
+// can be the OUTGOING pod, running a build that does not understand the field.
+// The resulting node joins Ready, lands in the right pool with the right taints,
+// runs every DaemonSet, logs no error anywhere, and never takes a single job.
+// Both production and canary hit exactly that on 2026-08-31 (the chart created
+// the Machine two seconds into the provider rollout) and it read as a scheduling
+// bug for about an hour.
+const KataRuntimeReadyCondition clusterv1.ConditionType = "KataRuntimeReady"
+
+const (
+	// KataRuntimeMissingReason is set the moment the gap is observed, before any
+	// repair is attempted, so a box the operator cannot reach is loudly broken
+	// instead of quietly retried.
+	KataRuntimeMissingReason = "KataRuntimeMissing"
+
+	// KataRuntimeRepairFailedReason is set when the in-place repair could not
+	// complete: the box is unreachable, or it refused the runtime (e.g. its
+	// containerd predates the v3 config syntax the handler is written in).
+	KataRuntimeRepairFailedReason = "KataRuntimeRepairFailed"
+)
+
+// kataRuntimeReadyGauge is the alertable form of the condition. Only machines
+// that asked for kata get a series, so `min_over_time(...) == 0` is a clean
+// "a runner box has been unable to take jobs" alert with no cache-fleet noise.
+var kataRuntimeReadyGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "capt_node_kata_runtime_ready",
+	Help: "1 when a machine with spec.kataRuntime carries the katacontainers.io/kata-runtime node label the kata-qemu RuntimeClass selects on, 0 when it does not (the node is Ready but no runner Pod can schedule on it). Machines that never asked for kata publish no series.",
+}, []string{"machine", "fleet"})
+
+func init() {
+	metrics.Registry.MustRegister(kataRuntimeReadyGauge)
+}
+
+func recordKataRuntimeReady(machine, fleet string, ready bool) {
+	value := 0.0
+	if ready {
+		value = 1
+	}
+	kataRuntimeReadyGauge.WithLabelValues(machine, fleet).Set(value)
+}
+
+// forgetKataRuntimeMetric drops a machine's series once it stops asking for kata
+// or its CR is gone, so a released box never alerts as a stuck runner node.
+func forgetKataRuntimeMetric(machine string) {
+	kataRuntimeReadyGauge.DeletePartialMatch(prometheus.Labels{"machine": machine})
+}
+
+// renderKataRuntimeRepairScript renders the minimal, idempotent script the
+// repair pipes over SSH to an already-Ready node that joined without kata.
+//
+// This is deliberately NOT a re-bootstrap. It never touches apt sources, the
+// kubelet install, the /data mounts, or the kubelet itself; it installs the
+// runtime, registers the handler, and re-renders the kubelet unit. That
+// restraint is what makes it safe to run unattended against a live box: the
+// worst it does is restart containerd, which does not kill running containers
+// (their shims are separate processes that outlive it and reattach), so no drain
+// is needed and no running job is disturbed. Re-bootstrapping — the manual
+// recovery used during the incident — would have wiped the box.
+//
+// The kubelet unit rewrite does not fix the live Node. kubelet applies
+// --node-labels only when it CREATES the Node object; on restart against an
+// existing Node it reconciles just the well-known kubernetes.io labels and
+// ignores custom ones. So the unit is re-rendered for the node's next
+// registration, and the controller patches the live Node itself — but only after
+// the verification block below proves the box can really run a kata Pod.
+// Labelling first would turn "never schedules" into "every Pod wedged in
+// ContainerCreating", which is strictly worse.
+func renderKataRuntimeRepairScript(opts linuxCloudInitOptions) string {
+	sudo, sudoE := escalation(opts.BootstrapUser)
+	kubeletUnit := kubeletUnitContent(
+		opts.NodeName,
+		taintArgFor(opts.Taints),
+		instanceTypeOrDefault(opts.InstanceType),
+		kataNodeLabelsArg(true),
+	)
+	return fmt.Sprintf(`#!/usr/bin/env bash
+set -euxo pipefail
+# The install below pulls zstd. The bootstrap gets its noninteractive frontend
+# and a fresh package index from the steps that precede it; this script has no
+# such steps, and a months-stale index on a long-running box no longer resolves
+# the version it lists.
+export DEBIAN_FRONTEND=noninteractive
+%[4]sapt-get update
+%[1]stee /etc/systemd/system/kubelet.service > /dev/null <<'TUIST_EOF'
+%[2]sTUIST_EOF
+%[1]ssystemctl daemon-reload
+# Restart containerd only when the handler was actually missing, so repairing a
+# box that merely lost its Node label costs no CRI blip at all.
+if %[1]sgrep -q "runtimes.kata-qemu" /etc/containerd/config.toml; then kata_handler_registered=1; else kata_handler_registered=0; fi
+%[3]s
+if [ "$kata_handler_registered" = 0 ]; then %[1]ssystemctl restart containerd; fi
+# Refuse to report success unless the box can really run a kata Pod. The
+# controller labels the Node on this script's exit status, so an install that
+# half-completed must fail here rather than advertise a broken box to the
+# scheduler.
+%[1]stest -x /opt/kata/bin/containerd-shim-kata-v2
+%[1]sgrep -q "runtimes.kata-qemu" /etc/containerd/config.toml
+%[1]ssystemctl is-active --quiet containerd
+`, sudo, ensureTrailingNewline(kubeletUnit), kataSetup(sudo, sudoE, true), sudoE)
+}
+
+// labelKataRuntimeNode patches the kata labels onto the live Node, which is the
+// step that actually makes the kata-qemu RuntimeClass select the box. Only
+// reached once the repair script has verified the runtime is installed.
+func labelKataRuntimeNode(ctx context.Context, c client.Client, node *corev1.Node) error {
+	helper, err := patch.NewHelper(node, c)
+	if err != nil {
+		return err
+	}
+	if node.Labels == nil {
+		node.Labels = map[string]string{}
+	}
+	for _, label := range kataNodeLabels {
+		node.Labels[label.Key] = label.Value
+	}
+	return helper.Patch(ctx, node)
+}
+
+// reconcileLinuxKataRuntimeDrift brings an already-Ready node onto the kata
+// runtime its Machine spec asked for, in place.
+//
+// The Linux self-join is rendered once at bootstrap and nothing re-runs it, so a
+// bootstrap-time capability that the rendering controller did not understand is
+// missing forever — the fleet MachineDeployments even use `strategy: OnDelete`,
+// so flipping the field on afterwards never rolls the existing machines either.
+// This closes that hole for kata by reconciling the node's observed state
+// against the spec rather than trusting that bootstrap got it right.
+//
+// It leaves Machine.Status.Ready alone: the node IS a healthy Kubernetes node,
+// and failing the Machine would make CAPI churn a box that needs a two-minute
+// in-place repair.
+//
+// Returns requeue=true when it did work or deferred, false when there was
+// nothing to do. On a converged node this is one map lookup.
+//
+// Any future bootstrap-time capability on these kinds needs the same treatment:
+// an observable on the Node, a check here, and a repair that is additive rather
+// than a re-bootstrap. See infra/cluster-api-provider-tuist/AGENTS.md.
+func reconcileLinuxKataRuntimeDrift(
+	ctx context.Context,
+	c client.Client,
+	cm *credentials.Manager,
+	machine conditions.Setter,
+	machineName, fleet string,
+	opts linuxCloudInitOptions,
+	node *corev1.Node,
+) (requeue bool, err error) {
+	logger := log.FromContext(ctx)
+
+	if !opts.KataRuntime {
+		conditions.Delete(machine, KataRuntimeReadyCondition)
+		forgetKataRuntimeMetric(machineName)
+		return false, nil
+	}
+	if node.Labels[KataRuntimeSelectorLabel] == "true" {
+		conditions.MarkTrue(machine, KataRuntimeReadyCondition)
+		recordKataRuntimeReady(machineName, fleet, true)
+		return false, nil
+	}
+
+	// Mark before attempting anything. Every path out of here that does not
+	// finish the repair leaves the machine visibly broken, which is the whole
+	// point: the incident's cost was that a node in this state looked healthy.
+	conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataRuntimeMissingReason,
+		clusterv1.ConditionSeverityError,
+		"node carries no %s label, so no runtimeClassName=kata-qemu Pod can schedule on it; repairing in place",
+		KataRuntimeSelectorLabel)
+	recordKataRuntimeReady(machineName, fleet, false)
+
+	host := nodeInternalIP(node)
+	if host == "" {
+		logger.Info("deferring kata runtime repair until the node reports an InternalIP", "node", node.Name)
+		return true, nil
+	}
+
+	privateKey, err := cm.EnsureFleetSSHKey(ctx, fleet)
+	if err != nil {
+		return false, fmt.Errorf("fleet ssh key for kata repair: %w", err)
+	}
+	known := ""
+	if creds, fpErr := cm.GetMachineBootstrap(ctx, machineName); fpErr != nil {
+		return false, fmt.Errorf("read host fingerprint for kata repair: %w", fpErr)
+	} else if creds != nil {
+		known = creds.HostFingerprint
+	}
+	hostKey := bootstrap.NewHostKeyState(known)
+
+	sshErr := bootstrapOverSSH(ctx, opts.BootstrapUser, host, privateKey, renderKataRuntimeRepairScript(opts), hostKey)
+	// Persist a newly TOFU'd key before anything else, matching the bootstrap and
+	// kubelet-config paths: the key was observed even if the script then failed.
+	if observed := hostKey.Observed(); observed != "" && observed != known {
+		if perr := cm.SetMachineHostFingerprint(ctx, machineName, observed); perr != nil {
+			logger.Error(perr, "persist host fingerprint after kata repair; will retry", "node", node.Name)
+		}
+	}
+	if sshErr != nil {
+		conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataRuntimeRepairFailedReason,
+			clusterv1.ConditionSeverityError,
+			"could not install the kata runtime on %s, so the node still takes no runner job: %v", host, sshErr)
+		return false, fmt.Errorf("repair kata runtime over ssh on %s: %w", host, sshErr)
+	}
+	if labelErr := labelKataRuntimeNode(ctx, c, node); labelErr != nil {
+		return false, fmt.Errorf("label node for the kata-qemu RuntimeClass: %w", labelErr)
+	}
+
+	conditions.MarkTrue(machine, KataRuntimeReadyCondition)
+	recordKataRuntimeReady(machineName, fleet, true)
+	logger.Info("installed the kata runtime on a node that joined without it and labelled it for the kata-qemu RuntimeClass",
+		"node", node.Name, "host", host)
+	return true, nil
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
@@ -93,10 +93,14 @@ func forgetKataRuntimeMetric(machine string) {
 // --node-labels only when it CREATES the Node object; on restart against an
 // existing Node it reconciles just the well-known kubernetes.io labels and
 // ignores custom ones. So the unit is re-rendered for the node's next
-// registration, and the controller patches the live Node itself — but only after
-// the verification block below proves the box can really run a kata Pod.
-// Labelling first would turn "never schedules" into "every Pod wedged in
-// ContainerCreating", which is strictly worse.
+// registration, and the controller patches the live Node itself.
+//
+// Both of those advertise the box to the scheduler, and neither may run ahead of
+// the proof. The script verifies the runtime first and writes the unit last; the
+// controller labels the live Node only on the script's exit status. Advertising
+// a box whose repair did not finish turns "no Pod ever schedules" into "every
+// Pod wedged in ContainerCreating", which is harder to diagnose and burns the
+// job instead of queueing it.
 func renderKataRuntimeRepairScript(opts linuxCloudInitOptions) string {
 	sudo, sudoE := escalation(opts.BootstrapUser)
 	kubeletUnit := kubeletUnitContent(
@@ -113,21 +117,31 @@ set -euxo pipefail
 # the version it lists.
 export DEBIAN_FRONTEND=noninteractive
 %[4]sapt-get update
+%[3]s
+# Check the shim and the handler BEFORE the restart: containerd must never
+# reload into a config naming a binary that is not on disk.
+%[1]stest -x /opt/kata/bin/containerd-shim-kata-v2
+%[1]sgrep -q "runtimes.kata-qemu" /etc/containerd/config.toml
+# Unconditional, and it has to be. The append above is idempotent, so from the
+# second attempt onwards the handler is already in the file; a restart
+# conditioned on it being absent would be skipped forever, and a first attempt
+# whose restart failed or timed out would leave a daemon still running the
+# pre-kata config while every file check passes. Restarting each time is what
+# makes "the script exited 0" mean "the running daemon loaded this config".
+# It costs nothing here: this script only ever runs on a runner box the
+# RuntimeClass cannot select yet, so there is no kata workload to blip, and a
+# containerd restart does not kill running containers anyway.
+%[1]ssystemctl restart containerd
+%[1]ssystemctl is-active --quiet containerd
+# The kubelet unit is written LAST, once the runtime is proven. It carries the
+# kata node labels, and kubelet self-applies those when it registers a Node — so
+# installing it before the runtime is verified would let a later Node
+# re-registration advertise a box whose repair failed, turning "no Pod ever
+# schedules" into "every Pod wedged in ContainerCreating". Failing before this
+# point leaves the old unit in place, which fails closed.
 %[1]stee /etc/systemd/system/kubelet.service > /dev/null <<'TUIST_EOF'
 %[2]sTUIST_EOF
 %[1]ssystemctl daemon-reload
-# Restart containerd only when the handler was actually missing, so repairing a
-# box that merely lost its Node label costs no CRI blip at all.
-if %[1]sgrep -q "runtimes.kata-qemu" /etc/containerd/config.toml; then kata_handler_registered=1; else kata_handler_registered=0; fi
-%[3]s
-if [ "$kata_handler_registered" = 0 ]; then %[1]ssystemctl restart containerd; fi
-# Refuse to report success unless the box can really run a kata Pod. The
-# controller labels the Node on this script's exit status, so an install that
-# half-completed must fail here rather than advertise a broken box to the
-# scheduler.
-%[1]stest -x /opt/kata/bin/containerd-shim-kata-v2
-%[1]sgrep -q "runtimes.kata-qemu" /etc/containerd/config.toml
-%[1]ssystemctl is-active --quiet containerd
 `, sudo, ensureTrailingNewline(kubeletUnit), kataSetup(sudo, sudoE, true), sudoE)
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
@@ -1,0 +1,271 @@
+package linux
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	encpem "encoding/pem"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/ovh"
+)
+
+// kataHarness drives the real OVH reconcile loop against a Ready node that asked
+// for kata, so the assertions are on what an operator would see on a live box.
+type kataHarness struct {
+	t       *testing.T
+	machine *infrav1.OVHDedicatedMachine
+	node    *corev1.Node
+	client  client.Client
+	r       *OVHDedicatedMachineReconciler
+}
+
+// newKataHarness builds a machine whose box has already joined: providerID set,
+// Node Ready, kubelet config already at the current hash (so the kubelet-config
+// drift loop no-ops and the kata check is what the reconcile exercises). The
+// Node deliberately reports no InternalIP, which parks the repair before it
+// dials SSH — the point under test is detection, not the re-push.
+func newKataHarness(t *testing.T, kataRuntime bool, nodeLabels map[string]string) *kataHarness {
+	t.Helper()
+	const ns = "tuist-fleet"
+	ca := []byte("-----BEGIN CERTIFICATE-----\nMIIBkataCAbytes\n-----END CERTIFICATE-----\n")
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, rbacv1.AddToScheme, infrav1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	machine := &infrav1.OVHDedicatedMachine{}
+	machine.Namespace = ns
+	machine.Name = "ovh-runner-1"
+	machine.Spec.FleetName = "runners-linux"
+	machine.Spec.KataRuntime = kataRuntime
+	providerID := "ovh://gra/ns1.ip-1-2-3.eu"
+	machine.Spec.ProviderID = &providerID
+	machine.Status.ServiceName = "ns1.ip-1-2-3.eu"
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        machine.Name,
+		Labels:      nodeLabels,
+		Annotations: map[string]string{kubeletConfigHashAnnotation: desiredKubeletConfigHash(ca)},
+	}}
+	node.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}
+
+	fleetKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns,
+			Name:        machine.Spec.FleetName + "-ssh",
+			Annotations: map[string]string{"scaleway.tuist.dev/ssh-key-id": "seeded"},
+		},
+		Data: map[string][]byte{"id_ed25519": testFleetPrivateKey(t)},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "tart-kubelet-" + machine.Name + "-token"},
+		Type:       corev1.SecretTypeServiceAccountToken,
+		Data:       map[string][]byte{"token": []byte("tok"), "ca.crt": ca},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node, tokenSecret, fleetKeySecret).WithStatusSubresource(node).Build()
+
+	r := &OVHDedicatedMachineReconciler{
+		Client:             cl,
+		APIReader:          cl,
+		OVHClient:          &ovh.Client{API: &fakeOVHAPI{body: map[string]any{}}},
+		Recorder:           record.NewFakeRecorder(100),
+		CredentialsManager: &credentials.Manager{Client: cl, Namespace: ns, NodeIdentityClusterRole: linuxNodeIdentityClusterRole},
+	}
+	return &kataHarness{t: t, machine: machine, node: node, client: cl, r: r}
+}
+
+// testFleetPrivateKey mints the same shape of key the credentials manager
+// persists, so EnsureFleetSSHKey reads one back instead of generating (and
+// registering) a fresh one.
+func testFleetPrivateKey(t *testing.T) []byte {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "tuist-capi-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encpem.EncodeToMemory(block)
+}
+
+func (h *kataHarness) reconcile() {
+	h.t.Helper()
+	if _, err := h.r.reconcileNormal(context.Background(), h.machine); err != nil {
+		h.t.Fatalf("reconcileNormal: %v", err)
+	}
+}
+
+func (h *kataHarness) liveNode() *corev1.Node {
+	h.t.Helper()
+	node := &corev1.Node{}
+	if err := h.client.Get(context.Background(), types.NamespacedName{Name: h.machine.Name}, node); err != nil {
+		h.t.Fatal(err)
+	}
+	return node
+}
+
+// A box bootstrapped by a provider that predates the kata support joins Ready,
+// lands in the right pool, runs its DaemonSets — and never takes a job, because
+// the kata-qemu RuntimeClass selects on a label the old self-join never wrote.
+// Nothing in the reconcile used to notice, which is what made the production and
+// canary incidents look like a scheduling bug for an hour. Reconciling such a
+// machine must leave a condition that names the actual fault.
+func TestKataRuntimeMissingIsSurfacedOnTheMachine(t *testing.T) {
+	h := newKataHarness(t, true, nil)
+	h.reconcile()
+
+	cond := conditions.Get(h.machine, clusterv1.ConditionType("KataRuntimeReady"))
+	if cond == nil {
+		t.Fatalf("expected a KataRuntimeReady condition on a machine whose node asked for kata but carries no %s label; conditions=%v",
+			"katacontainers.io/kata-runtime", h.machine.Status.Conditions)
+	}
+	if cond.Status != corev1.ConditionFalse {
+		t.Fatalf("KataRuntimeReady = %s (%s), want False", cond.Status, cond.Reason)
+	}
+	// The node is a healthy Kubernetes node, so the Machine stays Ready: flipping
+	// it would make CAPI churn a box that only needs an in-place repair.
+	if !h.machine.Status.Ready {
+		t.Fatalf("machine must stay Ready: the node is Ready, it is only missing a capability")
+	}
+	// Nothing may label the node until the box can actually run kata Pods —
+	// labelling an unrepaired box just moves the failure from "never schedules"
+	// to "every Pod stuck in ContainerCreating".
+	if h.liveNode().Labels["katacontainers.io/kata-runtime"] != "" {
+		t.Fatalf("node must not be labelled before the repair proves the shim is installed")
+	}
+}
+
+// The converged case: a node that already carries the label is what every
+// correctly-bootstrapped runner box looks like, and it must cost nothing.
+func TestKataRuntimeReadyWhenNodeCarriesTheLabel(t *testing.T) {
+	h := newKataHarness(t, true, map[string]string{"katacontainers.io/kata-runtime": "true"})
+	h.reconcile()
+
+	cond := conditions.Get(h.machine, clusterv1.ConditionType("KataRuntimeReady"))
+	if cond == nil || cond.Status != corev1.ConditionTrue {
+		t.Fatalf("expected KataRuntimeReady=True on a labelled node, got %v", cond)
+	}
+}
+
+// A cache fleet never asks for kata, so it must carry no kata condition at all.
+func TestKataRuntimeConditionAbsentWhenNotRequested(t *testing.T) {
+	h := newKataHarness(t, false, nil)
+	h.reconcile()
+
+	if cond := conditions.Get(h.machine, clusterv1.ConditionType("KataRuntimeReady")); cond != nil {
+		t.Fatalf("a fleet that never asked for kata must carry no KataRuntimeReady condition, got %v", cond)
+	}
+}
+
+// A repair the box did not accept must leave the node unlabelled and say so.
+// Labelling a box whose runtime is not really installed converts "no runner Pod
+// ever schedules here" into "every runner Pod wedges in ContainerCreating",
+// which is harder to diagnose and burns the job instead of queueing it.
+//
+// The unreachable host is loopback: nothing there will ever accept the fleet key,
+// so the SSH attempt fails within milliseconds either way (connection refused, or
+// a rejected publickey where the developer runs sshd).
+func TestKataRuntimeRepairFailureNeverLabelsTheNode(t *testing.T) {
+	h := newKataHarness(t, true, nil)
+	h.node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "127.0.0.1"}}
+	if err := h.client.Status().Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
+
+	requeue, err := reconcileLinuxKataRuntimeDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err == nil {
+		t.Fatalf("expected the repair to fail against an unreachable host, got requeue=%v", requeue)
+	}
+	if got := h.liveNode().Labels[KataRuntimeSelectorLabel]; got != "" {
+		t.Fatalf("node was labelled %q despite a failed repair", got)
+	}
+	cond := conditions.Get(h.machine, KataRuntimeReadyCondition)
+	if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != KataRuntimeRepairFailedReason {
+		t.Fatalf("expected KataRuntimeReady=False/%s after a failed repair, got %v", KataRuntimeRepairFailedReason, cond)
+	}
+}
+
+// The repair is an in-place, additive fix, not a re-bootstrap. That distinction
+// is what makes it safe to run unattended against a box that may be holding a
+// live runner: a re-bootstrap re-runs apt, regenerates the containerd config,
+// and re-lays the /data mounts, any of which would disturb running work.
+func TestRenderKataRuntimeRepairScript(t *testing.T) {
+	script := renderKataRuntimeRepairScript(linuxCloudInitOptions{
+		NodeName:      "ovh-runner-1",
+		KataRuntime:   true,
+		BootstrapUser: "ubuntu",
+		InstanceType:  "ovh",
+	})
+
+	for _, want := range []string{
+		// Installs the runtime and registers the handler.
+		"kata-static-" + kataVersion + "-amd64.tar.zst",
+		`runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"`,
+		// Re-renders the kubelet unit so a future re-registration keeps the labels.
+		"tee /etc/systemd/system/kubelet.service > /dev/null <<'TUIST_EOF'",
+		"--node-labels=node.cluster.x-k8s.io/instance-type=ovh,katacontainers.io/kata-runtime=true,tuist.dev/kata-runtime=true",
+		"systemctl daemon-reload",
+		// Proves the box can run a kata Pod before the controller advertises it.
+		"test -x /opt/kata/bin/containerd-shim-kata-v2",
+		"systemctl is-active --quiet containerd",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected the repair script to contain %q, got:\n%s", want, script)
+		}
+	}
+
+	// Not a re-bootstrap: no apt sources, no kubelet reinstall, no remounting of
+	// /data, no swapoff, and above all no kubelet restart — the node keeps
+	// serving whatever it is already running.
+	for _, banned := range []string{"pkgs.k8s.io", "install -y kubelet", "mount --bind", "swapoff", "systemctl restart kubelet", "containerd config default"} {
+		if strings.Contains(script, banned) {
+			t.Fatalf("repair must not run %q (that is a re-bootstrap, not an in-place repair), got:\n%s", banned, script)
+		}
+	}
+
+	// containerd restarts only when the handler was genuinely absent.
+	if !strings.Contains(script, `if [ "$kata_handler_registered" = 0 ]; then sudo systemctl restart containerd; fi`) {
+		t.Fatalf("expected the containerd restart to be conditional, got:\n%s", script)
+	}
+}
+
+// The repair retries against a box that keeps failing verification, so the
+// install block must not re-pull the ~250 MiB kata tarball on each attempt —
+// while a kataVersion bump must still reinstall.
+func TestKataInstallIsGuardedByAVersionStamp(t *testing.T) {
+	setup := kataSetup("sudo ", "sudo -E ", true)
+	if !strings.Contains(setup, `if [ "$(cat `+kataVersionStampPath+` 2>/dev/null)" != "`+kataVersion+`" ]; then`) {
+		t.Fatalf("expected the kata download to be guarded by a version stamp, got:\n%s", setup)
+	}
+	if !strings.Contains(setup, `printf '%s' "`+kataVersion+`" | sudo tee `+kataVersionStampPath) {
+		t.Fatalf("expected the install to stamp the version it unpacked, got:\n%s", setup)
+	}
+	if stamp, download := strings.Index(setup, kataVersionStampPath), strings.Index(setup, "curl -fsSL -o /tmp/kata.tar.zst"); stamp > download {
+		t.Fatalf("expected the stamp check before the download (stamp=%d download=%d)", stamp, download)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
@@ -248,9 +248,36 @@ func TestRenderKataRuntimeRepairScript(t *testing.T) {
 		}
 	}
 
-	// containerd restarts only when the handler was genuinely absent.
-	if !strings.Contains(script, `if [ "$kata_handler_registered" = 0 ]; then sudo systemctl restart containerd; fi`) {
-		t.Fatalf("expected the containerd restart to be conditional, got:\n%s", script)
+	// The restart must be unconditional. Once the first attempt has appended the
+	// handler, a restart conditioned on the handler being absent can never run
+	// again: a retry after a failed or timed-out restart would skip it, and the
+	// file checks would then pass against a daemon that never loaded the handler.
+	if strings.Contains(script, "kata_handler_registered") {
+		t.Fatalf("the containerd restart must not be conditioned on the handler already being in the config, got:\n%s", script)
+	}
+	if !strings.Contains(script, "systemctl restart containerd") {
+		t.Fatalf("expected an unconditional containerd restart, got:\n%s", script)
+	}
+
+	// Nothing may reload into a config naming a binary that is not there, so the
+	// shim is checked before the restart, not after it.
+	shim := strings.Index(script, "test -x /opt/kata/bin/containerd-shim-kata-v2")
+	restart := strings.Index(script, "systemctl restart containerd")
+	active := strings.Index(script, "systemctl is-active --quiet containerd")
+	if shim > restart {
+		t.Fatalf("expected the shim check before the containerd restart (shim=%d restart=%d)", shim, restart)
+	}
+	if active < restart {
+		t.Fatalf("expected the liveness check after the containerd restart (active=%d restart=%d)", active, restart)
+	}
+
+	// The kubelet unit carries the kata labels, so writing it before the runtime
+	// is verified would let a later Node re-registration self-apply the label on
+	// a box whose repair failed — jobs would schedule and wedge in
+	// ContainerCreating. It goes last, so a failed repair leaves the old unit.
+	unit := strings.Index(script, "tee /etc/systemd/system/kubelet.service")
+	if unit < active {
+		t.Fatalf("expected the labelled kubelet unit written only after verification (unit=%d verified=%d)", unit, active)
 	}
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
@@ -840,6 +840,10 @@ func dataKubeletMount(sudo string) string {
 // job behaves the same whichever fleet it lands on.
 const kataVersion = "3.30.0"
 
+// kataVersionStampPath records which kata release the box has unpacked, so the
+// install block above is a no-op on a box that already carries it.
+const kataVersionStampPath = "/opt/kata/.tuist-kata-version"
+
 // kataSetup installs kata-static and registers the kata-qemu handler with
 // containerd. Empty (a no-op) unless the fleet asked for it, so cache boxes
 // neither download it nor carry the runtime block.
@@ -869,10 +873,17 @@ func kataSetup(sudo, sudoE string, enabled bool) string {
 %[1]sgrep -q '^version = 3' /etc/containerd/config.toml || { echo "tuist: containerd config is not version 3; the kata-qemu handler would be ignored. Refusing to join a runner node that cannot run microVM Pods." >&2; exit 1; }
 %[2]sapt-get install -y zstd
 # kata-static expands with a top-level opt/, so extracting at / lands the shim
-# and its bundled qemu under /opt/kata/{bin,libexec,share}.
-curl -fsSL -o /tmp/kata.tar.zst "https://github.com/kata-containers/kata-containers/releases/download/%[3]s/kata-static-%[3]s-amd64.tar.zst"
-%[1]star --zstd -xf /tmp/kata.tar.zst -C /
-rm -f /tmp/kata.tar.zst
+# and its bundled qemu under /opt/kata/{bin,libexec,share}. Guarded on a version
+# stamp so a re-run costs nothing: the repair loop re-runs this block on every
+# retry against a box whose verification keeps failing, and an unguarded pull
+# would drag ~250 MiB off GitHub each time. Stamping the version (rather than
+# just testing for the shim) keeps a kataVersion bump reinstalling.
+if [ "$(cat %[4]s 2>/dev/null)" != "%[3]s" ]; then
+  curl -fsSL -o /tmp/kata.tar.zst "https://github.com/kata-containers/kata-containers/releases/download/%[3]s/kata-static-%[3]s-amd64.tar.zst"
+  %[1]star --zstd -xf /tmp/kata.tar.zst -C /
+  rm -f /tmp/kata.tar.zst
+  printf '%%s' "%[3]s" | %[1]stee %[4]s > /dev/null
+fi
 # Idempotent: a re-bootstrap of an already-kata box must not append twice.
 %[1]ssh -c 'grep -q "runtimes.kata-qemu" /etc/containerd/config.toml || cat >> /etc/containerd/config.toml' <<'TUIST_KATA_EOF'
 
@@ -893,20 +904,34 @@ ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml"
 # same block in infra/k8s/clusters/bare-metal.yaml for the measured detail.
 SystemdCgroup = true
 TUIST_KATA_EOF
-`, sudo, sudoE, kataVersion)
+`, sudo, sudoE, kataVersion, kataVersionStampPath)
 }
 
 // kataNodeLabels are appended to the kubelet's --node-labels when the fleet runs
-// kata. `katacontainers.io/kata-runtime` is what the kata-qemu RuntimeClass
-// selects on, so without it a runner Pod never schedules here; `tuist.dev/kata-runtime`
-// mirrors the Hetzner workers so anything keying off our own label sees both
-// fleets alike. Both sit outside the kubernetes.io/k8s.io namespaces the
-// NodeRestriction admission plugin reserves, so a kubelet may self-apply them.
+// kata, and are the same labels the repair loop patches onto a node that joined
+// without them. `katacontainers.io/kata-runtime` is what the kata-qemu
+// RuntimeClass selects on, so without it a runner Pod never schedules here;
+// `tuist.dev/kata-runtime` mirrors the Hetzner workers so anything keying off our
+// own label sees both fleets alike. Both sit outside the kubernetes.io/k8s.io
+// namespaces the NodeRestriction admission plugin reserves, so a kubelet may
+// self-apply them.
+//
+// An ordered slice, not a map: it renders into the kubelet unit, and a map's
+// iteration order would churn that unit's content between reconciles.
+var kataNodeLabels = []struct{ Key, Value string }{
+	{KataRuntimeSelectorLabel, "true"},
+	{"tuist.dev/kata-runtime", "true"},
+}
+
 func kataNodeLabelsArg(enabled bool) string {
 	if !enabled {
 		return ""
 	}
-	return ",katacontainers.io/kata-runtime=true,tuist.dev/kata-runtime=true"
+	var arg strings.Builder
+	for _, label := range kataNodeLabels {
+		arg.WriteString("," + label.Key + "=" + label.Value)
+	}
+	return arg.String()
 }
 
 // nopasswdSetup renders the one-time passwordless-sudo bootstrap: it uses the

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
@@ -233,18 +233,12 @@ func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, mac
 		if pwErr != nil {
 			return ctrl.Result{}, fmt.Errorf("fleet sudo password: %w", pwErr)
 		}
-		script := renderLinuxBootstrapScript(linuxCloudInitOptions{
-			NodeName:       machine.Name,
-			KubeconfigYAML: kubeconfigYAML,
-			ClusterCAPEM:   identity.CA,
-			K8sMinor:       firstNonEmpty(r.KubernetesMinor, "v1.34"),
-			Taints:         machine.Spec.NodeTaints,
-			KataRuntime:    machine.Spec.KataRuntime,
-			BootstrapUser:  ovhBootstrapUser,
-			ClusterDNS:     discoverClusterDNS(ctx, r.APIReader),
-			InstanceType:   ovhInstanceType,
-			SudoPassword:   sudoPassword,
-		})
+		opts := r.hostOptions(machine)
+		opts.KubeconfigYAML = kubeconfigYAML
+		opts.ClusterCAPEM = identity.CA
+		opts.ClusterDNS = discoverClusterDNS(ctx, r.APIReader)
+		opts.SudoPassword = sudoPassword
+		script := renderLinuxBootstrapScript(opts)
 
 		machine.Status.Phase = "Bootstrapping"
 		// TOFU host-key pinning: persist the fingerprint observed on the first
@@ -337,11 +331,33 @@ func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, mac
 			} else if requeue {
 				return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 			}
+			if requeue, kataErr := reconcileLinuxKataRuntimeDrift(ctx, r.Client, r.CredentialsManager, machine, machine.Name, fleet, r.hostOptions(machine), node); kataErr != nil {
+				logger.Error(kataErr, "kata runtime repair failed; will retry")
+				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			} else if requeue {
+				return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
+			}
 		}
 		return ctrl.Result{RequeueAfter: KubeletConfigDriftResyncInterval}, nil
 	}
 	machine.Status.Phase = "Bootstrapping"
 	return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
+}
+
+// hostOptions is the host shape both the first bootstrap and the in-place repair
+// paths render from. They share one builder deliberately: the repair can only
+// converge a node onto a capability it knows the machine asked for, so a future
+// bootstrap-time field added to the render must land in both — and here it does
+// so by construction rather than by remembering to update two call sites.
+func (r *OVHDedicatedMachineReconciler) hostOptions(machine *infrav1.OVHDedicatedMachine) linuxCloudInitOptions {
+	return linuxCloudInitOptions{
+		NodeName:      machine.Name,
+		K8sMinor:      firstNonEmpty(r.KubernetesMinor, "v1.34"),
+		Taints:        machine.Spec.NodeTaints,
+		KataRuntime:   machine.Spec.KataRuntime,
+		BootstrapUser: ovhBootstrapUser,
+		InstanceType:  ovhInstanceType,
+	}
 }
 
 // claimedServiceNames is the set of OVH service names already held by other
@@ -419,6 +435,7 @@ func (r *OVHDedicatedMachineReconciler) reconcileDelete(ctx context.Context, mac
 		logger.Info("reinstalling OVH box on release", "service", machine.Status.ServiceName)
 	}
 	shared.ForgetEgressMetrics(machine.Name)
+	forgetKataRuntimeMetric(machine.Name)
 	controllerutil.RemoveFinalizer(machine, OVHDedicatedMachineFinalizer)
 	return ctrl.Result{}, nil
 }

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -569,29 +569,6 @@ k8s-monitoring:
   #     One alert per fleet whose replicas > 1 — a single-replica fleet is
   #     already covered by the workload's own availability alerting.
   #
-  # Alert to create in Grafana Cloud (PromQL) — runner box that can take no
-  # job. A Linux runner node whose Machine asked for spec.kataRuntime but whose
-  # Node never got the katacontainers.io/kata-runtime label is Ready,
-  # correctly pooled and tainted, running all its DaemonSets — and unable to
-  # match the kata-qemu RuntimeClass, so no runner Pod ever schedules on it.
-  # Neither alert above sees it: its phase is Ready and the fleet is at full
-  # count. That is how the 2026-08-31 production and canary boxes read as a
-  # scheduling bug for an hour:
-  #
-  #   min by (cluster, machine, fleet) (capt_node_kata_runtime_ready) == 0
-  #
-  # Recommended config:
-  #   - For: 20m   (the provider repairs this in place on the next reconcile;
-  #                 20m means the repair itself is failing — an unreachable
-  #                 box, or one whose containerd cannot register the handler)
-  #   - Severity: warning
-  #   - Summary: "Runner box {{ $labels.machine }} carries no kata-runtime
-  #              label, so it takes no jobs. Read the KataRuntimeReady
-  #              condition on its OVHDedicatedMachine for why the in-place
-  #              repair is not converging."
-  #   - Note: only machines that asked for kata publish a series, so cache
-  #     fleets never match. The series is 1 as soon as the repair lands.
-  #
   # metricsPortName narrows the discovery output to a single target per
   # pod when the pod declares more than one container port. Without it,
   # Kubernetes pod-role discovery emits one target per declared port

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -569,6 +569,29 @@ k8s-monitoring:
   #     One alert per fleet whose replicas > 1 — a single-replica fleet is
   #     already covered by the workload's own availability alerting.
   #
+  # Alert to create in Grafana Cloud (PromQL) — runner box that can take no
+  # job. A Linux runner node whose Machine asked for spec.kataRuntime but whose
+  # Node never got the katacontainers.io/kata-runtime label is Ready,
+  # correctly pooled and tainted, running all its DaemonSets — and unable to
+  # match the kata-qemu RuntimeClass, so no runner Pod ever schedules on it.
+  # Neither alert above sees it: its phase is Ready and the fleet is at full
+  # count. That is how the 2026-08-31 production and canary boxes read as a
+  # scheduling bug for an hour:
+  #
+  #   min by (cluster, machine, fleet) (capt_node_kata_runtime_ready) == 0
+  #
+  # Recommended config:
+  #   - For: 20m   (the provider repairs this in place on the next reconcile;
+  #                 20m means the repair itself is failing — an unreachable
+  #                 box, or one whose containerd cannot register the handler)
+  #   - Severity: warning
+  #   - Summary: "Runner box {{ $labels.machine }} carries no kata-runtime
+  #              label, so it takes no jobs. Read the KataRuntimeReady
+  #              condition on its OVHDedicatedMachine for why the in-place
+  #              repair is not converging."
+  #   - Note: only machines that asked for kata publish a series, so cache
+  #     fleets never match. The series is 1 as soon as the repair lands.
+  #
   # metricsPortName narrows the discovery output to a single target per
   # pod when the pod declares more than one container port. Without it,
   # Kubernetes pod-role discovery emits one target per declared port


### PR DESCRIPTION
## What changed

The OVH machine reconciler now reconciles a Ready node's observed state against what its spec asked for, and repairs the gap in place. When a machine sets `kataRuntime: true` but its Node carries no `katacontainers.io/kata-runtime` label, the provider marks a new `KataRuntimeReady=False` condition, publishes `capt_node_kata_runtime_ready=0`, then installs the runtime over SSH and labels the Node.

New: [`controllers/linux/kata_runtime_drift.go`](https://github.com/tuist/tuist/blob/claude/competent-proskuriakova-8ce31f/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go). Supporting changes to the shared renderer, the OVH reconciler, and `AGENTS.md`. The matching Grafana alert has been created directly (see below), so nothing is added to the monitoring chart.

## Why

The Linux self-join is rendered **once**, at bootstrap, by whichever provider pod holds the leader lease at that moment. Nothing re-runs it.

During a rolling provider upgrade the chart applies the new provider Deployment and the fleet MachineDeployments in the same release. With `maxUnavailable: 0` the outgoing pod keeps the lease until it terminates, so a Machine created in that window is bootstrapped by the OLD build, which decodes the CR fine and silently drops any spec field its Go struct does not have.

On 2026-08-31 that put `kataRuntime: true` boxes into production and canary bootstrapped by `capi-scaleway@0.27.0`:

| event | time |
|---|---|
| [tuist/tuist#12716](https://github.com/tuist/tuist/pull/12716) merged (adds `kataRuntime`) | 10:44:47Z |
| `capi-scaleway@0.28.0` released | 12:06:55Z |
| new provider pods start | 12:30:18Z, 12:30:50Z |
| chart creates the Machine | 12:30:20Z |

The Machine was reconciled two seconds into the provider rollout. Its spec had `kataRuntime: true` the whole time; the controller reading it simply did not understand the field.

The result is a node that joins Ready, lands in the right pool with the right taint, runs every DaemonSet, logs no error anywhere, and never takes a single job, because the `kata-qemu` RuntimeClass selects on a label the old self-join never wrote. It read as a scheduling bug for about an hour, and both boxes were cleared by hand with `kubectl delete machine`.

## Why this approach

Three directions were on the table.

**Ordering the rollout cannot be expressed inside one Helm release.** A `pre-upgrade` hook runs before the new provider image is applied, so it cannot wait on a rollout that has not started. Moving the fleet MachineDeployments into a `post-upgrade` hook would take them out of the release entirely: hook resources are not release-tracked, and the default delete policy would reap them. Splitting the provider into its own release ahead of the chart would work but serializes every deploy behind a rollout that can wedge. Separately, the fleets use `strategy: OnDelete`, so flipping a bootstrap-time field on an existing MachineDeployment reaches zero live machines. Ordering would not fix that case at all.

**Version-stamping the bootstrap was skipped.** There is no version ldflag in the build today, so it needs Dockerfile plus CI plumbing for a field you would only consult once you already suspected the race, and it cannot act on what it finds.

**Detect and repair is the only mechanism that converges**, and the risk of automatic re-provisioning dissolves once the repair is additive rather than a re-bootstrap.

## The repair is not a re-bootstrap

This is the part worth reviewing closely, since these boxes run live jobs and the Kura cache boxes hold local state a reinstall destroys.

The script installs kata-static, registers the containerd handler, and re-renders the kubelet unit. It touches no apt source, no kubelet install, no `/data` mount, and never the kubelet itself. The only restart is containerd, which does not kill running containers, since their shims are separate processes that outlive it and reattach. So it needs no drain, and it never wipes a box.

Two details that shape the design:

1. **kubelet only applies custom `--node-labels` when it CREATES the Node object.** On restart against an existing Node it reconciles just the well-known `kubernetes.io` labels. So the unit rewrite fixes future re-registrations, and the controller patches the live Node itself.
2. **Nothing that advertises the box to the scheduler runs ahead of the proof.** The script verifies the shim is on disk and the handler is in the config, restarts containerd, checks it came back, and only then writes the kata-labelled kubelet unit. The controller patches the live Node only on the script's exit status. Advertising an unrepaired box would turn "no Pod ever schedules" into "every Pod wedged in ContainerCreating", which is harder to diagnose and burns the job instead of queueing it.

The containerd restart is unconditional, and has to be. The config append is idempotent, so from the second attempt onwards the handler is already in the file: a restart conditioned on it being absent would be skipped forever, and a first attempt whose restart failed or timed out would leave a daemon still running the pre-kata config while every file check passed. Restarting each time is what makes "the script exited 0" mean "the running daemon loaded this config". It costs nothing here, since this only ever runs on a runner box the RuntimeClass cannot select yet, so there is no kata workload to blip.

`Machine.Status.Ready` is deliberately left true: the node is a healthy Kubernetes node, and failing it would make CAPI churn a box that needs a two-minute in-place fix.

## Staying loud when the repair cannot land

The condition is marked False and the gauge set to 0 the moment the gap is observed, before any SSH, so an unreachable box is visibly broken rather than quietly retried. `KataRuntimeRepairFailed` carries the reason (unreachable, or a containerd whose config predates `version = 3`).

Neither existing provider alert sees this state: the machine's phase is Ready and the fleet is at full count.

The alert for it now exists in Grafana Cloud as **Runner Box Missing Kata Runtime**, in the Alerts folder's `Runners` group next to the other `capt_*` rules, sharing their datasource and Slack receiver (`for: 20m`, severity `warning`). Alerts for this operator are Grafana-managed rather than checked in, since managed clusters run no Prometheus Operator and there is no `PrometheusRule` to render. The reasoning and the recovery steps live in the rule's own description annotation, which is where its siblings keep theirs and where whoever the alert wakes will actually read them.

The query follows the house pattern: `A` returns the raw gauge and the threshold expression does the comparison.

```
A: min by (cluster, machine, fleet) (capt_node_kata_runtime_ready)
C: threshold on A, lt 1
```

Worth noting the comparison cannot live in the expression. PromQL `==` without `bool` filters rather than returning a boolean, so `... == 0` yields a series still valued `0`, which no `gt` threshold can catch. That is why the sibling rules also keep their documented `== 1` out of the query.

Only machines that asked for kata publish a series, so cache fleets never match. Nothing publishes the series until this ships, so the rule sits at NoData (`no_data_state: OK`) until then.

## Two supporting changes

- **The kata download is now guarded by a version stamp** at `/opt/kata/.tuist-kata-version`. The repair re-runs the install block on every retry, and an unguarded pull would drag ~250 MiB off GitHub each time. Stamping the version, rather than testing for the shim, keeps a `kataVersion` bump reinstalling.
- **Bootstrap and repair now render from one `hostOptions` builder**, so a future bootstrap-time field reaches both paths by construction rather than by remembering two call sites.

## Generality

The trap is not OVH-specific: `DediboxMachine` and `ScalewayElasticMetalMachine` share this renderer and the same once-at-bootstrap property. Only `OVHDedicatedMachine` carries a bootstrap-time capability today, so rather than build a registry with one entry, `AGENTS.md` now carries the rule for adding one (an observable on the Node, a check on the Ready path, an additive repair) plus a runbook entry for an on-caller who finds a Ready runner box taking no jobs.

## How to test locally

Red before green was observed, not inferred. Driving the real reconcile against a Ready node whose machine asked for kata left only the `NodeReady` condition, the exact silent state from the incident:

```
--- FAIL: TestKataRuntimeMissingIsSurfacedOnTheMachine
    expected a KataRuntimeReady condition on a machine whose node asked for kata
    but carries no katacontainers.io/kata-runtime label;
    conditions=[{NodeReady True ...}]
```

Run the suite:

```bash
cd infra/cluster-api-provider-tuist && go vet ./... && go test ./...
```

Tests cover detection, the converged no-op, the absent-condition case for cache fleets, and that a failed repair never labels the node. The rendered repair script is asserted to install and verify the runtime while running none of the re-bootstrap steps, to restart containerd unconditionally, and to order the shim check before that restart, the liveness check after it, and the kata-labelled kubelet unit after both. Both it and the full bootstrap were syntax-checked with `bash -n`.

The two review findings on `1077edd5` (a skippable containerd restart, and the labelled kubelet unit written before verification) are fixed in `a62c7c1`. Both were the same class of bug: verifying files rather than the running daemon, and advertising the box before proving anything. Test expectations were updated to the new properties and observed failing against the previous renderer before it was changed.

**Not yet validated:** the manual staging check. Reproducing the race needs a provider change and a fleet change deployed together, then confirming the node either gets the capability or is flagged. Worth doing on staging before this reaches canary.

