### PR TITLE
feat(kura): add traces, logs and geography to the Kura details dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-details.json
+++ b/infra/grafana-dashboards/tuist-kura-details.json
@@ -19331,7 +19331,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (level) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json [$__auto]))",
+                        "expr": "sum by (level) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\"} | pod=~\"$pod\" | json [$__auto]))",
                         "legendFormat": "{{level}}",
                         "queryType": "range"
                       },
@@ -19499,7 +19499,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (pod) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} [$__auto]))",
+                        "expr": "sum by (pod) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\"} | pod=~\"$pod\" [$__auto]))",
                         "legendFormat": "{{pod}}",
                         "queryType": "range"
                       },
@@ -19591,7 +19591,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json | level =~ \"ERROR|WARN\""
+                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\"} | pod=~\"$pod\" | json | level =~ \"ERROR|WARN\""
                       },
                       "version": "v0"
                     },
@@ -19656,7 +19656,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json"
+                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\"} | pod=~\"$pod\" | json"
                       },
                       "version": "v0"
                     },

--- a/infra/grafana-dashboards/tuist-kura-details.json
+++ b/infra/grafana-dashboards/tuist-kura-details.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Crosshair",
-    "description": "Every kura_* metric family exported by the Kura runtime (grouped by subsystem) plus the pod-level Kubernetes, cAdvisor and egress-tree series, filterable by environment and pod. Companion to Tuist Kura / Customer Overview: open a pod from there when a cell goes amber.",
+    "description": "Every kura_* metric family exported by the Kura runtime (grouped by subsystem) plus the pod-level Kubernetes, cAdvisor and egress-tree series, the pod's Loki logs, its Tempo traces and where it runs, filterable by environment and pod. Companion to Tuist Kura / Customer Overview: open a pod from there when a cell goes amber.",
     "editable": true,
     "elements": {
       "panel-1": {
@@ -19230,6 +19230,1472 @@
             "version": "12.0.0"
           }
         }
+      },
+      "panel-193": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (pod, region, country, subdivision) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})",
+                        "instant": false,
+                        "legendFormat": "{{region}} · {{country}}/{{subdivision}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Where this node physically runs, from `kura_node_geo_info` (region id · ISO country / subdivision). Cross-check against the account's expected region before blaming latency on the mesh.",
+          "id": 193,
+          "links": [],
+          "title": "Region",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-194": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$logs_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (level) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json [$__auto]))",
+                        "legendFormat": "{{level}}",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lines per query step by `level`, parsed out of the runtime's JSON logs. A step in ERROR/WARN is the cheapest first read on whether a pod's problem is loud or silent; every level dropping to zero on a live pod means the runtime stopped logging (wedged), not that it went quiet.",
+          "id": 194,
+          "links": [],
+          "title": "Log volume by level",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "ERROR"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "WARN"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "INFO"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "DEBUG"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "TRACE"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-195": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$logs_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (count_over_time({cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} [$__auto]))",
+                        "legendFormat": "{{pod}}",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lines per query step per pod, unparsed. With several pods selected this is where one node that is retrying or thrashing separates itself from its peers.",
+          "id": 195,
+          "links": [],
+          "title": "Log volume by pod",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-196": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$logs_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json | level =~ \"ERROR|WARN\""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "ERROR and WARN lines only. Expand a line to read the span fields the runtime stamps on every log (`span_kura_tenant_id`, `span_kura_region`, `trace_id`) and use `trace_id` to jump to the matching trace in the Traces row.",
+          "id": 196,
+          "links": [],
+          "title": "Errors \u0026 warnings",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": true,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-197": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$logs_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "{cluster=~\"tuist-$env\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Every line from the selected pods, JSON-parsed. Panel controls are on so a line filter can be typed here without leaving the dashboard. Non-JSON output (panics, pre-telemetry boot lines) still shows up, flagged with a parser error rather than dropped.",
+          "id": 197,
+          "links": [],
+          "title": "Kura logs",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": true,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showCommonLabels": false,
+                "showControls": true,
+                "showFieldSelector": true,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-198": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$traces_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 50,
+                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\" } with (most_recent=true)",
+                        "queryType": "traceql",
+                        "tableType": "traces"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Most recent spans exported by the selected pods, with liveness, readiness, scrape and rollout-status routes excluded so real client work is what's left. Traces carry the node's `kura.region`, `kura.tenant_id` and `geo.*` resource attributes, so a span identifies the node that served it.",
+          "id": 198,
+          "links": [],
+          "title": "Recent traces",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-199": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$traces_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 50,
+                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\"\n  \u0026\u0026 duration \u003e 500ms } with (most_recent=true)",
+                        "queryType": "traceql",
+                        "tableType": "traces"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Requests that took longer than half a second. Read alongside `public_request_latency_seconds` in the HTTP row: the histogram says the tail exists, this says which routes and payloads are in it.",
+          "id": 199,
+          "links": [],
+          "title": "Slow traces (\u003e 500 ms)",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-200": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$traces_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 50,
+                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 (status = error || span.http.response.status_code \u003e= 500) } with (most_recent=true)",
+                        "queryType": "traceql",
+                        "tableType": "traces"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Spans the runtime marked as errored, plus anything that answered 5xx. Empty here while `http_exceptions_total` climbs means the failures are being turned into 4xx responses, not faults.",
+          "id": 200,
+          "links": [],
+          "title": "Error traces",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-201": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$traces_datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 50,
+                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route =~ \"^/_internal/.*\" } with (most_recent=true)",
+                        "queryType": "traceql",
+                        "tableType": "traces"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Mesh-internal traffic only (`/_internal/*`): peer replication applies, backfill listings and body fetches. This is the row to open when the outbox or backfill panels show work that is not draining.",
+          "id": 201,
+          "links": [],
+          "title": "Peer replication \u0026 backfill traces",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-202": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (region) (\n  sum by (pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", pod=~\"$pod\", route!~\"/up|/ready|/metrics|/status/rollout|/_unmatched|/_internal/.*\"}[5m]))\n  * on (pod) group_left(region) max by (pod, region) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})\n)\nor sum by (region) (max by (pod, region) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"}) * 0)",
+                        "instant": true,
+                        "legendFormat": "{{region}}",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "SELECT __value__ AS Value, region,\n  CASE region\n    WHEN 'us-east'                 THEN 38.7509\n    WHEN 'us-west'                 THEN 45.5229\n    WHEN 'eu-central'              THEN 48.8566\n    WHEN 'ca-east'                 THEN 45.3168\n    WHEN 'ap-southeast'            THEN 1.3521\n    WHEN 'scw-fr-par-runners'      THEN 48.7871\n    WHEN 'hetzner-staging-runners' THEN 50.4779\n    ELSE NULL\n  END AS lat,\n  CASE region\n    WHEN 'us-east'                 THEN -77.6003\n    WHEN 'us-west'                 THEN -122.9898\n    WHEN 'eu-central'              THEN 2.3522\n    WHEN 'ca-east'                 THEN -73.8779\n    WHEN 'ap-southeast'            THEN 103.8198\n    WHEN 'scw-fr-par-runners'      THEN 2.3931\n    WHEN 'hetzner-staging-runners' THEN 12.3713\n    ELSE NULL\n  END AS lon\nFROM D LIMIT 20",
+                        "type": "sql"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max by (region, country, subdivision) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})",
+                        "instant": true,
+                        "legendFormat": "{{region}}",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "F"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "SELECT region, country, subdivision,\n  CASE region\n    WHEN 'us-east'                 THEN 38.7509\n    WHEN 'us-west'                 THEN 45.5229\n    WHEN 'eu-central'              THEN 48.8566\n    WHEN 'ca-east'                 THEN 45.3168\n    WHEN 'ap-southeast'            THEN 1.3521\n    WHEN 'scw-fr-par-runners'      THEN 48.7871\n    WHEN 'hetzner-staging-runners' THEN 50.4779\n    ELSE NULL\n  END AS lat,\n  CASE region\n    WHEN 'us-east'                 THEN -77.6003\n    WHEN 'us-west'                 THEN -122.9898\n    WHEN 'eu-central'              THEN 2.3522\n    WHEN 'ca-east'                 THEN -73.8779\n    WHEN 'ap-southeast'            THEN 103.8198\n    WHEN 'scw-fr-par-runners'      THEN 2.3931\n    WHEN 'hetzner-staging-runners' THEN 12.3713\n    ELSE NULL\n  END AS lon\nFROM F LIMIT 20",
+                        "type": "sql"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "G"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Where the selected pods run (white markers, labelled by region) and how much public request traffic each region is taking (amber bubbles, sized and coloured by client req/s). Coordinates are the datacentre cities behind `Tuist.Kura.Regions`; a region with no mapped coordinates is left off the map and shows up only in the table beside it.",
+          "id": 202,
+          "links": [],
+          "title": "Node locations \u0026 request traffic",
+          "vizConfig": {
+            "group": "geomap",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#f59e0b",
+                        "value": 0
+                      },
+                      {
+                        "color": "#f97316",
+                        "value": 30
+                      },
+                      {
+                        "color": "#ef4444",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "basemap": {
+                  "config": {},
+                  "name": "Layer 0",
+                  "type": "default"
+                },
+                "controls": {
+                  "mouseWheelZoom": true,
+                  "showAttribution": true,
+                  "showDebug": false,
+                  "showMeasure": false,
+                  "showScale": false,
+                  "showZoom": true
+                },
+                "layers": [
+                  {
+                    "config": {
+                      "showLegend": true,
+                      "style": {
+                        "color": {
+                          "field": "Value",
+                          "fixed": "#f59e0b"
+                        },
+                        "opacity": 0.35,
+                        "size": {
+                          "field": "Value",
+                          "fixed": 20,
+                          "max": 80,
+                          "min": 20
+                        },
+                        "symbol": {
+                          "fixed": "img/icons/marker/circle.svg",
+                          "mode": "fixed"
+                        },
+                        "symbolAlign": {
+                          "horizontal": "center",
+                          "vertical": "center"
+                        },
+                        "text": {
+                          "fixed": "",
+                          "mode": "fixed"
+                        },
+                        "textConfig": {
+                          "fontSize": 12,
+                          "offsetX": 0,
+                          "offsetY": 0
+                        }
+                      }
+                    },
+                    "filterData": {
+                      "id": "byRefId",
+                      "options": "E"
+                    },
+                    "location": {
+                      "latitude": "lat",
+                      "longitude": "lon",
+                      "mode": "coords"
+                    },
+                    "name": "Request traffic",
+                    "tooltip": true,
+                    "type": "markers"
+                  },
+                  {
+                    "config": {
+                      "showLegend": true,
+                      "style": {
+                        "color": {
+                          "fixed": "#ffffff"
+                        },
+                        "opacity": 1,
+                        "size": {
+                          "fixed": 14,
+                          "max": 14,
+                          "min": 14
+                        },
+                        "symbol": {
+                          "fixed": "img/icons/marker/circle.svg",
+                          "mode": "fixed"
+                        },
+                        "symbolAlign": {
+                          "horizontal": "center",
+                          "vertical": "center"
+                        },
+                        "text": {
+                          "field": "region",
+                          "fixed": "",
+                          "mode": "field"
+                        },
+                        "textConfig": {
+                          "fontSize": 12,
+                          "offsetX": 0,
+                          "offsetY": -18,
+                          "textAlign": "center",
+                          "textBaseline": "middle"
+                        }
+                      }
+                    },
+                    "filterData": {
+                      "id": "byRefId",
+                      "options": "G"
+                    },
+                    "location": {
+                      "latitude": "lat",
+                      "longitude": "lon",
+                      "mode": "coords"
+                    },
+                    "name": "Server nodes",
+                    "tooltip": true,
+                    "type": "markers"
+                  }
+                ],
+                "tooltip": {
+                  "mode": "details"
+                },
+                "view": {
+                  "allLayers": true,
+                  "dashboardVariable": false,
+                  "id": "coords",
+                  "lat": 25,
+                  "lon": 0,
+                  "noRepeat": false,
+                  "zoom": 1.4
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-203": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max by (pod, region, tenant_id, country, subdivision) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "labelsToFields",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "mode": "columns"
+                    }
+                  }
+                },
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "__name__": true,
+                        "container": true,
+                        "endpoint": true,
+                        "instance": true,
+                        "job": true,
+                        "namespace": true,
+                        "service": true
+                      },
+                      "indexByName": {
+                        "pod": 0,
+                        "region": 1,
+                        "tenant_id": 2,
+                        "country": 3,
+                        "subdivision": 4
+                      },
+                      "renameByName": {
+                        "country": "Country",
+                        "pod": "Pod",
+                        "region": "Region",
+                        "subdivision": "Subdivision",
+                        "tenant_id": "Customer"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Every selected pod with the region, tenant and ISO country / subdivision it reports. This is the authoritative list: unlike the map it needs no coordinate mapping, so a newly added region shows up here the moment its first node scrapes.",
+          "id": 203,
+          "links": [],
+          "title": "Node geography",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Pod"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 280
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "displayName": "Region"
+                  }
+                ]
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-204": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (region) (\n  sum by (pod) (rate(kura_http_requests_total_total{cluster=~\"tuist-$env\", pod=~\"$pod\", route!~\"/up|/ready|/metrics|/status/rollout|/_unmatched|/_internal/.*\"}[$__rate_interval]))\n  * on (pod) group_left(region) max by (pod, region) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})\n)",
+                        "instant": false,
+                        "legendFormat": "{{region}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Public request rate rolled up per region, joined from per-pod counters through `kura_node_geo_info` (the HTTP counters carry no region label of their own). Probes, scrapes, unmatched paths and mesh-internal routes are excluded, so this is client-facing traffic only.",
+          "id": 204,
+          "links": [],
+          "title": "Request rate by region",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-205": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.95, sum by (region, le) (\n  sum by (pod, le) (rate(kura_public_request_latency_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval]))\n  * on (pod) group_left(region) max by (pod, region) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})\n))",
+                        "instant": false,
+                        "legendFormat": "{{region}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "p95 of `public_request_latency_seconds` per region. Regions serve different client populations over different paths, so a tail that belongs to one region is a routing or placement question, not a runtime one.",
+          "id": 205,
+          "links": [],
+          "title": "p95 public latency by region",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-206": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (region) (\n  sum by (pod) (rate(kura_artifact_egress_bytes_total_total{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval]))\n  * on (pod) group_left(region) max by (pod, region) (kura_node_geo_info{cluster=~\"tuist-$env\", pod=~\"$pod\"})\n)",
+                        "instant": false,
+                        "legendFormat": "{{region}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Bytes served to clients per region. Read against the region's node NIC budget (`Bare-metal capacity` on Tuist Kura) when deciding whether a region needs another box.",
+          "id": 206,
+          "links": [],
+          "title": "Artifact egress by region",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
       }
     },
     "layout": {
@@ -19386,11 +20852,156 @@
                         "x": 16,
                         "y": 4
                       }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-193"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 20,
+                        "y": 4
+                      }
                     }
                   ]
                 }
               },
               "title": "State"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-194"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-195"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-196"
+                        },
+                        "height": 10,
+                        "width": 24,
+                        "x": 0,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-197"
+                        },
+                        "height": 12,
+                        "width": 24,
+                        "x": 0,
+                        "y": 18
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Logs (Loki) (4)"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-198"
+                        },
+                        "height": 10,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-199"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 0,
+                        "y": 10
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-200"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 12,
+                        "y": 10
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-201"
+                        },
+                        "height": 9,
+                        "width": 24,
+                        "x": 0,
+                        "y": 19
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Traces (Tempo) (4)"
             }
           },
           {
@@ -21445,6 +23056,85 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
+                          "name": "panel-202"
+                        },
+                        "height": 11,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-203"
+                        },
+                        "height": 11,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-204"
+                        },
+                        "height": 7,
+                        "width": 8,
+                        "x": 0,
+                        "y": 11
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-205"
+                        },
+                        "height": 7,
+                        "width": 8,
+                        "x": 8,
+                        "y": 11
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-206"
+                        },
+                        "height": 7,
+                        "width": 8,
+                        "x": 16,
+                        "y": 11
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Geography (5)"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
                           "name": "panel-157"
                         },
                         "height": 7,
@@ -22024,6 +23714,46 @@
           "name": "datasource",
           "options": [],
           "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "grafanacloud-tuist-logs",
+            "value": "grafanacloud-logs"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Logs (Loki)",
+          "multi": false,
+          "name": "logs_datasource",
+          "options": [],
+          "pluginId": "loki",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "grafanacloud-tuist-traces",
+            "value": "grafanacloud-traces"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Traces (Tempo)",
+          "multi": false,
+          "name": "traces_datasource",
+          "options": [],
+          "pluginId": "tempo",
           "refresh": "onDashboardLoad",
           "regex": "",
           "skipUrlSync": false

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -3169,7 +3169,7 @@
                       "group": "__expr__",
                       "kind": "DataQuery",
                       "spec": {
-                        "expression": "SELECT __value__ AS Value, region,\n  CASE region\n    WHEN 'us-east'    THEN 37.926868\n    WHEN 'us-west'    THEN 45.523064\n    WHEN 'eu-central' THEN 50.110922\n    ELSE 0\n  END AS lat,\n  CASE region\n    WHEN 'us-east'    THEN -77.054743\n    WHEN 'us-west'    THEN -122.676483\n    WHEN 'eu-central' THEN 8.682127\n    ELSE 0\n  END AS lon\nFROM D LIMIT 10",
+                        "expression": "SELECT __value__ AS Value, region,\n  CASE region\n    WHEN 'us-east'                 THEN 38.7509\n    WHEN 'us-west'                 THEN 45.5229\n    WHEN 'eu-central'              THEN 48.8566\n    WHEN 'ca-east'                 THEN 45.3168\n    WHEN 'ap-southeast'            THEN 1.3521\n    WHEN 'scw-fr-par-runners'      THEN 48.7871\n    WHEN 'hetzner-staging-runners' THEN 50.4779\n    ELSE NULL\n  END AS lat,\n  CASE region\n    WHEN 'us-east'                 THEN -77.6003\n    WHEN 'us-west'                 THEN -122.9898\n    WHEN 'eu-central'              THEN 2.3522\n    WHEN 'ca-east'                 THEN -73.8779\n    WHEN 'ap-southeast'            THEN 103.8198\n    WHEN 'scw-fr-par-runners'      THEN 2.3931\n    WHEN 'hetzner-staging-runners' THEN 12.3713\n    ELSE NULL\n  END AS lon\nFROM D LIMIT 20",
                         "type": "sql"
                       },
                       "version": "v0"
@@ -3211,7 +3211,7 @@
                       "group": "__expr__",
                       "kind": "DataQuery",
                       "spec": {
-                        "expression": "SELECT region,\n  CASE region\n    WHEN 'us-east'    THEN 37.926868\n    WHEN 'us-west'    THEN 45.523064\n    WHEN 'eu-central' THEN 50.110922\n    ELSE 0\n  END AS lat,\n  CASE region\n    WHEN 'us-east'    THEN -77.054743\n    WHEN 'us-west'    THEN -122.676483\n    WHEN 'eu-central' THEN 8.682127\n    ELSE 0\n  END AS lon\nFROM F LIMIT 10",
+                        "expression": "SELECT region,\n  CASE region\n    WHEN 'us-east'                 THEN 38.7509\n    WHEN 'us-west'                 THEN 45.5229\n    WHEN 'eu-central'              THEN 48.8566\n    WHEN 'ca-east'                 THEN 45.3168\n    WHEN 'ap-southeast'            THEN 1.3521\n    WHEN 'scw-fr-par-runners'      THEN 48.7871\n    WHEN 'hetzner-staging-runners' THEN 50.4779\n    ELSE NULL\n  END AS lat,\n  CASE region\n    WHEN 'us-east'                 THEN -77.6003\n    WHEN 'us-west'                 THEN -122.9898\n    WHEN 'eu-central'              THEN 2.3522\n    WHEN 'ca-east'                 THEN -73.8779\n    WHEN 'ap-southeast'            THEN 103.8198\n    WHEN 'scw-fr-par-runners'      THEN 2.3931\n    WHEN 'hetzner-staging-runners' THEN 12.3713\n    ELSE NULL\n  END AS lon\nFROM F LIMIT 20",
                         "type": "sql"
                       },
                       "version": "v0"
@@ -3224,7 +3224,7 @@
               "transformations": []
             }
           },
-          "description": "Server locations (blue squares) and request traffic volume (amber bubbles sized by req/s) on the same map. Fly.io-style: infrastructure markers sit on top of load bubbles.",
+          "description": "Server locations (white markers, labelled by region) and request traffic volume (amber bubbles sized by req/s) on the same map. Coordinates are the datacentre cities behind Tuist.Kura.Regions; a region with no mapped coordinates is left off the map rather than plotted at 0,0. Per-node geography for one pod lives on Tuist Kura / Details.",
           "id": 55,
           "links": [],
           "title": "Server Regions \u0026 Request Traffic",


### PR DESCRIPTION
## What changed

`Tuist Kura / Details` gains two datasource variables (Loki, Tempo) and 14 panels:

**State row** — `Region`: the node's region · ISO country/subdivision from `kura_node_geo_info`, in the row's one empty slot.

**Logs (Loki)** — new row, right after State:
- `Log volume by level` (stacked bars, ERROR red / WARN orange) and `Log volume by pod`
- `Errors & warnings` (`| json | level =~ "ERROR|WARN"`) and `Kura logs` (all lines, panel controls on so a line filter can be typed without leaving the dashboard)

**Traces (Tempo)** — new row:
- `Recent traces` (probe/scrape routes excluded), `Slow traces (> 500 ms)`, `Error traces` (span status error or 5xx), `Peer replication & backfill traces` (`/_internal/*`)

**Geography** — new row, after "Membership, readiness & node identity":
- `Node locations & request traffic` (geomap) and `Node geography` (table: pod / region / customer / country / subdivision)
- `Request rate by region`, `p95 public latency by region`, `Artifact egress by region`

`Tuist Kura` (fleet) gets one fix: the map's region → lat/lon table.

## Why

The details dashboard covered every `kura_*` metric family but neither of the other two signals, nor where the node physically runs. Debugging a single pod meant leaving it for `Tuist Kura`, which is fleet-scoped on a different variable set (`cluster`/`tenant`/`pod` rather than `env`/`pod`), and re-deriving the filter by hand. Everything here is scoped by the dashboard's own `$env`/`$pod`, so the pod you were already looking at is the pod you get.

## Reasoning behind the choices

**Traces are scoped by pod, not by a tenant name pattern.** The kura-controller sets `KURA_OTEL_SERVICE_NAME=$(POD_NAME)` (`infra/kura-controller/controllers/kurainstance_controller.go`, and the same in `kura/ops/helm/kura/templates/statefulset.yaml`), so `resource.service.name` *is* the pod name and the Pod variable selects traces exactly. The fleet dashboard approximates this with `kura-(${tenant})-.*`; on a per-pod dashboard the exact match is both simpler and correct. Environment comes from `resource.deployment.environment.name`, which the runtime stamps from `KURA_OTEL_DEPLOYMENT_ENVIRONMENT` — the same production/canary/staging values the `$env` variable already offers.

**All TraceQL regexes are anchored** (`^(...)$`). Tempo changed `=~` from unanchored to fully anchored between versions; under the unanchored reading, excluding `/up` would also have excluded `/upload`, and a pod filter of `kura-tuist-0` would have matched `kura-tuist-01`. Anchoring is correct under both.

**The per-region rollups join through `kura_node_geo_info`.** `kura/src/metrics.rs` builds a bare `Registry::default()` with no constant labels, and the Alloy scrape config adds only `namespace`/`pod`/`container` — so `kura_http_requests_total_total`, `kura_public_request_latency_seconds_bucket` and `kura_artifact_egress_bytes_total_total` carry no `region` label. Each rollup therefore does `* on (pod) group_left(region) max by (pod, region) (kura_node_geo_info)`, the same join the fleet map already uses. (Worth noting for a follow-up: the fleet dashboard's `Region` template variable filters `kura_http_requests_total_total{region=~"$region"}` directly, which cannot match anything for the same reason. Left alone here.)

**Geography is a row of its own rather than folded into Membership.** The membership row is about mesh identity over time (peers, generation, readiness) and its `node_geo_info` panel is a raw label timeseries. The map, the table and the three per-region rollups answer a different question — where load lands, and whether a tail belongs to one region — so they read better together and adjacent, rather than as five more panels in a row about a different subject.

**Map coordinates come from a shared table, with `ELSE NULL`.** The fleet map's `CASE` knew only us-east, us-west and eu-central and fell back to `ELSE 0`, so `ca-east`, `ap-southeast` and `scw-fr-par-runners` plotted in the Gulf of Guinea, and eu-central sat in Frankfurt although `Tuist.Kura.Regions` gives it FR-IDF. Both dashboards now carry the same table of all seven regions, at datacentre-city granularity, and leave an unmapped region off the map instead of inventing a location for it. The `Node geography` table beside it needs no coordinate mapping at all, so a newly added region is visible there the moment its first node scrapes — that pairing is why a false 0,0 marker is the worse failure mode of the two.

**Logs filter the pod *after* the stream selector.** `pod` is not a Loki stream label here: the k8s-monitoring Alloy pipeline moves it to structured metadata (`stage.structured_metadata` in the rendered `alloy-logs` config), so `{namespace="kura", container="kura", pod=~"$pod"}` matches no stream and fails silently — an unknown label in a selector simply matches nothing. The panels use `{cluster=..., namespace="kura", container="kura"} | pod=~"$pod"` instead, the form `Tuist Kura / Pod` already uses; it reads structured metadata correctly and keeps working if `pod` ever becomes a stream label again. (Caught on the first look at the live dashboard — the initial commit had the selector form and returned nothing.)

Worth knowing for whoever touches the fleet dashboard next: its logs panel hides the same mistake. Its Pod variable is a Loki `label_values(..., pod)` query, which comes back empty, and `pod=~""` then matches *every* stream because the label is absent everywhere — so the tenant line filter does the real work and the panel looks fine. Not changed here: fixing the selector without also fixing that variable would turn a working-by-accident panel into a broken one.

**Log/trace queries keep `"group": "prometheus"`.** That looks wrong, but it is what Grafana itself writes whenever the datasource is a variable it cannot resolve at save time — see the existing, working Loki and Tempo panels in `tuist-kura.json`. Files that reference a Loki datasource by concrete UID (`kura-pod.json`, `page-load-apdex.json`) get `"group": "loki"`. Matching the proven variable-datasource form avoids betting on a schema detail; Grafana will normalise it on the next UI save.

## Impact

Debugging one Kura pod no longer requires two dashboards. `ca-east`, `ap-southeast` and `scw-fr-par-runners` appear on the fleet map for the first time.

Dashboards are Git Sync'd with Grafana Cloud (`infra/AGENTS.md`), so merging provisions both.

## Validation

- Both files round-trip byte-identical in their existing on-disk JSON encoding, so the diff is exactly the intended change and nothing else.
- Structural checks on the edited dashboard: every element reference resolves, no orphan elements, panel ids unique and consistent with their element names, no overlapping or overflowing grid cells in any row.
- Metric names checked against `kura/src/metrics.rs`, including the doubled `_total` suffix the scrape produces; label availability (`region` absent from the request counters, present on `kura_node_geo_info`) checked against the label structs.
- Region coordinates checked against the `country`/`subdivision` in `server/lib/tuist/kura/regions.ex`.
- The Logs panels were checked against the live dashboard and corrected (see above).
- **Not run:** the remaining queries were not executed against a live datasource — I have no Grafana Cloud credentials in this session, so the PromQL joins, LogQL and TraceQL are correct by construction and review, not by execution. Worth a look at the rendered panels before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
