### PR TITLE
fix(server): correct a missed initial cache placement on the first day

### DIFF
--- a/server/lib/tuist/kura/placement.ex
+++ b/server/lib/tuist/kura/placement.ex
@@ -35,8 +35,8 @@ defmodule Tuist.Kura.Placement do
       correct_initial: %{
         window_days: 7,
         majority_share: 0.8,
-        min_runs_per_day: 10,
-        min_active_days: 3,
+        min_runs_per_day: 5,
+        min_active_days: 1,
         within_days: 14
       },
       relocate: %{
@@ -55,8 +55,8 @@ defmodule Tuist.Kura.Placement do
       correct_initial: %{
         window_days: 7,
         majority_share: 0.8,
-        min_runs_per_day: 10,
-        min_active_days: 3,
+        min_runs_per_day: 5,
+        min_active_days: 1,
         within_days: 14
       },
       relocate: %{
@@ -75,8 +75,8 @@ defmodule Tuist.Kura.Placement do
       correct_initial: %{
         window_days: 7,
         majority_share: 0.8,
-        min_runs_per_day: 10,
-        min_active_days: 3,
+        min_runs_per_day: 5,
+        min_active_days: 1,
         within_days: 14
       },
       relocate: %{
@@ -169,14 +169,28 @@ defmodule Tuist.Kura.Placement do
   # whose cache is days old and nearly cold is cheap, moving one with a warm
   # working set is not.
   #
-  # So this is narrow rather than merely faster. It reads the same short window
-  # the guess itself read, but demands a clearly higher majority for acting on
-  # less evidence, and it only ever runs while the primary is young AND was
-  # never decided. Applying it records a placement row, which makes the primary
+  # So this is narrow rather than slow. It reads the same short window the guess
+  # itself read, and it only ever runs while the primary is young AND was never
+  # decided. Applying it records a placement row, which makes the primary
   # decided and disqualifies this rung for good — the once-only guarantee needs
   # no counter of its own, and correcting a guess does not spend the quarterly
   # relocation budget, because converging on the right answer for the first
   # time is not churn.
+  #
+  # What holds it back is the majority, not the calendar. The reason other
+  # rungs wait for days to accumulate is flapping, and this one cannot flap:
+  # it fires at most once per account, ever. So a day count would buy no
+  # safety, and it costs the account a wrongly placed cache on every build
+  # until it elapses. Worse, `within_days` expires the rung entirely, so an
+  # account building a few days a week could fail to accumulate the days
+  # before the window closed and fall through to a rung measured in months —
+  # the outcome this exists to prevent.
+  #
+  # A single active day is therefore enough, and the floors that remain are
+  # the ones that mean something: a clear majority, so one developer on a
+  # VPN moves nothing unless they genuinely are the account's traffic, and a
+  # volume floor that a real working day clears and an evaluation from a
+  # conference does not.
   defp correct_initial(_context, %{correct_initial: nil}, _runs), do: nil
   defp correct_initial(%{primary: nil}, _plan_policy, _runs), do: nil
   defp correct_initial(%{primary_decided?: true}, _plan_policy, _runs), do: nil

--- a/server/test/tuist/kura/placement_test.exs
+++ b/server/test/tuist/kura/placement_test.exs
@@ -144,6 +144,43 @@ defmodule Tuist.Kura.PlacementTest do
       assert evidence["signal"] == "initial_placement_missed"
     end
 
+    test "corrects a guess on a single day of traffic" do
+      # The rung fires at most once per account, so waiting for days to
+      # accumulate buys no protection against flapping, and every build until
+      # they do is served from the wrong side of an ocean. An account that
+      # builds a few days a week could also fail to accumulate them before
+      # `within_days` closed the rung, which is the outcome it exists to
+      # prevent.
+      context =
+        context(
+          primary: "us-east",
+          primary_decided?: false,
+          serving: ["us-east"],
+          held_since: %{"us-east" => Date.add(@today, -1)},
+          rollups: [rollup("FR", @today, 40)]
+        )
+
+      assert {:correct, "us-east", "eu-central", evidence} = Placement.evaluate(context)
+      assert evidence["signal"] == "initial_placement_missed"
+      assert evidence["active_days"] == 1
+    end
+
+    test "does not correct on a single day too quiet to mean anything" do
+      # One day is enough only once it carries a working day's traffic. The
+      # volume floor is what still separates a team that moved from a couple
+      # of runs someone tried out at a conference.
+      context =
+        context(
+          primary: "us-east",
+          primary_decided?: false,
+          serving: ["us-east"],
+          held_since: %{"us-east" => Date.add(@today, -1)},
+          rollups: [rollup("FR", @today, 30)]
+        )
+
+      refute match?({:correct, _from, _to, _evidence}, Placement.evaluate(context))
+    end
+
     test "does not correct a placement something decided" do
       # The rung replaces a guess. An applied relocation, an operator pin or
       # the backfill are decisions, and a decision is not corrected on a week.


### PR DESCRIPTION
## What changed

The `correct_initial` placement rung now fires after **one** active day at **5** runs a day, down from three active days at ten. The 0.8 majority share and the 14-day reach are untouched, and the change applies identically to all three plans.

| | before | after |
|---|---|---|
| `min_active_days` | 3 | **1** |
| `min_runs_per_day` | 10 (70 across the window) | **5** (35 across the window) |
| `majority_share` | 0.8 | unchanged |
| `within_days` | 14 | unchanged |

## Why

A brand-new account has no traffic history, so its first region is a guess. `correct_initial` is the rung that replaces that guess once real traffic says where the account actually builds. Waiting three active days meant a new account in the wrong region served **every build for three days from the wrong side of an ocean**, which is the exact cost the rung exists to avoid.

The three-day floor was also fragile in a way that is easy to miss. `within_days: 14` expires the rung entirely, so an account building two or three days a week could fail to accumulate three active days before the window closed. It would then fall through to `relocate`, which is measured in months. The floor meant to make the rung careful could instead stop it firing at all, producing precisely the outcome it was added to prevent.

## Why the day count was not buying safety

The reason the other rungs wait for days to accumulate is flapping: a settled primary should not move on a bad week. This rung cannot flap. Applying it records a placement row, which makes the primary decided and disqualifies the rung permanently, so it fires **at most once per account, ever**. A day count therefore bought no protection against the thing day counts protect against, and charged an account a wrongly placed cache for the whole time it ran.

What actually guards the rung is the majority share. At 0.8 it takes a clear supermajority of the account's traffic to overturn the guess, so one developer on a VPN moves nothing unless they genuinely are the account's traffic. That floor is unchanged.

## Why lowering the volume floor is still safe

The volume floor is checked against the **window total**, not per day: `total >= min_runs_per_day * window_days`. At the new values a single active day must still carry **35 runs** to qualify. A real working day clears that comfortably; someone trying the product out at a conference does not. Alternatives considered and rejected: keeping ten runs a day would have demanded 70 runs in one day, a bar a small team's first real day would miss, which re-introduces the expiry problem in a different place.

## Impact

A new account whose region was guessed wrong converges on the right one after a single day of real traffic instead of three, or instead of never when its build cadence is uneven. Accounts with a decided placement are unaffected: the rung is skipped entirely for them. No existing behaviour for `relocate`, `expand` or `retire` changes.

## Validation

- `mix test test/tuist/kura/placement_test.exs test/tuist/kura/placement_proposals_test.exs` — 60 passed.
- Two tests added, and the first was confirmed **red before green**: reverting only the two floors makes `corrects a guess on a single day of traffic` fail while all 37 others stay green, so it pins the new behaviour rather than restating the config.
  - `corrects a guess on a single day of traffic` — one day, 40 runs, asserts `active_days == 1`.
  - `does not correct on a single day too quiet to mean anything` — one day, 30 runs, below the 35-run window floor, declines.
- `mix format --check-formatted` and `mix credo` clean on both files.

Follows [#12645](https://github.com/tuist/tuist/pull/12645) and [spec #87](https://hive.tuist.dev/specs/87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
