### PR TITLE
fix(cli): prevent duplicate module maps with binary cache

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -43,19 +43,9 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         let derivedDirectory = try await derivedDirectory(for: graph)
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
-        // Xcode processes every unconditionally direct xcframework into the build products directory. That copy is
-        // visible to the target graph, so adding the same vendor module map from a dynamic route would define the
-        // module twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route.
-        var unconditionallyDirectlyLinkedXCFrameworkPaths = Set<AbsolutePath>()
-        for (source, dependencies) in graph.dependencies {
-            guard case .target = source else { continue }
-            for dependency in dependencies {
-                guard graph.dependencyConditions[(source, dependency)] == nil,
-                      case let .xcframework(xcframework) = dependency
-                else { continue }
-                unconditionallyDirectlyLinkedXCFrameworkPaths.insert(xcframework.path)
-            }
-        }
+        let unconditionallyDirectlyLinkedXCFrameworkPaths = Self.unconditionallyDirectlyLinkedXCFrameworkPaths(
+            in: [graph, environment.initialGraphWithSources].compactMap { $0 }
+        )
 
         let graph = try await mapGraph(
             graph: graph
@@ -254,6 +244,27 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
     private static func nestedModuleMap(for xcframework: GraphDependency.XCFramework) -> AbsolutePath? {
         guard let moduleMap = xcframework.moduleMaps.first else { return nil }
         return moduleMap.parentDirectory.basename == xcframework.path.basenameWithoutExt ? moduleMap : nil
+    }
+
+    /// Xcode processes every unconditionally direct xcframework into the build products directory. That copy is
+    /// visible to the target graph, so adding the same vendor module map from a dynamic route would define the module
+    /// twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route. The original graph
+    /// is retained in the mapper environment before binary-cache replacement, which can otherwise remove the direct
+    /// dependency from the graph being generated.
+    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(in graphs: [Graph]) -> Set<AbsolutePath> {
+        var paths = Set<AbsolutePath>()
+        for graph in graphs {
+            for (source, dependencies) in graph.dependencies {
+                guard case .target = source else { continue }
+                for dependency in dependencies {
+                    guard graph.dependencyConditions[(source, dependency)] == nil,
+                          case let .xcframework(xcframework) = dependency
+                    else { continue }
+                    paths.insert(xcframework.path)
+                }
+            }
+        }
+        return paths
     }
 
     /// Only called for flat layouts, which point at the derived module map whose umbrella header was

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -276,6 +276,86 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertBetterEqual([], gotSideEffects)
     }
 
+    func test_map_when_static_xcframework_library_was_linked_directly_before_binary_cache_replacement() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let cachedDynamicFramework: GraphDependency = .testXCFramework(
+            path: try temporaryPath()
+                .appending(component: "Consumer.xcframework")
+        )
+        let project: Project = .test(
+            path: projectPath,
+            targets: [
+                .test(name: "App"),
+            ]
+        )
+        let graphWithSources: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    googleMaps,
+                ],
+            ]
+        )
+        let graphWithBinaryCache: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [projectPath: project],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    cachedDynamicFramework,
+                ],
+                cachedDynamicFramework: [
+                    googleMaps,
+                ],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = graphWithSources
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graphWithBinaryCache,
+            environment: environment
+        )
+
+        // Then
+        XCTAssertBetterEqual(graphWithBinaryCache, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
     func test_map_when_static_xcframework_library_is_linked_directly_for_other_platforms() async throws {
         // Given
         let projectPath = try temporaryPath()


### PR DESCRIPTION
> Prevent duplicate module maps after binary-cache replacement.

## What changed

- Preserve unconditional direct framework-bundle paths from the original graph while mapping the generated binary-cache graph.
- Add regression coverage for a direct static framework bundle that becomes transitive through a cached dynamic framework bundle.

## Why

The earlier direct-link fix did not cover binary-cache generation because replacement removed the direct dependency from the graph inspected by the mapper.

## Root cause

The mapper re-added the vendor module map after the binary cache rewrote the graph, while Xcode still exposed the copy produced for the original direct dependency. The compiler then discovered two definitions of the same module.

## Approach

Collect unconditional direct framework-bundle paths from both the current graph and the preserved source graph. Platform-qualified links remain excluded because they cannot prove coverage of the dynamic route.

## Impact

Binary-cache builds no longer reintroduce duplicate module maps for static framework bundles that are both directly linked and reachable through cached dynamic framework bundles.

## Validation

- `mise run cli:lint --fix`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO` (22 tests passed)

### How to test locally

Generate a graph where a static framework bundle is directly linked by an application target and also reached through a dynamic framework bundle. Run generation with the binary cache enabled and verify the resulting target settings do not add a second vendor module map.
