### PR TITLE
fix(swifterpm): stop an unusable ambient GitHub token from breaking a public git fetch

### DIFF
--- a/swifterpm/Sources/swifterpm/GitFetch.swift
+++ b/swifterpm/Sources/swifterpm/GitFetch.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// One attempt at reaching a package's source control: a candidate location paired with the
+/// `git -c` arguments that authenticate it, empty when the attempt is anonymous.
+struct GitFetchAttempt {
+    let location: String
+    let configArguments: [String]
+
+    var isAuthenticated: Bool { !configArguments.isEmpty }
+}
+
+struct GitFetchAttemptFailure {
+    let attempt: GitFetchAttempt
+    let error: any Error
+}
+
+/// Drives the ordered attempts a git operation makes to reach a package.
+///
+/// Every candidate that carries a credential is also attempted anonymously before the next
+/// candidate is tried. github.com answers a credential it does not accept with a 401 rather
+/// than serving a public repository anonymously, git then asks for a username, and
+/// `GIT_TERMINAL_PROMPT=0` turns that question into a hard failure. Without the anonymous
+/// retry an ambient token that does not belong to the host, such as the one GitHub Actions
+/// exports on a runner attached to a GitHub Enterprise Server instance, makes a dependency
+/// that plain `git clone` would have fetched unfetchable.
+enum GitFetch {
+    static func attempts(for location: String) async -> [GitFetchAttempt] {
+        var attempts: [GitFetchAttempt] = []
+        for candidate in SourceControlLocations.fetchCandidates(location) {
+            let configArguments = await GitTransportAuth.configArguments(for: candidate)
+            attempts.append(
+                contentsOf: Self.attempts(for: candidate, authenticatedWith: configArguments)
+            )
+        }
+        return attempts
+    }
+
+    static func attempts(for candidate: String, authenticatedWith configArguments: [String])
+        -> [GitFetchAttempt]
+    {
+        let authenticated = GitFetchAttempt(location: candidate, configArguments: configArguments)
+        guard authenticated.isAuthenticated else { return [authenticated] }
+        return [authenticated, GitFetchAttempt(location: candidate, configArguments: [])]
+    }
+
+    static func perform<T>(
+        _ attempts: [GitFetchAttempt],
+        for location: String,
+        operation: (GitFetchAttempt) async throws -> T
+    ) async throws -> T {
+        var failures: [GitFetchAttemptFailure] = []
+        for attempt in attempts {
+            do {
+                return try await operation(attempt)
+            } catch {
+                failures.append(GitFetchAttemptFailure(attempt: attempt, error: error))
+            }
+        }
+        throw GitFetchFailure.error(location: location, failures: failures)
+    }
+
+    static func withAttempts<T>(
+        for location: String,
+        operation: (GitFetchAttempt) async throws -> T
+    ) async throws -> T {
+        try await perform(await attempts(for: location), for: location, operation: operation)
+    }
+}
+
+/// Reports every attempt that was made and how each failed. Reporting only the last error
+/// would surface the trailing SSH candidate for an SSH-declared dependency, masking whether
+/// the HTTPS fallback was attempted at all and why it failed.
+enum GitFetchFailure {
+    static func error(location: String, failures: [GitFetchAttemptFailure]) -> ToolError {
+        guard !failures.isEmpty else {
+            return ToolError.message("no source-control locations available for \(location)")
+        }
+        let details = reported(failures)
+            .map { "  - \($0.label): \($0.description)" }
+            .joined(separator: "\n")
+        return ToolError.message(
+            "could not fetch any candidate location for \(location):\n\(details)"
+        )
+    }
+
+    private struct ReportedFailure {
+        let label: String
+        let description: String
+    }
+
+    /// A candidate is attempted twice whenever it carries a credential, so reporting every
+    /// attempt verbatim would list most candidates twice for the same reason. Repeats of a
+    /// description a candidate already reported are dropped, and only a genuinely different
+    /// outcome from dropping the credential earns its own line.
+    private static func reported(_ failures: [GitFetchAttemptFailure]) -> [ReportedFailure] {
+        var reported: [ReportedFailure] = []
+        for candidate in candidates(of: failures) {
+            var descriptions: Set<String> = []
+            for failure in failures where failure.attempt.location == candidate {
+                let description = "\(failure.error)"
+                guard descriptions.insert(description).inserted else { continue }
+                let label = descriptions.count == 1 ? candidate : "\(candidate) (unauthenticated)"
+                reported.append(ReportedFailure(label: label, description: description))
+            }
+        }
+        return reported
+    }
+
+    private static func candidates(of failures: [GitFetchAttemptFailure]) -> [String] {
+        var candidates: [String] = []
+        for failure in failures where !candidates.contains(failure.attempt.location) {
+            candidates.append(failure.attempt.location)
+        }
+        return candidates
+    }
+}

--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -36,7 +36,9 @@ private actor GitHubTokenCache {
             return token
         }
 
-        guard let output = try? await SystemProcess.output("/usr/bin/env", ["gh", "auth", "token"])
+        guard let output = try? await SystemProcess.output(
+            "/usr/bin/env", ["gh", "auth", "token", "--hostname", "github.com"]
+        )
         else {
             return nil
         }
@@ -49,14 +51,23 @@ private actor GitHubTokenCache {
 private let githubTokenCache = GitHubTokenCache()
 
 enum GitHubAuth {
-    private static let envKeys = ["SWIFTERPM_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"]
+    private static let dedicatedEnvKey = "SWIFTERPM_GITHUB_TOKEN"
+    private static let ambientEnvKeys = ["GITHUB_TOKEN", "GH_TOKEN"]
 
+    /// `GitHubAuth` only ever authenticates github.com: `GitHubRepo` rejects every other host
+    /// and the API calls go to api.github.com. `GITHUB_TOKEN` and `GH_TOKEN` are ambient, and
+    /// GitHub Actions on a GitHub Enterprise Server instance exports them holding a credential
+    /// for that instance, which github.com answers with a 401. `GITHUB_SERVER_URL`,
+    /// `GITHUB_API_URL` and `GH_HOST` name the instance those credentials belong to, so they
+    /// are only used when all of them point at github.com. Naming `SWIFTERPM_GITHUB_TOKEN` is
+    /// itself a statement that the token is meant for github.com, so it is taken as given.
     static func envToken(from environment: [String: String]) -> String? {
-        for key in envKeys {
-            if let value = environment[key] {
-                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty { return trimmed }
-            }
+        if let token = nonEmpty(environment[dedicatedEnvKey]) {
+            return token
+        }
+        guard belongsToGitHubDotCom(environment) else { return nil }
+        for key in ambientEnvKeys {
+            if let token = nonEmpty(environment[key]) { return token }
         }
         return nil
     }
@@ -67,6 +78,28 @@ enum GitHubAuth {
 
     static func hasSession() async -> Bool {
         await token() != nil
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func belongsToGitHubDotCom(_ environment: [String: String]) -> Bool {
+        ["GITHUB_SERVER_URL", "GITHUB_API_URL", "GH_HOST"]
+            .compactMap { environment[$0] }
+            .compactMap(host(of:))
+            .allSatisfy { $0 == "github.com" || $0 == "api.github.com" }
+    }
+
+    private static func host(of value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let host = URL(string: trimmed)?.host {
+            return host.lowercased()
+        }
+        return trimmed.split(separator: "/").first.map { $0.lowercased() }
     }
 }
 

--- a/swifterpm/Sources/swifterpm/Remote.swift
+++ b/swifterpm/Sources/swifterpm/Remote.swift
@@ -54,20 +54,14 @@ enum RemoteMetadata {
     }
 
     private static func gitRemoteVersions(location: String) async throws -> [RemoteVersion] {
-        var attempts: [(candidate: String, error: any Error)] = []
-        for candidate in SourceControlLocations.fetchCandidates(location) {
-            do {
-                let authArguments = await GitTransportAuth.configArguments(for: candidate)
-                let output = try await SystemProcess.output(
-                    "/usr/bin/git", authArguments + ["ls-remote", "--tags", candidate],
-                    environment: SystemProcess.nonInteractiveGitEnvironment
-                )
-                return parseGitRemoteVersions(output)
-            } catch {
-                attempts.append((candidate, error))
-            }
+        try await GitFetch.withAttempts(for: location) { attempt in
+            let output = try await SystemProcess.output(
+                "/usr/bin/git",
+                attempt.configArguments + ["ls-remote", "--tags", attempt.location],
+                environment: SystemProcess.nonInteractiveGitEnvironment
+            )
+            return parseGitRemoteVersions(output)
         }
-        throw GitFetchFailure.error(location: location, attempts: attempts)
     }
 
     private static func parseGitRemoteVersions(_ output: String) -> [RemoteVersion] {
@@ -145,25 +139,19 @@ enum RemoteMetadata {
     }
 
     static func resolveNamedRef(location: String, name: String) async throws -> String {
-        var attempts: [(candidate: String, error: any Error)] = []
-        for candidate in SourceControlLocations.fetchCandidates(location) {
-            do {
-                let authArguments = await GitTransportAuth.configArguments(for: candidate)
-                let output = try await SystemProcess.output(
-                    "/usr/bin/git", authArguments + ["ls-remote", candidate, name],
-                    environment: SystemProcess.nonInteractiveGitEnvironment
-                )
-                guard let line = output.split(separator: "\n").first,
-                      let revision = line.split(whereSeparator: \.isWhitespace).first
-                else {
-                    throw ToolError.message("\(name) was not found in \(candidate)")
-                }
-                return String(revision)
-            } catch {
-                attempts.append((candidate, error))
+        try await GitFetch.withAttempts(for: location) { attempt in
+            let output = try await SystemProcess.output(
+                "/usr/bin/git",
+                attempt.configArguments + ["ls-remote", attempt.location, name],
+                environment: SystemProcess.nonInteractiveGitEnvironment
+            )
+            guard let line = output.split(separator: "\n").first,
+                  let revision = line.split(whereSeparator: \.isWhitespace).first
+            else {
+                throw ToolError.message("\(name) was not found in \(attempt.location)")
             }
+            return String(revision)
         }
-        throw GitFetchFailure.error(location: location, attempts: attempts)
     }
 
     static func parseSwiftTagVersion(_ tag: String) -> SemVer? {

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -891,41 +891,34 @@ enum WorkspaceRestorer {
         let revision = try pin.revision()
         let isLocalSourceControlPackage =
             try await PackageResolver.localSourceControlPackageLocation(pin.location) != nil
-        var attempts: [(candidate: String, error: any Error)] = []
-        for location in SourceControlLocations.fetchCandidates(pin.location) {
-            do {
-                try await resetDirectory(destination)
-                try await SystemProcess.run("/usr/bin/git", ["init", destination.path])
-                try await SystemProcess.run(
-                    "/usr/bin/git", ["-C", destination.path, "remote", "add", "origin", location]
-                )
-                let authArguments = await GitTransportAuth.configArguments(for: location)
-                try await SystemProcess.run(
-                    "/usr/bin/git",
-                    authArguments
-                        + ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
-                    environment: SystemProcess.nonInteractiveGitEnvironment
-                )
-                try await SystemProcess.run(
-                    "/usr/bin/git", ["-C", destination.path, "checkout", "--detach", "FETCH_HEAD"]
-                )
-                try await updateSubmodulesIfNeeded(
-                    in: destination,
-                    gitConfigArguments: authArguments,
-                    allowFileProtocol: isLocalSourceControlPackage
-                )
-                let gitDir = destination.appendingPathComponent(".git")
-                if !isLocalSourceControlPackage,
-                   try await fileSystem.exists(gitDir.absolutePath)
-                {
-                    try await fileSystem.remove(gitDir.absolutePath)
-                }
-                return
-            } catch {
-                attempts.append((location, error))
+        try await GitFetch.withAttempts(for: pin.location) { attempt in
+            try await resetDirectory(destination)
+            try await SystemProcess.run("/usr/bin/git", ["init", destination.path])
+            try await SystemProcess.run(
+                "/usr/bin/git",
+                ["-C", destination.path, "remote", "add", "origin", attempt.location]
+            )
+            try await SystemProcess.run(
+                "/usr/bin/git",
+                attempt.configArguments
+                    + ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
+                environment: SystemProcess.nonInteractiveGitEnvironment
+            )
+            try await SystemProcess.run(
+                "/usr/bin/git", ["-C", destination.path, "checkout", "--detach", "FETCH_HEAD"]
+            )
+            try await updateSubmodulesIfNeeded(
+                in: destination,
+                gitConfigArguments: attempt.configArguments,
+                allowFileProtocol: isLocalSourceControlPackage
+            )
+            let gitDir = destination.appendingPathComponent(".git")
+            if !isLocalSourceControlPackage,
+               try await fileSystem.exists(gitDir.absolutePath)
+            {
+                try await fileSystem.remove(gitDir.absolutePath)
             }
         }
-        throw GitFetchFailure.error(location: pin.location, attempts: attempts)
     }
 
     private static func updateSubmodulesIfNeeded(

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -36,26 +36,6 @@ enum ToolError: Error, CustomStringConvertible {
     }
 }
 
-/// Reports every candidate location that was tried and how each failed, instead of only the
-/// last error. The previous behaviour surfaced just `lastError`, which for an SSH-declared
-/// dependency is always the trailing SSH candidate, masking whether the HTTPS fallback was
-/// even attempted and why it failed. Listing each attempt makes the actual cause diagnosable.
-enum GitFetchFailure {
-    static func error(location: String, attempts: [(candidate: String, error: any Error)])
-        -> ToolError
-    {
-        guard !attempts.isEmpty else {
-            return ToolError.message("no source-control locations available for \(location)")
-        }
-        let details = attempts
-            .map { "  - \($0.candidate): \($0.error)" }
-            .joined(separator: "\n")
-        return ToolError.message(
-            "could not fetch any candidate location for \(location):\n\(details)"
-        )
-    }
-}
-
 enum SystemProcess {
     /// swifterpm invokes git non-interactively: output is captured and fetches run
     /// in parallel, so a built-in credential prompt (git opens /dev/tty directly)

--- a/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
@@ -30,8 +30,8 @@ struct GitFetchTests {
 
                 #expect(output.contains("refs/tags/1.0.0"))
                 #expect(attempted == [configArguments, []])
-                #expect(server.authenticatedRequests.isEmpty == false)
-                #expect(server.anonymousRequests.isEmpty == false)
+                #expect(server.authenticatedRequests.contains("/repo.git/info/refs"))
+                #expect(server.anonymousRequests.contains("/repo.git/info/refs"))
             }
         }
     }

--- a/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import SwifterPMCore
+
+struct GitFetchTests {
+    @Test
+    func retriesTheSameCandidateAnonymouslyWhenTheCredentialIsRejected() async throws {
+        try await withTemporaryDirectory { root in
+            try await withLocalGitHTTPServer(root: root, repository: "repo.git", tag: "1.0.0") {
+                server in
+                let location = server.url(path: "/repo.git")
+                let credential = Data("x-access-token:not-a-github-com-token".utf8)
+                    .base64EncodedString()
+                let configArguments = [
+                    "-c", "http.\(server.baseURL).extraheader=Authorization: Basic \(credential)",
+                ]
+
+                let attempted = Attempted()
+                let output = try await GitFetch.perform(
+                    GitFetch.attempts(for: location, authenticatedWith: configArguments),
+                    for: location
+                ) { attempt in
+                    attempted.record(attempt)
+                    return try await SystemProcess.output(
+                        "/usr/bin/git",
+                        attempt.configArguments + ["ls-remote", "--tags", attempt.location],
+                        environment: SystemProcess.nonInteractiveGitEnvironment
+                    )
+                }
+
+                #expect(output.contains("refs/tags/1.0.0"))
+                #expect(attempted.configArguments == [configArguments, []])
+                #expect(server.authenticatedRequests.isEmpty == false)
+                #expect(server.anonymousRequests.isEmpty == false)
+            }
+        }
+    }
+
+    @Test
+    func attemptsACandidateOnlyOnceWhenItCarriesNoCredential() {
+        #expect(
+            GitFetch.attempts(
+                for: "git@github.com:acme/private-lib.git", authenticatedWith: []
+            )
+            .map(\.configArguments) == [[]]
+        )
+    }
+
+    @Test
+    func attemptsACredentialledCandidateAnonymouslyBeforeMovingOn() {
+        let configArguments = ["-c", "http.https://github.com/.extraheader=Authorization: Basic x"]
+        let attempts = GitFetch.attempts(
+            for: "https://github.com/acme/public-lib.git", authenticatedWith: configArguments
+        )
+
+        #expect(attempts.map(\.location) == Array(repeating: "https://github.com/acme/public-lib.git", count: 2))
+        #expect(attempts.map(\.configArguments) == [configArguments, []])
+    }
+
+    @Test
+    func failureReportsEachCandidateOnceWhenDroppingTheCredentialChangesNothing() {
+        let error = GitFetchFailure.error(
+            location: "https://github.com/acme/lib",
+            failures: [
+                failure("https://github.com/acme/lib", authenticated: true, "repository not found"),
+                failure("https://github.com/acme/lib", authenticated: false, "repository not found"),
+                failure("git@github.com:acme/lib.git", authenticated: false, "Host key verification failed."),
+            ]
+        )
+
+        #expect(
+            "\(error)" == """
+            could not fetch any candidate location for https://github.com/acme/lib:
+              - https://github.com/acme/lib: repository not found
+              - git@github.com:acme/lib.git: Host key verification failed.
+            """
+        )
+    }
+
+    @Test
+    func failureDistinguishesTheAnonymousRetryWhenItFailedDifferently() {
+        let error = GitFetchFailure.error(
+            location: "https://github.com/acme/lib",
+            failures: [
+                failure("https://github.com/acme/lib", authenticated: true, "terminal prompts disabled"),
+                failure("https://github.com/acme/lib", authenticated: false, "repository not found"),
+            ]
+        )
+
+        #expect(
+            "\(error)" == """
+            could not fetch any candidate location for https://github.com/acme/lib:
+              - https://github.com/acme/lib: terminal prompts disabled
+              - https://github.com/acme/lib (unauthenticated): repository not found
+            """
+        )
+    }
+
+    private func failure(_ location: String, authenticated: Bool, _ message: String)
+        -> GitFetchAttemptFailure
+    {
+        GitFetchAttemptFailure(
+            attempt: GitFetchAttempt(
+                location: location,
+                configArguments: authenticated ? ["-c", "http.extraheader=Authorization: Basic x"] : []
+            ),
+            error: ToolError.message(message)
+        )
+    }
+}
+
+private final class Attempted: @unchecked Sendable {
+    private(set) var configArguments: [[String]] = []
+
+    func record(_ attempt: GitFetchAttempt) {
+        configArguments.append(attempt.configArguments)
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitFetchTests.swift
@@ -15,12 +15,12 @@ struct GitFetchTests {
                     "-c", "http.\(server.baseURL).extraheader=Authorization: Basic \(credential)",
                 ]
 
-                let attempted = Attempted()
+                var attempted: [[String]] = []
                 let output = try await GitFetch.perform(
                     GitFetch.attempts(for: location, authenticatedWith: configArguments),
                     for: location
                 ) { attempt in
-                    attempted.record(attempt)
+                    attempted.append(attempt.configArguments)
                     return try await SystemProcess.output(
                         "/usr/bin/git",
                         attempt.configArguments + ["ls-remote", "--tags", attempt.location],
@@ -29,7 +29,7 @@ struct GitFetchTests {
                 }
 
                 #expect(output.contains("refs/tags/1.0.0"))
-                #expect(attempted.configArguments == [configArguments, []])
+                #expect(attempted == [configArguments, []])
                 #expect(server.authenticatedRequests.isEmpty == false)
                 #expect(server.anonymousRequests.isEmpty == false)
             }
@@ -53,7 +53,12 @@ struct GitFetchTests {
             for: "https://github.com/acme/public-lib.git", authenticatedWith: configArguments
         )
 
-        #expect(attempts.map(\.location) == Array(repeating: "https://github.com/acme/public-lib.git", count: 2))
+        #expect(
+            attempts.map(\.location) == [
+                "https://github.com/acme/public-lib.git",
+                "https://github.com/acme/public-lib.git",
+            ]
+        )
         #expect(attempts.map(\.configArguments) == [configArguments, []])
     }
 
@@ -106,13 +111,5 @@ struct GitFetchTests {
             ),
             error: ToolError.message(message)
         )
-    }
-}
-
-private final class Attempted: @unchecked Sendable {
-    private(set) var configArguments: [[String]] = []
-
-    func record(_ attempt: GitFetchAttempt) {
-        configArguments.append(attempt.configArguments)
     }
 }

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -64,6 +64,64 @@ struct GitHubTests {
     }
 
     @Test
+    func ambientTokenIsUsedWhenTheWorkflowRunsAgainstGitHubDotCom() {
+        #expect(GitHubAuth.envToken(from: ["GITHUB_TOKEN": "ghs_secret"]) == "ghs_secret")
+        #expect(GitHubAuth.envToken(from: ["GH_TOKEN": "gho_secret"]) == "gho_secret")
+        #expect(
+            GitHubAuth.envToken(
+                from: [
+                    "GITHUB_TOKEN": "ghs_secret",
+                    "GITHUB_SERVER_URL": "https://github.com",
+                    "GITHUB_API_URL": "https://api.github.com",
+                ]
+            ) == "ghs_secret"
+        )
+        #expect(GitHubAuth.envToken(from: ["GITHUB_TOKEN": "   "]) == nil)
+        #expect(GitHubAuth.envToken(from: [:]) == nil)
+    }
+
+    @Test
+    func ambientTokenIsIgnoredWhenItBelongsToAnotherGitHubInstance() {
+        #expect(
+            GitHubAuth.envToken(
+                from: [
+                    "GITHUB_TOKEN": "ghs_secret",
+                    "GITHUB_SERVER_URL": "https://github.acme-internal.test",
+                ]
+            ) == nil
+        )
+        #expect(
+            GitHubAuth.envToken(
+                from: [
+                    "GITHUB_TOKEN": "ghs_secret",
+                    "GITHUB_API_URL": "https://github.acme-internal.test/api/v3",
+                ]
+            ) == nil
+        )
+        #expect(
+            GitHubAuth.envToken(
+                from: ["GH_TOKEN": "gho_secret", "GH_HOST": "github.acme-internal.test"]
+            ) == nil
+        )
+    }
+
+    @Test
+    func dedicatedTokenIsUsedEvenWhenTheWorkflowRunsAgainstAnotherGitHubInstance() {
+        // Naming SWIFTERPM_GITHUB_TOKEN is itself a statement that the token is meant for
+        // github.com, which is the whole point of the variable on a runner attached to a
+        // GitHub Enterprise Server instance.
+        #expect(
+            GitHubAuth.envToken(
+                from: [
+                    "SWIFTERPM_GITHUB_TOKEN": "ghp_dedicated",
+                    "GITHUB_TOKEN": "ghs_secret",
+                    "GITHUB_SERVER_URL": "https://github.acme-internal.test",
+                ]
+            ) == "ghp_dedicated"
+        )
+    }
+
+    @Test
     func gitHubTransportAuthInjectsBearerTokenAsBasicExtraHeader() {
         let encoded = Data("x-access-token:ghp_secret".utf8).base64EncodedString()
         #expect(

--- a/swifterpm/Tests/swifterpmTests/LocalGitHTTPServer.swift
+++ b/swifterpm/Tests/swifterpmTests/LocalGitHTTPServer.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Synchronization
+@testable import SwifterPMCore
+
+#if canImport(Glibc)
+    import Glibc
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
+    import Darwin
+#endif
+
+/// A loopback HTTP/1.1 server that publishes a git repository over git's dumb HTTP transport
+/// and answers any request carrying an `Authorization` header with a 401, the way github.com
+/// rejects a credential it does not accept instead of serving a public repository anonymously.
+final class LocalGitHTTPServer: Sendable {
+    private struct State {
+        var authenticatedRequests: [String] = []
+        var anonymousRequests: [String] = []
+        var stopped = false
+    }
+
+    private let root: URL
+    private let state = Mutex(State())
+    private let listeningSocket: Int32
+
+    let port: UInt16
+
+    enum Failure: Error {
+        case socketUnavailable
+        case bindFailed
+    }
+
+    init(root: URL) throws {
+        #if canImport(Glibc)
+            let streamType = Int32(SOCK_STREAM.rawValue)
+        #else
+            let streamType = SOCK_STREAM
+        #endif
+
+        let descriptor = socket(AF_INET, streamType, 0)
+        guard descriptor >= 0 else { throw Failure.socketUnavailable }
+
+        var reuse: Int32 = 1
+        setsockopt(
+            descriptor, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size)
+        )
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(descriptor, 16) == 0 else {
+            close(descriptor)
+            throw Failure.bindFailed
+        }
+
+        var boundAddress = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(descriptor, $0, &length)
+            }
+        }
+        guard named == 0 else {
+            close(descriptor)
+            throw Failure.bindFailed
+        }
+
+        self.root = root
+        listeningSocket = descriptor
+        port = UInt16(bigEndian: boundAddress.sin_port)
+    }
+
+    /// The base git matches `http.<base>.*` configuration against.
+    var baseURL: String { "http://127.0.0.1:\(port)/" }
+
+    func url(path: String) -> String { "http://127.0.0.1:\(port)\(path)" }
+
+    var authenticatedRequests: [String] { state.withLock { $0.authenticatedRequests } }
+
+    var anonymousRequests: [String] { state.withLock { $0.anonymousRequests } }
+
+    func start() {
+        let thread = Thread { [self] in acceptLoop() }
+        thread.stackSize = 512 * 1024
+        thread.start()
+    }
+
+    func stop() {
+        let alreadyStopped = state.withLock { state -> Bool in
+            let wasStopped = state.stopped
+            state.stopped = true
+            return wasStopped
+        }
+        guard !alreadyStopped else { return }
+        shutdown(listeningSocket, Int32(SHUT_RDWR))
+        close(listeningSocket)
+    }
+
+    private func acceptLoop() {
+        while !state.withLock({ $0.stopped }) {
+            let connection = accept(listeningSocket, nil, nil)
+            guard connection >= 0 else { return }
+            serve(connection: connection)
+            close(connection)
+        }
+    }
+
+    private func serve(connection: Int32) {
+        guard let head = readRequestHead(connection: connection) else { return }
+        let lines = head.components(separatedBy: "\r\n")
+        let requestLine = lines.first?.split(separator: " ") ?? []
+        guard requestLine.count >= 2 else { return }
+        let path = String(requestLine[1].split(separator: "?", maxSplits: 1)[0])
+        let isAuthenticated = lines.dropFirst().contains {
+            $0.lowercased().hasPrefix("authorization:")
+        }
+
+        state.withLock { state in
+            if isAuthenticated {
+                state.authenticatedRequests.append(path)
+            } else {
+                state.anonymousRequests.append(path)
+            }
+        }
+
+        guard !isAuthenticated else {
+            write(
+                statusCode: 401,
+                headers: ["WWW-Authenticate": #"Basic realm="git""#],
+                body: Data(),
+                to: connection
+            )
+            return
+        }
+        guard let contents = contents(at: path) else {
+            write(statusCode: 404, headers: [:], body: Data(), to: connection)
+            return
+        }
+        write(
+            statusCode: 200,
+            headers: ["Content-Type": "application/octet-stream"],
+            body: contents,
+            to: connection
+        )
+    }
+
+    private func readRequestHead(connection: Int32) -> String? {
+        var accumulated: [UInt8] = []
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while accumulated.count < 64 * 1024 {
+            let received = recv(connection, &buffer, buffer.count, 0)
+            guard received > 0 else { break }
+            accumulated.append(contentsOf: buffer[0 ..< received])
+            if let head = String(bytes: accumulated, encoding: .utf8), head.contains("\r\n\r\n") {
+                return head
+            }
+        }
+        return String(bytes: accumulated, encoding: .utf8)
+    }
+
+    private func contents(at path: String) -> Data? {
+        let components = path.split(separator: "/").map(String.init)
+        guard !components.contains("..") else { return nil }
+        let url = components.reduce(root) { $0.appendingPathComponent($1) }
+        return try? Data(contentsOf: url)
+    }
+
+    private func write(statusCode: Int, headers: [String: String], body: Data, to connection: Int32) {
+        var head = "HTTP/1.1 \(statusCode) \(Self.reason(for: statusCode))\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n"
+        for (name, value) in headers {
+            head += "\(name): \(value)\r\n"
+        }
+        head += "\r\n"
+
+        var payload = Array(head.utf8)
+        payload.append(contentsOf: body)
+        payload.withUnsafeBufferPointer { buffer in
+            var sent = 0
+            while sent < buffer.count {
+                let written = send(connection, buffer.baseAddress! + sent, buffer.count - sent, 0)
+                guard written > 0 else { return }
+                sent += written
+            }
+        }
+    }
+
+    private static func reason(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200: return "OK"
+        case 401: return "Unauthorized"
+        case 404: return "Not Found"
+        default: return "Status"
+        }
+    }
+}
+
+/// Publishes `repository` as a git dumb HTTP repository underneath `root`, and returns the
+/// server that serves it anonymously while rejecting every authenticated request.
+func withLocalGitHTTPServer<T>(
+    root: URL,
+    repository: String,
+    tag: String,
+    _ body: (LocalGitHTTPServer) async throws -> T
+) async throws -> T {
+    let work = root.appendingPathComponent("work")
+    try await fileSystem.makeDirectory(
+        at: work.absolutePath, options: [.createTargetParentDirectories]
+    )
+    try await fileSystem.atomicWrite("public\n", to: work.appendingPathComponent("README.md"))
+    try await SystemProcess.run("/usr/bin/git", ["init", "-q"], workingDirectory: work)
+    try await SystemProcess.run("/usr/bin/git", ["add", "."], workingDirectory: work)
+    try await SystemProcess.run(
+        "/usr/bin/git",
+        [
+            "-c", "user.name=Repro",
+            "-c", "user.email=repro@example.com",
+            "commit", "-q", "-m", "initial",
+        ],
+        workingDirectory: work
+    )
+    try await SystemProcess.run("/usr/bin/git", ["tag", tag], workingDirectory: work)
+    // Git's dumb HTTP transport reads the static `info/refs` this writes, so the repository
+    // can be served as plain files instead of needing a git-aware backend.
+    try await SystemProcess.run("/usr/bin/git", ["update-server-info"], workingDirectory: work)
+    try await fileSystem.move(
+        from: work.appendingPathComponent(".git").absolutePath,
+        to: root.appendingPathComponent(repository).absolutePath,
+        options: []
+    )
+    try await fileSystem.remove(work.absolutePath)
+
+    let server = try LocalGitHTTPServer(root: root)
+    server.start()
+    do {
+        let result = try await body(server)
+        server.stop()
+        return result
+    } catch {
+        server.stop()
+        throw error
+    }
+}

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -436,6 +436,31 @@ struct SupportTests {
     }
 
     @Test
+    func gitHubDownloadsDropAnAmbientTokenThatBelongsToAnotherGitHubInstance() async throws {
+        let asset = URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1")!
+
+        let scoped = try await Environment.$values.withValue([
+            "GITHUB_TOKEN": "ghs_secret",
+            "GITHUB_SERVER_URL": "https://github.acme-internal.test",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(for: asset)
+            }
+        }
+        #expect(scoped != "Bearer ghs_secret")
+
+        let ownInstance = try await Environment.$values.withValue([
+            "GITHUB_TOKEN": "ghs_secret",
+            "GITHUB_SERVER_URL": "https://github.com",
+        ]) {
+            try await Environment.withNetrc(.empty) {
+                await HTTPAuthorization.header(for: asset)
+            }
+        }
+        #expect(ownInstance == "Bearer ghs_secret")
+    }
+
+    @Test
     func realpathFollowsSymlinksAndKeepsThePathWhenItCannotResolve() async throws {
         try await withTemporaryDirectory { directory in
             let target = directory.appendingPathComponent("Target")


### PR DESCRIPTION
## What changed

swifterpm retries a git fetch candidate anonymously when the authenticated attempt fails, and it only attaches an ambient GitHub token to github.com when the environment says that token belongs to github.com.

## The bug

`GitTransportAuth.configArguments(for:)` emits `-c http.https://github.com/.extraheader=Authorization: Basic <...>` whenever `GitHubAuth.token()` returns anything at all. Nothing checked that the token is valid for github.com, and there was no exemption for public repositories.

The three candidate loops (`RemoteMetadata.gitRemoteVersions`, `RemoteMetadata.resolveNamedRef` and `WorkspaceRestorer.shallowFetchCheckout`) computed those arguments per candidate and, when an attempt failed, recorded the failure and moved on to the next candidate. None of them retried the same candidate with the arguments removed. `SystemProcess.nonInteractiveGitEnvironment` sets `GIT_TERMINAL_PROMPT=0`.

Chained together: github.com answers an invalid or wrongly scoped credential with a 401 instead of serving the repository anonymously, git tries to prompt for a username, prompts are disabled, and the fetch fails hard.

```
could not fetch any candidate location for https://github.com/<owner>/<repo>:
  - https://github.com/<owner>/<repo>: fatal: could not read Username for 'https://github.com': terminal prompts disabled
  - https://github.com/<owner>/<repo>.git: fatal: could not read Username for 'https://github.com': terminal prompts disabled
  - git@github.com:<owner>/<repo>.git: Host key verification failed.
```

Both HTTPS candidates were poisoned by the injected token, and the repository is public. It was reported from a CI setup whose Actions runners are attached to a GitHub Enterprise Server instance, so the ambient `GITHUB_TOKEN` is a credential for that instance which github.com rejects. A dependency that plain `git clone` would have fetched with no credentials at all became unfetchable.

SwiftPM cannot hit this, because it never attaches credentials to git operations. `SWIFTPM_SOURCE_CONTROL_TOKEN` is documented upstream as not affecting `git clone` or `git fetch`. swifterpm's token injection is a deliberate divergence that exists so an SSH declared private dependency can be fetched over HTTPS in CI with only a token available, so it stays. The goal here is to recover SwiftPM's property that an unrelated ambient token can never break a fetch that would otherwise have succeeded.

## The fix

**Retry the same candidate anonymously.** Every candidate that carries a credential is now attempted a second time without it before the next candidate is tried. The three loops share one `GitFetch` abstraction that plans the attempts and runs them, so the submodule update in `shallowFetchCheckout` automatically uses the arguments of whichever attempt succeeded rather than the ones the loop happened to compute last. Failure reporting collapses the repeated attempt of a candidate into a single line unless dropping the credential actually changed the outcome, so the report does not double in length now that each candidate can be attempted twice.

**Scope the token to the host it belongs to.** `GitHubAuth` only ever authenticates github.com: `GitHubRepo` rejects every other host and the API calls go to api.github.com. It nevertheless accepted any `GITHUB_TOKEN` or `GH_TOKEN` it found. GitHub Actions on a GitHub Enterprise Server instance exports the same variable holding a credential for that instance. `GITHUB_SERVER_URL`, `GITHUB_API_URL` and `GH_HOST` name the instance the ambient credentials belong to, so those two variables are now only used when all three point at github.com, and the `gh` CLI fallback asks for the github.com token explicitly instead of the token of whichever host `gh` happens to default to. `SWIFTERPM_GITHUB_TOKEN` keeps its precedence and is deliberately exempt from the host check, since naming it is already a statement that the token is meant for github.com. The scoping lands in the single `GitHubAuth.envToken(from:)` lookup, so the api.github.com download path in `HTTPAuthorization` picks it up too, and a public release asset is no longer requested with a credential that answers 401.

The two changes are complementary rather than redundant. Scoping stops the common case from ever attaching a credential github.com will reject, and the anonymous retry is the backstop for every credential that is wrong for a reason the environment does not advertise: an expired token, a fine grained token without access to the repository, or a token from a source swifterpm cannot introspect.

## Why not remove the token injection

Removing it would match SwiftPM exactly, but it would also break the case the injection was added for: an SSH declared private dependency that CI can only reach over HTTPS with a token. The retry keeps that working and makes the token best effort rather than fatal.

## Impact

A public dependency now resolves in any environment that happens to export a GitHub token swifterpm cannot use, instead of failing the build. A private dependency behaves exactly as before when the token is valid, and now reports both the authenticated and the anonymous failure when it is not.

The cost is one extra failing request per credentialled candidate on the path where the fetch was going to fail anyway.

## Validation

- `mise run test:unit` from `swifterpm`: 196 tests pass.
- The regression test drives real `git ls-remote` against a loopback server that publishes a repository over git's dumb HTTP transport and answers any request carrying an `Authorization` header with a 401, the way github.com rejects a credential it does not accept. It was written first and failed with `fatal: could not read Username for 'http://127.0.0.1:<port>': terminal prompts disabled`, the same error as the report.
- Reproduced and fixed against real github.com. `swifterpm restore` of a lockfile pinning a public repository, in a clean environment carrying an invalid `GITHUB_TOKEN`, fails on the binary built from `main`:

  ```
  Error: failed to restore swift-argument-parser from https://github.com/apple/swift-argument-parser at 626b5b7b2f45: could not fetch any candidate location for https://github.com/apple/swift-argument-parser:
    - https://github.com/apple/swift-argument-parser: fatal: could not read Username for 'https://github.com': terminal prompts disabled
    - https://github.com/apple/swift-argument-parser.git: fatal: could not read Username for 'https://github.com': terminal prompts disabled
    - git@github.com:apple/swift-argument-parser.git: git@github.com: Permission denied (publickey).
  ```

  The same command on this branch restores the checkout.
- `mise run test:e2e` on this branch and on `main`: same 19 examples, same 6 failures on both, so no regression. Those 6 are unrelated to this change (a registry archive checksum mismatch against the local test registry, `jq` reading lockfiles whose `pins` it cannot iterate, and a missing local checkout in one fixture).

## Related

Follow up to https://github.com/tuist/tuist/pull/12724, which adds `SWIFTERPM_GITHUB_TOKEN` so a CI setup hosted on a GitHub Enterprise Server instance can supply a valid github.com token. That variable is worth having on its own, and the review there promised this follow up: it is an opt in workaround, while this is the fix that makes an unusable ambient token harmless without any configuration.

This branch is rebased onto that change, so the two compose in one lookup: `SWIFTERPM_GITHUB_TOKEN` first and unconditional, then `GITHUB_TOKEN` and `GH_TOKEN` only when the environment says they belong to github.com, and an anonymous retry behind all of it.

