### PR TITLE
fix(cli): forward TUIST_CAS_LOG into the CAS proxy launch agent

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -481,6 +481,13 @@ struct SetupCacheCommandService {
         if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
             environmentVariables["TUIST_CAS_PROXY_REGISTRY"] = registry
         }
+        // The proxy's diagnostics (the `incomplete closure` shapes and the
+        // periodic stats line) are written only to the file this variable names,
+        // never to stdout or stderr, so without forwarding it there is no way to
+        // turn them on for a proxy running under launchd.
+        if let logPath = Environment.current.variables["TUIST_CAS_LOG"] {
+            environmentVariables["TUIST_CAS_LOG"] = logPath
+        }
         // Trunk ingestion pays for itself only where the machine can warm the CAS
         // BEFORE a build: it pulls the trunk closure in the background so the next
         // build finds it local. CI has no such window. The proxy and the build

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -388,6 +388,42 @@ struct SetupCacheCommandServiceTests {
             .called(1)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_forwardsCASLogPath() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let token = "test-auth-token-123"
+        environment.variables[Constants.EnvironmentVariables.token] = token
+        environment.variables["TUIST_CAS_LOG"] = "/tmp/cas.log"
+
+        let config = Tuist.test(fullHandle: "organization/project")
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(config)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: the proxy writes its diagnostics only to the file this variable
+        // names, so without forwarding them they cannot be turned on for a proxy
+        // running under launchd.
+        verify(launchAgentService)
+            .setupLaunchAgent(
+                label: .any,
+                plistFileName: .any,
+                programArguments: .any,
+                environmentVariables: .value([
+                    "TUIST_CAS_TOKEN": token,
+                    "TUIST_TOKEN": token,
+                    "TUIST_FEATURE_FLAG_KURA": "1",
+                    "TUIST_CAS_LOG": "/tmp/cas.log",
+                ])
+            )
+            .called(1)
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()


### PR DESCRIPTION
## What changed

`tuist setup cache` now forwards `TUIST_CAS_LOG` into the environment of the `tuist.cas-proxy` launchd agent when the variable is set in the caller's environment, following the same pattern already used for `TUIST_CACHE_ENDPOINT` and `TUIST_CAS_PROXY_REGISTRY`.

## Why

The CAS proxy emits the only log lines that discriminate between the different `missing object` failure shapes:

- `incomplete closure, root already local` (the shape PR #12555 knowingly does not cover)
- `incomplete closure, root withheld`
- `incomplete closure, root unavailable`
- `withheld root not produced, closure still incomplete`
- the periodic `proxy stats:` line carrying `incomplete_closures`, `withheld_refused`, `withheld_repaired`

All of them go through `log_line` in `cas-plugin/src/lib.rs`, which writes only to the file named by `$TUIST_CAS_LOG` and is a no-op when the variable is unset.

The proxy runs as a launchd agent, which does not inherit the caller's environment, and `installProxy` built the agent's environment explicitly: `TUIST_CAS_TOKEN`, `TUIST_TOKEN`, the client feature flags, `TUIST_CACHE_ENDPOINT`, `TUIST_CAS_PROXY_REGISTRY` and `TUIST_CAS_PREFETCH`. `TUIST_CAS_LOG` was not among them, and the string did not appear anywhere under `cli/`.

Net effect: a customer hitting a CAS failure on CI had no way to turn on the diagnostics that identify which failure shape they were hitting. That blocked a real escalation for several rounds of back and forth.

The proxy's launchd agent already redirects stdout and stderr to `<state>/tuist.cas-proxy.{stdout,stderr}.log`, but `log_line` does not write to stderr, so capturing those streams is not an alternative to this change.

## Why only the proxy path

`installLegacyDaemon` in the same file deliberately does not get the same treatment. `TUIST_CAS_LOG` is read only by the Rust `cas-plugin` crate; the legacy per-project daemon is the Swift `cache-start` path in `cli/Sources/TuistCAS` and never runs that code. Forwarding it there would set a variable nothing reads.

## Impact

`TUIST_CAS_LOG=/path/to/cas.log` in a CI job's environment now reaches the proxy, so support can ask for the proxy-side diagnostics instead of inferring the failure shape from the build log. Behaviour is unchanged when the variable is unset.

## Validation

- Added `setupCache_forwardsCASLogPath` alongside the existing `setupCache_forwardsCacheEndpointOverride` assertion, in the same style.
- Confirmed red before green: with the source change reverted, that test is the only failure in the suite; with it applied the whole suite passes.

```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistKitTests/SetupCacheCommandServiceTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

`Test run with 22 tests in 1 suite passed` / `** TEST SUCCEEDED **`.

- `mise run lint` passes (SwiftFormat clean, no new SwiftLint findings, graph and CSS token checks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
