### PR TITLE
fix(cli): keep schemes whose project is tree-shaken away

### DIFF
--- a/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -35,7 +35,10 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
         // other projects. An aggregate test scheme declared on the app project is the common case:
         // a cache hit on the app's own test target empties that project, and dropping the scheme
         // with it would leave the non-cached test targets of every other project unrunnable.
-        var reparentedSchemes: [Scheme] = []
+        // The originating path is carried so that two removed projects declaring a same-named
+        // scheme resolve to the same winner on every run, rather than to whichever one
+        // `graph.projects` happened to yield first.
+        var reparentedSchemes: [(projectPath: AbsolutePath, scheme: Scheme)] = []
 
         for (projectPath, project) in graph.projects {
             let (treeShakenTargets, projecttreeShakenDependencies) = treeShake(
@@ -51,7 +54,7 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
                 prunedTargets: prunedTargets
             )
             if treeShakenTargets.isEmpty {
-                reparentedSchemes.append(contentsOf: schemes)
+                reparentedSchemes.append(contentsOf: schemes.map { (projectPath, $0) })
             } else {
                 var project = project
                 project.schemes = schemes
@@ -70,7 +73,9 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
             projects: Array(treeShakenProjects.values),
             sourceTargets: sourceTargets,
             prunedTargets: prunedTargets,
-            reparentedSchemes: reparentedSchemes.sorted(by: { $0.name < $1.name })
+            reparentedSchemes: reparentedSchemes
+                .sorted { ($0.scheme.name, $0.projectPath.pathString) < ($1.scheme.name, $1.projectPath.pathString) }
+                .map(\.scheme)
         )
 
         var graph = graph
@@ -94,6 +99,10 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
             sourceTargets: sourceTargets,
             prunedTargets: prunedTargets
         )
+        // A workspace can only hold one scheme per name, so a reparented scheme yields to a
+        // workspace scheme that already owns its name, and to the reparented scheme that sorts
+        // first. `reparentedSchemes` arrives ordered by name and originating project path, which
+        // is what makes the surviving scheme the same on every run.
         var schemeNames = Set(schemes.map(\.name))
         for scheme in reparentedSchemes where !schemeNames.contains(scheme.name) {
             schemes.append(scheme)

--- a/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -31,6 +31,11 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
 
         var treeShakenProjects: [AbsolutePath: Project] = [:]
         var treeShakenDependencies: [GraphDependency: Set<GraphDependency>] = graph.dependencies
+        // Schemes of projects that lost every target, but that still reference targets kept in
+        // other projects. An aggregate test scheme declared on the app project is the common case:
+        // a cache hit on the app's own test target empties that project, and dropping the scheme
+        // with it would leave the non-cached test targets of every other project unrunnable.
+        var reparentedSchemes: [Scheme] = []
 
         for (projectPath, project) in graph.projects {
             let (treeShakenTargets, projecttreeShakenDependencies) = treeShake(
@@ -40,12 +45,14 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
                 graph: graph,
                 sourceTargets: sourceTargets
             )
-            if !treeShakenTargets.isEmpty {
-                let schemes = treeShake(
-                    schemes: project.schemes,
-                    sourceTargets: sourceTargets,
-                    prunedTargets: prunedTargets
-                )
+            let schemes = treeShake(
+                schemes: project.schemes,
+                sourceTargets: sourceTargets,
+                prunedTargets: prunedTargets
+            )
+            if treeShakenTargets.isEmpty {
+                reparentedSchemes.append(contentsOf: schemes)
+            } else {
                 var project = project
                 project.schemes = schemes
                 project.targets = Dictionary(
@@ -62,7 +69,8 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
             workspace: graph.workspace,
             projects: Array(treeShakenProjects.values),
             sourceTargets: sourceTargets,
-            prunedTargets: prunedTargets
+            prunedTargets: prunedTargets,
+            reparentedSchemes: reparentedSchemes.sorted(by: { $0.name < $1.name })
         )
 
         var graph = graph
@@ -76,15 +84,21 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
         workspace: Workspace,
         projects: [Project],
         sourceTargets: Set<TargetReference>,
-        prunedTargets: Set<TargetReference>
+        prunedTargets: Set<TargetReference>,
+        reparentedSchemes: [Scheme]
     ) -> Workspace {
         let projectPaths = Set(projects.map(\.path))
         let projects = workspace.projects.filter { projectPaths.contains($0) }
-        let schemes = treeShake(
+        var schemes = treeShake(
             schemes: workspace.schemes,
             sourceTargets: sourceTargets,
             prunedTargets: prunedTargets
         )
+        var schemeNames = Set(schemes.map(\.name))
+        for scheme in reparentedSchemes where !schemeNames.contains(scheme.name) {
+            schemes.append(scheme)
+            schemeNames.insert(scheme.name)
+        }
         var workspace = workspace
         workspace.schemes = schemes
         workspace.projects = projects

--- a/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -378,6 +378,66 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_keeps_project_schemes_referencing_kept_targets_when_their_project_is_removed() throws {
+        // Given: an aggregate test scheme declared on the app project, whose test action also
+        // references test targets from other projects. The app project's only test target gets a
+        // selective-testing cache hit and is pruned, emptying the project. The scheme must survive
+        // so the non-cached test targets still run.
+        let appProjectPath = try AbsolutePath(validating: "/App")
+        let featureProjectPath = try AbsolutePath(validating: "/Feature")
+
+        let appTests = Target.test(
+            name: "AppTests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+
+        let unitTestsScheme = Scheme.test(
+            name: "UnitTests",
+            buildAction: nil,
+            testAction: .test(
+                targets: [
+                    TestableTarget(target: .init(projectPath: appProjectPath, name: appTests.name)),
+                    TestableTarget(target: .init(projectPath: featureProjectPath, name: featureTests.name)),
+                ]
+            ),
+            runAction: nil
+        )
+
+        let appProject = Project.test(path: appProjectPath, targets: [appTests], schemes: [unitTestsScheme])
+        let featureProject = Project.test(path: featureProjectPath, targets: [featureTests])
+
+        let workspace = Workspace.test(
+            projects: [appProjectPath, featureProjectPath]
+        )
+
+        let graph = Graph.test(
+            path: appProjectPath,
+            workspace: workspace,
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertNil(gotGraph.projects[appProjectPath], "The emptied project should still be removed")
+        let gotScheme = GraphTraverser(graph: gotGraph).schemes().first(where: { $0.name == "UnitTests" })
+        XCTAssertNotNil(
+            gotScheme,
+            "UnitTests should survive the removal of the project that declared it because it still references kept targets"
+        )
+        XCTAssertEqual(
+            gotScheme?.testAction?.targets.map(\.target.name),
+            ["FeatureTests"]
+        )
+    }
+
     func test_map_removes_the_workspace_projects_that_no_longer_exist() throws {
         // Given
         let path = try AbsolutePath(validating: "/project")

--- a/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Path
+import Testing
 import XcodeGraph
 import XCTest
 @testable import TuistCore
@@ -375,66 +376,6 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         XCTAssertNil(
             gotScheme?.testAction?.expandVariableFromTarget,
             "The expandVariableFromTarget reference should be cleared rather than dropping the scheme"
-        )
-    }
-
-    func test_map_keeps_project_schemes_referencing_kept_targets_when_their_project_is_removed() throws {
-        // Given: an aggregate test scheme declared on the app project, whose test action also
-        // references test targets from other projects. The app project's only test target gets a
-        // selective-testing cache hit and is pruned, emptying the project. The scheme must survive
-        // so the non-cached test targets still run.
-        let appProjectPath = try AbsolutePath(validating: "/App")
-        let featureProjectPath = try AbsolutePath(validating: "/Feature")
-
-        let appTests = Target.test(
-            name: "AppTests",
-            product: .unitTests,
-            metadata: .metadata(tags: ["tuist:prunable"])
-        )
-        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
-
-        let unitTestsScheme = Scheme.test(
-            name: "UnitTests",
-            buildAction: nil,
-            testAction: .test(
-                targets: [
-                    TestableTarget(target: .init(projectPath: appProjectPath, name: appTests.name)),
-                    TestableTarget(target: .init(projectPath: featureProjectPath, name: featureTests.name)),
-                ]
-            ),
-            runAction: nil
-        )
-
-        let appProject = Project.test(path: appProjectPath, targets: [appTests], schemes: [unitTestsScheme])
-        let featureProject = Project.test(path: featureProjectPath, targets: [featureTests])
-
-        let workspace = Workspace.test(
-            projects: [appProjectPath, featureProjectPath]
-        )
-
-        let graph = Graph.test(
-            path: appProjectPath,
-            workspace: workspace,
-            projects: [
-                appProjectPath: appProject,
-                featureProjectPath: featureProject,
-            ],
-            dependencies: [:]
-        )
-
-        // When
-        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
-
-        // Then
-        XCTAssertNil(gotGraph.projects[appProjectPath], "The emptied project should still be removed")
-        let gotScheme = GraphTraverser(graph: gotGraph).schemes().first(where: { $0.name == "UnitTests" })
-        XCTAssertNotNil(
-            gotScheme,
-            "UnitTests should survive the removal of the project that declared it because it still references kept targets"
-        )
-        XCTAssertEqual(
-            gotScheme?.testAction?.targets.map(\.target.name),
-            ["FeatureTests"]
         )
     }
 
@@ -832,5 +773,201 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
             TargetReference(projectPath: path, name: surviveTests.name),
             "Should fall back to the surviving test plan target, not the build action's target."
         )
+    }
+}
+
+struct TreeShakePrunedTargetsGraphMapperSchemeReparentingTests {
+    private let subject = TreeShakePrunedTargetsGraphMapper()
+
+    @Test func map_keeps_project_schemes_referencing_kept_targets_when_their_project_is_removed() throws {
+        // Given: an aggregate test scheme declared on the app project, whose test action also
+        // references test targets from other projects. The app project's only test target gets a
+        // selective-testing cache hit and is pruned, emptying the project. The scheme must survive
+        // so the non-cached test targets still run.
+        let appProjectPath = try AbsolutePath(validating: "/App")
+        let featureProjectPath = try AbsolutePath(validating: "/Feature")
+
+        let appTests = Target.test(
+            name: "AppTests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+
+        let appProject = Project.test(
+            path: appProjectPath,
+            targets: [appTests],
+            schemes: [
+                Scheme.test(
+                    name: "UnitTests",
+                    buildAction: nil,
+                    testAction: .test(
+                        targets: [
+                            TestableTarget(target: .init(projectPath: appProjectPath, name: appTests.name)),
+                            TestableTarget(target: .init(projectPath: featureProjectPath, name: featureTests.name)),
+                        ]
+                    ),
+                    runAction: nil
+                ),
+            ]
+        )
+        let featureProject = Project.test(path: featureProjectPath, targets: [featureTests])
+
+        let graph = Graph.test(
+            path: appProjectPath,
+            workspace: Workspace.test(projects: [appProjectPath, featureProjectPath]),
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        #expect(gotGraph.projects[appProjectPath] == nil)
+        let gotScheme = try #require(
+            GraphTraverser(graph: gotGraph).schemes().first(where: { $0.name == "UnitTests" }),
+            "UnitTests should survive the removal of the project that declared it because it still references kept targets"
+        )
+        #expect(gotScheme.testAction?.targets.map(\.target.name) == ["FeatureTests"])
+    }
+
+    @Test func map_resolves_reparented_scheme_name_collisions_by_project_path() throws {
+        // Given: two removed projects that each declare a scheme with the same name, both still
+        // referencing kept targets. Only one can live on the workspace, so the winner has to be
+        // picked deterministically rather than following the ordering of `graph.projects`.
+        let firstProjectPath = try AbsolutePath(validating: "/A")
+        let secondProjectPath = try AbsolutePath(validating: "/B")
+        let featureProjectPath = try AbsolutePath(validating: "/Feature")
+
+        let firstTests = Target.test(
+            name: "ATests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let secondTests = Target.test(
+            name: "BTests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let featureATests = Target.test(name: "FeatureATests", product: .unitTests)
+        let featureBTests = Target.test(name: "FeatureBTests", product: .unitTests)
+
+        func scheme(ownTests: Target, ownPath: AbsolutePath, featureTests: Target) -> Scheme {
+            Scheme.test(
+                name: "UnitTests",
+                buildAction: nil,
+                testAction: .test(
+                    targets: [
+                        TestableTarget(target: .init(projectPath: ownPath, name: ownTests.name)),
+                        TestableTarget(target: .init(projectPath: featureProjectPath, name: featureTests.name)),
+                    ]
+                ),
+                runAction: nil
+            )
+        }
+
+        let firstProject = Project.test(
+            path: firstProjectPath,
+            targets: [firstTests],
+            schemes: [scheme(ownTests: firstTests, ownPath: firstProjectPath, featureTests: featureATests)]
+        )
+        let secondProject = Project.test(
+            path: secondProjectPath,
+            targets: [secondTests],
+            schemes: [scheme(ownTests: secondTests, ownPath: secondProjectPath, featureTests: featureBTests)]
+        )
+        let featureProject = Project.test(path: featureProjectPath, targets: [featureATests, featureBTests])
+
+        let graph = Graph.test(
+            path: firstProjectPath,
+            workspace: Workspace.test(projects: [firstProjectPath, secondProjectPath, featureProjectPath]),
+            projects: [
+                firstProjectPath: firstProject,
+                secondProjectPath: secondProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let gotSchemes = gotGraph.workspace.schemes.filter { $0.name == "UnitTests" }
+        #expect(gotSchemes.count == 1)
+        #expect(gotSchemes.first?.testAction?.targets.map(\.target.name) == ["FeatureATests"])
+    }
+
+    @Test func map_prefers_an_existing_workspace_scheme_over_a_reparented_one() throws {
+        // Given: the workspace already owns a scheme whose name a removed project's scheme also
+        // uses. The workspace scheme is already in its final container and must not be replaced.
+        let appProjectPath = try AbsolutePath(validating: "/App")
+        let featureProjectPath = try AbsolutePath(validating: "/Feature")
+
+        let appTests = Target.test(
+            name: "AppTests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+        let otherFeatureTests = Target.test(name: "OtherFeatureTests", product: .unitTests)
+
+        let appProject = Project.test(
+            path: appProjectPath,
+            targets: [appTests],
+            schemes: [
+                Scheme.test(
+                    name: "UnitTests",
+                    buildAction: nil,
+                    testAction: .test(
+                        targets: [
+                            TestableTarget(target: .init(projectPath: appProjectPath, name: appTests.name)),
+                            TestableTarget(target: .init(projectPath: featureProjectPath, name: featureTests.name)),
+                        ]
+                    ),
+                    runAction: nil
+                ),
+            ]
+        )
+        let featureProject = Project.test(
+            path: featureProjectPath,
+            targets: [featureTests, otherFeatureTests]
+        )
+
+        let workspaceScheme = Scheme.test(
+            name: "UnitTests",
+            buildAction: nil,
+            testAction: .test(
+                targets: [
+                    TestableTarget(target: .init(projectPath: featureProjectPath, name: otherFeatureTests.name)),
+                ]
+            ),
+            runAction: nil
+        )
+
+        let graph = Graph.test(
+            path: appProjectPath,
+            workspace: Workspace.test(
+                projects: [appProjectPath, featureProjectPath],
+                schemes: [workspaceScheme]
+            ),
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let gotSchemes = gotGraph.workspace.schemes.filter { $0.name == "UnitTests" }
+        #expect(gotSchemes.count == 1)
+        #expect(gotSchemes.first?.testAction?.targets.map(\.target.name) == ["OtherFeatureTests"])
     }
 }


### PR DESCRIPTION
## What changed

`TreeShakePrunedTargetsGraphMapper` no longer deletes a project's schemes together with the project when tree-shaking prunes every one of that project's targets. A scheme that still references targets kept in other projects is moved to the workspace instead.

## Why

A user reported that `tuist test --scheme <SomeUnitTests>` logged

```
The scheme SomeUnitTests's test action has no tests to run, finishing early.
```

and exited 0, while the run report for the same run correctly showed one test module as a selective-testing miss. So a module whose content had genuinely changed never had its tests executed, and CI stayed green.

Digging into the runs of that job showed a perfect correlation: the run proceeded if and only if one specific test target, the one living in the same project as the scheme, was itself a selective-testing miss. Whenever that single target was a cache hit, nothing ran, no matter how many other modules were misses. When tests did run, the number of executed modules always equalled the number of misses, so selective testing itself was choosing correctly.

## Root cause

The mapper rebuilds `graph.projects` and skips any project left with no targets:

```swift
if !treeShakenTargets.isEmpty {
    let schemes = treeShake(schemes: project.schemes, ...)
    ...
    treeShakenProjects[projectPath] = project
}
```

Project level schemes live on `Project.schemes`, so an emptied project takes its schemes with it. That is fine for a scheme that only referenced targets of that project, and it is what `treeShake(schemes:)` already handles. It is wrong for an aggregate test scheme that lists test targets from many projects: the scheme is declared on one project (typically the app project), and a cache hit on that project's own test target is enough to empty it while the scheme's other test targets, the non-cached ones that must run, are untouched in their own projects.

`TestService` then falls into the scheme-not-found branch, which finds the scheme only in `mapperEnvironment.initialGraph`, logs "has no tests to run, finishing early", and returns. Selective-testing analytics are computed separately from that same initial graph, which is why the report still showed the miss accurately. The report was the honest half; the skipped test run was the defect.

Workspace level schemes were never affected, because `treeShake(workspace:)` shakes them by content rather than dropping them with a project.

## Why this shape of fix

Two alternatives were considered:

1. Keep the emptied project alive so its schemes retain a container. This makes the generator emit an `.xcodeproj` with no targets purely to host a scheme, and every consumer of `graph.projects` then has to tolerate empty projects.
2. Leave the behaviour as is and only improve the log line. That keeps a green CI run that silently skips changed tests, which is a correctness problem rather than a reporting one.

Moving the scheme to the workspace uses the container that the mapper already treats as the home for schemes spanning several projects, and it is the only container guaranteed to still exist.

Note that this does not make the scheme run implicitly: `BuildGraphInspector.workspaceSchemes` selects autogenerated workspace schemes by the `<workspace name>-Workspace` naming convention, so a reparented scheme is not picked up by `tuist test` when no scheme is passed. It only becomes findable again by name, which is what `--scheme` needs.

## Name collisions

A workspace holds at most one scheme per name, so when several schemes compete for a name one of them has to lose. The order is now fully specified rather than left to dictionary iteration:

1. A workspace scheme that already owns the name wins. It is already in its final container and was there before tree-shaking.
2. Otherwise the reparented scheme sorting first by name and then by originating project path wins.

Two removed projects declaring a same-named scheme is legal in Xcode, and in that case the losing scheme's surviving test targets stay unreachable under that name. That is not a regression (today both schemes are dropped outright), but it is now at least reproducible rather than varying per run, which was the practical hazard: the same commit could generate different workspaces on different machines.

## Impact

Projects that declare an aggregate test scheme on a project rather than on the workspace stop silently skipping their whole test run whenever the scheme's own project happens to be fully cached. Everything else is unchanged: projects with no surviving targets are still removed, and schemes with no surviving targets are still dropped.

## Validation

Written test first, confirmed red before the fix:

- `map_keeps_project_schemes_referencing_kept_targets_when_their_project_is_removed` fails on the unfixed mapper (the scheme is absent from `GraphTraverser.schemes()`) and passes after the change.
- `map_resolves_reparented_scheme_name_collisions_by_project_path` was mutation checked by inverting the path comparator: it fails, while the other two reparenting tests keep passing, so it really pins the ordering rather than passing by accident.
- `map_prefers_an_existing_workspace_scheme_over_a_reparented_one` covers rule 1 above.
- Full `-only-testing TuistKitTests`: 684 passed, 0 failed.
- `swiftformat --lint` clean on both touched files. `swiftlint` reports the same four pre-existing violations on this file as on `main` (three `function_body_length`, one `large_tuple`); no new rule is triggered.

The new tests use Swift Testing (`@Test`, `#expect`, `#require`) in a `TreeShakePrunedTargetsGraphMapperSchemeReparentingTests` suite alongside the file's legacy XCTest class, per the repository's Swift review rules.

## Follow up, not in this PR

Both early-exit branches in `TestService` return before `shouldRunTest`, so the "targets have not changed since the last successful run and will be skipped" line is never printed and the log gives no hint about what was skipped or why. That is what made this failure mode unexplainable from CI output, and it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
