### PR TITLE
fix(server): align MCP metadata with Marketplace review

### DIFF
--- a/server/lib/tuist/mcp/components/tools/codebase_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/codebase_tools.ex
@@ -194,12 +194,10 @@ defmodule Tuist.MCP.Components.Tools.SearchTuistCode do
 
   @impl EMCP.Tool
   def description do
-    "Use this instead of an unrelated local checkout or general web search when a Tuist question depends on current " <>
-      "command behavior, defaults, configuration, feature gates, error handling, or undocumented implementation details. " <>
-      "Search for literal identifiers, command names, configuration keys, or error messages, then inspect relevant call " <>
-      "sites and tests with read_tuist_file. " <>
-      "The search covers a fixed source revision with bounded traversal, input, time, and output. " <>
-      "A truncated response is partial; narrow the path or file_glob and search again."
+    "Search a fixed revision of public Tuist source code for implementation details. Use when the user asks about " <>
+      "current command behavior, defaults, configuration, feature gates, error handling, or behavior not covered by " <>
+      "public documentation. Search literal identifiers, command names, configuration keys, or error messages. Results " <>
+      "have bounded traversal, input, time, and output; narrow the path or file_glob when a response is truncated."
   end
 
   def execute(_conn, arguments), do: CodebaseSearch.search(arguments)
@@ -249,7 +247,7 @@ defmodule Tuist.MCP.Components.Tools.ListTuistFiles do
   @impl EMCP.Tool
   def description do
     "Use this when the relevant Tuist source path is unknown and you need to discover a subsystem or nearby tests. " <>
-      "List only a narrow repository-relative path instead of enumerating the entire repository. " <>
+      "List a narrow repository-relative path to avoid broad repository enumeration. " <>
       "The listing covers a fixed source revision with bounded depth, traversal, time, and output. " <>
       "A truncated response is partial; narrow the path or file_glob and list again."
   end
@@ -296,8 +294,8 @@ defmodule Tuist.MCP.Components.Tools.ReadTuistFile do
 
   @impl EMCP.Tool
   def description do
-    "Use this after a source search or file listing to inspect the smallest relevant line range in an implementation " <>
-      "file, call site, or focused test. The file comes from a fixed Tuist source revision and the read is bounded. " <>
+    "Read a bounded line range from a fixed Tuist source revision. Use when the relevant source path is known and " <>
+      "you need to inspect an implementation file, call site, or focused test. " <>
       "When truncated, continue from next_start_line rather than increasing the limit."
   end
 

--- a/server/lib/tuist/mcp/components/tools/get_gradle_integration_guide.ex
+++ b/server/lib/tuist/mcp/components/tools/get_gradle_integration_guide.ex
@@ -44,7 +44,7 @@ defmodule Tuist.MCP.Components.Tools.GetGradleIntegrationGuide do
 
   @impl EMCP.Tool
   def description do
-    "Call this before editing when a user asks to speed up, optimize, or connect an existing Gradle or Android build with Tuist. It covers authentication, project creation, plugin setup, cache policy, and proof."
+    "Return the workflow for integrating an existing Gradle or Android build with Tuist. Use when the user asks to speed up, optimize, or connect that build. Covers authentication, project creation, plugin setup, cache policy, and proof."
   end
 
   def execute(_conn, args) do

--- a/server/lib/tuist/mcp/components/tools/list_accounts.ex
+++ b/server/lib/tuist/mcp/components/tools/list_accounts.ex
@@ -39,7 +39,7 @@ defmodule Tuist.MCP.Components.Tools.ListAccounts do
 
   @impl EMCP.Tool
   def description do
-    "List personal and organization account handles available to the authenticated user. Call this before create_project when the account handle is unknown."
+    "List personal and organization account handles available to the authenticated user. Use when the account handle for a project is unknown."
   end
 
   def execute(%{assigns: %{current_user: user}}, _args) do

--- a/server/lib/tuist/mcp/components/tools/search_tuist.ex
+++ b/server/lib/tuist/mcp/components/tools/search_tuist.ex
@@ -69,10 +69,9 @@ defmodule Tuist.MCP.Components.Tools.SearchTuist do
 
   @impl EMCP.Tool
   def description do
-    "Call this first whenever the user asks a Tuist question, before inspecting local files or using general web search. " <>
-      "It searches public documentation, the application programming interface reference, release notes, community " <>
-      "discussions, and issues, returning explanations, terminology, and links to cite. " <>
-      "Use the Tuist source tools as well when current implementation details determine the answer."
+    "Search public Tuist documentation, the application programming interface reference, release notes, community " <>
+      "discussions, and issues. Use when the user asks about documented behavior, released changes, terminology, or " <>
+      "known issues. Returns matching excerpts and source links."
   end
 
   def execute(_conn, arguments), do: Search.search(arguments)

--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -7,6 +7,8 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
     name: "update_test_case",
     title: "Update Test Case",
     read_only_hint: false,
+    open_world_hint: true,
+    destructive_hint: true,
     schema: %{
       "type" => "object",
       "properties" => %{
@@ -66,7 +68,7 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
   @impl EMCP.Tool
   def description,
     do:
-      "Update mutable fields on a test case. Supports changing `state` between `enabled`, `muted`, and `skipped`, and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+      "Update mutable fields on a test case. Supports changing `state` between `enabled`, `muted`, and `skipped`, and toggling `is_flaky`. A change can dispatch a test-case event to webhook endpoints configured by the account, including external services. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
 
   @impl EMCP.Tool
   def call(conn, args) do

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -97,17 +97,17 @@ defmodule Tuist.MCP.Server do
   ]
 
   @source_answer_instructions """
-  Answer Tuist questions with the Tuist tools before using local files or general web search. Start with `search_tuist` for public explanations and terminology. When current behavior depends on implementation, use `search_tuist_code`, `list_tuist_files`, and `read_tuist_file`; inspect focused tests and call sites, treat truncated results as partial, and cite returned links and the source revision. Keep the answer focused on the user's question rather than describing the codebase.
+  Use the relevant Tuist tool when its documentation or source results are needed to answer a Tuist question. `search_tuist` covers public explanations and terminology. When current behavior depends on implementation, `search_tuist_code`, `list_tuist_files`, and `read_tuist_file` provide a fixed source revision; inspect focused tests and call sites, treat truncated results as partial, and cite returned links and the source revision. Keep the answer focused on the user's question rather than describing the codebase.
   """
 
   @agent_workflow_instructions """
-  If this server is unauthenticated, fetch the `auth_md` URL from the 401 response. If only the discovery documents are available, read `agent_auth.skill` from the authorization-server metadata. Follow that deployment-local document through registration, identity-assertion exchange, and claim polling before falling back to browser Open Authorization. Never invent credentials. Prefer anonymous registration when no trusted provider assertion is available. Before sending a service-authenticated email or starting an anonymous claim, explicitly ask the user to confirm the email address for their Tuist account; do not derive it from a provider profile, Git configuration, environment variables, or session metadata. During a claim, show the verification link and six-digit code together, and tell the user to enter the code on the Tuist page rather than sending it back to the agent. When a user asks to speed up or connect a Gradle or Android build, call get_gradle_integration_guide before editing. Call list_accounts before create_project when the account handle is unknown. Model Context Protocol authentication only authorizes Tuist tools; Gradle requires separate `tuist auth whoami --url` authentication. Never continue a verification build after that check fails. Verify integrations through Tuist read-back tools before reporting success.
+  If this server is unauthenticated, fetch the `auth_md` URL from the 401 response. If only the discovery documents are available, read `agent_auth.skill` from the authorization-server metadata. Follow that deployment-local document through registration, identity-assertion exchange, and claim polling before falling back to browser Open Authorization. Never invent credentials. Prefer anonymous registration when no trusted provider assertion is available. Before sending a service-authenticated email or starting an anonymous claim, explicitly ask the user to confirm the email address for their Tuist account; do not derive it from a provider profile, Git configuration, environment variables, or session metadata. During a claim, show the verification link and six-digit code together, and tell the user to enter the code on the Tuist page rather than sending it back to the agent. The `get_gradle_integration_guide` tool provides the Gradle and Android integration workflow. Use `list_accounts` when an account handle is unknown. Model Context Protocol authentication only authorizes Tuist tools; Gradle requires separate `tuist auth whoami --url` authentication. Never continue a verification build after that check fails. Verify integrations through Tuist read-back tools before reporting success.
   """
 
   def server do
     EMCP.Server.new(
       name: "tuist",
-      version: "1.22.0",
+      version: "1.23.0",
       title: "Tuist",
       description: "Tuist project setup, build, cache, and test insights.",
       instructions: instructions(),

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -11,7 +11,7 @@
 It makes applications such as [Claude](https://claude.ai/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex/), and editors like [Zed](https://zed.dev), [Cursor](https://www.cursor.com), or [Visual Studio Code](https://code.visualstudio.com) interoperable with Tuist.
 
 Tuist hosts a server-side Model Context Protocol endpoint at `https://tuist.dev/mcp`. By connecting your client to it, agents can access your Tuist project data, including test insights, flaky test analysis, and more.
-Most tools are read-only and scoped to authenticated Tuist project data. Account setup tools can list accounts, create organizations, create projects, and add existing users to organizations when the authenticated user has the required permissions.
+Most tools are read-only and scoped to authenticated Tuist project data. Account setup tools can list accounts, create organizations, create projects, and add existing users to organizations when the authenticated user has the required permissions. Every tool advertises annotations that state whether it is read-only, whether it can cause a difficult-to-reverse change, and whether it can change public Internet state.
 The account setup tools require user authentication. They are not available to project tokens or ordinary account tokens. After a user claims an `auth.md` registration, Tuist associates that credential with the confirming user only on the Model Context Protocol endpoint so the setup tools can complete the requested workflow.
 
 ## Model Context Protocol versus skills
@@ -204,13 +204,13 @@ This read-only tool searches Tuist's documentation, [application programming int
 
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
-| `search_tuist` | Start answering Tuist questions from public documentation, the application programming interface reference, GitHub releases, community discussions, and GitHub issues. Optionally restrict to one `source` (`docs`, `api_reference`, `releases`, `forum`, `issues`). | `query` |
+| `search_tuist` | Search public Tuist documentation, the application programming interface reference, GitHub releases, community discussions, and GitHub issues. Optionally restrict to one `source` (`docs`, `api_reference`, `releases`, `forum`, `issues`). | `query` |
 
 #### Source-backed answers
 
 These read-only tools let agents use the exact public Tuist source revision deployed alongside the hosted server as the source of truth for answers that depend on current behavior. They are only available at `https://tuist.dev/mcp`.
 
-Compatible clients receive server instructions during initialization that route ordinary Tuist questions through documentation and source-backed tools before local files or general web search. This means users can ask a question directly without invoking the `ask_tuist` prompt first. The prompt remains available when users want to start the same workflow explicitly.
+Compatible clients receive server instructions during initialization that describe when documentation and source-backed tools can provide useful evidence. This means users can ask a question directly without invoking the `ask_tuist` prompt first. The prompt remains available when users want to start the same workflow explicitly.
 
 Every operation has fixed limits for concurrency, duration, traversal, bytes read, and response size. Search and listing results include `truncated` and `truncation_reason` fields. When a result is truncated, narrow the path, file pattern, or search term instead of treating the result as exhaustive.
 
@@ -298,7 +298,7 @@ Webhook tools use the same administrator-only permission as the dashboard. Deliv
 | `get_test_case_run` | Get failure details and repetitions for a specific test case run. | `test_case_run_id` |
 | `list_test_case_run_attachments` | List attachments for a test case run. Each attachment includes a temporary download URL. | `test_case_run_id` |
 | `list_test_case_events` | List state changes for a test case, such as muting or skipping it. | `test_case_id` |
-| `update_test_case` | Update a test case's state or flaky classification. | `test_case_id` or `identifier` + `account_handle` + `project_handle` |
+| `update_test_case` | Update a test case's state or flaky classification. A change can dispatch an event to configured webhook endpoints, including external services. | `test_case_id` or `identifier` + `account_handle` + `project_handle` |
 | `list_xcode_test_targets` | List selective-testing target results for a test run. | `test_run_id` |
 
 #### Bundles

--- a/server/test/tuist/mcp/components/tools/codebase_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/codebase_tools_test.exs
@@ -7,14 +7,13 @@ defmodule Tuist.MCP.Components.Tools.CodebaseToolsTest do
   alias Tuist.MCP.Components.Tools.ReadTuistFile
   alias Tuist.MCP.Components.Tools.SearchTuistCode
 
-  test "descriptions guide agents through source-backed questions" do
+  test "descriptions state the scope of source-backed tools" do
     assert SearchTuistCode.description() =~ "current command behavior"
-    assert SearchTuistCode.description() =~ "instead of an unrelated local checkout or general web search"
-    assert SearchTuistCode.description() =~ "relevant call sites and tests"
-    assert SearchTuistCode.description() =~ "truncated response is partial"
+    assert SearchTuistCode.description() =~ "behavior not covered by public documentation"
+    assert SearchTuistCode.description() =~ "literal identifiers"
     assert ListTuistFiles.description() =~ "relevant Tuist source path is unknown"
-    assert ListTuistFiles.description() =~ "instead of enumerating the entire repository"
-    assert ReadTuistFile.description() =~ "smallest relevant line range"
+    assert ListTuistFiles.description() =~ "avoid broad repository enumeration"
+    assert ReadTuistFile.description() =~ "bounded line range"
     assert ReadTuistFile.description() =~ "implementation file, call site, or focused test"
   end
 

--- a/server/test/tuist/mcp/components/tools/search_tuist_test.exs
+++ b/server/test/tuist/mcp/components/tools/search_tuist_test.exs
@@ -5,13 +5,13 @@ defmodule Tuist.MCP.Components.Tools.SearchTuistTest do
   alias Tuist.MCP.Components.Tools.SearchTuist
   alias Tuist.MCP.Search
 
-  test "description guides agents to start with public Tuist material" do
+  test "description states the scope of public Tuist material" do
     description = SearchTuist.description()
 
-    assert description =~ "Call this first whenever the user asks a Tuist question"
-    assert description =~ "before inspecting local files or using general web search"
-    assert description =~ "links to cite"
-    assert description =~ "source tools"
+    assert description =~ "public Tuist documentation"
+    assert description =~ "documented behavior"
+    assert description =~ "known issues"
+    assert description =~ "source links"
   end
 
   test "search_tuist forwards searches to the Typesense-backed search" do

--- a/server/test/tuist/mcp/server_test.exs
+++ b/server/test/tuist/mcp/server_test.exs
@@ -7,7 +7,9 @@ defmodule Tuist.MCP.ServerTest do
   alias Tuist.MCP.Components.Tools.CreateOrganization
   alias Tuist.MCP.Components.Tools.CreateProject
   alias Tuist.MCP.Components.Tools.GetGradleIntegrationGuide
+  alias Tuist.MCP.Components.Tools.UpdateTestCase
   alias Tuist.MCP.Server
+  alias Tuist.MCP.Tool
 
   describe "server/0" do
     test "returns a server with all tools" do
@@ -68,12 +70,14 @@ defmodule Tuist.MCP.ServerTest do
       assert "list_previews" in tool_names
       assert "get_preview" in tool_names
       assert "get_latest_preview" in tool_names
-      assert server.version == "1.22.0"
+      assert server.version == "1.23.0"
       assert server.instructions =~ "agent_auth.skill"
       assert server.instructions =~ "identity-assertion exchange"
       assert server.instructions =~ "enter the code on the Tuist page"
       assert server.instructions =~ "explicitly ask the user to confirm the email address"
-      assert server.instructions =~ "call get_gradle_integration_guide before editing"
+
+      assert server.instructions =~
+               "get_gradle_integration_guide` tool provides the Gradle and Android integration workflow"
     end
 
     test "offers search_tuist only on the Tuist-hosted installation" do
@@ -110,8 +114,8 @@ defmodule Tuist.MCP.ServerTest do
       server = Server.server()
 
       for {name, module} <- server.tools do
-        descriptor = Tuist.MCP.Tool.descriptor(module)
-        annotations = module.annotations()
+        descriptor = Tool.descriptor(module)
+        annotations = descriptor["annotations"]
 
         assert is_binary(descriptor["description"]) and descriptor["description"] != "",
                "tool #{name} is missing a non-empty description"
@@ -127,13 +131,13 @@ defmodule Tuist.MCP.ServerTest do
         ExJsonSchema.Schema.resolve(descriptor["outputSchema"])
 
         assert is_binary(annotations[:title]) and annotations[:title] != "",
-               "tool #{name} is missing a non-empty :title annotation"
+               "tool #{name} is missing a non-empty title annotation"
 
         assert is_boolean(annotations[:readOnlyHint]),
                "tool #{name} must declare readOnlyHint"
 
-        assert annotations[:openWorldHint] == false,
-               "tool #{name} must declare openWorldHint: false"
+        assert is_boolean(annotations[:openWorldHint]),
+               "tool #{name} must declare openWorldHint"
 
         assert is_boolean(annotations[:destructiveHint]),
                "tool #{name} must declare destructiveHint"
@@ -177,15 +181,61 @@ defmodule Tuist.MCP.ServerTest do
 
       instructions = Server.server().instructions
 
-      assert instructions =~ "Answer Tuist questions with the Tuist tools"
+      assert instructions =~ "Use the relevant Tuist tool"
       assert instructions =~ "search_tuist_code"
       assert instructions =~ "treat truncated results as partial"
       assert instructions =~ "source revision"
 
       stub(Environment, :codebase_search_enabled?, fn -> false end)
       instructions = Server.server().instructions
-      refute instructions =~ "Answer Tuist questions with the Tuist tools"
+      refute instructions =~ "Use the relevant Tuist tool"
       assert instructions =~ "agent_auth.skill"
+    end
+
+    test "tool descriptions state their capability without steering tool selection" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :codebase_search_enabled?, fn -> true end)
+
+      for {_name, module} <- Server.server().tools do
+        description = Tool.descriptor(module)["description"]
+
+        refute description =~ "Call this first"
+        refute description =~ "instead of"
+        refute description =~ "general web search"
+        refute description =~ "Use this after"
+      end
+    end
+
+    test "mutating tools advertise annotations that match their effects" do
+      assert CreateOrganization.annotations() == %{
+               title: "Create Organization",
+               readOnlyHint: false,
+               openWorldHint: false,
+               destructiveHint: false
+             }
+
+      assert CreateProject.annotations() == %{
+               title: "Create Project",
+               readOnlyHint: false,
+               openWorldHint: false,
+               destructiveHint: false
+             }
+
+      assert AddOrganizationMember.annotations() == %{
+               title: "Add Organization Member",
+               readOnlyHint: false,
+               openWorldHint: false,
+               destructiveHint: true
+             }
+
+      assert UpdateTestCase.annotations() == %{
+               title: "Update Test Case",
+               readOnlyHint: false,
+               openWorldHint: true,
+               destructiveHint: true
+             }
+
+      assert Tool.descriptor(UpdateTestCase)["description"] =~ "webhook endpoints"
     end
   end
 end

--- a/server/test/tuist/runners/allowance_test.exs
+++ b/server/test/tuist/runners/allowance_test.exs
@@ -202,8 +202,11 @@ defmodule Tuist.Runners.AllowanceTest do
       # Three days of 60 minutes against a 100 minute allowance: the
       # first is entirely free, the second straddles the boundary, the
       # third is entirely billed.
+      now = DateTime.utc_now()
+      period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
+
       for days_ago <- [3, 2, 1] do
-        started = DateTime.add(DateTime.utc_now(), -days_ago, :day)
+        started = DateTime.add(now, -days_ago, :day)
 
         Repo.insert!(%RunnerSession{
           account_id: account.id,
@@ -223,7 +226,7 @@ defmodule Tuist.Runners.AllowanceTest do
         })
       end
 
-      breakdown = Allowance.period_breakdown(account)
+      breakdown = Allowance.period_breakdown(account, period)
 
       assert breakdown.minutes == 180
       # 180 minutes at $0.075, of which 80 are past the allowance.
@@ -452,7 +455,7 @@ defmodule Tuist.Runners.AllowanceTest do
     test "leaves a day that ran wholly inside the trial with nothing billed", %{account: account} do
       # Past the allowance, so a day the trial covered has to be zeroed
       # deliberately rather than by the free tier happening to reach it.
-      now = DateTime.utc_now()
+      now = DateTime.utc_now() |> DateTime.to_date() |> DateTime.new!(~T[12:00:00], "Etc/UTC")
       period = {DateTime.add(now, -4, :day), DateTime.add(now, 1, :day)}
       account = trial_ended(account, DateTime.add(now, -2, :day))
 

--- a/server/test/tuist/runners/prepaid_test.exs
+++ b/server/test/tuist/runners/prepaid_test.exs
@@ -625,8 +625,8 @@ defmodule Tuist.Runners.PrepaidTest do
     defp account, do: %Account{customer_id: "cus_#{System.unique_integer([:positive])}"}
 
     test "sums what is left and reports the soonest expiry" do
-      soon = ~U[2026-09-01 00:00:00Z]
-      later = ~U[2027-01-01 00:00:00Z]
+      soon = DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.truncate(:second)
+      later = DateTime.add(soon, 365, :day)
 
       soon_grant = grant(%{expires_at: DateTime.to_unix(soon)})
       later_grant = grant(%{expires_at: DateTime.to_unix(later)})

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -502,8 +502,11 @@ defmodule TuistWeb.UsageLiveTest do
 
   describe "runner usage receipt" do
     test "walks from minutes to money, showing the allowance as a credit", %{conn: conn, user: user} do
+      now = ~U[2026-01-17 12:00:00.000000Z]
+      stub(DateTime, :utc_now, fn -> now end)
+
       account = user.account
-      started = DateTime.add(DateTime.utc_now(), -2, :hour)
+      started = DateTime.add(now, -2, :hour)
 
       Tuist.Repo.insert!(%Tuist.Runners.RunnerSession{
         account_id: account.id,
@@ -518,8 +521,8 @@ defmodule TuistWeb.UsageLiveTest do
         started_at: started,
         job_started_at: started,
         job_ended_at: DateTime.add(started, 120 * 60, :second),
-        inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
-        updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+        inserted_at: DateTime.truncate(now, :second),
+        updated_at: DateTime.truncate(now, :second)
       })
 
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")


### PR DESCRIPTION
## What changed

- Rewrote Model Context Protocol ([MCP](https://modelcontextprotocol.io/)) tool descriptions and server instructions to describe capability and scope without directing the client away from local files, web search, or another tool.
- Marked update_test_case as non-read-only, destructive, and open-world because it can dispatch configured webhooks to external services.
- Require every emitted tool descriptor to include boolean review annotations, and add focused assertions for the state-changing tools.
- Bumped the MCP server version and updated the public MCP guide.
- Stabilized runner usage fixtures around calendar, expiry, and day-boundary conditions so the test suite has a meaningful result for this change.

## Why

The Marketplace review rejected the submission because its tool annotations and descriptions did not sufficiently match actual behavior or the description-quality requirements.

The full validation run also uncovered unrelated time-dependent fixtures. Repairing them prevents the pull request from failing based on when the suite happens to run.

## Root cause

Several descriptions used routing language such as asking the client to use Tuist before local files or general web search. update_test_case was advertised as private and reversible even though updates can notify configured external webhook endpoints.

The runner tests used dates that had passed, relied on the default calendar billing period, and allowed a test session to cross a date boundary.

## Approach

The server already serializes all three annotation values for every tool. This change validates the exact descriptor used in tool discovery and makes the state-changing classifications reflect the effects that users can trigger. The descriptions now state what each tool returns and the situations it covers, without comparing it to another service or tool.

The runner tests now anchor their fixtures to a fixed test clock or an explicit test period, depending on the behavior under test.

## Impact

After deployment, rescanning tools in the Marketplace will import the corrected metadata. The resubmission still needs per-tool justifications in the Marketplace dashboard that match the scanned values.

The server test suite is no longer dependent on the current date or time for these cases.

## Validation

- mix format --check-formatted for all changed Elixir files
- MIX_ENV=test mix compile
- Serialized all tool descriptors and verified all three review annotations are booleans
- Searched MCP tool descriptions for the rejected routing phrases
- git diff --check
- MIX_ENV=test mix test test/tuist/runners/prepaid_test.exs:627 test/tuist/runners/allowance_test.exs:201 test/tuist/runners/allowance_test.exs:452 test/tuist_web/live/usage_live_test.exs:504 was attempted, but the shared local PostgreSQL server rejected new connections because it had reached its connection limit.