### PR TITLE
feat(server): record which host a runner session ran on

### DIFF
--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -1039,6 +1039,11 @@ defmodule Tuist.Runners do
       affinity_outcome: affinity_outcome
     } = context
 
+    # Already resolved upstream for cache-volume affinity, so recording it on
+    # the session costs nothing and is the only chance to capture it: the Pod
+    # carrying this mapping is reaped when the job ends.
+    node_name = Map.get(context, :node_name)
+
     case Accounts.get_account_by_id(candidate.account_id) do
       {:ok, account} ->
         pod_name = pod_name_from_sa(sa_name)
@@ -1085,6 +1090,7 @@ defmodule Tuist.Runners do
             vcpus: resources.vcpus,
             memory_gb: resources.memory_gb,
             pod_name: pod_name,
+            node_name: node_name,
             runner_name: runner_name,
             repository: Map.get(candidate, :repository, ""),
             workflow_name: Map.get(candidate, :workflow_name, ""),

--- a/server/lib/tuist/runners/runner_session.ex
+++ b/server/lib/tuist/runners/runner_session.ex
@@ -26,6 +26,12 @@ defmodule Tuist.Runners.RunnerSession do
     field :job_ended_at, :utc_datetime_usec
     field :pod_name, :string, default: ""
     field :runner_name, :string, default: ""
+    # The host the Pod ran on. Recorded here because the pod-to-node mapping
+    # lives only in Kubernetes and disappears when the Pod is reaped, so
+    # without it a finished job cannot be attributed to a machine. NULL for
+    # sessions opened before the column existed, and for any dispatch that
+    # could not resolve a node.
+    field :node_name, :string
     # The workflow_job GitHub actually ran on this runner, learned
     # from the `in_progress` / `completed` webhook. Durable ground
     # truth that outlives the pod; NULL until GitHub proves it.

--- a/server/lib/tuist/runners/runner_sessions.ex
+++ b/server/lib/tuist/runners/runner_sessions.ex
@@ -102,6 +102,9 @@ defmodule Tuist.Runners.RunnerSessions do
       # that already ran.
       billing_multiplier: Catalog.billing_multiplier(platform, vcpus, memory_gb),
       pod_name: pod_name,
+      # Optional: a dispatch that could not resolve the node still bills
+      # correctly, it just cannot be attributed to a machine afterwards.
+      node_name: Map.get(attrs, :node_name),
       runner_name: Map.get(attrs, :runner_name, ""),
       repository: Map.get(attrs, :repository, ""),
       workflow_name: Map.get(attrs, :workflow_name, ""),

--- a/server/priv/repo/migrations/20260831143700_add_node_name_to_runner_sessions.exs
+++ b/server/priv/repo/migrations/20260831143700_add_node_name_to_runner_sessions.exs
@@ -1,0 +1,24 @@
+defmodule Tuist.Repo.Migrations.AddNodeNameToRunnerSessions do
+  use Ecto.Migration
+
+  # Which host a job ran on was previously unrecoverable. The session records
+  # pod_name, but the pod-to-node mapping lives only in Kubernetes as
+  # Pod.spec.nodeName, and runner Pods are reaped when the job finishes. So a
+  # completed job could never be attributed to a machine after the fact.
+  #
+  # That bites exactly when it matters most: during a fleet migration, comparing
+  # the new hardware against the old is the question everyone asks, and it could
+  # only be answered by snapshotting live pods on a timer and hoping to catch
+  # them before they were reaped. Jobs that completed before someone started
+  # watching were lost for good.
+  #
+  # Nullable with no backfill: rows written before this cannot be attributed,
+  # and inventing a value for them would be worse than leaving the gap visible.
+  # Dispatch already resolves the node for cache-volume affinity, so populating
+  # it costs no extra Kubernetes call.
+  def change do
+    alter table(:runner_sessions) do
+      add :node_name, :string
+    end
+  end
+end

--- a/server/test/tuist/runners/runner_sessions_test.exs
+++ b/server/test/tuist/runners/runner_sessions_test.exs
@@ -45,6 +45,43 @@ defmodule Tuist.Runners.RunnerSessionsTest do
       assert session.vcpus == 4
       assert session.memory_gb == 16
     end
+
+    test "records the host the Pod ran on" do
+      account = account_fixture()
+
+      assert {:ok, session} =
+               RunnerSessions.open(%{
+                 workflow_job_id: 79_002,
+                 account_id: account.id,
+                 fleet_name: "tuist-runner-pool-linux-4vcpu-16gb",
+                 platform: :linux,
+                 vcpus: 4,
+                 memory_gb: 16,
+                 pod_name: "pod-on-a-node",
+                 node_name: "tuist-tuist-ovh-fleet-runners-linux-abc",
+                 started_at: DateTime.utc_now()
+               })
+
+      assert session.node_name == "tuist-tuist-ovh-fleet-runners-linux-abc"
+    end
+
+    test "opens without a node, since billing must not depend on attribution" do
+      account = account_fixture()
+
+      assert {:ok, session} =
+               RunnerSessions.open(%{
+                 workflow_job_id: 79_003,
+                 account_id: account.id,
+                 fleet_name: "tuist-runner-pool-linux-4vcpu-16gb",
+                 platform: :linux,
+                 vcpus: 4,
+                 memory_gb: 16,
+                 pod_name: "pod-without-a-node",
+                 started_at: DateTime.utc_now()
+               })
+
+      assert is_nil(session.node_name)
+    end
   end
 
   describe "occupied_counts_per_fleet/0" do


### PR DESCRIPTION
Adds a nullable `node_name` to `runner_sessions` and populates it at dispatch.

Replaces #12730, which was branched off the pre-squash OVH branch and so replayed 13 already-merged commits. Same commit, cut against `main`: 5 files, +76 lines.

## Why

Which machine ran a job was unrecoverable. The session records `pod_name`, but the pod-to-node mapping lives only in Kubernetes as `Pod.spec.nodeName`, and runner Pods are reaped when the job finishes. Once a job completed, nothing could say which host it ran on.

That bites hardest during a fleet migration, which is exactly when the question gets asked. Comparing the new OVH Gravelines boxes against the Hetzner AX162-R hosts meant snapshotting live Pods on a 30-second timer for half an hour to attribute **nine** jobs, against controls of hundreds of runs, and every job that finished before the watching started is unattributable for good. With this column it is one query.

## How

`node_name` is already resolved upstream and carried in the claim context, because cache-volume affinity needs it to place a Pod near an account's warm master. This only threads the value dispatch already holds into the session row, so it costs no extra Kubernetes call on the dispatch hot path.

## Deliberately nullable, with no backfill

Rows written before this cannot be attributed, and inventing a value for them would be worse than leaving the gap visible.

A dispatch that cannot resolve a node still opens a session and still bills correctly; it just cannot be attributed afterwards. There is a test pinning that, so billing never quietly grows a dependency on attribution.

## Not changed

The ClickHouse session replica (`session_replication.ex`) projects an explicit narrow subset for the Concurrency card and has no use for this, so it is untouched.

## Validation

- `mix test test/tuist/runners/` passes: 738 tests, rebased onto current `main`
- Two new tests on `open/1`: one asserting the host is recorded, one asserting a session opens without a node
- `mix credo` clean on the changed modules
- `mix excellent_migrations.check_safety` reports nothing new; adding a nullable column takes no lock worth worrying about

### How to test locally

```bash
cd server && mix test test/tuist/runners/runner_sessions_test.exs
```

Once deployed, attribution that previously took a timer and a lot of luck:

```sql
SELECT node_name, workflow_name, vcpus, memory_gb, COUNT(*) AS runs,
       ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (
         ORDER BY EXTRACT(EPOCH FROM (job_ended_at - job_started_at)))) AS p50_secs
FROM runner_sessions
WHERE platform = 'linux' AND job_ended_at IS NOT NULL AND node_name IS NOT NULL
GROUP BY node_name, workflow_name, vcpus, memory_gb
ORDER BY runs DESC;
```
